### PR TITLE
Remove 'Mac mac_unopt' in favor of Linux

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -362,15 +362,7 @@ targets:
       $flutter/osx_sdk : >-
         { "sdk_version": "14a5294e" }
 
-  - name: Mac mac_unopt
-    recipe: engine_v2/engine_v2
-    properties:
-      config_name: mac_unopt
-      add_recipes_cq: "true"
-    timeout: 60
-
   - name: Linux mac_unopt
-    bringup: true
     recipe: engine_v2/engine_v2
     properties:
       config_name: mac_unopt

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -30,6 +30,11 @@
                 "config": "host_debug_unopt",
                 "targets": []
             },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14a5294e"
+                }
+            },
             "tests": [
                 {
                     "language": "python3",
@@ -85,6 +90,11 @@
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
                 ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14a5294e"
+                }
             },
             "tests": [
                 {
@@ -145,6 +155,11 @@
                 "targets": [
                 ]
             },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14a5294e"
+                }
+            },
             "tests": []
         },
         {
@@ -187,6 +202,11 @@
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
                 ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14a5294e"
+                }
             },
             "tests": [
                 {

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -91,11 +91,6 @@
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
                 ]
             },
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "sdk_version": "14a5294e"
-                }
-            },
             "tests": [
                 {
                     "language": "python3",
@@ -202,11 +197,6 @@
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
                 ]
-            },
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "sdk_version": "14a5294e"
-                }
             },
             "tests": [
                 {


### PR DESCRIPTION
`Linux mac_unopt`: https://ci.chromium.org/p/flutter/builders/try/Linux%20mac_unopt/4
Remove `bringup` and remove `Mac mac_unopt` in favor of the Linux orchestrator https://github.com/flutter/engine/pull/41184

Add the `xcode` version to the mac_unopt json file since it's no longer being inherited from `Mac mac_unopt`.

Fixes https://github.com/flutter/flutter/issues/124912