### PR TITLE
[Impeller] remove unref queue usage on Impeller.

### DIFF
--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -48,7 +48,8 @@ ShellIOManager::ShellIOManager(
       unref_queue_(fml::MakeRefCounted<flutter::SkiaUnrefQueue>(
           std::move(unref_queue_task_runner),
           unref_queue_drain_delay,
-          resource_context_)),
+          resource_context_,
+          /*drain_immediate=*/!!impeller_context)),
       is_gpu_disabled_sync_switch_(std::move(is_gpu_disabled_sync_switch)),
       impeller_context_(std::move(impeller_context)),
       weak_factory_(this) {


### PR DESCRIPTION
Using the unref queue can cause frame drops: https://github.com/flutter/flutter/issues/122634

While this does not remove it altogether, it does completely avoid the delayed scheduling and instead immediately unrefs any objects given.

We do not use the texture functionality of unref queue with Impeller.
