### PR TITLE
Migrate windows host engine to engine v2.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -464,6 +464,7 @@ targets:
     timeout: 60
 
   - name: Windows Host Engine
+    bringup: true
     recipe: engine/engine
     timeout: 60
     properties:

--- a/ci/builders/windows_host_engine.json
+++ b/ci/builders/windows_host_engine.json
@@ -13,7 +13,8 @@
                         "out/host_debug/zip_archives/windows-x64-debug/windows-x64-flutter.zip",
                         "out/host_debug/zip_archives/windows-x64/flutter-cpp-client-wrapper.zip"
                     ],
-                    "name": "host_debug"
+                    "name": "host_debug",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -63,7 +64,8 @@
                     "include_paths": [
                         "out/host_profile/zip_archives/windows-x64-profile/windows-x64-flutter.zip"
                     ],
-                    "name": "host_profile"
+                    "name": "host_profile",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -96,7 +98,8 @@
                     "include_paths": [
                         "out/host_release/zip_archives/windows-x64-release/windows-x64-flutter.zip"
                     ],
-                    "name": "host_profile"
+                    "name": "host_profile",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [


### PR DESCRIPTION
Windows host engine and windows_engine_host_engine builds are generating the artifacts using gn+ninja. This PR is sending the legacy build to staging and starts uploading the engine v2 artifacts to prod.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
