### PR TITLE
[macOS] Build unittests on all macOS host builds

### DIFF
--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -10,9 +10,12 @@ import("//third_party/dart/sdk_args.gni")
 is_aot_test =
     flutter_runtime_mode == "profile" || flutter_runtime_mode == "release"
 
-# Unit tests targets are only enabled for host machines and Fuchsia right now
+# Build unit tests when any of the following are true:
+# * host_toolchain: non-cross-compile, so we can run tests on the host.
+# * is_mac: arm64 builds can run x64 binaries.
+# * is_fuchsia: build unittests for testing on device.
 declare_args() {
-  enable_unittests = current_toolchain == host_toolchain || is_fuchsia
+  enable_unittests = current_toolchain == host_toolchain || is_fuchsia || is_mac
 }
 
 # Creates a translation unit that defines the flutter::testing::GetFixturesPath


### PR DESCRIPTION
Whether we're building an x64 or arm64 macOS host build, always build unit tests.

Issue: https://github.com/flutter/flutter/issues/124840

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
