### PR TITLE
Don't build wasm targets for the web sdk archive in host mode.

### DIFF
--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -574,10 +574,15 @@ if (!is_fuchsia) {
     deps = [
              ":flutter_ddc_modules",
              ":flutter_platform_dills",
-             "//flutter/third_party/canvaskit:canvaskit_group",
-             "//flutter/third_party/canvaskit:canvaskit_chromium_group",
-             "//flutter/third_party/canvaskit:skwasm_group",
            ] + web_engine_libraries
+
+    if (is_wasm) {
+      deps += [
+        "//flutter/third_party/canvaskit:canvaskit_chromium_group",
+        "//flutter/third_party/canvaskit:canvaskit_group",
+        "//flutter/third_party/canvaskit:skwasm_group",
+      ]
+    }
 
     # flutter_ddc_modules
     sources = get_target_outputs(":flutter_dartdevc_kernel_sdk")
@@ -595,15 +600,17 @@ if (!is_fuchsia) {
     sources += get_target_outputs(":flutter_dartdevc_kernel_sdk_outline_sound")
     sources += get_target_outputs(":flutter_dart2js_kernel_sdk_full_unsound")
     sources += get_target_outputs(":flutter_dart2js_kernel_sdk_full_sound")
-    sources += [
-      "$root_out_dir/flutter_web_sdk/canvaskit/canvaskit.js",
-      "$root_out_dir/flutter_web_sdk/canvaskit/canvaskit.wasm",
-      "$root_out_dir/flutter_web_sdk/canvaskit/chromium/canvaskit.js",
-      "$root_out_dir/flutter_web_sdk/canvaskit/chromium/canvaskit.wasm",
-      "$root_out_dir/flutter_web_sdk/canvaskit/skwasm.js",
-      "$root_out_dir/flutter_web_sdk/canvaskit/skwasm.wasm",
-      "$root_out_dir/flutter_web_sdk/canvaskit/skwasm.worker.js",
-    ]
+    if (is_wasm) {
+      sources += [
+        "$root_out_dir/flutter_web_sdk/canvaskit/canvaskit.js",
+        "$root_out_dir/flutter_web_sdk/canvaskit/canvaskit.wasm",
+        "$root_out_dir/flutter_web_sdk/canvaskit/chromium/canvaskit.js",
+        "$root_out_dir/flutter_web_sdk/canvaskit/chromium/canvaskit.wasm",
+        "$root_out_dir/flutter_web_sdk/canvaskit/skwasm.js",
+        "$root_out_dir/flutter_web_sdk/canvaskit/skwasm.wasm",
+        "$root_out_dir/flutter_web_sdk/canvaskit/skwasm.worker.js",
+      ]
+    }
 
     # TODO(jacksongardner): remove these once they are no longer used by the flutter tool
     # https://github.com/flutter/flutter/issues/113303


### PR DESCRIPTION
The HHH bot and dart monorepo still build the web archive in a host build. We can't build wasm artifacts in this mode, so just skip them.