### PR TITLE
[fuchsia] Remove implementations & clients of deprecated CreateView

### DIFF
--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -628,16 +628,6 @@ void ComponentV2::OnEngineTerminate(const Engine* shell_holder) {
   }
 }
 
-void ComponentV2::CreateView(
-    zx::eventpair token,
-    fidl::InterfaceRequest<fuchsia::sys::ServiceProvider> /*incoming_services*/,
-    fidl::InterfaceHandle<
-        fuchsia::sys::ServiceProvider> /*outgoing_services*/) {
-  auto view_ref_pair = scenic::ViewRefPair::New();
-  CreateViewWithViewRef(std::move(token), std::move(view_ref_pair.control_ref),
-                        std::move(view_ref_pair.view_ref));
-}
-
 void ComponentV2::CreateViewWithViewRef(
     zx::eventpair view_token,
     fuchsia::ui::views::ViewRefControl control_ref,

--- a/shell/platform/fuchsia/flutter/component_v2.h
+++ b/shell/platform/fuchsia/flutter/component_v2.h
@@ -111,12 +111,6 @@ class ComponentV2 final
   void Stop() override;
 
   // |fuchsia::ui::app::ViewProvider|
-  void CreateView(
-      zx::eventpair token,
-      fidl::InterfaceRequest<fuchsia::sys::ServiceProvider> incoming_services,
-      fuchsia::sys::ServiceProviderHandle outgoing_services) override;
-
-  // |fuchsia::ui::app::ViewProvider|
   void CreateViewWithViewRef(zx::eventpair view_token,
                              fuchsia::ui::views::ViewRefControl control_ref,
                              fuchsia::ui::views::ViewRef view_ref) override;

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/lib/parent_view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/lib/parent_view.dart
@@ -238,9 +238,13 @@ ViewHolderToken _launchGfxChildView() {
   final viewTokens = EventPairPair();
   assert(viewTokens.status == ZX.OK);
   final viewHolderToken = ViewHolderToken(value: viewTokens.first);
-  final viewToken = ViewToken(value: viewTokens.second);
 
-  viewProvider.createView(viewToken.value, null, null);
+  final viewRefs = EventPairPair();
+  assert(viewRefs.status == ZX.OK);
+  final viewRefControl = ViewRefControl(reference: viewRefs.first.duplicate(ZX.DEFAULT_EVENTPAIR_RIGHTS & ~ZX.RIGHT_DUPLICATE));
+  final viewRef = ViewRef(reference: viewRefs.second.duplicate(ZX.RIGHTS_BASIC));
+
+  viewProvider.createViewWithViewRef(viewTokens.second, viewRefControl, viewRef);
   viewProvider.ctrl.close();
 
   return viewHolderToken;

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/lib/embedding-flutter-view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/lib/embedding-flutter-view.dart
@@ -238,9 +238,13 @@ ViewHolderToken _launchGfxChildView() {
   final viewTokens = EventPairPair();
   assert(viewTokens.status == ZX.OK);
   final viewHolderToken = ViewHolderToken(value: viewTokens.first);
-  final viewToken = ViewToken(value: viewTokens.second);
 
-  viewProvider.createView(viewToken.value, null, null);
+  final viewRefs = EventPairPair();
+  assert(viewRefs.status == ZX.OK);
+  final viewRefControl = ViewRefControl(reference: viewRefs.first.duplicate(ZX.DEFAULT_EVENTPAIR_RIGHTS & ~ZX.RIGHT_DUPLICATE));
+  final viewRef = ViewRef(reference: viewRefs.second.duplicate(ZX.RIGHTS_BASIC));
+
+  viewProvider.createViewWithViewRef(viewTokens.second, viewRefControl, viewRef);
   viewProvider.ctrl.close();
 
   return viewHolderToken;


### PR DESCRIPTION
Prepare Flutter's Fuchsia port for removal of the fuchsia.ui.app.ViewProvider.CreateView() API.
The Flutter engine's implementation of the API, which has long been deprecated, is removed.
Calls to the deprecated CreateView() in tests are replaced with CreateViewWithViewRef().

Bug fxbug.dev/81285

