### PR TITLE
Reland "Upload windows arm artifacts to production bucket."

### DIFF
--- a/ci/builders/windows_arm_host_engine.json
+++ b/ci/builders/windows_arm_host_engine.json
@@ -13,7 +13,8 @@
                         "out/host_debug_arm64/zip_archives/windows-arm64-debug/windows-arm64-flutter.zip",
                         "out/host_debug_arm64/zip_archives/windows-arm64/flutter-cpp-client-wrapper.zip"
                     ],
-                    "name": "host_debug_arm64"
+                    "name": "host_debug_arm64",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -52,7 +53,8 @@
                     "include_paths": [
                         "out/host_profile_arm64/zip_archives/windows-arm64-profile/windows-arm64-flutter.zip"
                     ],
-                    "name": "host_profile_arm64"
+                    "name": "host_profile_arm64",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -88,7 +90,8 @@
                     "include_paths": [
                         "out/host_release_arm64/zip_archives/windows-arm64-release/windows-arm64-flutter.zip"
                     ],
-                    "name": "host_profile_arm64"
+                    "name": "host_profile_arm64",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [


### PR DESCRIPTION
Reverts flutter/engine#41372

The duplicated artifacts were removed from Windows Host Engine in https://flutter-review.googlesource.com/c/recipes/+/42340. After the recipes change lands and is propagated it will be safe to update the `Windows windows_arm_host_engine` build to upload the artifacts to prod.

Bug: https://github.com/flutter/flutter/issues/125262