### PR TITLE
[Impeller] Add a CommandBuffer::WaitUntilScheduled API

### DIFF
--- a/impeller/renderer/backend/gles/command_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/command_buffer_gles.cc
@@ -39,6 +39,11 @@ bool CommandBufferGLES::OnSubmitCommands(CompletionCallback callback) {
 }
 
 // |CommandBuffer|
+void CommandBufferGLES::OnWaitUntilScheduled() {
+  reactor_->GetProcTable().Flush();
+}
+
+// |CommandBuffer|
 std::shared_ptr<RenderPass> CommandBufferGLES::OnCreateRenderPass(
     RenderTarget target) {
   if (!IsValid()) {

--- a/impeller/renderer/backend/gles/command_buffer_gles.h
+++ b/impeller/renderer/backend/gles/command_buffer_gles.h
@@ -35,6 +35,9 @@ class CommandBufferGLES final : public CommandBuffer {
   bool OnSubmitCommands(CompletionCallback callback) override;
 
   // |CommandBuffer|
+  void OnWaitUntilScheduled() override;
+
+  // |CommandBuffer|
   std::shared_ptr<RenderPass> OnCreateRenderPass(RenderTarget target) override;
 
   // |CommandBuffer|

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -119,6 +119,7 @@ struct GLProc {
   PROC(DrawElements);                        \
   PROC(Enable);                              \
   PROC(EnableVertexAttribArray);             \
+  PROC(Flush);                               \
   PROC(FramebufferRenderbuffer);             \
   PROC(FramebufferTexture2D);                \
   PROC(FrontFace);                           \

--- a/impeller/renderer/backend/metal/command_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.h
@@ -34,6 +34,9 @@ class CommandBufferMTL final : public CommandBuffer {
   bool OnSubmitCommands(CompletionCallback callback) override;
 
   // |CommandBuffer|
+  void OnWaitUntilScheduled() override;
+
+  // |CommandBuffer|
   std::shared_ptr<RenderPass> OnCreateRenderPass(RenderTarget target) override;
 
   // |CommandBuffer|

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -192,6 +192,8 @@ bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
   return true;
 }
 
+void CommandBufferMTL::OnWaitUntilScheduled() {}
+
 std::shared_ptr<RenderPass> CommandBufferMTL::OnCreateRenderPass(
     RenderTarget target) {
   if (!buffer_) {

--- a/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -55,6 +55,8 @@ bool CommandBufferVK::OnSubmitCommands(CompletionCallback callback) {
   return submit;
 }
 
+void CommandBufferVK::OnWaitUntilScheduled() {}
+
 std::shared_ptr<RenderPass> CommandBufferVK::OnCreateRenderPass(
     RenderTarget target) {
   auto context = context_.lock();

--- a/impeller/renderer/backend/vulkan/command_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.h
@@ -42,6 +42,9 @@ class CommandBufferVK final
   bool OnSubmitCommands(CompletionCallback callback) override;
 
   // |CommandBuffer|
+  void OnWaitUntilScheduled() override;
+
+  // |CommandBuffer|
   std::shared_ptr<RenderPass> OnCreateRenderPass(RenderTarget target) override;
 
   // |CommandBuffer|

--- a/impeller/renderer/command_buffer.cc
+++ b/impeller/renderer/command_buffer.cc
@@ -32,6 +32,10 @@ bool CommandBuffer::SubmitCommands() {
   return SubmitCommands(nullptr);
 }
 
+void CommandBuffer::WaitUntilScheduled() {
+  return OnWaitUntilScheduled();
+}
+
 std::shared_ptr<RenderPass> CommandBuffer::CreateRenderPass(
     const RenderTarget& render_target) {
   auto pass = OnCreateRenderPass(render_target);

--- a/impeller/renderer/command_buffer.h
+++ b/impeller/renderer/command_buffer.h
@@ -66,6 +66,11 @@ class CommandBuffer {
   [[nodiscard]] bool SubmitCommands();
 
   //----------------------------------------------------------------------------
+  /// @brief      Force execution of pending GPU commands.
+  ///
+  void WaitUntilScheduled();
+
+  //----------------------------------------------------------------------------
   /// @brief      Create a render pass to record render commands into.
   ///
   /// @param[in]  render_target  The description of the render target this pass
@@ -101,6 +106,8 @@ class CommandBuffer {
   virtual std::shared_ptr<BlitPass> OnCreateBlitPass() const = 0;
 
   [[nodiscard]] virtual bool OnSubmitCommands(CompletionCallback callback) = 0;
+
+  virtual void OnWaitUntilScheduled() = 0;
 
   virtual std::shared_ptr<ComputePass> OnCreateComputePass() const = 0;
 

--- a/impeller/renderer/testing/mocks.h
+++ b/impeller/renderer/testing/mocks.h
@@ -78,6 +78,7 @@ class MockCommandBuffer : public CommandBuffer {
   MOCK_CONST_METHOD1(SetLabel, void(const std::string& label));
   MOCK_CONST_METHOD0(OnCreateBlitPass, std::shared_ptr<BlitPass>());
   MOCK_METHOD1(OnSubmitCommands, bool(CompletionCallback callback));
+  MOCK_METHOD0(OnWaitUntilScheduled, void());
   MOCK_CONST_METHOD0(OnCreateComputePass, std::shared_ptr<ComputePass>());
   MOCK_METHOD1(OnCreateRenderPass,
                std::shared_ptr<RenderPass>(RenderTarget render_target));

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -362,6 +362,7 @@ sk_sp<DlImage> ImageDecoderImpeller::UploadTextureToShared(
       FML_DLOG(ERROR) << "Failed to submit blit pass command buffer.";
       return nullptr;
     }
+    command_buffer->WaitUntilScheduled();
   }
 
   return impeller::DlImageImpeller::Make(std::move(texture));


### PR DESCRIPTION
This can be used by IO thread operations such as image decoding to ensure that the results of GPU commands become visible to the raster thread.
