### PR TITLE
Deprecate --use-local-canvaskit flag

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -20,10 +20,6 @@ vars = {
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
   'skia_revision': 'c55605969a599681f4a5530ba84402f67f55bfa1',
 
-  # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
-  # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.
-  'canvaskit_cipd_instance': '61aeJQ9laGfEFF_Vlc_u0MCkqB6xb2hAYHRBxKH-Uw4C',
-
   # Do not download the Emscripten SDK by default.
   # This prevents us from downloading the Emscripten toolchain for builds
   # which do not build for the web. This toolchain is needed to build CanvasKit
@@ -720,16 +716,6 @@ deps = {
        }
      ],
      'condition': 'download_android_deps',
-     'dep_type': 'cipd',
-   },
-
-  'src/third_party/web_dependencies': {
-     'packages': [
-       {
-         'package': 'flutter/web/canvaskit_bundle',
-         'version': Var('canvaskit_cipd_instance')
-       }
-     ],
      'dep_type': 'cipd',
    },
 

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -188,7 +188,7 @@ Future<void> copyCanvasKitFiles() async {
   if (!localCanvasKitExists && !isLuci) {
     throw ArgumentError('Could not find the local CanvasKit build. Try running `felt build`');
   }
-  
+ 
   final io.Directory targetDir = io.Directory(pathlib.join(
     environment.webUiBuildDir.path,
     'canvaskit',

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -188,7 +188,7 @@ Future<void> copyCanvasKitFiles() async {
   if (!localCanvasKitExists && !isLuci) {
     throw ArgumentError('Could not find the local CanvasKit build. Try running `felt build`');
   }
- 
+
   final io.Directory targetDir = io.Directory(pathlib.join(
     environment.webUiBuildDir.path,
     'canvaskit',

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -185,9 +185,9 @@ final io.File _localCanvasKitWasm = io.File(pathlib.join(
 
 Future<void> copyCanvasKitFiles() async {
   final bool localCanvasKitExists = _localCanvasKitWasm.existsSync();
-  // if (!localCanvasKitExists && !isLuci) {
-  //   throw ArgumentError('Could not find the local CanvasKit build. Try running `felt build`');
-  // }
+  if (!localCanvasKitExists && !isLuci) {
+    throw ArgumentError('Could not find the local CanvasKit build. Try running `felt build`');
+  }
   
   final io.Directory targetDir = io.Directory(pathlib.join(
     environment.webUiBuildDir.path,

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -80,8 +80,7 @@ class TestCommand extends Command<bool> with ArgUtils<bool> {
       )
       ..addFlag(
         'use-local-canvaskit',
-        help: 'Optional. Whether or not to use the locally built version of '
-              'CanvasKit in the tests.',
+        help: 'Deprecated. Has no effect. The local CanvasKit is always used.'
       );
   }
 
@@ -126,9 +125,6 @@ class TestCommand extends Command<bool> with ArgUtils<bool> {
   /// Path to a CanvasKit build. Overrides the default CanvasKit.
   String? get overridePathToCanvasKit => argResults!['canvaskit-path'] as String?;
 
-  /// Whether or not to use the locally built version of CanvasKit.
-  bool get useLocalCanvasKit => boolArg('use-local-canvaskit');
-
   @override
   Future<bool> run() async {
     final List<FilePath> testFiles = runAllTests
@@ -139,7 +135,6 @@ class TestCommand extends Command<bool> with ArgUtils<bool> {
       if (isWatchMode) ClearTerminalScreenStep(),
       CompileTestsStep(
         testFiles: testFiles,
-        useLocalCanvasKit: useLocalCanvasKit,
         isWasm: isWasm
       ),
       RunTestsStep(


### PR DESCRIPTION
We should always use the locally-built CanvasKit in tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
