### PR TITLE
[Impeller] Print a log on all non-recoverable failure paths in EntityPass

### DIFF
--- a/impeller/entity/entity_pass_target.cc
+++ b/impeller/entity/entity_pass_target.cc
@@ -59,7 +59,7 @@ const RenderTarget& EntityPassTarget::GetRenderTarget() const {
 }
 
 bool EntityPassTarget::IsValid() const {
-  return !target_.GetColorAttachments().empty();
+  return target_.IsValid();
 }
 
 }  // namespace impeller

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -55,10 +55,14 @@ bool InlinePassContext::EndPass() {
   }
 
   if (!pass_->EncodeCommands()) {
+    VALIDATION_LOG
+        << "Failed to encode commands while ending the current render pass.";
     return false;
   }
 
   if (!command_buffer_->SubmitCommands()) {
+    VALIDATION_LOG
+        << "Failed to submit command buffer while ending render pass.";
     return false;
   }
 


### PR DESCRIPTION
This eliminates a lot of surface area when debugging non-recoverable frame failures such as https://github.com/flutter/engine/pull/41129. Every failure case should be covered with at least one log, but without recursive log spam.