### PR TITLE
[Impeller] remove advanced blend special casing

### DIFF
--- a/fml/mapping.cc
+++ b/fml/mapping.cc
@@ -73,6 +73,9 @@ DataMapping::DataMapping(std::vector<uint8_t> data) : data_(std::move(data)) {}
 DataMapping::DataMapping(const std::string& string)
     : data_(string.begin(), string.end()) {}
 
+DataMapping::DataMapping(std::array<uint8_t, 4> color)
+    : data_(color.begin(), color.end()) {}
+
 DataMapping::~DataMapping() = default;
 
 size_t DataMapping::GetSize() const {

--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -95,6 +95,8 @@ class DataMapping final : public Mapping {
 
   explicit DataMapping(const std::string& string);
 
+  explicit DataMapping(std::array<uint8_t, 4> color);
+
   ~DataMapping() override;
 
   // |Mapping|

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -135,7 +135,7 @@ static std::optional<Entity> AdvancedBlend(
 
       auto mapping = std::make_shared<fml::NonOwnedMapping>(
           foreground_color.value().ToR8G8B8A8().begin(), 4u);
-      if (!texture->SetContents(mapping)) {
+      if (!texture->SetContents(std::move(mapping))) {
         return false;
       }
       auto src_sampler =

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -133,8 +133,8 @@ static std::optional<Entity> AdvancedBlend(
           renderer.GetContext()->GetResourceAllocator()->CreateTexture(
               texture_descriptor);
 
-      auto mapping = std::make_shared<fml::NonOwnedMapping>(
-          foreground_color.value().ToR8G8B8A8().begin(), 4u);
+      auto mapping = std::make_shared<fml::DataMapping>(
+          foreground_color.value().ToR8G8B8A8());
       if (!texture->SetContents(std::move(mapping))) {
         return false;
       }

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -9,8 +9,6 @@
 
 uniform BlendInfo {
   float dst_input_alpha;
-  float color_factor;
-  vec4 color;  // This color input is expected to be unpremultiplied.
 }
 blend_info;
 
@@ -29,12 +27,10 @@ void main() {
                     blend_info.dst_input_alpha;
 
   vec4 dst = IPUnpremultiply(dst_sample);
-  vec4 src = blend_info.color_factor > 0
-                 ? blend_info.color
-                 : IPUnpremultiply(IPSampleDecal(
-                       texture_sampler_src,  // sampler
-                       v_src_texture_coords  // texture coordinates
-                       ));
+  vec4 src =
+      IPUnpremultiply(IPSampleDecal(texture_sampler_src,  // sampler
+                                    v_src_texture_coords  // texture coordinates
+                                    ));
 
   vec4 blended = vec4(Blend(dst.rgb, src.rgb), 1) * dst.a;
 


### PR DESCRIPTION
From my understanding with the branching we're essentially always sampling from the source sampler anyway. Can we special case this and fill in the foreground with a host visible texture.