### PR TITLE
Macmini8,1 for another target that runs host tests

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -128,7 +128,8 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=x86",
+                "mac_model=Macmini8,1"
             ],
             "dependencies": [
                 {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}


### PR DESCRIPTION
This target also runs impeller_unittests that aren't safe to run right now on Macmini7,1

I missed this in https://github.com/flutter/engine/pull/41159