### PR TITLE
[web:canvaskit] move shaders to UniqueRef; fix minor memory leaks

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/shader.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/shader.dart
@@ -5,45 +5,59 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
 
 import '../util.dart';
 import '../validators.dart';
 import 'canvaskit_api.dart';
 import 'image.dart';
-import 'skia_object_cache.dart';
+import 'native_memory.dart';
 
-abstract class CkShader extends ManagedSkiaObject<SkShader>
-    implements ui.Shader {
-  SkShader withQuality(ui.FilterQuality contextualQuality) => skiaObject;
+/// Refines the generic [ui.Shader] interface with CanvasKit-specific features.
+abstract class CkShader implements ui.Shader {
+  /// Returns a Skia shader at requested filter quality, if that shader supports
+  /// altering its filter quality.
+  ///
+  /// If the implementation supports changing filter quality, and the value of
+  /// [contextualQuality] is the same as a previously passed value, the
+  /// implementation may return the same object as before. If a new Skia object
+  /// is created, the previous object is released and cannot be used again. For
+  /// this reason, do not store the returned value long-term to prevent dangling
+  /// pointer errors.
+  SkShader getSkShader(ui.FilterQuality contextualQuality);
+}
 
-  @override
-  void delete() {
-    rawSkiaObject?.delete();
+/// Base class for shader implementations with a simple memory model that do not
+/// support contextual filter quality.
+///
+/// Provides common memory mangement logic for shaders that map one-to-one to a
+/// [SkShader] object. The lifetime of this shader is hard-linked to the
+/// lifetime of the [SkShader]. [getSkShader] always returns the one and only
+/// [SkShader] object, ignoring contextual filter quality.
+abstract class SimpleCkShader implements CkShader {
+  SimpleCkShader() {
+    _ref = UniqueRef<SkShader>(this, createSkiaObject(), debugOwnerLabel);
   }
 
-  bool _disposed = false;
+  late final UniqueRef<SkShader> _ref;
 
   @override
-  bool get debugDisposed {
-    late bool disposed;
-    assert(() {
-      disposed = _disposed;
-      return true;
-    }());
-    return disposed;
-  }
+  SkShader getSkShader(ui.FilterQuality contextualQuality) => _ref.nativeObject;
+
+  String get debugOwnerLabel;
+  SkShader createSkiaObject();
+
+  @override
+  bool get debugDisposed => _ref.isDisposed;
 
   @override
   void dispose() {
-    assert(() {
-      _disposed = true;
-      return true;
-    }());
+    _ref.dispose();
   }
 }
 
-class CkGradientSweep extends CkShader implements ui.Gradient {
+class CkGradientSweep extends SimpleCkShader implements ui.Gradient {
   CkGradientSweep(this.center, this.colors, this.colorStops, this.tileMode,
       this.startAngle, this.endAngle, this.matrix4)
       : assert(offsetIsValid(center)),
@@ -51,6 +65,9 @@ class CkGradientSweep extends CkShader implements ui.Gradient {
         assert(matrix4 == null || matrix4IsValid(matrix4)) {
     validateColorStops(colors, colorStops);
   }
+
+  @override
+  String get debugOwnerLabel => 'Gradient.sweep';
 
   final ui.Offset center;
   final List<ui.Color> colors;
@@ -61,7 +78,7 @@ class CkGradientSweep extends CkShader implements ui.Gradient {
   final Float32List? matrix4;
 
   @override
-  SkShader createDefault() {
+  SkShader createSkiaObject() {
     const double toDegrees = 180.0 / math.pi;
     return canvasKit.Shader.MakeSweepGradient(
       center.dx,
@@ -75,14 +92,9 @@ class CkGradientSweep extends CkShader implements ui.Gradient {
       toDegrees * endAngle,
     );
   }
-
-  @override
-  SkShader resurrect() {
-    return createDefault();
-  }
 }
 
-class CkGradientLinear extends CkShader implements ui.Gradient {
+class CkGradientLinear extends SimpleCkShader implements ui.Gradient {
   CkGradientLinear(
     this.from,
     this.to,
@@ -107,7 +119,10 @@ class CkGradientLinear extends CkShader implements ui.Gradient {
   final Float32List? matrix4;
 
   @override
-  SkShader createDefault() {
+  String get debugOwnerLabel => 'Gradient.linear';
+
+  @override
+  SkShader createSkiaObject() {
     return canvasKit.Shader.MakeLinearGradient(
       toSkPoint(from),
       toSkPoint(to),
@@ -117,12 +132,9 @@ class CkGradientLinear extends CkShader implements ui.Gradient {
       matrix4 != null ? toSkMatrixFromFloat32(matrix4!) : null,
     );
   }
-
-  @override
-  SkShader resurrect() => createDefault();
 }
 
-class CkGradientRadial extends CkShader implements ui.Gradient {
+class CkGradientRadial extends SimpleCkShader implements ui.Gradient {
   CkGradientRadial(this.center, this.radius, this.colors, this.colorStops,
       this.tileMode, this.matrix4);
 
@@ -134,7 +146,10 @@ class CkGradientRadial extends CkShader implements ui.Gradient {
   final Float32List? matrix4;
 
   @override
-  SkShader createDefault() {
+  String get debugOwnerLabel => 'Gradient.radial';
+
+  @override
+  SkShader createSkiaObject() {
     return canvasKit.Shader.MakeRadialGradient(
       toSkPoint(center),
       radius,
@@ -145,12 +160,9 @@ class CkGradientRadial extends CkShader implements ui.Gradient {
       0,
     );
   }
-
-  @override
-  SkShader resurrect() => createDefault();
 }
 
-class CkGradientConical extends CkShader implements ui.Gradient {
+class CkGradientConical extends SimpleCkShader implements ui.Gradient {
   CkGradientConical(this.focal, this.focalRadius, this.center, this.radius,
       this.colors, this.colorStops, this.tileMode, this.matrix4);
 
@@ -164,7 +176,10 @@ class CkGradientConical extends CkShader implements ui.Gradient {
   final Float32List? matrix4;
 
   @override
-  SkShader createDefault() {
+  String get debugOwnerLabel => 'Gradient.radial(conical)';
+
+  @override
+  SkShader createSkiaObject() {
     return canvasKit.Shader.MakeTwoPointConicalGradient(
       toSkPoint(focal),
       focalRadius,
@@ -177,15 +192,25 @@ class CkGradientConical extends CkShader implements ui.Gradient {
       0,
     );
   }
-
-  @override
-  SkShader resurrect() => createDefault();
 }
 
-class CkImageShader extends CkShader implements ui.ImageShader {
+/// Implements [ui.ImageShader] for CanvasKit.
+///
+/// The memory management model is different from other shaders (backed by
+/// [SimpleCkShader]) in that this object is not one-to-one to its Skia
+/// counterpart [SkShader]. During initialization a default [SkShader] is
+/// created based on the [filterQuality] specified in the constructor. However,
+/// when [withQuality] is called with a different [ui.FilterQuality] value the
+/// previous [SkShader] is discarded and a new [SkShader] is created. Therefore,
+/// over the lifetime of this object, multiple [SkShader] instances may be
+/// generated depending on the _usage_ of this object in [ui.Paint] and other
+/// scenarios that want a shader at different filter quality levels.
+class CkImageShader implements ui.ImageShader, CkShader {
   CkImageShader(ui.Image image, this.tileModeX, this.tileModeY, this.matrix4,
       this.filterQuality)
-      : _image = image as CkImage;
+      : _image = image as CkImage {
+    _initializeSkImageShader(filterQuality ?? ui.FilterQuality.none);
+  }
 
   final ui.TileMode tileModeX;
   final ui.TileMode tileModeY;
@@ -193,53 +218,67 @@ class CkImageShader extends CkShader implements ui.ImageShader {
   final ui.FilterQuality? filterQuality;
   final CkImage _image;
 
+  /// Owns the reference to the currently [SkShader].
+  ///
+  /// This reference changes when [withQuality] is called with different filter
+  /// quality levels.
+  @visibleForTesting
+  UniqueRef<SkShader>? ref;
+
+  /// The filter quality at which the latest [SkShader] was initialized.
+  @visibleForTesting
+  late ui.FilterQuality currentQuality;
+
   int get imageWidth => _image.width;
 
   int get imageHeight => _image.height;
 
-  ui.FilterQuality? _cachedQuality;
   @override
-  SkShader withQuality(ui.FilterQuality contextualQuality) {
+  SkShader getSkShader(ui.FilterQuality contextualQuality) {
+    assert(!debugDisposed, 'Cannot make a copy of a disposed ImageShader.');
     final ui.FilterQuality quality = filterQuality ?? contextualQuality;
-    SkShader? shader = rawSkiaObject;
-    if (_cachedQuality != quality || shader == null) {
-      if (quality == ui.FilterQuality.high) {
-        shader = _image.skImage.makeShaderCubic(
-          toSkTileMode(tileModeX),
-          toSkTileMode(tileModeY),
-          1.0 / 3.0,
-          1.0 / 3.0,
-          toSkMatrixFromFloat64(matrix4),
-        );
-      } else {
-        shader = _image.skImage.makeShaderOptions(
-          toSkTileMode(tileModeX),
-          toSkTileMode(tileModeY),
-          toSkFilterMode(quality),
-          toSkMipmapMode(quality),
-          toSkMatrixFromFloat64(matrix4),
-        );
-      }
-      _cachedQuality = quality;
-      rawSkiaObject = shader;
+    if (currentQuality != quality) {
+      _initializeSkImageShader(quality);
     }
-    return shader;
+    return ref!.nativeObject;
   }
 
-  @override
-  SkShader createDefault() => withQuality(ui.FilterQuality.none);
+  void _initializeSkImageShader(ui.FilterQuality quality) {
+    final SkShader skShader;
+    if (quality == ui.FilterQuality.high) {
+      skShader = _image.skImage.makeShaderCubic(
+        toSkTileMode(tileModeX),
+        toSkTileMode(tileModeY),
+        1.0 / 3.0,
+        1.0 / 3.0,
+        toSkMatrixFromFloat64(matrix4),
+      );
+    } else {
+      skShader = _image.skImage.makeShaderOptions(
+        toSkTileMode(tileModeX),
+        toSkTileMode(tileModeY),
+        toSkFilterMode(quality),
+        toSkMipmapMode(quality),
+        toSkMatrixFromFloat64(matrix4),
+      );
+    }
 
-  @override
-  SkShader resurrect() => withQuality(_cachedQuality ?? ui.FilterQuality.none);
-
-  @override
-  void delete() {
-    rawSkiaObject?.delete();
+    currentQuality = quality;
+    ref?.dispose();
+    ref = UniqueRef<SkShader>(this, skShader, 'ImageShader');
   }
+
+  bool _isDisposed = false;
+
+  @override
+  bool get debugDisposed => _isDisposed;
 
   @override
   void dispose() {
-    super.dispose();
+    assert(!_isDisposed, 'Cannot dispose ImageShader more than once.');
+    _isDisposed = true;
     _image.dispose();
+    ref?.dispose();
+    ref = null;
   }
 }


### PR DESCRIPTION
Move all classes implementing the `Shader` interface from `ManagedSkiaObject` to `UniqueRef`.

Fix two (probably minor) memory leaks:

* `CkImageShader` was leaking intermediate instances of `SkShader` because those were neither attached to a `FinalizationRegistry`, nor disposed of explicitly through the `dispose()` method.
* `CkFragmentShader` was leaking `SkShader` instances because it never called `CkFragmentInstance.dispose`. Additionally, the `CkFragmentInstance` class isn't really necessary, because `UniqueRef` is fully sufficient to manage instances of `SkShader` objects for fragment shaders.