### PR TITLE
Double zip FlutterMacOS.dSYM.zip.

### DIFF
--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -164,14 +164,17 @@ def process_framework(dst, args, fat_framework, fat_framework_binary):
   # Zip FlutterMacOS.framework.
   if args.zip:
     filepath_with_entitlements = ''
-    filepath_without_entitlements = 'FlutterMacOS.framework/Versions/A/FlutterMacOS'
+
+    framework_dst = os.path.join(dst, 'FlutterMacOS.framework')
+    filepath_without_entitlements = 'Versions/A/FlutterMacOS'
 
     embed_codesign_configuration(
-        os.path.join(dst, 'entitlements.txt'), filepath_with_entitlements
+        os.path.join(framework_dst, 'entitlements.txt'),
+        filepath_with_entitlements
     )
 
     embed_codesign_configuration(
-        os.path.join(dst, 'without_entitlements.txt'),
+        os.path.join(framework_dst, 'without_entitlements.txt'),
         filepath_without_entitlements
     )
     subprocess.check_call([
@@ -179,11 +182,11 @@ def process_framework(dst, args, fat_framework, fat_framework_binary):
         '-r',
         '-y',
         'FlutterMacOS.framework.zip',
-        'FlutterMacOS.framework',
+        '.',
         'entitlements.txt',
         'without_entitlements.txt',
     ],
-                          cwd=dst)
+                          cwd=framework_dst)
     # Double zip to make it consistent with legacy artifacts.
     # TODO(fujino): remove this once https://github.com/flutter/flutter/issues/125067 is resolved
     subprocess.check_call([
@@ -192,9 +195,9 @@ def process_framework(dst, args, fat_framework, fat_framework_binary):
         'FlutterMacOS.framework_.zip',
         'FlutterMacOS.framework.zip',
     ],
-                          cwd=dst)
+                          cwd=framework_dst)
     # Use doubled zipped file.
-    final_src_path = os.path.join(dst, 'FlutterMacOS.framework_.zip')
+    final_src_path = os.path.join(framework_dst, 'FlutterMacOS.framework_.zip')
     final_dst_path = os.path.join(dst, 'FlutterMacOS.framework.zip')
     shutil.move(final_src_path, final_dst_path)
 

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -166,7 +166,8 @@ def process_framework(dst, args, fat_framework, fat_framework_binary):
     filepath_with_entitlements = ''
 
     framework_dst = os.path.join(dst, 'FlutterMacOS.framework')
-    filepath_without_entitlements = 'Versions/A/FlutterMacOS'
+    # TODO(xilaizhang): Remove the zip file from the path when outer zip is removed.
+    filepath_without_entitlements = 'FlutterMacOS.framework.zip/Versions/A/FlutterMacOS'
 
     embed_codesign_configuration(
         os.path.join(framework_dst, 'entitlements.txt'),
@@ -183,19 +184,22 @@ def process_framework(dst, args, fat_framework, fat_framework_binary):
         '-y',
         'FlutterMacOS.framework.zip',
         '.',
-        'entitlements.txt',
-        'without_entitlements.txt',
     ],
                           cwd=framework_dst)
     # Double zip to make it consistent with legacy artifacts.
     # TODO(fujino): remove this once https://github.com/flutter/flutter/issues/125067 is resolved
-    subprocess.check_call([
-        'zip',
-        '-y',
-        'FlutterMacOS.framework_.zip',
-        'FlutterMacOS.framework.zip',
-    ],
-                          cwd=framework_dst)
+    subprocess.check_call(
+        [
+            'zip',
+            '-y',
+            'FlutterMacOS.framework_.zip',
+            'FlutterMacOS.framework.zip',
+            # TODO(xilaizhang): Move these files to inner zip before removing the outer zip.
+            'entitlements.txt',
+            'without_entitlements.txt',
+        ],
+        cwd=framework_dst
+    )
     # Use doubled zipped file.
     final_src_path = os.path.join(framework_dst, 'FlutterMacOS.framework_.zip')
     final_dst_path = os.path.join(dst, 'FlutterMacOS.framework.zip')

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -137,10 +137,22 @@ def process_framework(dst, args, fat_framework, fat_framework_binary):
     dsym_out = os.path.splitext(fat_framework)[0] + '.dSYM'
     subprocess.check_call([DSYMUTIL, '-o', dsym_out, fat_framework_binary])
     if args.zip:
+      dsym_dst = os.path.join(dst, 'FlutterMacOS.dSYM')
+      subprocess.check_call(['zip', '-r', '-y', 'FlutterMacOS.dSYM.zip', '.'],
+                            cwd=dsym_dst)
+      # Double zip to make it consistent with legacy artifacts.
+      # TODO(fujino): remove this once https://github.com/flutter/flutter/issues/125067 is resolved
       subprocess.check_call([
-          'zip', '-r', '-y', 'FlutterMacOS.dSYM.zip', 'FlutterMacOS.dSYM'
+          'zip',
+          '-y',
+          'FlutterMacOS.dSYM_.zip',
+          'FlutterMacOS.dSYM.zip',
       ],
-                            cwd=dst)
+                            cwd=dsym_dst)
+      # Use doubled zipped file.
+      dsym_final_src_path = os.path.join(dsym_dst, 'FlutterMacOS.dSYM_.zip')
+      dsym_final_dst_path = os.path.join(dst, 'FlutterMacOS.dSYM.zip')
+      shutil.move(dsym_final_src_path, dsym_final_dst_path)
 
   if args.strip:
     # copy unstripped


### PR DESCRIPTION
The flutter tool is expecting FlutterMacOS.dSYM.zip to be double zipped.

Bug: https://github.com/flutter/flutter/issues/124911

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
