### PR TITLE
[Impeller] dont use waitUntilScheduled on iOS

### DIFF
--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -167,7 +167,7 @@ bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
 
   [buffer_ commit];
 
-#if (FML_OS_MACOSX || FML_OS_IOS_SIMULATOR)
+#if (FML_OS_IOS_SIMULATOR || !FML_OS_IOS)
   // We're using waitUntilScheduled on macOS and iOS simulator to force a hard
   // barrier between the execution of different command buffers. This forces all
   // renderable texture access to be synchronous (i.e. a write from a previous


### PR DESCRIPTION
IIRC this was perfectly safe, we needed to disable it for macOS and iOS simulator. Unfortunately `FML_OS_MACOSX` is defined on all apple platforms so this was still running.
