### PR TITLE
[Impeller] Apply binding base correction to all shader variants.

### DIFF
--- a/impeller/compiler/compiler.cc
+++ b/impeller/compiler/compiler.cc
@@ -463,10 +463,7 @@ Compiler::Compiler(const fml::Mapping& source_mapping,
   }
 
   spirv_options.SetAutoBindUniforms(true);
-  if (source_options.target_platform == TargetPlatform::kVulkan ||
-      source_options.target_platform == TargetPlatform::kRuntimeStageVulkan) {
-    SetBindingBase(spirv_options);
-  }
+  SetBindingBase(spirv_options);
   spirv_options.SetAutoMapLocations(true);
 
   std::vector<std::string> included_file_names;


### PR DESCRIPTION
This makes the generated metadata for all backends interchangeable. The Metal backends don't use the this offset at all so it doesn't matter.

This unblocks macOS Vulkan builds.