### PR TITLE
Revert "Migrate ios_builders to engine_v2."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -423,7 +423,6 @@ targets:
       - "**.mm"
 
   - name: Mac iOS Engine
-    bringup: true
     recipe: engine/engine
     properties:
       add_recipes_cq: "true"
@@ -492,7 +491,6 @@ targets:
     timeout: 75
 
   - name: Mac iOS Engine Profile
-    bringup: true
     recipe: engine/engine
     properties:
       build_ios: "true"
@@ -504,7 +502,6 @@ targets:
       - ci/**
 
   - name: Mac iOS Engine Release
-    bringup: true
     recipe: engine/engine
     properties:
       build_ios: "true"

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -1,6 +1,7 @@
 {
     "builds": [
         {
+            "archives": [],
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
@@ -15,10 +16,13 @@
             ],
             "name": "ios_debug_sim",
             "ninja": {
-                "config": "ios_debug_sim"
-            }
+                "config": "ios_debug_sim",
+                "targets": []
+            },
+            "tests": []
         },
         {
+            "archives": [],
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
@@ -34,10 +38,19 @@
             ],
             "name": "ios_debug_sim_arm64",
             "ninja": {
-                "config": "ios_debug_sim_arm64"
-            }
+                "config": "ios_debug_sim_arm64",
+                "targets": []
+            },
+            "tests": []
         },
         {
+            "archives": [
+                {
+                    "base_path": "out/ios_debug/zip_archives/",
+                    "include_paths": [],
+                    "name": "ios_debug"
+                }
+            ],
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
@@ -54,9 +67,11 @@
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework"
                 ]
-            }
+            },
+            "tests": []
         },
 	{
+            "archives": [],
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
@@ -74,9 +89,11 @@
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
                 ]
-            }
+            },
+            "tests": []
         },
 	{
+            "archives": [],
             "drone_dimensions": [
                 "device_type=none",
                 "mac_model=Macmini8,1",
@@ -94,9 +111,11 @@
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
                 ]
-            }
+            },
+            "tests": []
         }
     ],
+    "tests": [],
     "generators": {
         "tasks": [
             {
@@ -169,28 +188,23 @@
     "archives": [
         {
             "source": "out/debug/artifacts.zip",
-            "destination": "ios/artifacts.zip",
-	    "realm": "production"
+            "destination": "ios/artifacts.zip"
         },
 	{
             "source": "out/profile/artifacts.zip",
-            "destination": "ios-profile/artifacts.zip",
-	    "realm": "production"
+            "destination": "ios-profile/artifacts.zip"
         },
         {
             "source": "out/debug/ios-objcdoc.zip",
-            "destination": "ios-objcdoc.zip",
-	    "realm": "production"
+            "destination": "ios-objcdoc.zip"
         },
 	{
             "source": "out/release/artifacts.zip",
-            "destination": "ios-release/artifacts.zip",
-	    "realm": "production"
+            "destination": "ios-release/artifacts.zip"
         },
         {
             "source": "out/release/Flutter.dSYM.zip",
-            "destination": "ios-release/Flutter.dSYM.zip",
-	    "realm": "production"
+            "destination": "ios-release/Flutter.dSYM.zip"
         }
     ]
 }


### PR DESCRIPTION
Reverts flutter/engine#40844

We suspect this may be the cause of https://github.com/flutter/flutter/issues/124572