### PR TITLE
[Impeller] Absorb root pass DrawPaints for most blend modes

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1230,11 +1230,17 @@ TEST_P(AiksTest, TextRotated) {
 }
 
 TEST_P(AiksTest, CanDrawPaint) {
-  Paint paint;
-  paint.color = Color::MediumTurquoise();
   Canvas canvas;
   canvas.Scale(Vector2(0.2, 0.2));
-  canvas.DrawPaint(paint);
+  canvas.DrawPaint({.color = Color::MediumTurquoise()});
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, CanDrawPaintMultipleTimes) {
+  Canvas canvas;
+  canvas.Scale(Vector2(0.2, 0.2));
+  canvas.DrawPaint({.color = Color::MediumTurquoise()});
+  canvas.DrawPaint({.color = Color::Color::OrangeRed().WithAlpha(0.5)});
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -167,15 +167,15 @@ void Canvas::DrawPath(const Path& path, const Paint& paint) {
 }
 
 void Canvas::DrawPaint(const Paint& paint) {
-  bool is_clear =
-      paint.blend_mode == BlendMode::kSource ||
-      (paint.blend_mode == BlendMode::kSourceOver && paint.color.alpha == 1);
   if (xformation_stack_.size() == 1 &&  // If we're recording the root pass,
       GetCurrentPass().GetElementCount() == 0 &&  // and this is the first item,
-      is_clear  // and the backdrop is being replaced
+      // TODO(bdero): Add remaining blend modes to Color::BlendColor.
+      paint.blend_mode < BlendMode::kHue  //
   ) {
     // Then we can absorb this drawPaint as the clear color of the pass.
-    GetCurrentPass().SetClearColor(paint.color);
+    auto color = Color::BlendColor(
+        paint.color, GetCurrentPass().GetClearColor(), paint.blend_mode);
+    GetCurrentPass().SetClearColor(color);
     return;
   }
 


### PR DESCRIPTION
We can be a lot more aggressive with absorbing DrawPaints by just cheaply blending them together on the CPU. We're missing some blend modes at the moment but can slot those in later.