### PR TITLE
[fuchsia] Reduce noise from child view disconnects

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_platform_view.cc
+++ b/shell/platform/fuchsia/flutter/flatland_platform_view.cc
@@ -187,8 +187,8 @@ void FlatlandPlatformView::OnCreateView(ViewCallback on_view_created,
 
     child_view_watcher.set_error_handler(
         [weak, view_id, content_id](zx_status_t status) {
-          FML_LOG(ERROR) << "Interface error on: ChildViewWatcher status: "
-                         << status;
+          FML_LOG(WARNING) << "Child disconnected. ChildViewWatcher status: "
+                           << status;
 
           if (!weak) {
             FML_LOG(WARNING)


### PR DESCRIPTION
This CL changes ERROR to WARNING for the logs when a child disconnects and ChildViewWatcher is closed. This may happen due to other apps and doesn't necessarily indicate a flutter error. 

Bug:fxb/125256