### PR TITLE
Specify allowed Macmini models

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -55,9 +55,9 @@ platform_properties:
       cpu: x86
       os: Mac-12
       xcode: 14a5294e # xcode 14.0 beta 5
-      dimensions: {
-        mac_model: ["Macmini8,1", "Macmini9.1"]
-      }
+      dimensions:
+        mac_model: >-
+          ["Macmini8,1", "Macmini9.1"]
   windows:
     properties:
       build_host: "false"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -55,9 +55,8 @@ platform_properties:
       cpu: x86
       os: Mac-12
       xcode: 14a5294e # xcode 14.0 beta 5
-      dimensions:
-        mac_model: >-
-          ["Macmini8,1", "Macmini9.1"]
+    dimensions:
+      mac_model: "Macmini8,1|Macmini9.1"
   windows:
     properties:
       build_host: "false"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -55,6 +55,9 @@ platform_properties:
       cpu: x86
       os: Mac-12
       xcode: 14a5294e # xcode 14.0 beta 5
+      dimensions: {
+        mac_model: ["Macmini8,1", "Macmini9.1"]
+      }
   windows:
     properties:
       build_host: "false"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -56,7 +56,7 @@ platform_properties:
       os: Mac-12
       xcode: 14a5294e # xcode 14.0 beta 5
     dimensions:
-      mac_model: "Macmini8,1|Macmini9.1"
+      mac_model: "Macmini8,1|Macmini9,1"
   windows:
     properties:
       build_host: "false"


### PR DESCRIPTION
This excludes Macmini7,1.

Fixes https://github.com/flutter/flutter/issues/124877
