### PR TITLE
Promote mac_unopt to prod.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -363,14 +363,14 @@ targets:
         { "sdk_version": "14a5294e" }
 
   - name: Mac mac_unopt
-    bringup: true
     recipe: engine_v2/engine_v2
     properties:
       config_name: mac_unopt
       add_recipes_cq: "true"
-    timeout: 180  # set timeout to 3H while this runs on staging.
+    timeout: 60
 
   - name: Mac Unopt
+    bringup: true
     recipe: engine/engine_unopt
     properties:
       add_recipes_cq: "true"


### PR DESCRIPTION
Mac_unopt is ready to replace Mac Unopt build. This change promotes the engine v2 build to use prod resources and moves the legacy Mac Unopt to staging.

Note: the failures in staging are related to lack of mac resources on staging to run successfully.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
