### PR TITLE
Support disabling backtrace support

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -19,6 +19,9 @@ declare_args() {
 
   # Whether to build host-side development artifacts.
   flutter_build_engine_artifacts = true
+
+  # Whether to include backtrace support.
+  enable_backtrace = true
 }
 
 # feature_defines_list ---------------------------------------------------------

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -97,7 +97,7 @@ source_set("fml") {
     "wakeable.h",
   ]
 
-  if (is_mac || is_linux || is_win || (is_ios && is_debug)) {
+  if (enable_backtrace) {
     sources += [ "backtrace.cc" ]
   } else {
     sources += [ "backtrace_stub.cc" ]
@@ -116,7 +116,7 @@ source_set("fml") {
     "//third_party/icu",
   ]
 
-  if (is_mac || is_linux || is_win || (is_ios && is_debug)) {
+  if (enable_backtrace) {
     # This abseil dependency is only used by backtrace.cc.
     deps += [ "//third_party/abseil-cpp/absl/debugging:symbolize" ]
   }

--- a/tools/gn
+++ b/tools/gn
@@ -393,6 +393,15 @@ def to_gn_args(args):
   # flags allow preventing those targets from being part of the build tree.
   gn_args['enable_desktop_embeddings'] = not args.disable_desktop_embeddings
 
+  # Determine whether backtace support should be compiled in.
+  if args.backtrace:
+    gn_args['enable_backtrace'] = (
+        args.target_os in ['linux', 'mac', 'win'] or
+        args.target_os == 'ios' and runtime_mode == 'debug'
+    )
+  else:
+    gn_args['enable_backtrace'] = False
+
   # Overrides whether Boring SSL is compiled with system as. Only meaningful
   # on Android.
   gn_args['bssl_use_clang_integrated_as'] = True
@@ -772,6 +781,17 @@ def parse_args(args):
   parser.add_argument(
       '--arm-float-abi', type=str, choices=['hard', 'soft', 'softfp']
   )
+
+  # Whether to compile in backtrace support.
+  # Available for Windows and POSIX platforms whose libc includes execinfo.h.
+  # MUSL doesn't include execinfo.h should be build with --no-backtrace.
+  parser.add_argument(
+      '--backtrace',
+      default=True,
+      action='store_true',
+      help='Whether OS support exists for collecting backtraces.'
+  )
+  parser.add_argument('--no-backtrace', dest='backtrace', action='store_false')
 
   parser.add_argument(
       '--build-engine-artifacts',


### PR DESCRIPTION
This adds a gn flag (--backtrace, --no-backtrace) that defaults to enabling backtraces, which drives a gn variable `enable_backtrace` which is defaulted true for debug builds.

Backtrace collection is supported on Windows, and on POSIX-like operating systems via execinfo.h. execinfo support exists in Android, macOS/iOS, and in glibc and uclibc on Linux. musl libc notably does not include execinfo support, so this provides an escape hatch to build with backtrace_stub.cc for situations in which compile time support doesn't exist.

Proposed as an alternative to
https://github.com/flutter/engine/pull/40958 by @selfisekai.

Issue: https://github.com/flutter/flutter/issues/124285

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
