### PR TITLE
Add PlatformDisplatcher.initialKeyboardState

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -72,6 +72,11 @@ void _updateInitialLifecycleState(String state) {
 }
 
 @pragma('vm:entry-point')
+void _updateInitialKeyboardState(List<int> state) {
+  PlatformDispatcher.instance._updateInitialKeyboardState(state);
+}
+
+@pragma('vm:entry-point')
 void _updateSemanticsEnabled(bool enabled) {
   PlatformDispatcher.instance._updateSemanticsEnabled(enabled);
 }

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -506,6 +506,24 @@ class PlatformDispatcher {
     return keyData;
   }
 
+  /// The engine keyboard state during framework startup.
+  ///
+  /// This is list of int representing the pressed keys. Even indexes are
+  /// physical key codes and odd indexes the corresponding logical key codes.
+  ///
+  /// It is used to initialize [HardwareKeyboard] pressed keys at startup.
+  List<int> get initialKeyboardState {
+    return _initialKeyboardState ?? <int>[];
+  }
+
+  List<int>? _initialKeyboardState;
+
+  // Called from the engine, via hooks.dart
+  void _updateInitialKeyboardState(List<int> pressedKeys) {
+    assert(pressedKeys.length.isEven);
+    _initialKeyboardState = pressedKeys;
+  }
+
   /// A callback that is invoked to report the [FrameTiming] of recently
   /// rasterized frames.
   ///

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -299,6 +299,22 @@ class PlatformConfiguration final {
   void UpdateInitialLifecycleState(const std::string& data);
 
   //----------------------------------------------------------------------------
+  /// @brief      Both engine and framework maintain a state representing the
+  ///             current pressed keys. The engine registers to system key
+  ///             events and notifies the framework using a BinaryMessenger.
+  ///             Because the engine starts quicker than the framework, initial
+  ///             pressed keys events can be lost. This method is used by the
+  ///             the engine to send the initial keyboard state which will be
+  ///             read on the framework side when it is ready to initialize its
+  ///             keyboard manager.
+  ///
+  /// @param[in]  keys  A vector representing the pressed keys. Even indexes are
+  ///                   physical key codes and odd indexes the corresponding
+  ///                   logical key codes.
+  ///
+  void UpdateInitialKeyboardState(const std::vector<int64_t>& keys);
+
+  //----------------------------------------------------------------------------
   /// @brief      Notifies the PlatformConfiguration that the embedder has
   ///             expressed an opinion about whether the accessibility tree
   ///             should be generated or not. This call originates in the
@@ -444,6 +460,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;
   tonic::DartPersistentValue report_timings_;
+  tonic::DartPersistentValue update_initial_keyboard_state_;
 
   std::unordered_map<int64_t, std::unique_ptr<Window>> windows_;
 

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -48,6 +48,9 @@ abstract class PlatformDispatcher {
   KeyDataCallback? get onKeyData;
   set onKeyData(KeyDataCallback? callback);
 
+  List<int> get initialKeyboardState;
+  set initialKeyboardState(List<int> keys);
+
   TimingsCallback? get onReportTimings;
   set onReportTimings(TimingsCallback? callback);
 

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -322,6 +322,20 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     }
   }
 
+  /// The engine keyboard state during framework startup.
+  ///
+  /// This is list of int representing the pressed keys. Even indexes are
+  /// physical key codes and odd indexes the corresponding logical key codes.
+  ///
+  /// It is used to initialize [HardwareKeyboard] pressed keys at startup.
+  @override
+  List<int> get initialKeyboardState => _initialKeyboardState;
+  List<int> _initialKeyboardState = <int>[];
+  @override
+  set initialKeyboardState(List<int> keys) {
+    _initialKeyboardState = keys;
+  }
+
   /// A callback that is invoked to report the [FrameTiming] of recently
   /// rasterized frames.
   ///

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -170,6 +170,16 @@ bool RuntimeController::SetInitialLifecycleState(const std::string& data) {
   return false;
 }
 
+bool RuntimeController::SetInitialKeyboardState(
+    const std::vector<int64_t>& keys) {
+  if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
+    platform_configuration->UpdateInitialKeyboardState(keys);
+    return true;
+  }
+
+  return false;
+}
+
 bool RuntimeController::SetSemanticsEnabled(bool enabled) {
   platform_data_.semantics_enabled = enabled;
 

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -222,6 +222,15 @@ class RuntimeController : public PlatformConfigurationClient {
   bool SetInitialLifecycleState(const std::string& data);
 
   //----------------------------------------------------------------------------
+  /// @brief      Forward the initial keyboard state to the running isolate.
+  ///
+  /// @param[in]  keys  A vector representing the pressed keys. Even indexes are
+  ///                   physical key codes and odd indexes the corresponding
+  ///                   logical key codes.
+  ///
+  bool SetInitialKeyboardState(const std::vector<int64_t>& keys);
+
+  //----------------------------------------------------------------------------
   /// @brief      Notifies the running isolate about whether the semantics tree
   ///             should be generated or not. If the isolate is not running,
   ///             this preference will be saved and flushed to the isolate when

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -408,6 +408,10 @@ void Engine::HandleSettingsPlatformMessage(PlatformMessage* message) {
   }
 }
 
+void Engine::SetInitialKeyboardState(std::vector<int64_t>& keys) {
+  runtime_controller_->SetInitialKeyboardState(keys);
+}
+
 void Engine::DispatchPointerDataPacket(
     std::unique_ptr<PointerDataPacket> packet,
     uint64_t trace_flow_id) {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -696,6 +696,18 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   void DispatchPlatformMessage(std::unique_ptr<PlatformMessage> message);
 
   //----------------------------------------------------------------------------
+  /// @brief      Notifies the engine that the embedder has sent it the current
+  ///             keyboard state. This call originates on the platform view and
+  ///             has been forwarded to the engine here on the UI task runner by
+  ///             the shell.
+  ///
+  /// @param[in]  keys  A vector representing the pressed keys. Even indexes are
+  ///                   physical key codes and odd indexes the corresponding
+  ///                   logical key codes.
+  ///
+  void SetInitialKeyboardState(std::vector<int64_t>& keys);
+
+  //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder has sent it a pointer
   ///             data packet. A pointer data packet may contain multiple
   ///             input events. This call originates in the platform view and

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -36,6 +36,10 @@ void PlatformView::DispatchPointerDataPacket(
       pointer_data_packet_converter_.Convert(std::move(packet)));
 }
 
+void PlatformView::SetInitialKeyboardState(const std::vector<int64_t>& keys) {
+  delegate_.OnPlatformViewSetInitialKeyboardState(keys);
+}
+
 void PlatformView::DispatchSemanticsAction(int32_t node_id,
                                            SemanticsAction action,
                                            fml::MallocMapping args) {

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -138,6 +138,18 @@ class PlatformView {
     virtual void OnPlatformViewDispatchPointerDataPacket(
         std::unique_ptr<PointerDataPacket> packet) = 0;
 
+    //----------------------------------------------------------------------------
+    /// @brief      Notifies the delegate that the platform view has specified a
+    ///             new keyboard state. This information needs to be forwarded
+    ///             to the root isolate running on the UI thread.
+    ///
+    /// @param[in]  keys  A vector representing the pressed keys. Even indexes
+    ///                   are physical key codes and odd indexes the
+    ///                   corresponding logical key codes.
+    ///
+    virtual void OnPlatformViewSetInitialKeyboardState(
+        const std::vector<int64_t>& keys) = 0;
+
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the platform view has encountered
     ///             an accessibility related action on the specified node. This
@@ -604,6 +616,16 @@ class PlatformView {
   /// @param[in]  packet  The pointer data packet to dispatch to the framework.
   ///
   void DispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Forward the initial keyboard state from the embadder to the
+  ///             framework.
+  ///
+  /// @param[in]  keys  A vector representing the pressed keys. Even indexes are
+  ///                   physical key codes and odd indexes the corresponding
+  ///                   logical key codes.
+  ///
+  void SetInitialKeyboardState(const std::vector<int64_t>& keys);
 
   //--------------------------------------------------------------------------
   /// @brief      Used by the embedder to specify a texture that it wants the

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -995,6 +995,19 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
 }
 
 // |PlatformView::Delegate|
+void Shell::OnPlatformViewSetInitialKeyboardState(
+    const std::vector<int64_t>& keys) {
+  FML_DCHECK(is_setup_);
+  FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
+  task_runners_.GetUITaskRunner()->PostTask(
+      fml::MakeCopyable([engine = weak_engine_, keys = keys]() mutable {
+        if (engine) {
+          engine->SetInitialKeyboardState(keys);
+        }
+      }));
+}
+
+// |PlatformView::Delegate|
 void Shell::OnPlatformViewDispatchSemanticsAction(int32_t node_id,
                                                   SemanticsAction action,
                                                   fml::MallocMapping args) {

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -545,6 +545,10 @@ class Shell final : public PlatformView::Delegate,
       std::unique_ptr<PointerDataPacket> packet) override;
 
   // |PlatformView::Delegate|
+  void OnPlatformViewSetInitialKeyboardState(
+      const std::vector<int64_t>& keys) override;
+
+  // |PlatformView::Delegate|
   void OnPlatformViewDispatchSemanticsAction(int32_t node_id,
                                              SemanticsAction action,
                                              fml::MallocMapping args) override;

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -80,6 +80,9 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   MOCK_METHOD1(OnPlatformViewDispatchPointerDataPacket,
                void(std::unique_ptr<PointerDataPacket> packet));
 
+  MOCK_METHOD1(OnPlatformViewSetInitialKeyboardState,
+               void(const std::vector<int64_t>& keys));
+
   MOCK_METHOD3(OnPlatformViewDispatchSemanticsAction,
                void(int32_t id,
                     SemanticsAction action,

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <memory>
+#include <vector>
 #define FML_USED_ON_EMBEDDER
 
 #import <OCMock/OCMock.h>
@@ -29,6 +30,7 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  void OnPlatformViewSetInitialKeyboardState(const std::vector<int64_t>& keys) override {}
   void OnPlatformViewDispatchSemanticsAction(int32_t id,
                                              SemanticsAction action,
                                              fml::MallocMapping args) override {}

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <vector>
+
 #import <OCMock/OCMock.h>
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
@@ -98,6 +100,7 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  void OnPlatformViewSetInitialKeyboardState(const std::vector<int64_t>& keys) override {}
   void OnPlatformViewDispatchSemanticsAction(int32_t id,
                                              SemanticsAction action,
                                              fml::MallocMapping args) override {}

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <vector>
+
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
@@ -82,6 +84,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  void OnPlatformViewSetInitialKeyboardState(const std::vector<int64_t>& keys) override {}
   void OnPlatformViewDispatchSemanticsAction(int32_t id,
                                              SemanticsAction action,
                                              fml::MallocMapping args) override {}

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2365,6 +2365,26 @@ FlutterEngineResult FlutterEngineSendKeyEvent(FLUTTER_API_SYMBOL(FlutterEngine)
       message_data);
 }
 
+FlutterEngineResult FlutterEngineSetInitialKeyboardState(
+    FLUTTER_API_SYMBOL(FlutterEngine) engine,
+    const int64_t* keys,
+    size_t keys_count) {
+  if (engine == nullptr) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments, "Engine handle was invalid.");
+  }
+
+  if (keys == nullptr) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments, "Invalid keys.");
+  }
+
+  if (!reinterpret_cast<flutter::EmbedderEngine*>(engine)
+           ->SetInitialKeyboardState(keys, keys_count)) {
+    return LOG_EMBEDDER_ERROR(kInternalInconsistency,
+                              "Could not send the initial keyboard state.");
+  }
+  return kSuccess;
+}
+
 FlutterEngineResult FlutterEngineSendPlatformMessage(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
     const FlutterPlatformMessage* flutter_message) {
@@ -3082,6 +3102,7 @@ FlutterEngineResult FlutterEngineGetProcAddresses(
   SET_PROC(SendWindowMetricsEvent, FlutterEngineSendWindowMetricsEvent);
   SET_PROC(SendPointerEvent, FlutterEngineSendPointerEvent);
   SET_PROC(SendKeyEvent, FlutterEngineSendKeyEvent);
+  SET_PROC(SetInitialKeyboardState, FlutterEngineSetInitialKeyboardState);
   SET_PROC(SendPlatformMessage, FlutterEngineSendPlatformMessage);
   SET_PROC(PlatformMessageCreateResponseHandle,
            FlutterPlatformMessageCreateResponseHandle);

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -2280,6 +2280,24 @@ FlutterEngineResult FlutterEngineSendKeyEvent(FLUTTER_API_SYMBOL(FlutterEngine)
                                               FlutterKeyEventCallback callback,
                                               void* user_data);
 
+//------------------------------------------------------------------------------
+/// @brief      Set the initial keyboard state of the engine. The framework will
+///             use this value to initialize its keyboard manager.
+///
+/// @param[in]  engine      A running engine instance.
+/// @param[in]  keys        The array containing the pressed keys. Even indexes
+///                         are physical key codes and odd indexes the
+///                         corresponding logical key codes.
+/// @param[in]  keys_count  The length of the keys array.
+///
+/// @return     The result of the call.
+///
+FLUTTER_EXPORT
+FlutterEngineResult FlutterEngineSetInitialKeyboardState(
+    FLUTTER_API_SYMBOL(FlutterEngine) engine,
+    const int64_t* keys,
+    size_t keys_count);
+
 FLUTTER_EXPORT
 FlutterEngineResult FlutterEngineSendPlatformMessage(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
@@ -2829,6 +2847,10 @@ typedef FlutterEngineResult (*FlutterEngineSendKeyEventFnPtr)(
     const FlutterKeyEvent* event,
     FlutterKeyEventCallback callback,
     void* user_data);
+typedef FlutterEngineResult (*FlutterEngineSetInitialKeyboardStateFnPtr)(
+    FLUTTER_API_SYMBOL(FlutterEngine) engine,
+    const int64_t* keys,
+    size_t keys_count);
 typedef FlutterEngineResult (*FlutterEngineSendPlatformMessageFnPtr)(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
     const FlutterPlatformMessage* message);
@@ -2929,6 +2951,7 @@ typedef struct {
   FlutterEngineSendWindowMetricsEventFnPtr SendWindowMetricsEvent;
   FlutterEngineSendPointerEventFnPtr SendPointerEvent;
   FlutterEngineSendKeyEventFnPtr SendKeyEvent;
+  FlutterEngineSetInitialKeyboardStateFnPtr SetInitialKeyboardState;
   FlutterEngineSendPlatformMessageFnPtr SendPlatformMessage;
   FlutterEnginePlatformMessageCreateResponseHandleFnPtr
       PlatformMessageCreateResponseHandle;

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -128,6 +128,23 @@ bool EmbedderEngine::DispatchPointerDataPacket(
   return true;
 }
 
+bool EmbedderEngine::SetInitialKeyboardState(const int64_t* keys,
+                                             size_t keys_count) {
+  if (!IsValid()) {
+    return false;
+  }
+
+  auto platform_view = shell_->GetPlatformView();
+  if (!platform_view) {
+    return false;
+  }
+
+  std::vector<int64_t> pressedKeys(keys, keys + keys_count);
+
+  platform_view->SetInitialKeyboardState(pressedKeys);
+  return true;
+}
+
 bool EmbedderEngine::SendPlatformMessage(
     std::unique_ptr<PlatformMessage> message) {
   if (!IsValid() || !message) {

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -53,6 +53,8 @@ class EmbedderEngine {
   bool DispatchPointerDataPacket(
       std::unique_ptr<flutter::PointerDataPacket> packet);
 
+  bool SetInitialKeyboardState(const int64_t* keys, size_t keys_count);
+
   bool SendPlatformMessage(std::unique_ptr<PlatformMessage> message);
 
   bool RegisterTexture(int64_t texture);

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -714,6 +714,13 @@ void key_data_late_echo() async {
   signalNativeTest();
 }
 
+// After platform channel 'test/starts_echo' receives a message, starts echoing
+// the event data with `_echoKeyEvent`, and returns synthesized as handled.
+@pragma('vm:entry-point')
+void can_send_keyboard_initial_state() async {
+  notifyStringValue('${PlatformDispatcher.instance.initialKeyboardState}');
+}
+
 @pragma('vm:entry-point')
 void render_gradient() {
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {

--- a/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -27,6 +27,8 @@ class MockDelegate : public PlatformView::Delegate {
                void(std::unique_ptr<PlatformMessage> message));
   MOCK_METHOD1(OnPlatformViewDispatchPointerDataPacket,
                void(std::unique_ptr<PointerDataPacket> packet));
+  MOCK_METHOD1(OnPlatformViewSetInitialKeyboardState,
+               void(const std::vector<int64_t>& keys));
   MOCK_METHOD3(OnPlatformViewDispatchSemanticsAction,
                void(int32_t id,
                     SemanticsAction action,

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -102,6 +102,9 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     message_ = std::move(message);
   }
   // |flutter::PlatformView::Delegate|
+  void OnPlatformViewSetInitialKeyboardState(
+      const std::vector<int64_t>& keys){};
+  // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchPointerDataPacket(
       std::unique_ptr<flutter::PointerDataPacket> packet) {
     pointer_packets_.push_back(std::move(packet));

--- a/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_platform_view_unittest.cc
@@ -101,6 +101,9 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     message_ = std::move(message);
   }
   // |flutter::PlatformView::Delegate|
+  void OnPlatformViewSetInitialKeyboardState(
+      const std::vector<int64_t>& keys){};
+  // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchPointerDataPacket(
       std::unique_ptr<flutter::PointerDataPacket> packet) {
     pointer_packets_.push_back(std::move(packet));


### PR DESCRIPTION
## Description

This draft PR which introduces `PlatformDisplatcher.initialKeyboardState` which will be set by the engine and used by the framework to initialize the `HardwareKeyboard` initial pressed state.

The framework draft PR using this is https://github.com/flutter/flutter/pull/124588.

This work is not yet done, these drafts PR are meant to validate the proposed approach.

## Related Issue

Engine side implementation for https://github.com/flutter/flutter/issues/87391

## Tests

Adds 1 test.
More tests to add once this is validated.
