### PR TITLE
Ensure all golden filenames end in .png.

### DIFF
--- a/lib/web_ui/test/canvaskit/font_variation_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/font_variation_golden_test.dart
@@ -56,7 +56,7 @@ void testMain() {
       canvas.drawParagraph(paragraph, const ui.Offset(10, 10));
       final CkPicture picture = recorder.endRecording();
       await matchPictureGolden(
-        'font_variation.jpg',
+        'font_variation.png',
         picture,
         region: ui.Rect.fromLTRB(0, 0, testWidth, paragraph.height + 20),
       );

--- a/lib/web_ui/test/canvaskit/image_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/image_golden_test.dart
@@ -779,7 +779,7 @@ void _testForImageCodecs({required bool useBrowserImageDecoder}) {
       }
       CanvasKitRenderer.instance.rasterizer.draw(sb.build().layerTree);
       await matchGoldenFile(
-        'canvaskit_picture_texture_toimage',
+        'canvaskit_picture_texture_toimage.png',
         region: const ui.Rect.fromLTRB(0, 0, 128, 128),
       );
       mandrill.dispose();

--- a/web_sdk/web_engine_tester/lib/golden_tester.dart
+++ b/web_sdk/web_engine_tester/lib/golden_tester.dart
@@ -49,6 +49,9 @@ enum PixelComparison {
 /// [pixelComparison] determines the algorithm used to compare pixels. Uses
 /// fuzzy comparison by default.
 Future<void> matchGoldenFile(String filename, {Rect? region}) async {
+  if (!filename.endsWith('.png')) {
+    throw ArgumentError('Filename must end in .png or SkiaGold will ignore it.');
+  }
   final Map<String, dynamic> serverParams = <String, dynamic>{
     'filename': filename,
     'region': region == null


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/121906

Skia seems to silently ignore files without an extension, so we should double-check the extension before sending the screenshot.