### PR TITLE
[Fuchsia] Implement thread priorities.

### DIFF
--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -158,6 +158,7 @@ template("runner_sources") {
              "$fuchsia_sdk_root/fidl:fuchsia.images",
              "$fuchsia_sdk_root/fidl:fuchsia.intl",
              "$fuchsia_sdk_root/fidl:fuchsia.io",
+             "$fuchsia_sdk_root/fidl:fuchsia.media",
              "$fuchsia_sdk_root/fidl:fuchsia.memorypressure",
              "$fuchsia_sdk_root/fidl:fuchsia.sys",
              "$fuchsia_sdk_root/fidl:fuchsia.ui.app",

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -48,7 +48,9 @@ class Engine final : public fuchsia::memorypressure::Watcher {
     virtual void OnEngineTerminate(const Engine* holder) = 0;
   };
 
-  static flutter::ThreadHost CreateThreadHost(const std::string& name_prefix);
+  static flutter::ThreadHost CreateThreadHost(
+      const std::string& name_prefix,
+      const std::shared_ptr<sys::ServiceDirectory>& runner_services = nullptr);
 
   // Gfx connection ctor.
   Engine(Delegate& delegate,

--- a/shell/platform/fuchsia/flutter/meta/common.shard.cml
+++ b/shell/platform/fuchsia/flutter/meta/common.shard.cml
@@ -31,6 +31,7 @@
                 "fuchsia.fonts.Provider",
                 "fuchsia.intl.PropertyProvider",
                 "fuchsia.logger.LogSink", // Copied from syslog/client.shard.cml.
+                "fuchsia.media.ProfileProvider",
                 "fuchsia.memorypressure.Provider",
                 "fuchsia.net.name.Lookup",
                 "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -16,6 +16,7 @@
             "fuchsia.fonts.Provider",
             "fuchsia.intl.PropertyProvider",
             "fuchsia.logger.LogSink",
+            "fuchsia.media.ProfileProvider",
             "fuchsia.memorypressure.Provider",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
@@ -16,6 +16,7 @@
             "fuchsia.fonts.Provider",
             "fuchsia.intl.PropertyProvider",
             "fuchsia.logger.LogSink",
+            "fuchsia.media.ProfileProvider",
             "fuchsia.memorypressure.Provider",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -17,6 +17,7 @@
             "fuchsia.fonts.Provider",
             "fuchsia.intl.PropertyProvider",
             "fuchsia.logger.LogSink",
+            "fuchsia.media.ProfileProvider",
             "fuchsia.memorypressure.Provider",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
@@ -17,6 +17,7 @@
             "fuchsia.fonts.Provider",
             "fuchsia.intl.PropertyProvider",
             "fuchsia.logger.LogSink",
+            "fuchsia.media.ProfileProvider",
             "fuchsia.memorypressure.Provider",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",


### PR DESCRIPTION
Implement thread priorities using the Fuchsia media profile provider API to enable system / product configuration of host threads.

Bug: b/275114261

This is a CP of https://github.com/flutter/engine/pull/40970 with a couple of changes to .cmx files that no longer exist on master.