### PR TITLE
`SemanticsAction` / `SemanticsFlag` cleanup part 5

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -235,16 +235,6 @@ class SemanticsAction {
 
   static SemanticsAction? fromIndex(int index) => _kActionById[index];
 
-  /// Temporary API until [values] return a list.
-  /// https://github.com/flutter/flutter/issues/123346
-  @Deprecated('This getter is temporary and will be removed shortly.')
-  static List<SemanticsAction> get doNotUseWillBeDeletedWithoutWarningValuesAsList => values;
-
-  /// Temporary API until [values] return a list.
-  /// https://github.com/flutter/flutter/issues/123346
-  @Deprecated('This getter is temporary and will be removed shortly.')
-  static Iterable<int> get doNotUseWillBeDeletedWithoutWarningKeys => _kActionById.keys;
-
   @override
   String toString() => 'SemanticsAction.$name';
 }
@@ -572,16 +562,6 @@ class SemanticsFlag {
   static List<SemanticsFlag> get values => _kFlagById.values.toList(growable: false);
 
   static SemanticsFlag? fromIndex(int index) => _kFlagById[index];
-
-  /// Temporary API until [values] return a list.
-  /// https://github.com/flutter/flutter/issues/123346
-  @Deprecated('This getter is temporary and will be removed shortly.')
-  static List<SemanticsFlag> get doNotUseWillBeDeletedWithoutWarningValuesAsList => values;
-
-  /// Temporary API until [values] return a list.
-  /// https://github.com/flutter/flutter/issues/123346
-  @Deprecated('This getter is temporary and will be removed shortly.')
-  static Iterable<int> get doNotUseWillBeDeletedWithoutWarningKeys => _kFlagById.keys;
 
   @override
   String toString() => 'SemanticsFlag.$name';

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -85,16 +85,6 @@ class SemanticsAction {
 
   static SemanticsAction? fromIndex(int index) => _kActionById[index];
 
-  /// Temporary API until [values] return a list.
-  /// https://github.com/flutter/flutter/issues/123346
-  @Deprecated('This getter is temporary and will be removed shortly.')
-  static List<SemanticsAction> get doNotUseWillBeDeletedWithoutWarningValuesAsList => values;
-
-  /// Temporary API until [values] return a list.
-  /// https://github.com/flutter/flutter/issues/123346
-  @Deprecated('This getter is temporary and will be removed shortly.')
-  static Iterable<int> get doNotUseWillBeDeletedWithoutWarningKeys => _kActionById.keys;
-
   @override
   String toString() => 'SemanticsAction.$name';
 }
@@ -191,16 +181,6 @@ class SemanticsFlag {
   static List<SemanticsFlag> get values => _kFlagById.values.toList(growable: false);
 
   static SemanticsFlag? fromIndex(int index) => _kFlagById[index];
-
-  /// Temporary API until [values] return a list.
-  /// https://github.com/flutter/flutter/issues/123346
-  @Deprecated('This getter is temporary and will be removed shortly.')
-  static List<SemanticsFlag> get doNotUseWillBeDeletedWithoutWarningValuesAsList => values;
-
-  /// Temporary API until [values] return a list.
-  /// https://github.com/flutter/flutter/issues/123346
-  @Deprecated('This getter is temporary and will be removed shortly.')
-  static Iterable<int> get doNotUseWillBeDeletedWithoutWarningKeys => _kFlagById.keys;
 
   @override
   String toString() => 'SemanticsFlag.$name';


### PR DESCRIPTION
Final part of https://github.com/flutter/flutter/issues/123346 (before deprecating describeEnum)
Remove temporary variables.