### PR TITLE
[Impeller] Removed requirement for multisample buffers from egl setup.

### DIFF
--- a/impeller/toolkit/egl/display.cc
+++ b/impeller/toolkit/egl/display.cc
@@ -136,16 +136,6 @@ std::unique_ptr<Config> Display::ChooseConfig(ConfigDescriptor config) const {
     attributes.push_back(static_cast<EGLint>(config.stencil_bits));
   }
 
-  {
-    const auto sample_count = static_cast<EGLint>(config.samples);
-    if (sample_count > 1) {
-      attributes.push_back(EGL_SAMPLE_BUFFERS);
-      attributes.push_back(1);
-    }
-    attributes.push_back(EGL_SAMPLES);
-    attributes.push_back(sample_count);
-  }
-
   // termination sentinel must be present.
   attributes.push_back(EGL_NONE);
 

--- a/impeller/toolkit/egl/display.cc
+++ b/impeller/toolkit/egl/display.cc
@@ -136,27 +136,48 @@ std::unique_ptr<Config> Display::ChooseConfig(ConfigDescriptor config) const {
     attributes.push_back(static_cast<EGLint>(config.stencil_bits));
   }
 
+  // On android emulators multisample buffer configs don't work, so we fallback
+  // to a config without them.
+  std::vector<EGLint> attributes_sans_multisample = attributes;
+
+  {
+    const auto sample_count = static_cast<EGLint>(config.samples);
+    if (sample_count > 1) {
+      attributes.push_back(EGL_SAMPLE_BUFFERS);
+      attributes.push_back(1);
+    }
+    attributes.push_back(EGL_SAMPLES);
+    attributes.push_back(sample_count);
+  }
+
   // termination sentinel must be present.
   attributes.push_back(EGL_NONE);
+  attributes_sans_multisample.push_back(EGL_NONE);
 
-  EGLConfig config_out = nullptr;
-  EGLint config_count_out = 0;
-  if (::eglChooseConfig(display_,           // display
-                        attributes.data(),  // attributes (null terminated)
-                        &config_out,        // matched configs
-                        1,                  // configs array size
-                        &config_count_out   // match configs count
-                        ) != EGL_TRUE) {
-    IMPELLER_LOG_EGL_ERROR;
-    return nullptr;
+  std::vector<std::vector<EGLint>> attribute_options = {
+      attributes, attributes_sans_multisample};
+
+  for (const auto& attribute_option : attribute_options) {
+    EGLConfig config_out = nullptr;
+    EGLint config_count_out = 0;
+    if (::eglChooseConfig(
+            display_,                 // display
+            attribute_option.data(),  // attributes (null terminated)
+            &config_out,              // matched configs
+            1,                        // configs array size
+            &config_count_out         // match configs count
+            ) != EGL_TRUE) {
+      IMPELLER_LOG_EGL_ERROR;
+      continue;
+    }
+
+    if (config_count_out == 1u) {
+      return std::make_unique<Config>(config, config_out);
+    }
   }
 
-  if (config_count_out != 1u) {
-    IMPELLER_LOG_EGL_ERROR;
-    return nullptr;
-  }
-
-  return std::make_unique<Config>(config, config_out);
+  IMPELLER_LOG_EGL_ERROR;
+  return nullptr;
 }
 
 std::unique_ptr<Surface> Display::CreateWindowSurface(


### PR DESCRIPTION
I reviewed the code and I don't think this requirement is necessary.  Offscreen MSAA is already guarded by a flag and looking at the opengles code it doesn't seem to be using multisample buffers.

When removing it the emulator no longer crashes and behaves identically to on device (which is rendering incorrect colors and crashing when pressing a the counter button).

fixes https://github.com/flutter/flutter/issues/105323

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
