### PR TITLE
[Impeller] Fail GN when building an enabled Impeller backend is impossible.

### DIFF
--- a/impeller/renderer/backend/BUILD.gn
+++ b/impeller/renderer/backend/BUILD.gn
@@ -8,14 +8,17 @@ group("backend") {
   public_deps = []
 
   if (impeller_enable_metal) {
+    assert(is_mac || is_ios)
     public_deps += [ "metal" ]
   }
 
   if (impeller_enable_opengles) {
+    assert(is_mac || is_linux || is_win || is_android)
     public_deps += [ "gles" ]
   }
 
   if (impeller_enable_vulkan) {
+    assert(is_mac || is_linux || is_win || is_android)
     public_deps += [ "vulkan" ]
   }
 }


### PR DESCRIPTION
When `--enable-impeller-*` args write `impeller_enable_*` args, and so `declare_args` in `impeller.gni` are ignored and it'll always attempt to build enabled backends even if they will obviously fail.

I ran into some confusion when accidentally flipping on Vulkan for iOS: https://gist.github.com/bdero/fa11a596ece56055d50e5afecfd4d03d