### PR TITLE
[Impeller] iOS/macOS: Only wait for command scheduling prior to present

### DIFF
--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -167,27 +167,6 @@ bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
 
   [buffer_ commit];
 
-#if (FML_OS_MACOSX || FML_OS_IOS_SIMULATOR)
-  // We're using waitUntilScheduled on macOS and iOS simulator to force a hard
-  // barrier between the execution of different command buffers. This forces all
-  // renderable texture access to be synchronous (i.e. a write from a previous
-  // command buffer will not get scheduled to happen at the same time as a read
-  // in a future command buffer).
-  //
-  // Metal hazard tracks shared memory resources by default, and we don't need
-  // to do any additional work to synchronize access to MTLTextures and
-  // MTLBuffers on iOS devices with UMA. However, shared textures are disallowed
-  // on macOS according to the documentation:
-  // https://developer.apple.com/documentation/metal/mtlstoragemode/shared
-  // And so this is a stopgap solution that has been present in Impeller since
-  // multi-pass rendering/SaveLayer support was first set up.
-  //
-  // TODO(bdero): Remove this for all targets once a solution for resource
-  //              tracking that works everywhere is established:
-  //              https://github.com/flutter/flutter/issues/120406
-  [buffer_ waitUntilScheduled];
-#endif
-
   buffer_ = nil;
   return true;
 }

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -64,6 +64,8 @@ class ContextMTL final : public Context,
   // |Context|
   bool UpdateOffscreenLayerPixelFormat(PixelFormat format) override;
 
+  id<MTLCommandBuffer> CreateMTLCommandBuffer() const;
+
  private:
   id<MTLDevice> device_ = nullptr;
   id<MTLCommandQueue> command_queue_ = nullptr;

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -290,4 +290,8 @@ bool ContextMTL::UpdateOffscreenLayerPixelFormat(PixelFormat format) {
   return true;
 }
 
+id<MTLCommandBuffer> ContextMTL::CreateMTLCommandBuffer() const {
+  return [command_queue_ commandBuffer];
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/surface_mtl.h
+++ b/impeller/renderer/backend/metal/surface_mtl.h
@@ -43,9 +43,12 @@ class SurfaceMTL final : public Surface {
   id<MTLDrawable> drawable() const { return drawable_; }
 
  private:
+  std::weak_ptr<Context> context_;
   id<MTLDrawable> drawable_ = nil;
 
-  SurfaceMTL(const RenderTarget& target, id<MTLDrawable> drawable);
+  SurfaceMTL(const std::weak_ptr<Context>& context,
+             const RenderTarget& target,
+             id<MTLDrawable> drawable);
 
   // |Surface|
   bool Present() const override;

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/trace_event.h"
 #include "impeller/base/validation.h"
+#include "impeller/renderer/backend/metal/context_mtl.h"
 #include "impeller/renderer/backend/metal/formats_mtl.h"
 #include "impeller/renderer/backend/metal/texture_mtl.h"
 #include "impeller/renderer/render_target.h"
@@ -111,12 +112,14 @@ std::unique_ptr<SurfaceMTL> SurfaceMTL::WrapCurrentMetalLayerDrawable(
   render_target_desc.SetStencilAttachment(stencil0);
 
   // The constructor is private. So make_unique may not be used.
-  return std::unique_ptr<SurfaceMTL>(
-      new SurfaceMTL(render_target_desc, current_drawable));
+  return std::unique_ptr<SurfaceMTL>(new SurfaceMTL(
+      context->weak_from_this(), render_target_desc, current_drawable));
 }
 
-SurfaceMTL::SurfaceMTL(const RenderTarget& target, id<MTLDrawable> drawable)
-    : Surface(target), drawable_(drawable) {}
+SurfaceMTL::SurfaceMTL(const std::weak_ptr<Context>& context,
+                       const RenderTarget& target,
+                       id<MTLDrawable> drawable)
+    : Surface(target), context_(context), drawable_(drawable) {}
 
 // |Surface|
 SurfaceMTL::~SurfaceMTL() = default;
@@ -127,7 +130,11 @@ bool SurfaceMTL::Present() const {
     return false;
   }
 
-  [drawable_ present];
+  id<MTLCommandBuffer> command_buffer =
+      ContextMTL::Cast(context_.lock().get())->CreateMTLCommandBuffer();
+  [command_buffer presentDrawable:drawable_];
+  [command_buffer commit];
+
   return true;
 }
 #pragma GCC diagnostic pop

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -130,8 +130,13 @@ bool SurfaceMTL::Present() const {
     return false;
   }
 
+  auto context = context_.lock();
+  if (!context) {
+    return false;
+  }
+
   id<MTLCommandBuffer> command_buffer =
-      ContextMTL::Cast(context_.lock().get())->CreateMTLCommandBuffer();
+      ContextMTL::Cast(context.get())->CreateMTLCommandBuffer();
   [command_buffer presentDrawable:drawable_];
   [command_buffer commit];
 


### PR DESCRIPTION
edit: This was updated to just wait for scheduling in a new command buffer. Similar to how we already do in the macOS embedder, but better because we don't even block on the current thread thanks to presentDrawable.

This patch makes us conform to the docs and sync properly for the drawable present, and gets rid of the excessive `waitUntilScheduled` blocking on iOS sim. Tested on iPhone 12, iPhone 6s, and x64 sim.

Open to ideas for better architecting this. Waiting for the last committed command buffer to be scheduled is the same as waiting for _all_ previously committed command buffers to be scheduled. Command buffers are scheduled in queue order. 

Explanation:

Sleuthing through the Metal docs for all the calls we're making, I found one thing that's unsafe about not doing `waitUntilScheduled` on iOS, but I'm only able to reproduce symptoms of an actual problem on iOS sim. Wondrous on iPhone 12 and iPhone 6s seems to run perfectly fine without `waitUntilScheduled`, but the simulator is a choppy mess because we're flipping too fast:

https://user-images.githubusercontent.com/919017/228845732-2c592ba9-6d74-489a-ae04-a99a0ea1273f.mov


The problem is that immediately after we're done committing our buffers to the root texture, we present by calling `MTLDrawable.present()`. 

The docs for `present` say:
> When you call this method, the drawable presents its contents as soon as possible after all scheduled render or write requests for that drawable are complete.

The _scheduled_ part is key here -- _committing_ the buffer signals to the queue that it's ready to be _scheduled_. `MTLCommandBuffer.commit()` docs:
> The commit() method sends the command buffer to the MTLCommandQueue instance that owns it, which then schedules it to run on the GPU.

This is slightly ambiguous, but we know this call doesn't block on scheduling; scheduling happens in the background sometime after `commit()` is called, hence the existence of `waitUntilScheduled()`.