### PR TITLE
[Impeller] convert blend shaders to half precision

### DIFF
--- a/impeller/compiler/shader_lib/impeller/branching.glsl
+++ b/impeller/compiler/shader_lib/impeller/branching.glsl
@@ -49,4 +49,24 @@ vec3 IPVec3Choose(vec3 a, vec3 b, vec3 value) {
   return IPVec3ChooseCutoff(a, b, value, 0.5);
 }
 
+/// Perform a branchless greater than check for each vec3 component.
+///
+/// Returns 1.0 if x > y, otherwise 0.0.
+f16vec3 IPHalfVec3IsGreaterThan(f16vec3 x, f16vec3 y) {
+  return max(sign(x - y), 0.0hf);
+}
+
+/// For each vec3 component, if value > cutoff, return b, otherwise return a.
+f16vec3 IPHalfVec3ChooseCutoff(f16vec3 a,
+                               f16vec3 b,
+                               f16vec3 value,
+                               float16_t cutoff) {
+  return mix(a, b, IPHalfVec3IsGreaterThan(value, f16vec3(cutoff)));
+}
+
+/// For each vec3 component, if value > 0.5, return b, otherwise return a.
+f16vec3 IPHalfVec3Choose(f16vec3 a, f16vec3 b, f16vec3 value) {
+  return IPHalfVec3ChooseCutoff(a, b, value, 0.5hf);
+}
+
 #endif

--- a/impeller/compiler/shader_lib/impeller/branching.glsl
+++ b/impeller/compiler/shader_lib/impeller/branching.glsl
@@ -53,7 +53,7 @@ vec3 IPVec3Choose(vec3 a, vec3 b, vec3 value) {
 ///
 /// Returns 1.0 if x > y, otherwise 0.0.
 f16vec3 IPHalfVec3IsGreaterThan(f16vec3 x, f16vec3 y) {
-  return max(sign(x - y), 0.0hf);
+  return max(sign(x - y), float16_t(0.0hf));
 }
 
 /// For each vec3 component, if value > cutoff, return b, otherwise return a.
@@ -66,7 +66,7 @@ f16vec3 IPHalfVec3ChooseCutoff(f16vec3 a,
 
 /// For each vec3 component, if value > 0.5, return b, otherwise return a.
 f16vec3 IPHalfVec3Choose(f16vec3 a, f16vec3 b, f16vec3 value) {
-  return IPHalfVec3ChooseCutoff(a, b, value, 0.5hf);
+  return IPHalfVec3ChooseCutoff(a, b, value, float16_t(0.5hf));
 }
 
 #endif

--- a/impeller/compiler/shader_lib/impeller/constants.glsl
+++ b/impeller/compiler/shader_lib/impeller/constants.glsl
@@ -5,7 +5,12 @@
 #ifndef CONSTANTS_GLSL_
 #define CONSTANTS_GLSL_
 
+#include <impeller/types.glsl>
+
 const float kEhCloseEnough = 0.000001;
+
+// 1/1024.
+const float16_t kEhCloseEnoughHalf = 0.0009765625hf;
 
 // 1 / (2 * pi)
 const float k1Over2Pi = 0.1591549430918;

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -8,21 +8,21 @@
 #include <impeller/types.glsl>
 
 uniform BlendInfo {
-  float dst_input_alpha;
-  float color_factor;
-  vec4 color;  // This color input is expected to be unpremultiplied.
+  float16_t dst_input_alpha;
+  float16_t color_factor;
+  f16vec4 color;  // This color input is expected to be unpremultiplied.
 }
 blend_info;
 
-uniform sampler2D texture_sampler_dst;
-uniform sampler2D texture_sampler_src;
+uniform f16sampler2D texture_sampler_dst;
+uniform f16sampler2D texture_sampler_src;
 
 in vec2 v_dst_texture_coords;
 in vec2 v_src_texture_coords;
 
-out vec4 frag_color;
+out f16vec4 frag_color;
 
-vec4 Sample(sampler2D texture_sampler, vec2 texture_coords) {
+f16vec4 Sample(f16sampler2D texture_sampler, vec2 texture_coords) {
 // gles 2.0 is the only backend without native decal support.
 #ifdef IMPELLER_TARGET_OPENGLES
   return IPSampleDecal(texture_sampler, texture_coords);
@@ -32,20 +32,20 @@ vec4 Sample(sampler2D texture_sampler, vec2 texture_coords) {
 }
 
 void main() {
-  vec4 dst_sample = Sample(texture_sampler_dst,  // sampler
-                           v_dst_texture_coords  // texture coordinates
-                           ) *
-                    blend_info.dst_input_alpha;
+  f16vec4 dst_sample = Sample(texture_sampler_dst,  // sampler
+                              v_dst_texture_coords  // texture coordinates
+                              ) *
+                       blend_info.dst_input_alpha;
 
-  vec4 dst = IPUnpremultiply(dst_sample);
-  vec4 src =
-      blend_info.color_factor > 0
-          ? blend_info.color
-          : IPUnpremultiply(Sample(texture_sampler_src,  // sampler
-                                   v_src_texture_coords  // texture coordinates
-                                   ));
+  f16vec4 dst = IPHalfUnpremultiply(dst_sample);
+  f16vec4 src = blend_info.color_factor > 0.0hf
+                    ? blend_info.color
+                    : IPHalfUnpremultiply(Sample(
+                          texture_sampler_src,  // sampler
+                          v_src_texture_coords  // texture coordinates
+                          ));
 
-  vec4 blended = vec4(Blend(dst.rgb, src.rgb), 1) * dst.a;
+  f16vec4 blended = f16vec4(Blend(dst.rgb, src.rgb), 1.0hf) * dst.a;
 
   frag_color = mix(dst_sample, blended, src.a);
 }

--- a/impeller/entity/shaders/blending/advanced_blend_color.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_color.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendColor(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendColorBurn(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendColorDodge(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_darken.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_darken.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendDarken(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_difference.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_difference.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendDifference(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_exclusion.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_exclusion.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendExclusion(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_hardlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_hardlight.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendHardLight(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_hue.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_hue.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendHue(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_lighten.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_lighten.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendLighten(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_luminosity.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_luminosity.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendLuminosity(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_multiply.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_multiply.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendMultiply(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_overlay.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_overlay.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendOverlay(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_saturation.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_saturation.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendSaturation(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_screen.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_screen.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendScreen(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/advanced_blend_softlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_softlight.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendSoftLight(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/blend.frag
+++ b/impeller/entity/shaders/blending/blend.frag
@@ -5,16 +5,16 @@
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 
-uniform sampler2D texture_sampler_src;
+uniform f16sampler2D texture_sampler_src;
 
 uniform FragInfo {
-  float input_alpha;
+  float16_t input_alpha;
 }
 frag_info;
 
 in vec2 v_texture_coords;
 
-out vec4 frag_color;
+out f16vec4 frag_color;
 
 void main() {
   frag_color =

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend.glsl
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend.glsl
@@ -31,14 +31,14 @@ in vec2 v_src_texture_coords;
 out vec4 frag_color;
 
 void main() {
-  vec4 dst_sample = ReadDestination();
-  vec4 dst = IPUnpremultiply(dst_sample);
-  vec4 src =
-      IPUnpremultiply(texture(texture_sampler_src,  // sampler
-                              v_src_texture_coords  // texture coordinates
-                              ));
+  f16vec4 dst_sample = f16vec4(ReadDestination());
+  f16vec4 dst = IPHalfUnpremultiply(dst_sample);
+  f16vec4 src = IPHalfUnpremultiply(
+      f16vec4(texture(texture_sampler_src,  // sampler
+                      v_src_texture_coords  // texture coordinates
+                      )));
 
-  vec4 blended = vec4(Blend(dst.rgb, src.rgb), 1) * dst.a;
+  f16vec4 blended = f16vec4(Blend(dst.rgb, src.rgb), 1.0hf) * dst.a;
 
-  frag_color = mix(dst_sample, blended, src.a);
+  frag_color = vec4(mix(dst_sample, blended, src.a));
 }

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_color.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_color.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendColor(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_colorburn.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_colorburn.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendColorBurn(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_colordodge.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_colordodge.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendColorDodge(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_darken.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_darken.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendDarken(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_difference.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_difference.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendDifference(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_exclusion.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_exclusion.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendExclusion(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_hardlight.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_hardlight.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendHardLight(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_hue.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_hue.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendHue(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_lighten.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_lighten.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendLighten(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_luminosity.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_luminosity.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendLuminosity(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_multiply.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_multiply.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendMultiply(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_overlay.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_overlay.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendOverlay(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_saturation.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_saturation.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendSaturation(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_screen.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_screen.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendScreen(dst, src);
 }
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_softlight.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_softlight.frag
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 #include <impeller/blending.glsl>
+#include <impeller/types.glsl>
 
-vec3 Blend(vec3 dst, vec3 src) {
+f16vec3 Blend(f16vec3 dst, f16vec3 src) {
   return IPBlendSoftLight(dst, src);
 }
 

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -124,7 +124,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 59,
+          "fp16_arithmetic": 88,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -132,9 +132,9 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.65625,
-              0.65625,
-              0.328125,
+              0.59375,
+              0.59375,
+              0.28125,
               0.25,
               0.0,
               0.5,
@@ -167,9 +167,9 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.65625,
-              0.65625,
-              0.375,
+              0.59375,
+              0.59375,
+              0.328125,
               0.25,
               0.0,
               0.5,
@@ -179,7 +179,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 15
+          "work_registers_used": 12
         }
       }
     }
@@ -197,7 +197,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 70,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -205,9 +205,9 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.4375,
-              0.296875,
-              0.4375,
+              0.421875,
+              0.265625,
+              0.421875,
               0.3125,
               0.0,
               0.5,
@@ -227,9 +227,9 @@
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.421875,
-              0.265625,
-              0.421875,
+              0.40625,
+              0.234375,
+              0.40625,
               0.25,
               0.0,
               0.25,
@@ -240,9 +240,9 @@
               "texture"
             ],
             "total_cycles": [
-              0.484375,
-              0.296875,
-              0.484375,
+              0.46875,
+              0.265625,
+              0.46875,
               0.3125,
               0.0,
               0.5,
@@ -251,7 +251,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 8,
+          "uniform_registers_used": 12,
           "work_registers_used": 15
         }
       }
@@ -270,7 +270,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 65,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -278,9 +278,9 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.4375,
-              0.265625,
-              0.4375,
+              0.421875,
+              0.234375,
+              0.421875,
               0.3125,
               0.0,
               0.5,
@@ -300,9 +300,9 @@
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.421875,
-              0.234375,
-              0.421875,
+              0.40625,
+              0.203125,
+              0.40625,
               0.25,
               0.0,
               0.25,
@@ -313,9 +313,9 @@
               "texture"
             ],
             "total_cycles": [
-              0.484375,
-              0.265625,
-              0.484375,
+              0.46875,
+              0.234375,
+              0.46875,
               0.3125,
               0.0,
               0.5,
@@ -324,8 +324,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 8,
-          "work_registers_used": 15
+          "uniform_registers_used": 12,
+          "work_registers_used": 13
         }
       }
     }
@@ -637,7 +637,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 69,
+          "fp16_arithmetic": 91,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -645,9 +645,9 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.762499988079071,
-              0.762499988079071,
-              0.5,
+              0.699999988079071,
+              0.699999988079071,
+              0.453125,
               0.3125,
               0.0,
               0.5,
@@ -680,9 +680,9 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.762499988079071,
-              0.762499988079071,
-              0.578125,
+              0.699999988079071,
+              0.699999988079071,
+              0.53125,
               0.3125,
               0.0,
               0.5,
@@ -692,7 +692,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 15
+          "work_registers_used": 13
         }
       }
     }
@@ -783,7 +783,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 59,
+          "fp16_arithmetic": 88,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -791,9 +791,9 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.65625,
-              0.65625,
-              0.328125,
+              0.59375,
+              0.59375,
+              0.28125,
               0.25,
               0.0,
               0.5,
@@ -826,9 +826,9 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.65625,
-              0.65625,
-              0.375,
+              0.59375,
+              0.59375,
+              0.328125,
               0.25,
               0.0,
               0.5,
@@ -838,7 +838,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 15
+          "work_registers_used": 12
         }
       }
     }
@@ -1002,7 +1002,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 69,
+          "fp16_arithmetic": 91,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -1010,9 +1010,9 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.762499988079071,
-              0.762499988079071,
-              0.5,
+              0.699999988079071,
+              0.699999988079071,
+              0.453125,
               0.3125,
               0.0,
               0.5,
@@ -1045,9 +1045,9 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.762499988079071,
-              0.762499988079071,
-              0.578125,
+              0.699999988079071,
+              0.699999988079071,
+              0.53125,
               0.3125,
               0.0,
               0.5,
@@ -1057,7 +1057,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 15
+          "work_registers_used": 13
         }
       }
     }
@@ -3687,16 +3687,16 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 82,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "arith_total",
-              "arith_fma"
+              "arith_sfu"
             ],
             "longest_path_cycles": [
-              0.65625,
-              0.65625,
+              0.625,
+              0.59375,
               0.53125,
               0.625,
               0.0,
@@ -3727,11 +3727,11 @@
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_fma"
+              "arith_sfu"
             ],
             "total_cycles": [
-              0.65625,
-              0.65625,
+              0.625,
+              0.59375,
               0.578125,
               0.625,
               0.0,
@@ -3741,7 +3741,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
+          "uniform_registers_used": 10,
           "work_registers_used": 20
         }
       }
@@ -4531,7 +4531,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 86,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -4539,8 +4539,8 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.762499988079071,
-              0.762499988079071,
+              0.699999988079071,
+              0.699999988079071,
               0.6875,
               0.6875,
               0.0,
@@ -4575,7 +4575,7 @@
             ],
             "total_cycles": [
               0.78125,
-              0.762499988079071,
+              0.699999988079071,
               0.78125,
               0.6875,
               0.0,
@@ -4585,7 +4585,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
+          "uniform_registers_used": 10,
           "work_registers_used": 21
         }
       }
@@ -4771,16 +4771,16 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 82,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "arith_total",
-              "arith_fma"
+              "arith_sfu"
             ],
             "longest_path_cycles": [
-              0.65625,
-              0.65625,
+              0.625,
+              0.59375,
               0.53125,
               0.625,
               0.0,
@@ -4811,11 +4811,11 @@
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_fma"
+              "arith_sfu"
             ],
             "total_cycles": [
-              0.65625,
-              0.65625,
+              0.625,
+              0.59375,
               0.578125,
               0.625,
               0.0,
@@ -4825,7 +4825,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
+          "uniform_registers_used": 10,
           "work_registers_used": 20
         }
       }
@@ -5133,7 +5133,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 86,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -5141,8 +5141,8 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.762499988079071,
-              0.762499988079071,
+              0.699999988079071,
+              0.699999988079071,
               0.6875,
               0.6875,
               0.0,
@@ -5177,7 +5177,7 @@
             ],
             "total_cycles": [
               0.78125,
-              0.762499988079071,
+              0.699999988079071,
               0.78125,
               0.6875,
               0.0,
@@ -5187,7 +5187,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
+          "uniform_registers_used": 10,
           "work_registers_used": 21
         }
       }
@@ -9817,7 +9817,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 12,
+          "fp16_arithmetic": 34,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -9861,9 +9861,9 @@
               "arith_cvt"
             ],
             "total_cycles": [
-              0.5625,
+              0.546875,
               0.5,
-              0.5625,
+              0.546875,
               0.375,
               0.0,
               0.25,
@@ -12852,7 +12852,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 15,
+          "fp16_arithmetic": 34,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -12862,8 +12862,8 @@
             "longest_path_cycles": [
               0.421875,
               0.421875,
-              0.359375,
-              0.3125,
+              0.328125,
+              0.25,
               0.0,
               0.25,
               0.25
@@ -12884,8 +12884,8 @@
             "shortest_path_cycles": [
               0.328125,
               0.328125,
-              0.21875,
-              0.3125,
+              0.1875,
+              0.25,
               0.0,
               0.25,
               0.0
@@ -12897,8 +12897,8 @@
             "total_cycles": [
               0.453125,
               0.453125,
-              0.421875,
-              0.3125,
+              0.375,
+              0.25,
               0.0,
               0.25,
               0.25
@@ -12906,8 +12906,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
-          "work_registers_used": 16
+          "uniform_registers_used": 18,
+          "work_registers_used": 15
         }
       }
     }
@@ -12925,7 +12925,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 20,
+          "fp16_arithmetic": 31,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -12951,13 +12951,13 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.3125,
               0.28125,
-              0.1875,
-              0.3125,
+              0.28125,
+              0.171875,
+              0.25,
               0.0,
               0.25,
               0.0
@@ -12966,10 +12966,10 @@
               "load_store"
             ],
             "total_cycles": [
-              0.6875,
-              0.5625,
-              0.6875,
-              0.375,
+              0.65625,
+              0.546875,
+              0.65625,
+              0.3125,
               4.0,
               0.25,
               0.0
@@ -12978,7 +12978,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 16,
-          "work_registers_used": 20
+          "work_registers_used": 18
         }
       }
     }


### PR DESCRIPTION
Converts all advanced blend fragment shaders to half precision. The framebuffer blend shaders must still sample at high precision and then convert for now. We can't use the GLSL extensions and Vulkan semantics required for the subpass, so this needs more work.

Work towards https://github.com/flutter/flutter/issues/115044