### PR TITLE
Revert "Return an empty JavaScript object as a replacement for exports/module in patchCanvasKitModule"

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -2660,7 +2660,7 @@ void patchCanvasKitModule(DomHTMLScriptElement canvasKitScript) {
     final Object? exportsAccessor = js_util.jsify(<String, dynamic>{
       'get': allowInterop(() {
         if (domDocument.currentScript == canvasKitScript) {
-          return js_util.callConstructor(objectConstructor, null);
+          return objectConstructor;
         } else {
           return _flutterWebCachedExports;
         }
@@ -2677,7 +2677,7 @@ void patchCanvasKitModule(DomHTMLScriptElement canvasKitScript) {
     final Object? moduleAccessor = js_util.jsify(<String, dynamic>{
       'get': allowInterop(() {
         if (domDocument.currentScript == canvasKitScript) {
-          return js_util.callConstructor(objectConstructor, null);
+          return objectConstructor;
         } else {
           return _flutterWebCachedModule;
         }


### PR DESCRIPTION
Reverts flutter/engine#40582

To fix possible breakage of engine roll.