### PR TITLE
Migrate mac_unopt to engine_v2.

### DIFF
--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -1,0 +1,108 @@
+{
+    "builds": [
+        {
+            "archives": [
+                {
+                    "base_path": "out/host_debug_unopt/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                    ],
+                    "name": "host_debug_unopt"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=x86"
+            ],
+            "gclient_custom_vars": {
+                "download_android_deps": false
+            },
+            "gn": [
+		"--runtime-mode debug",
+	       "--unoptimized",
+	       "--no-lto",
+	       "--prebuilt-dart-sdk"
+            ],
+            "name": "host_debug_unopt",
+            "ninja": {
+                "config": "host_debug_unopt",
+                "targets": [
+                ]
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_debug_unopt",
+                    "parameters": [
+                        "--variant",
+                        "host_profile",
+                        "--type",
+                        "dart,engine",
+                        "--engine-capture-core-dump"
+                    ],
+                    "script": "flutter/testing/run_tests.py",
+                    "type": "local"
+                }
+	    ]
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ios_debug_sim/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                    ],
+                    "name": "ios_debug_sim"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=x86"
+            ],
+            "gclient_custom_vars": {
+                "download_android_deps": false
+            },
+            "gn": [
+		"--ios",
+	        "--runtime-mode debug",
+	        "--simulator",
+	       	"--no-lto"
+            ],
+            "name": "ios_debug_sim",
+            "ninja": {
+                "config": "ios_debug_sim",
+                "targets": [
+                ]
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Tests for ios_debug_sim",
+                    "parameters": [
+                        "--variant",
+                        "ios_debug_sim",
+                        "--type",
+                        "objc",
+                        "--engine-capture-core-dump",
+			"--ios-variant",
+                        "ios_debug_sim"
+                    ],
+                    "script": "flutter/testing/run_tests.py",
+                    "type": "local"
+                },
+                {
+                    "name": "Scenario App Integration Tests",
+                    "parameters": [
+                        "ios_debug_sim"
+                    ],
+                    "script": "flutter/testing/scenario_app/run_ios_tests.sh",
+                    "type": "local"
+                }
+
+            ]
+        }
+    ],
+    "tests": []
+}


### PR DESCRIPTION
Initial migration of mac_unopt to engine_v2 builds.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
