### PR TITLE
Double zip FlutterMacOS.framework.zip.

### DIFF
--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -172,6 +172,18 @@ def process_framework(dst, args, fat_framework, fat_framework_binary):
         'without_entitlements.txt',
     ],
                           cwd=dst)
+    # Double zip to make it consistent with legacy artifacts.
+    subprocess.check_call([
+        'zip',
+        '-y',
+        'FlutterMacOS.framework_.zip',
+        'FlutterMacOS.framework.zip',
+    ],
+                          cwd=dst)
+    # Use doubled zipped file.
+    final_src_path = os.path.join(dst, 'FlutterMacOS.framework_.zip')
+    final_dst_path = os.path.join(dst, 'FlutterMacOS.framework.zip')
+    shutil.move(final_src_path, final_dst_path)
 
 
 if __name__ == '__main__':

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -173,6 +173,7 @@ def process_framework(dst, args, fat_framework, fat_framework_binary):
     ],
                           cwd=dst)
     # Double zip to make it consistent with legacy artifacts.
+    # TODO(fujino): remove this once https://github.com/flutter/flutter/issues/125067 is resolved
     subprocess.check_call([
         'zip',
         '-y',


### PR DESCRIPTION
This is required to make the artifact consistent with the legacy artifacts while the tool is modified to remove the need of double zipping.

Bug: https://github.com/flutter/flutter/issues/124911

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
