### PR TITLE
Revert "[Impeller] iOS/macOS: Only wait for command scheduling prior to present"

### DIFF
--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -167,6 +167,27 @@ bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
 
   [buffer_ commit];
 
+#if (FML_OS_MACOSX || FML_OS_IOS_SIMULATOR)
+  // We're using waitUntilScheduled on macOS and iOS simulator to force a hard
+  // barrier between the execution of different command buffers. This forces all
+  // renderable texture access to be synchronous (i.e. a write from a previous
+  // command buffer will not get scheduled to happen at the same time as a read
+  // in a future command buffer).
+  //
+  // Metal hazard tracks shared memory resources by default, and we don't need
+  // to do any additional work to synchronize access to MTLTextures and
+  // MTLBuffers on iOS devices with UMA. However, shared textures are disallowed
+  // on macOS according to the documentation:
+  // https://developer.apple.com/documentation/metal/mtlstoragemode/shared
+  // And so this is a stopgap solution that has been present in Impeller since
+  // multi-pass rendering/SaveLayer support was first set up.
+  //
+  // TODO(bdero): Remove this for all targets once a solution for resource
+  //              tracking that works everywhere is established:
+  //              https://github.com/flutter/flutter/issues/120406
+  [buffer_ waitUntilScheduled];
+#endif
+
   buffer_ = nil;
   return true;
 }

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -64,8 +64,6 @@ class ContextMTL final : public Context,
   // |Context|
   bool UpdateOffscreenLayerPixelFormat(PixelFormat format) override;
 
-  id<MTLCommandBuffer> CreateMTLCommandBuffer() const;
-
  private:
   id<MTLDevice> device_ = nullptr;
   id<MTLCommandQueue> command_queue_ = nullptr;

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -291,8 +291,4 @@ bool ContextMTL::UpdateOffscreenLayerPixelFormat(PixelFormat format) {
   return true;
 }
 
-id<MTLCommandBuffer> ContextMTL::CreateMTLCommandBuffer() const {
-  return [command_queue_ commandBuffer];
-}
-
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/surface_mtl.h
+++ b/impeller/renderer/backend/metal/surface_mtl.h
@@ -43,12 +43,9 @@ class SurfaceMTL final : public Surface {
   id<MTLDrawable> drawable() const { return drawable_; }
 
  private:
-  std::weak_ptr<Context> context_;
   id<MTLDrawable> drawable_ = nil;
 
-  SurfaceMTL(const std::weak_ptr<Context>& context,
-             const RenderTarget& target,
-             id<MTLDrawable> drawable);
+  SurfaceMTL(const RenderTarget& target, id<MTLDrawable> drawable);
 
   // |Surface|
   bool Present() const override;

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -6,7 +6,6 @@
 
 #include "flutter/fml/trace_event.h"
 #include "impeller/base/validation.h"
-#include "impeller/renderer/backend/metal/context_mtl.h"
 #include "impeller/renderer/backend/metal/formats_mtl.h"
 #include "impeller/renderer/backend/metal/texture_mtl.h"
 #include "impeller/renderer/render_target.h"
@@ -112,14 +111,12 @@ std::unique_ptr<SurfaceMTL> SurfaceMTL::WrapCurrentMetalLayerDrawable(
   render_target_desc.SetStencilAttachment(stencil0);
 
   // The constructor is private. So make_unique may not be used.
-  return std::unique_ptr<SurfaceMTL>(new SurfaceMTL(
-      context->weak_from_this(), render_target_desc, current_drawable));
+  return std::unique_ptr<SurfaceMTL>(
+      new SurfaceMTL(render_target_desc, current_drawable));
 }
 
-SurfaceMTL::SurfaceMTL(const std::weak_ptr<Context>& context,
-                       const RenderTarget& target,
-                       id<MTLDrawable> drawable)
-    : Surface(target), context_(context), drawable_(drawable) {}
+SurfaceMTL::SurfaceMTL(const RenderTarget& target, id<MTLDrawable> drawable)
+    : Surface(target), drawable_(drawable) {}
 
 // |Surface|
 SurfaceMTL::~SurfaceMTL() = default;
@@ -130,16 +127,7 @@ bool SurfaceMTL::Present() const {
     return false;
   }
 
-  auto context = context_.lock();
-  if (!context) {
-    return false;
-  }
-
-  id<MTLCommandBuffer> command_buffer =
-      ContextMTL::Cast(context.get())->CreateMTLCommandBuffer();
-  [command_buffer presentDrawable:drawable_];
-  [command_buffer commit];
-
+  [drawable_ present];
   return true;
 }
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Reverts flutter/engine#40781

Fixes https://github.com/flutter/flutter/issues/124056

When unmerging threads we appear to get stuck for multiple seconds. Haven't debugged further, but bisected to this commit.