### PR TITLE
Don't use `OffscreenCanvas` in Safari, it doesn't support WebGL.

### DIFF
--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -1056,5 +1056,8 @@ class OffScreenCanvas {
 
   /// Feature detects OffscreenCanvas.
   static bool get supported => _supported ??=
-      js_util.hasProperty(domWindow, 'OffscreenCanvas');
+      // Safari 16.4 implements OffscreenCanvas, but without WebGL support. So
+      // it's not really supported in a way that is useful to us.
+      !isSafari
+      && js_util.hasProperty(domWindow, 'OffscreenCanvas');
 }

--- a/lib/web_ui/test/engine/browser_detect_test.dart
+++ b/lib/web_ui/test/engine/browser_detect_test.dart
@@ -196,8 +196,15 @@ void testMain() {
       expect(browserSupportsCanvaskitChromium, isFalse);
     });
   });
-}
 
+  group('OffscreenCanvas', () {
+    test('OffscreenCanvas is detected as unsupported in Safari', () {
+      debugBrowserEngineOverride = BrowserEngine.webkit;
+      expect(OffScreenCanvas.supported, isFalse);
+      debugBrowserEngineOverride = null;
+    });
+  });
+}
 
 @JS('window.Intl.v8BreakIterator')
 external dynamic get v8BreakIterator;


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/124726

Safari 16.4 adds OffscreenCanvas support, but only for 2D rendering. We basically only use `OffscreenCanvas` for WebGL rendering, so we shouldn't consider it "supported".