### PR TITLE
[Impeller] dont unconditionally clear the screen

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <utility>
+
 #include "flutter/flow/layers/layer_tree.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 
@@ -162,7 +163,10 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
       paint.setBlendMode(DlBlendMode::kSrc);
       canvas()->SaveLayer(&bounds, &paint);
     }
-    canvas()->Clear(DlColor::kTransparent());
+    // Impeller does not require a full screen clear.
+    if (gr_context_) {
+      canvas()->Clear(DlColor::kTransparent());
+    }
   }
   layer_tree.Paint(*this, ignore_raster_cache);
   // The canvas()->Restore() is taken care of by the DlAutoCanvasRestore

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -56,7 +56,7 @@ class TextContents final : public Contents {
  private:
   TextFrame frame_;
   Color color_;
-  Scalar inherited_opacity_;
+  Scalar inherited_opacity_ = 1.0;
   mutable std::shared_ptr<LazyGlyphAtlas> lazy_atlas_;
   Matrix inverse_matrix_;
 

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -56,7 +56,7 @@ class TextContents final : public Contents {
  private:
   TextFrame frame_;
   Color color_;
-  Scalar inherited_opacity_ = 1.0;
+  Scalar inherited_opacity_;
   mutable std::shared_ptr<LazyGlyphAtlas> lazy_atlas_;
   Matrix inverse_matrix_;
 


### PR DESCRIPTION
This causes a measureable amount of extra work as it is implemented as a full screen draw instead of a load action. Its unecessary anyway for impeller.
