### PR TITLE
[web] use callConstructor for FinalizationRegistry

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -3569,9 +3569,12 @@ extension JsConstructorExtension on JsConstructor {
 @JS('window.FinalizationRegistry')
 @staticInterop
 class SkObjectFinalizationRegistry {
-  // TODO(hterkelsen): Add a type for the `cleanup` function when
-  // native constructors support type parameters.
-  external factory SkObjectFinalizationRegistry(JSFunction cleanup);
+  factory SkObjectFinalizationRegistry(JSFunction cleanup) {
+    return js_util.callConstructor(
+      _finalizationRegistryConstructor!.toObjectShallow,
+      <Object>[cleanup],
+    );
+  }
 }
 
 extension SkObjectFinalizationRegistryExtension on SkObjectFinalizationRegistry {

--- a/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
@@ -11,9 +11,11 @@ import 'canvaskit_api.dart';
 
 /// Collects native objects that weren't explicitly disposed of using
 /// [UniqueRef.dispose] or [CountedRef.unref].
-SkObjectFinalizationRegistry _finalizationRegistry = SkObjectFinalizationRegistry((UniqueRef<Object> uniq) {
-  uniq.collect();
-}.toJS);
+SkObjectFinalizationRegistry _finalizationRegistry = SkObjectFinalizationRegistry(
+  (UniqueRef<Object> uniq) {
+    uniq.collect();
+  }.toJS
+);
 
 NativeMemoryFinalizationRegistry nativeMemoryFinalizationRegistry = NativeMemoryFinalizationRegistry();
 

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:js_interop';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -1892,6 +1893,15 @@ void _paragraphTests() {
       canvasKitWasmModuleUrl('canvaskit.wasm', 'http://localhost:1234/foo/'),
       'http://localhost:1234/foo/canvaskit.wasm',
     );
+  });
+
+  test('SkObjectFinalizationRegistry', () {
+    // There's no reliable way to test the actual functionality of
+    // FinalizationRegistry because it depends on GC, which cannot be controlled,
+    // So the test simply tests that a FinalizationRegistry can be constructed
+    // and its `register` method can be called.
+    final SkObjectFinalizationRegistry registry = SkObjectFinalizationRegistry((String arg) {}.toJS);
+    registry.register(Object(), Object());
   });
 }
 


### PR DESCRIPTION
Use `js_util.callConstructor` to initialize `FinalizationRegistry` to make it compatible with `dart2js`.

Fixes b/276167870

This is the second attempt to land https://github.com/flutter/engine/pull/40798. The previous attempt failed because in JS strings are not objects 🤷 