### PR TITLE
Revert "[Android] Send connectionClosed message when keyboard becomes invisible to ensure framework focus state is correct."

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -367,14 +367,6 @@ public class TextInputChannel {
         "TextInputClient.performPrivateCommand", Arrays.asList(inputClientId, json));
   }
 
-  /** Instructs Flutter to execute a "onConnectionClosed" action. */
-  public void onConnectionClosed(int inputClientId) {
-    Log.v(TAG, "Sending 'onConnectionClosed' message.");
-    channel.invokeMethod(
-        "TextInputClient.onConnectionClosed",
-        Arrays.asList(inputClientId, "TextInputClient.onConnectionClosed"));
-  }
-
   /**
    * Sets the {@link TextInputMethodHandler} which receives all events and requests that are parsed
    * from the underlying platform channel.

--- a/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
+++ b/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
@@ -14,8 +14,6 @@ import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import java.util.List;
 
 // Loosely based off of
@@ -56,7 +54,6 @@ class ImeSyncDeferringInsetsCallback {
   private WindowInsets lastWindowInsets;
   private AnimationCallback animationCallback;
   private InsetsListener insetsListener;
-  private ImeVisibleListener imeVisibleListener;
 
   // True when an animation that matches deferredInsetTypes is active.
   //
@@ -91,11 +88,6 @@ class ImeSyncDeferringInsetsCallback {
     view.setOnApplyWindowInsetsListener(null);
   }
 
-  // Set a listener to be notified when the IME visibility changes.
-  void setImeVisibleListener(ImeVisibleListener imeVisibleListener) {
-    this.imeVisibleListener = imeVisibleListener;
-  }
-
   @VisibleForTesting
   View.OnApplyWindowInsetsListener getInsetsListener() {
     return insetsListener;
@@ -104,11 +96,6 @@ class ImeSyncDeferringInsetsCallback {
   @VisibleForTesting
   WindowInsetsAnimation.Callback getAnimationCallback() {
     return animationCallback;
-  }
-
-  @VisibleForTesting
-  ImeVisibleListener getImeVisibleListener() {
-    return imeVisibleListener;
   }
 
   // WindowInsetsAnimation.Callback was introduced in API level 30.  The callback
@@ -126,20 +113,6 @@ class ImeSyncDeferringInsetsCallback {
         animating = true;
         needsSave = true;
       }
-    }
-
-    @NonNull
-    @Override
-    public WindowInsetsAnimation.Bounds onStart(
-        @NonNull WindowInsetsAnimation animation, @NonNull WindowInsetsAnimation.Bounds bounds) {
-      // Observe changes to software keyboard visibility and notify listener when animation start.
-      // See https://developer.android.com/develop/ui/views/layout/sw-keyboard.
-      WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(view);
-      if (insets != null && imeVisibleListener != null) {
-        boolean imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
-        imeVisibleListener.onImeVisibleChanged(imeVisible);
-      }
-      return super.onStart(animation, bounds);
     }
 
     @Override
@@ -225,10 +198,5 @@ class ImeSyncDeferringInsetsCallback {
       // inset handling.
       return view.onApplyWindowInsets(windowInsets);
     }
-  }
-
-  // Listener for IME visibility changes.
-  public interface ImeVisibleListener {
-    void onImeVisibleChanged(boolean visible);
   }
 }

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -94,17 +94,6 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
               WindowInsets.Type.ime() // Deferred, insets that will animate
               );
       imeSyncCallback.install();
-
-      // When the IME is hidden, we need to notify the framework that close connection.
-      imeSyncCallback.setImeVisibleListener(
-          new ImeSyncDeferringInsetsCallback.ImeVisibleListener() {
-            @Override
-            public void onImeVisibleChanged(boolean visible) {
-              if (!visible) {
-                onConnectionClosed();
-              }
-            }
-          });
     }
 
     this.textInputChannel = textInputChannel;
@@ -849,8 +838,4 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
     textInputChannel.updateEditingStateWithTag(inputTarget.id, editingValues);
   }
   // -------- End: Autofill -------
-
-  public void onConnectionClosed() {
-    textInputChannel.onConnectionClosed(inputTarget.id);
-  }
 }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -2118,19 +2118,6 @@ public class TextInputPluginTest {
     assertEquals(0, viewportMetricsCaptor.getValue().viewInsetTop);
   }
 
-  @Test
-  @TargetApi(30)
-  @Config(sdk = 30)
-  public void onConnectionClosed_imeInvisible() {
-    View testView = new View(ctx);
-    TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
-    TextInputPlugin textInputPlugin =
-        new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
-    ImeSyncDeferringInsetsCallback imeSyncCallback = textInputPlugin.getImeSyncCallback();
-    imeSyncCallback.getImeVisibleListener().onImeVisibleChanged(false);
-    verify(textInputChannel, times(1)).onConnectionClosed(anyInt());
-  }
-
   interface EventHandler {
     void sendAppPrivateCommand(View view, String action, Bundle data);
   }


### PR DESCRIPTION
Reverts flutter/engine#40746

Googler bug: b/278174021

Failing on

```
shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java:239: Error: This method should only be accessed from tests or within private scope [VisibleForTests]
      imeSyncCallback.remove();
```