### PR TITLE
Roll buildroot to 059d155b4d452efd9c4427c45cddfd9445144869

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -244,7 +244,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '48f8487897b7f40e2744c808694535478d06ca47',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '059d155b4d452efd9c4427c45cddfd9445144869',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Changes since last roll:
```
059d155 [dart] Add identifier needed for zlib roll (#718)
459d3e5 Bump github/codeql-action from 2.2.11 to 2.2.12 (#716)
91f1ba5 Bump actions/checkout from 3.5.1 to 3.5.2 (#715)
2e5c483 Bump actions/checkout from 3.5.0 to 3.5.1 (#714)
a5af13d Remove codeql. (#713)
```