### PR TITLE
[macOS] Fix Ctrl+Tab is broken

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -6,6 +6,7 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 
 #include <Carbon/Carbon.h>
+#import <objc/message.h>
 
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h"
@@ -163,6 +164,8 @@ NSData* currentKeyboardLayoutData() {
 
 - (void)setBackgroundColor:(NSColor*)color;
 
+- (BOOL)performKeyEquivalent:(NSEvent*)event;
+
 @end
 
 /**
@@ -239,6 +242,37 @@ NSData* currentKeyboardLayoutData() {
 
 @end
 
+#pragma mark - NSEvent (KeyEquivalentMarker) protocol
+
+@interface NSEvent (KeyEquivalentMarker)
+
+// Internally marks that the event was received through performKeyEquivalent:.
+// When text editing is active, keyboard events that have modifier keys pressed
+// are received through performKeyEquivalent: instead of keyDown:. If such event
+// is passed to TextInputContext but doesn't result in a text editing action it
+// needs to be forwarded by FlutterKeyboardManager to the next responder.
+- (void)markAsKeyEquivalent;
+
+// Returns YES if the event is marked as a key equivalent.
+- (BOOL)isKeyEquivalent;
+
+@end
+
+@implementation NSEvent (KeyEquivalentMarker)
+
+// This field doesn't need a value because only its address is used as a unique identifier.
+static char markerKey;
+
+- (void)markAsKeyEquivalent {
+  objc_setAssociatedObject(self, &markerKey, @true, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (BOOL)isKeyEquivalent {
+  return [objc_getAssociatedObject(self, &markerKey) boolValue] == YES;
+}
+
+@end
+
 #pragma mark - Private dependant functions
 
 namespace {
@@ -258,12 +292,15 @@ void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
 
 @implementation FlutterViewWrapper {
   FlutterView* _flutterView;
+  FlutterViewController* _controller;
 }
 
-- (instancetype)initWithFlutterView:(FlutterView*)view {
+- (instancetype)initWithFlutterView:(FlutterView*)view
+                         controller:(FlutterViewController*)controller {
   self = [super initWithFrame:NSZeroRect];
   if (self) {
     _flutterView = view;
+    _controller = controller;
     view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     [self addSubview:view];
   }
@@ -272,6 +309,24 @@ void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
 
 - (void)setBackgroundColor:(NSColor*)color {
   [_flutterView setBackgroundColor:color];
+}
+
+- (BOOL)performKeyEquivalent:(NSEvent*)event {
+  if ([_controller isDispatchingKeyEvent:event]) {
+    // When NSWindow is nextResponder, keyboard manager will send to it
+    // unhandled events (through [NSWindow keyDown:]). If event has both
+    // control and cmd modifiers set (i.e. cmd+control+space - emoji picker)
+    // NSWindow will then send this event as performKeyEquivalent: to first
+    // responder, which might be FlutterTextInputPlugin. If that's the case, the
+    // plugin must not handle the event, otherwise the emoji picker would not
+    // work (due to first responder returning YES from performKeyEquivalent:)
+    // and there would be endless loop, because FlutterViewController will
+    // send the event back to [keyboardManager handleEvent:].
+    return NO;
+  }
+  [event markAsKeyEquivalent];
+  [_flutterView keyDown:event];
+  return YES;
 }
 
 - (NSArray*)accessibilityChildren {
@@ -405,7 +460,8 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
   if (_backgroundColor != nil) {
     [flutterView setBackgroundColor:_backgroundColor];
   }
-  FlutterViewWrapper* wrapperView = [[FlutterViewWrapper alloc] initWithFlutterView:flutterView];
+  FlutterViewWrapper* wrapperView = [[FlutterViewWrapper alloc] initWithFlutterView:flutterView
+                                                                         controller:self];
   self.view = wrapperView;
   _flutterView = flutterView;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -320,7 +320,7 @@ void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
     // responder, which might be FlutterTextInputPlugin. If that's the case, the
     // plugin must not handle the event, otherwise the emoji picker would not
     // work (due to first responder returning YES from performKeyEquivalent:)
-    // and there would be endless loop, because FlutterViewController will
+    // and there would be an infinite loop, because FlutterViewController will
     // send the event back to [keyboardManager handleEvent:].
     return NO;
   }


### PR DESCRIPTION
## Description

This PR fixes Ctrl+Tab shortcut on macOS.

From https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/HandlingKeyEvents/HandlingKeyEvents.html#//apple_ref/doc/uid/10000060i-CH7-SW11, some key events, such as Ctrl+Tab, are notified by calling `performKeyEvent`: instead of `keyDown:`.

The text input plugin already implement this method, this is why the shortcut works only when there is a TextField (TextInputPlugin is then activated), see 'Step 6' of https://github.com/flutter/flutter/issues/122084 description.

## Implementation

I had to implement `performKeyEvent:` on `FlutterViewWrapper` because when adding it to `FlutterView` it was not called (see this similar comment related to setBackgroundColor: https://github.com/flutter/engine/pull/36906#discussion_r1006253709).

I also duplicated some code from FlutterTextInputPlugin.mm (the `KeyEquivalentMarker` definition) because `FlutterViewWrapper.performKeyEvent:` takes precedence over `FlutterTextInputPlugin.performKeyEvent:` so setting the marker is important to not break `FlutterTextInputPlugin.handleKeyEvent:`.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/122084

## Tests

Adds 1 test.
