### PR TITLE
Remove cores dimension from Mac Host clang-tidy

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -390,7 +390,6 @@ targets:
     recipe: engine/engine_lint
     properties:
       add_recipes_cq: "true"
-      cores: "8"
       cpu: arm64
       lint_host: "true"
       lint_ios: "false"


### PR DESCRIPTION
Follow up to #41183.  Remove the `cores` dimensions so this builder can run on any arm machine which currently all have 8 cores but there's no reason to specify now that the arch is arm.

Introduced in #38261 to avoid 4-core Intel machines. 
