### PR TITLE
[fuchsia] migrate touch-input integration tests to scene manager test ui stack variants

### DIFF
--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_session.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_session.h
@@ -59,7 +59,6 @@ namespace flutter_runner::testing {
 //   +Error handling / session disconnection is still WIP.  FakeSession will
 //   likely generate a CHECK in any place where the real scenic would disconnect
 //   the session or send a ScenicError.
-//   +root_presenter-only commands e.g. CreateLayer are not handled.
 //   +Deprecated / obsolete commands are not handled.
 //   +Input is not handled.
 //   +Rendering is not handled.

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
@@ -55,7 +55,7 @@
         "fuchsia.test": {
             "deprecated-allowed-packages": [
                 "embedding-flutter-view",
-                "gfx-root-presenter-test-ui-stack",
+                "gfx-scene-manager-test-ui-stack",
                 "oot_flutter_aot_runner",
                 "oot_flutter_jit_runner",
                 "oot_flutter_jit_product_runner",


### PR DESCRIPTION
This change migrates `touch-input` integration tests from the gfx-root-presenter-test-ui-stack UI test realm variant to run parameterized tests of two types: gfx-scene-manager-test-ui-stack and flatland-scene-manager-test-ui-stack. This will enable fuchsia.git to remove the gfx-root-presenter-test-ui-stack variant, which will no longer be supported.

Note that this change does not modify the `embedder` integration tests, which use a generic `test-ui-stack` variant as defined by the fuchsia pkg url: `fuchsia-pkg://fuchsia.com/test-ui-stack#meta/test-ui-stack.cm`. Since the contents of this package is defined in fuchsia.git, the realm under test can adapt to changes in fuchsia.git so long as they update the test-ui-stack build target (which they do in https://fxrev.dev/831359, the change that relies on the touch changes in this repo described above.)

This change fixes https://fxbug.dev/125304

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.