### PR TITLE
[Impeller] Fix accumulating translucency opacity peephole bug

### DIFF
--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -31,7 +31,7 @@ std::shared_ptr<Contents> Paint::CreateContentsForGeometry(
     auto& source = color_source.value();
     auto contents = source();
     contents->SetGeometry(std::move(geometry));
-    contents->SetAlpha(color.alpha);
+    contents->SetOpacity(color.alpha);
     return contents;
   }
   auto solid_color = std::make_shared<SolidColorContents>();
@@ -46,7 +46,7 @@ std::shared_ptr<Contents> Paint::CreateContentsForGeometry(
     auto& source = color_source.value();
     auto contents = source();
     contents->SetGeometry(geometry);
-    contents->SetAlpha(color.alpha);
+    contents->SetOpacity(color.alpha);
     return contents;
   }
   auto solid_color = std::make_shared<SolidColorContents>();

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -97,7 +97,7 @@ bool OpacityPeepholePassDelegate::CanCollapseIntoParentPass(
   auto had_subpass = entity_pass->IterateUntilSubpass(
       [&all_coverages, &all_can_accept](Entity& entity) {
         auto contents = entity.GetContents();
-        if (!contents->CanAcceptOpacity(entity)) {
+        if (!contents->CanInheritOpacity(entity)) {
           all_can_accept = false;
           return false;
         }

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -70,7 +70,7 @@ bool ClipContents::ShouldRender(
   return true;
 }
 
-bool ClipContents::CanAcceptOpacity(const Entity& entity) const {
+bool ClipContents::CanInheritOpacity(const Entity& entity) const {
   return true;
 }
 
@@ -172,7 +172,7 @@ bool ClipRestoreContents::ShouldRender(
   return true;
 }
 
-bool ClipRestoreContents::CanAcceptOpacity(const Entity& entity) const {
+bool ClipRestoreContents::CanInheritOpacity(const Entity& entity) const {
   return true;
 }
 

--- a/impeller/entity/contents/clip_contents.h
+++ b/impeller/entity/contents/clip_contents.h
@@ -42,7 +42,7 @@ class ClipContents final : public Contents {
               const Entity& entity,
               RenderPass& pass) const override;
   // |Contents|
-  bool CanAcceptOpacity(const Entity& entity) const override;
+  bool CanInheritOpacity(const Entity& entity) const override;
 
   // |Contents|
   void SetInheritedOpacity(Scalar opacity) override;
@@ -84,7 +84,7 @@ class ClipRestoreContents final : public Contents {
               RenderPass& pass) const override;
 
   // |Contents|
-  bool CanAcceptOpacity(const Entity& entity) const override;
+  bool CanInheritOpacity(const Entity& entity) const override;
 
   // |Contents|
   void SetInheritedOpacity(Scalar opacity) override;

--- a/impeller/entity/contents/color_source_contents.cc
+++ b/impeller/entity/contents/color_source_contents.cc
@@ -21,12 +21,12 @@ const std::shared_ptr<Geometry>& ColorSourceContents::GetGeometry() const {
   return geometry_;
 }
 
-void ColorSourceContents::SetAlpha(Scalar alpha) {
-  alpha_ = alpha;
+void ColorSourceContents::SetOpacity(Scalar alpha) {
+  opacity_ = alpha;
 }
 
-Scalar ColorSourceContents::GetAlpha() const {
-  return alpha_;
+Scalar ColorSourceContents::GetOpacity() const {
+  return opacity_ * inherited_opacity_;
 }
 
 void ColorSourceContents::SetEffectTransform(Matrix matrix) {
@@ -42,12 +42,12 @@ std::optional<Rect> ColorSourceContents::GetCoverage(
   return geometry_->GetCoverage(entity.GetTransformation());
 };
 
-bool ColorSourceContents::CanAcceptOpacity(const Entity& entity) const {
+bool ColorSourceContents::CanInheritOpacity(const Entity& entity) const {
   return true;
 }
 
 void ColorSourceContents::SetInheritedOpacity(Scalar opacity) {
-  SetAlpha(GetAlpha() * opacity);
+  inherited_opacity_ = opacity;
 }
 
 bool ColorSourceContents::ShouldRender(

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -24,7 +24,7 @@ class ColorSourceContents : public Contents {
 
   const Matrix& GetInverseMatrix() const;
 
-  void SetAlpha(Scalar alpha);
+  void SetOpacity(Scalar opacity);
 
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
@@ -33,13 +33,13 @@ class ColorSourceContents : public Contents {
   bool ShouldRender(const Entity& entity,
                     const std::optional<Rect>& stencil_coverage) const override;
 
-  // | Contents|
-  bool CanAcceptOpacity(const Entity& entity) const override;
+  // |Contents|
+  bool CanInheritOpacity(const Entity& entity) const override;
 
-  // | Contents|
+  // |Contents|
   void SetInheritedOpacity(Scalar opacity) override;
 
-  Scalar GetAlpha() const;
+  Scalar GetOpacity() const;
 
  protected:
   const std::shared_ptr<Geometry>& GetGeometry() const;
@@ -47,7 +47,8 @@ class ColorSourceContents : public Contents {
  private:
   std::shared_ptr<Geometry> geometry_;
   Matrix inverse_matrix_;
-  Scalar alpha_ = 1.0;
+  Scalar opacity_ = 1.0;
+  Scalar inherited_opacity_ = 1.0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ColorSourceContents);
 };

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -70,7 +70,7 @@ bool ConicalGradientContents::RenderSSBO(const ContentContext& renderer,
   frag_info.center = center_;
   frag_info.radius = radius_;
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  frag_info.alpha = GetAlpha();
+  frag_info.alpha = GetOpacity();
   if (focus_) {
     frag_info.focus = focus_.value();
     frag_info.focus_radius = focus_radius_;
@@ -141,7 +141,7 @@ bool ConicalGradientContents::RenderTexture(const ContentContext& renderer,
   frag_info.radius = radius_;
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
   frag_info.texture_sampler_y_coord_scale = gradient_texture->GetYCoordScale();
-  frag_info.alpha = GetAlpha();
+  frag_info.alpha = GetOpacity();
   frag_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
                                  0.5 / gradient_texture->GetSize().height);
   if (focus_) {

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -95,7 +95,7 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
   return snapshot;
 }
 
-bool Contents::CanAcceptOpacity(const Entity& entity) const {
+bool Contents::CanInheritOpacity(const Entity& entity) const {
   return false;
 }
 

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -94,7 +94,7 @@ class Contents {
   ///        a way that makes accepting opacity impossible. It is always safe
   ///        to return false, especially if computing overlap would be
   ///        computationally expensive.
-  virtual bool CanAcceptOpacity(const Entity& entity) const;
+  virtual bool CanInheritOpacity(const Entity& entity) const;
 
   /// @brief Inherit the provided opacity.
   ///

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -71,7 +71,7 @@ bool LinearGradientContents::RenderTexture(const ContentContext& renderer,
   frag_info.end_point = end_point_;
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
   frag_info.texture_sampler_y_coord_scale = gradient_texture->GetYCoordScale();
-  frag_info.alpha = GetAlpha();
+  frag_info.alpha = GetOpacity();
   frag_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
                                  0.5 / gradient_texture->GetSize().height);
 
@@ -126,7 +126,7 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
   frag_info.start_point = start_point_;
   frag_info.end_point = end_point_;
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  frag_info.alpha = GetAlpha();
+  frag_info.alpha = GetOpacity();
 
   auto& host_buffer = pass.GetTransientsBuffer();
   auto colors = CreateGradientColors(colors_, stops_);

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -64,7 +64,7 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
   frag_info.center = center_;
   frag_info.radius = radius_;
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  frag_info.alpha = GetAlpha();
+  frag_info.alpha = GetOpacity();
 
   auto& host_buffer = pass.GetTransientsBuffer();
   auto colors = CreateGradientColors(colors_, stops_);
@@ -128,7 +128,7 @@ bool RadialGradientContents::RenderTexture(const ContentContext& renderer,
   frag_info.radius = radius_;
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
   frag_info.texture_sampler_y_coord_scale = gradient_texture->GetYCoordScale();
-  frag_info.alpha = GetAlpha();
+  frag_info.alpha = GetOpacity();
   frag_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
                                  0.5 / gradient_texture->GetSize().height);
 

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -37,7 +37,7 @@ void RuntimeEffectContents::SetTextureInputs(
   texture_inputs_ = std::move(texture_inputs);
 }
 
-bool RuntimeEffectContents::CanAcceptOpacity(const Entity& entity) const {
+bool RuntimeEffectContents::CanInheritOpacity(const Entity& entity) const {
   return false;
 }
 

--- a/impeller/entity/contents/runtime_effect_contents.h
+++ b/impeller/entity/contents/runtime_effect_contents.h
@@ -26,7 +26,7 @@ class RuntimeEffectContents final : public ColorSourceContents {
   void SetTextureInputs(std::vector<TextureInput> texture_inputs);
 
   // | Contents|
-  bool CanAcceptOpacity(const Entity& entity) const override;
+  bool CanInheritOpacity(const Entity& entity) const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -33,10 +33,10 @@ class SolidColorContents final : public Contents {
 
   void SetColor(Color color);
 
-  const Color& GetColor() const;
+  Color GetColor() const;
 
   // | Contents|
-  bool CanAcceptOpacity(const Entity& entity) const override;
+  bool CanInheritOpacity(const Entity& entity) const override;
 
   // | Contents|
   void SetInheritedOpacity(Scalar opacity) override;
@@ -57,6 +57,7 @@ class SolidColorContents final : public Contents {
   std::shared_ptr<Geometry> geometry_;
 
   Color color_;
+  Scalar inherited_opacity_ = 1.0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(SolidColorContents);
 };

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -70,7 +70,7 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
   frag_info.bias = bias_;
   frag_info.scale = scale_;
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  frag_info.alpha = GetAlpha();
+  frag_info.alpha = GetOpacity();
 
   auto& host_buffer = pass.GetTransientsBuffer();
   auto colors = CreateGradientColors(colors_, stops_);
@@ -135,7 +135,7 @@ bool SweepGradientContents::RenderTexture(const ContentContext& renderer,
   frag_info.scale = scale_;
   frag_info.texture_sampler_y_coord_scale = gradient_texture->GetYCoordScale();
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
-  frag_info.alpha = GetAlpha();
+  frag_info.alpha = GetOpacity();
   frag_info.half_texel = Vector2(0.5 / gradient_texture->GetSize().width,
                                  0.5 / gradient_texture->GetSize().height);
 

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -51,16 +51,15 @@ void TextContents::SetColor(Color color) {
 }
 
 Color TextContents::GetColor() const {
-  return color_;
+  return color_.WithAlpha(color_.alpha * inherited_opacity_);
 }
 
-bool TextContents::CanAcceptOpacity(const Entity& entity) const {
+bool TextContents::CanInheritOpacity(const Entity& entity) const {
   return !frame_.MaybeHasOverlapping();
 }
 
 void TextContents::SetInheritedOpacity(Scalar opacity) {
-  auto color = color_;
-  color_ = color.WithAlpha(color.alpha * opacity);
+  inherited_opacity_ = opacity;
 }
 
 void TextContents::SetInverseMatrix(Matrix matrix) {
@@ -230,13 +229,14 @@ bool TextContents::RenderSdf(const ContentContext& renderer,
   cmd.stencil_reference = entity.GetStencilDepth();
 
   return CommonRender<GlyphAtlasSdfPipeline>(
-      renderer, entity, pass, color_, frame_, inverse_matrix_, atlas, cmd);
+      renderer, entity, pass, GetColor(), frame_, inverse_matrix_, atlas, cmd);
 }
 
 bool TextContents::Render(const ContentContext& renderer,
                           const Entity& entity,
                           RenderPass& pass) const {
-  if (color_.IsTransparent()) {
+  auto color = GetColor();
+  if (color.IsTransparent()) {
     return true;
   }
 
@@ -264,8 +264,8 @@ bool TextContents::Render(const ContentContext& renderer,
   cmd.pipeline = renderer.GetGlyphAtlasPipeline(opts);
   cmd.stencil_reference = entity.GetStencilDepth();
 
-  return CommonRender<GlyphAtlasPipeline>(renderer, entity, pass, color_,
-                                          frame_, inverse_matrix_, atlas, cmd);
+  return CommonRender<GlyphAtlasPipeline>(renderer, entity, pass, color, frame_,
+                                          inverse_matrix_, atlas, cmd);
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -34,7 +34,7 @@ class TextContents final : public Contents {
 
   Color GetColor() const;
 
-  bool CanAcceptOpacity(const Entity& entity) const override;
+  bool CanInheritOpacity(const Entity& entity) const override;
 
   void SetInheritedOpacity(Scalar opacity) override;
 
@@ -56,6 +56,7 @@ class TextContents final : public Contents {
  private:
   TextFrame frame_;
   Color color_;
+  Scalar inherited_opacity_;
   mutable std::shared_ptr<LazyGlyphAtlas> lazy_atlas_;
   Matrix inverse_matrix_;
 

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -66,7 +66,7 @@ class TextureContents final : public Contents {
               RenderPass& pass) const override;
 
   // |Contents|
-  bool CanAcceptOpacity(const Entity& entity) const override;
+  bool CanInheritOpacity(const Entity& entity) const override;
 
   // |Contents|
   void SetInheritedOpacity(Scalar opacity) override;
@@ -83,6 +83,7 @@ class TextureContents final : public Contents {
   SamplerDescriptor sampler_descriptor_ = {};
   Rect source_rect_;
   Scalar opacity_ = 1.0f;
+  Scalar inherited_opacity_ = 1.0f;
   bool defer_applying_opacity_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TextureContents);

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -109,7 +109,7 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
   FS::FragInfo frag_info;
   frag_info.x_tile_mode = static_cast<Scalar>(x_tile_mode_);
   frag_info.y_tile_mode = static_cast<Scalar>(y_tile_mode_);
-  frag_info.alpha = GetAlpha();
+  frag_info.alpha = GetOpacity();
 
   Command cmd;
   cmd.label = "TiledTextureFill";

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2387,8 +2387,10 @@ TEST_P(EntityTest, InheritOpacityTest) {
   // Texture contents can always accept opacity.
   auto texture_contents = std::make_shared<TextureContents>();
   texture_contents->SetOpacity(0.5);
-  ASSERT_TRUE(texture_contents->CanAcceptOpacity(entity));
+  ASSERT_TRUE(texture_contents->CanInheritOpacity(entity));
 
+  texture_contents->SetInheritedOpacity(0.5);
+  ASSERT_EQ(texture_contents->GetOpacity(), 0.25);
   texture_contents->SetInheritedOpacity(0.5);
   ASSERT_EQ(texture_contents->GetOpacity(), 0.25);
 
@@ -2399,8 +2401,10 @@ TEST_P(EntityTest, InheritOpacityTest) {
       Geometry::MakeRect(Rect::MakeLTRB(100, 100, 200, 200)));
   solid_color->SetColor(Color::Blue().WithAlpha(0.5));
 
-  ASSERT_TRUE(solid_color->CanAcceptOpacity(entity));
+  ASSERT_TRUE(solid_color->CanInheritOpacity(entity));
 
+  solid_color->SetInheritedOpacity(0.5);
+  ASSERT_EQ(solid_color->GetColor().alpha, 0.25);
   solid_color->SetInheritedOpacity(0.5);
   ASSERT_EQ(solid_color->GetColor().alpha, 0.25);
 
@@ -2409,12 +2413,14 @@ TEST_P(EntityTest, InheritOpacityTest) {
   auto tiled_texture = std::make_shared<TiledTextureContents>();
   tiled_texture->SetGeometry(
       Geometry::MakeRect(Rect::MakeLTRB(100, 100, 200, 200)));
-  tiled_texture->SetAlpha(0.5);
+  tiled_texture->SetOpacity(0.5);
 
-  ASSERT_TRUE(tiled_texture->CanAcceptOpacity(entity));
+  ASSERT_TRUE(tiled_texture->CanInheritOpacity(entity));
 
   tiled_texture->SetInheritedOpacity(0.5);
-  ASSERT_EQ(tiled_texture->GetAlpha(), 0.25);
+  ASSERT_EQ(tiled_texture->GetOpacity(), 0.25);
+  tiled_texture->SetInheritedOpacity(0.5);
+  ASSERT_EQ(tiled_texture->GetOpacity(), 0.25);
 
   // Text contents can accept opacity if the text frames do not
   // overlap
@@ -2429,18 +2435,20 @@ TEST_P(EntityTest, InheritOpacityTest) {
   text_contents->SetTextFrame(frame);
   text_contents->SetColor(Color::Blue().WithAlpha(0.5));
 
-  ASSERT_TRUE(text_contents->CanAcceptOpacity(entity));
+  ASSERT_TRUE(text_contents->CanInheritOpacity(entity));
 
+  text_contents->SetInheritedOpacity(0.5);
+  ASSERT_EQ(text_contents->GetColor().alpha, 0.25);
   text_contents->SetInheritedOpacity(0.5);
   ASSERT_EQ(text_contents->GetColor().alpha, 0.25);
 
   // Clips and restores trivially accept opacity.
-  ASSERT_TRUE(ClipContents().CanAcceptOpacity(entity));
-  ASSERT_TRUE(ClipRestoreContents().CanAcceptOpacity(entity));
+  ASSERT_TRUE(ClipContents().CanInheritOpacity(entity));
+  ASSERT_TRUE(ClipRestoreContents().CanInheritOpacity(entity));
 
   // Runtime effect contents can't accept opacity.
   auto runtime_effect = std::make_shared<RuntimeEffectContents>();
-  ASSERT_FALSE(runtime_effect->CanAcceptOpacity(entity));
+  ASSERT_FALSE(runtime_effect->CanInheritOpacity(entity));
 }
 
 }  // namespace testing


### PR DESCRIPTION
EntityPasses can be rendered multiple times (i.e. as Pictures), and so the act of pushing the opacity into the collapsed entities needs to be idempotent.

`impeller_unittests --timeout=0 --gtest_filter="Play/AiksTest.CanSaveLayerStandalone/Metal"`

https://user-images.githubusercontent.com/919017/227769459-f93cb621-f040-4a86-9a46-ba0dbc925cbb.mov


Doubled up the `SetInheritedOpacity` asserts in `Play/EntityTest.InheritOpacityTest/Metal` to catch regressions.
