### PR TITLE
Add static linking to embedder

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -14,6 +14,7 @@ declare_args() {
   embedder_enable_vulkan = shell_enable_vulkan
   embedder_enable_gl = shell_enable_gl
   embedder_enable_metal = shell_enable_metal
+  embedder_static = false
 }
 
 shell_gpu_configuration("embedder_gpu_configuration") {
@@ -377,7 +378,13 @@ if (enable_unittests) {
   }
 }
 
-shared_library("flutter_engine_library") {
+if (embedder_static) {
+  embedder_type = "static_library"
+} else {
+  embedder_type = "shared_library"
+}
+
+target(embedder_type, "flutter_engine_library") {
   visibility = [ ":*" ]
 
   output_name = "flutter_engine"
@@ -539,7 +546,7 @@ if (host_os == "linux" || host_os == "win") {
         "$full_target_platform_name/$full_target_platform_name-embedder.zip"
     deps = [
       "//flutter/shell/platform/embedder:copy_headers",
-      "//flutter/shell/platform/embedder:flutter_engine_library",
+      ":flutter_engine_library",
     ]
     files = [
       {
@@ -547,13 +554,22 @@ if (host_os == "linux" || host_os == "win") {
         destination = "flutter_embedder.h"
       },
     ]
-    if (host_os == "linux") {
+    if (embedder_static) {
       files += [
         {
-          source = "$root_out_dir/libflutter_engine.so"
-          destination = "libflutter_engine.so"
+          source = "$root_out_dir/libflutter_engine.a"
+          destination = "libflutter_engine.a"
         },
       ]
+    } else {
+      if (host_os == "linux") {
+        files += [
+          {
+            source = "$root_out_dir/libflutter_engine.so"
+            destination = "libflutter_engine.so"
+          },
+        ]
+      }
     }
     if (host_os == "win") {
       files += [

--- a/tools/gn
+++ b/tools/gn
@@ -513,6 +513,9 @@ def to_gn_args(args):
 
   if args.asan:
     gn_args['is_asan'] = True
+  
+  if args.static:
+    gn_args['embedder_static'] = True
 
   if args.tsan:
     gn_args['is_tsan'] = True
@@ -1076,6 +1079,8 @@ def parse_args(args):
   parser.add_argument('--msan', default=False, action='store_true')
   parser.add_argument('--tsan', default=False, action='store_true')
   parser.add_argument('--ubsan', default=False, action='store_true')
+
+  parser.add_argument('--static', default=False, action='store_true')
 
   parser.add_argument(
       '--fstack-protector',


### PR DESCRIPTION
Adds static linking to the embedder and adds new `gn` option for it called `--static`.

Relevant issue: https://github.com/flutter/flutter/issues/124902

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
