### PR TITLE
[Impeller] Keep a reference to BlitPassGLES in the EncodeCommands lambda to prevent use-after-free

### DIFF
--- a/impeller/renderer/backend/gles/blit_pass_gles.cc
+++ b/impeller/renderer/backend/gles/blit_pass_gles.cc
@@ -86,10 +86,12 @@ bool BlitPassGLES::EncodeCommands(
     return true;
   }
 
-  return reactor_->AddOperation([transients_allocator, &commands = commands_,
+  std::shared_ptr<const BlitPassGLES> shared_this = shared_from_this();
+  return reactor_->AddOperation([transients_allocator,
+                                 blit_pass = std::move(shared_this),
                                  label = label_](const auto& reactor) {
-    auto result =
-        EncodeCommandsInReactor(transients_allocator, reactor, commands, label);
+    auto result = EncodeCommandsInReactor(transients_allocator, reactor,
+                                          blit_pass->commands_, label);
     FML_CHECK(result) << "Must be able to encode GL commands without error.";
   });
 }

--- a/impeller/renderer/backend/gles/blit_pass_gles.h
+++ b/impeller/renderer/backend/gles/blit_pass_gles.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "flutter/fml/macros.h"
 #include "flutter/impeller/base/config.h"
 #include "flutter/impeller/renderer/backend/gles/reactor_gles.h"
@@ -12,7 +14,8 @@
 
 namespace impeller {
 
-class BlitPassGLES final : public BlitPass {
+class BlitPassGLES final : public BlitPass,
+                           public std::enable_shared_from_this<BlitPassGLES> {
  public:
   // |BlitPass|
   ~BlitPassGLES() override;


### PR DESCRIPTION
Without this the BlitPassGLES and its command list can be destructed before the reactor executes the lambda.
