### PR TITLE
[Impeller] Fix EntityPass target flip for Vulkan

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1823,10 +1823,6 @@ TEST_P(AiksTest, SiblingSaveLayerBoundsAreRespected) {
 }
 
 TEST_P(AiksTest, CanRenderClippedLayers) {
-  if (GetBackend() == PlaygroundBackend::kVulkan) {
-    GTEST_SKIP_("Temporarily disabled.");
-  }
-
   Canvas canvas;
 
   canvas.DrawPaint({.color = Color::White()});

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -679,10 +679,6 @@ TEST_P(DisplayListTest, SaveLayerWithBlendFiltersAndAlphaDrawCorrectly) {
 }
 
 TEST_P(DisplayListTest, CanDrawBackdropFilter) {
-  if (GetBackend() == PlaygroundBackend::kVulkan) {
-    GTEST_SKIP_("Temporarily disabled.");
-  }
-
   auto texture = CreateTextureForFixture("embarcadero.jpg");
 
   auto callback = [&]() {

--- a/impeller/entity/entity_pass_target.cc
+++ b/impeller/entity/entity_pass_target.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/entity/entity_pass_target.h"
 
+#include "impeller/base/validation.h"
+#include "impeller/renderer/formats.h"
 #include "impeller/renderer/texture.h"
 
 namespace impeller {
@@ -15,8 +17,16 @@ EntityPassTarget::EntityPassTarget(const RenderTarget& render_target,
 
 std::shared_ptr<Texture> EntityPassTarget::Flip(Allocator& allocator) {
   auto color0 = target_.GetColorAttachments().find(0)->second;
+  if (!color0.resolve_texture) {
+    VALIDATION_LOG << "EntityPassTarget Flip should never be called for a "
+                      "non-MSAA target.";
+    // ...because there is never a circumstance where doing so would be
+    // necessary. Unlike MSAA passes, non-MSAA passes can be trivially loaded
+    // with `LoadAction::kLoad`.
+    return color0.texture;
+  }
 
-  if (supports_read_from_resolve_ && color0.resolve_texture) {
+  if (supports_read_from_resolve_) {
     // Just return the current resolve texture, which is safe to read in the
     // next render pass that'll resolve to `target_`.
     //
@@ -26,7 +36,8 @@ std::shared_ptr<Texture> EntityPassTarget::Flip(Allocator& allocator) {
 
   if (!secondary_color_texture_) {
     // The second texture is allocated lazily to avoid unused allocations.
-    TextureDescriptor new_descriptor = color0.texture->GetTextureDescriptor();
+    TextureDescriptor new_descriptor =
+        color0.resolve_texture->GetTextureDescriptor();
     secondary_color_texture_ = allocator.CreateTexture(new_descriptor);
 
     if (!secondary_color_texture_) {
@@ -34,8 +45,7 @@ std::shared_ptr<Texture> EntityPassTarget::Flip(Allocator& allocator) {
     }
   }
 
-  std::swap(color0.resolve_texture ? color0.resolve_texture : color0.texture,
-            secondary_color_texture_);
+  std::swap(color0.resolve_texture, secondary_color_texture_);
 
   target_.SetColorAttachment(color0, 0);
 


### PR DESCRIPTION
Re-enables `AiksTest.CanRenderClippedLayers` and `DisplayListTest.CanDrawBackdropFilter` for Vulkan.

- Use the resolve texture descriptor when making the second texture instead of the `texture` field (this was the real bug).
- Removed the non-MSAA logic from `EntityPassTarget::Flip`, as it should only ever be called when MSAA is in use.