### PR TITLE
Add trace event when updating ViewportMetrics

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -123,6 +123,7 @@ bool RuntimeController::FlushRuntimeStateToIsolate() {
 }
 
 bool RuntimeController::SetViewportMetrics(const ViewportMetrics& metrics) {
+  TRACE_EVENT0("flutter", "SetViewportMetrics");
   platform_data_.viewport_metrics = metrics;
 
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {


### PR DESCRIPTION
Since both android and ios use `SetViewportMetrics` to update the `MediaQuery` in framework side to implement keyboard animation. So adding this trace is better for debugging workflow.

