### PR TITLE
[Impeller] Fix AtlasContents crash

### DIFF
--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -304,15 +304,18 @@ bool AtlasTextureContents::Render(const ContentContext& renderer,
   using VS = TextureFillVertexShader;
   using FS = TextureFillFragmentShader;
 
-  auto texture = texture_.value_or(parent_.GetTexture());
+  auto texture = texture_ ? texture_ : parent_.GetTexture();
+  if (texture == nullptr) {
+    return true;
+  }
+
   std::vector<Rect> texture_coords;
   std::vector<Matrix> transforms;
-  if (subatlas_.has_value()) {
-    auto subatlas = subatlas_.value();
-    texture_coords = use_destination_ ? subatlas->result_texture_coords
-                                      : subatlas->sub_texture_coords;
-    transforms = use_destination_ ? subatlas->result_transforms
-                                  : subatlas->sub_transforms;
+  if (subatlas_) {
+    texture_coords = use_destination_ ? subatlas_->result_texture_coords
+                                      : subatlas_->sub_texture_coords;
+    transforms = use_destination_ ? subatlas_->result_transforms
+                                  : subatlas_->sub_transforms;
   } else {
     texture_coords = parent_.GetTextureCoordinates();
     transforms = parent_.GetTransforms();

--- a/impeller/entity/contents/atlas_contents.h
+++ b/impeller/entity/contents/atlas_contents.h
@@ -118,9 +118,9 @@ class AtlasTextureContents final : public Contents {
   const AtlasContents& parent_;
   Scalar alpha_ = 1.0;
   Rect coverage_;
-  std::optional<std::shared_ptr<Texture>> texture_;
+  std::shared_ptr<Texture> texture_;
   bool use_destination_ = false;
-  std::optional<std::shared_ptr<SubAtlasResult>> subatlas_ = std::nullopt;
+  std::shared_ptr<SubAtlasResult> subatlas_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AtlasTextureContents);
 };


### PR DESCRIPTION
Fixes crash of `impeller_unittests --timeout=0 --gtest_filter="Play/EntityTest.DrawAtlasWithColorAdvanced/Metal"` and removes double empty states.

Fixes https://github.com/flutter/flutter/issues/122531