### PR TITLE
[web] LRU cache for text segmentation

### DIFF
--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -269,5 +269,4 @@ int _detectWebGLVersion() {
 }
 
 /// Whether the current browser supports the Chromium variant of CanvasKit.
-bool get browserSupportsCanvaskitChromium =>
-    browserSupportsImageDecoder && domIntl.v8BreakIterator != null;
+bool get browserSupportsCanvaskitChromium => domIntl.v8BreakIterator != null;

--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -5,7 +5,6 @@
 import 'package:meta/meta.dart';
 
 import 'dom.dart';
-import 'safe_browser_api.dart';
 
 // iOS 15 launched WebGL 2.0, but there's something broken about it, which
 // leads to apps failing to load. For now, we're forcing WebGL 1 on iOS.

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -17,6 +17,8 @@ import 'skia_object_cache.dart';
 import 'text_fragmenter.dart';
 import 'util.dart';
 
+final bool _ckRequiresClientICU = canvasKit.ParagraphBuilder.RequiresClientICU();
+
 final List<String> _testFonts = <String>['FlutterTest', 'Ahem'];
 String? _effectiveFontFamily(String? fontFamily) {
   return ui.debugEmulateFlutterTesterEnvironment && !_testFonts.contains(fontFamily)
@@ -887,7 +889,7 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
 
   /// Builds the CkParagraph with the builder and deletes the builder.
   SkParagraph _buildSkParagraph() {
-    if (canvasKit.ParagraphBuilder.RequiresClientICU()) {
+    if (_ckRequiresClientICU) {
       injectClientICU(_paragraphBuilder);
     }
     final SkParagraph result = _paragraphBuilder.build();

--- a/lib/web_ui/test/engine/browser_detect_test.dart
+++ b/lib/web_ui/test/engine/browser_detect_test.dart
@@ -177,7 +177,9 @@ void testMain() {
       v8BreakIterator = Object(); // Any non-null value.
       browserSupportsImageDecoder = false;
 
-      expect(browserSupportsCanvaskitChromium, isFalse);
+      // TODO(mdebbar): we don't check image codecs for now.
+      // https://github.com/flutter/flutter/issues/122331
+      expect(browserSupportsCanvaskitChromium, isTrue);
     });
 
     test('Detect browsers that do not support v8BreakIterator', () {

--- a/lib/web_ui/test/engine/lru_cache_test.dart
+++ b/lib/web_ui/test/engine/lru_cache_test.dart
@@ -1,0 +1,99 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine/util.dart';
+
+typedef TestCacheEntry = ({String key, int value});
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  test('$LruCache starts out empty', () {
+    final LruCache<String, int> cache = LruCache<String, int>(10);
+    expect(cache.length, 0);
+  });
+
+  test('$LruCache adds up to a maximum number of items in most recently used first order', () {
+    final LruCache<String, int> cache = LruCache<String, int>(3);
+    cache.cache('a', 1);
+    expect(cache.debugItemQueue.toList(), <TestCacheEntry>[
+      (key: 'a', value: 1),
+    ]);
+    expect(cache['a'], 1);
+    expect(cache['b'], isNull);
+
+    cache.cache('b', 2);
+    expect(cache.debugItemQueue.toList(), <TestCacheEntry>[
+      (key: 'b', value: 2),
+      (key: 'a', value: 1),
+    ]);
+    expect(cache['a'], 1);
+    expect(cache['b'], 2);
+
+    cache.cache('c', 3);
+    expect(cache.debugItemQueue.toList(), <TestCacheEntry>[
+      (key: 'c', value: 3),
+      (key: 'b', value: 2),
+      (key: 'a', value: 1),
+    ]);
+
+    cache.cache('d', 4);
+    expect(cache.debugItemQueue.toList(), <TestCacheEntry>[
+      (key: 'd', value: 4),
+      (key: 'c', value: 3),
+      (key: 'b', value: 2),
+    ]);
+
+    cache.cache('e', 5);
+    expect(cache.debugItemQueue.toList(), <TestCacheEntry>[
+      (key: 'e', value: 5),
+      (key: 'd', value: 4),
+      (key: 'c', value: 3),
+    ]);
+  });
+
+  test('$LruCache promotes entry to most recently used position', () {
+    final LruCache<String, int> cache = LruCache<String, int>(3);
+    cache.cache('a', 1);
+    cache.cache('b', 2);
+    cache.cache('c', 3);
+    expect(cache.debugItemQueue.toList(), <TestCacheEntry>[
+      (key: 'c', value: 3),
+      (key: 'b', value: 2),
+      (key: 'a', value: 1),
+    ]);
+
+    cache.cache('b', 2);
+    expect(cache.debugItemQueue.toList(), <TestCacheEntry>[
+      (key: 'b', value: 2),
+      (key: 'c', value: 3),
+      (key: 'a', value: 1),
+    ]);
+  });
+
+  test('$LruCache updates and promotes entry to most recently used position', () {
+    final LruCache<String, int> cache = LruCache<String, int>(3);
+    cache.cache('a', 1);
+    cache.cache('b', 2);
+    cache.cache('c', 3);
+    expect(cache.debugItemQueue.toList(), <TestCacheEntry>[
+      (key: 'c', value: 3),
+      (key: 'b', value: 2),
+      (key: 'a', value: 1),
+    ]);
+    expect(cache['b'], 2);
+
+    cache.cache('b', 42);
+    expect(cache.debugItemQueue.toList(), <TestCacheEntry>[
+      (key: 'b', value: 42),
+      (key: 'c', value: 3),
+      (key: 'a', value: 1),
+    ]);
+    expect(cache['b'], 42);
+  });
+}


### PR DESCRIPTION
There are a few changes in this PR:

1. Implement an LRU cache for text segmentation results to improve layout operations on repetitive paragraphs (thanks @yjbanov for the initial implementation of the cache).
2. Invoke `ParagraphBuilder.RequiresClientICU()` only once and cache the result.
3. Remove the image codecs check from `browserSupportsCanvaskitChromium`.