### PR TITLE
[web] Print screenshot paths at the right spot

### DIFF
--- a/web_sdk/web_test_utils/lib/image_compare.dart
+++ b/web_sdk/web_test_utils/lib/image_compare.dart
@@ -70,13 +70,13 @@ Future<String> compareImage(
     // At the moment, we don't support local screenshot testing because we use
     // Skia Gold to handle our screenshots and diffing. In the future, we might
     // implement local screenshot testing if there's a need.
+    if (verbose) {
+      print('Screenshot generated: file://$screenshotPath'); // ignore: avoid_print
+    }
     return 'OK';
   }
 
   // TODO(mdebbar): Use the Gold tool to locally diff the golden.
-  if (verbose) {
-    print('Screenshot generated: file://$screenshotPath'); // ignore: avoid_print
-  }
   return 'OK';
 }
 


### PR DESCRIPTION
At [some point](https://github.com/flutter/engine/pull/39984/commits/ba83669072b333ee987a3b88c1ff178327a3688c) in the (large) test reorganization PR, the print statements for screenshot files was put in the wrong spot, making it unreachable.