### PR TITLE
Run mac_host_engine orchestrator on arm Macs

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -353,6 +353,7 @@ targets:
     timeout: 60
     properties:
       release_build: "true"
+      cpu: arm64
       config_name: mac_host_engine
       dependencies: >-
         [


### PR DESCRIPTION
Intel Mac capacity is limited. Run the `mac_host_engine` orchestrator builder on Mac arm bots which we have a higher capacity of than the Intel Macs.  It needs Xcode to stitch together the frameworks and therefore to run on Mac, but isn't building anything itself.

Running on arm: https://ci.chromium.org/p/flutter/builders/try/Mac%20mac_host_engine/8593

I wasn't able to get this working on `mac_ios_engine` due to a gem issue, filed https://github.com/flutter/flutter/issues/124833