### PR TITLE
[Impeller] Allow toggling vulkan validation using a command line test flag.

### DIFF
--- a/impeller/golden_tests/metal_screenshoter.mm
+++ b/impeller/golden_tests/metal_screenshoter.mm
@@ -15,7 +15,8 @@ namespace testing {
 
 MetalScreenshoter::MetalScreenshoter() {
   FML_CHECK(::glfwInit() == GLFW_TRUE);
-  playground_ = PlaygroundImpl::Create(PlaygroundBackend::kMetal);
+  playground_ =
+      PlaygroundImpl::Create(PlaygroundBackend::kMetal, PlaygroundSwitches{});
   aiks_context_.reset(new AiksContext(playground_->GetContext()));
 }
 

--- a/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -52,7 +52,7 @@ void PlaygroundImplGLES::DestroyWindowHandle(WindowHandle handle) {
 }
 
 PlaygroundImplGLES::PlaygroundImplGLES(PlaygroundSwitches switches)
-    : PlaygroundImpl(std::move(switches)),
+    : PlaygroundImpl(switches),
       handle_(nullptr, &DestroyWindowHandle),
       worker_(std::shared_ptr<ReactorWorker>(new ReactorWorker())) {
   ::glfwDefaultWindowHints();

--- a/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -51,8 +51,9 @@ void PlaygroundImplGLES::DestroyWindowHandle(WindowHandle handle) {
   ::glfwDestroyWindow(reinterpret_cast<GLFWwindow*>(handle));
 }
 
-PlaygroundImplGLES::PlaygroundImplGLES()
-    : handle_(nullptr, &DestroyWindowHandle),
+PlaygroundImplGLES::PlaygroundImplGLES(PlaygroundSwitches switches)
+    : PlaygroundImpl(std::move(switches)),
+      handle_(nullptr, &DestroyWindowHandle),
       worker_(std::shared_ptr<ReactorWorker>(new ReactorWorker())) {
   ::glfwDefaultWindowHints();
 

--- a/impeller/playground/backend/gles/playground_impl_gles.h
+++ b/impeller/playground/backend/gles/playground_impl_gles.h
@@ -11,7 +11,7 @@ namespace impeller {
 
 class PlaygroundImplGLES final : public PlaygroundImpl {
  public:
-  PlaygroundImplGLES();
+  explicit PlaygroundImplGLES(PlaygroundSwitches switches);
 
   ~PlaygroundImplGLES();
 

--- a/impeller/playground/backend/metal/playground_impl_mtl.h
+++ b/impeller/playground/backend/metal/playground_impl_mtl.h
@@ -13,7 +13,7 @@ namespace impeller {
 
 class PlaygroundImplMTL final : public PlaygroundImpl {
  public:
-  PlaygroundImplMTL();
+  explicit PlaygroundImplMTL(PlaygroundSwitches switches);
 
   ~PlaygroundImplMTL();
 

--- a/impeller/playground/backend/metal/playground_impl_mtl.mm
+++ b/impeller/playground/backend/metal/playground_impl_mtl.mm
@@ -63,7 +63,7 @@ void PlaygroundImplMTL::DestroyWindowHandle(WindowHandle handle) {
 }
 
 PlaygroundImplMTL::PlaygroundImplMTL(PlaygroundSwitches switches)
-    : PlaygroundImpl(std::move(switches)),
+    : PlaygroundImpl(switches),
       handle_(nullptr, &DestroyWindowHandle),
       data_(std::make_unique<Data>()) {
   ::glfwDefaultWindowHints();

--- a/impeller/playground/backend/metal/playground_impl_mtl.mm
+++ b/impeller/playground/backend/metal/playground_impl_mtl.mm
@@ -62,8 +62,10 @@ void PlaygroundImplMTL::DestroyWindowHandle(WindowHandle handle) {
   ::glfwDestroyWindow(reinterpret_cast<GLFWwindow*>(handle));
 }
 
-PlaygroundImplMTL::PlaygroundImplMTL()
-    : handle_(nullptr, &DestroyWindowHandle), data_(std::make_unique<Data>()) {
+PlaygroundImplMTL::PlaygroundImplMTL(PlaygroundSwitches switches)
+    : PlaygroundImpl(std::move(switches)),
+      handle_(nullptr, &DestroyWindowHandle),
+      data_(std::make_unique<Data>()) {
   ::glfwDefaultWindowHints();
   ::glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
   ::glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);

--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -49,7 +49,7 @@ void PlaygroundImplVK::DestroyWindowHandle(WindowHandle handle) {
 }
 
 PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
-    : PlaygroundImpl(std::move(switches)),
+    : PlaygroundImpl(switches),
       concurrent_loop_(fml::ConcurrentMessageLoop::Create()),
       handle_(nullptr, &DestroyWindowHandle) {
   if (!::glfwVulkanSupported()) {

--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -48,8 +48,9 @@ void PlaygroundImplVK::DestroyWindowHandle(WindowHandle handle) {
   ::glfwDestroyWindow(reinterpret_cast<GLFWwindow*>(handle));
 }
 
-PlaygroundImplVK::PlaygroundImplVK()
-    : concurrent_loop_(fml::ConcurrentMessageLoop::Create()),
+PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
+    : PlaygroundImpl(std::move(switches)),
+      concurrent_loop_(fml::ConcurrentMessageLoop::Create()),
       handle_(nullptr, &DestroyWindowHandle) {
   if (!::glfwVulkanSupported()) {
     VALIDATION_LOG << "Attempted to initialize a Vulkan playground on a system "
@@ -76,6 +77,7 @@ PlaygroundImplVK::PlaygroundImplVK()
   context_settings.shader_libraries_data = ShaderLibraryMappingsForPlayground();
   context_settings.cache_directory = fml::paths::GetCachesDirectory();
   context_settings.worker_task_runner = concurrent_loop_->GetTaskRunner();
+  context_settings.enable_validation = switches_.enable_vulkan_validation;
 
   auto context = ContextVK::Create(std::move(context_settings));
 

--- a/impeller/playground/backend/vulkan/playground_impl_vk.h
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.h
@@ -13,7 +13,7 @@ namespace impeller {
 
 class PlaygroundImplVK final : public PlaygroundImpl {
  public:
-  PlaygroundImplVK();
+  explicit PlaygroundImplVK(PlaygroundSwitches switches);
 
   ~PlaygroundImplVK();
 

--- a/impeller/playground/compute_playground_test.cc
+++ b/impeller/playground/compute_playground_test.cc
@@ -4,11 +4,13 @@
 
 #include "flutter/fml/time/time_point.h"
 
+#include "flutter/testing/test_args.h"
 #include "impeller/playground/compute_playground_test.h"
 
 namespace impeller {
 
-ComputePlaygroundTest::ComputePlaygroundTest() = default;
+ComputePlaygroundTest::ComputePlaygroundTest()
+    : Playground(PlaygroundSwitches{flutter::testing::GetArgsForProcess()}) {}
 
 ComputePlaygroundTest::~ComputePlaygroundTest() = default;
 

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -74,7 +74,7 @@ struct Playground::GLFWInitializer {
 };
 
 Playground::Playground(PlaygroundSwitches switches)
-    : switches_(std::move(switches)),
+    : switches_(switches),
       glfw_initializer_(std::make_unique<GLFWInitializer>()) {}
 
 Playground::~Playground() = default;

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -73,8 +73,9 @@ struct Playground::GLFWInitializer {
   }
 };
 
-Playground::Playground()
-    : glfw_initializer_(std::make_unique<GLFWInitializer>()) {}
+Playground::Playground(PlaygroundSwitches switches)
+    : switches_(std::move(switches)),
+      glfw_initializer_(std::make_unique<GLFWInitializer>()) {}
 
 Playground::~Playground() = default;
 
@@ -109,7 +110,7 @@ bool Playground::SupportsBackend(PlaygroundBackend backend) {
 void Playground::SetupContext(PlaygroundBackend backend) {
   FML_CHECK(SupportsBackend(backend));
 
-  impl_ = PlaygroundImpl::Create(backend);
+  impl_ = PlaygroundImpl::Create(backend, switches_);
   if (!impl_) {
     return;
   }

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -13,6 +13,7 @@
 #include "impeller/geometry/point.h"
 #include "impeller/image/compressed_image.h"
 #include "impeller/image/decompressed_image.h"
+#include "impeller/playground/switches.h"
 #include "impeller/renderer/renderer.h"
 #include "impeller/renderer/texture.h"
 #include "impeller/runtime_stage/runtime_stage.h"
@@ -33,7 +34,7 @@ class Playground {
  public:
   using SinglePassCallback = std::function<bool(RenderPass& pass)>;
 
-  explicit Playground();
+  explicit Playground(PlaygroundSwitches switches);
 
   virtual ~Playground();
 
@@ -92,6 +93,8 @@ class Playground {
   virtual std::string GetWindowTitle() const = 0;
 
  protected:
+  const PlaygroundSwitches switches_;
+
   virtual bool ShouldKeepRendering() const;
 
  private:

--- a/impeller/playground/playground_impl.cc
+++ b/impeller/playground/playground_impl.cc
@@ -22,19 +22,20 @@
 namespace impeller {
 
 std::unique_ptr<PlaygroundImpl> PlaygroundImpl::Create(
-    PlaygroundBackend backend) {
+    PlaygroundBackend backend,
+    PlaygroundSwitches switches) {
   switch (backend) {
 #if IMPELLER_ENABLE_METAL
     case PlaygroundBackend::kMetal:
-      return std::make_unique<PlaygroundImplMTL>();
+      return std::make_unique<PlaygroundImplMTL>(std::move(switches));
 #endif  // IMPELLER_ENABLE_METAL
 #if IMPELLER_ENABLE_OPENGLES
     case PlaygroundBackend::kOpenGLES:
-      return std::make_unique<PlaygroundImplGLES>();
+      return std::make_unique<PlaygroundImplGLES>(std::move(switches));
 #endif  // IMPELLER_ENABLE_OPENGLES
 #if IMPELLER_ENABLE_VULKAN
     case PlaygroundBackend::kVulkan:
-      return std::make_unique<PlaygroundImplVK>();
+      return std::make_unique<PlaygroundImplVK>(std::move(switches));
 #endif  // IMPELLER_ENABLE_VULKAN
     default:
       FML_CHECK(false) << "Attempted to create playground with backend that "
@@ -44,7 +45,8 @@ std::unique_ptr<PlaygroundImpl> PlaygroundImpl::Create(
   FML_UNREACHABLE();
 }
 
-PlaygroundImpl::PlaygroundImpl() = default;
+PlaygroundImpl::PlaygroundImpl(PlaygroundSwitches switches)
+    : switches_(std::move(switches)) {}
 
 PlaygroundImpl::~PlaygroundImpl() = default;
 

--- a/impeller/playground/playground_impl.cc
+++ b/impeller/playground/playground_impl.cc
@@ -27,15 +27,15 @@ std::unique_ptr<PlaygroundImpl> PlaygroundImpl::Create(
   switch (backend) {
 #if IMPELLER_ENABLE_METAL
     case PlaygroundBackend::kMetal:
-      return std::make_unique<PlaygroundImplMTL>(std::move(switches));
+      return std::make_unique<PlaygroundImplMTL>(switches);
 #endif  // IMPELLER_ENABLE_METAL
 #if IMPELLER_ENABLE_OPENGLES
     case PlaygroundBackend::kOpenGLES:
-      return std::make_unique<PlaygroundImplGLES>(std::move(switches));
+      return std::make_unique<PlaygroundImplGLES>(switches);
 #endif  // IMPELLER_ENABLE_OPENGLES
 #if IMPELLER_ENABLE_VULKAN
     case PlaygroundBackend::kVulkan:
-      return std::make_unique<PlaygroundImplVK>(std::move(switches));
+      return std::make_unique<PlaygroundImplVK>(switches);
 #endif  // IMPELLER_ENABLE_VULKAN
     default:
       FML_CHECK(false) << "Attempted to create playground with backend that "
@@ -46,7 +46,7 @@ std::unique_ptr<PlaygroundImpl> PlaygroundImpl::Create(
 }
 
 PlaygroundImpl::PlaygroundImpl(PlaygroundSwitches switches)
-    : switches_(std::move(switches)) {}
+    : switches_(switches) {}
 
 PlaygroundImpl::~PlaygroundImpl() = default;
 

--- a/impeller/playground/playground_impl.h
+++ b/impeller/playground/playground_impl.h
@@ -8,6 +8,7 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/playground/playground.h"
+#include "impeller/playground/switches.h"
 #include "impeller/renderer/context.h"
 #include "impeller/renderer/surface.h"
 
@@ -15,7 +16,8 @@ namespace impeller {
 
 class PlaygroundImpl {
  public:
-  static std::unique_ptr<PlaygroundImpl> Create(PlaygroundBackend backend);
+  static std::unique_ptr<PlaygroundImpl> Create(PlaygroundBackend backend,
+                                                PlaygroundSwitches switches);
 
   virtual ~PlaygroundImpl();
 
@@ -31,7 +33,9 @@ class PlaygroundImpl {
   Vector2 GetContentScale() const;
 
  protected:
-  PlaygroundImpl();
+  const PlaygroundSwitches switches_;
+
+  explicit PlaygroundImpl(PlaygroundSwitches switches);
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(PlaygroundImpl);

--- a/impeller/playground/playground_test.cc
+++ b/impeller/playground/playground_test.cc
@@ -10,7 +10,7 @@
 namespace impeller {
 
 PlaygroundTest::PlaygroundTest()
-    : switches_(flutter::testing::GetArgsForProcess()) {}
+    : Playground(PlaygroundSwitches{flutter::testing::GetArgsForProcess()}) {}
 
 PlaygroundTest::~PlaygroundTest() = default;
 

--- a/impeller/playground/playground_test.h
+++ b/impeller/playground/playground_test.h
@@ -39,8 +39,6 @@ class PlaygroundTest : public Playground,
   std::string GetWindowTitle() const override;
 
  private:
-  const PlaygroundSwitches switches_;
-
   // |Playground|
   bool ShouldKeepRendering() const;
 

--- a/impeller/playground/switches.cc
+++ b/impeller/playground/switches.cc
@@ -13,6 +13,7 @@ PlaygroundSwitches::PlaygroundSwitches(const fml::CommandLine& args) {
   if (args.GetOptionValue("playground_timeout_ms", &timeout_str)) {
     timeout = std::chrono::milliseconds(atoi(timeout_str.c_str()));
   }
+  enable_vulkan_validation = args.HasOption("enable_vulkan_validation");
 }
 
 }  // namespace impeller

--- a/impeller/playground/switches.cc
+++ b/impeller/playground/switches.cc
@@ -8,6 +8,8 @@
 
 namespace impeller {
 
+PlaygroundSwitches::PlaygroundSwitches() = default;
+
 PlaygroundSwitches::PlaygroundSwitches(const fml::CommandLine& args) {
   std::string timeout_str;
   if (args.GetOptionValue("playground_timeout_ms", &timeout_str)) {

--- a/impeller/playground/switches.h
+++ b/impeller/playground/switches.h
@@ -17,6 +17,7 @@ struct PlaygroundSwitches {
   // specified in the timeout. If the timeout is zero, exactly one frame will be
   // rendered in the playground.
   std::optional<std::chrono::milliseconds> timeout;
+  bool enable_vulkan_validation = false;
 
   explicit PlaygroundSwitches(const fml::CommandLine& args);
 };

--- a/impeller/playground/switches.h
+++ b/impeller/playground/switches.h
@@ -19,6 +19,8 @@ struct PlaygroundSwitches {
   std::optional<std::chrono::milliseconds> timeout;
   bool enable_vulkan_validation = false;
 
+  PlaygroundSwitches();
+
   explicit PlaygroundSwitches(const fml::CommandLine& args);
 };
 

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -15,6 +15,9 @@ static constexpr const char* kInstanceLayer = "ImpellerInstance";
 
 CapabilitiesVK::CapabilitiesVK(bool enable_validations)
     : enable_validations_(enable_validations) {
+  if (enable_validations_) {
+    FML_LOG(INFO) << "Vulkan validations are enabled.";
+  }
   auto extensions = vk::enumerateInstanceExtensionProperties();
   auto layers = vk::enumerateInstanceLayerProperties();
 

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -24,7 +24,7 @@ class ContextVK;
 class CapabilitiesVK final : public Capabilities,
                              public BackendCast<CapabilitiesVK, Capabilities> {
  public:
-  explicit CapabilitiesVK(bool enable_validations = false);
+  explicit CapabilitiesVK(bool enable_validations);
 
   ~CapabilitiesVK();
 

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -114,7 +114,8 @@ void ContextVK::Setup(Settings settings) {
   auto& dispatcher = VULKAN_HPP_DEFAULT_DISPATCHER;
   dispatcher.init(settings.proc_address_callback);
 
-  auto caps = std::shared_ptr<CapabilitiesVK>(new CapabilitiesVK());
+  auto caps = std::shared_ptr<CapabilitiesVK>(
+      new CapabilitiesVK(settings.enable_validation));
 
   if (!caps->IsValid()) {
     VALIDATION_LOG << "Could not determine device capabilities.";

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -36,6 +36,7 @@ class ContextVK final : public Context, public BackendCast<ContextVK, Context> {
     std::vector<std::shared_ptr<fml::Mapping>> shader_libraries_data;
     fml::UniqueFD cache_directory;
     std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner;
+    bool enable_validation = false;
 
     Settings() = default;
 


### PR DESCRIPTION
The `--enable_vulkan_validation` playground flag controls this instead of needing to patch sources.
