### PR TITLE
Revert "Add ui_web to embedder.yaml so that the analyzer knows about it."

### DIFF
--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -239,7 +239,6 @@ generated_file("_embedder_yaml") {
     "  \"dart:math\": \"math/math.dart\"",
     "  \"dart:typed_data\": \"typed_data/typed_data.dart\"",
     "  \"dart:ui\": \"ui/ui.dart\"",
-    "  \"dart:ui_web\": \"ui_web/ui_web.dart\"",
     "  \"dart:wasm\": \"wasm/wasm_types.dart\"",
     "",
     "  \"dart:_http\": \"_http/http.dart\"",


### PR DESCRIPTION
Reverts flutter/engine#40827

This is causing the engine -> framework roll to fail in docs generation