### PR TITLE
The `dart:wasm` library is no longer used directly by user code.

### DIFF
--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -25,7 +25,6 @@ import("//third_party/dart/sdk/lib/js_interop/js_interop_sources.gni")
 import("//third_party/dart/sdk/lib/js_util/js_util_sources.gni")
 import("//third_party/dart/sdk/lib/math/math_sources.gni")
 import("//third_party/dart/sdk/lib/typed_data/typed_data_sources.gni")
-import("//third_party/dart/sdk/lib/wasm/wasm_sources.gni")
 
 if (!is_fuchsia) {
   copy("copy_sky_engine_authors") {
@@ -170,13 +169,6 @@ copy("typed_data") {
   ]
 }
 
-copy("wasm") {
-  lib_path = rebase_path("wasm", "", dart_sdk_lib_path)
-  sources = rebase_path(wasm_sdk_sources, "", lib_path)
-  outputs =
-      [ "$root_gen_dir/dart-pkg/sky_engine/lib/wasm/{{source_file_part}}" ]
-}
-
 copy("copy_dart_ui") {
   sources = dart_ui_files
 
@@ -213,7 +205,6 @@ group("copy_dart_sdk") {
     ":js_util",
     ":math",
     ":typed_data",
-    ":wasm",
   ]
 }
 
@@ -239,7 +230,6 @@ generated_file("_embedder_yaml") {
     "  \"dart:math\": \"math/math.dart\"",
     "  \"dart:typed_data\": \"typed_data/typed_data.dart\"",
     "  \"dart:ui\": \"ui/ui.dart\"",
-    "  \"dart:wasm\": \"wasm/wasm_types.dart\"",
     "",
     "  \"dart:_http\": \"_http/http.dart\"",
     "  \"dart:_interceptors\": \"_interceptors/interceptors.dart\"",

--- a/sky/packages/sky_engine/lib/_embedder.yaml
+++ b/sky/packages/sky_engine/lib/_embedder.yaml
@@ -17,7 +17,6 @@ embedded_libs:
   "dart:math": "../../../../../third_party/dart/sdk/lib/math/math.dart"
   "dart:typed_data": "../../../../../third_party/dart/sdk/lib/typed_data/typed_data.dart"
   "dart:ui": "../../../../lib/ui/ui.dart"
-  "dart:wasm": "../../../../../third_party/dart/sdk/lib/wasm/wasm_types.dart"
 
   "dart:_http": "../../../../../third_party/dart/sdk/lib/_http/http.dart"
   "dart:_interceptors": "../../../../../third_party/dart/sdk/lib/_interceptors/interceptors.dart"


### PR DESCRIPTION
The dart sdk is trying to remove this library from public API. We should not include it in sky_engine.