### PR TITLE
[Impeller] Fix the cmake example build.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -450,12 +450,11 @@ targets:
     timeout: 60
     properties:
       release_build: "true"
-      config_name: impeller_cmake_build_test
+      config_name: mac_impeller_cmake_example
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }
       dependencies: >-
         [
-          {"dependency": "cmake", "version": "build_id:8784715802296535313"},
           {"dependency": "jazzy", "version": "0.14.1"}
         ]
 

--- a/DEPS
+++ b/DEPS
@@ -100,6 +100,10 @@ vars = {
   # Setup Git hooks by default.
   "setup_githooks": True,
 
+  # This is not downloaded be default because it increases the
+  # `gclient sync` time by between 1 and 3 minutes. This option is enabled
+  # in flutter/ci/builders/mac_impeller_cmake_example.json, and is likely to
+  # only be useful locally when reproducing issues found by the bot.
   'download_impeller_cmake_example': False,
 
   # Upstream URLs for third party dependencies, used in
@@ -853,6 +857,18 @@ deps = {
      'url': Var('github_git') + '/bdero/impeller-cmake-example.git' + '@' + '4d728722ac1559f59db28a3ef061fe929d6be4c6',
      'condition': 'download_impeller_cmake_example',
   },
+
+  # cmake is only used by impeller-cmake-example.
+  'src/buildtools/mac-x64/cmake': {
+    'packages': [
+      {
+        'package': 'infra/3pp/tools/cmake/mac-amd64',
+        'version': 'CGpMvZoP962wdEINR9d4OEvEW7ZOv0MPrHNKbBUBS0sC',
+      }
+    ],
+    'condition': 'download_impeller_cmake_example and host_os == "mac"',
+    'dep_type': 'cipd',
+  }
 }
 
 recursedeps = [

--- a/ci/builders/mac_impeller_cmake_example.json
+++ b/ci/builders/mac_impeller_cmake_example.json
@@ -1,37 +1,27 @@
 {
     "builds": [
         {
-            "name": "impeller_cmake_build_test",
+            "name": "impeller-cmake-example",
             "archives": [],
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
-            "gclient_custom_vars": {
+            "gclient_variables": {
                 "download_android_deps": false,
                 "download_impeller_cmake_example": true
             },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "cmake",
-                    "script": "flutter/ci/impeller_cmake_build_test.py",
-                    "parameters": [
-                        "--cmake"
-                    ],
-                    "type": "local"
-                },
-                {
-                    "language": "python3",
-                    "name": "build",
-                    "script": "flutter/ci/impeller_cmake_build_test.py",
-                    "parameters": [
-                        "--build"
-                    ],
-                    "type": "local"
-                }
-            ]
+            "gn": [
+               "--impeller-cmake-example",
+               "--xcode-symlinks"
+            ],
+            "ninja": {
+                "config": "impeller-cmake-example",
+                "targets": [
+                ]
+            },
+            "tests": []
         }
     ],
     "tests": []

--- a/tools/gn
+++ b/tools/gn
@@ -672,6 +672,35 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['flutter_prebuilt_dart_sdk'] = True
 
 
+def run_impeller_cmake(args):
+  impeller_cmake_dir = os.path.join('third_party', 'impeller-cmake-example')
+  if not os.path.isdir(os.path.join(SRC_ROOT, impeller_cmake_dir)):
+    print(
+        'The Impeller cmake example directory "{}" does not exist'
+        .format(impeller_cmake_dir)
+    )
+    return 1
+  goma_gn_args = setup_goma(args)
+  goma_dir = goma_gn_args['goma_dir']
+  cmake_cmd = [
+      'python3',
+      os.path.join(SRC_ROOT, 'flutter', 'ci', 'impeller_cmake_build_test.py'),
+      '--path',
+      impeller_cmake_dir,
+      '--cmake',
+  ]
+  if goma_dir is not None:
+    cmake_cmd = cmake_cmd + ['--goma-dir', goma_dir]
+  if args.xcode_symlinks:
+    cmake_cmd = cmake_cmd + ['--xcode-symlinks']
+  try:
+    cmake_call_result = subprocess.call(cmake_cmd, cwd=SRC_ROOT)
+  except subprocess.CalledProcessError as exc:
+    print('Failed to generate cmake files: ', exc.returncode, exc.output)
+    return 1
+  return cmake_call_result
+
+
 def parse_args(args):
   args = args[1:]
   parser = argparse.ArgumentParser(description='A script to run `gn gen`.')
@@ -1032,6 +1061,13 @@ def parse_args(args):
       '--malioc-path', type=str, help='The path to the malioc tool.'
   )
 
+  parser.add_argument(
+      '--impeller-cmake-example',
+      default=False,
+      action='store_true',
+      help='Do not run GN. Instead configure the Impeller cmake example build.',
+  )
+
   # Sanitizers.
   parser.add_argument('--asan', default=False, action='store_true')
   parser.add_argument('--lsan', default=False, action='store_true')
@@ -1083,6 +1119,9 @@ def validate_args(args):
 def main(argv):
   args = parse_args(argv)
   validate_args(args)
+
+  if args.impeller_cmake_example:
+    return run_impeller_cmake(args)
 
   exe = '.exe' if sys.platform.startswith(('cygwin', 'win')) else ''
 


### PR DESCRIPTION
To fit in better with the `engine_v2` context, this PR shifts the `cmake` step for the `impeller-cmake-example` to run within the `flutter/tools/gn` script. That way, the recipe will ensure that `GOMA_DIR` is defined, goma is running, etc.. Since we use `cmake` to generate a ninja build for `impeller-cmake-example`, the engine_v2 `ninja` step can build it, and that feature of the python script is no longer needed.

Successful run is here https://ci.chromium.org/ui/p/flutter/builders/try/Mac%20impeller-cmake-example/12/overview