### PR TITLE
Only set `dart_include_wasm_opt` when we are actually building the dart sdk.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -383,10 +383,6 @@ def to_gn_args(args):
   else:
     gn_args['dart_runtime_mode'] = runtime_mode
 
-  # If we are building the dart sdk in-tree, exclude the wasm-opt target, as
-  # it doesn't build properly with our gn configuration.
-  gn_args['dart_include_wasm_opt'] = False
-
   # Desktop embeddings can have more dependencies than the engine library,
   # which can be problematic in some build environments (e.g., building on
   # Linux will bring in pkg-config dependencies at generation time). These
@@ -494,6 +490,10 @@ def to_gn_args(args):
           'source by setting `--no-prebuilt-dart-sdk` flag to tools/gn'
       )
   elif is_host_build(args):
+    # If we are building the dart sdk in-tree, exclude the wasm-opt target, as
+    # it doesn't build properly with our gn configuration.
+    gn_args['dart_include_wasm_opt'] = False
+
     # dart_platform_sdk is only defined for host builds, linux arm host builds
     # specify target_os=linux.
     # dart_platform_sdk=True means exclude web-related files, e.g. dart2js,


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/123629

We were getting a warning when specifying this and not building the dart SDK.