### PR TITLE
Revert "Unregister the FlutterWindowsView on its destruction"

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -416,9 +416,7 @@ bool FlutterWindowsEngine::Stop() {
 
 void FlutterWindowsEngine::SetView(FlutterWindowsView* view) {
   view_ = view;
-  if (view) {
-    InitializeKeyboard();
-  }
+  InitializeKeyboard();
 }
 
 void FlutterWindowsEngine::OnVsync(intptr_t baton) {

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -49,9 +49,6 @@ FlutterWindowsView::FlutterWindowsView(
 }
 
 FlutterWindowsView::~FlutterWindowsView() {
-  if (engine_) {
-    engine_->SetView(nullptr);
-  }
   DestroyRenderSurface();
 }
 

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -1032,32 +1032,5 @@ TEST(FlutterWindowsViewTest, TooltipNodeData) {
   EXPECT_EQ(uia_tooltip, "tooltip");
 }
 
-TEST(FlutterWindowsViewTest, DestructorTest) {
-  bool destroyed = false;
-  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
-  // Use this pointer to reference the view in the Destruct callback, which must
-  // be defined before the view is.
-  FlutterWindowsView* view_ptr = nullptr;
-
-  auto window_binding_handler =
-      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
-  ON_CALL(*window_binding_handler, Destruct)
-      .WillByDefault([&destroyed, &view_ptr]() {
-        EXPECT_FALSE(destroyed);
-        destroyed = true;
-        ASSERT_NE(view_ptr, nullptr);
-        EXPECT_EQ(view_ptr->GetEngine()->view(), nullptr);
-      });
-
-  {
-    FlutterWindowsView view(std::move(window_binding_handler));
-    view_ptr = &view;
-    view.SetEngine(std::move(engine));
-    // Destruct view before continuing.
-  }
-
-  EXPECT_TRUE(destroyed);
-}
-
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/testing/mock_window_binding_handler.cc
+++ b/shell/platform/windows/testing/mock_window_binding_handler.cc
@@ -9,9 +9,7 @@ namespace testing {
 
 MockWindowBindingHandler::MockWindowBindingHandler() : WindowBindingHandler(){};
 
-MockWindowBindingHandler::~MockWindowBindingHandler() {
-  Destruct();
-}
+MockWindowBindingHandler::~MockWindowBindingHandler() = default;
 
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -36,7 +36,6 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD0(SendInitialAccessibilityFeatures, void());
   MOCK_METHOD0(GetAlertDelegate, AlertPlatformNodeDelegate*());
   MOCK_METHOD0(GetAlert, ui::AXPlatformNodeWin*());
-  MOCK_METHOD0(Destruct, void());
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowBindingHandler);


### PR DESCRIPTION
Reverts flutter/engine#39824

This PR appears to be responsible for the following error upon app shutdown:

    [ERROR:flutter/shell/gpu/gpu_surface_gl_skia.cc(97)] Could not make the context current to destroy the GrDirectContext resources.