### PR TITLE
`SemanticsFlag`/`SemanticsAction` enum migration (part 1)

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -228,6 +228,9 @@ class SemanticsAction {
     _kSetTextIndex: setText,
   };
 
+  /// Temporary API until [values] return a list.
+  List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
+
   @override
   String toString() {
     switch (index) {
@@ -597,6 +600,9 @@ class SemanticsFlag {
     _kIsKeyboardKeyIndex: isKeyboardKey,
     _kIsCheckStateMixedIndex: isCheckStateMixed,
   };
+
+  /// Temporary API until [values] return a list.
+  List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
 
   @override
   String toString() {

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -229,7 +229,9 @@ class SemanticsAction {
   };
 
   /// Temporary API until [values] return a list.
-  List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This getter is temporary and will be removed shortly.')
+  static List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
 
   @override
   String toString() {
@@ -602,7 +604,9 @@ class SemanticsFlag {
   };
 
   /// Temporary API until [values] return a list.
-  List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This getter is temporary and will be removed shortly.')
+  static List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
 
   @override
   String toString() {

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -231,12 +231,12 @@ class SemanticsAction {
   /// Temporary API until [values] return a list.
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
-  static List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
+  static List<SemanticsAction> get doNotUseWillBeDeletedWithoutWarningValuesAsList => values.values.toList(growable: false);
 
   /// Temporary API until [values] return a list.
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
-  static Iterable<int> get keys => values.keys;
+  static Iterable<int> get doNotUseWillBeDeletedWithoutWarningKeys => values.keys;
 
   @override
   String toString() {
@@ -611,12 +611,12 @@ class SemanticsFlag {
   /// Temporary API until [values] return a list.
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
-  static List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
+  static List<SemanticsFlag> get doNotUseWillBeDeletedWithoutWarningValuesAsList => values.values.toList(growable: false);
 
   /// Temporary API until [values] return a list.
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
-  static Iterable<int> get keys => values.keys;
+  static Iterable<int> get doNotUseWillBeDeletedWithoutWarningKeys => values.keys;
 
   @override
   String toString() {

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -233,6 +233,11 @@ class SemanticsAction {
   @Deprecated('This getter is temporary and will be removed shortly.')
   static List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
 
+  /// Temporary API until [values] return a list.
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This getter is temporary and will be removed shortly.')
+  static Iterable<int> get keys => values.keys;
+
   @override
   String toString() {
     switch (index) {
@@ -607,6 +612,11 @@ class SemanticsFlag {
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
   static List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
+
+  /// Temporary API until [values] return a list.
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This getter is temporary and will be removed shortly.')
+  static Iterable<int> get keys => values.keys;
 
   @override
   String toString() {

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -80,6 +80,9 @@ class SemanticsAction {
     _kSetTextIndex: setText,
   };
 
+  /// Temporary API until [values] return a list.
+  List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
+
   @override
   String toString() {
     switch (index) {
@@ -220,6 +223,9 @@ class SemanticsFlag {
     _kIsKeyboardKeyIndex: isKeyboardKey,
     _kIsCheckStateMixedIndex: isCheckStateMixed,
   };
+
+  /// Temporary API until [values] return a list.
+  List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
 
   @override
   String toString() {

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -83,12 +83,12 @@ class SemanticsAction {
   /// Temporary API until [values] return a list.
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
-  static List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
+  static List<SemanticsAction> get doNotUseWillBeDeletedWithoutWarningValuesAsList => values.values.toList(growable: false);
 
   /// Temporary API until [values] return a list.
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
-  static Iterable<int> get keys => values.keys;
+  static Iterable<int> get doNotUseWillBeDeletedWithoutWarningKeys => values.keys;
 
   @override
   String toString() {
@@ -234,12 +234,12 @@ class SemanticsFlag {
   /// Temporary API until [values] return a list.
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
-  static List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
+  static List<SemanticsFlag> get doNotUseWillBeDeletedWithoutWarningValuesAsList => values.values.toList(growable: false);
 
   /// Temporary API until [values] return a list.
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
-  static Iterable<int> get keys => values.keys;
+  static Iterable<int> get doNotUseWillBeDeletedWithoutWarningKeys => values.keys;
 
   @override
   String toString() {

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -85,6 +85,11 @@ class SemanticsAction {
   @Deprecated('This getter is temporary and will be removed shortly.')
   static List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
 
+  /// Temporary API until [values] return a list.
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This getter is temporary and will be removed shortly.')
+  static Iterable<int> get keys => values.keys;
+
   @override
   String toString() {
     switch (index) {
@@ -230,6 +235,11 @@ class SemanticsFlag {
   /// https://github.com/flutter/flutter/issues/123346
   @Deprecated('This getter is temporary and will be removed shortly.')
   static List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
+
+  /// Temporary API until [values] return a list.
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This getter is temporary and will be removed shortly.')
+  static Iterable<int> get keys => values.keys;
 
   @override
   String toString() {

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -81,7 +81,9 @@ class SemanticsAction {
   };
 
   /// Temporary API until [values] return a list.
-  List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This getter is temporary and will be removed shortly.')
+  static List<SemanticsAction> get valuesAsList => values.values.toList(growable: false);
 
   @override
   String toString() {
@@ -225,7 +227,9 @@ class SemanticsFlag {
   };
 
   /// Temporary API until [values] return a list.
-  List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This getter is temporary and will be removed shortly.')
+  static List<SemanticsFlag> get valuesAsList => values.values.toList(growable: false);
 
   @override
   String toString() {


### PR DESCRIPTION
Add temporary API.
cc @chunhtai 

part of https://github.com/flutter/flutter/issues/123346

Steps:
**part 1: [engine] add `valuesAsList`** <-- we are here
part 2: [flutter] use `valuesAsList`
part 3: [engine] convert to enum
part 4: [flutter] use `values` again.
part 5: [engine] remove valuesAsList.
part 6: [flutter] deprecate describeEnum.