### PR TITLE
Fixes to strip symbols correctly.

### DIFF
--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -104,7 +104,6 @@ def main():
       args, dst, framework, arm64_framework, simulator_framework,
       simulator_x64_framework, simulator_arm64_framework
   )
-  framework_binary = os.path.join(framework, 'Flutter')
   generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir)
   zip_archive(dst)
   return 0

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -105,7 +105,6 @@ def main():
       simulator_x64_framework, simulator_arm64_framework
   )
   framework_binary = os.path.join(framework, 'Flutter')
-  process_framework(args, dst, framework, framework_binary)
   generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir)
   zip_archive(dst)
   return 0
@@ -129,6 +128,7 @@ def create_framework(  # pylint: disable=too-many-arguments
   shutil.rmtree(framework, True)
   shutil.copytree(arm64_framework, framework)
   framework_binary = os.path.join(framework, 'Flutter')
+  process_framework(args, dst, framework, framework_binary)
 
   if args.simulator_arm64_out_dir is not None:
     shutil.rmtree(simulator_framework, True)
@@ -159,6 +159,7 @@ def create_framework(  # pylint: disable=too-many-arguments
       framework_binary
   ])
 
+  process_framework(args, dst, framework, framework_binary)
   return 0
 
 


### PR DESCRIPTION
The arm_64 Flutter binary was not stripping symbols correctly. This PR ensures the binary is stripped before creating the frameworks.

Bug: https://github.com/flutter/flutter/issues/124572

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
