### PR TITLE
[CP] [web] Fix HashUrlStrategy.addPopStateListener

### DIFF
--- a/lib/web_ui/lib/src/engine/navigation/url_strategy.dart
+++ b/lib/web_ui/lib/src/engine/navigation/url_strategy.dart
@@ -35,7 +35,10 @@ class HashUrlStrategy extends ui_web.UrlStrategy {
 
   @override
   ui.VoidCallback addPopStateListener(ui_web.PopStateListener fn) {
-    final DomEventListener wrappedFn = createDomEventListener(fn);
+    final DomEventListener wrappedFn = createDomEventListener((DomEvent event) {
+      // `fn` expects `event.state`, not a `DomEvent`.
+      fn((event as DomPopStateEvent).state);
+    });
     _platformLocation.addPopStateListener(wrappedFn);
     return () => _platformLocation.removePopStateListener(wrappedFn);
   }


### PR DESCRIPTION
This PR cherry-picks: https://github.com/flutter/engine/commit/8d9f17e07633b0f8f2400bf00c95c4fac18f599e

Fixes https://github.com/flutter/flutter/issues/125317

---

During a JS-interop refactor, we introduced a small bug in the `addPopStateListener` method of the `HashUrlStrategy` object (web).

This wasn't caught before because the existing tests were mocking the refactored code.

## Issues

Fixes: https://github.com/flutter/flutter/issues/125228

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
