### PR TITLE
[Impeller] Update API name to indicate descriptor set registrations.

### DIFF
--- a/impeller/renderer/pipeline_builder.h
+++ b/impeller/renderer/pipeline_builder.h
@@ -93,7 +93,7 @@ struct PipelineBuilder {
             << VertexShader::kLabel << "'.";
         return false;
       }
-      if (!vertex_descriptor->SetDescriptorSetLayouts(
+      if (!vertex_descriptor->RegisterDescriptorSetLayouts(
               VertexShader::kDescriptorSetLayouts)) {
         VALIDATION_LOG << "Cound not configure vertex descriptor set layout for"
                           " pipeline named '"
@@ -101,7 +101,7 @@ struct PipelineBuilder {
         return false;
       }
 
-      if (!vertex_descriptor->SetDescriptorSetLayouts(
+      if (!vertex_descriptor->RegisterDescriptorSetLayouts(
               FragmentShader::kDescriptorSetLayouts)) {
         VALIDATION_LOG << "Cound not configure vertex descriptor set layout for"
                           " pipeline named '"

--- a/impeller/renderer/vertex_descriptor.cc
+++ b/impeller/renderer/vertex_descriptor.cc
@@ -20,7 +20,7 @@ bool VertexDescriptor::SetStageInputs(
   return true;
 }
 
-bool VertexDescriptor::SetDescriptorSetLayouts(
+bool VertexDescriptor::RegisterDescriptorSetLayouts(
     const DescriptorSetLayout desc_set_layout[],
     size_t count) {
   desc_set_layouts_.reserve(desc_set_layouts_.size() + count);

--- a/impeller/renderer/vertex_descriptor.h
+++ b/impeller/renderer/vertex_descriptor.h
@@ -37,16 +37,16 @@ class VertexDescriptor final : public Comparable<VertexDescriptor> {
   }
 
   template <size_t Size>
-  bool SetDescriptorSetLayouts(
+  bool RegisterDescriptorSetLayouts(
       const std::array<DescriptorSetLayout, Size>& inputs) {
-    return SetDescriptorSetLayouts(inputs.data(), inputs.size());
+    return RegisterDescriptorSetLayouts(inputs.data(), inputs.size());
   }
 
   bool SetStageInputs(const ShaderStageIOSlot* const stage_inputs[],
                       size_t count);
 
-  bool SetDescriptorSetLayouts(const DescriptorSetLayout desc_set_layout[],
-                               size_t count);
+  bool RegisterDescriptorSetLayouts(const DescriptorSetLayout desc_set_layout[],
+                                    size_t count);
 
   const std::vector<ShaderStageIOSlot>& GetStageInputs() const;
 


### PR DESCRIPTION
`SetRegisterDescriptorSetLayouts` made it seem like the old setting was replaced. All this call does add new descriptor set registrations.