### PR TITLE
[web:canvaskit] remove unnecessary instrumentation from picture

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -6,7 +6,6 @@ import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
 
-import '../profiler.dart';
 import '../util.dart';
 import 'canvas.dart';
 import 'canvaskit_api.dart';
@@ -77,9 +76,6 @@ class CkPicture implements ui.Picture {
       return true;
     }());
     ui.Picture.onDispose?.call(this);
-    if (Instrumentation.enabled) {
-      Instrumentation.instance.incrementCounter('Picture disposed');
-    }
     _isDisposed = true;
     _ref.dispose();
   }

--- a/lib/web_ui/test/canvaskit/native_memory_test.dart
+++ b/lib/web_ui/test/canvaskit/native_memory_test.dart
@@ -81,6 +81,45 @@ void testMain() {
       // there must not be anything else calling into this object for anything
       // useful.
     });
+
+    test('dispose instrumentation', () {
+      Instrumentation.enabled = true;
+      Instrumentation.instance.debugCounters.clear();
+
+      final Object owner = Object();
+      final TestSkDeletable nativeObject = TestSkDeletable();
+
+      expect(Instrumentation.instance.debugCounters, <String, int>{});
+      final UniqueRef<TestSkDeletable> ref = UniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
+      expect(Instrumentation.instance.debugCounters, <String, int>{
+        'TestSkDeletable Created': 1,
+      });
+      ref.dispose();
+      expect(Instrumentation.instance.debugCounters, <String, int>{
+        'TestSkDeletable Created': 1,
+        'TestSkDeletable Deleted': 1,
+      });
+    });
+
+    test('collect instrumentation', () {
+      Instrumentation.enabled = true;
+      Instrumentation.instance.debugCounters.clear();
+
+      final Object owner = Object();
+      final TestSkDeletable nativeObject = TestSkDeletable();
+
+      expect(Instrumentation.instance.debugCounters, <String, int>{});
+      final UniqueRef<TestSkDeletable> ref = UniqueRef<TestSkDeletable>(owner, nativeObject, 'TestSkDeletable');
+      expect(Instrumentation.instance.debugCounters, <String, int>{
+        'TestSkDeletable Created': 1,
+      });
+      ref.collect();
+      expect(Instrumentation.instance.debugCounters, <String, int>{
+        'TestSkDeletable Created': 1,
+        'TestSkDeletable Leaked': 1,
+        'TestSkDeletable Deleted': 1,
+      });
+    });
   });
 
   group(CountedRef, () {


### PR DESCRIPTION
Remove unnecessary instrumentation from picture. `UniqueRef` automatically instruments all allocations, disposals, and garbage collections, which covers `CkPicture`.