### PR TITLE
[Impeller] Add subpass blend goldens

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1287,6 +1287,8 @@ TEST_P(AiksTest, PaintBlendModeIsRespected) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+#define BLEND_MODE_TUPLE(blend_mode) {#blend_mode, BlendMode::k##blend_mode},
+
 TEST_P(AiksTest, ColorWheel) {
   // Compare with https://fiddle.skia.org/c/@BlendModes
 
@@ -1294,38 +1296,7 @@ TEST_P(AiksTest, ColorWheel) {
   std::vector<BlendMode> blend_mode_values;
   {
     const std::vector<std::tuple<const char*, BlendMode>> blends = {
-        // Pipeline blends (Porter-Duff alpha compositing)
-        {"Clear", BlendMode::kClear},
-        {"Source", BlendMode::kSource},
-        {"Destination", BlendMode::kDestination},
-        {"SourceOver", BlendMode::kSourceOver},
-        {"DestinationOver", BlendMode::kDestinationOver},
-        {"SourceIn", BlendMode::kSourceIn},
-        {"DestinationIn", BlendMode::kDestinationIn},
-        {"SourceOut", BlendMode::kSourceOut},
-        {"DestinationOut", BlendMode::kDestinationOut},
-        {"SourceATop", BlendMode::kSourceATop},
-        {"DestinationATop", BlendMode::kDestinationATop},
-        {"Xor", BlendMode::kXor},
-        {"Plus", BlendMode::kPlus},
-        {"Modulate", BlendMode::kModulate},
-        // Advanced blends (color component blends)
-        {"Screen", BlendMode::kScreen},
-        {"Overlay", BlendMode::kOverlay},
-        {"Darken", BlendMode::kDarken},
-        {"Lighten", BlendMode::kLighten},
-        {"ColorDodge", BlendMode::kColorDodge},
-        {"ColorBurn", BlendMode::kColorBurn},
-        {"HardLight", BlendMode::kHardLight},
-        {"SoftLight", BlendMode::kSoftLight},
-        {"Difference", BlendMode::kDifference},
-        {"Exclusion", BlendMode::kExclusion},
-        {"Multiply", BlendMode::kMultiply},
-        {"Hue", BlendMode::kHue},
-        {"Saturation", BlendMode::kSaturation},
-        {"Color", BlendMode::kColor},
-        {"Luminosity", BlendMode::kLuminosity},
-    };
+        IMPELLER_FOR_EACH_BLEND_MODE(BLEND_MODE_TUPLE)};
     assert(blends.size() ==
            static_cast<size_t>(Entity::kLastAdvancedBlendMode) + 1);
     for (const auto& [name, mode] : blends) {
@@ -1939,7 +1910,7 @@ TEST_P(AiksTest, DrawPaintAbsorbsClears) {
   ASSERT_EQ(picture.pass->GetClearColor(), Color::CornflowerBlue());
 }
 
-Picture BlendModeTest(BlendMode blend_mode) {
+static Picture BlendModeSaveLayerTest(BlendMode blend_mode) {
   Canvas canvas;
   canvas.DrawPaint({.color = Color::CornflowerBlue().WithAlpha(0.75)});
   canvas.SaveLayer({.blend_mode = blend_mode});
@@ -1950,9 +1921,9 @@ Picture BlendModeTest(BlendMode blend_mode) {
   return canvas.EndRecordingAsPicture();
 }
 
-#define BLEND_MODE_TEST(blend_mode)                              \
-  TEST_P(AiksTest, BlendMode##blend_mode) {                      \
-    OpenPlaygroundHere(BlendModeTest(BlendMode::k##blend_mode)); \
+#define BLEND_MODE_TEST(blend_mode)                                       \
+  TEST_P(AiksTest, BlendModeSaveLayer##blend_mode) {                      \
+    OpenPlaygroundHere(BlendModeSaveLayerTest(BlendMode::k##blend_mode)); \
   }
 IMPELLER_FOR_EACH_BLEND_MODE(BLEND_MODE_TEST)
 

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1939,5 +1939,22 @@ TEST_P(AiksTest, DrawPaintAbsorbsClears) {
   ASSERT_EQ(picture.pass->GetClearColor(), Color::CornflowerBlue());
 }
 
+Picture BlendModeTest(BlendMode blend_mode) {
+  Canvas canvas;
+  canvas.DrawPaint({.color = Color::CornflowerBlue().WithAlpha(0.75)});
+  canvas.SaveLayer({.blend_mode = blend_mode});
+  for (auto& color : {Color::White(), Color::LimeGreen(), Color::Black()}) {
+    canvas.DrawRect({100, 100, 200, 200}, {.color = color.WithAlpha(0.75)});
+    canvas.Translate(Vector2(150, 100));
+  }
+  return canvas.EndRecordingAsPicture();
+}
+
+#define BLEND_MODE_TEST(blend_mode)                              \
+  TEST_P(AiksTest, BlendMode##blend_mode) {                      \
+    OpenPlaygroundHere(BlendModeTest(BlendMode::k##blend_mode)); \
+  }
+IMPELLER_FOR_EACH_BLEND_MODE(BLEND_MODE_TEST)
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/geometry/color.cc
+++ b/impeller/geometry/color.cc
@@ -13,6 +13,28 @@
 
 namespace impeller {
 
+#define _IMPELLER_ASSERT_BLEND_MODE(blend_mode)                            \
+  auto enum_##blend_mode = static_cast<std::underlying_type_t<BlendMode>>( \
+      BlendMode::k##blend_mode);                                           \
+  if (i != enum_##blend_mode) {                                            \
+    return false;                                                          \
+  }                                                                        \
+  ++i;
+
+constexpr inline bool ValidateBlendModes() {
+  std::underlying_type_t<BlendMode> i = 0;
+  // Ensure the order of the blend modes match.
+  IMPELLER_FOR_EACH_BLEND_MODE(_IMPELLER_ASSERT_BLEND_MODE)
+  // Ensure the total number of blend modes match.
+  if (i - 1 !=
+      static_cast<std::underlying_type_t<BlendMode>>(BlendMode::kLast)) {
+    return false;
+  }
+  return true;
+}
+static_assert(ValidateBlendModes(),
+              "IMPELLER_FOR_EACH_BLEND_MODE must match impeller::BlendMode.");
+
 ColorHSB ColorHSB::FromRGB(Color rgb) {
   Scalar R = rgb.red;
   Scalar G = rgb.green;

--- a/impeller/geometry/color.cc
+++ b/impeller/geometry/color.cc
@@ -21,7 +21,7 @@ namespace impeller {
   }                                                                        \
   ++i;
 
-constexpr inline bool ValidateBlendModes() {
+static constexpr inline bool ValidateBlendModes() {
   std::underlying_type_t<BlendMode> i = 0;
   // Ensure the order of the blend modes match.
   IMPELLER_FOR_EACH_BLEND_MODE(_IMPELLER_ASSERT_BLEND_MODE)

--- a/impeller/geometry/color.h
+++ b/impeller/geometry/color.h
@@ -8,7 +8,39 @@
 #include <array>
 #include <cstdlib>
 #include <ostream>
+#include <type_traits>
 #include "impeller/geometry/scalar.h"
+
+#define IMPELLER_FOR_EACH_BLEND_MODE(V) \
+  V(Clear)                              \
+  V(Source)                             \
+  V(Destination)                        \
+  V(SourceOver)                         \
+  V(DestinationOver)                    \
+  V(SourceIn)                           \
+  V(DestinationIn)                      \
+  V(SourceOut)                          \
+  V(DestinationOut)                     \
+  V(SourceATop)                         \
+  V(DestinationATop)                    \
+  V(Xor)                                \
+  V(Plus)                               \
+  V(Modulate)                           \
+  V(Screen)                             \
+  V(Overlay)                            \
+  V(Darken)                             \
+  V(Lighten)                            \
+  V(ColorDodge)                         \
+  V(ColorBurn)                          \
+  V(HardLight)                          \
+  V(SoftLight)                          \
+  V(Difference)                         \
+  V(Exclusion)                          \
+  V(Multiply)                           \
+  V(Hue)                                \
+  V(Saturation)                         \
+  V(Color)                              \
+  V(Luminosity)
 
 namespace impeller {
 
@@ -55,6 +87,8 @@ enum class BlendMode {
   kSaturation,
   kColor,
   kLuminosity,
+
+  kLast = kLuminosity,
 };
 
 /**


### PR DESCRIPTION
Adds a checked macro "loop" for the blend modes in the style of `FOR_EACH_DISPLAY_LIST_OP` + a quick golden for each blend mode that runs the `EntityPass` subpass blending paths.

We should also add Aiks tests to verify the filters in a more comprehensive way (including the blend filter). I can do this in a follow-up. The BlendFilter actually uses different shaders than SaveLayer for the advanced blends on Metal -- the two code paths are wildly different, and we've had serious regressions for both cases.


https://user-images.githubusercontent.com/919017/229463806-c3f20baf-f379-4d14-999b-aab3aec188d7.mov
