### PR TITLE
Revert "[web] use callConstructor for FinalizationRegistry due to bug…

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -3569,12 +3569,9 @@ extension JsConstructorExtension on JsConstructor {
 @JS('window.FinalizationRegistry')
 @staticInterop
 class SkObjectFinalizationRegistry {
-  factory SkObjectFinalizationRegistry(JSFunction cleanup) {
-    return js_util.callConstructor(
-      _finalizationRegistryConstructor!.toObjectShallow,
-      <Object>[cleanup],
-    );
-  }
+  // TODO(hterkelsen): Add a type for the `cleanup` function when
+  // native constructors support type parameters.
+  external factory SkObjectFinalizationRegistry(JSFunction cleanup);
 }
 
 extension SkObjectFinalizationRegistryExtension on SkObjectFinalizationRegistry {

--- a/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
@@ -11,11 +11,9 @@ import 'canvaskit_api.dart';
 
 /// Collects native objects that weren't explicitly disposed of using
 /// [UniqueRef.dispose] or [CountedRef.unref].
-SkObjectFinalizationRegistry _finalizationRegistry = SkObjectFinalizationRegistry(
-  (UniqueRef<Object> uniq) {
-    uniq.collect();
-  }.toJS
-);
+SkObjectFinalizationRegistry _finalizationRegistry = SkObjectFinalizationRegistry((UniqueRef<Object> uniq) {
+  uniq.collect();
+}.toJS);
 
 NativeMemoryFinalizationRegistry nativeMemoryFinalizationRegistry = NativeMemoryFinalizationRegistry();
 

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -1893,15 +1892,6 @@ void _paragraphTests() {
       canvasKitWasmModuleUrl('canvaskit.wasm', 'http://localhost:1234/foo/'),
       'http://localhost:1234/foo/canvaskit.wasm',
     );
-  });
-
-  test('SkObjectFinalizationRegistry', () {
-    // There's no reliable way to test the actual functionality of
-    // FinalizationRegistry because it depends on GC, which cannot be controlled,
-    // So the test simply tests that a FinalizationRegistry can be constructed
-    // and its `register` method can be called.
-    final SkObjectFinalizationRegistry registry = SkObjectFinalizationRegistry((String arg) {}.toJS);
-    registry.register('foo', 'bar');
   });
 }
 


### PR DESCRIPTION
… in dart2js (#40798)"

This reverts commit d5a0b29132197a851dfeb594fe63ba9cffa045d0.

The original PR resulted in a silent failure.