### PR TITLE
[Impeller] Store the root stencil on iOS

### DIFF
--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -83,7 +83,7 @@ std::unique_ptr<SurfaceMTL> SurfaceMTL::WrapCurrentMetalLayerDrawable(
   color0.resolve_texture = resolve_tex;
 
   TextureDescriptor stencil_tex_desc;
-  stencil_tex_desc.storage_mode = StorageMode::kDeviceTransient;
+  stencil_tex_desc.storage_mode = StorageMode::kDevicePrivate;
   stencil_tex_desc.type = TextureType::kTexture2DMultisample;
   stencil_tex_desc.sample_count = SampleCount::kCount4;
   stencil_tex_desc.format =

--- a/impeller/renderer/backend/vulkan/surface_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_vk.cc
@@ -62,7 +62,7 @@ std::unique_ptr<SurfaceVK> SurfaceVK::WrapSwapchainImage(
 
   TextureDescriptor stencil0_tex;
   stencil0_tex.storage_mode = StorageMode::kDevicePrivate;
-  stencil0_tex.type = TextureType::kTexture2D;
+  stencil0_tex.type = TextureType::kTexture2DMultisample;
   stencil0_tex.sample_count = SampleCount::kCount4;
   stencil0_tex.format = context->GetCapabilities()->GetDefaultStencilFormat();
   stencil0_tex.size = msaa_tex_desc.size;

--- a/impeller/renderer/backend/vulkan/surface_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_vk.cc
@@ -61,7 +61,7 @@ std::unique_ptr<SurfaceVK> SurfaceVK::WrapSwapchainImage(
   color0.resolve_texture = resolve_tex;
 
   TextureDescriptor stencil0_tex;
-  stencil0_tex.storage_mode = StorageMode::kDeviceTransient;
+  stencil0_tex.storage_mode = StorageMode::kDevicePrivate;
   stencil0_tex.type = TextureType::kTexture2D;
   stencil0_tex.sample_count = SampleCount::kCount4;
   stencil0_tex.format = context->GetCapabilities()->GetDefaultStencilFormat();

--- a/impeller/renderer/render_target.h
+++ b/impeller/renderer/render_target.h
@@ -76,6 +76,13 @@ class RenderTarget final {
 
   bool IsValid() const;
 
+  void SetupStencilAttachment(const Context& context,
+                              ISize size,
+                              bool msaa,
+                              const std::string& label = "Offscreen",
+                              AttachmentConfig stencil_attachment_config =
+                                  kDefaultStencilAttachmentConfig);
+
   SampleCount GetSampleCount() const;
 
   bool HasColorAttachment(size_t index) const;


### PR DESCRIPTION
Switch the root RenderPass stencil from transient to device private, add validation logs, and dry the offscreen stencil setup. Also make the multisample root stencil setup valid in Vulkan (the attachment mismatched the texture -- this didn't matter before since we were always replacing it).

Fixes a bug where the stencil gets erased between root render passes -- this issue was introduced when we removed the root blit on iOS.

Before:

https://user-images.githubusercontent.com/919017/234528788-fe6f69a6-b77e-4b36-8db6-b7691e822873.mov

After:

https://user-images.githubusercontent.com/919017/234528755-5bb0d977-a8a0-43f8-8c13-ae048484d36e.mov

