### PR TITLE
[Impeller] Always use BGRA10_XR for wide gamut

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -96,11 +96,7 @@ static BOOL IsWideGamutSupported() {
       CGColorSpaceRef srgb = CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB);
       layer.colorspace = srgb;
       CFRelease(srgb);
-      if (self.opaque) {
-        layer.pixelFormat = MTLPixelFormatBGR10_XR;
-      } else {
-        layer.pixelFormat = MTLPixelFormatBGRA10_XR;
-      }
+      layer.pixelFormat = MTLPixelFormatBGRA10_XR;
     }
   }
 

--- a/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
@@ -10,15 +10,6 @@
 
 namespace flutter {
 
-static impeller::PixelFormat InferOffscreenLayerPixelFormat(impeller::PixelFormat pixel_format) {
-  switch (pixel_format) {
-    case impeller::PixelFormat::kB10G10R10XR:
-      return impeller::PixelFormat::kB10G10R10A10XR;
-    default:
-      return pixel_format;
-  }
-}
-
 IOSSurfaceMetalImpeller::IOSSurfaceMetalImpeller(const fml::scoped_nsobject<CAMetalLayer>& layer,
                                                  const std::shared_ptr<IOSContext>& context)
     : IOSSurface(context),
@@ -47,7 +38,7 @@ void IOSSurfaceMetalImpeller::UpdateStorageSizeIfNecessary() {
 // |IOSSurface|
 std::unique_ptr<Surface> IOSSurfaceMetalImpeller::CreateGPUSurface(GrDirectContext*) {
   impeller_context_->UpdateOffscreenLayerPixelFormat(
-      InferOffscreenLayerPixelFormat(impeller::FromMTLPixelFormat(layer_.get().pixelFormat)));
+      impeller::FromMTLPixelFormat(layer_.get().pixelFormat));
   return std::make_unique<GPUSurfaceMetalImpeller>(this,              //
                                                    impeller_context_  //
   );


### PR DESCRIPTION
Reopens https://github.com/flutter/flutter/issues/120641.

There are errors blitting from offscreen textures to onscreen textures when wide gamut is enabled due to the mismatching formats.
It looks like we don't currently use a different format when wide gamut is off either.

```
2023-04-21 09:14:39.470 ios_dev[61385/0x1fb959e40] [lvl=1] -[GAMImpressionLogger buildAndQueueImpression:sendInvariants:] Adding impression: event_code 69047, seq_num 41
-[MTLDebugBlitCommandEncoder internalValidateCopyFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:options:]:388: failed assertion `Copy From Texture Validation
[sourceTexture pixelFormat](MTLPixelFormatBGRA10_XR) must be compatible with [destinationTexture pixelFormat](MTLPixelFormatBGR10_XR).
'
-[MTLDebugBlitCommandEncoder internalValidateCopyFromTexture:sourceSlice:sourceLevel:sourceOrigin:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:options:]:388: failed assertion `Copy From Texture Validation
[sourceTexture pixelFormat](MTLPixelFormatBGRA10_XR) must be compatible with [destinationTexture pixelFormat](MTLPixelFormatBGR10_XR).
```