### PR TITLE
[impeller] runtime effect doesnt accept opacity

### DIFF
--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -37,6 +37,10 @@ void RuntimeEffectContents::SetTextureInputs(
   texture_inputs_ = std::move(texture_inputs);
 }
 
+bool RuntimeEffectContents::CanAcceptOpacity(const Entity& entity) const {
+  return false;
+}
+
 bool RuntimeEffectContents::Render(const ContentContext& renderer,
                                    const Entity& entity,
                                    RenderPass& pass) const {

--- a/impeller/entity/contents/runtime_effect_contents.h
+++ b/impeller/entity/contents/runtime_effect_contents.h
@@ -25,6 +25,9 @@ class RuntimeEffectContents final : public ColorSourceContents {
 
   void SetTextureInputs(std::vector<TextureInput> texture_inputs);
 
+  // | Contents|
+  bool CanAcceptOpacity(const Entity& entity) const override;
+
   // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2437,6 +2437,10 @@ TEST_P(EntityTest, InheritOpacityTest) {
   // Clips and restores trivially accept opacity.
   ASSERT_TRUE(ClipContents().CanAcceptOpacity(entity));
   ASSERT_TRUE(ClipRestoreContents().CanAcceptOpacity(entity));
+
+  // Runtime effect contents can't accept opacity.
+  auto runtime_effect = std::make_shared<RuntimeEffectContents>();
+  ASSERT_FALSE(runtime_effect->CanAcceptOpacity(entity));
 }
 
 }  // namespace testing


### PR DESCRIPTION
Noticed while bisecting other issues.
