### PR TITLE
Use new SkImages namespace instead of legacy SkImage static functions

### DIFF
--- a/display_list/benchmarking/dl_benchmarks.cc
+++ b/display_list/benchmarking/dl_benchmarks.cc
@@ -8,6 +8,7 @@
 #include "flutter/display_list/skia/dl_sk_canvas.h"
 
 #include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPoint.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
@@ -915,7 +916,7 @@ sk_sp<SkImage> ImageFromBitmapWithNewID(const SkBitmap& bitmap) {
   // so we will avoid hitting the cache.
   SkPixmap pixmap;
   bitmap.peekPixels(&pixmap);
-  return SkImage::MakeFromRaster(pixmap, nullptr, nullptr);
+  return SkImages::RasterFromPixmap(pixmap, nullptr, nullptr);
 }
 
 // Draws `kImagesToDraw` bitmaps to a canvas, either with texture-backed

--- a/display_list/benchmarking/dl_complexity_unittests.cc
+++ b/display_list/benchmarking/dl_complexity_unittests.cc
@@ -13,6 +13,7 @@
 
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkColor.h"
+#include "third_party/skia/include/core/SkImage.h"
 
 namespace flutter {
 namespace testing {
@@ -353,7 +354,7 @@ TEST(DisplayListComplexity, DrawImage) {
                         SkAlphaType::kPremul_SkAlphaType);
   SkBitmap bitmap;
   bitmap.allocPixels(info, 0);
-  auto image = SkImage::MakeFromBitmap(bitmap);
+  auto image = SkImages::RasterFromBitmap(bitmap);
 
   DisplayListBuilder builder;
   builder.DrawImage(DlImage::Make(image), SkPoint::Make(0, 0),
@@ -372,7 +373,7 @@ TEST(DisplayListComplexity, DrawImageNine) {
                         SkAlphaType::kPremul_SkAlphaType);
   SkBitmap bitmap;
   bitmap.allocPixels(info, 0);
-  auto image = SkImage::MakeFromBitmap(bitmap);
+  auto image = SkImages::RasterFromBitmap(bitmap);
 
   SkIRect center = SkIRect::MakeXYWH(5, 5, 20, 20);
   SkRect dest = SkRect::MakeXYWH(0, 0, 50, 50);
@@ -394,7 +395,7 @@ TEST(DisplayListComplexity, DrawImageRect) {
                         SkAlphaType::kPremul_SkAlphaType);
   SkBitmap bitmap;
   bitmap.allocPixels(info, 0);
-  auto image = SkImage::MakeFromBitmap(bitmap);
+  auto image = SkImages::RasterFromBitmap(bitmap);
 
   SkRect src = SkRect::MakeXYWH(0, 0, 50, 50);
   SkRect dest = SkRect::MakeXYWH(0, 0, 50, 50);
@@ -416,7 +417,7 @@ TEST(DisplayListComplexity, DrawAtlas) {
                         SkAlphaType::kPremul_SkAlphaType);
   SkBitmap bitmap;
   bitmap.allocPixels(info, 0);
-  auto image = SkImage::MakeFromBitmap(bitmap);
+  auto image = SkImages::RasterFromBitmap(bitmap);
 
   std::vector<SkRect> rects;
   std::vector<SkRSXform> xforms;

--- a/flow/paint_utils.cc
+++ b/flow/paint_utils.cc
@@ -21,7 +21,7 @@ std::shared_ptr<DlColorSource> CreateCheckerboardShader(SkColor c1,
   bm.eraseColor(c1);
   bm.eraseArea(SkIRect::MakeLTRB(0, 0, size, size), c2);
   bm.eraseArea(SkIRect::MakeLTRB(size, size, 2 * size, 2 * size), c2);
-  auto image = DlImage::Make(SkImage::MakeFromBitmap(bm));
+  auto image = DlImage::Make(SkImages::RasterFromBitmap(bm));
   return std::make_shared<DlImageColorSource>(
       image, DlTileMode::kRepeat, DlTileMode::kRepeat,
       DlImageSampling::kNearestNeighbor);

--- a/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
@@ -5,6 +5,8 @@
 #include "flutter/lib/ui/painting/display_list_deferred_image_gpu_skia.h"
 
 #include "third_party/skia/include/core/SkColorSpace.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
+#include "third_party/skia/include/core/SkImage.h"
 
 namespace flutter {
 
@@ -144,7 +146,7 @@ sk_sp<SkImage> DlDeferredImageGPUSkia::ImageWrapper::CreateSkiaImage() const {
   FML_DCHECK(raster_task_runner_->RunsTasksOnCurrentThread());
 
   if (texture_.isValid() && context_) {
-    return SkImage::MakeFromTexture(
+    return SkImages::BorrowTextureFrom(
         context_.get(), texture_, kTopLeft_GrSurfaceOrigin,
         image_info_.colorType(), image_info_.alphaType(),
         image_info_.refColorSpace());

--- a/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
@@ -5,8 +5,8 @@
 #include "flutter/lib/ui/painting/display_list_deferred_image_gpu_skia.h"
 
 #include "third_party/skia/include/core/SkColorSpace.h"
-#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 
 namespace flutter {
 

--- a/lib/ui/painting/image_decoder_skia.cc
+++ b/lib/ui/painting/image_decoder_skia.cc
@@ -10,8 +10,8 @@
 #include "flutter/fml/make_copyable.h"
 #include "flutter/lib/ui/painting/display_list_image_gpu.h"
 #include "third_party/skia/include/core/SkBitmap.h"
-#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 
 namespace flutter {
 
@@ -198,12 +198,13 @@ static SkiaGPUObject<SkImage> UploadRasterImage(
           .SetIfFalse([&result, context = io_manager->GetResourceContext(),
                        &pixmap, queue = io_manager->GetSkiaUnrefQueue()] {
             TRACE_EVENT0("flutter", "MakeCrossContextImageFromPixmap");
-            sk_sp<SkImage> texture_image = SkImages::CrossContextTextureFromPixmap(
-                context.get(),  // context
-                pixmap,         // pixmap
-                true,           // buildMips,
-                true            // limitToMaxTextureSize
-            );
+            sk_sp<SkImage> texture_image =
+                SkImages::CrossContextTextureFromPixmap(
+                    context.get(),  // context
+                    pixmap,         // pixmap
+                    true,           // buildMips,
+                    true            // limitToMaxTextureSize
+                );
             if (!texture_image) {
               FML_LOG(ERROR) << "Could not make x-context image.";
               result = {};

--- a/lib/ui/painting/image_decoder_skia.cc
+++ b/lib/ui/painting/image_decoder_skia.cc
@@ -10,6 +10,7 @@
 #include "flutter/fml/make_copyable.h"
 #include "flutter/lib/ui/painting/display_list_image_gpu.h"
 #include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/skia/include/core/SkImage.h"
 
 namespace flutter {
@@ -63,7 +64,7 @@ static sk_sp<SkImage> ResizeRasterImage(const sk_sp<SkImage>& image,
   // instead of copying.
   scaled_bitmap.setImmutable();
 
-  auto scaled_image = SkImage::MakeFromBitmap(scaled_bitmap);
+  auto scaled_image = SkImages::RasterFromBitmap(scaled_bitmap);
   if (!scaled_image) {
     FML_LOG(ERROR) << "Could not create a scaled image from a scaled bitmap.";
     return nullptr;
@@ -79,7 +80,7 @@ static sk_sp<SkImage> ImageFromDecompressedData(
     const fml::tracing::TraceFlow& flow) {
   TRACE_EVENT0("flutter", __FUNCTION__);
   flow.Step(__FUNCTION__);
-  auto image = SkImage::MakeRasterData(
+  auto image = SkImages::RasterFromData(
       descriptor->image_info(), descriptor->data(), descriptor->row_bytes());
 
   if (!image) {
@@ -139,7 +140,7 @@ sk_sp<SkImage> ImageDecoderSkia::ImageFromCompressedData(
       // the pixels instead of copying.
       scaled_bitmap.setImmutable();
 
-      auto decoded_image = SkImage::MakeFromBitmap(scaled_bitmap);
+      auto decoded_image = SkImages::RasterFromBitmap(scaled_bitmap);
       FML_DCHECK(decoded_image);
       if (!decoded_image) {
         FML_LOG(ERROR)
@@ -186,7 +187,7 @@ static SkiaGPUObject<SkImage> UploadRasterImage(
       fml::SyncSwitch::Handlers()
           .SetIfTrue([&result, &pixmap, &image] {
             SkSafeRef(image.get());
-            sk_sp<SkImage> texture_image = SkImage::MakeFromRaster(
+            sk_sp<SkImage> texture_image = SkImages::RasterFromPixmap(
                 pixmap,
                 [](const void* pixels, SkImage::ReleaseContext context) {
                   SkSafeUnref(static_cast<SkImage*>(context));
@@ -197,7 +198,7 @@ static SkiaGPUObject<SkImage> UploadRasterImage(
           .SetIfFalse([&result, context = io_manager->GetResourceContext(),
                        &pixmap, queue = io_manager->GetSkiaUnrefQueue()] {
             TRACE_EVENT0("flutter", "MakeCrossContextImageFromPixmap");
-            sk_sp<SkImage> texture_image = SkImage::MakeCrossContextFromPixmap(
+            sk_sp<SkImage> texture_image = SkImages::CrossContextTextureFromPixmap(
                 context.get(),  // context
                 pixmap,         // pixmap
                 true,           // buildMips,

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -24,6 +24,7 @@
 #include "third_party/skia/include/codec/SkCodecAnimation.h"
 #include "third_party/skia/include/core/SkData.h"
 #include "third_party/skia/include/core/SkEncodedImageFormat.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkSize.h"
 
@@ -361,7 +362,7 @@ TEST_F(ImageDecoderFixtureTest, ImpellerNullColorspace) {
   SkBitmap bitmap;
   bitmap.allocPixels(info, 10 * 4);
   auto data = SkData::MakeWithoutCopy(bitmap.getPixels(), 10 * 10 * 4);
-  auto image = SkImage::MakeFromBitmap(bitmap);
+  auto image = SkImages::RasterFromBitmap(bitmap);
   ASSERT_TRUE(image != nullptr);
   ASSERT_EQ(SkISize::Make(10, 10), image->dimensions());
   ASSERT_EQ(nullptr, image->colorSpace());
@@ -384,7 +385,7 @@ TEST_F(ImageDecoderFixtureTest, ImpellerNullColorspace) {
 
 TEST_F(ImageDecoderFixtureTest, ImpellerWideGamutDisplayP3) {
   auto data = OpenFixtureAsSkData("DisplayP3Logo.png");
-  auto image = SkImage::MakeFromEncoded(data);
+  auto image = SkImages::DeferredFromEncodedData(data);
   ASSERT_TRUE(image != nullptr);
   ASSERT_EQ(SkISize::Make(100, 100), image->dimensions());
 
@@ -439,7 +440,7 @@ TEST_F(ImageDecoderFixtureTest, ImpellerPixelConversion32F) {
   SkBitmap bitmap;
   bitmap.allocPixels(info, 10 * 16);
   auto data = SkData::MakeWithoutCopy(bitmap.getPixels(), 10 * 10 * 16);
-  auto image = SkImage::MakeFromBitmap(bitmap);
+  auto image = SkImages::RasterFromBitmap(bitmap);
   ASSERT_TRUE(image != nullptr);
   ASSERT_EQ(SkISize::Make(10, 10), image->dimensions());
   ASSERT_EQ(nullptr, image->colorSpace());
@@ -473,7 +474,7 @@ float DecodeBGR10(uint32_t x) {
 
 TEST_F(ImageDecoderFixtureTest, ImpellerWideGamutDisplayP3Opaque) {
   auto data = OpenFixtureAsSkData("DisplayP3Logo.jpg");
-  auto image = SkImage::MakeFromEncoded(data);
+  auto image = SkImages::DeferredFromEncodedData(data);
   ASSERT_TRUE(image != nullptr);
   ASSERT_EQ(SkISize::Make(100, 100), image->dimensions());
 
@@ -525,7 +526,7 @@ TEST_F(ImageDecoderFixtureTest, ImpellerWideGamutDisplayP3Opaque) {
 
 TEST_F(ImageDecoderFixtureTest, ImpellerNonWideGamut) {
   auto data = OpenFixtureAsSkData("Horizontal.jpg");
-  auto image = SkImage::MakeFromEncoded(data);
+  auto image = SkImages::DeferredFromEncodedData(data);
   ASSERT_TRUE(image != nullptr);
   ASSERT_EQ(SkISize::Make(600, 200), image->dimensions());
 
@@ -670,7 +671,7 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
 
 TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   const auto image_dimensions =
-      SkImage::MakeFromEncoded(OpenFixtureAsSkData("DashInNooglerHat.jpg"))
+      SkImages::DeferredFromEncodedData(OpenFixtureAsSkData("DashInNooglerHat.jpg"))
           ->dimensions();
 
   ASSERT_FALSE(image_dimensions.isEmpty());
@@ -767,7 +768,7 @@ TEST(ImageDecoderTest,
 
 TEST(ImageDecoderTest, VerifySimpleDecoding) {
   auto data = OpenFixtureAsSkData("Horizontal.jpg");
-  auto image = SkImage::MakeFromEncoded(data);
+  auto image = SkImages::DeferredFromEncodedData(data);
   ASSERT_TRUE(image != nullptr);
   ASSERT_EQ(SkISize::Make(600, 200), image->dimensions());
 
@@ -809,7 +810,7 @@ TEST(ImageDecoderTest, VerifySubpixelDecodingPreservesExifOrientation) {
   auto descriptor =
       fml::MakeRefCounted<ImageDescriptor>(data, std::move(generator));
 
-  auto image = SkImage::MakeFromEncoded(data);
+  auto image = SkImages::DeferredFromEncodedData(data);
   ASSERT_TRUE(image != nullptr);
   ASSERT_EQ(SkISize::Make(600, 200), image->dimensions());
 

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -670,9 +670,9 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
 }
 
 TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
-  const auto image_dimensions =
-      SkImages::DeferredFromEncodedData(OpenFixtureAsSkData("DashInNooglerHat.jpg"))
-          ->dimensions();
+  const auto image_dimensions = SkImages::DeferredFromEncodedData(
+                                    OpenFixtureAsSkData("DashInNooglerHat.jpg"))
+                                    ->dimensions();
 
   ASSERT_FALSE(image_dimensions.isEmpty());
 

--- a/lib/ui/painting/image_encoding_impeller.cc
+++ b/lib/ui/painting/image_encoding_impeller.cc
@@ -10,6 +10,7 @@
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/context.h"
 #include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkImage.h"
 
 namespace flutter {
 namespace {
@@ -51,7 +52,7 @@ sk_sp<SkImage> ConvertBufferToSkImage(
                        new std::shared_ptr<impeller::DeviceBuffer>(buffer));
   bitmap.setImmutable();
 
-  sk_sp<SkImage> raster_image = SkImage::MakeFromBitmap(bitmap);
+  sk_sp<SkImage> raster_image = SkImages::RasterFromBitmap(bitmap);
   return raster_image;
 }
 

--- a/lib/ui/painting/image_generator.cc
+++ b/lib/ui/painting/image_generator.cc
@@ -8,6 +8,7 @@
 
 #include "flutter/fml/logging.h"
 #include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkImage.h"
 
 namespace flutter {
 
@@ -29,7 +30,7 @@ sk_sp<SkImage> ImageGenerator::GetImage() {
     return nullptr;
   }
   bitmap.setImmutable();
-  return SkImage::MakeFromBitmap(bitmap);
+  return SkImages::RasterFromBitmap(bitmap);
 }
 
 BuiltinSkiaImageGenerator::~BuiltinSkiaImageGenerator() = default;

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -12,10 +12,10 @@
 #include "flutter/lib/ui/painting/image_decoder_impeller.h"
 #endif  // IMPELLER_SUPPORTS_RENDERING
 #include "third_party/dart/runtime/include/dart_api.h"
-#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
-#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/codec/SkCodecAnimation.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPixelRef.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/tonic/logging/dart_invoke.h"
 
 namespace flutter {

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -12,6 +12,8 @@
 #include "flutter/lib/ui/painting/image_decoder_impeller.h"
 #endif  // IMPELLER_SUPPORTS_RENDERING
 #include "third_party/dart/runtime/include/dart_api.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/codec/SkCodecAnimation.h"
 #include "third_party/skia/include/core/SkPixelRef.h"
 #include "third_party/tonic/logging/dart_invoke.h"
@@ -163,19 +165,19 @@ sk_sp<DlImage> MultiFrameCodec::State::GetNextFrameImage(
             // Defer decoding until time of draw later on the raster thread.
             // Can happen when GL operations are currently forbidden such as
             // in the background on iOS.
-            skImage = SkImage::MakeFromBitmap(bitmap);
+            skImage = SkImages::RasterFromBitmap(bitmap);
           })
           .SetIfFalse([&skImage, &resourceContext, &bitmap] {
             if (resourceContext) {
               SkPixmap pixmap(bitmap.info(), bitmap.pixelRef()->pixels(),
                               bitmap.pixelRef()->rowBytes());
-              skImage = SkImage::MakeCrossContextFromPixmap(
+              skImage = SkImages::CrossContextTextureFromPixmap(
                   resourceContext.get(), pixmap, true);
             } else {
               // Defer decoding until time of draw later on the raster thread.
               // Can happen when GL operations are currently forbidden such as
               // in the background on iOS.
-              skImage = SkImage::MakeFromBitmap(bitmap);
+              skImage = SkImages::RasterFromBitmap(bitmap);
             }
           }));
 

--- a/shell/common/serialization_callbacks.cc
+++ b/shell/common/serialization_callbacks.cc
@@ -75,7 +75,7 @@ sk_sp<SkImage> DeserializeImageWithoutData(const void* data,
       SkData::MakeUninitialized(image_size.width() * image_size.height() * 4);
   memset(image_data->writable_data(), 0x0f, image_data->size());
   sk_sp<SkImage> image =
-      SkImage::MakeRasterData(info, image_data, image_size.width() * 4);
+      SkImages::RasterFromData(info, image_data, image_size.width() * 4);
 
   return image;
 };

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -12,10 +12,10 @@
 #include "third_party/skia/include/core/SkAlphaType.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkColorType.h"
-#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 
 namespace flutter {
 

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -12,6 +12,7 @@
 #include "third_party/skia/include/core/SkAlphaType.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkColorType.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
@@ -60,7 +61,7 @@ void AndroidExternalTextureGL::Paint(PaintContext& context,
   GrGLTextureInfo textureInfo = {GL_TEXTURE_EXTERNAL_OES, texture_name_,
                                  GL_RGBA8_OES};
   GrBackendTexture backendTexture(1, 1, GrMipMapped::kNo, textureInfo);
-  sk_sp<SkImage> image = SkImage::MakeFromTexture(
+  sk_sp<SkImage> image = SkImages::BorrowTextureFrom(
       context.gr_context, backendTexture, kTopLeft_GrSurfaceOrigin,
       kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
   if (image) {

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -210,8 +210,8 @@ FLUTTER_ASSERT_ARC
             ? impeller::YUVColorSpace::kBT601LimitedRange
             : impeller::YUVColorSpace::kBT601FullRange;
 
-    return impeller::DlImageImpeller::TextureFromYUVATextures(context.aiks_context, yTexture,
-                                                              uvTexture, yuvColorSpace);
+    return impeller::DlImageImpeller::MakeFromYUVTextures(context.aiks_context, yTexture,
+                                                          uvTexture, yuvColorSpace);
   }
 
   SkYUVColorSpace colorSpace = _pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -210,8 +210,8 @@ FLUTTER_ASSERT_ARC
             ? impeller::YUVColorSpace::kBT601LimitedRange
             : impeller::YUVColorSpace::kBT601FullRange;
 
-    return impeller::DlImageImpeller::MakeFromYUVTextures(context.aiks_context, yTexture,
-                                                          uvTexture, yuvColorSpace);
+    return impeller::DlImageImpeller::MakeFromYUVTextures(context.aiks_context, yTexture, uvTexture,
+                                                          yuvColorSpace);
   }
 
   SkYUVColorSpace colorSpace = _pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -12,6 +12,8 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/GrYUVABackendTextures.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
+#include "third_party/skia/include/core/SkImage.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -208,8 +210,8 @@ FLUTTER_ASSERT_ARC
             ? impeller::YUVColorSpace::kBT601LimitedRange
             : impeller::YUVColorSpace::kBT601FullRange;
 
-    return impeller::DlImageImpeller::MakeFromYUVTextures(context.aiks_context, yTexture, uvTexture,
-                                                          yuvColorSpace);
+    return impeller::DlImageImpeller::TextureFromYUVATextures(context.aiks_context, yTexture, uvTexture,
+                                                              yuvColorSpace);
   }
 
   SkYUVColorSpace colorSpace = _pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
@@ -320,7 +322,7 @@ FLUTTER_ASSERT_ARC
                                       /*mipMapped=*/GrMipMapped ::kNo,
                                       /*textureInfo=*/skiaTextureInfo);
 
-  return SkImage::MakeFromTexture(grContext, skiaBackendTexture, kTopLeft_GrSurfaceOrigin,
+  return SkImages::BorrowTextureFrom(grContext, skiaBackendTexture, kTopLeft_GrSurfaceOrigin,
                                   kBGRA_8888_SkColorType, kPremul_SkAlphaType,
                                   /*imageColorSpace=*/nullptr, /*releaseProc*/ nullptr,
                                   /*releaseContext*/ nullptr);

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -306,8 +306,9 @@ FLUTTER_ASSERT_ARC
   GrYUVABackendTextures yuvaBackendTextures(yuvaInfo, skiaBackendTextures,
                                             kTopLeft_GrSurfaceOrigin);
 
-  return SkImage::MakeFromYUVATextures(grContext, yuvaBackendTextures, /*imageColorSpace=*/nullptr,
-                                       /*releaseProc*/ nullptr, /*releaseContext*/ nullptr);
+  return SkImages::TextureFromYUVATextures(grContext, yuvaBackendTextures,
+                                           /*imageColorSpace=*/nullptr,
+                                           /*releaseProc*/ nullptr, /*releaseContext*/ nullptr);
 }
 
 + (sk_sp<SkImage>)wrapRGBATexture:(id<MTLTexture>)rgbaTex

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -8,12 +8,12 @@
 #include "impeller/display_list/display_list_image_impeller.h"
 #include "impeller/renderer/backend/metal/texture_mtl.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkYUVAInfo.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/GrYUVABackendTextures.h"
 #include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
-#include "third_party/skia/include/core/SkImage.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -210,8 +210,8 @@ FLUTTER_ASSERT_ARC
             ? impeller::YUVColorSpace::kBT601LimitedRange
             : impeller::YUVColorSpace::kBT601FullRange;
 
-    return impeller::DlImageImpeller::TextureFromYUVATextures(context.aiks_context, yTexture, uvTexture,
-                                                              yuvColorSpace);
+    return impeller::DlImageImpeller::TextureFromYUVATextures(context.aiks_context, yTexture,
+                                                              uvTexture, yuvColorSpace);
   }
 
   SkYUVColorSpace colorSpace = _pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
@@ -323,8 +323,8 @@ FLUTTER_ASSERT_ARC
                                       /*textureInfo=*/skiaTextureInfo);
 
   return SkImages::BorrowTextureFrom(grContext, skiaBackendTexture, kTopLeft_GrSurfaceOrigin,
-                                  kBGRA_8888_SkColorType, kPremul_SkAlphaType,
-                                  /*imageColorSpace=*/nullptr, /*releaseProc*/ nullptr,
-                                  /*releaseContext*/ nullptr);
+                                     kBGRA_8888_SkColorType, kPremul_SkAlphaType,
+                                     /*imageColorSpace=*/nullptr, /*releaseProc*/ nullptr,
+                                     /*releaseContext*/ nullptr);
 }
 @end

--- a/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -12,9 +12,9 @@
 #include "third_party/skia/include/core/SkColorType.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSize.h"
-#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 
 namespace flutter {
 
@@ -82,13 +82,13 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTexture(
   SkImage::TextureReleaseProc release_proc = texture->destruction_callback;
   auto image =
       SkImages::BorrowTextureFrom(context,                   // context
-                               gr_backend_texture,        // texture handle
-                               kTopLeft_GrSurfaceOrigin,  // origin
-                               kRGBA_8888_SkColorType,    // color type
-                               kPremul_SkAlphaType,       // alpha type
-                               nullptr,                   // colorspace
-                               release_proc,       // texture release proc
-                               texture->user_data  // texture release context
+                                  gr_backend_texture,        // texture handle
+                                  kTopLeft_GrSurfaceOrigin,  // origin
+                                  kRGBA_8888_SkColorType,    // color type
+                                  kPremul_SkAlphaType,       // alpha type
+                                  nullptr,                   // colorspace
+                                  release_proc,       // texture release proc
+                                  texture->user_data  // texture release context
       );
 
   if (!image) {

--- a/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -12,6 +12,7 @@
 #include "third_party/skia/include/core/SkColorType.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSize.h"
+#include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 
@@ -80,7 +81,7 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTexture(
                                       gr_texture_info);
   SkImage::TextureReleaseProc release_proc = texture->destruction_callback;
   auto image =
-      SkImage::MakeFromTexture(context,                   // context
+      SkImages::BorrowTextureFrom(context,                   // context
                                gr_backend_texture,        // texture handle
                                kTopLeft_GrSurfaceOrigin,  // origin
                                kRGBA_8888_SkColorType,    // color type

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -8,6 +8,7 @@
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "tests/embedder_test_context.h"
 #include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkImage.h"
 
 #ifdef SHELL_ENABLE_GL
 #include "flutter/shell/platform/embedder/tests/embedder_test_compositor_gl.h"
@@ -100,7 +101,7 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
         }
         bitmap.setImmutable();
         return reinterpret_cast<EmbedderTestContextSoftware*>(context)->Present(
-            SkImage::MakeFromBitmap(bitmap));
+            SkImages::RasterFromBitmap(bitmap));
       };
 
   // The first argument is always the executable name. Don't make tests have to

--- a/shell/platform/embedder/tests/embedder_unittests_util.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_util.cc
@@ -157,7 +157,8 @@ bool ImageMatchesFixture(const std::string& fixture_file_name,
   auto encoded_image = SkData::MakeWithoutCopy(
       fixture_image_mapping.GetMapping(), fixture_image_mapping.GetSize());
   auto fixture_image =
-      SkImages::DeferredFromEncodedData(std::move(encoded_image))->makeRasterImage();
+      SkImages::DeferredFromEncodedData(std::move(encoded_image))
+          ->makeRasterImage();
 
   FML_CHECK(fixture_image) << "Could not create image from fixture: "
                            << fixture_file_name;

--- a/shell/platform/embedder/tests/embedder_unittests_util.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_util.cc
@@ -10,6 +10,7 @@
 #include "flutter/shell/platform/embedder/tests/embedder_test_backingstore_producer.h"
 #include "flutter/shell/platform/embedder/tests/embedder_unittests_util.h"
 
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
@@ -156,7 +157,7 @@ bool ImageMatchesFixture(const std::string& fixture_file_name,
   auto encoded_image = SkData::MakeWithoutCopy(
       fixture_image_mapping.GetMapping(), fixture_image_mapping.GetSize());
   auto fixture_image =
-      SkImage::MakeFromEncoded(std::move(encoded_image))->makeRasterImage();
+      SkImages::DeferredFromEncodedData(std::move(encoded_image))->makeRasterImage();
 
   FML_CHECK(fixture_image) << "Could not create image from fixture: "
                            << fixture_file_name;


### PR DESCRIPTION
In https://skia-review.googlesource.com/c/skia/+/661059, Skia added a new SkImages namespace and deprecated using static functions on SkImage as part of an effort to separate the SkImage class and the GPU backends.

This PR replaces all old calls with the new calls, which should be functionally the same. It makes sure `SkImage.h` and `SkImageGanesh.h` are #included where appropriate.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
