### PR TITLE
Remove `Mac mac_android_aot_engine` in favor of Linux

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -341,14 +341,7 @@ targets:
       mac_model: "Macmini8,1"
     timeout: 75
 
-  - name: Mac mac_android_aot_engine
-    recipe: engine_v2/engine_v2
-    timeout: 60
-    properties:
-      config_name: mac_android_aot_engine
-
   - name: Linux mac_android_aot_engine
-    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:


### PR DESCRIPTION
`Linux mac_android_aot_engine` is passing: https://ci.chromium.org/p/flutter/builders/try/Linux%20mac_android_aot_engine/1
 
Remove `bringup` and remove `Mac mac_android_aot_engine` in favor of the Linux orchestrator #41181