### PR TITLE
[Impeller] Remove glyph pixel rounding during text frame conversion

### DIFF
--- a/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -76,7 +76,7 @@ TextFrame TextFrameFromTextBlob(const sk_sp<SkTextBlob>& blob, Scalar scale) {
                                  : Glyph::Type::kPath;
 
           text_run.AddGlyph(Glyph{glyphs[i], type, ToRect(glyph_bounds[i])},
-                            Point{point->x(), point->y()}.Round());
+                            Point{point->x(), point->y()});
         }
         break;
       }


### PR DESCRIPTION
A tale of glyph alignment problems:

- This rounding was originally introduced to solve: https://github.com/flutter/flutter/issues/121531. This was to align all of the glyphs to the pixel grid during text frame conversion.
- However, doing so introduced: https://github.com/flutter/flutter/issues/124310.
- When working on fixing https://github.com/flutter/flutter/issues/121887, I reworked the UV handling/rounding in text_contents in a way that normalizes the glyph rounding per-textframe, which actually solves both problems.

..and so we can just get rid of this early rounding now.

Before:
![Screenshot 2023-04-17 at 6 36 20 PM](https://user-images.githubusercontent.com/919017/232647028-4a299138-e94b-4f0f-b675-3b8f9e0fbe1c.png)


After:
![Screenshot 2023-04-17 at 6 33 09 PM](https://user-images.githubusercontent.com/919017/232647004-c18ac7a1-8c43-414b-8d66-7fc58deeae77.png)

All of the glyphs in a text frame still snap together:

https://user-images.githubusercontent.com/919017/232648307-cc298fd9-603d-4cd6-a927-c44834225303.mov

