### PR TITLE
Migrate Windows AOT Engine to Engine V2.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -456,6 +456,7 @@ targets:
       config_name: mac_impeller_cmake_example
 
   - name: Windows Android AOT Engine
+    bringup: true
     recipe: engine/engine
     properties:
       build_android_aot: "true"

--- a/ci/builders/windows_android_aot_engine.json
+++ b/ci/builders/windows_android_aot_engine.json
@@ -8,7 +8,8 @@
                     "include_paths": [
                         "out/android_profile/zip_archives/android-arm-profile/windows-x64.zip"
                     ],
-                    "name": "android_profile"
+                    "name": "android_profile",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -36,7 +37,8 @@
                     "include_paths": [
                         "out/android_profile_arm64/zip_archives/android-arm64-profile/windows-x64.zip"
                     ],
-                    "name": "android_profile_arm64"
+                    "name": "android_profile_arm64",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -65,7 +67,8 @@
                     "include_paths": [
                         "out/android_profile_x64/zip_archives/android-x64-profile/windows-x64.zip"
                     ],
-                    "name": "android_profile_x64"
+                    "name": "android_profile_x64",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -94,7 +97,8 @@
                     "include_paths": [
                         "out/android_release/zip_archives/android-arm-release/windows-x64.zip"
                     ],
-                    "name": "android_release"
+                    "name": "android_release",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -122,7 +126,8 @@
                     "include_paths": [
                         "out/android_release_arm64/zip_archives/android-arm64-release/windows-x64.zip"
                     ],
-                    "name": "android_release_arm64"
+                    "name": "android_release_arm64",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -151,7 +156,8 @@
                     "include_paths": [
                         "out/android_release_x64/zip_archives/android-x64-release/windows-x64.zip"
                     ],
-                    "name": "android_release_x64"
+                    "name": "android_release_x64",
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [


### PR DESCRIPTION
Both builds are generating artifacts in the same way. This is moving the legacy builder to staging and updating Windows windows_aot_engine build to upload artifacts to prod.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
