### PR TITLE
Allow `mac_android_aot_engine` swarming tasks to run on arm bots

### DIFF
--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -13,8 +13,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -47,8 +46,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -82,8 +80,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -117,8 +114,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -151,8 +147,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -186,8 +181,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false

--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -14,7 +14,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -48,7 +48,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -83,7 +83,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -118,7 +118,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -152,7 +152,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false
@@ -187,7 +187,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_custom_vars": {
                 "download_android_deps": false


### PR DESCRIPTION
Don't specify a cpu dimension on `mac_android_aot_engine` swarming tasks to let the scheduler figure out which bots to run based on capacity.

All swarming tests pass on arm Macs: https://ci.chromium.org/p/flutter/builders/try/Mac%20mac_android_aot_engine/7608
