### PR TITLE
[Impeller] Fixed blit command missing tracking and added mock vulkan for tests

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -144,6 +144,8 @@
 ../../../flutter/impeller/golden_tests_harvester/test
 ../../../flutter/impeller/image/README.md
 ../../../flutter/impeller/playground
+../../../flutter/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+../../../flutter/impeller/renderer/backend/vulkan/test
 ../../../flutter/impeller/renderer/capabilities_unittests.cc
 ../../../flutter/impeller/renderer/compute_subgroup_unittests.cc
 ../../../flutter/impeller/renderer/compute_unittests.cc

--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -97,6 +97,12 @@ impeller_component("impeller_unittests") {
     ]
   }
 
+  if (impeller_enable_vulkan) {
+    deps += [
+      "//flutter/impeller/renderer/backend/vulkan:vulkan_unittests",
+    ]
+  }
+
   if (impeller_enable_compute) {
     deps += [ "renderer:compute_tessellation_unittests" ]
   }

--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -98,9 +98,7 @@ impeller_component("impeller_unittests") {
   }
 
   if (impeller_enable_vulkan) {
-    deps += [
-      "//flutter/impeller/renderer/backend/vulkan:vulkan_unittests",
-    ]
+    deps += [ "//flutter/impeller/renderer/backend/vulkan:vulkan_unittests" ]
   }
 
   if (impeller_enable_compute) {

--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -6,8 +6,15 @@ import("../../../tools/impeller.gni")
 
 impeller_component("vulkan_unittests") {
   testonly = true
-  sources = [ "blit_command_vk_unittests.cc" ]
-  deps = [ ":vulkan", "//flutter/testing:testing_lib" ]
+  sources = [
+    "blit_command_vk_unittests.cc",
+    "test/mock_vulkan.cc",
+    "test/mock_vulkan.h",
+  ]
+  deps = [
+    ":vulkan",
+    "//flutter/testing:testing_lib",
+  ]
 }
 
 impeller_component("vulkan") {

--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -4,6 +4,12 @@
 
 import("../../../tools/impeller.gni")
 
+impeller_component("vulkan_unittests") {
+  testonly = true
+  sources = [ "blit_command_vk_unittests.cc" ]
+  deps = [ ":vulkan", "//flutter/testing:testing_lib" ]
+}
+
 impeller_component("vulkan") {
   sources = [
     "allocator_vk.cc",

--- a/impeller/renderer/backend/vulkan/blit_command_vk.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk.cc
@@ -100,7 +100,7 @@ bool BlitCopyTextureToBufferCommandVK::Encode(CommandEncoderVK& encoder) const {
   // cast source and destination to TextureVK
   const auto& src = TextureVK::Cast(*source);
 
-  if (!encoder.Track(source)) {
+  if (!encoder.Track(source) || !encoder.Track(destination)) {
     return false;
   }
 

--- a/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
@@ -65,6 +65,7 @@ void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
   pProperties->limits.framebufferColorSampleCounts =
       static_cast<VkSampleCountFlags>(VK_SAMPLE_COUNT_1_BIT |
                                       VK_SAMPLE_COUNT_4_BIT);
+  pProperties->limits.maxImageDimension2D = 4096;
 }
 
 void vkGetPhysicalDeviceQueueFamilyProperties(
@@ -114,7 +115,9 @@ void vkGetPhysicalDeviceMemoryProperties(
     VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
   pMemoryProperties->memoryTypeCount = 1;
   pMemoryProperties->memoryTypes[0].heapIndex = 0;
-  pMemoryProperties->memoryTypes[0].propertyFlags = 0;
+  // pMemoryProperties->memoryTypes[0].propertyFlags =
+  //     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+  //     VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD;
   pMemoryProperties->memoryHeapCount = 1;
   pMemoryProperties->memoryHeaps[0].size = 1024 * 1024 * 1024;
   pMemoryProperties->memoryHeaps[0].flags = 0;
@@ -128,6 +131,103 @@ VkResult vkCreatePipelineCache(VkDevice device,
   return VK_SUCCESS;
 }
 
+VkResult vkCreateCommandPool(VkDevice device,
+                             const VkCommandPoolCreateInfo* pCreateInfo,
+                             const VkAllocationCallbacks* pAllocator,
+                             VkCommandPool* pCommandPool) {
+  *pCommandPool = reinterpret_cast<VkCommandPool>(0xc0de0001);
+  return VK_SUCCESS;
+}
+
+VkResult vkAllocateCommandBuffers(
+    VkDevice device,
+    const VkCommandBufferAllocateInfo* pAllocateInfo,
+    VkCommandBuffer* pCommandBuffers) {
+  *pCommandBuffers = reinterpret_cast<VkCommandBuffer>(0x0b0ffe12);
+  return VK_SUCCESS;
+}
+
+VkResult vkBeginCommandBuffer(VkCommandBuffer commandBuffer,
+                              const VkCommandBufferBeginInfo* pBeginInfo) {
+  return VK_SUCCESS;
+}
+
+VkResult vkCreateImage(VkDevice device,
+                       const VkImageCreateInfo* pCreateInfo,
+                       const VkAllocationCallbacks* pAllocator,
+                       VkImage* pImage) {
+  *pImage = reinterpret_cast<VkImage>(0xD0D0CACA);
+  return VK_SUCCESS;
+}
+
+void vkGetImageMemoryRequirements2KHR(
+    VkDevice device,
+    const VkImageMemoryRequirementsInfo2* pInfo,
+    VkMemoryRequirements2* pMemoryRequirements) {
+  pMemoryRequirements->memoryRequirements.size = 1024;
+  pMemoryRequirements->memoryRequirements.memoryTypeBits = 1;
+}
+
+VkResult vkAllocateMemory(VkDevice device,
+                          const VkMemoryAllocateInfo* pAllocateInfo,
+                          const VkAllocationCallbacks* pAllocator,
+                          VkDeviceMemory* pMemory) {
+  *pMemory = reinterpret_cast<VkDeviceMemory>(0xCAFEB0BA);
+  return VK_SUCCESS;
+}
+
+VkResult vkBindImageMemory(VkDevice device,
+                           VkImage image,
+                           VkDeviceMemory memory,
+                           VkDeviceSize memoryOffset) {
+  return VK_SUCCESS;
+}
+
+PFN_vkVoidFunction GetProcAddress(VkInstance instance, const char* pName) {
+  if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties;
+  } else if (strcmp("vkEnumerateInstanceLayerProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties;
+  } else if (strcmp("vkEnumeratePhysicalDevices", pName) == 0) {
+    return (PFN_vkVoidFunction)vkEnumeratePhysicalDevices;
+  } else if (strcmp("vkGetPhysicalDeviceFormatProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetPhysicalDeviceFormatProperties;
+  } else if (strcmp("vkGetPhysicalDeviceProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetPhysicalDeviceProperties;
+  } else if (strcmp("vkGetPhysicalDeviceQueueFamilyProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetPhysicalDeviceQueueFamilyProperties;
+  } else if (strcmp("vkEnumerateDeviceExtensionProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkEnumerateDeviceExtensionProperties;
+  } else if (strcmp("vkCreateDevice", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateDevice;
+  } else if (strcmp("vkCreateInstance", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateInstance;
+  } else if (strcmp("vkGetPhysicalDeviceMemoryProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetPhysicalDeviceMemoryProperties;
+  } else if (strcmp("vkCreatePipelineCache", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreatePipelineCache;
+  } else if (strcmp("vkCreateCommandPool", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateCommandPool;
+  } else if (strcmp("vkAllocateCommandBuffers", pName) == 0) {
+    return (PFN_vkVoidFunction)vkAllocateCommandBuffers;
+  } else if (strcmp("vkBeginCommandBuffer", pName) == 0) {
+    return (PFN_vkVoidFunction)vkBeginCommandBuffer;
+  } else if (strcmp("vkCreateImage", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateImage;
+  } else if (strcmp("vkGetInstanceProcAddr", pName) == 0) {
+    return (PFN_vkVoidFunction)GetProcAddress;
+  } else if (strcmp("vkGetDeviceProcAddr", pName) == 0) {
+    return (PFN_vkVoidFunction)GetProcAddress;
+  } else if (strcmp("vkGetImageMemoryRequirements2KHR", pName) == 0 ||
+             strcmp("vkGetImageMemoryRequirements2", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetImageMemoryRequirements2KHR;
+  } else if (strcmp("vkAllocateMemory", pName) == 0) {
+    return (PFN_vkVoidFunction)vkAllocateMemory;
+  } else if (strcmp("vkBindImageMemory", pName) == 0) {
+    return (PFN_vkVoidFunction)vkBindImageMemory;
+  }
+  return noop;
+}
 }  // namespace
 
 TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
@@ -135,37 +235,18 @@ TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
   auto message_loop = fml::ConcurrentMessageLoop::Create();
   settings.worker_task_runner =
       std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
-  settings.proc_address_callback = [](VkInstance instance,
-                                      const char* pName) -> PFN_vkVoidFunction {
-    if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
-      return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties;
-    } else if (strcmp("vkEnumerateInstanceLayerProperties", pName) == 0) {
-      return (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties;
-    } else if (strcmp("vkEnumeratePhysicalDevices", pName) == 0) {
-      return (PFN_vkVoidFunction)vkEnumeratePhysicalDevices;
-    } else if (strcmp("vkGetPhysicalDeviceFormatProperties", pName) == 0) {
-      return (PFN_vkVoidFunction)vkGetPhysicalDeviceFormatProperties;
-    } else if (strcmp("vkGetPhysicalDeviceProperties", pName) == 0) {
-      return (PFN_vkVoidFunction)vkGetPhysicalDeviceProperties;
-    } else if (strcmp("vkGetPhysicalDeviceQueueFamilyProperties", pName) == 0) {
-      return (PFN_vkVoidFunction)vkGetPhysicalDeviceQueueFamilyProperties;
-    } else if (strcmp("vkEnumerateDeviceExtensionProperties", pName) == 0) {
-      return (PFN_vkVoidFunction)vkEnumerateDeviceExtensionProperties;
-    } else if (strcmp("vkCreateDevice", pName) == 0) {
-      return (PFN_vkVoidFunction)vkCreateDevice;
-    } else if (strcmp("vkCreateInstance", pName) == 0) {
-      return (PFN_vkVoidFunction)vkCreateInstance;
-    } else if (strcmp("vkGetPhysicalDeviceMemoryProperties", pName) == 0) {
-      return (PFN_vkVoidFunction)vkGetPhysicalDeviceMemoryProperties;
-    } else if (strcmp("vkCreatePipelineCache", pName) == 0) {
-      return (PFN_vkVoidFunction)vkCreatePipelineCache;
-    }
-    return noop;
-  };
+  settings.proc_address_callback = GetProcAddress;
   auto context = ContextVK::Create(std::move(settings));
+  auto pool = CommandPoolVK::GetThreadLocal(context.get());
   CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
                            {}, context->GetFenceWaiter());
   BlitCopyTextureToTextureCommandVK cmd;
+  cmd.source = context->GetResourceAllocator()->CreateTexture({
+      .size = ISize(100, 100),
+  });
+  cmd.destination = context->GetResourceAllocator()->CreateTexture({
+      .size = ISize(100, 100),
+  });
   bool result = cmd.Encode(encoder);
   ASSERT_TRUE(result);
 }

--- a/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
@@ -183,6 +183,14 @@ VkResult vkBindImageMemory(VkDevice device,
   return VK_SUCCESS;
 }
 
+VkResult vkCreateImageView(VkDevice device,
+                           const VkImageViewCreateInfo* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator,
+                           VkImageView* pView) {
+  *pView = reinterpret_cast<VkImageView>(0xFEE1DEAD);
+  return VK_SUCCESS;
+}
+
 PFN_vkVoidFunction GetProcAddress(VkInstance instance, const char* pName) {
   if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
     return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties;
@@ -225,6 +233,8 @@ PFN_vkVoidFunction GetProcAddress(VkInstance instance, const char* pName) {
     return (PFN_vkVoidFunction)vkAllocateMemory;
   } else if (strcmp("vkBindImageMemory", pName) == 0) {
     return (PFN_vkVoidFunction)vkBindImageMemory;
+  } else if (strcmp("vkCreateImageView", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateImageView;
   }
   return noop;
 }
@@ -239,7 +249,7 @@ TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
   auto context = ContextVK::Create(std::move(settings));
   auto pool = CommandPoolVK::GetThreadLocal(context.get());
   CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
-                           {}, context->GetFenceWaiter());
+                           pool, context->GetFenceWaiter());
   BlitCopyTextureToTextureCommandVK cmd;
   cmd.source = context->GetResourceAllocator()->CreateTexture({
       .size = ISize(100, 100),

--- a/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
@@ -163,8 +163,8 @@ TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
     return noop;
   };
   auto context = ContextVK::Create(std::move(settings));
-  CommandEncoderVK encoder(context->GetDevice(), {}, {},
-                           context->GetFenceWaiter());
+  CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
+                           {}, context->GetFenceWaiter());
   BlitCopyTextureToTextureCommandVK cmd;
   bool result = cmd.Encode(encoder);
   ASSERT_TRUE(result);

--- a/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
@@ -33,28 +33,28 @@ TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
   EXPECT_TRUE(encoder.IsTracking(cmd.destination));
 }
 
-// TEST(BlitCommandVkTest, BlitCopyTextureToBufferCommandVK) {
-//   ContextVK::Settings settings;
-//   auto message_loop = fml::ConcurrentMessageLoop::Create();
-//   settings.worker_task_runner =
-//       std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
-//   settings.proc_address_callback = GetMockVulkanProcAddress;
-//   auto context = ContextVK::Create(std::move(settings));
-//   auto pool = CommandPoolVK::GetThreadLocal(context.get());
-//   CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
-//                            pool, context->GetFenceWaiter());
-//   BlitCopyTextureToBufferCommandVK cmd;
-//   cmd.source = context->GetResourceAllocator()->CreateTexture({
-//       .size = ISize(100, 100),
-//   });
-//   cmd.destination = context->GetResourceAllocator()->CreateTexture({
-//       .size = ISize(100, 100),
-//   });
-//   bool result = cmd.Encode(encoder);
-//   EXPECT_TRUE(result);
-//   EXPECT_TRUE(encoder.IsTracking(cmd.source));
-//   EXPECT_TRUE(encoder.IsTracking(cmd.destination));
-// }
+TEST(BlitCommandVkTest, BlitCopyTextureToBufferCommandVK) {
+  ContextVK::Settings settings;
+  auto message_loop = fml::ConcurrentMessageLoop::Create();
+  settings.worker_task_runner =
+      std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
+  settings.proc_address_callback = GetMockVulkanProcAddress;
+  auto context = ContextVK::Create(std::move(settings));
+  auto pool = CommandPoolVK::GetThreadLocal(context.get());
+  CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
+                           pool, context->GetFenceWaiter());
+  BlitCopyTextureToBufferCommandVK cmd;
+  cmd.source = context->GetResourceAllocator()->CreateTexture({
+      .size = ISize(100, 100),
+  });
+  cmd.destination = context->GetResourceAllocator()->CreateBuffer({
+      .size = 1,
+  });
+  bool result = cmd.Encode(encoder);
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(encoder.IsTracking(cmd.source));
+  EXPECT_TRUE(encoder.IsTracking(cmd.destination));
+}
 
 TEST(BlitCommandVkTest, BlitGenerateMipmapCommandVK) {
   ContextVK::Settings settings;

--- a/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
@@ -11,12 +11,7 @@ namespace impeller {
 namespace testing {
 
 TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
-  ContextVK::Settings settings;
-  auto message_loop = fml::ConcurrentMessageLoop::Create();
-  settings.worker_task_runner =
-      std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
-  settings.proc_address_callback = GetMockVulkanProcAddress;
-  auto context = ContextVK::Create(std::move(settings));
+  auto context = CreateMockVulkanContext();
   auto pool = CommandPoolVK::GetThreadLocal(context.get());
   CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
                            pool, context->GetFenceWaiter());
@@ -34,12 +29,7 @@ TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
 }
 
 TEST(BlitCommandVkTest, BlitCopyTextureToBufferCommandVK) {
-  ContextVK::Settings settings;
-  auto message_loop = fml::ConcurrentMessageLoop::Create();
-  settings.worker_task_runner =
-      std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
-  settings.proc_address_callback = GetMockVulkanProcAddress;
-  auto context = ContextVK::Create(std::move(settings));
+  auto context = CreateMockVulkanContext();
   auto pool = CommandPoolVK::GetThreadLocal(context.get());
   CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
                            pool, context->GetFenceWaiter());
@@ -57,12 +47,7 @@ TEST(BlitCommandVkTest, BlitCopyTextureToBufferCommandVK) {
 }
 
 TEST(BlitCommandVkTest, BlitGenerateMipmapCommandVK) {
-  ContextVK::Settings settings;
-  auto message_loop = fml::ConcurrentMessageLoop::Create();
-  settings.worker_task_runner =
-      std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
-  settings.proc_address_callback = GetMockVulkanProcAddress;
-  auto context = ContextVK::Create(std::move(settings));
+  auto context = CreateMockVulkanContext();
   auto pool = CommandPoolVK::GetThreadLocal(context.get());
   CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
                            pool, context->GetFenceWaiter());

--- a/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
@@ -33,5 +33,48 @@ TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
   EXPECT_TRUE(encoder.IsTracking(cmd.destination));
 }
 
+// TEST(BlitCommandVkTest, BlitCopyTextureToBufferCommandVK) {
+//   ContextVK::Settings settings;
+//   auto message_loop = fml::ConcurrentMessageLoop::Create();
+//   settings.worker_task_runner =
+//       std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
+//   settings.proc_address_callback = GetMockVulkanProcAddress;
+//   auto context = ContextVK::Create(std::move(settings));
+//   auto pool = CommandPoolVK::GetThreadLocal(context.get());
+//   CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
+//                            pool, context->GetFenceWaiter());
+//   BlitCopyTextureToBufferCommandVK cmd;
+//   cmd.source = context->GetResourceAllocator()->CreateTexture({
+//       .size = ISize(100, 100),
+//   });
+//   cmd.destination = context->GetResourceAllocator()->CreateTexture({
+//       .size = ISize(100, 100),
+//   });
+//   bool result = cmd.Encode(encoder);
+//   EXPECT_TRUE(result);
+//   EXPECT_TRUE(encoder.IsTracking(cmd.source));
+//   EXPECT_TRUE(encoder.IsTracking(cmd.destination));
+// }
+
+TEST(BlitCommandVkTest, BlitGenerateMipmapCommandVK) {
+  ContextVK::Settings settings;
+  auto message_loop = fml::ConcurrentMessageLoop::Create();
+  settings.worker_task_runner =
+      std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
+  settings.proc_address_callback = GetMockVulkanProcAddress;
+  auto context = ContextVK::Create(std::move(settings));
+  auto pool = CommandPoolVK::GetThreadLocal(context.get());
+  CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
+                           pool, context->GetFenceWaiter());
+  BlitGenerateMipmapCommandVK cmd;
+  cmd.texture = context->GetResourceAllocator()->CreateTexture({
+      .size = ISize(100, 100),
+      .mip_count = 2,
+  });
+  bool result = cmd.Encode(encoder);
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(encoder.IsTracking(cmd.texture));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
@@ -34,12 +34,6 @@ VkResult vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
   return VK_SUCCESS;
 }
 
-VkResult vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
-                          const VkAllocationCallbacks* pAllocator,
-                          VkInstance* pInstance) {
-  return VK_SUCCESS;
-}
-
 VkResult vkEnumeratePhysicalDevices(VkInstance instance,
                                     uint32_t* pPhysicalDeviceCount,
                                     VkPhysicalDevice* pPhysicalDevices) {
@@ -107,18 +101,46 @@ VkResult vkCreateDevice(VkPhysicalDevice physicalDevice,
   *pDevice = reinterpret_cast<VkDevice>(0xcafebabe);
   return VK_SUCCESS;
 }
+
+VkResult vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
+                          const VkAllocationCallbacks* pAllocator,
+                          VkInstance* pInstance) {
+  *pInstance = reinterpret_cast<VkInstance>(0xbaadf00d);
+  return VK_SUCCESS;
+}
+
+void vkGetPhysicalDeviceMemoryProperties(
+    VkPhysicalDevice physicalDevice,
+    VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
+  pMemoryProperties->memoryTypeCount = 1;
+  pMemoryProperties->memoryTypes[0].heapIndex = 0;
+  pMemoryProperties->memoryTypes[0].propertyFlags = 0;
+  pMemoryProperties->memoryHeapCount = 1;
+  pMemoryProperties->memoryHeaps[0].size = 1024 * 1024 * 1024;
+  pMemoryProperties->memoryHeaps[0].flags = 0;
+}
+
+VkResult vkCreatePipelineCache(VkDevice device,
+                               const VkPipelineCacheCreateInfo* pCreateInfo,
+                               const VkAllocationCallbacks* pAllocator,
+                               VkPipelineCache* pPipelineCache) {
+  *pPipelineCache = reinterpret_cast<VkPipelineCache>(0xb000dead);
+  return VK_SUCCESS;
+}
+
 }  // namespace
 
 TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
   ContextVK::Settings settings;
+  auto message_loop = fml::ConcurrentMessageLoop::Create();
+  settings.worker_task_runner =
+      std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
   settings.proc_address_callback = [](VkInstance instance,
                                       const char* pName) -> PFN_vkVoidFunction {
     if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
       return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties;
     } else if (strcmp("vkEnumerateInstanceLayerProperties", pName) == 0) {
       return (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties;
-    } else if (strcmp("vkCreateInstance", pName) == 0) {
-      return (PFN_vkVoidFunction)vkCreateInstance;
     } else if (strcmp("vkEnumeratePhysicalDevices", pName) == 0) {
       return (PFN_vkVoidFunction)vkEnumeratePhysicalDevices;
     } else if (strcmp("vkGetPhysicalDeviceFormatProperties", pName) == 0) {
@@ -131,6 +153,12 @@ TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
       return (PFN_vkVoidFunction)vkEnumerateDeviceExtensionProperties;
     } else if (strcmp("vkCreateDevice", pName) == 0) {
       return (PFN_vkVoidFunction)vkCreateDevice;
+    } else if (strcmp("vkCreateInstance", pName) == 0) {
+      return (PFN_vkVoidFunction)vkCreateInstance;
+    } else if (strcmp("vkGetPhysicalDeviceMemoryProperties", pName) == 0) {
+      return (PFN_vkVoidFunction)vkGetPhysicalDeviceMemoryProperties;
+    } else if (strcmp("vkCreatePipelineCache", pName) == 0) {
+      return (PFN_vkVoidFunction)vkCreatePipelineCache;
     }
     return noop;
   };

--- a/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
@@ -5,247 +5,17 @@
 #include "flutter/testing/testing.h"
 #include "impeller/renderer/backend/vulkan/blit_command_vk.h"
 #include "impeller/renderer/backend/vulkan/command_encoder_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
 
 namespace impeller {
 namespace testing {
-
-namespace {
-void noop() {}
-
-VkResult vkEnumerateInstanceExtensionProperties(
-    const char* pLayerName,
-    uint32_t* pPropertyCount,
-    VkExtensionProperties* pProperties) {
-  if (!pProperties) {
-    *pPropertyCount = 2;
-
-  } else {
-    strcpy(pProperties[0].extensionName, "VK_KHR_surface");
-    pProperties[0].specVersion = 0;
-    strcpy(pProperties[1].extensionName, "VK_MVK_macos_surface");
-    pProperties[1].specVersion = 0;
-  }
-  return VK_SUCCESS;
-}
-
-VkResult vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
-                                            VkLayerProperties* pProperties) {
-  *pPropertyCount = 0;
-  return VK_SUCCESS;
-}
-
-VkResult vkEnumeratePhysicalDevices(VkInstance instance,
-                                    uint32_t* pPhysicalDeviceCount,
-                                    VkPhysicalDevice* pPhysicalDevices) {
-  if (!pPhysicalDevices) {
-    *pPhysicalDeviceCount = 1;
-  } else {
-    pPhysicalDevices[0] = reinterpret_cast<VkPhysicalDevice>(0xfeedface);
-  }
-  return VK_SUCCESS;
-}
-
-void vkGetPhysicalDeviceFormatProperties(
-    VkPhysicalDevice physicalDevice,
-    VkFormat format,
-    VkFormatProperties* pFormatProperties) {
-  if (format == VK_FORMAT_B8G8R8A8_UNORM) {
-    pFormatProperties->optimalTilingFeatures =
-        static_cast<VkFormatFeatureFlags>(
-            vk::FormatFeatureFlagBits::eColorAttachment);
-  } else if (format == VK_FORMAT_S8_UINT) {
-    pFormatProperties->optimalTilingFeatures =
-        static_cast<VkFormatFeatureFlags>(
-            vk::FormatFeatureFlagBits::eDepthStencilAttachment);
-  }
-}
-
-void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
-                                   VkPhysicalDeviceProperties* pProperties) {
-  pProperties->limits.framebufferColorSampleCounts =
-      static_cast<VkSampleCountFlags>(VK_SAMPLE_COUNT_1_BIT |
-                                      VK_SAMPLE_COUNT_4_BIT);
-  pProperties->limits.maxImageDimension2D = 4096;
-}
-
-void vkGetPhysicalDeviceQueueFamilyProperties(
-    VkPhysicalDevice physicalDevice,
-    uint32_t* pQueueFamilyPropertyCount,
-    VkQueueFamilyProperties* pQueueFamilyProperties) {
-  if (!pQueueFamilyProperties) {
-    *pQueueFamilyPropertyCount = 1;
-  } else {
-    pQueueFamilyProperties[0].queueCount = 3;
-    pQueueFamilyProperties[0].queueFlags = static_cast<VkQueueFlags>(
-        VK_QUEUE_TRANSFER_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT);
-  }
-}
-
-VkResult vkEnumerateDeviceExtensionProperties(
-    VkPhysicalDevice physicalDevice,
-    const char* pLayerName,
-    uint32_t* pPropertyCount,
-    VkExtensionProperties* pProperties) {
-  if (!pProperties) {
-    *pPropertyCount = 1;
-  } else {
-    strcpy(pProperties[0].extensionName, "VK_KHR_swapchain");
-    pProperties[0].specVersion = 0;
-  }
-  return VK_SUCCESS;
-}
-
-VkResult vkCreateDevice(VkPhysicalDevice physicalDevice,
-                        const VkDeviceCreateInfo* pCreateInfo,
-                        const VkAllocationCallbacks* pAllocator,
-                        VkDevice* pDevice) {
-  *pDevice = reinterpret_cast<VkDevice>(0xcafebabe);
-  return VK_SUCCESS;
-}
-
-VkResult vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
-                          const VkAllocationCallbacks* pAllocator,
-                          VkInstance* pInstance) {
-  *pInstance = reinterpret_cast<VkInstance>(0xbaadf00d);
-  return VK_SUCCESS;
-}
-
-void vkGetPhysicalDeviceMemoryProperties(
-    VkPhysicalDevice physicalDevice,
-    VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
-  pMemoryProperties->memoryTypeCount = 1;
-  pMemoryProperties->memoryTypes[0].heapIndex = 0;
-  // pMemoryProperties->memoryTypes[0].propertyFlags =
-  //     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
-  //     VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD;
-  pMemoryProperties->memoryHeapCount = 1;
-  pMemoryProperties->memoryHeaps[0].size = 1024 * 1024 * 1024;
-  pMemoryProperties->memoryHeaps[0].flags = 0;
-}
-
-VkResult vkCreatePipelineCache(VkDevice device,
-                               const VkPipelineCacheCreateInfo* pCreateInfo,
-                               const VkAllocationCallbacks* pAllocator,
-                               VkPipelineCache* pPipelineCache) {
-  *pPipelineCache = reinterpret_cast<VkPipelineCache>(0xb000dead);
-  return VK_SUCCESS;
-}
-
-VkResult vkCreateCommandPool(VkDevice device,
-                             const VkCommandPoolCreateInfo* pCreateInfo,
-                             const VkAllocationCallbacks* pAllocator,
-                             VkCommandPool* pCommandPool) {
-  *pCommandPool = reinterpret_cast<VkCommandPool>(0xc0de0001);
-  return VK_SUCCESS;
-}
-
-VkResult vkAllocateCommandBuffers(
-    VkDevice device,
-    const VkCommandBufferAllocateInfo* pAllocateInfo,
-    VkCommandBuffer* pCommandBuffers) {
-  *pCommandBuffers = reinterpret_cast<VkCommandBuffer>(0x0b0ffe12);
-  return VK_SUCCESS;
-}
-
-VkResult vkBeginCommandBuffer(VkCommandBuffer commandBuffer,
-                              const VkCommandBufferBeginInfo* pBeginInfo) {
-  return VK_SUCCESS;
-}
-
-VkResult vkCreateImage(VkDevice device,
-                       const VkImageCreateInfo* pCreateInfo,
-                       const VkAllocationCallbacks* pAllocator,
-                       VkImage* pImage) {
-  *pImage = reinterpret_cast<VkImage>(0xD0D0CACA);
-  return VK_SUCCESS;
-}
-
-void vkGetImageMemoryRequirements2KHR(
-    VkDevice device,
-    const VkImageMemoryRequirementsInfo2* pInfo,
-    VkMemoryRequirements2* pMemoryRequirements) {
-  pMemoryRequirements->memoryRequirements.size = 1024;
-  pMemoryRequirements->memoryRequirements.memoryTypeBits = 1;
-}
-
-VkResult vkAllocateMemory(VkDevice device,
-                          const VkMemoryAllocateInfo* pAllocateInfo,
-                          const VkAllocationCallbacks* pAllocator,
-                          VkDeviceMemory* pMemory) {
-  *pMemory = reinterpret_cast<VkDeviceMemory>(0xCAFEB0BA);
-  return VK_SUCCESS;
-}
-
-VkResult vkBindImageMemory(VkDevice device,
-                           VkImage image,
-                           VkDeviceMemory memory,
-                           VkDeviceSize memoryOffset) {
-  return VK_SUCCESS;
-}
-
-VkResult vkCreateImageView(VkDevice device,
-                           const VkImageViewCreateInfo* pCreateInfo,
-                           const VkAllocationCallbacks* pAllocator,
-                           VkImageView* pView) {
-  *pView = reinterpret_cast<VkImageView>(0xFEE1DEAD);
-  return VK_SUCCESS;
-}
-
-PFN_vkVoidFunction GetProcAddress(VkInstance instance, const char* pName) {
-  if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
-    return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties;
-  } else if (strcmp("vkEnumerateInstanceLayerProperties", pName) == 0) {
-    return (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties;
-  } else if (strcmp("vkEnumeratePhysicalDevices", pName) == 0) {
-    return (PFN_vkVoidFunction)vkEnumeratePhysicalDevices;
-  } else if (strcmp("vkGetPhysicalDeviceFormatProperties", pName) == 0) {
-    return (PFN_vkVoidFunction)vkGetPhysicalDeviceFormatProperties;
-  } else if (strcmp("vkGetPhysicalDeviceProperties", pName) == 0) {
-    return (PFN_vkVoidFunction)vkGetPhysicalDeviceProperties;
-  } else if (strcmp("vkGetPhysicalDeviceQueueFamilyProperties", pName) == 0) {
-    return (PFN_vkVoidFunction)vkGetPhysicalDeviceQueueFamilyProperties;
-  } else if (strcmp("vkEnumerateDeviceExtensionProperties", pName) == 0) {
-    return (PFN_vkVoidFunction)vkEnumerateDeviceExtensionProperties;
-  } else if (strcmp("vkCreateDevice", pName) == 0) {
-    return (PFN_vkVoidFunction)vkCreateDevice;
-  } else if (strcmp("vkCreateInstance", pName) == 0) {
-    return (PFN_vkVoidFunction)vkCreateInstance;
-  } else if (strcmp("vkGetPhysicalDeviceMemoryProperties", pName) == 0) {
-    return (PFN_vkVoidFunction)vkGetPhysicalDeviceMemoryProperties;
-  } else if (strcmp("vkCreatePipelineCache", pName) == 0) {
-    return (PFN_vkVoidFunction)vkCreatePipelineCache;
-  } else if (strcmp("vkCreateCommandPool", pName) == 0) {
-    return (PFN_vkVoidFunction)vkCreateCommandPool;
-  } else if (strcmp("vkAllocateCommandBuffers", pName) == 0) {
-    return (PFN_vkVoidFunction)vkAllocateCommandBuffers;
-  } else if (strcmp("vkBeginCommandBuffer", pName) == 0) {
-    return (PFN_vkVoidFunction)vkBeginCommandBuffer;
-  } else if (strcmp("vkCreateImage", pName) == 0) {
-    return (PFN_vkVoidFunction)vkCreateImage;
-  } else if (strcmp("vkGetInstanceProcAddr", pName) == 0) {
-    return (PFN_vkVoidFunction)GetProcAddress;
-  } else if (strcmp("vkGetDeviceProcAddr", pName) == 0) {
-    return (PFN_vkVoidFunction)GetProcAddress;
-  } else if (strcmp("vkGetImageMemoryRequirements2KHR", pName) == 0 ||
-             strcmp("vkGetImageMemoryRequirements2", pName) == 0) {
-    return (PFN_vkVoidFunction)vkGetImageMemoryRequirements2KHR;
-  } else if (strcmp("vkAllocateMemory", pName) == 0) {
-    return (PFN_vkVoidFunction)vkAllocateMemory;
-  } else if (strcmp("vkBindImageMemory", pName) == 0) {
-    return (PFN_vkVoidFunction)vkBindImageMemory;
-  } else if (strcmp("vkCreateImageView", pName) == 0) {
-    return (PFN_vkVoidFunction)vkCreateImageView;
-  }
-  return noop;
-}
-}  // namespace
 
 TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
   ContextVK::Settings settings;
   auto message_loop = fml::ConcurrentMessageLoop::Create();
   settings.worker_task_runner =
       std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
-  settings.proc_address_callback = GetProcAddress;
+  settings.proc_address_callback = GetMockVulkanProcAddress;
   auto context = ContextVK::Create(std::move(settings));
   auto pool = CommandPoolVK::GetThreadLocal(context.get());
   CommandEncoderVK encoder(context->GetDevice(), context->GetGraphicsQueue(),
@@ -258,7 +28,9 @@ TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
       .size = ISize(100, 100),
   });
   bool result = cmd.Encode(encoder);
-  ASSERT_TRUE(result);
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(encoder.IsTracking(cmd.source));
+  EXPECT_TRUE(encoder.IsTracking(cmd.destination));
 }
 
 }  // namespace testing

--- a/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
@@ -1,0 +1,146 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"
+#include "impeller/renderer/backend/vulkan/blit_command_vk.h"
+#include "impeller/renderer/backend/vulkan/command_encoder_vk.h"
+
+namespace impeller {
+namespace testing {
+
+namespace {
+void noop() {}
+
+VkResult vkEnumerateInstanceExtensionProperties(
+    const char* pLayerName,
+    uint32_t* pPropertyCount,
+    VkExtensionProperties* pProperties) {
+  if (!pProperties) {
+    *pPropertyCount = 2;
+
+  } else {
+    strcpy(pProperties[0].extensionName, "VK_KHR_surface");
+    pProperties[0].specVersion = 0;
+    strcpy(pProperties[1].extensionName, "VK_MVK_macos_surface");
+    pProperties[1].specVersion = 0;
+  }
+  return VK_SUCCESS;
+}
+
+VkResult vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
+                                            VkLayerProperties* pProperties) {
+  *pPropertyCount = 0;
+  return VK_SUCCESS;
+}
+
+VkResult vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
+                          const VkAllocationCallbacks* pAllocator,
+                          VkInstance* pInstance) {
+  return VK_SUCCESS;
+}
+
+VkResult vkEnumeratePhysicalDevices(VkInstance instance,
+                                    uint32_t* pPhysicalDeviceCount,
+                                    VkPhysicalDevice* pPhysicalDevices) {
+  if (!pPhysicalDevices) {
+    *pPhysicalDeviceCount = 1;
+  } else {
+    pPhysicalDevices[0] = reinterpret_cast<VkPhysicalDevice>(0xfeedface);
+  }
+  return VK_SUCCESS;
+}
+
+void vkGetPhysicalDeviceFormatProperties(
+    VkPhysicalDevice physicalDevice,
+    VkFormat format,
+    VkFormatProperties* pFormatProperties) {
+  if (format == VK_FORMAT_B8G8R8A8_UNORM) {
+    pFormatProperties->optimalTilingFeatures =
+        static_cast<VkFormatFeatureFlags>(
+            vk::FormatFeatureFlagBits::eColorAttachment);
+  } else if (format == VK_FORMAT_S8_UINT) {
+    pFormatProperties->optimalTilingFeatures =
+        static_cast<VkFormatFeatureFlags>(
+            vk::FormatFeatureFlagBits::eDepthStencilAttachment);
+  }
+}
+
+void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
+                                   VkPhysicalDeviceProperties* pProperties) {
+  pProperties->limits.framebufferColorSampleCounts =
+      static_cast<VkSampleCountFlags>(VK_SAMPLE_COUNT_1_BIT |
+                                      VK_SAMPLE_COUNT_4_BIT);
+}
+
+void vkGetPhysicalDeviceQueueFamilyProperties(
+    VkPhysicalDevice physicalDevice,
+    uint32_t* pQueueFamilyPropertyCount,
+    VkQueueFamilyProperties* pQueueFamilyProperties) {
+  if (!pQueueFamilyProperties) {
+    *pQueueFamilyPropertyCount = 1;
+  } else {
+    pQueueFamilyProperties[0].queueCount = 3;
+    pQueueFamilyProperties[0].queueFlags = static_cast<VkQueueFlags>(
+        VK_QUEUE_TRANSFER_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT);
+  }
+}
+
+VkResult vkEnumerateDeviceExtensionProperties(
+    VkPhysicalDevice physicalDevice,
+    const char* pLayerName,
+    uint32_t* pPropertyCount,
+    VkExtensionProperties* pProperties) {
+  if (!pProperties) {
+    *pPropertyCount = 1;
+  } else {
+    strcpy(pProperties[0].extensionName, "VK_KHR_swapchain");
+    pProperties[0].specVersion = 0;
+  }
+  return VK_SUCCESS;
+}
+
+VkResult vkCreateDevice(VkPhysicalDevice physicalDevice,
+                        const VkDeviceCreateInfo* pCreateInfo,
+                        const VkAllocationCallbacks* pAllocator,
+                        VkDevice* pDevice) {
+  *pDevice = reinterpret_cast<VkDevice>(0xcafebabe);
+  return VK_SUCCESS;
+}
+}  // namespace
+
+TEST(BlitCommandVkTest, BlitCopyTextureToTextureCommandVK) {
+  ContextVK::Settings settings;
+  settings.proc_address_callback = [](VkInstance instance,
+                                      const char* pName) -> PFN_vkVoidFunction {
+    if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
+      return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties;
+    } else if (strcmp("vkEnumerateInstanceLayerProperties", pName) == 0) {
+      return (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties;
+    } else if (strcmp("vkCreateInstance", pName) == 0) {
+      return (PFN_vkVoidFunction)vkCreateInstance;
+    } else if (strcmp("vkEnumeratePhysicalDevices", pName) == 0) {
+      return (PFN_vkVoidFunction)vkEnumeratePhysicalDevices;
+    } else if (strcmp("vkGetPhysicalDeviceFormatProperties", pName) == 0) {
+      return (PFN_vkVoidFunction)vkGetPhysicalDeviceFormatProperties;
+    } else if (strcmp("vkGetPhysicalDeviceProperties", pName) == 0) {
+      return (PFN_vkVoidFunction)vkGetPhysicalDeviceProperties;
+    } else if (strcmp("vkGetPhysicalDeviceQueueFamilyProperties", pName) == 0) {
+      return (PFN_vkVoidFunction)vkGetPhysicalDeviceQueueFamilyProperties;
+    } else if (strcmp("vkEnumerateDeviceExtensionProperties", pName) == 0) {
+      return (PFN_vkVoidFunction)vkEnumerateDeviceExtensionProperties;
+    } else if (strcmp("vkCreateDevice", pName) == 0) {
+      return (PFN_vkVoidFunction)vkCreateDevice;
+    }
+    return noop;
+  };
+  auto context = ContextVK::Create(std::move(settings));
+  CommandEncoderVK encoder(context->GetDevice(), {}, {},
+                           context->GetFenceWaiter());
+  BlitCopyTextureToTextureCommandVK cmd;
+  bool result = cmd.Encode(encoder);
+  ASSERT_TRUE(result);
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -65,6 +65,13 @@ class TrackedObjectsVK {
     tracked_textures_.insert(std::move(texture));
   }
 
+  bool IsTracking(const std::shared_ptr<const TextureSourceVK>& texture) const {
+    if (!texture) {
+      return false;
+    }
+    return tracked_textures_.find(texture) != tracked_textures_.end();
+  }
+
   vk::CommandBuffer GetCommandBuffer() const { return *buffer_; }
 
   DescriptorPoolVK& GetDescriptorPool() { return desc_pool_; }
@@ -188,6 +195,15 @@ bool CommandEncoderVK::Track(const std::shared_ptr<const Texture>& texture) {
     return true;
   }
   return Track(TextureVK::Cast(*texture).GetTextureSource());
+}
+
+bool CommandEncoderVK::IsTracking(
+    const std::shared_ptr<const Texture>& texture) const {
+  if (!IsValid()) {
+    return false;
+  }
+  std::shared_ptr<const TextureSourceVK> source = TextureVK::Cast(*texture).GetTextureSource();
+  return tracked_objects_->IsTracking(source);
 }
 
 std::optional<vk::DescriptorSet> CommandEncoderVK::AllocateDescriptorSet(

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -58,6 +58,13 @@ class TrackedObjectsVK {
     tracked_buffers_.insert(std::move(buffer));
   }
 
+  bool IsTracking(const std::shared_ptr<const DeviceBuffer>& buffer) const {
+    if (!buffer) {
+      return false;
+    }
+    return tracked_buffers_.find(buffer) != tracked_buffers_.end();
+  }
+
   void Track(std::shared_ptr<const TextureSourceVK> texture) {
     if (!texture) {
       return;
@@ -177,6 +184,14 @@ bool CommandEncoderVK::Track(std::shared_ptr<const DeviceBuffer> buffer) {
   }
   tracked_objects_->Track(std::move(buffer));
   return true;
+}
+
+bool CommandEncoderVK::IsTracking(
+    const std::shared_ptr<const DeviceBuffer>& buffer) const {
+  if (!IsValid()) {
+    return false;
+  }
+  return tracked_objects_->IsTracking(buffer);
 }
 
 bool CommandEncoderVK::Track(std::shared_ptr<const TextureSourceVK> texture) {

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -202,7 +202,8 @@ bool CommandEncoderVK::IsTracking(
   if (!IsValid()) {
     return false;
   }
-  std::shared_ptr<const TextureSourceVK> source = TextureVK::Cast(*texture).GetTextureSource();
+  std::shared_ptr<const TextureSourceVK> source =
+      TextureVK::Cast(*texture).GetTextureSource();
   return tracked_objects_->IsTracking(source);
 }
 

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -16,6 +16,10 @@
 
 namespace impeller {
 
+namespace testing {
+  class BlitCommandVkTest_BlitCopyTextureToTextureCommandVK_Test;
+}
+
 class ContextVK;
 class DeviceBuffer;
 class Texture;
@@ -52,6 +56,7 @@ class CommandEncoderVK {
 
  private:
   friend class ContextVK;
+  friend class ::impeller::testing::BlitCommandVkTest_BlitCopyTextureToTextureCommandVK_Test;
 
   vk::Device device_ = {};
   std::shared_ptr<QueueVK> queue_;

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -18,7 +18,9 @@ namespace impeller {
 
 namespace testing {
 class BlitCommandVkTest_BlitCopyTextureToTextureCommandVK_Test;
-}
+class BlitCommandVkTest_BlitCopyTextureToBufferCommandVK_Test;
+class BlitCommandVkTest_BlitGenerateMipmapCommandVK_Test;
+}  // namespace testing
 
 class ContextVK;
 class DeviceBuffer;
@@ -60,6 +62,10 @@ class CommandEncoderVK {
   friend class ContextVK;
   friend class ::impeller::testing::
       BlitCommandVkTest_BlitCopyTextureToTextureCommandVK_Test;
+  friend class ::impeller::testing::
+      BlitCommandVkTest_BlitCopyTextureToBufferCommandVK_Test;
+  friend class ::impeller::testing::
+      BlitCommandVkTest_BlitGenerateMipmapCommandVK_Test;
 
   vk::Device device_ = {};
   std::shared_ptr<QueueVK> queue_;

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -17,7 +17,7 @@
 namespace impeller {
 
 namespace testing {
-  class BlitCommandVkTest_BlitCopyTextureToTextureCommandVK_Test;
+class BlitCommandVkTest_BlitCopyTextureToTextureCommandVK_Test;
 }
 
 class ContextVK;
@@ -56,7 +56,8 @@ class CommandEncoderVK {
 
  private:
   friend class ContextVK;
-  friend class ::impeller::testing::BlitCommandVkTest_BlitCopyTextureToTextureCommandVK_Test;
+  friend class ::impeller::testing::
+      BlitCommandVkTest_BlitCopyTextureToTextureCommandVK_Test;
 
   vk::Device device_ = {};
   std::shared_ptr<QueueVK> queue_;

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -54,6 +54,8 @@ class CommandEncoderVK {
   std::optional<vk::DescriptorSet> AllocateDescriptorSet(
       const vk::DescriptorSetLayout& layout);
 
+  bool IsTracking(const std::shared_ptr<const Texture>& texture) const;
+
  private:
   friend class ContextVK;
   friend class ::impeller::testing::

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -41,7 +41,11 @@ class CommandEncoderVK {
 
   bool Track(std::shared_ptr<const DeviceBuffer> buffer);
 
+  bool IsTracking(const std::shared_ptr<const DeviceBuffer>& texture) const;
+
   bool Track(const std::shared_ptr<const Texture>& texture);
+
+  bool IsTracking(const std::shared_ptr<const Texture>& texture) const;
 
   bool Track(std::shared_ptr<const TextureSourceVK> texture);
 
@@ -55,8 +59,6 @@ class CommandEncoderVK {
 
   std::optional<vk::DescriptorSet> AllocateDescriptorSet(
       const vk::DescriptorSetLayout& layout);
-
-  bool IsTracking(const std::shared_ptr<const Texture>& texture) const;
 
  private:
   friend class ContextVK;

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -7,9 +7,6 @@
 namespace impeller {
 namespace testing {
 
-PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
-                                            const char* pName);
-
 namespace {
 void noop() {}
 
@@ -215,8 +212,6 @@ VkResult vkBindBufferMemory(VkDevice device,
   return VK_SUCCESS;
 }
 
-}  // namespace
-
 PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
                                             const char* pName) {
   if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
@@ -271,6 +266,17 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return (PFN_vkVoidFunction)vkBindBufferMemory;
   }
   return noop;
+}
+
+}  // namespace
+
+std::shared_ptr<ContextVK> CreateMockVulkanContext(void) {
+  ContextVK::Settings settings;
+  auto message_loop = fml::ConcurrentMessageLoop::Create();
+  settings.worker_task_runner =
+      std::make_shared<fml::ConcurrentTaskRunner>(message_loop);
+  settings.proc_address_callback = GetMockVulkanProcAddress;
+  return ContextVK::Create(std::move(settings));
 }
 
 }  // namespace testing

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -192,6 +192,29 @@ VkResult vkCreateImageView(VkDevice device,
   return VK_SUCCESS;
 }
 
+VkResult vkCreateBuffer(VkDevice device,
+                        const VkBufferCreateInfo* pCreateInfo,
+                        const VkAllocationCallbacks* pAllocator,
+                        VkBuffer* pBuffer) {
+  *pBuffer = reinterpret_cast<VkBuffer>(0xDEADDEAD);
+  return VK_SUCCESS;
+}
+
+void vkGetBufferMemoryRequirements2KHR(
+    VkDevice device,
+    const VkBufferMemoryRequirementsInfo2* pInfo,
+    VkMemoryRequirements2* pMemoryRequirements) {
+  pMemoryRequirements->memoryRequirements.size = 1024;
+  pMemoryRequirements->memoryRequirements.memoryTypeBits = 1;
+}
+
+VkResult vkBindBufferMemory(VkDevice device,
+                            VkBuffer buffer,
+                            VkDeviceMemory memory,
+                            VkDeviceSize memoryOffset) {
+  return VK_SUCCESS;
+}
+
 }  // namespace
 
 PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
@@ -239,6 +262,13 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return (PFN_vkVoidFunction)vkBindImageMemory;
   } else if (strcmp("vkCreateImageView", pName) == 0) {
     return (PFN_vkVoidFunction)vkCreateImageView;
+  } else if (strcmp("vkCreateBuffer", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateBuffer;
+  } else if (strcmp("vkGetBufferMemoryRequirements2KHR", pName) == 0 ||
+             strcmp("vkGetBufferMemoryRequirements2", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetBufferMemoryRequirements2KHR;
+  } else if (strcmp("vkBindBufferMemory", pName) == 0) {
+    return (PFN_vkVoidFunction)vkBindBufferMemory;
   }
   return noop;
 }

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -1,0 +1,247 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
+
+namespace impeller {
+namespace testing {
+
+PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
+                                            const char* pName);
+
+namespace {
+void noop() {}
+
+VkResult vkEnumerateInstanceExtensionProperties(
+    const char* pLayerName,
+    uint32_t* pPropertyCount,
+    VkExtensionProperties* pProperties) {
+  if (!pProperties) {
+    *pPropertyCount = 2;
+
+  } else {
+    strcpy(pProperties[0].extensionName, "VK_KHR_surface");
+    pProperties[0].specVersion = 0;
+    strcpy(pProperties[1].extensionName, "VK_MVK_macos_surface");
+    pProperties[1].specVersion = 0;
+  }
+  return VK_SUCCESS;
+}
+
+VkResult vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
+                                            VkLayerProperties* pProperties) {
+  *pPropertyCount = 0;
+  return VK_SUCCESS;
+}
+
+VkResult vkEnumeratePhysicalDevices(VkInstance instance,
+                                    uint32_t* pPhysicalDeviceCount,
+                                    VkPhysicalDevice* pPhysicalDevices) {
+  if (!pPhysicalDevices) {
+    *pPhysicalDeviceCount = 1;
+  } else {
+    pPhysicalDevices[0] = reinterpret_cast<VkPhysicalDevice>(0xfeedface);
+  }
+  return VK_SUCCESS;
+}
+
+void vkGetPhysicalDeviceFormatProperties(
+    VkPhysicalDevice physicalDevice,
+    VkFormat format,
+    VkFormatProperties* pFormatProperties) {
+  if (format == VK_FORMAT_B8G8R8A8_UNORM) {
+    pFormatProperties->optimalTilingFeatures =
+        static_cast<VkFormatFeatureFlags>(
+            vk::FormatFeatureFlagBits::eColorAttachment);
+  } else if (format == VK_FORMAT_S8_UINT) {
+    pFormatProperties->optimalTilingFeatures =
+        static_cast<VkFormatFeatureFlags>(
+            vk::FormatFeatureFlagBits::eDepthStencilAttachment);
+  }
+}
+
+void vkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
+                                   VkPhysicalDeviceProperties* pProperties) {
+  pProperties->limits.framebufferColorSampleCounts =
+      static_cast<VkSampleCountFlags>(VK_SAMPLE_COUNT_1_BIT |
+                                      VK_SAMPLE_COUNT_4_BIT);
+  pProperties->limits.maxImageDimension2D = 4096;
+}
+
+void vkGetPhysicalDeviceQueueFamilyProperties(
+    VkPhysicalDevice physicalDevice,
+    uint32_t* pQueueFamilyPropertyCount,
+    VkQueueFamilyProperties* pQueueFamilyProperties) {
+  if (!pQueueFamilyProperties) {
+    *pQueueFamilyPropertyCount = 1;
+  } else {
+    pQueueFamilyProperties[0].queueCount = 3;
+    pQueueFamilyProperties[0].queueFlags = static_cast<VkQueueFlags>(
+        VK_QUEUE_TRANSFER_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT);
+  }
+}
+
+VkResult vkEnumerateDeviceExtensionProperties(
+    VkPhysicalDevice physicalDevice,
+    const char* pLayerName,
+    uint32_t* pPropertyCount,
+    VkExtensionProperties* pProperties) {
+  if (!pProperties) {
+    *pPropertyCount = 1;
+  } else {
+    strcpy(pProperties[0].extensionName, "VK_KHR_swapchain");
+    pProperties[0].specVersion = 0;
+  }
+  return VK_SUCCESS;
+}
+
+VkResult vkCreateDevice(VkPhysicalDevice physicalDevice,
+                        const VkDeviceCreateInfo* pCreateInfo,
+                        const VkAllocationCallbacks* pAllocator,
+                        VkDevice* pDevice) {
+  *pDevice = reinterpret_cast<VkDevice>(0xcafebabe);
+  return VK_SUCCESS;
+}
+
+VkResult vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
+                          const VkAllocationCallbacks* pAllocator,
+                          VkInstance* pInstance) {
+  *pInstance = reinterpret_cast<VkInstance>(0xbaadf00d);
+  return VK_SUCCESS;
+}
+
+void vkGetPhysicalDeviceMemoryProperties(
+    VkPhysicalDevice physicalDevice,
+    VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
+  pMemoryProperties->memoryTypeCount = 1;
+  pMemoryProperties->memoryTypes[0].heapIndex = 0;
+  // pMemoryProperties->memoryTypes[0].propertyFlags =
+  //     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+  //     VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD;
+  pMemoryProperties->memoryHeapCount = 1;
+  pMemoryProperties->memoryHeaps[0].size = 1024 * 1024 * 1024;
+  pMemoryProperties->memoryHeaps[0].flags = 0;
+}
+
+VkResult vkCreatePipelineCache(VkDevice device,
+                               const VkPipelineCacheCreateInfo* pCreateInfo,
+                               const VkAllocationCallbacks* pAllocator,
+                               VkPipelineCache* pPipelineCache) {
+  *pPipelineCache = reinterpret_cast<VkPipelineCache>(0xb000dead);
+  return VK_SUCCESS;
+}
+
+VkResult vkCreateCommandPool(VkDevice device,
+                             const VkCommandPoolCreateInfo* pCreateInfo,
+                             const VkAllocationCallbacks* pAllocator,
+                             VkCommandPool* pCommandPool) {
+  *pCommandPool = reinterpret_cast<VkCommandPool>(0xc0de0001);
+  return VK_SUCCESS;
+}
+
+VkResult vkAllocateCommandBuffers(
+    VkDevice device,
+    const VkCommandBufferAllocateInfo* pAllocateInfo,
+    VkCommandBuffer* pCommandBuffers) {
+  *pCommandBuffers = reinterpret_cast<VkCommandBuffer>(0x0b0ffe12);
+  return VK_SUCCESS;
+}
+
+VkResult vkBeginCommandBuffer(VkCommandBuffer commandBuffer,
+                              const VkCommandBufferBeginInfo* pBeginInfo) {
+  return VK_SUCCESS;
+}
+
+VkResult vkCreateImage(VkDevice device,
+                       const VkImageCreateInfo* pCreateInfo,
+                       const VkAllocationCallbacks* pAllocator,
+                       VkImage* pImage) {
+  *pImage = reinterpret_cast<VkImage>(0xD0D0CACA);
+  return VK_SUCCESS;
+}
+
+void vkGetImageMemoryRequirements2KHR(
+    VkDevice device,
+    const VkImageMemoryRequirementsInfo2* pInfo,
+    VkMemoryRequirements2* pMemoryRequirements) {
+  pMemoryRequirements->memoryRequirements.size = 1024;
+  pMemoryRequirements->memoryRequirements.memoryTypeBits = 1;
+}
+
+VkResult vkAllocateMemory(VkDevice device,
+                          const VkMemoryAllocateInfo* pAllocateInfo,
+                          const VkAllocationCallbacks* pAllocator,
+                          VkDeviceMemory* pMemory) {
+  *pMemory = reinterpret_cast<VkDeviceMemory>(0xCAFEB0BA);
+  return VK_SUCCESS;
+}
+
+VkResult vkBindImageMemory(VkDevice device,
+                           VkImage image,
+                           VkDeviceMemory memory,
+                           VkDeviceSize memoryOffset) {
+  return VK_SUCCESS;
+}
+
+VkResult vkCreateImageView(VkDevice device,
+                           const VkImageViewCreateInfo* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator,
+                           VkImageView* pView) {
+  *pView = reinterpret_cast<VkImageView>(0xFEE1DEAD);
+  return VK_SUCCESS;
+}
+
+}  // namespace
+
+PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
+                                            const char* pName) {
+  if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties;
+  } else if (strcmp("vkEnumerateInstanceLayerProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties;
+  } else if (strcmp("vkEnumeratePhysicalDevices", pName) == 0) {
+    return (PFN_vkVoidFunction)vkEnumeratePhysicalDevices;
+  } else if (strcmp("vkGetPhysicalDeviceFormatProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetPhysicalDeviceFormatProperties;
+  } else if (strcmp("vkGetPhysicalDeviceProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetPhysicalDeviceProperties;
+  } else if (strcmp("vkGetPhysicalDeviceQueueFamilyProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetPhysicalDeviceQueueFamilyProperties;
+  } else if (strcmp("vkEnumerateDeviceExtensionProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkEnumerateDeviceExtensionProperties;
+  } else if (strcmp("vkCreateDevice", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateDevice;
+  } else if (strcmp("vkCreateInstance", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateInstance;
+  } else if (strcmp("vkGetPhysicalDeviceMemoryProperties", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetPhysicalDeviceMemoryProperties;
+  } else if (strcmp("vkCreatePipelineCache", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreatePipelineCache;
+  } else if (strcmp("vkCreateCommandPool", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateCommandPool;
+  } else if (strcmp("vkAllocateCommandBuffers", pName) == 0) {
+    return (PFN_vkVoidFunction)vkAllocateCommandBuffers;
+  } else if (strcmp("vkBeginCommandBuffer", pName) == 0) {
+    return (PFN_vkVoidFunction)vkBeginCommandBuffer;
+  } else if (strcmp("vkCreateImage", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateImage;
+  } else if (strcmp("vkGetInstanceProcAddr", pName) == 0) {
+    return (PFN_vkVoidFunction)GetMockVulkanProcAddress;
+  } else if (strcmp("vkGetDeviceProcAddr", pName) == 0) {
+    return (PFN_vkVoidFunction)GetMockVulkanProcAddress;
+  } else if (strcmp("vkGetImageMemoryRequirements2KHR", pName) == 0 ||
+             strcmp("vkGetImageMemoryRequirements2", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetImageMemoryRequirements2KHR;
+  } else if (strcmp("vkAllocateMemory", pName) == 0) {
+    return (PFN_vkVoidFunction)vkAllocateMemory;
+  } else if (strcmp("vkBindImageMemory", pName) == 0) {
+    return (PFN_vkVoidFunction)vkBindImageMemory;
+  } else if (strcmp("vkCreateImageView", pName) == 0) {
+    return (PFN_vkVoidFunction)vkCreateImageView;
+  }
+  return noop;
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "impeller/renderer/backend/vulkan/vk.h"
+
+namespace impeller {
+namespace testing {
+
+PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
+                                            const char* pName);
+
+}
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -4,13 +4,12 @@
 
 #pragma once
 
-#include "impeller/renderer/backend/vulkan/vk.h"
+#include "impeller/renderer/backend/vulkan/context_vk.h"
 
 namespace impeller {
 namespace testing {
 
-PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
-                                            const char* pName);
+std::shared_ptr<ContextVK> CreateMockVulkanContext(void);
 
 }
 }  // namespace impeller


### PR DESCRIPTION
Adds test for https://github.com/flutter/engine/pull/41347 and adds an extra fix for https://github.com/flutter/flutter/issues/125147.

Testing this is possible because I've mocked out all of vulkan.  We can expand on this in the future we want to be more robust.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
