### PR TITLE
Do not use Macmini7,1 for host tests

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -16,7 +16,8 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=x86",
+                "mac_model=Macmini8,1"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -72,7 +73,8 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=x86",
+                "mac_model=Macmini8,1"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -13,7 +13,8 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=x86",
+                "mac_model=Macmini8,1"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/124678

those machines do not support compute subgroups. They make up only a relatively small fraction of the pool.

This does not restrict the arm machines, as they're already restricted by the cpu architecture dimension.