### PR TITLE
Revert "[iOS] Send connectionClosed message when resignFirstResponder to ensure framework focus state is correct."

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -1095,14 +1095,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                               arguments:@[ @(client) ]];
 }
 
-- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
-    didResignFirstResponderWithTextInputClient:(int)client {
-  // When flutter text input view resign first responder, send a message to
-  // framework to ensure the focus state is correct. This is useful when close
-  // keyboard from platform side.
-  [_textInputChannel.get() invokeMethod:@"TextInputClient.onConnectionClosed"
-                              arguments:@[ @(client) ]];
-
+- (void)flutterTextInputViewDidResignFirstResponder:(FlutterTextInputView*)textInputView {
   // Platform view's first responder detection logic:
   //
   // All text input widgets (e.g. EditableText) are backed by a dummy UITextInput view

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -13,13 +13,8 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 
 FLUTTER_ASSERT_ARC
-
-@interface FlutterEngine () <FlutterTextInputDelegate>
-
-@end
 
 @interface FlutterEngineTest : XCTestCase
 @end
@@ -316,19 +311,6 @@ FLUTTER_ASSERT_ARC
     FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
     XCTAssertTrue(engine.enableEmbedderAPI);
   }
-}
-
-- (void)testFlutterTextInputViewDidResignFirstResponderWillCallTextInputClientConnectionClosed {
-  id mockBinaryMessenger = OCMClassMock([FlutterBinaryMessengerRelay class]);
-  FlutterEngine* engine = [[FlutterEngine alloc] init];
-  [engine setBinaryMessenger:mockBinaryMessenger];
-  [engine runWithEntrypoint:FlutterDefaultDartEntrypoint initialRoute:@"test"];
-  [engine flutterTextInputView:nil didResignFirstResponderWithTextInputClient:1];
-  FlutterMethodCall* methodCall =
-      [FlutterMethodCall methodCallWithMethodName:@"TextInputClient.onConnectionClosed"
-                                        arguments:@[ @(1) ]];
-  NSData* encodedMethodCall = [[FlutterJSONMethodCodec sharedInstance] encodeMethodCall:methodCall];
-  OCMVerify([mockBinaryMessenger sendOnChannel:@"flutter/textinput" message:encodedMethodCall]);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -59,8 +59,8 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
     insertTextPlaceholderWithSize:(CGSize)size
                        withClient:(int)client;
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView removeTextPlaceholder:(int)client;
-- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
-    didResignFirstResponderWithTextInputClient:(int)client;
+- (void)flutterTextInputViewDidResignFirstResponder:(FlutterTextInputView*)textInputView;
+
 @end
 
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTDELEGATE_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1043,8 +1043,7 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
 - (BOOL)resignFirstResponder {
   BOOL success = [super resignFirstResponder];
   if (success) {
-    [self.textInputDelegate flutterTextInputView:self
-        didResignFirstResponderWithTextInputClient:_textInputClient];
+    [self.textInputDelegate flutterTextInputViewDidResignFirstResponder:self];
   }
   return success;
 }


### PR DESCRIPTION
Reverts flutter/engine#40703

I found that since the `connectionClosed` will invoke `_finalizeEditing(TextInputAction.done, shouldUnfocus: true);`.
This will invoke onSubmit.....But actually we do expect just unfocus and do not expect any submit.. This will cause some break change. Need to have further invesigate to reland