### PR TITLE
[Impeller] Make Metal layers readable

### DIFF
--- a/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
@@ -61,6 +61,10 @@ GPUCAMetalLayerHandle IOSSurfaceMetalImpeller::GetCAMetalLayer(const SkISize& fr
     layer.drawableSize = drawable_size;
   }
 
+  // Flutter needs to read from the color attachment in cases where there are effects such as
+  // backdrop filters. Flutter plugins that create platform views may also read from the layer.
+  layer.framebufferOnly = NO;
+
   // When there are platform views in the scene, the drawable needs to be presented in the same
   // transaction as the one created for platform views. When the drawable are being presented from
   // the raster thread, there is no such transaction.

--- a/shell/platform/darwin/ios/ios_surface_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_skia.mm
@@ -55,7 +55,7 @@ GPUCAMetalLayerHandle IOSSurfaceMetalSkia::GetCAMetalLayer(const SkISize& frame_
 
   layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
   // Flutter needs to read from the color attachment in cases where there are effects such as
-  // backdrop filters.
+  // backdrop filters. Flutter plugins that create platform views may also read from the layer.
   layer.framebufferOnly = NO;
 
   const auto drawable_size = CGSizeMake(frame_info.width(), frame_info.height());


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/124612.

Doing this would also allow us to remove the final blit on iOS when advanced blends/backdrop filters are present (all of the facilities would remain in place for GLES + Vulkan though).