### PR TITLE
[Impeller] migrate gaussian to half precision on Metal

### DIFF
--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -143,6 +143,15 @@ vec4 IPSampleDecal(sampler2D texture_sampler, vec2 coords) {
   return texture(texture_sampler, coords);
 }
 
+/// Sample a texture with decal tile mode.
+f16vec4 IPHalfSampleDecal(f16sampler2D texture_sampler, f16vec2 coords) {
+  if (any(lessThan(coords, f16vec2(0.0hf))) ||
+      any(greaterThanEqual(coords, f16vec2(1.0hf)))) {
+    return f16vec4(0.0hf);
+  }
+  return texture(texture_sampler, coords);
+}
+
 /// Sample a texture, emulating a specific tile mode.
 ///
 /// This is useful for Impeller graphics backend that don't have native support

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur.glsl
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur.glsl
@@ -18,68 +18,70 @@
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 
-uniform sampler2D texture_sampler;
+uniform f16sampler2D texture_sampler;
 
 uniform BlurInfo {
-  vec2 texture_size;
-  vec2 blur_direction;
+  f16vec2 texture_size;
+  f16vec2 blur_direction;
 
   // The blur sigma and radius have a linear relationship which is defined
   // host-side, but both are useful controls here. Sigma (pixels per standard
   // deviation) is used to define the gaussian function itself, whereas the
   // radius is used to limit how much of the function is integrated.
-  float blur_sigma;
-  float blur_radius;
+  float16_t blur_sigma;
+  float16_t blur_radius;
 }
 blur_info;
 
 #if ENABLE_ALPHA_MASK
-uniform sampler2D alpha_mask_sampler;
+uniform f16sampler2D alpha_mask_sampler;
 
 uniform MaskInfo {
-  float src_factor;
-  float inner_blur_factor;
-  float outer_blur_factor;
+  float16_t src_factor;
+  float16_t inner_blur_factor;
+  float16_t outer_blur_factor;
 }
 mask_info;
 #endif
 
-vec4 Sample(sampler2D tex, vec2 coords) {
+f16vec4 Sample(f16sampler2D tex, f16vec2 coords) {
 #if ENABLE_DECAL_SPECIALIZATION
-  return IPSampleDecal(tex, coords);
+  return IPHalfSampleDecal(tex, coords);
 #else
   return texture(tex, coords);
 #endif
 }
 
-in vec2 v_texture_coords;
-in vec2 v_src_texture_coords;
+in f16vec2 v_texture_coords;
+in f16vec2 v_src_texture_coords;
 
-out vec4 frag_color;
+out f16vec4 frag_color;
 
 void main() {
-  vec4 total_color = vec4(0);
-  float gaussian_integral = 0;
-  vec2 blur_uv_offset = blur_info.blur_direction / blur_info.texture_size;
+  f16vec4 total_color = f16vec4(0.0hf);
+  float16_t gaussian_integral = 0.0hf;
+  f16vec2 blur_uv_offset = blur_info.blur_direction / blur_info.texture_size;
 
-  for (float i = -blur_info.blur_radius; i <= blur_info.blur_radius; i++) {
-    float gaussian = IPGaussian(i, blur_info.blur_sigma);
+  for (float i = blur_info.blur_radius; i <= blur_info.blur_radius; i++) {
+    float16_t gaussian = float16_t(IPGaussian(i, blur_info.blur_sigma));
     gaussian_integral += gaussian;
     total_color +=
-        gaussian *
-        Sample(texture_sampler,                       // sampler
-               v_texture_coords + blur_uv_offset * i  // texture coordinates
-        );
+        gaussian * Sample(
+                       texture_sampler,  // sampler
+                       v_texture_coords +
+                           blur_uv_offset * float16_t(i)  // texture coordinates
+                   );
   }
 
   frag_color = total_color / gaussian_integral;
 
 #if ENABLE_ALPHA_MASK
-  vec4 src_color = Sample(alpha_mask_sampler,   // sampler
-                          v_src_texture_coords  // texture coordinates
+  f16vec4 src_color = Sample(alpha_mask_sampler,   // sampler
+                             v_src_texture_coords  // texture coordinates
   );
-  float blur_factor = mask_info.inner_blur_factor * float(src_color.a > 0) +
-                      mask_info.outer_blur_factor * float(src_color.a == 0);
+  float16_t blur_factor =
+      mask_info.inner_blur_factor * float16_t(src_color.a > 0.0hf) +
+      mask_info.outer_blur_factor * float16_t(src_color.a == 0.0hf);
 
   frag_color = frag_color * blur_factor + src_color * mask_info.src_factor;
 #endif

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur.vert
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur.vert
@@ -16,13 +16,13 @@ in vec2 vertices;
 in vec2 texture_coords;
 in vec2 src_texture_coords;
 
-out vec2 v_texture_coords;
-out vec2 v_src_texture_coords;
+out f16vec2 v_texture_coords;
+out f16vec2 v_src_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
-  v_texture_coords =
-      IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);
-  v_src_texture_coords = IPRemapCoords(
-      src_texture_coords, frame_info.alpha_mask_sampler_y_coord_scale);
+  v_texture_coords = f16vec2(
+      IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale));
+  v_src_texture_coords = f16vec2(IPRemapCoords(
+      src_texture_coords, frame_info.alpha_mask_sampler_y_coord_scale));
 }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -3279,7 +3279,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 55,
+          "fp16_arithmetic": 53,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -3351,7 +3351,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 47,
+          "fp16_arithmetic": 45,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -3404,7 +3404,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 14,
+          "uniform_registers_used": 12,
           "work_registers_used": 15
         }
       }
@@ -3423,7 +3423,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 42,
+          "fp16_arithmetic": 40,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -3476,7 +3476,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 10,
+          "uniform_registers_used": 8,
           "work_registers_used": 16
         }
       }
@@ -3495,7 +3495,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 35,
+          "fp16_arithmetic": 33,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -3548,7 +3548,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 10,
+          "uniform_registers_used": 8,
           "work_registers_used": 13
         }
       }
@@ -6636,7 +6636,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 63,
+          "fp16_arithmetic": 61,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -6662,17 +6662,16 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_cvt",
               "arith_sfu",
               "varying"
             ],
             "shortest_path_cycles": [
-              0.25,
-              0.171875,
-              0.25,
-              0.25,
+              0.5,
+              0.34375,
+              0.390625,
+              0.5,
               0.0,
-              0.25,
+              0.5,
               0.0
             ],
             "total_bound_pipelines": [
@@ -6683,8 +6682,8 @@
             ],
             "total_cycles": [
               0.5,
-              0.359375,
-              0.484375,
+              0.34375,
+              0.421875,
               0.5,
               0.0,
               0.5,
@@ -6694,7 +6693,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 21
+          "work_registers_used": 20
         }
       }
     },
@@ -6757,7 +6756,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 58,
+          "fp16_arithmetic": 55,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -6786,22 +6785,22 @@
               "texture"
             ],
             "shortest_path_cycles": [
-              0.171875,
-              0.171875,
-              0.109375,
-              0.0625,
+              0.34375,
+              0.34375,
+              0.15625,
+              0.125,
               0.0,
-              0.25,
-              0.25
+              0.5,
+              0.5
             ],
             "total_bound_pipelines": [
               "varying",
               "texture"
             ],
             "total_cycles": [
-              0.359375,
-              0.359375,
-              0.234375,
+              0.34375,
+              0.34375,
+              0.1875,
               0.125,
               0.0,
               0.5,
@@ -6874,7 +6873,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 61,
+          "fp16_arithmetic": 57,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -6900,15 +6899,15 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_cvt"
+              "arith_sfu"
             ],
             "shortest_path_cycles": [
-              0.078125,
-              0.046875,
-              0.078125,
-              0.0625,
+              0.3125,
+              0.21875,
+              0.21875,
+              0.3125,
               0.0,
-              0.0,
+              0.25,
               0.0
             ],
             "total_bound_pipelines": [
@@ -6917,8 +6916,8 @@
             ],
             "total_cycles": [
               0.3125,
-              0.234375,
-              0.296875,
+              0.21875,
+              0.25,
               0.3125,
               0.0,
               0.25,
@@ -6928,7 +6927,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 20
+          "work_registers_used": 19
         }
       }
     },
@@ -6991,7 +6990,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 57,
+          "fp16_arithmetic": 52,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -7016,26 +7015,26 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.078125,
-              0.046875,
-              0.078125,
-              0.0625,
+              0.21875,
+              0.21875,
+              0.125,
+              0.125,
               0.0,
-              0.0,
-              0.0
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
               "varying",
               "texture"
             ],
             "total_cycles": [
-              0.234375,
-              0.234375,
-              0.203125,
+              0.21875,
+              0.21875,
+              0.15625,
               0.125,
               0.0,
               0.25,


### PR DESCRIPTION
A redo of https://github.com/flutter/engine/pull/40752.

This only migrates the shader and the interpolants and not gaussian.glsl to half precision. Locally this doubles the frame throughput on the ios backdropfilter benchmark.


Local engine before:

```
Task result:
{
  "success": true,
  "data": {
    "average_frame_build_time_millis": 0.30974999999999997,
    "90th_percentile_frame_build_time_millis": 0.409,
    "99th_percentile_frame_build_time_millis": 0.459,
    "worst_frame_build_time_millis": 0.459,
    "missed_frame_build_budget_count": 0,
    "average_frame_rasterizer_time_millis": 251.06689743589746,
    "90th_percentile_frame_rasterizer_time_millis": 251.512,
    "99th_percentile_frame_rasterizer_time_millis": 252.051,
    "worst_frame_rasterizer_time_millis": 252.051,
    "missed_frame_rasterizer_budget_count": 39,
    "frame_count": 40,
    "frame_rasterizer_count": 39,
    "new_gen_gc_count": 0,
    "old_gen_gc_count": 0,
 ```
 
 After
 
 ```
{
  "success": true,
  "data": {
    "average_frame_build_time_millis": 0.3017714285714285,
    "90th_percentile_frame_build_time_millis": 0.37,
    "99th_percentile_frame_build_time_millis": 0.476,
    "worst_frame_build_time_millis": 0.476,
    "missed_frame_build_budget_count": 0,
    "average_frame_rasterizer_time_millis": 286.54435294117644,
    "90th_percentile_frame_rasterizer_time_millis": 286.778,
    "99th_percentile_frame_rasterizer_time_millis": 287.042,
    "worst_frame_rasterizer_time_millis": 287.042,
    "missed_frame_rasterizer_budget_count": 34,
    "frame_count": 35,
    "frame_rasterizer_count": 34,
    "new_gen_gc_count": 0,
    "old_gen_gc_count": 0,
    "frame_build_times": [
 ```