### PR TITLE
[Impeller] Enable RendererTest::TheImpeller for Vulkan.

### DIFF
--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -810,9 +810,6 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
 }
 
 TEST_P(RendererTest, TheImpeller) {
-  if (GetBackend() == PlaygroundBackend::kVulkan) {
-    GTEST_SKIP_("Temporarily disabled.");
-  }
   using VS = ImpellerVertexShader;
   using FS = ImpellerFragmentShader;
 


### PR DESCRIPTION
This was disabled as I was investigating a write-after-write sync hazard which has already been fixed.