### PR TITLE
[Impeller] Fix SupportsReadFromOnscreenTexture capability check

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -144,6 +144,7 @@
 ../../../flutter/impeller/golden_tests_harvester/test
 ../../../flutter/impeller/image/README.md
 ../../../flutter/impeller/playground
+../../../flutter/impeller/renderer/capabilities_unittests.cc
 ../../../flutter/impeller/renderer/compute_subgroup_unittests.cc
 ../../../flutter/impeller/renderer/compute_unittests.cc
 ../../../flutter/impeller/renderer/device_buffer_unittests.cc

--- a/impeller/renderer/BUILD.gn
+++ b/impeller/renderer/BUILD.gn
@@ -119,6 +119,7 @@ impeller_component("renderer_unittests") {
   testonly = true
 
   sources = [
+    "capabilities_unittests.cc",
     "device_buffer_unittests.cc",
     "host_buffer_unittests.cc",
     "pipeline_descriptor_unittests.cc",

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -71,7 +71,8 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
             .SetSupportsFramebufferFetch(false)
             .SetDefaultColorFormat(PixelFormat::kR8G8B8A8UNormInt)
             .SetDefaultStencilFormat(PixelFormat::kS8UInt)
-            .SetSupportsCompute(false, false)
+            .SetSupportsCompute(false)
+            .SetSupportsComputeSubgroups(false)
             .SetSupportsReadFromResolve(false)
             .SetSupportsReadFromOnscreenTexture(false)
             .Build();

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -58,7 +58,8 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetSupportsFramebufferFetch(DeviceSupportsFramebufferFetch(device))
       .SetDefaultColorFormat(color_format)
       .SetDefaultStencilFormat(PixelFormat::kS8UInt)
-      .SetSupportsCompute(true, DeviceSupportsComputeSubgroups(device))
+      .SetSupportsCompute(true)
+      .SetSupportsComputeSubgroups(DeviceSupportsComputeSubgroups(device))
       .SetSupportsReadFromResolve(true)
       .SetSupportsReadFromOnscreenTexture(true)
       .Build();

--- a/impeller/renderer/capabilities.cc
+++ b/impeller/renderer/capabilities.cc
@@ -162,16 +162,20 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsFramebufferFetch(
   return *this;
 }
 
-CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsCompute(bool compute,
-                                                             bool subgroups) {
-  supports_compute_ = compute;
-  supports_compute_subgroups_ = subgroups;
+CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsCompute(bool value) {
+  supports_compute_ = value;
+  return *this;
+}
+
+CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsComputeSubgroups(
+    bool value) {
+  supports_compute_subgroups_ = value;
   return *this;
 }
 
 CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsReadFromOnscreenTexture(
     bool read_from_onscreen_texture) {
-  supports_read_from_resolve_ = read_from_onscreen_texture;
+  supports_read_from_onscreen_texture_ = read_from_onscreen_texture;
   return *this;
 }
 

--- a/impeller/renderer/capabilities.h
+++ b/impeller/renderer/capabilities.h
@@ -65,12 +65,13 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetSupportsFramebufferFetch(bool value);
 
-  CapabilitiesBuilder& SetSupportsCompute(bool compute, bool subgroups);
+  CapabilitiesBuilder& SetSupportsCompute(bool value);
 
-  CapabilitiesBuilder& SetSupportsReadFromOnscreenTexture(
-      bool read_from_onscreen_texture);
+  CapabilitiesBuilder& SetSupportsComputeSubgroups(bool value);
 
-  CapabilitiesBuilder& SetSupportsReadFromResolve(bool read_from_resolve);
+  CapabilitiesBuilder& SetSupportsReadFromOnscreenTexture(bool value);
+
+  CapabilitiesBuilder& SetSupportsReadFromResolve(bool value);
 
   CapabilitiesBuilder& SetDefaultColorFormat(PixelFormat value);
 

--- a/impeller/renderer/capabilities_unittests.cc
+++ b/impeller/renderer/capabilities_unittests.cc
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"
+#include "impeller/renderer/capabilities.h"
+
+#include "gtest/gtest.h"
+
+namespace impeller {
+namespace testing {
+
+#define CAPABILITY_TEST(name, default_value)                                 \
+  TEST(CapabilitiesTest, name) {                                             \
+    auto defaults = CapabilitiesBuilder().Build();                           \
+    ASSERT_EQ(defaults->name(), default_value);                              \
+    auto opposite = CapabilitiesBuilder().Set##name(!default_value).Build(); \
+    ASSERT_EQ(opposite->name(), !default_value);                             \
+  }
+
+CAPABILITY_TEST(HasThreadingRestrictions, false);
+CAPABILITY_TEST(SupportsOffscreenMSAA, false);
+CAPABILITY_TEST(SupportsSSBO, false);
+CAPABILITY_TEST(SupportsBufferToTextureBlits, false);
+CAPABILITY_TEST(SupportsTextureToTextureBlits, false);
+CAPABILITY_TEST(SupportsFramebufferFetch, false);
+CAPABILITY_TEST(SupportsCompute, false);
+CAPABILITY_TEST(SupportsComputeSubgroups, false);
+CAPABILITY_TEST(SupportsReadFromOnscreenTexture, false);
+CAPABILITY_TEST(SupportsReadFromResolve, false);
+CAPABILITY_TEST(SupportsDecalTileMode, false);
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
I noticed we still weren't going down the blit-less path on iOS, and it turned out that the wrong capability was getting assigned in the builder.