### PR TITLE
[Impeller] Remove redundant TargetPlatformNeedsSL.

### DIFF
--- a/impeller/compiler/compiler.cc
+++ b/impeller/compiler/compiler.cc
@@ -362,8 +362,7 @@ Compiler::Compiler(const fml::Mapping& source_mapping,
   shaderc::CompileOptions spirv_options;
 
   // Make sure reflection is as effective as possible. The generated shaders
-  // will be processed later by backend specific compilers. So optimizations
-  // here are irrelevant and get in the way of generating reflection code.
+  // will be processed later by backend specific compilers.
   spirv_options.SetGenerateDebugInfo();
 
   switch (options_.source_language) {
@@ -509,11 +508,6 @@ Compiler::Compiler(const fml::Mapping& source_mapping,
     return;
   } else {
     included_file_names_ = std::move(included_file_names);
-  }
-
-  if (!TargetPlatformNeedsSL(source_options.target_platform)) {
-    is_valid_ = true;
-    return;
   }
 
   // SL Generation.

--- a/impeller/compiler/compiler_test.cc
+++ b/impeller/compiler/compiler_test.cc
@@ -107,19 +107,17 @@ bool CompilerTest::CanCompileAndReflect(const char* fixture_name,
     return false;
   }
 
-  if (TargetPlatformNeedsSL(GetParam())) {
-    auto sl_source = compiler.GetSLShaderSource();
-    if (!sl_source) {
-      VALIDATION_LOG << "No SL source was generated.";
-      return false;
-    }
+  auto sl_source = compiler.GetSLShaderSource();
+  if (!sl_source) {
+    VALIDATION_LOG << "No SL source was generated.";
+    return false;
+  }
 
-    if (!fml::WriteAtomically(intermediates_directory_,
-                              SLFileName(fixture_name, GetParam()).c_str(),
-                              *sl_source)) {
-      VALIDATION_LOG << "Could not write SL intermediates.";
-      return false;
-    }
+  if (!fml::WriteAtomically(intermediates_directory_,
+                            SLFileName(fixture_name, GetParam()).c_str(),
+                            *sl_source)) {
+    VALIDATION_LOG << "Could not write SL intermediates.";
+    return false;
   }
 
   if (TargetPlatformNeedsReflection(GetParam())) {

--- a/impeller/compiler/switches.cc
+++ b/impeller/compiler/switches.cc
@@ -214,7 +214,7 @@ bool Switches::AreValid(std::ostream& explain) const {
     valid = false;
   }
 
-  if (sl_file_name.empty() && TargetPlatformNeedsSL(target_platform)) {
+  if (sl_file_name.empty()) {
     explain << "Target shading language file name was empty." << std::endl;
     valid = false;
   }

--- a/impeller/compiler/types.cc
+++ b/impeller/compiler/types.cc
@@ -123,24 +123,6 @@ std::string EntryPointFunctionNameFromSourceName(
   return stream.str();
 }
 
-bool TargetPlatformNeedsSL(TargetPlatform platform) {
-  switch (platform) {
-    case TargetPlatform::kMetalIOS:
-    case TargetPlatform::kMetalDesktop:
-    case TargetPlatform::kOpenGLES:
-    case TargetPlatform::kOpenGLDesktop:
-    case TargetPlatform::kRuntimeStageMetal:
-    case TargetPlatform::kRuntimeStageGLES:
-    case TargetPlatform::kRuntimeStageVulkan:
-    case TargetPlatform::kSkSL:
-    case TargetPlatform::kVulkan:
-      return true;
-    case TargetPlatform::kUnknown:
-      return false;
-  }
-  FML_UNREACHABLE();
-}
-
 bool TargetPlatformNeedsReflection(TargetPlatform platform) {
   switch (platform) {
     case TargetPlatform::kMetalIOS:

--- a/impeller/compiler/types.h
+++ b/impeller/compiler/types.h
@@ -66,8 +66,6 @@ std::string EntryPointFunctionNameFromSourceName(
     SourceLanguage source_language,
     const std::string& entry_point_name);
 
-bool TargetPlatformNeedsSL(TargetPlatform platform);
-
 bool TargetPlatformNeedsReflection(TargetPlatform platform);
 
 bool TargetPlatformBundlesSkSL(TargetPlatform platform);


### PR DESCRIPTION
TargetPlatformNeedsSL was true for all target platforms.

I believe we reworked this after we started embedding metadata in IPLR files perhaps? In any case, this seemed unused and was making the code harder to read. Just a cleanup that I didn't want to include in the compiler rework for SPIRV.