### PR TITLE
Remove package:js references and move to dart:js_interop

### DIFF
--- a/lib/web_ui/lib/src/engine/app_bootstrap.dart
+++ b/lib/web_ui/lib/src/engine/app_bootstrap.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:js/js.dart';
+import 'package:js/js_util.dart' show allowInterop;
 
 import 'configuration.dart';
 import 'js_interop/js_loader.dart';

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -16,7 +16,6 @@ import 'dart:js_interop';
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
-import 'package:js/js.dart';
 import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
 
@@ -3623,14 +3622,14 @@ void patchCanvasKitModule(DomHTMLScriptElement canvasKitScript) {
   // CommonJS is being used, and we shouldn't have any problems.
   if (exports == null) {
     final Object? exportsAccessor = js_util.jsify(<String, dynamic>{
-      'get': allowInterop(() {
+      'get': js_util.allowInterop(() {
         if (domDocument.currentScript == canvasKitScript) {
           return js_util.callConstructor(objectConstructor, <Object>[]);
         } else {
           return _flutterWebCachedExports;
         }
       }),
-      'set': allowInterop((dynamic value) {
+      'set': js_util.allowInterop((dynamic value) {
         _flutterWebCachedExports = value;
       }),
       'configurable': true,
@@ -3640,14 +3639,14 @@ void patchCanvasKitModule(DomHTMLScriptElement canvasKitScript) {
   }
   if (module == null) {
     final Object? moduleAccessor = js_util.jsify(<String, dynamic>{
-      'get': allowInterop(() {
+      'get': js_util.allowInterop(() {
         if (domDocument.currentScript == canvasKitScript) {
           return js_util.callConstructor(objectConstructor, <Object>[]);
         } else {
           return _flutterWebCachedModule;
         }
       }),
-      'set': allowInterop((dynamic value) {
+      'set': js_util.allowInterop((dynamic value) {
         _flutterWebCachedModule = value;
       }),
       'configurable': true,

--- a/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
@@ -14,7 +14,6 @@ import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:js/js.dart';
 import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
 

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -45,7 +45,7 @@
 library configuration;
 
 import 'dart:js_interop';
-import 'package:js/js.dart';
+
 import 'package:meta/meta.dart';
 import 'canvaskit/renderer.dart';
 import 'dom.dart';

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -7,7 +7,6 @@ import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:js/js.dart';
 import 'package:js/js_util.dart' as js_util;
 import 'package:meta/meta.dart';
 

--- a/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
@@ -5,7 +5,8 @@
 @JS()
 library js_loader;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
+
 import 'package:js/js_util.dart' as js_util;
 
 import '../configuration.dart';

--- a/lib/web_ui/lib/src/engine/js_interop/js_promise.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_promise.dart
@@ -5,7 +5,8 @@
 @JS()
 library js_promise;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
+
 import 'package:js/js_util.dart' as js_util;
 
 import '../util.dart';
@@ -38,7 +39,7 @@ abstract class Promise<T extends Object?> {
 typedef PromiseExecutor<T extends Object?> = void Function(PromiseResolver<T> resolve, PromiseRejecter reject);
 
 Promise<T> futureToPromise<T extends Object>(Future<T> future) {
-  return Promise<T>(allowInterop((PromiseResolver<T> resolver, PromiseRejecter rejecter) {
+  return Promise<T>(js_util.allowInterop((PromiseResolver<T> resolver, PromiseRejecter rejecter) {
     future.then(
       (T value) => resolver.resolve(value),
       onError: (Object? error) {

--- a/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
+++ b/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
@@ -5,7 +5,8 @@
 @JS()
 library js_url_strategy;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
+
 import 'package:ui/ui.dart' as ui;
 
 import '../dom.dart';

--- a/lib/web_ui/lib/src/engine/profiler.dart
+++ b/lib/web_ui/lib/src/engine/profiler.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:js_interop';
 
-import 'package:js/js.dart';
 import 'package:ui/ui.dart' as ui;
 
 import 'dom.dart';

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -17,7 +17,6 @@ import 'dart:js_util' as js_util;
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:js/js.dart';
 import 'package:ui/ui.dart' as ui;
 
 import 'browser_detection.dart';
@@ -25,7 +24,7 @@ import 'dom.dart';
 import 'platform_dispatcher.dart';
 import 'vector_math.dart';
 
-export 'package:js/js.dart' show allowInterop;
+export 'package:js/js_util.dart' show allowInterop;
 
 
 /// Returns true if [object] has property [name], false otherwise.

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/js_functions.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/js_functions.dart
@@ -4,8 +4,6 @@
 
 import 'dart:js_interop';
 
-import 'package:js/js.dart';
-
 @JS()
 @staticInterop
 class SkwasmInstance {}

--- a/lib/web_ui/lib/src/engine/svg.dart
+++ b/lib/web_ui/lib/src/engine/svg.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:js_interop';
-import 'package:js/js.dart';
 
 import 'dom.dart';
 

--- a/lib/web_ui/lib/src/engine/view_embedder/hot_restart_cache_handler.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/hot_restart_cache_handler.dart
@@ -4,7 +4,6 @@
 
 import 'dart:js_interop';
 
-import 'package:js/js.dart';
 import 'package:ui/src/engine.dart';
 
 import '../dom.dart';

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -6,9 +6,9 @@
 library window;
 
 import 'dart:async';
+import 'dart:js_interop';
 import 'dart:typed_data';
 
-import 'package:js/js.dart';
 import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -6,7 +6,6 @@ import 'dart:js_interop';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:js/js.dart';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 

--- a/lib/web_ui/test/canvaskit/native_memory_test.dart
+++ b/lib/web_ui/test/canvaskit/native_memory_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:js_interop';
-import 'package:js/js.dart';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';

--- a/lib/web_ui/test/engine/browser_detect_test.dart
+++ b/lib/web_ui/test/engine/browser_detect_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';

--- a/lib/web_ui/test/engine/embedder_test.dart
+++ b/lib/web_ui/test/engine/embedder_test.dart
@@ -5,7 +5,7 @@
 library embedder_test; // We need this to mess with the ShadowDOM.
 
 import 'dart:js_interop';
-import 'package:js/js.dart';
+
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';

--- a/lib/web_ui/test/engine/initialization_test.dart
+++ b/lib/web_ui/test/engine/initialization_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:js_interop';
-import 'package:js/js.dart';
+
 import 'package:js/js_util.dart' as js_util;
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
@@ -21,7 +21,7 @@ void main() {
   // Prepare _flutter.loader.didCreateEngineInitializer, so it's ready in the page ASAP.
   loader = js_util.jsify(<String, Object>{
     'loader': <String, Object>{
-      'didCreateEngineInitializer': allowInterop(() { print('not mocked'); }),
+      'didCreateEngineInitializer': js_util.allowInterop(() { print('not mocked'); }),
     },
   });
   internalBootstrapBrowserTest(() => testMain);
@@ -36,7 +36,7 @@ void testMain() {
     }
 
     // Prepare the DOM for: _flutter.loader.didCreateEngineInitializer
-    didCreateEngineInitializer = allowInterop(didCreateEngineInitializerMock);
+    didCreateEngineInitializer = js_util.allowInterop(didCreateEngineInitializerMock);
 
     // Reset the engine
     engine.debugResetEngineInitializationState();

--- a/lib/web_ui/test/engine/profiler_test.dart
+++ b/lib/web_ui/test/engine/profiler_test.dart
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:js_interop';
-import 'package:js/js.dart';
+
+import 'package:js/js_util.dart' as js_util;
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -45,7 +46,7 @@ void _profilerTests() {
 
   test('can listen to benchmarks', () {
     final List<BenchmarkDatapoint> data = <BenchmarkDatapoint>[];
-    onBenchmark = allowInterop((String name, num value) {
+    onBenchmark = js_util.allowInterop((String name, num value) {
       data.add(BenchmarkDatapoint(name, value));
     });
 
@@ -68,7 +69,7 @@ void _profilerTests() {
     final List<BenchmarkDatapoint> data = <BenchmarkDatapoint>[];
 
     // Wrong callback signature.
-    onBenchmark = allowInterop((num value) {
+    onBenchmark = js_util.allowInterop((num value) {
       data.add(BenchmarkDatapoint('bad', value));
     });
     expect(

--- a/web_sdk/web_engine_tester/lib/static/host.dart
+++ b/web_sdk/web_engine_tester/lib/static/host.dart
@@ -11,7 +11,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
 
-import 'package:js/js.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:stream_channel/stream_channel.dart';
 // ignore: implementation_imports


### PR DESCRIPTION
dart:js_interop and package:js will start conflicting. Eventually, we want people to only use dart:js_interop, so this CL refactors code to do that.

Unblocks https://dart-review.googlesource.com/c/sdk/+/294130/8 and prevents confusing shadowing of dart:js_interop annotations like we do today.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [Mentioned CL that is unblocked] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [Need test-exemption] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.