### PR TITLE
Remove jazzy and Xcode properties from impeller-cmake-example builder

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -448,7 +448,6 @@ targets:
         ]
 
   - name: Mac impeller-cmake-example
-    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -448,6 +448,7 @@ targets:
         ]
 
   - name: Mac impeller-cmake-example
+    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -455,12 +455,6 @@ targets:
       release_build: "true"
       cpu: arm64
       config_name: mac_impeller_cmake_example
-      $flutter/osx_sdk : >-
-        { "sdk_version": "14a5294e" }
-      dependencies: >-
-        [
-          {"dependency": "jazzy", "version": "0.14.1"}
-        ]
 
   - name: Windows Android AOT Engine
     recipe: engine/engine


### PR DESCRIPTION
This builder doesn't use or install jazzy or Xcode, remove the properties from the config.

Passing without these properties: https://ci.chromium.org/p/flutter/builders/try/Mac%20impeller-cmake-example/14
