### PR TITLE
Revert "[Impeller] Load instead of restore drawing for non-MSAA passes"

### DIFF
--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -100,10 +100,7 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
 
   RenderPassResult result;
 
-  if (pass_count_ > 0 && pass_target_.GetRenderTarget()
-                             .GetColorAttachments()
-                             .find(0)
-                             ->second.resolve_texture) {
+  if (pass_count_ > 0) {
     result.backdrop_texture =
         pass_target_.Flip(*context_->GetResourceAllocator());
     if (!result.backdrop_texture) {
@@ -114,12 +111,8 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
   auto color0 =
       pass_target_.GetRenderTarget().GetColorAttachments().find(0)->second;
 
-  if (pass_count_ > 0) {
-    color0.load_action =
-        color0.resolve_texture ? LoadAction::kDontCare : LoadAction::kLoad;
-  } else {
-    color0.load_action = LoadAction::kClear;
-  }
+  color0.load_action =
+      pass_count_ > 0 ? LoadAction::kDontCare : LoadAction::kClear;
 
   color0.store_action = color0.resolve_texture
                             ? StoreAction::kMultisampleResolve

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -15,7 +15,6 @@ class InlinePassContext {
  public:
   struct RenderPassResult {
     std::shared_ptr<RenderPass> pass;
-
     std::shared_ptr<Texture> backdrop_texture;
   };
 


### PR DESCRIPTION
Reverts flutter/engine#40436

I believe https://github.com/flutter/engine/pull/41052 fixes the actual problem that was occurring here when the Flip use is present. According to @jason-simmons, this change is actually breaking the Cupertino picker in gallery.

I'm not sure why this is broken in GLES yet. There should be no problem "loading" (doing nothing in GLES) to prepare continued writes to single sample textures when we begin the next pass.