### PR TITLE
[web] Accepts assetBase through JS config.

### DIFF
--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -158,6 +158,32 @@ class FlutterConfiguration {
   // runtime. Runtime-supplied values take precedence over environment
   // variables.
 
+  /// The absolute base URL of the location of the `assets` directory of the app.
+  ///
+  /// This value is useful when Flutter web assets are deployed to a separate
+  /// domain (or subdirectory) from which the index.html is served, for example:
+  ///
+  /// * Application: https://www.my-app.com/
+  /// * Flutter Assets: https://cdn.example.com/my-app/build-hash/assets/
+  ///
+  /// The `assetBase` value would be set to:
+  ///
+  /// * `'https://cdn.example.com/my-app/build-hash/'`
+  ///
+  /// It is also useful in the case that a Flutter web application is embedded
+  /// into another web app, in a way that the `<base>` tag of the index.html
+  /// cannot be set (because it'd break the host app), for example:
+  ///
+  /// * Application: https://www.my-app.com/
+  /// * Flutter Assets: https://www.my-app.com/static/companion/flutter/assets/
+  ///
+  /// The `assetBase` would be set to:
+  ///
+  /// * `'/static/companion/flutter/'`
+  ///
+  /// Do not confuse this configuration value with [canvasKitBaseUrl].
+  String? get assetBase => _configuration?.assetBase;
+
   /// The base URL to use when downloading the CanvasKit script and associated
   /// wasm.
   ///
@@ -267,6 +293,10 @@ external JsFlutterConfiguration? get _jsConfiguration;
 class JsFlutterConfiguration {}
 
 extension JsFlutterConfigurationExtension on JsFlutterConfiguration {
+  @JS('assetBase')
+  external JSString? get _assetBase;
+  String? get assetBase => _assetBase?.toDart;
+
   @JS('canvasKitBaseUrl')
   external JSString? get _canvasKitBaseUrl;
   String? get canvasKitBaseUrl => _canvasKitBaseUrl?.toDart;

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -211,7 +211,7 @@ Future<void> initializeEngineServices({
     }
   };
 
-  assetManager ??= const AssetManager();
+  assetManager ??= AssetManager(assetBase: configuration.assetBase);
   _setAssetManager(assetManager);
 
   Future<void> initializeRendererCallback () async => renderer.initialize();

--- a/lib/web_ui/test/engine/assets_test.dart
+++ b/lib/web_ui/test/engine/assets_test.dart
@@ -1,0 +1,141 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('browser')
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+import '../matchers.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('AssetManager getAssetUrl', () {
+    setUp(() {
+      // Remove the meta-tag from the environment before each test.
+      removeAssetBaseMeta();
+    });
+
+    test('initializes with default values', () {
+      final AssetManager assets = AssetManager();
+
+      expect(
+        assets.getAssetUrl('asset.txt'),
+        'assets/asset.txt',
+        reason: 'Default `assetsDir` is "assets".',
+      );
+    });
+
+    test('assetsDir changes the directory where assets are stored', () {
+      final AssetManager assets = AssetManager(assetsDir: 'static');
+
+      expect(assets.getAssetUrl('asset.txt'), 'static/asset.txt');
+    });
+
+    test('assetBase must end with slash', () {
+      expect(() {
+        AssetManager(assetBase: '/deployment');
+      }, throwsAssertionError);
+    });
+
+    test('assetBase can be relative', () {
+      final AssetManager assets = AssetManager(assetBase: 'base/');
+
+      expect(assets.getAssetUrl('asset.txt'), 'base/assets/asset.txt');
+    });
+
+    test('assetBase can be absolute', () {
+      final AssetManager assets = AssetManager(
+        assetBase: 'https://www.gstatic.com/my-app/',
+      );
+
+      expect(
+        assets.getAssetUrl('asset.txt'),
+        'https://www.gstatic.com/my-app/assets/asset.txt',
+      );
+    });
+
+    test('assetBase in conjunction with assetsDir, fully custom paths', () {
+      final AssetManager assets = AssetManager(
+        assetBase: '/asset/base/',
+        assetsDir: 'static',
+      );
+
+      expect(assets.getAssetUrl('asset.txt'), '/asset/base/static/asset.txt');
+    });
+
+    test('Fully-qualified asset URLs are untouched', () {
+      final AssetManager assets = AssetManager();
+
+      expect(
+        assets.getAssetUrl('https://static.my-app.com/favicon.ico'),
+        'https://static.my-app.com/favicon.ico',
+      );
+    });
+
+    test('Fully-qualified asset URLs are untouched (even with assetBase)', () {
+      final AssetManager assets = AssetManager(
+        assetBase: 'https://static.my-app.com/',
+      );
+
+      expect(
+        assets.getAssetUrl('https://static.my-app.com/favicon.ico'),
+        'https://static.my-app.com/favicon.ico',
+      );
+    });
+  });
+
+  group('AssetManager getAssetUrl with <meta name=assetBase> tag', () {
+    setUp(() {
+      removeAssetBaseMeta();
+      addAssetBaseMeta('/dom/base/');
+    });
+
+    test('reads value from DOM', () {
+      final AssetManager assets = AssetManager();
+
+      expect(assets.getAssetUrl('asset.txt'), '/dom/base/assets/asset.txt');
+    });
+
+    test('reads value from DOM (only once!)', () {
+      final AssetManager firstManager = AssetManager();
+      expect(
+        firstManager.getAssetUrl('asset.txt'),
+        '/dom/base/assets/asset.txt',
+      );
+
+      removeAssetBaseMeta();
+      final AssetManager anotherManager = AssetManager();
+
+      expect(
+        firstManager.getAssetUrl('asset.txt'),
+        '/dom/base/assets/asset.txt',
+        reason: 'The old value of the assetBase meta should be cached.',
+      );
+      expect(anotherManager.getAssetUrl('asset.txt'), 'assets/asset.txt');
+    });
+  });
+}
+
+/// Removes all meta-tags with name=assetBase.
+void removeAssetBaseMeta() {
+  domWindow.document
+      .querySelectorAll('meta[name=assetBase]')
+      .forEach((DomElement element) {
+    element.remove();
+  });
+}
+
+/// Adds a meta-tag with name=assetBase and the passed-in [value].
+void addAssetBaseMeta(String value) {
+  final DomHTMLMetaElement meta = createDomHTMLMetaElement()
+    ..name = 'assetBase'
+    ..content = value;
+
+  domDocument.head!.append(meta);
+}


### PR DESCRIPTION
Adds `assetBase` as a JS Configuration object that can be pased to initializeEngine, and warns users of the old meta-tag that they should stop doing it, and using the new style.

Adds unit tests for the `getAssetUrl` method with different configuration options.

### Issues

Fixes: https://github.com/flutter/flutter/issues/122987

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
