### PR TITLE
Exit early on invalid gn CPU argument combos for simulators

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -1036,12 +1036,14 @@ def validate_args(args):
   if args.simulator:
     if args.mac_cpu != 'x64':
       print(
-          "Specified a non-default mac-cpu for a simulator build. Did you mean to use `--simulator-cpu`?"
+          'Specified a non-default mac-cpu for a simulator build. Did you mean '
+          'to use `--simulator-cpu`?'
       )
       valid = False
     if args.ios_cpu != 'arm64':
       print(
-          "Specified a non-default ios-cpu for a simulator build. Did you mean to use `--simulator-cpu`?"
+          'Specified a non-default ios-cpu for a simulator build. Did you mean '
+          'to use `--simulator-cpu`?'
       )
       valid = False
 

--- a/tools/gn
+++ b/tools/gn
@@ -85,15 +85,6 @@ def to_command_line(gn_args):
   return [merge(x, y) for x, y in gn_args.items()]
 
 
-def cpu_for_target_arch(arch):
-  if arch in ['ia32', 'x86', 'arm', 'armv6', 'armv5te', 'mips', 'simarm',
-              'simarmv6', 'simarmv5te', 'simmips', 'simdbc', 'armsimdbc']:
-    return 'x86'
-  if arch in ['x64', 'arm64', 'simarm64', 'simdbc64', 'armsimdbc64']:
-    return 'x64'
-  return None
-
-
 def is_host_build(args):
   # If target_os == None, then this is a host build.
   if args.target_os is None:
@@ -1040,8 +1031,27 @@ def parse_args(args):
   return parser.parse_args(args)
 
 
+def validate_args(args):
+  valid = True
+  if args.simulator:
+    if args.mac_cpu != 'x64':
+      print(
+          "Specified a non-default mac-cpu for a simulator build. Did you mean to use `--simulator-cpu`?"
+      )
+      valid = False
+    if args.ios_cpu != 'arm64':
+      print(
+          "Specified a non-default ios-cpu for a simulator build. Did you mean to use `--simulator-cpu`?"
+      )
+      valid = False
+
+  if not valid:
+    sys.exit(-1)
+
+
 def main(argv):
   args = parse_args(argv)
+  validate_args(args)
 
   exe = '.exe' if sys.platform.startswith(('cygwin', 'win')) else ''
 


### PR DESCRIPTION
This isn't really foolproof, but would catch some simple mistakes.

I mistakenly tried to build an arm64 simulator build by doing `./flutter/tools/gn --simulator --unopt --mac-cpu=arm64`. It generated the expected out directory (out/ios_debug_sim_unopt_arm64), but did not set the gn arguments for the simulator build and resulted in linker errors down the line.

Also deletes an otherwise unused function.

fixes https://github.com/flutter/flutter/issues/124067