### PR TITLE
[Impeller] Cleanup unusued Vulkan APIs and enable more tests.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1877,9 +1877,6 @@ TEST_P(AiksTest, SaveLayerFiltersScaleWithTransform) {
 }
 
 TEST_P(AiksTest, SceneColorSource) {
-  if (GetBackend() == PlaygroundBackend::kVulkan) {
-    GTEST_SKIP_("Temporarily disabled.");
-  }
   // Load up the scene.
   auto mapping =
       flutter::testing::OpenFixtureAsMapping("flutter_logo_baked.glb.ipscene");

--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -311,37 +311,6 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
     }
   }
 
-  bool SetContents(const TextureDescriptor& desc,
-                   const uint8_t* contents,
-                   size_t length,
-                   size_t slice) override {
-    void* data = nullptr;
-    if (::vmaMapMemory(allocator_, allocation_, &data) != VK_SUCCESS) {
-      VALIDATION_LOG << "Could not map texture memory to write to.";
-      return false;
-    }
-
-    std::memcpy(static_cast<uint8_t*>(data) + (length * slice),  //
-                contents,                                        //
-                length                                           //
-    );
-
-    const auto flushed = ::vmaFlushAllocation(allocator_,      // allocator
-                                              allocation_,     // allocation
-                                              length * slice,  // offset
-                                              length           // size
-                                              ) == VK_SUCCESS;
-
-    ::vmaUnmapMemory(allocator_, allocation_);
-
-    if (!flushed) {
-      VALIDATION_LOG << "Could not flush written mapped memory.";
-      return false;
-    }
-
-    return true;
-  }
-
   bool IsValid() const { return is_valid_; }
 
   vk::Image GetImage() const override { return image_; }

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -397,6 +397,7 @@ vk::Device ContextVK::GetDevice() const {
 }
 
 std::unique_ptr<Surface> ContextVK::AcquireNextSurface() {
+  TRACE_EVENT0("impeller", __FUNCTION__);
   auto surface = swapchain_ ? swapchain_->AcquireNextDrawable() : nullptr;
   if (surface && pipeline_library_) {
     pipeline_library_->DidAcquireSurfaceFrame();

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -29,7 +29,7 @@ struct FrameSynchronizer {
     if (acquire_res.result != vk::Result::eSuccess ||
         render_res.result != vk::Result::eSuccess ||
         present_res.result != vk::Result::eSuccess) {
-      VALIDATION_LOG << "Could not create synchornizer.";
+      VALIDATION_LOG << "Could not create synchronizer.";
       return;
     }
     acquire = std::move(acquire_res.value);
@@ -41,14 +41,18 @@ struct FrameSynchronizer {
   ~FrameSynchronizer() = default;
 
   bool WaitForFence(const vk::Device& device) {
-    if (device.waitForFences(
+    if (auto result = device.waitForFences(
             *acquire,                             // fence
             true,                                 // wait all
             std::numeric_limits<uint64_t>::max()  // timeout (ns)
-            ) != vk::Result::eSuccess) {
+        );
+        result != vk::Result::eSuccess) {
+      VALIDATION_LOG << "Fence wait failed: " << vk::to_string(result);
       return false;
     }
-    if (device.resetFences(*acquire) != vk::Result::eSuccess) {
+    if (auto result = device.resetFences(*acquire);
+        result != vk::Result::eSuccess) {
+      VALIDATION_LOG << "Could not reset fence: " << vk::to_string(result);
       return false;
     }
     return true;

--- a/impeller/renderer/backend/vulkan/texture_source_vk.cc
+++ b/impeller/renderer/backend/vulkan/texture_source_vk.cc
@@ -58,11 +58,4 @@ bool TextureSourceVK::SetLayout(const LayoutTransition& transition) const {
   return true;
 }
 
-bool TextureSourceVK::SetContents(const TextureDescriptor& desc,
-                                  const uint8_t* contents,
-                                  size_t length,
-                                  size_t slice) {
-  return false;
-}
-
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -18,11 +18,6 @@ class TextureSourceVK {
 
   const TextureDescriptor& GetTextureDescriptor() const;
 
-  virtual bool SetContents(const TextureDescriptor& desc,
-                           const uint8_t* contents,
-                           size_t length,
-                           size_t slice);
-
   virtual vk::Image GetImage() const = 0;
 
   virtual vk::ImageView GetImageView() const = 0;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -278,9 +278,6 @@ TEST_P(RendererTest, CanRenderMultiplePrimitives) {
 }
 
 TEST_P(RendererTest, CanRenderToTexture) {
-  if (GetBackend() == PlaygroundBackend::kVulkan) {
-    GTEST_SKIP_("Temporarily disabled.");
-  }
   using VS = BoxFadeVertexShader;
   using FS = BoxFadeFragmentShader;
   auto context = GetContext();
@@ -312,9 +309,9 @@ TEST_P(RendererTest, CanRenderToTexture) {
   ASSERT_TRUE(bridge && boston);
   auto sampler = context->GetSamplerLibrary()->GetSampler({});
   ASSERT_TRUE(sampler);
-
   std::shared_ptr<RenderPass> r2t_pass;
-
+  auto cmd_buffer = context->CreateCommandBuffer();
+  ASSERT_TRUE(cmd_buffer);
   {
     ColorAttachment color0;
     color0.load_action = LoadAction::kClear;
@@ -352,7 +349,6 @@ TEST_P(RendererTest, CanRenderToTexture) {
     RenderTarget r2t_desc;
     r2t_desc.SetColorAttachment(color0, 0u);
     r2t_desc.SetStencilAttachment(stencil0);
-    auto cmd_buffer = context->CreateCommandBuffer();
     r2t_pass = cmd_buffer->CreateRenderPass(r2t_desc);
     ASSERT_TRUE(r2t_pass && r2t_pass->IsValid());
   }


### PR DESCRIPTION
`CanRenderToTexture` was letting go of the command buffer and then adding to a pass which was tripping an assertion.