### PR TITLE
Migrate uses of deprecated SkImage->encodeToData

### DIFF
--- a/display_list/testing/dl_test_surface_provider.cc
+++ b/display_list/testing/dl_test_surface_provider.cc
@@ -6,7 +6,9 @@
 
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkData.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/encode/SkPngEncoder.h"
 
 #ifdef ENABLE_SOFTWARE_BENCHMARKS
 #include "flutter/display_list/testing/dl_test_surface_software.h"
@@ -55,7 +57,7 @@ bool DlSurfaceProvider::Snapshot(std::string& filename) const {
   if (!raster) {
     return false;
   }
-  auto data = raster->encodeToData();
+  auto data = SkPngEncoder::Encode(nullptr, raster.get(), {});
   if (!data) {
     return false;
   }

--- a/flow/layers/offscreen_surface.cc
+++ b/flow/layers/offscreen_surface.cc
@@ -5,11 +5,13 @@
 #include "flutter/flow/layers/offscreen_surface.h"
 
 #include "third_party/skia/include/core/SkColorSpace.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "third_party/skia/include/core/SkPixmap.h"
 #include "third_party/skia/include/core/SkSerialProcs.h"
 #include "third_party/skia/include/core/SkSurfaceCharacterization.h"
+#include "third_party/skia/include/encode/SkPngEncoder.h"
 #include "third_party/skia/include/utils/SkBase64.h"
 
 namespace flutter {
@@ -54,7 +56,7 @@ static sk_sp<SkData> GetRasterData(const sk_sp<SkSurface>& offscreen_surface,
   // If the caller want the pixels to be compressed, there is a Skia utility to
   // compress to PNG. Use that.
   if (compressed) {
-    return cpu_snapshot->encodeToData();
+    return SkPngEncoder::Encode(nullptr, cpu_snapshot.get(), {});
   }
 
   // Copy it into a bitmap and return the same.

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -91,7 +91,8 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
   layer.Paint(paint_context);
 
   sk_sp<SkImage> snapshot = surface->makeImageSnapshot();
-  sk_sp<SkData> snapshot_data = SkPngEncoder::Encode(nullptr, snapshot.get(), {});
+  sk_sp<SkData> snapshot_data =
+      SkPngEncoder::Encode(nullptr, snapshot.get(), {});
 
   sk_sp<SkData> golden_data =
       SkData::MakeFromFileName(golden_file_path.c_str());

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -12,10 +12,12 @@
 #include "flutter/flow/testing/layer_test.h"
 #include "flutter/testing/mock_canvas.h"
 #include "third_party/skia/include/core/SkData.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSerialProcs.h"
 #include "third_party/skia/include/core/SkStream.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
+#include "third_party/skia/include/encode/SkPngEncoder.h"
 #include "third_party/skia/include/utils/SkBase64.h"
 
 namespace flutter {
@@ -89,7 +91,7 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
   layer.Paint(paint_context);
 
   sk_sp<SkImage> snapshot = surface->makeImageSnapshot();
-  sk_sp<SkData> snapshot_data = snapshot->encodeToData();
+  sk_sp<SkData> snapshot_data = SkPngEncoder::Encode(nullptr, snapshot.get(), {});
 
   sk_sp<SkData> golden_data =
       SkData::MakeFromFileName(golden_file_path.c_str());

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -24,10 +24,10 @@
 #include "flutter/testing/testing.h"
 #include "third_party/skia/include/codec/SkCodecAnimation.h"
 #include "third_party/skia/include/core/SkData.h"
-#include "third_party/skia/include/core/SkEncodedImageFormat.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkSize.h"
+#include "third_party/skia/include/encode/SkPngEncoder.h"
 
 // CREATE_NATIVE_ENTRY is leaky by design
 // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
@@ -892,8 +892,7 @@ TEST(ImageDecoderTest, VerifySubpixelDecodingPreservesExifOrientation) {
 
   auto assert_image = [&](auto decoded_image) {
     ASSERT_EQ(decoded_image->dimensions(), SkISize::Make(300, 100));
-    ASSERT_TRUE(decoded_image->encodeToData(SkEncodedImageFormat::kPNG, 100)
-                    ->equals(expected_data.get()));
+    ASSERT_TRUE(SkPngEncoder::Encode(nullptr, decoded_image.get(), {})->equals(expected_data.get()));
   };
 
   assert_image(decode(300, 100));

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -892,7 +892,8 @@ TEST(ImageDecoderTest, VerifySubpixelDecodingPreservesExifOrientation) {
 
   auto assert_image = [&](auto decoded_image) {
     ASSERT_EQ(decoded_image->dimensions(), SkISize::Make(300, 100));
-    ASSERT_TRUE(SkPngEncoder::Encode(nullptr, decoded_image.get(), {})->equals(expected_data.get()));
+    ASSERT_TRUE(SkPngEncoder::Encode(nullptr, decoded_image.get(), {})
+                    ->equals(expected_data.get()));
   };
 
   assert_image(decode(300, 100));

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -17,8 +17,9 @@
 #include "flutter/lib/ui/painting/image_encoding_impeller.h"
 #endif  // IMPELLER_SUPPORTS_RENDERING
 #include "flutter/lib/ui/painting/image_encoding_skia.h"
-#include "third_party/skia/include/core/SkEncodedImageFormat.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/encode/SkPngEncoder.h"
 #include "third_party/tonic/dart_persistent_value.h"
 #include "third_party/tonic/logging/dart_invoke.h"
 #include "third_party/tonic/typed_data/typed_list.h"
@@ -116,8 +117,7 @@ sk_sp<SkData> EncodeImage(const sk_sp<SkImage>& raster_image,
 
   switch (format) {
     case kPNG: {
-      auto png_image =
-          raster_image->encodeToData(SkEncodedImageFormat::kPNG, 0);
+      auto png_image = SkPngEncoder::Encode(nullptr, raster_image.get(), {});
 
       if (png_image == nullptr) {
         FML_LOG(ERROR) << "Could not convert raster image to PNG.";

--- a/shell/platform/embedder/tests/embedder_unittests_util.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_util.cc
@@ -12,6 +12,7 @@
 
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/encode/SkPngEncoder.h"
 
 namespace flutter {
 namespace testing {
@@ -136,7 +137,7 @@ bool WriteImageToDisk(const fml::UniqueFD& directory,
     return false;
   }
 
-  auto data = image->encodeToData();
+  auto data = SkPngEncoder::Encode(nullptr, image.get(), {});
 
   if (!data) {
     return false;


### PR DESCRIPTION
In https://skia-review.googlesource.com/c/skia/+/667296, Skia deprecated `SkImage->encodeToData`.

This PR fixes all uses in Flutter of that API by using SkPngEncoder directly.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
