### PR TITLE
[Impeller] Change the default color format for the GLES backend to RGBA

### DIFF
--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -69,7 +69,7 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
             .SetSupportsTextureToTextureBlits(
                 reactor_->GetProcTable().BlitFramebuffer.IsAvailable())
             .SetSupportsFramebufferFetch(false)
-            .SetDefaultColorFormat(PixelFormat::kB8G8R8A8UNormInt)
+            .SetDefaultColorFormat(PixelFormat::kR8G8B8A8UNormInt)
             .SetDefaultStencilFormat(PixelFormat::kS8UInt)
             .SetSupportsCompute(false, false)
             .SetSupportsReadFromResolve(false)


### PR DESCRIPTION
This provides compatibility with BlitCopyTextureToBufferCommandGLES::Encode and glReadPixels (which only guarantees support for RGBA).
