### PR TITLE
SemanticsFlag/SemanticsAction enum migration (part 2.1)

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -13,7 +13,7 @@ part of dart.ui;
 /// See also:
 ///   - file://./../../lib/ui/semantics/semantics_node.h
 class SemanticsAction {
-  const SemanticsAction._(this.index);
+  const SemanticsAction._(this.index): value = index;
 
   static const int _kTapIndex = 1 << 0;
   static const int _kLongPressIndex = 1 << 1;
@@ -45,6 +45,11 @@ class SemanticsAction {
   ///
   /// Each action has one bit set in this bit field.
   final int index;
+
+  /// Temporary API until the following is complete:
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This property is temporary and might be removed shortly.')
+  final int value;
 
   /// The equivalent of a user briefly tapping the screen with the finger
   /// without moving it.
@@ -299,12 +304,17 @@ class SemanticsAction {
 // accessibility services, `flutter_test/controller.dart#SemanticsController._importantFlags`
 // must be updated as well.
 class SemanticsFlag {
-  const SemanticsFlag._(this.index);
+  const SemanticsFlag._(this.index): value = index;
 
   /// The numerical value for this flag.
   ///
   /// Each flag has one bit set in this bit field.
   final int index;
+
+  /// Temporary API to represent [index] until the following is complete:
+  /// https://github.com/flutter/flutter/issues/123346
+  @Deprecated('This property is temporary and might be removed shortly.')
+  final int value;
 
   static const int _kHasCheckedStateIndex = 1 << 0;
   static const int _kIsCheckedIndex = 1 << 1;

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -5,7 +5,7 @@
 part of ui;
 
 class SemanticsAction {
-  const SemanticsAction._(this.index);
+  const SemanticsAction._(this.index): value = index;
 
   static const int _kTapIndex = 1 << 0;
   static const int _kLongPressIndex = 1 << 1;
@@ -31,6 +31,9 @@ class SemanticsAction {
   static const int _kSetTextIndex = 1 << 21;
 
   final int index;
+
+  @Deprecated('This property is temporary and might be removed shortly.')
+  final int value;
 
   static const SemanticsAction tap = SemanticsAction._(_kTapIndex);
   static const SemanticsAction longPress = SemanticsAction._(_kLongPressIndex);
@@ -144,9 +147,12 @@ class SemanticsAction {
 }
 
 class SemanticsFlag {
-  const SemanticsFlag._(this.index);
+  const SemanticsFlag._(this.index): value = index;
 
   final int index;
+
+  @Deprecated('This property is temporary and might be removed shortly.')
+  final int value;
 
   static const int _kHasCheckedStateIndex = 1 << 0;
   static const int _kIsCheckedIndex = 1 << 1;


### PR DESCRIPTION
Discussion: https://github.com/flutter/engine/pull/40567#issuecomment-1500676949
Migrate `index` to `value`. 