### PR TITLE
[Impeller] Guard against empty grid sizes

### DIFF
--- a/impeller/renderer/backend/metal/compute_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.mm
@@ -55,6 +55,8 @@ bool ComputePassMTL::OnEncodeCommands(const Context& context,
     return false;
   }
 
+  FML_DCHECK(!grid_size_.IsEmpty() && !thread_group_size_.IsEmpty());
+
   // TODO(dnfield): Support non-serial dispatch type on higher iOS versions.
   auto compute_command_encoder = [buffer_ computeCommandEncoder];
 

--- a/impeller/renderer/compute_pass.cc
+++ b/impeller/renderer/compute_pass.cc
@@ -47,6 +47,11 @@ bool ComputePass::AddCommand(ComputeCommand command) {
 }
 
 bool ComputePass::EncodeCommands() const {
+  if (grid_size_.IsEmpty() || thread_group_size_.IsEmpty()) {
+    FML_DLOG(WARNING) << "Attempted to encode a compute pass with an empty "
+                         "grid or thread group size.";
+    return false;
+  }
   auto context = context_.lock();
   // The context could have been collected in the meantime.
   if (!context) {


### PR DESCRIPTION
On Metal, this will trigger a runtime assert if not guarded against further down. We should avoid doing the dispatch at all if the grid size is zero in any dimension.