### PR TITLE
[Impeller] Skip TextRotated golden test.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1317,6 +1317,9 @@ TEST_P(AiksTest, CanRenderTextOutsideBoundaries) {
 }
 
 TEST_P(AiksTest, TextRotated) {
+#ifdef IMPELLER_GOLDEN_TESTS
+  GTEST_SKIP() << "Test has small differences on different mac hosts";
+#endif
   Canvas canvas;
   canvas.Transform(Matrix(0.5, -0.3, 0, -0.002,  //
                           0, 1, 0, 0,            //


### PR DESCRIPTION
This test ends up with small differences depending on which mac host it runs on and will end up blocking rollers.