### PR TITLE
Allow Mac ci builders to run on arm

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -52,7 +52,7 @@ platform_properties:
           {"dependency": "open_jdk", "version": "version:11"}
         ]
       device_type: none
-      cpu: x86
+      cpu: arm64
       os: Mac-12
       xcode: 14a5294e # xcode 14.0 beta 5
   windows:
@@ -438,6 +438,7 @@ targets:
     timeout: 60
     properties:
       release_build: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/124833
       config_name: mac_ios_engine
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -383,8 +383,6 @@ targets:
     recipe: engine/engine_lint
     properties:
       add_recipes_cq: "true"
-      cores: "8"
-      cpu: arm64
       lint_host: "true"
       lint_ios: "false"
     timeout: 75
@@ -406,7 +404,6 @@ targets:
     recipe: engine/engine_lint
     properties:
       add_recipes_cq: "true"
-      cpu: arm64
       lint_host: "false"
       lint_ios: "true"
     timeout: 75
@@ -453,7 +450,6 @@ targets:
     timeout: 60
     properties:
       release_build: "true"
-      cpu: arm64
       config_name: mac_impeller_cmake_example
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -338,6 +338,7 @@ targets:
         {"download_emsdk": true}
       add_recipes_cq: "true"
       build_host: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/124877
       mac_model: "Macmini8,1"
     timeout: 75
 
@@ -372,6 +373,7 @@ targets:
     recipe: engine/engine_unopt
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/124877
       runtime_versions: >-
         [
           "ios-16-0_14a5294e"


### PR DESCRIPTION
Ideally we wouldn't specify a cpu except for the builders that needed either Intel or arm specifically, respectively, and let the scheduler figure out which bots to run based on capacity.

Allow all the Mac .ci.yaml builders (not ci/builders) on arm Macs.  Pin the ones to x64 that need to for one reason or another.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
