### PR TITLE
Stop specifiying Macmini8,1 in ci builders, use inherited mac_model dimension

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -341,7 +341,6 @@ targets:
         {"download_emsdk": true}
       add_recipes_cq: "true"
       build_host: "true"
-      mac_model: "Macmini8,1"
     timeout: 75
 
   - name: Linux mac_android_aot_engine
@@ -380,7 +379,6 @@ targets:
         [
           "ios-16-0_14a5294e"
         ]
-      mac_model: "Macmini8,1"
     timeout: 75
 
   - name: Mac Host clang-tidy


### PR DESCRIPTION
As of https://github.com/flutter/engine/pull/41219 all the .ci.yaml builders will run on either Macmini8,1 (x64) or Macmini9,1 (arm).  Stop specifying `Macmini8,1` on individual builders and let the specified architecture be the deciding factor.

Reverts #41203