### PR TITLE
Re-enable some wasm tests which have been fixed now.

### DIFF
--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -802,7 +802,7 @@ void testMain() {
 
     test('emoji text with skin tone', () async {
       await testSampleText('emoji_with_skin_tone', '👋🏿 👋🏾 👋🏽 👋🏼 👋🏻');
-    }, skip: isWasm || isSafari || isFirefox); // https://github.com/flutter/flutter/issues/124068
+    });
 
     // Make sure we clear the canvas in between frames.
     test('empty frame after contentful frame', () async {

--- a/lib/web_ui/test/canvaskit/image_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/image_golden_test.dart
@@ -889,7 +889,7 @@ void _testCkBrowserImageDecoder() {
     testCollector.collectNow();
     // TODO(jacksongardner): enable on wasm
     // see https://github.com/flutter/flutter/issues/118334
-  }, skip: isWasm);
+  });
 
   test('ImageDecoder expires after inactivity', () async {
     const Duration testExpireDuration = Duration(milliseconds: 100);
@@ -936,7 +936,7 @@ void _testCkBrowserImageDecoder() {
     debugRestoreWebDecoderExpireDuration();
     // TODO(jacksongardner): enable on wasm
     // see https://github.com/flutter/flutter/issues/118334
-  }, skip: isWasm);
+  });
 }
 
 Future<void> expectFrameData(ui.FrameInfo frame, List<int> data) async {

--- a/lib/web_ui/test/engine/channel_buffers_test.dart
+++ b/lib/web_ui/test/engine/channel_buffers_test.dart
@@ -271,7 +271,7 @@ void testMain() {
       'b: seven',
       '-9',
     ]);
-  }, skip: isWasm); // https://github.com/dart-lang/sdk/issues/50778
+  });
 
   test('ChannelBuffers.clearListener', () async {
     final List<String> log = <String>[];
@@ -365,7 +365,7 @@ void testMain() {
       'callback1: true',
       'callback2: true',
     ]);
-  }, skip: isWasm); // https://github.com/dart-lang/sdk/issues/50778
+  });
 }
 
 class _TestChannelBuffers extends ui.ChannelBuffers {

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -997,7 +997,7 @@ void _testVerticalScrolling() {
     expect(scrollable.scrollTop >= (10 - browserMaxScrollDiff), isTrue);
 
     semantics().semanticsEnabled = false;
-  }, skip: isWasm); // https://github.com/dart-lang/sdk/issues/50778
+  });
 }
 
 void _testHorizontalScrolling() {
@@ -1130,7 +1130,7 @@ void _testHorizontalScrolling() {
     expect(scrollable.scrollLeft >= (10 - browserMaxScrollDiff), isTrue);
 
     semantics().semanticsEnabled = false;
-  }, skip: isWasm); // https://github.com/dart-lang/sdk/issues/50778
+  });
 }
 
 void _testIncrementables() {


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/124068.

It appears https://github.com/dart-lang/sdk/issues/50778 is partially fixed, so we can re-enable some of the tests but there is still one left that relies on a specific ordering that cannot be guaranteed.

This fixes https://github.com/flutter/flutter/issues/118334. It appears the JS interop boundary has been enhanced enough that we can now copy bytes out of video frames.