### PR TITLE
Always set orientation preferences on iOS 16+

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1544,21 +1544,17 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
           continue;
         }
         UIWindowScene* windowScene = (UIWindowScene*)scene;
-        UIInterfaceOrientationMask currentInterfaceOrientation =
-            1 << windowScene.interfaceOrientation;
-        if (!(_orientationPreferences & currentInterfaceOrientation)) {
-          [self setNeedsUpdateOfSupportedInterfaceOrientations];
-          UIWindowSceneGeometryPreferencesIOS* preference =
-              [[UIWindowSceneGeometryPreferencesIOS alloc]
-                  initWithInterfaceOrientations:_orientationPreferences];
-          [windowScene
-              requestGeometryUpdateWithPreferences:preference
-                                      errorHandler:^(NSError* error) {
-                                        os_log_error(OS_LOG_DEFAULT,
-                                                     "Failed to change device orientation: %@",
-                                                     error);
-                                      }];
-        }
+        UIWindowSceneGeometryPreferencesIOS* preference =
+            [[UIWindowSceneGeometryPreferencesIOS alloc]
+                initWithInterfaceOrientations:_orientationPreferences];
+        [windowScene
+            requestGeometryUpdateWithPreferences:preference
+                                    errorHandler:^(NSError* error) {
+                                      os_log_error(OS_LOG_DEFAULT,
+                                                   "Failed to change device orientation: %@",
+                                                   error);
+                                    }];
+        [self setNeedsUpdateOfSupportedInterfaceOrientations];
       }
     } else {
       UIInterfaceOrientationMask currentInterfaceOrientation =

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -891,13 +891,17 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   id mockApplication = OCMClassMock([UIApplication class]);
   id mockWindowScene;
   id deviceMock;
+  FlutterViewController* realVC = [[FlutterViewController alloc] initWithEngine:self.mockEngine
+                                                                        nibName:nil
+                                                                         bundle:nil];
   if (@available(iOS 16.0, *)) {
     mockWindowScene = OCMClassMock([UIWindowScene class]);
-    OCMStub([mockWindowScene interfaceOrientation]).andReturn(currentOrientation);
-    if (!didChange) {
+    if (realVC.supportedInterfaceOrientations == mask) {
       OCMReject([mockWindowScene requestGeometryUpdateWithPreferences:[OCMArg any]
                                                          errorHandler:[OCMArg any]]);
     } else {
+      // iOS 16 will decide whether to rotate based on the new preference, so always set it
+      // when it changes.
       OCMExpect([mockWindowScene
           requestGeometryUpdateWithPreferences:[OCMArg checkWithBlock:^BOOL(
                                                            UIWindowSceneGeometryPreferencesIOS*
@@ -919,9 +923,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
     OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
     OCMStub([mockApplication statusBarOrientation]).andReturn(currentOrientation);
   }
-  FlutterViewController* realVC = [[FlutterViewController alloc] initWithEngine:self.mockEngine
-                                                                        nibName:nil
-                                                                         bundle:nil];
 
   [realVC performOrientationUpdate:mask];
   if (@available(iOS 16.0, *)) {


### PR DESCRIPTION
Cherry-pick https://github.com/flutter/engine/pull/38230 onto stable.

CP request at https://github.com/flutter/flutter/issues/124208.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
