### PR TITLE
Log dlopen errors in opt builds

### DIFF
--- a/fml/platform/posix/native_library_posix.cc
+++ b/fml/platform/posix/native_library_posix.cc
@@ -14,7 +14,7 @@ NativeLibrary::NativeLibrary(const char* path) {
   handle_ = ::dlopen(path, RTLD_NOW);
   if (handle_ == nullptr) {
     FML_LOG(ERROR) << "Could not open library '" << path << "' due to error '"
-                    << ::dlerror() << "'.";
+                   << ::dlerror() << "'.";
   }
 }
 

--- a/fml/platform/posix/native_library_posix.cc
+++ b/fml/platform/posix/native_library_posix.cc
@@ -13,7 +13,7 @@ NativeLibrary::NativeLibrary(const char* path) {
   ::dlerror();
   handle_ = ::dlopen(path, RTLD_NOW);
   if (handle_ == nullptr) {
-    FML_DLOG(ERROR) << "Could not open library '" << path << "' due to error '"
+    FML_LOG(ERROR) << "Could not open library '" << path << "' due to error '"
                     << ::dlerror() << "'.";
   }
 }

--- a/fml/platform/posix/native_library_posix.cc
+++ b/fml/platform/posix/native_library_posix.cc
@@ -13,6 +13,7 @@ NativeLibrary::NativeLibrary(const char* path) {
   ::dlerror();
   handle_ = ::dlopen(path, RTLD_NOW);
   if (handle_ == nullptr) {
+    // TODO(jiahaog): Use FML_DLOG: https://github.com/flutter/flutter/issues/125523
     FML_LOG(ERROR) << "Could not open library '" << path << "' due to error '"
                    << ::dlerror() << "'.";
   }

--- a/fml/platform/posix/native_library_posix.cc
+++ b/fml/platform/posix/native_library_posix.cc
@@ -13,7 +13,8 @@ NativeLibrary::NativeLibrary(const char* path) {
   ::dlerror();
   handle_ = ::dlopen(path, RTLD_NOW);
   if (handle_ == nullptr) {
-    // TODO(jiahaog): Use FML_DLOG: https://github.com/flutter/flutter/issues/125523
+    // TODO(jiahaog): Use FML_DLOG:
+    // https://github.com/flutter/flutter/issues/125523
     FML_LOG(ERROR) << "Could not open library '" << path << "' due to error '"
                    << ::dlerror() << "'.";
   }


### PR DESCRIPTION
As the Engine uses `dlopen` to find the `libapp.so`, https://github.com/flutter/flutter/issues/59834 can happen which will prevent `dlopen` from finding the binary. In theory this should be mitigated by https://github.com/flutter/engine/pull/9762, but an internal customer observed errors that could be related. 

The additional logging here can help to rule out that hypothesis. For Googlers, see b/276657840 for more details.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
