### PR TITLE
[Impeller] Fix transform regressions for chained filters

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1955,7 +1955,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithBlendColorFilterDrawsCorrectly) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
-TEST_P(AiksTest, TranslucentSaveLayerWithBlendImageFilterAndDrawsCorrectly) {
+TEST_P(AiksTest, TranslucentSaveLayerWithBlendImageFilterDrawsCorrectly) {
   Canvas canvas;
 
   canvas.DrawRect(Rect::MakeXYWH(100, 100, 300, 300), {.color = Color::Blue()});
@@ -1976,7 +1976,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithBlendImageFilterAndDrawsCorrectly) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
-TEST_P(AiksTest, TranslucentSaveLayerWithColorImageFilterAndDrawsCorrectly) {
+TEST_P(AiksTest, TranslucentSaveLayerWithColorAndImageFilterDrawsCorrectly) {
   Canvas canvas;
 
   canvas.DrawRect(Rect::MakeXYWH(100, 100, 300, 300), {.color = Color::Blue()});
@@ -2052,6 +2052,38 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixImageFilterDrawsCorrectly) {
                                                              0, 0, 1, 0, 0,  //
                                                              0, 0, 0, 2, 0   //
                                                          }});
+          },
+  });
+  canvas.DrawImage(image, {100, 500}, {});
+  canvas.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest,
+       TranslucentSaveLayerWithColorFilterAndImageFilterDrawsCorrectly) {
+  Canvas canvas;
+
+  auto image = std::make_shared<Image>(CreateTextureForFixture("airplane.jpg"));
+  canvas.DrawImage(image, {100, 100}, {});
+
+  canvas.SaveLayer({
+      .color = Color::Black().WithAlpha(0.5),
+      .image_filter =
+          [](FilterInput::Ref input, const Matrix& effect_transform,
+             bool is_subpass) {
+            return ColorFilterContents::MakeColorMatrix(
+                {std::move(input)}, {.array = {
+                                         1, 0,   0, 0,   0,  //
+                                         0, 1,   0, 0,   0,  //
+                                         0, 0.2, 1, 0,   0,  //
+                                         0, 0,   0, 0.5, 0   //
+                                     }});
+          },
+      .color_filter =
+          [](FilterInput::Ref input) {
+            return ColorFilterContents::MakeBlend(
+                BlendMode::kModulate, {std::move(input)}, Color::Green());
           },
   });
   canvas.DrawImage(image, {100, 500}, {});

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -442,7 +442,8 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
 
     FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
 
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                     entity.GetTransformation();
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
@@ -460,7 +461,6 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
   Entity sub_entity;
   sub_entity.SetContents(std::move(contents));
   sub_entity.SetStencilDepth(entity.GetStencilDepth());
-  sub_entity.SetTransformation(entity.GetTransformation());
 
   return sub_entity;
 }

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -304,7 +304,8 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
     auto blend_uniform = host_buffer.EmplaceUniform(blend_info);
     FS::BindBlendInfo(cmd, blend_uniform);
 
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                     entity.GetTransformation();
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
@@ -313,7 +314,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
   };
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage;
+    return coverage.TransformBounds(entity.GetTransformation());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);
@@ -321,7 +322,6 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
   Entity sub_entity;
   sub_entity.SetContents(std::move(contents));
   sub_entity.SetStencilDepth(entity.GetStencilDepth());
-  sub_entity.SetTransformation(entity.GetTransformation());
 
   return sub_entity;
 }
@@ -453,7 +453,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage;
+    return coverage.TransformBounds(entity.GetTransformation());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -115,7 +115,8 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     cmd.stencil_reference = entity.GetStencilDepth();
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                     entity.GetTransformation();
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 
@@ -136,7 +137,7 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage;
+    return coverage.TransformBounds(entity.GetTransformation());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);
@@ -144,7 +145,6 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
   Entity sub_entity;
   sub_entity.SetContents(std::move(contents));
   sub_entity.SetStencilDepth(entity.GetStencilDepth());
-  sub_entity.SetTransformation(entity.GetTransformation());
   sub_entity.SetBlendMode(entity.GetBlendMode());
   return sub_entity;
 }

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -49,7 +49,7 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
   //----------------------------------------------------------------------------
   /// Create AnonymousContents for rendering.
   ///
-  RenderProc render_proc = [input_snapshot, color_matrix = matrix_, coverage,
+  RenderProc render_proc = [input_snapshot, color_matrix = matrix_,
                             absorb_opacity = GetAbsorbOpacity()](
                                const ContentContext& renderer,
                                const Entity& entity, RenderPass& pass) -> bool {
@@ -60,27 +60,24 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     auto options = OptionsFromPassAndEntity(pass, entity);
     cmd.pipeline = renderer.GetColorMatrixColorFilterPipeline(options);
 
+    auto size = input_snapshot->texture->GetSize();
+
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
-        {coverage.origin, Point(0, 0)},
-        {{coverage.origin.x + coverage.size.width, coverage.origin.y},
-         Point(1, 0)},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         Point(1, 1)},
-        {coverage.origin, Point(0, 0)},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         Point(1, 1)},
-        {{coverage.origin.x, coverage.origin.y + coverage.size.height},
-         Point(0, 1)},
+        {Point(0, 0)},
+        {Point(size.width, 0)},
+        {Point(size.width, size.height)},
+        {Point(0, 0)},
+        {Point(size.width, size.height)},
+        {Point(0, size.height)},
     });
     auto& host_buffer = pass.GetTransientsBuffer();
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
     cmd.BindVertices(vtx_buffer);
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                     entity.GetTransformation() * input_snapshot->transform;
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 
@@ -107,7 +104,7 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage;
+    return coverage.TransformBounds(entity.GetTransformation());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -65,11 +65,11 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
         {Point(0, 0)},
-        {Point(size.width, 0)},
-        {Point(size.width, size.height)},
+        {Point(1, 0)},
+        {Point(1, 1)},
         {Point(0, 0)},
-        {Point(size.width, size.height)},
-        {Point(0, size.height)},
+        {Point(1, 1)},
+        {Point(0, 1)},
     });
     auto& host_buffer = pass.GetTransientsBuffer();
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
@@ -77,7 +77,8 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation() * input_snapshot->transform;
+                     entity.GetTransformation() * input_snapshot->transform *
+                     Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 
@@ -112,8 +113,6 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
   Entity sub_entity;
   sub_entity.SetContents(std::move(contents));
   sub_entity.SetStencilDepth(entity.GetStencilDepth());
-  sub_entity.SetTransformation(Matrix::MakeTranslation(coverage.origin) *
-                               entity.GetTransformation());
   sub_entity.SetBlendMode(entity.GetBlendMode());
   return sub_entity;
 }

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -55,11 +55,11 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
         {Point(0, 0)},
-        {Point(size.width, 0)},
-        {Point(size.width, size.height)},
+        {Point(1, 0)},
+        {Point(1, 1)},
         {Point(0, 0)},
-        {Point(size.width, size.height)},
-        {Point(0, size.height)},
+        {Point(1, 1)},
+        {Point(0, 1)},
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();
@@ -68,7 +68,8 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation() * input_snapshot->transform;
+                     entity.GetTransformation() * input_snapshot->transform *
+                     Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -36,16 +36,10 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  auto maybe_input_uvs = input_snapshot->GetCoverageUVs(coverage);
-  if (!maybe_input_uvs.has_value()) {
-    return std::nullopt;
-  }
-  auto input_uvs = maybe_input_uvs.value();
-
   //----------------------------------------------------------------------------
   /// Create AnonymousContents for rendering.
   ///
-  RenderProc render_proc = [input_snapshot, coverage, input_uvs,
+  RenderProc render_proc = [input_snapshot,
                             absorb_opacity = GetAbsorbOpacity()](
                                const ContentContext& renderer,
                                const Entity& entity, RenderPass& pass) -> bool {
@@ -56,20 +50,16 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     auto options = OptionsFromPassAndEntity(pass, entity);
     cmd.pipeline = renderer.GetLinearToSrgbFilterPipeline(options);
 
+    auto size = input_snapshot->texture->GetSize();
+
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
-        {coverage.origin, input_uvs[0]},
-        {{coverage.origin.x + coverage.size.width, coverage.origin.y},
-         input_uvs[1]},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         input_uvs[3]},
-        {coverage.origin, input_uvs[0]},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         input_uvs[3]},
-        {{coverage.origin.x, coverage.origin.y + coverage.size.height},
-         input_uvs[2]},
+        {Point(0, 0)},
+        {Point(size.width, 0)},
+        {Point(size.width, size.height)},
+        {Point(0, 0)},
+        {Point(size.width, size.height)},
+        {Point(0, size.height)},
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();
@@ -77,7 +67,8 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     cmd.BindVertices(vtx_buffer);
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                     entity.GetTransformation() * input_snapshot->transform;
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 
@@ -94,7 +85,7 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage;
+    return coverage.TransformBounds(entity.GetTransformation());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);
@@ -102,7 +93,6 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
   Entity sub_entity;
   sub_entity.SetContents(std::move(contents));
   sub_entity.SetStencilDepth(entity.GetStencilDepth());
-  sub_entity.SetTransformation(entity.GetTransformation());
   sub_entity.SetBlendMode(entity.GetBlendMode());
   return sub_entity;
 }

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -36,16 +36,10 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  auto maybe_input_uvs = input_snapshot->GetCoverageUVs(coverage);
-  if (!maybe_input_uvs.has_value()) {
-    return std::nullopt;
-  }
-  auto input_uvs = maybe_input_uvs.value();
-
   //----------------------------------------------------------------------------
   /// Create AnonymousContents for rendering.
   ///
-  RenderProc render_proc = [input_snapshot, coverage, input_uvs,
+  RenderProc render_proc = [input_snapshot,
                             absorb_opacity = GetAbsorbOpacity()](
                                const ContentContext& renderer,
                                const Entity& entity, RenderPass& pass) -> bool {
@@ -56,20 +50,16 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     auto options = OptionsFromPassAndEntity(pass, entity);
     cmd.pipeline = renderer.GetSrgbToLinearFilterPipeline(options);
 
+    auto size = input_snapshot->texture->GetSize();
+
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
-        {coverage.origin, input_uvs[0]},
-        {{coverage.origin.x + coverage.size.width, coverage.origin.y},
-         input_uvs[1]},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         input_uvs[3]},
-        {coverage.origin, input_uvs[0]},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         input_uvs[3]},
-        {{coverage.origin.x, coverage.origin.y + coverage.size.height},
-         input_uvs[2]},
+        {Point(0, 0)},
+        {Point(size.width, 0)},
+        {Point(size.width, size.height)},
+        {Point(0, 0)},
+        {Point(size.width, size.height)},
+        {Point(0, size.height)},
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();
@@ -77,7 +67,8 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     cmd.BindVertices(vtx_buffer);
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                     entity.GetTransformation() * input_snapshot->transform;
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 
@@ -94,7 +85,7 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage;
+    return coverage.TransformBounds(entity.GetTransformation());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -55,11 +55,11 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
         {Point(0, 0)},
-        {Point(size.width, 0)},
-        {Point(size.width, size.height)},
+        {Point(1, 0)},
+        {Point(1, 1)},
         {Point(0, 0)},
-        {Point(size.width, size.height)},
-        {Point(0, size.height)},
+        {Point(1, 1)},
+        {Point(0, 1)},
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();
@@ -68,7 +68,8 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation() * input_snapshot->transform;
+                     entity.GetTransformation() * input_snapshot->transform *
+                     Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 
@@ -93,7 +94,6 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
   Entity sub_entity;
   sub_entity.SetContents(std::move(contents));
   sub_entity.SetStencilDepth(entity.GetStencilDepth());
-  sub_entity.SetTransformation(entity.GetTransformation());
   sub_entity.SetBlendMode(entity.GetBlendMode());
   return sub_entity;
 }

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -56,12 +56,6 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  auto maybe_input_uvs = y_input_snapshot->GetCoverageUVs(coverage);
-  if (!maybe_input_uvs.has_value()) {
-    return std::nullopt;
-  }
-  auto input_uvs = maybe_input_uvs.value();
-
   if (y_input_snapshot->texture->GetTextureDescriptor().format !=
           PixelFormat::kR8UNormInt ||
       uv_input_snapshot->texture->GetTextureDescriptor().format !=
@@ -72,8 +66,8 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
   //----------------------------------------------------------------------------
   /// Create AnonymousContents for rendering.
   ///
-  RenderProc render_proc = [y_input_snapshot, uv_input_snapshot, coverage,
-                            yuv_color_space = yuv_color_space_, input_uvs](
+  RenderProc render_proc = [y_input_snapshot, uv_input_snapshot,
+                            yuv_color_space = yuv_color_space_](
                                const ContentContext& renderer,
                                const Entity& entity, RenderPass& pass) -> bool {
     Command cmd;
@@ -83,20 +77,16 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     auto options = OptionsFromPassAndEntity(pass, entity);
     cmd.pipeline = renderer.GetYUVToRGBFilterPipeline(options);
 
+    auto size = y_input_snapshot->texture->GetSize();
+
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
-        {coverage.origin, input_uvs[0]},
-        {{coverage.origin.x + coverage.size.width, coverage.origin.y},
-         input_uvs[1]},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         input_uvs[3]},
-        {coverage.origin, input_uvs[0]},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         input_uvs[3]},
-        {{coverage.origin.x, coverage.origin.y + coverage.size.height},
-         input_uvs[2]},
+        {Point(0, 0)},
+        {Point(size.width, 0)},
+        {Point(size.width, size.height)},
+        {Point(0, 0)},
+        {Point(size.width, size.height)},
+        {Point(0, size.height)},
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();
@@ -104,7 +94,8 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     cmd.BindVertices(vtx_buffer);
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                     entity.GetTransformation() * y_input_snapshot->transform;
     frame_info.texture_sampler_y_coord_scale =
         y_input_snapshot->texture->GetYCoordScale();
 
@@ -131,7 +122,7 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage;
+    return coverage.TransformBounds(entity.GetTransformation());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);
@@ -139,7 +130,6 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
   Entity sub_entity;
   sub_entity.SetContents(std::move(contents));
   sub_entity.SetStencilDepth(entity.GetStencilDepth());
-  sub_entity.SetTransformation(entity.GetTransformation());
   sub_entity.SetBlendMode(entity.GetBlendMode());
   return sub_entity;
 }

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -82,11 +82,11 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
         {Point(0, 0)},
-        {Point(size.width, 0)},
-        {Point(size.width, size.height)},
+        {Point(1, 0)},
+        {Point(1, 1)},
         {Point(0, 0)},
-        {Point(size.width, size.height)},
-        {Point(0, size.height)},
+        {Point(1, 1)},
+        {Point(0, 1)},
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();
@@ -95,7 +95,8 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation() * y_input_snapshot->transform;
+                     entity.GetTransformation() * y_input_snapshot->transform *
+                     Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         y_input_snapshot->texture->GetYCoordScale();
 

--- a/impeller/entity/shaders/color_matrix_color_filter.vert
+++ b/impeller/entity/shaders/color_matrix_color_filter.vert
@@ -12,12 +12,11 @@ uniform FrameInfo {
 frame_info;
 
 in vec2 position;
-in highp vec2 texture_coords;
 
 out highp vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_texture_coords =
-      IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);
+      IPRemapCoords(position, frame_info.texture_sampler_y_coord_scale);
 }

--- a/impeller/entity/shaders/linear_to_srgb_filter.vert
+++ b/impeller/entity/shaders/linear_to_srgb_filter.vert
@@ -12,12 +12,11 @@ uniform FrameInfo {
 frame_info;
 
 in vec2 position;
-in highp vec2 texture_coords;
 
 out highp vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_texture_coords =
-      IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);
+      IPRemapCoords(position, frame_info.texture_sampler_y_coord_scale);
 }

--- a/impeller/entity/shaders/srgb_to_linear_filter.vert
+++ b/impeller/entity/shaders/srgb_to_linear_filter.vert
@@ -12,12 +12,11 @@ uniform FrameInfo {
 frame_info;
 
 in vec2 position;
-in highp vec2 texture_coords;
 
 out highp vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_texture_coords =
-      IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);
+      IPRemapCoords(position, frame_info.texture_sampler_y_coord_scale);
 }

--- a/impeller/entity/shaders/yuv_to_rgb_filter.vert
+++ b/impeller/entity/shaders/yuv_to_rgb_filter.vert
@@ -12,12 +12,11 @@ uniform FrameInfo {
 frame_info;
 
 in vec2 position;
-in highp vec2 texture_coords;
 
 out highp vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
   v_texture_coords =
-      IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);
+      IPRemapCoords(position, frame_info.texture_sampler_y_coord_scale);
 }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -6570,16 +6570,16 @@
           "work_registers_used": 32
         },
         "Varying": {
-          "fp16_arithmetic": 0,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "load_store"
             ],
             "longest_path_cycles": [
-              0.078125,
+              0.0625,
               0.015625,
-              0.078125,
+              0.0625,
               0.0,
               3.0,
               0.0
@@ -6597,7 +6597,7 @@
             ],
             "shortest_path_cycles": [
               0.0625,
-              0.0,
+              0.015625,
               0.0625,
               0.0,
               3.0,
@@ -6607,9 +6607,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.078125,
+              0.0625,
               0.015625,
-              0.078125,
+              0.0625,
               0.0,
               3.0,
               0.0
@@ -6636,7 +6636,7 @@
             ],
             "longest_path_cycles": [
               2.9700000286102295,
-              5.0,
+              4.0,
               0.0
             ],
             "pipelines": [
@@ -6649,7 +6649,7 @@
             ],
             "shortest_path_cycles": [
               2.9700000286102295,
-              5.0,
+              4.0,
               0.0
             ],
             "total_bound_pipelines": [
@@ -6657,7 +6657,7 @@
             ],
             "total_cycles": [
               3.0,
-              5.0,
+              4.0,
               0.0
             ]
           },
@@ -8421,16 +8421,16 @@
           "work_registers_used": 32
         },
         "Varying": {
-          "fp16_arithmetic": 0,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "load_store"
             ],
             "longest_path_cycles": [
-              0.078125,
+              0.0625,
               0.015625,
-              0.078125,
+              0.0625,
               0.0,
               3.0,
               0.0
@@ -8448,7 +8448,7 @@
             ],
             "shortest_path_cycles": [
               0.0625,
-              0.0,
+              0.015625,
               0.0625,
               0.0,
               3.0,
@@ -8458,9 +8458,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.078125,
+              0.0625,
               0.015625,
-              0.078125,
+              0.0625,
               0.0,
               3.0,
               0.0
@@ -8487,7 +8487,7 @@
             ],
             "longest_path_cycles": [
               2.9700000286102295,
-              5.0,
+              4.0,
               0.0
             ],
             "pipelines": [
@@ -8500,7 +8500,7 @@
             ],
             "shortest_path_cycles": [
               2.9700000286102295,
-              5.0,
+              4.0,
               0.0
             ],
             "total_bound_pipelines": [
@@ -8508,7 +8508,7 @@
             ],
             "total_cycles": [
               3.0,
-              5.0,
+              4.0,
               0.0
             ]
           },
@@ -10176,16 +10176,16 @@
           "work_registers_used": 32
         },
         "Varying": {
-          "fp16_arithmetic": 0,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "load_store"
             ],
             "longest_path_cycles": [
-              0.078125,
+              0.0625,
               0.015625,
-              0.078125,
+              0.0625,
               0.0,
               3.0,
               0.0
@@ -10203,7 +10203,7 @@
             ],
             "shortest_path_cycles": [
               0.0625,
-              0.0,
+              0.015625,
               0.0625,
               0.0,
               3.0,
@@ -10213,9 +10213,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.078125,
+              0.0625,
               0.015625,
-              0.078125,
+              0.0625,
               0.0,
               3.0,
               0.0
@@ -10242,7 +10242,7 @@
             ],
             "longest_path_cycles": [
               2.9700000286102295,
-              5.0,
+              4.0,
               0.0
             ],
             "pipelines": [
@@ -10255,7 +10255,7 @@
             ],
             "shortest_path_cycles": [
               2.9700000286102295,
-              5.0,
+              4.0,
               0.0
             ],
             "total_bound_pipelines": [
@@ -10263,7 +10263,7 @@
             ],
             "total_cycles": [
               3.0,
-              5.0,
+              4.0,
               0.0
             ]
           },
@@ -11239,16 +11239,16 @@
           "work_registers_used": 32
         },
         "Varying": {
-          "fp16_arithmetic": 0,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "load_store"
             ],
             "longest_path_cycles": [
-              0.078125,
+              0.0625,
               0.015625,
-              0.078125,
+              0.0625,
               0.0,
               3.0,
               0.0
@@ -11266,7 +11266,7 @@
             ],
             "shortest_path_cycles": [
               0.0625,
-              0.0,
+              0.015625,
               0.0625,
               0.0,
               3.0,
@@ -11276,9 +11276,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.078125,
+              0.0625,
               0.015625,
-              0.078125,
+              0.0625,
               0.0,
               3.0,
               0.0
@@ -11305,7 +11305,7 @@
             ],
             "longest_path_cycles": [
               2.9700000286102295,
-              5.0,
+              4.0,
               0.0
             ],
             "pipelines": [
@@ -11318,7 +11318,7 @@
             ],
             "shortest_path_cycles": [
               2.9700000286102295,
-              5.0,
+              4.0,
               0.0
             ],
             "total_bound_pipelines": [
@@ -11326,7 +11326,7 @@
             ],
             "total_cycles": [
               3.0,
-              5.0,
+              4.0,
               0.0
             ]
           },


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/124956.

Fixes some recent transform issues that mainly apply to chained filters (like when both a color + image filter has been set).

- For all filters, the returned entity should just be an identity matrix because the snapshot transform gets fully absorbed.
- For all filters, given entity's transform should be applied in the coverage proc (although this currently makes no difference because of the way coverage is queried when snapshotting).
- For filters drawing with coverage + transforming UVs, the transform handed to the contents of the deferred entity needs to be applied. Otherwise the entity won't get repositioned correctly while snapshotting.

New golden: `Play/AiksTest.TranslucentSaveLayerWithColorFilterAndImageFilterDrawsCorrectly/Metal`

```bash
autoninja -C ../out/host_debug_unopt/ -j 1000 flutter/impeller:impeller_unittests && ../out/host_debug_unopt/impeller_unittests --timeout=0 --gtest_filter="Play/AiksTest.TranslucentSaveLayerWithColorFilterAndImageFilterDrawsCorrectly/Metal" --enable_playground
```

Before:
![Screenshot 2023-04-19 at 12 03 57 AM](https://user-images.githubusercontent.com/919017/233018073-986d2708-c5a9-4761-9441-b8497bdd31f8.png)
![Screenshot 2023-04-19 at 3 02 06 AM](https://user-images.githubusercontent.com/919017/233041611-c322b5be-e89c-4e55-8acb-02bbafcf80b8.png)



After:
![Screenshot 2023-04-19 at 12 00 34 AM](https://user-images.githubusercontent.com/919017/233018091-cbe37378-99ce-4de3-b80b-3f866146b12e.png)
![Screenshot 2023-04-19 at 2 59 56 AM](https://user-images.githubusercontent.com/919017/233041632-ebd68b7c-340d-4c5e-9e17-06a187eeac5e.png)
