### PR TITLE
[Impeller] Ensure that embedded blobs are placed at aligned addresses.

### DIFF
--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -459,7 +459,7 @@ template("_impeller_shaders_metal") {
     symbol_name = shaders_base_name
     blob = metal_library_files[0]
     hdr = "$target_gen_dir/mtl/$shaders_base_name.h"
-    cc = "$target_gen_dir/mtl/$shaders_base_name.c"
+    cc = "$target_gen_dir/mtl/$shaders_base_name.cc"
     deps = [ ":$mtl_lib" ]
   }
 
@@ -553,7 +553,7 @@ template("_impeller_shaders_gles") {
     symbol_name = shaders_base_name
     blob = gles_library_files[0]
     hdr = "$target_gen_dir/gles/$shaders_base_name.h"
-    cc = "$target_gen_dir/gles/$shaders_base_name.c"
+    cc = "$target_gen_dir/gles/$shaders_base_name.cc"
     deps = [ ":$gles_lib" ]
   }
 
@@ -629,7 +629,7 @@ template("_impeller_shaders_vk") {
     symbol_name = shaders_base_name
     blob = vk_library_files[0]
     hdr = "$target_gen_dir/vk/$shaders_base_name.h"
-    cc = "$target_gen_dir/vk/$shaders_base_name.c"
+    cc = "$target_gen_dir/vk/$shaders_base_name.cc"
     deps = [ ":$vk_lib" ]
   }
 

--- a/impeller/tools/xxd.py
+++ b/impeller/tools/xxd.py
@@ -60,7 +60,10 @@ def main():
   with open(args.source, 'rb') as source, open(output_source, 'w') as output:
     data_len = 0
     output.write(f'#include "{output_header_basename}"\n')
-    output.write(f'const unsigned char impeller_{args.symbol_name}_data[] =\n')
+    output.write('#include <cstddef>\n')
+    output.write(
+        f'alignas(std::max_align_t) const unsigned char impeller_{args.symbol_name}_data[] =\n'
+    )
     output.write('{\n')
     while True:
       byte = source.read(1)


### PR DESCRIPTION
FlatBuffer deserialization may segfault if the buffer is based at an unaligned address.
