### PR TITLE
[Impeller] Fix stroke cap disconnection

### DIFF
--- a/impeller/display_list/display_list_playground.cc
+++ b/impeller/display_list/display_list_playground.cc
@@ -7,6 +7,8 @@
 #include "flutter/testing/testing.h"
 #include "impeller/aiks/aiks_context.h"
 #include "impeller/display_list/display_list_dispatcher.h"
+
+#include "third_party/imgui/imgui.h"
 #include "third_party/skia/include/core/SkData.h"
 
 namespace impeller {
@@ -37,6 +39,12 @@ bool DisplayListPlayground::OpenPlaygroundHere(
   }
   return Playground::OpenPlaygroundHere(
       [&context, &callback](RenderTarget& render_target) -> bool {
+        static bool wireframe = false;
+        if (ImGui::IsKeyPressed(ImGuiKey_Z)) {
+          wireframe = !wireframe;
+          context.GetContentContext().SetWireframe(wireframe);
+        }
+
         auto list = callback();
 
         DisplayListDispatcher dispatcher;

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -158,7 +158,7 @@ TEST_P(DisplayListTest, CanDrawArc) {
     ImGui::Begin("Controls", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
     ImGui::SliderFloat("Start angle", &start_angle, -360, 360);
     ImGui::SliderFloat("Sweep angle", &sweep_angle, -360, 360);
-    ImGui::SliderFloat("Stroke width", &stroke_width, 0, 100);
+    ImGui::SliderFloat("Stroke width", &stroke_width, 0, 300);
     ImGui::Combo("Cap", &selected_cap, cap_names,
                  sizeof(cap_names) / sizeof(char*));
     ImGui::Checkbox("Use center", &use_center);

--- a/impeller/entity/geometry.h
+++ b/impeller/entity/geometry.h
@@ -149,7 +149,8 @@ class StrokePathGeometry : public Geometry {
       std::function<void(VertexBufferBuilder<VS::PerVertexData>& vtx_builder,
                          const Point& position,
                          const Point& offset,
-                         Scalar scale)>;
+                         Scalar scale,
+                         bool reverse)>;
   using JoinProc =
       std::function<void(VertexBufferBuilder<VS::PerVertexData>& vtx_builder,
                          const Point& position,
@@ -188,7 +189,6 @@ class StrokePathGeometry : public Geometry {
   CreateSolidStrokeVertices(const Path& path,
                             Scalar stroke_width,
                             Scalar scaled_miter_limit,
-                            Cap cap,
                             const JoinProc& join_proc,
                             const CapProc& cap_proc,
                             Scalar scale);


### PR DESCRIPTION
Also adds wireframe to DisplayList playgrounds. This fix follows up https://github.com/flutter/engine/pull/39481, which fixed cap disconnections for the butt cap.

Before:


https://user-images.githubusercontent.com/919017/227774962-6996c46e-0021-4911-94b8-8e5d8e803433.mov


After:

https://user-images.githubusercontent.com/919017/227774815-919f363f-bc62-4f45-b610-cc22acf66b2c.mov

