### PR TITLE
Run clang tidy builds on arm Macs

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -383,7 +383,7 @@ targets:
     recipe: engine/engine_lint
     properties:
       add_recipes_cq: "true"
-      cores: "12"
+      cpu: arm64
       lint_host: "true"
       lint_ios: "false"
     timeout: 75
@@ -405,6 +405,7 @@ targets:
     recipe: engine/engine_lint
     properties:
       add_recipes_cq: "true"
+      cpu: arm64
       lint_host: "false"
       lint_ios: "true"
     timeout: 75

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -383,6 +383,7 @@ targets:
     recipe: engine/engine_lint
     properties:
       add_recipes_cq: "true"
+      cores: "8"
       cpu: arm64
       lint_host: "true"
       lint_ios: "false"


### PR DESCRIPTION
Intel Mac capacity is limited.  Swap the two Mac clang-tidy builders to arm bots.  The clang-tidy linter should run with arm natively.

### Mac Host clang-tidy
Prod x64: https://ci.chromium.org/p/flutter/builders/prod/Mac%20Host%20clang-tidy/3318 Execution 35 mins 2 secs
This PR arm: https://ci.chromium.org/p/flutter/builders/try/Mac%20Host%20clang-tidy/8087 Execution 36 mins 30 secs (this hit an Xcode cache miss which added 4 minutes)

### Mac iOS clang-tidy
Prod x64: https://ci.chromium.org/p/flutter/builders/prod/Mac%20iOS%20clang-tidy/3303 Execution 11 mins 57 secs
This PR arm: https://ci.chromium.org/p/flutter/builders/try/Mac%20iOS%20clang-tidy/8087 Execution 18 mins 10 secs (this hit an Xcode cache miss which added 5 minutes)
