### PR TITLE
[WIP] Position caret based on glyph cluster boundaries (engine part)

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -219,6 +219,7 @@ typedef CanvasPath Path;
   V(Paragraph, getPositionForOffset, 3)                \
   V(Paragraph, getRectsForPlaceholders, 1)             \
   V(Paragraph, getRectsForRange, 5)                    \
+  V(Paragraph, getGlyphClusterIndex, 1)                \
   V(Paragraph, getWordBoundary, 2)                     \
   V(Paragraph, height, 1)                              \
   V(Paragraph, ideographicBaseline, 1)                 \

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -219,7 +219,7 @@ typedef CanvasPath Path;
   V(Paragraph, getPositionForOffset, 3)                \
   V(Paragraph, getRectsForPlaceholders, 1)             \
   V(Paragraph, getRectsForRange, 5)                    \
-  V(Paragraph, getGlyphClusterIndex, 1)                \
+  V(Paragraph, getNextGlyphClusterBoundary, 2)         \
   V(Paragraph, getWordBoundary, 2)                     \
   V(Paragraph, height, 1)                              \
   V(Paragraph, ideographicBaseline, 1)                 \

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2814,7 +2814,8 @@ class Paragraph extends NativeFieldWrapperClass1 {
   @Native<Handle Function(Pointer<Void>, Double, Double)>(symbol: 'Paragraph::getPositionForOffset')
   external List<int> _getPositionForOffset(double dx, double dy);
 
-  /// Returns the glyph cluster index at the given [offset].
+  /// Returns the index of the next glyph cluster boundary in display order, in the given
+  /// direction.
   int getNextGlyphClusterBoundary(int offset, bool forward) {
     return _getNextGlyphClusterBoundary(offset, forward ? 1 : 0);
   }

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2815,12 +2815,12 @@ class Paragraph extends NativeFieldWrapperClass1 {
   external List<int> _getPositionForOffset(double dx, double dy);
 
   /// Returns the glyph cluster index at the given [offset].
-  int getGlyphClusterIndex(int offset) {
-    return _getGlyphClusterIndex(offset);
+  int getNextGlyphClusterBoundary(int offset, bool forward) {
+    return _getNextGlyphClusterBoundary(offset, forward ? 1 : 0);
   }
 
-  @Native<Handle Function(Pointer<Void>, Uint32)>(symbol: 'Paragraph::getGlyphClusterIndex')
-  external int _getGlyphClusterIndex(int offset);
+  @Native<Uint32 Function(Pointer<Void>, Uint32, Uint32)>(symbol: 'Paragraph::getNextGlyphClusterBoundary')
+  external int _getNextGlyphClusterBoundary(int offset, int forward);
 
   /// Returns the [TextRange] of the word at the given [TextPosition].
   ///

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2814,6 +2814,14 @@ class Paragraph extends NativeFieldWrapperClass1 {
   @Native<Handle Function(Pointer<Void>, Double, Double)>(symbol: 'Paragraph::getPositionForOffset')
   external List<int> _getPositionForOffset(double dx, double dy);
 
+  /// Returns the glyph cluster index at the given [offset].
+  int getGlyphClusterIndex(int offset) {
+    return _getGlyphClusterIndex(offset);
+  }
+
+  @Native<Handle Function(Pointer<Void>, Uint32)>(symbol: 'Paragraph::getGlyphClusterIndex')
+  external int _getGlyphClusterIndex(int offset);
+
   /// Returns the [TextRange] of the word at the given [TextPosition].
   ///
   /// Characters not part of a word, such as spaces, symbols, and punctuation,

--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -116,8 +116,8 @@ Dart_Handle Paragraph::getPositionForOffset(double dx, double dy) {
   return tonic::DartConverter<decltype(result)>::ToDart(result);
 }
 
-unsigned Paragraph::getGlyphClusterIndex(unsigned offset) {
-  return m_paragraph->GetGlyphClusterIndex(offset);
+unsigned Paragraph::getNextGlyphClusterBoundary(unsigned offset, int forward) {
+  return m_paragraph->GetNextGlyphClusterBoundary(offset, forward == 1);
 }
 
 Dart_Handle Paragraph::getWordBoundary(unsigned offset) {

--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -116,6 +116,10 @@ Dart_Handle Paragraph::getPositionForOffset(double dx, double dy) {
   return tonic::DartConverter<decltype(result)>::ToDart(result);
 }
 
+unsigned Paragraph::getGlyphClusterIndex(unsigned offset) {
+  return m_paragraph->GetGlyphClusterIndex(offset);
+}
+
 Dart_Handle Paragraph::getWordBoundary(unsigned offset) {
   txt::Paragraph::Range<size_t> point = m_paragraph->GetWordBoundary(offset);
   std::vector<size_t> result = {point.start, point.end};

--- a/lib/ui/text/paragraph.h
+++ b/lib/ui/text/paragraph.h
@@ -45,6 +45,7 @@ class Paragraph : public RefCountedDartWrappable<Paragraph> {
                                       unsigned boxWidthStyle);
   tonic::Float32List getRectsForPlaceholders();
   Dart_Handle getPositionForOffset(double dx, double dy);
+  unsigned getGlyphClusterIndex(unsigned offset);
   Dart_Handle getWordBoundary(unsigned offset);
   Dart_Handle getLineBoundary(unsigned offset);
   tonic::Float64List computeLineMetrics();

--- a/lib/ui/text/paragraph.h
+++ b/lib/ui/text/paragraph.h
@@ -45,7 +45,7 @@ class Paragraph : public RefCountedDartWrappable<Paragraph> {
                                       unsigned boxWidthStyle);
   tonic::Float32List getRectsForPlaceholders();
   Dart_Handle getPositionForOffset(double dx, double dy);
-  unsigned getGlyphClusterIndex(unsigned offset);
+  unsigned getNextGlyphClusterBoundary(unsigned offset, int forward);
   Dart_Handle getWordBoundary(unsigned offset);
   Dart_Handle getLineBoundary(unsigned offset);
   tonic::Float64List computeLineMetrics();

--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -268,6 +268,10 @@ Paragraph::PositionWithAffinity ParagraphSkia::GetGlyphPositionAtCoordinate(
       skia_pos.position, static_cast<Affinity>(skia_pos.affinity));
 }
 
+size_t ParagraphSkia::GetGlyphClusterIndex(size_t offset) {
+  return paragraph_->clusterIndex(offset);
+}
+
 Paragraph::Range<size_t> ParagraphSkia::GetWordBoundary(size_t offset) {
   skt::SkRange<size_t> range = paragraph_->getWordBoundary(offset);
   return Paragraph::Range<size_t>(range.start, range.end);

--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -268,8 +268,15 @@ Paragraph::PositionWithAffinity ParagraphSkia::GetGlyphPositionAtCoordinate(
       skia_pos.position, static_cast<Affinity>(skia_pos.affinity));
 }
 
-size_t ParagraphSkia::GetGlyphClusterIndex(size_t offset) {
-  return paragraph_->clusterIndex(offset);
+size_t ParagraphSkia::GetNextGlyphClusterBoundary(size_t offset, bool forward) {
+  GlyphClusterInfo glyphInfo;
+  bool found = paragraph_->getGlyphClusterAt(offset, &glyphInfo);
+  if (found) {
+    return (forward == (glyphInfo.fGlyphClusterPosition == TextDirection::kLtr))
+        ? glyphInfo.fClusterTextRange.end
+        : glyphInfo.fClusterTextRange.start;
+  }
+  return -1;
 }
 
 Paragraph::Range<size_t> ParagraphSkia::GetWordBoundary(size_t offset) {

--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -272,9 +272,10 @@ size_t ParagraphSkia::GetNextGlyphClusterBoundary(size_t offset, bool forward) {
   struct skt::Paragraph::GlyphClusterInfo glyphInfo;
   bool found = paragraph_->getGlyphClusterAt(offset, &glyphInfo);
   if (found) {
-    return (forward == (glyphInfo.fGlyphClusterPosition == skt::TextDirection::kLtr))
-        ? glyphInfo.fClusterTextRange.end
-        : glyphInfo.fClusterTextRange.start;
+    return (forward ==
+            (glyphInfo.fGlyphClusterPosition == skt::TextDirection::kLtr))
+               ? glyphInfo.fClusterTextRange.end
+               : glyphInfo.fClusterTextRange.start;
   }
   return -1;
 }

--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -269,7 +269,7 @@ Paragraph::PositionWithAffinity ParagraphSkia::GetGlyphPositionAtCoordinate(
 }
 
 size_t ParagraphSkia::GetNextGlyphClusterBoundary(size_t offset, bool forward) {
-  GlyphClusterInfo glyphInfo;
+  struct GlyphClusterInfo glyphInfo;
   bool found = paragraph_->getGlyphClusterAt(offset, &glyphInfo);
   if (found) {
     return (forward == (glyphInfo.fGlyphClusterPosition == TextDirection::kLtr))

--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -269,10 +269,10 @@ Paragraph::PositionWithAffinity ParagraphSkia::GetGlyphPositionAtCoordinate(
 }
 
 size_t ParagraphSkia::GetNextGlyphClusterBoundary(size_t offset, bool forward) {
-  struct GlyphClusterInfo glyphInfo;
+  struct skt::Paragraph::GlyphClusterInfo glyphInfo;
   bool found = paragraph_->getGlyphClusterAt(offset, &glyphInfo);
   if (found) {
-    return (forward == (glyphInfo.fGlyphClusterPosition == TextDirection::kLtr))
+    return (forward == (glyphInfo.fGlyphClusterPosition == skt::TextDirection::kLtr))
         ? glyphInfo.fClusterTextRange.end
         : glyphInfo.fClusterTextRange.start;
   }

--- a/third_party/txt/src/skia/paragraph_skia.h
+++ b/third_party/txt/src/skia/paragraph_skia.h
@@ -66,6 +66,8 @@ class ParagraphSkia : public Paragraph {
   PositionWithAffinity GetGlyphPositionAtCoordinate(double dx,
                                                     double dy) override;
 
+  size_t GetGlyphClusterIndex(size_t offset) override;
+
   Range<size_t> GetWordBoundary(size_t offset) override;
 
  private:

--- a/third_party/txt/src/skia/paragraph_skia.h
+++ b/third_party/txt/src/skia/paragraph_skia.h
@@ -66,7 +66,7 @@ class ParagraphSkia : public Paragraph {
   PositionWithAffinity GetGlyphPositionAtCoordinate(double dx,
                                                     double dy) override;
 
-  size_t GetGlyphClusterIndex(size_t offset) override;
+  size_t GetNextGlyphClusterBoundary(size_t offset, bool forward) override;
 
   Range<size_t> GetWordBoundary(size_t offset) override;
 

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -175,7 +175,7 @@ class Paragraph {
 
   // Returns the next glyph cluster boundary offset after or before the given
   // index offset.
-  size_t GetNextGlyphClusterBoundary(size_t offset, bool forward) = 0;
+  virtual size_t GetNextGlyphClusterBoundary(size_t offset, bool forward) = 0;
 
   // Finds the first and last glyphs that define a word containing the glyph at
   // index offset.

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -173,8 +173,9 @@ class Paragraph {
   virtual PositionWithAffinity GetGlyphPositionAtCoordinate(double dx,
                                                             double dy) = 0;
 
-  // Returns the glyph cluster index at the given index offset.
-  virtual size_t GetGlyphClusterIndex(size_t offset) = 0;
+  // Returns the next glyph cluster boundary offset after or before the given
+  // index offset.
+  size_t GetNextGlyphClusterBoundary(size_t offset, bool forward) = 0;
 
   // Finds the first and last glyphs that define a word containing the glyph at
   // index offset.

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -173,6 +173,9 @@ class Paragraph {
   virtual PositionWithAffinity GetGlyphPositionAtCoordinate(double dx,
                                                             double dy) = 0;
 
+  // Returns the glyph cluster index at the given index offset.
+  virtual size_t GetGlyphClusterIndex(size_t offset) = 0;
+
   // Finds the first and last glyphs that define a word containing the glyph at
   // index offset.
   virtual Range<size_t> GetWordBoundary(size_t offset) = 0;


### PR DESCRIPTION
*WIP*

This PR exposes an API to get glyph cluster index at a given text offset.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
