### PR TITLE
Change v2 `mac_android_aot_engine` orchestrator builder to Linux

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -345,8 +345,6 @@ targets:
     timeout: 60
     properties:
       config_name: mac_android_aot_engine
-      $flutter/osx_sdk : >-
-        { "sdk_version": "14a5294e" }
 
   - name: Linux mac_android_aot_engine
     bringup: true
@@ -369,14 +367,6 @@ targets:
         { "sdk_version": "14a5294e" }
 
   - name: Mac mac_unopt
-    recipe: engine_v2/engine_v2
-    properties:
-      config_name: mac_unopt
-      add_recipes_cq: "true"
-    timeout: 60
-
-  - name: Linux mac_unopt
-    bringup: true
     recipe: engine_v2/engine_v2
     properties:
       config_name: mac_unopt

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -340,7 +340,16 @@ targets:
       build_host: "true"
     timeout: 75
 
+  - name: Mac mac_android_aot_engine
+    recipe: engine_v2/engine_v2
+    timeout: 60
+    properties:
+      config_name: mac_android_aot_engine
+      $flutter/osx_sdk : >-
+        { "sdk_version": "14a5294e" }
+
   - name: Linux mac_android_aot_engine
+    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
@@ -359,7 +368,15 @@ targets:
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }
 
+  - name: Mac mac_unopt
+    recipe: engine_v2/engine_v2
+    properties:
+      config_name: mac_unopt
+      add_recipes_cq: "true"
+    timeout: 60
+
   - name: Linux mac_unopt
+    bringup: true
     recipe: engine_v2/engine_v2
     properties:
       config_name: mac_unopt

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -340,13 +340,11 @@ targets:
       build_host: "true"
     timeout: 75
 
-  - name: Mac mac_android_aot_engine
+  - name: Linux mac_android_aot_engine
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
       config_name: mac_android_aot_engine
-      $flutter/osx_sdk : >-
-        { "sdk_version": "14a5294e" }
 
   - name: Mac mac_host_engine
     recipe: engine_v2/engine_v2
@@ -361,7 +359,7 @@ targets:
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }
 
-  - name: Mac mac_unopt
+  - name: Linux mac_unopt
     recipe: engine_v2/engine_v2
     properties:
       config_name: mac_unopt


### PR DESCRIPTION
`mac_android_aot_engine` orchestrator kicks off Mac swarming tasks, but don't seem to need to run on a Mac.  Swap Linux bots which are more plentiful and have a shorter queue time.

Start by adding new `bringup` builder to see if it passes in staging.  If it passes I will remove the Mac variants ASAP.

Keep `mac_ios_engine` and `mac_host_engine` as Macs since they need to run Xcodes on Macs to create the xcframeworks.
