### PR TITLE
[Impeller] Check coverage after screen clip

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2099,5 +2099,25 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixImageFilterDrawsCorrectly) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+/// This is a regression check for https://github.com/flutter/engine/pull/41129
+/// The entire screen is green if successful. If failing, no frames will render,
+/// or the entire screen will be transparent black.
+TEST_P(AiksTest, CanRenderTinyOverlappingSubpasses) {
+  Canvas canvas;
+  canvas.DrawPaint({.color = Color::Red()});
+
+  // Draw two overlapping subpixel circles.
+  canvas.SaveLayer({});
+  canvas.DrawCircle({100, 100}, 0.1, {.color = Color::Yellow()});
+  canvas.Restore();
+  canvas.SaveLayer({});
+  canvas.DrawCircle({100, 100}, 0.1, {.color = Color::Yellow()});
+  canvas.Restore();
+
+  canvas.DrawPaint({.color = Color::Green()});
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -397,13 +397,18 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       }
     }
 
-    if (!subpass_coverage.has_value() || subpass_coverage->size.IsEmpty()) {
+    if (!subpass_coverage.has_value()) {
       // The subpass doesn't contain anything visible, so skip it.
       return EntityPass::EntityResult::Skip();
     }
 
     subpass_coverage =
         subpass_coverage->Intersection(Rect::MakeSize(root_pass_size));
+    if (!subpass_coverage.has_value() ||
+        ISize(subpass_coverage->size).IsEmpty()) {
+      // The subpass doesn't contain anything visible, so skip it.
+      return EntityPass::EntityResult::Skip();
+    }
 
     auto subpass_target =
         CreateRenderTarget(renderer,                                  //


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/124658.

Need to add error messages around all failed scenarios in EntityPass since we don't have a recovery and the whole frame fails to render. Will CP this.

Before: Failed rendering.

After:

![image](https://user-images.githubusercontent.com/919017/231572633-0e1e508d-5eb2-4cf6-a3bf-bdaa78dbb5c6.png)
