### PR TITLE
[Impeller] Make validation logs non-fatal by default.

### DIFF
--- a/impeller/base/validation.h
+++ b/impeller/base/validation.h
@@ -24,7 +24,9 @@ class ValidationLog {
   FML_DISALLOW_COPY_ASSIGN_AND_MOVE(ValidationLog);
 };
 
-void ImpellerValidationBreak();
+void ImpellerValidationBreak(const char* message);
+
+void ImpellerValidationErrorsSetFatal(bool fatal);
 
 struct ScopedValidationDisable {
   ScopedValidationDisable();

--- a/impeller/playground/playground_test.cc
+++ b/impeller/playground/playground_test.cc
@@ -5,6 +5,7 @@
 #include "flutter/fml/time/time_point.h"
 
 #include "impeller/base/timing.h"
+#include "impeller/base/validation.h"
 #include "impeller/playground/playground_test.h"
 
 namespace impeller {
@@ -24,6 +25,8 @@ void PlaygroundTest::SetUp() {
     GTEST_SKIP_("Skipping due to user action.");
     return;
   }
+
+  ImpellerValidationErrorsSetFatal(true);
 
   SetupContext(GetParam());
   SetupWindow();


### PR DESCRIPTION
They will still be fatal in tests and no logs will show up in release.

Fixes https://github.com/flutter/flutter/issues/123884

In fixing the linked issue, I didn't want to risk us having a stray validation log tear down the release process. This is safer and gets us the information we need during development.