### PR TITLE
Complete the update semantics embedder API migration

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -47,21 +47,6 @@ void AccessibilityBridge::AddFlutterSemanticsCustomActionUpdate(
       FromFlutterSemanticsCustomAction(action);
 }
 
-// TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
-// See: https://github.com/flutter/flutter/issues/121176
-void AccessibilityBridge::AddFlutterSemanticsNodeUpdate(
-    const FlutterSemanticsNode& node) {
-  pending_semantics_node_updates_[node.id] = FromFlutterSemanticsNode(node);
-}
-
-// TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
-// See: https://github.com/flutter/flutter/issues/121176
-void AccessibilityBridge::AddFlutterSemanticsCustomActionUpdate(
-    const FlutterSemanticsCustomAction& action) {
-  pending_semantics_custom_action_updates_[action.id] =
-      FromFlutterSemanticsCustomAction(action);
-}
-
 void AccessibilityBridge::CommitUpdates() {
   // AXTree cannot move a node in a single update.
   // This must be split across two updates:
@@ -645,77 +630,6 @@ AccessibilityBridge::FromFlutterSemanticsNode(
 AccessibilityBridge::SemanticsCustomAction
 AccessibilityBridge::FromFlutterSemanticsCustomAction(
     const FlutterSemanticsCustomAction2& flutter_custom_action) {
-  SemanticsCustomAction result;
-  result.id = flutter_custom_action.id;
-  result.override_action = flutter_custom_action.override_action;
-  if (flutter_custom_action.label) {
-    result.label = std::string(flutter_custom_action.label);
-  }
-  if (flutter_custom_action.hint) {
-    result.hint = std::string(flutter_custom_action.hint);
-  }
-  return result;
-}
-
-// TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
-// See: https://github.com/flutter/flutter/issues/121176
-AccessibilityBridge::SemanticsNode
-AccessibilityBridge::FromFlutterSemanticsNode(
-    const FlutterSemanticsNode& flutter_node) {
-  SemanticsNode result;
-  result.id = flutter_node.id;
-  result.flags = flutter_node.flags;
-  result.actions = flutter_node.actions;
-  result.text_selection_base = flutter_node.text_selection_base;
-  result.text_selection_extent = flutter_node.text_selection_extent;
-  result.scroll_child_count = flutter_node.scroll_child_count;
-  result.scroll_index = flutter_node.scroll_index;
-  result.scroll_position = flutter_node.scroll_position;
-  result.scroll_extent_max = flutter_node.scroll_extent_max;
-  result.scroll_extent_min = flutter_node.scroll_extent_min;
-  result.elevation = flutter_node.elevation;
-  result.thickness = flutter_node.thickness;
-  if (flutter_node.label) {
-    result.label = std::string(flutter_node.label);
-  }
-  if (flutter_node.hint) {
-    result.hint = std::string(flutter_node.hint);
-  }
-  if (flutter_node.value) {
-    result.value = std::string(flutter_node.value);
-  }
-  if (flutter_node.increased_value) {
-    result.increased_value = std::string(flutter_node.increased_value);
-  }
-  if (flutter_node.decreased_value) {
-    result.decreased_value = std::string(flutter_node.decreased_value);
-  }
-  if (flutter_node.tooltip) {
-    result.tooltip = std::string(flutter_node.tooltip);
-  }
-  result.text_direction = flutter_node.text_direction;
-  result.rect = flutter_node.rect;
-  result.transform = flutter_node.transform;
-  if (flutter_node.child_count > 0) {
-    result.children_in_traversal_order = std::vector<int32_t>(
-        flutter_node.children_in_traversal_order,
-        flutter_node.children_in_traversal_order + flutter_node.child_count);
-  }
-  if (flutter_node.custom_accessibility_actions_count > 0) {
-    result.custom_accessibility_actions = std::vector<int32_t>(
-        flutter_node.custom_accessibility_actions,
-        flutter_node.custom_accessibility_actions +
-            flutter_node.custom_accessibility_actions_count);
-  }
-  return result;
-}
-
-// TODO(loicsharma): Remove this as FlutterSemanticsCustomAction is
-// deprecated.
-// See: https://github.com/flutter/flutter/issues/121176
-AccessibilityBridge::SemanticsCustomAction
-AccessibilityBridge::FromFlutterSemanticsCustomAction(
-    const FlutterSemanticsCustomAction& flutter_custom_action) {
   SemanticsCustomAction result;
   result.id = flutter_custom_action.id;
   result.override_action = flutter_custom_action.override_action;

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -68,30 +68,6 @@ class AccessibilityBridge
       const FlutterSemanticsCustomAction2& action);
 
   //------------------------------------------------------------------------------
-  /// @brief      Adds a semantics node update to the pending semantics update.
-  ///             Calling this method alone will NOT update the semantics tree.
-  ///             To flush the pending updates, call the CommitUpdates().
-  ///
-  /// @param[in]  node           A reference to the semantics node update.
-  //  TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
-  //  See: https://github.com/flutter/flutter/issues/121176
-  void AddFlutterSemanticsNodeUpdate(const FlutterSemanticsNode& node);
-
-  //------------------------------------------------------------------------------
-  /// @brief      Adds a custom semantics action update to the pending semantics
-  ///             update. Calling this method alone will NOT update the
-  ///             semantics tree. To flush the pending updates, call the
-  ///             CommitUpdates().
-  ///
-  /// @param[in]  action           A reference to the custom semantics action
-  ///                              update.
-  //  TODO(loicsharma): Remove this as FlutterSemanticsCustomAction is
-  //  deprecated.
-  //  See: https://github.com/flutter/flutter/issues/121176
-  void AddFlutterSemanticsCustomActionUpdate(
-      const FlutterSemanticsCustomAction& action);
-
-  //------------------------------------------------------------------------------
   /// @brief      Flushes the pending updates and applies them to this
   ///             accessibility bridge. Calling this with no pending updates
   ///             does nothing, and callers should call this method at the end
@@ -272,17 +248,6 @@ class AccessibilityBridge
       const FlutterSemanticsNode2& flutter_node);
   SemanticsCustomAction FromFlutterSemanticsCustomAction(
       const FlutterSemanticsCustomAction2& flutter_custom_action);
-
-  // TODO(loicsharma): Remove this as FlutterSemanticsNode is deprecated.
-  // See: https://github.com/flutter/flutter/issues/121176
-  SemanticsNode FromFlutterSemanticsNode(
-      const FlutterSemanticsNode& flutter_node);
-
-  // TODO(loicsharma): Remove this as FlutterSemanticsCustomAction is
-  // deprecated.
-  // See: https://github.com/flutter/flutter/issues/121176
-  SemanticsCustomAction FromFlutterSemanticsCustomAction(
-      const FlutterSemanticsCustomAction& flutter_custom_action);
 
   // |AXTreeObserver|
   void OnNodeWillBeDeleted(ui::AXTree* tree, ui::AXNode* node) override;

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -15,7 +15,7 @@ namespace testing {
 
 using ::testing::Contains;
 
-FlutterSemanticsNode CreateSemanticsNode(
+FlutterSemanticsNode2 CreateSemanticsNode(
     int32_t id,
     const char* label,
     const std::vector<int32_t>* children = nullptr) {
@@ -42,9 +42,9 @@ TEST(AccessibilityBridgeTest, BasicTest) {
       std::make_shared<TestAccessibilityBridge>();
 
   std::vector<int32_t> children{1, 2};
-  FlutterSemanticsNode root = CreateSemanticsNode(0, "root", &children);
-  FlutterSemanticsNode child1 = CreateSemanticsNode(1, "child 1");
-  FlutterSemanticsNode child2 = CreateSemanticsNode(2, "child 2");
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root", &children);
+  FlutterSemanticsNode2 child1 = CreateSemanticsNode(1, "child 1");
+  FlutterSemanticsNode2 child2 = CreateSemanticsNode(2, "child 2");
 
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->AddFlutterSemanticsNodeUpdate(child1);
@@ -74,9 +74,9 @@ TEST(AccessibilityBridgeTest, AccessibilityRootId) {
       std::make_shared<TestAccessibilityBridge>();
 
   std::vector<int32_t> children{456, 789};
-  FlutterSemanticsNode root = CreateSemanticsNode(123, "root", &children);
-  FlutterSemanticsNode child1 = CreateSemanticsNode(456, "child 1");
-  FlutterSemanticsNode child2 = CreateSemanticsNode(789, "child 2");
+  FlutterSemanticsNode2 root = CreateSemanticsNode(123, "root", &children);
+  FlutterSemanticsNode2 child1 = CreateSemanticsNode(456, "child 1");
+  FlutterSemanticsNode2 child2 = CreateSemanticsNode(789, "child 2");
 
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->AddFlutterSemanticsNodeUpdate(child1);
@@ -113,13 +113,13 @@ TEST(AccessibilityBridgeTest, AddOrder) {
   std::vector<int32_t> root_children{34, 56};
   std::vector<int32_t> child2_children{78};
   std::vector<int32_t> child3_children{90};
-  FlutterSemanticsNode root = CreateSemanticsNode(12, "root", &root_children);
-  FlutterSemanticsNode child1 = CreateSemanticsNode(34, "child 1");
-  FlutterSemanticsNode child2 =
+  FlutterSemanticsNode2 root = CreateSemanticsNode(12, "root", &root_children);
+  FlutterSemanticsNode2 child1 = CreateSemanticsNode(34, "child 1");
+  FlutterSemanticsNode2 child2 =
       CreateSemanticsNode(56, "child 2", &child2_children);
-  FlutterSemanticsNode child3 =
+  FlutterSemanticsNode2 child3 =
       CreateSemanticsNode(78, "child 3", &child3_children);
-  FlutterSemanticsNode child4 = CreateSemanticsNode(90, "child 4");
+  FlutterSemanticsNode2 child4 = CreateSemanticsNode(90, "child 4");
 
   bridge->AddFlutterSemanticsNodeUpdate(child3);
   bridge->AddFlutterSemanticsNodeUpdate(child2);
@@ -162,8 +162,8 @@ TEST(AccessibilityBridgeTest, CanFireChildrenChangedCorrectly) {
       std::make_shared<TestAccessibilityBridge>();
 
   std::vector<int32_t> children{1};
-  FlutterSemanticsNode root = CreateSemanticsNode(0, "root", &children);
-  FlutterSemanticsNode child1 = CreateSemanticsNode(1, "child 1");
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root", &children);
+  FlutterSemanticsNode2 child1 = CreateSemanticsNode(1, "child 1");
 
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->AddFlutterSemanticsNodeUpdate(child1);
@@ -185,7 +185,7 @@ TEST(AccessibilityBridgeTest, CanFireChildrenChangedCorrectly) {
   int32_t new_children[] = {1, 2};
   root.children_in_traversal_order = new_children;
 
-  FlutterSemanticsNode child2 = CreateSemanticsNode(2, "child 2");
+  FlutterSemanticsNode2 child2 = CreateSemanticsNode(2, "child 2");
 
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->AddFlutterSemanticsNodeUpdate(child2);
@@ -210,8 +210,8 @@ TEST(AccessibilityBridgeTest, CanRecreateNodeDelegates) {
       std::make_shared<TestAccessibilityBridge>();
 
   std::vector<int32_t> children{1};
-  FlutterSemanticsNode root = CreateSemanticsNode(0, "root", &children);
-  FlutterSemanticsNode child1 = CreateSemanticsNode(1, "child 1");
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root", &children);
+  FlutterSemanticsNode2 child1 = CreateSemanticsNode(1, "child 1");
 
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->AddFlutterSemanticsNodeUpdate(child1);
@@ -242,7 +242,7 @@ TEST(AccessibilityBridgeTest, CanRecreateNodeDelegates) {
 TEST(AccessibilityBridgeTest, CanHandleSelectionChangeCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root = CreateSemanticsNode(0, "root");
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsFocused);
@@ -274,7 +274,7 @@ TEST(AccessibilityBridgeTest, CanHandleSelectionChangeCorrectly) {
 TEST(AccessibilityBridgeTest, DoesNotAssignEditableRootToSelectableText) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root = CreateSemanticsNode(0, "root");
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly);
@@ -290,7 +290,7 @@ TEST(AccessibilityBridgeTest, DoesNotAssignEditableRootToSelectableText) {
 TEST(AccessibilityBridgeTest, ToggleHasToggleButtonRole) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root = CreateSemanticsNode(0, "root");
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasToggledState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasEnabledState |
@@ -305,7 +305,7 @@ TEST(AccessibilityBridgeTest, ToggleHasToggleButtonRole) {
 TEST(AccessibilityBridgeTest, SliderHasSliderRole) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root = CreateSemanticsNode(0, "root");
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsSlider |
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasEnabledState |
@@ -326,7 +326,7 @@ TEST(AccessibilityBridgeTest, SliderHasSliderRole) {
 TEST(AccessibilityBridgeTest, CanSetCheckboxChecked) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root = CreateSemanticsNode(0, "root");
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root");
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasCheckedState |
       FlutterSemanticsFlag::kFlutterSemanticsFlagIsChecked);
@@ -346,10 +346,10 @@ TEST(AccessibilityBridgeTest, CanReparentNode) {
 
   std::vector<int32_t> root_children{1};
   std::vector<int32_t> child1_children{2};
-  FlutterSemanticsNode root = CreateSemanticsNode(0, "root", &root_children);
-  FlutterSemanticsNode child1 =
+  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root", &root_children);
+  FlutterSemanticsNode2 child1 =
       CreateSemanticsNode(1, "child 1", &child1_children);
-  FlutterSemanticsNode child2 = CreateSemanticsNode(2, "child 2");
+  FlutterSemanticsNode2 child2 = CreateSemanticsNode(2, "child 2");
 
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->AddFlutterSemanticsNodeUpdate(child1);
@@ -417,15 +417,15 @@ TEST(AccessibilityBridgeTest, CanReparentMultipleNodes) {
   std::vector<int32_t> root_children{intermediary1_id, intermediary2_id};
   std::vector<int32_t> intermediary1_children{leaf1_id};
   std::vector<int32_t> intermediary2_children{leaf2_id, leaf3_id};
-  FlutterSemanticsNode root =
+  FlutterSemanticsNode2 root =
       CreateSemanticsNode(root_id, "root", &root_children);
-  FlutterSemanticsNode intermediary1 = CreateSemanticsNode(
+  FlutterSemanticsNode2 intermediary1 = CreateSemanticsNode(
       intermediary1_id, "intermediary 1", &intermediary1_children);
-  FlutterSemanticsNode intermediary2 = CreateSemanticsNode(
+  FlutterSemanticsNode2 intermediary2 = CreateSemanticsNode(
       intermediary2_id, "intermediary 2", &intermediary2_children);
-  FlutterSemanticsNode leaf1 = CreateSemanticsNode(leaf1_id, "leaf 1");
-  FlutterSemanticsNode leaf2 = CreateSemanticsNode(leaf2_id, "leaf 2");
-  FlutterSemanticsNode leaf3 = CreateSemanticsNode(leaf3_id, "leaf 3");
+  FlutterSemanticsNode2 leaf1 = CreateSemanticsNode(leaf1_id, "leaf 1");
+  FlutterSemanticsNode2 leaf2 = CreateSemanticsNode(leaf2_id, "leaf 2");
+  FlutterSemanticsNode2 leaf3 = CreateSemanticsNode(leaf3_id, "leaf 3");
 
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->AddFlutterSemanticsNodeUpdate(intermediary1);
@@ -508,13 +508,13 @@ TEST(AccessibilityBridgeTest, CanReparentNodeWithChild) {
 
   std::vector<int32_t> root_children{intermediary1_id, intermediary2_id};
   std::vector<int32_t> intermediary1_children{leaf1_id};
-  FlutterSemanticsNode root =
+  FlutterSemanticsNode2 root =
       CreateSemanticsNode(root_id, "root", &root_children);
-  FlutterSemanticsNode intermediary1 = CreateSemanticsNode(
+  FlutterSemanticsNode2 intermediary1 = CreateSemanticsNode(
       intermediary1_id, "intermediary 1", &intermediary1_children);
-  FlutterSemanticsNode intermediary2 =
+  FlutterSemanticsNode2 intermediary2 =
       CreateSemanticsNode(intermediary2_id, "intermediary 2");
-  FlutterSemanticsNode leaf1 = CreateSemanticsNode(leaf1_id, "leaf 1");
+  FlutterSemanticsNode2 leaf1 = CreateSemanticsNode(leaf1_id, "leaf 1");
 
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->AddFlutterSemanticsNodeUpdate(intermediary1);
@@ -593,7 +593,7 @@ TEST(AccessibilityBridgeTest, LineBreakingObjectTest) {
 
   const int32_t root_id = 0;
 
-  FlutterSemanticsNode root = CreateSemanticsNode(root_id, "root", {});
+  FlutterSemanticsNode2 root = CreateSemanticsNode(root_id, "root", {});
 
   bridge->AddFlutterSemanticsNodeUpdate(root);
   bridge->CommitUpdates();

--- a/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -17,14 +17,14 @@ TEST(FlutterPlatformNodeDelegateTest, NodeDelegateHasUniqueId) {
       std::make_shared<TestAccessibilityBridge>();
 
   // Add node 0: root.
-  FlutterSemanticsNode node0{sizeof(FlutterSemanticsNode), 0};
+  FlutterSemanticsNode2 node0{sizeof(FlutterSemanticsNode2), 0};
   std::vector<int32_t> node0_children{1};
   node0.child_count = node0_children.size();
   node0.children_in_traversal_order = node0_children.data();
   node0.children_in_hit_test_order = node0_children.data();
 
   // Add node 1: text child of node 0.
-  FlutterSemanticsNode node1{sizeof(FlutterSemanticsNode), 1};
+  FlutterSemanticsNode2 node1{sizeof(FlutterSemanticsNode2), 1};
   node1.label = "prefecture";
   node1.value = "Kyoto";
 
@@ -40,7 +40,7 @@ TEST(FlutterPlatformNodeDelegateTest, NodeDelegateHasUniqueId) {
 TEST(FlutterPlatformNodeDelegateTest, canPerfomActions) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField;
   root.actions = static_cast<FlutterSemanticsAction>(0);
@@ -85,7 +85,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetAXNode) {
   // Set up a flutter accessibility node.
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField;
   root.actions = static_cast<FlutterSemanticsAction>(0);
@@ -110,7 +110,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetAXNode) {
 TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -126,7 +126,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode child1;
+  FlutterSemanticsNode2 child1;
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";
@@ -156,7 +156,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
 TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -172,7 +172,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode child1;
+  FlutterSemanticsNode2 child1;
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";
@@ -202,7 +202,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
 TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -218,7 +218,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode child1;
+  FlutterSemanticsNode2 child1;
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";
@@ -249,7 +249,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
 TEST(FlutterPlatformNodeDelegateTest, selfIsLowestPlatformAncestor) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -271,7 +271,7 @@ TEST(FlutterPlatformNodeDelegateTest, selfIsLowestPlatformAncestor) {
 TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -285,7 +285,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
   root.custom_accessibility_actions_count = 0;
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode child1;
+  FlutterSemanticsNode2 child1;
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -73,7 +73,7 @@ TEST(AccessibilityBridgeMacTest, SendsAccessibilityCreateNotificationToWindowOfF
   engine.semanticsEnabled = YES;
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
@@ -135,7 +135,7 @@ TEST(AccessibilityBridgeMacTest, NonZeroRootNodeId) {
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
 
-  FlutterSemanticsNode node1;
+  FlutterSemanticsNode2 node1;
   std::vector<int32_t> node1_children{2};
   node1.id = 1;
   node1.flags = static_cast<FlutterSemanticsFlag>(0);
@@ -153,7 +153,7 @@ TEST(AccessibilityBridgeMacTest, NonZeroRootNodeId) {
   node1.children_in_hit_test_order = node1_children.data();
   node1.custom_accessibility_actions_count = 0;
 
-  FlutterSemanticsNode node2;
+  FlutterSemanticsNode2 node2;
   node2.id = 2;
   node2.flags = static_cast<FlutterSemanticsFlag>(0);
   node2.actions = static_cast<FlutterSemanticsAction>(0);
@@ -198,7 +198,7 @@ TEST(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhenH
   engine.semanticsEnabled = YES;
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
@@ -245,7 +245,7 @@ TEST(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhenN
   engine.semanticsEnabled = YES;
   auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
       viewController.accessibilityBridge.lock());
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -35,7 +35,7 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
   ;
@@ -71,7 +71,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags =
       static_cast<FlutterSemanticsFlag>(FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
@@ -113,7 +113,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags =
       static_cast<FlutterSemanticsFlag>(FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
@@ -160,7 +160,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   engine.semanticsEnabled = YES;
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -174,7 +174,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   root.custom_accessibility_actions_count = 0;
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode child1;
+  FlutterSemanticsNode2 child1;
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";
@@ -235,7 +235,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
 
   auto bridge = viewController.accessibilityBridge.lock();
   // Initialize ax node data.
-  FlutterSemanticsNode root;
+  FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
@@ -256,7 +256,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   double rectSize = 50;
   double transformFactor = 0.5;
 
-  FlutterSemanticsNode child1;
+  FlutterSemanticsNode2 child1;
   child1.id = 1;
   child1.flags = FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField;
   child1.actions = static_cast<FlutterSemanticsAction>(0);

--- a/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -125,31 +125,31 @@ std::unique_ptr<FlutterWindowsEngineSpy> GetTestEngine() {
 // node4 is a static text node with no text, and hence has the "ignored" state.
 void PopulateAXTree(std::shared_ptr<AccessibilityBridge> bridge) {
   // Add node 0: root.
-  FlutterSemanticsNode node0{sizeof(FlutterSemanticsNode), 0};
+  FlutterSemanticsNode2 node0{sizeof(FlutterSemanticsNode2), 0};
   std::vector<int32_t> node0_children{1, 2};
   node0.child_count = node0_children.size();
   node0.children_in_traversal_order = node0_children.data();
   node0.children_in_hit_test_order = node0_children.data();
 
   // Add node 1: text child of node 0.
-  FlutterSemanticsNode node1{sizeof(FlutterSemanticsNode), 1};
+  FlutterSemanticsNode2 node1{sizeof(FlutterSemanticsNode2), 1};
   node1.label = "prefecture";
   node1.value = "Kyoto";
 
   // Add node 2: subtree child of node 0.
-  FlutterSemanticsNode node2{sizeof(FlutterSemanticsNode), 2};
+  FlutterSemanticsNode2 node2{sizeof(FlutterSemanticsNode2), 2};
   std::vector<int32_t> node2_children{3, 4};
   node2.child_count = node2_children.size();
   node2.children_in_traversal_order = node2_children.data();
   node2.children_in_hit_test_order = node2_children.data();
 
   // Add node 3: text child of node 2.
-  FlutterSemanticsNode node3{sizeof(FlutterSemanticsNode), 3};
+  FlutterSemanticsNode2 node3{sizeof(FlutterSemanticsNode2), 3};
   node3.label = "city";
   node3.value = "Uji";
 
   // Add node 4: text child (with no text) of node 2.
-  FlutterSemanticsNode node4{sizeof(FlutterSemanticsNode), 4};
+  FlutterSemanticsNode2 node4{sizeof(FlutterSemanticsNode2), 4};
 
   bridge->AddFlutterSemanticsNodeUpdate(node0);
   bridge->AddFlutterSemanticsNodeUpdate(node1);

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -158,7 +158,7 @@ TEST(FlutterWindowsView, AddSemanticsNodeUpdate) {
   ASSERT_TRUE(bridge);
 
   // Add root node.
-  FlutterSemanticsNode node{sizeof(FlutterSemanticsNode), 0};
+  FlutterSemanticsNode2 node{sizeof(FlutterSemanticsNode2), 0};
   node.label = "name";
   node.value = "value";
   node.platform_view_id = -1;
@@ -257,21 +257,21 @@ TEST(FlutterWindowsView, AddSemanticsNodeUpdateWithChildren) {
   ASSERT_TRUE(bridge);
 
   // Add root node.
-  FlutterSemanticsNode node0{sizeof(FlutterSemanticsNode), 0};
+  FlutterSemanticsNode2 node0{sizeof(FlutterSemanticsNode2), 0};
   std::vector<int32_t> node0_children{1, 2};
   node0.child_count = node0_children.size();
   node0.children_in_traversal_order = node0_children.data();
   node0.children_in_hit_test_order = node0_children.data();
 
-  FlutterSemanticsNode node1{sizeof(FlutterSemanticsNode), 1};
+  FlutterSemanticsNode2 node1{sizeof(FlutterSemanticsNode2), 1};
   node1.label = "prefecture";
   node1.value = "Kyoto";
-  FlutterSemanticsNode node2{sizeof(FlutterSemanticsNode), 2};
+  FlutterSemanticsNode2 node2{sizeof(FlutterSemanticsNode2), 2};
   std::vector<int32_t> node2_children{3};
   node2.child_count = node2_children.size();
   node2.children_in_traversal_order = node2_children.data();
   node2.children_in_hit_test_order = node2_children.data();
-  FlutterSemanticsNode node3{sizeof(FlutterSemanticsNode), 3};
+  FlutterSemanticsNode2 node3{sizeof(FlutterSemanticsNode2), 3};
   node3.label = "city";
   node3.value = "Uji";
 
@@ -455,13 +455,13 @@ TEST(FlutterWindowsView, NonZeroSemanticsRoot) {
   ASSERT_TRUE(bridge);
 
   // Add root node.
-  FlutterSemanticsNode node1{sizeof(FlutterSemanticsNode), 1};
+  FlutterSemanticsNode2 node1{sizeof(FlutterSemanticsNode2), 1};
   std::vector<int32_t> node1_children{2};
   node1.child_count = node1_children.size();
   node1.children_in_traversal_order = node1_children.data();
   node1.children_in_hit_test_order = node1_children.data();
 
-  FlutterSemanticsNode node2{sizeof(FlutterSemanticsNode), 2};
+  FlutterSemanticsNode2 node2{sizeof(FlutterSemanticsNode2), 2};
   node2.label = "prefecture";
   node2.value = "Kyoto";
 
@@ -587,7 +587,7 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
   ASSERT_TRUE(bridge);
 
   // Add root node at origin. Size 500x500.
-  FlutterSemanticsNode node0{sizeof(FlutterSemanticsNode), 0};
+  FlutterSemanticsNode2 node0{sizeof(FlutterSemanticsNode2), 0};
   std::vector<int32_t> node0_children{1, 2};
   node0.rect = {0, 0, 500, 500};
   node0.transform = kIdentityTransform;
@@ -596,14 +596,14 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
   node0.children_in_hit_test_order = node0_children.data();
 
   // Add node 1 located at 0,0 relative to node 0. Size 250x500.
-  FlutterSemanticsNode node1{sizeof(FlutterSemanticsNode), 1};
+  FlutterSemanticsNode2 node1{sizeof(FlutterSemanticsNode2), 1};
   node1.rect = {0, 0, 250, 500};
   node1.transform = kIdentityTransform;
   node1.label = "prefecture";
   node1.value = "Kyoto";
 
   // Add node 2 located at 250,0 relative to node 0. Size 250x500.
-  FlutterSemanticsNode node2{sizeof(FlutterSemanticsNode), 2};
+  FlutterSemanticsNode2 node2{sizeof(FlutterSemanticsNode2), 2};
   std::vector<int32_t> node2_children{3};
   node2.rect = {0, 0, 250, 500};
   node2.transform = {1, 0, 250, 0, 1, 0, 0, 0, 1};
@@ -612,7 +612,7 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
   node2.children_in_hit_test_order = node2_children.data();
 
   // Add node 3 located at 0,250 relative to node 2. Size 250, 250.
-  FlutterSemanticsNode node3{sizeof(FlutterSemanticsNode), 3};
+  FlutterSemanticsNode2 node3{sizeof(FlutterSemanticsNode2), 3};
   node3.rect = {0, 0, 250, 250};
   node3.transform = {1, 0, 0, 0, 1, 250, 0, 0, 1};
   node3.label = "city";
@@ -731,7 +731,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   auto bridge = view.GetEngine()->accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
-  FlutterSemanticsNode root{sizeof(FlutterSemanticsNode), 0};
+  FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -877,7 +877,7 @@ TEST(FlutterWindowsViewTest, SwitchNativeState) {
   auto bridge = view.GetEngine()->accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
-  FlutterSemanticsNode root{sizeof(FlutterSemanticsNode), 0};
+  FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -994,7 +994,7 @@ TEST(FlutterWindowsViewTest, TooltipNodeData) {
   auto bridge = view.GetEngine()->accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
-  FlutterSemanticsNode root{sizeof(FlutterSemanticsNode), 0};
+  FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
   root.id = 0;
   root.label = "root";
   root.hint = "";


### PR DESCRIPTION
The old "update semantics" embedder API was deprecated as it could not guarantee ABI stability (see https://github.com/flutter/flutter/issues/121176). It was replaced by a new embedder API (https://github.com/flutter/engine/pull/39807) and all affected embedders were migrated to this new embedder API (https://github.com/flutter/engine/pull/40072, https://github.com/flutter/engine/pull/40584).

This change:
1. Removes plumbing that was used for the old "update semantics" embedder API
2. Moves all remaining tests to the types used by the new "update semantics" embedder API

Completes: https://github.com/flutter/flutter/issues/121176

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
