### PR TITLE
[Impeller] Don't crash in image decompression if the context is unavailable.

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -406,7 +406,10 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
        result,
        supports_wide_gamut = supports_wide_gamut_  //
   ]() {
-        FML_CHECK(context) << "No valid impeller context";
+        if (!context) {
+          result(nullptr);
+          return;
+        }
         auto max_size_supported =
             context->GetResourceAllocator()->GetMaxTextureSizeSupported();
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/123027.

Turns out, this isn't an issue with backgrounding. This can only happen if the IO manager is torn down before worker pool has had a chance to process the decompression job, or if the UI manager was never setup. It is hard to imaging how this could happen in a real application. If it does though, we should not crash. This patch makes the change to return an error instead. The linked issue was a test environment and the failure was addressed in https://github.com/flutter/engine/pull/40535.