### PR TITLE
[a11y] Improve EmbedderA11yTest, fixture comments

### DIFF
--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -124,23 +124,23 @@ Future<SemanticsActionData> get semanticsAction {
 
 @pragma('vm:entry-point')
 void a11y_main() async {
-  // Return initial state (semantics disabled).
+  // 1: Return initial state (semantics disabled).
   notifySemanticsEnabled(PlatformDispatcher.instance.semanticsEnabled);
 
-  // Await semantics enabled from embedder.
+  // 2: Await semantics enabled from embedder.
   await semanticsChanged;
   notifySemanticsEnabled(PlatformDispatcher.instance.semanticsEnabled);
 
-  // Return initial state of accessibility features.
+  // 3: Return initial state of accessibility features.
   notifyAccessibilityFeatures(
       PlatformDispatcher.instance.accessibilityFeatures.reduceMotion);
 
-  // Await accessibility features changed from embedder.
+  // 4: Await accessibility features changed from embedder.
   await accessibilityFeaturesChanged;
   notifyAccessibilityFeatures(
       PlatformDispatcher.instance.accessibilityFeatures.reduceMotion);
 
-  // Fire semantics update.
+  // 5: Fire semantics update.
   final SemanticsUpdateBuilder builder = SemanticsUpdateBuilder()
     ..updateNode(
       id: 42,
@@ -284,7 +284,7 @@ void a11y_main() async {
 
   signalNativeTest();
 
-  // Await semantics action from embedder.
+  // 6: Await semantics action from embedder.
   final SemanticsActionData data = await semanticsAction;
   final List<int> actionArgs = <int>[
     data.args!.getInt8(0),
@@ -292,7 +292,7 @@ void a11y_main() async {
   ];
   notifySemanticsAction(data.id, data.action.index, actionArgs);
 
-  // Await semantics disabled from embedder.
+  // 7: Await semantics disabled from embedder.
   await semanticsChanged;
   notifySemanticsEnabled(PlatformDispatcher.instance.semanticsEnabled);
 }

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -177,7 +177,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
   auto engine = builder.LaunchEngine();
   ASSERT_TRUE(engine.is_valid());
 
-  // Wait for initial NotifySemanticsEnabled(false).
+  // 1: Wait for initial notifySemanticsEnabled(false).
   fml::AutoResetWaitableEvent notify_semantics_enabled_latch;
   notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -188,7 +188,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
   };
   notify_semantics_enabled_latch.Wait();
 
-  // Prepare to NotifyAccessibilityFeatures call
+  // Prepare notifyAccessibilityFeatures callback.
   fml::AutoResetWaitableEvent notify_features_latch;
   notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -198,7 +198,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
     notify_features_latch.Signal();
   };
 
-  // Enable semantics. Wait for NotifySemanticsEnabled(true).
+  // 2: Enable semantics. Wait for notifySemanticsEnabled(true).
   fml::AutoResetWaitableEvent notify_semantics_enabled_latch_2;
   notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -211,10 +211,10 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
   notify_semantics_enabled_latch_2.Wait();
 
-  // Wait for initial accessibility features (reduce_motion == false)
+  // 3: Wait for notifyAccessibilityFeatures (reduce_motion == false)
   notify_features_latch.Wait();
 
-  // Set accessibility features: (reduce_motion == true)
+  // 4: Wait for notifyAccessibilityFeatures (reduce_motion == true)
   fml::AutoResetWaitableEvent notify_features_latch_2;
   notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -228,12 +228,12 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
   notify_features_latch_2.Wait();
 
-  // Wait for UpdateSemantics callback on platform (current) thread.
+  // 5: Wait for UpdateSemantics callback on platform (current) thread.
   signal_native_latch.Wait();
   fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
   semantics_update_latch.Wait();
 
-  // Dispatch a tap to semantics node 42. Wait for NotifySemanticsAction.
+  // 6: Dispatch a tap to semantics node 42. Wait for NotifySemanticsAction.
   fml::AutoResetWaitableEvent notify_semantics_action_latch;
   notify_semantics_action_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -257,7 +257,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
   notify_semantics_action_latch.Wait();
 
-  // Disable semantics. Wait for NotifySemanticsEnabled(false).
+  // 7: Disable semantics. Wait for NotifySemanticsEnabled(false).
   fml::AutoResetWaitableEvent notify_semantics_enabled_latch_3;
   notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -353,7 +353,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
   auto engine = builder.LaunchEngine();
   ASSERT_TRUE(engine.is_valid());
 
-  // Wait for initial NotifySemanticsEnabled(false).
+  // 1: Wait for initial notifySemanticsEnabled(false).
   fml::AutoResetWaitableEvent notify_semantics_enabled_latch;
   notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -364,7 +364,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
   };
   notify_semantics_enabled_latch.Wait();
 
-  // Prepare to NotifyAccessibilityFeatures call
+  // Prepare notifyAccessibilityFeatures callback.
   fml::AutoResetWaitableEvent notify_features_latch;
   notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -374,7 +374,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
     notify_features_latch.Signal();
   };
 
-  // Enable semantics. Wait for NotifySemanticsEnabled(true).
+  // 2: Enable semantics. Wait for notifySemanticsEnabled(true).
   fml::AutoResetWaitableEvent notify_semantics_enabled_latch_2;
   notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -387,10 +387,10 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
   notify_semantics_enabled_latch_2.Wait();
 
-  // Wait for initial accessibility features (reduce_motion == false)
+  // 3: Wait for notifyAccessibilityFeatures (reduce_motion == false)
   notify_features_latch.Wait();
 
-  // Set accessibility features: (reduce_motion == true)
+  // 4: Wait for notifyAccessibilityFeatures (reduce_motion == true)
   fml::AutoResetWaitableEvent notify_features_latch_2;
   notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -404,12 +404,12 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
   notify_features_latch_2.Wait();
 
-  // Wait for UpdateSemantics callback on platform (current) thread.
+  // 5: Wait for UpdateSemantics callback on platform (current) thread.
   signal_native_latch.Wait();
   fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
   semantics_update_latch.Wait();
 
-  // Dispatch a tap to semantics node 42. Wait for NotifySemanticsAction.
+  // 6: Dispatch a tap to semantics node 42. Wait for NotifySemanticsAction.
   fml::AutoResetWaitableEvent notify_semantics_action_latch;
   notify_semantics_action_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -433,7 +433,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
   notify_semantics_action_latch.Wait();
 
-  // Disable semantics. Wait for NotifySemanticsEnabled(false).
+  // 7: Disable semantics. Wait for NotifySemanticsEnabled(false).
   fml::AutoResetWaitableEvent notify_semantics_enabled_latch_3;
   notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -546,7 +546,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
   auto engine = builder.LaunchEngine();
   ASSERT_TRUE(engine.is_valid());
 
-  // Wait for initial NotifySemanticsEnabled(false).
+  // 1: Wait for initial notifySemanticsEnabled(false).
   fml::AutoResetWaitableEvent notify_semantics_enabled_latch;
   notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -557,7 +557,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
   };
   notify_semantics_enabled_latch.Wait();
 
-  // Prepare to NotifyAccessibilityFeatures call
+  // Prepare notifyAccessibilityFeatures callback.
   fml::AutoResetWaitableEvent notify_features_latch;
   notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -567,7 +567,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
     notify_features_latch.Signal();
   };
 
-  // Enable semantics. Wait for NotifySemanticsEnabled(true).
+  // 2: Enable semantics. Wait for notifySemanticsEnabled(true).
   fml::AutoResetWaitableEvent notify_semantics_enabled_latch_2;
   notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -580,10 +580,10 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
   notify_semantics_enabled_latch_2.Wait();
 
-  // Wait for initial accessibility features (reduce_motion == false)
+  // 3: Wait for notifyAccessibilityFeatures (reduce_motion == false)
   notify_features_latch.Wait();
 
-  // Set accessibility features: (reduce_motion == true)
+  // 4: Wait for notifyAccessibilityFeatures (reduce_motion == true)
   fml::AutoResetWaitableEvent notify_features_latch_2;
   notify_accessibility_features_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -597,7 +597,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
   notify_features_latch_2.Wait();
 
-  // Wait for UpdateSemantics callback on platform (current) thread.
+  // 5: Wait for UpdateSemantics callback on platform (current) thread.
   signal_native_latch.Wait();
   fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
   semantics_node_latch.Wait();
@@ -607,7 +607,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
   ASSERT_EQ(1, action_count);
   ASSERT_EQ(1, action_batch_end_count);
 
-  // Dispatch a tap to semantics node 42. Wait for NotifySemanticsAction.
+  // 6: Dispatch a tap to semantics node 42. Wait for NotifySemanticsAction.
   fml::AutoResetWaitableEvent notify_semantics_action_latch;
   notify_semantics_action_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
@@ -631,7 +631,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
   notify_semantics_action_latch.Wait();
 
-  // Disable semantics. Wait for NotifySemanticsEnabled(false).
+  // 7: Disable semantics. Wait for NotifySemanticsEnabled(false).
   fml::AutoResetWaitableEvent notify_semantics_enabled_latch_3;
   notify_semantics_enabled_callback = [&](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;


### PR DESCRIPTION
Applies cleanup/simplification to EmbedderA11yTest unit tests.
* Add numbered breadcrumbs to identify corresponding sections of the C++ and Dart fixture tests.
* Eliminates duplicated native method implementations for notifying:
  * whether semantics is enabled
  * whether a particular accessibility feature is enabled
  * which semantics action was fired

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
