### PR TITLE
Refactor vuln scan into separate yaml

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -9,22 +9,6 @@ on:
 permissions: read-all
 
 jobs:
-  vuln-scan:
-    name: Vulnerability scanning
-    runs-on: ubuntu-20.04
-    if: ${{ github.repository == 'flutter/engine' }}
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-        with:
-          persist-credentials: false
-      - name: "setup python"
-        uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
-        with:
-          python-version: '3.7.7' # install the python version needed
-      - name: "execute py script"
-        run: python ci/deps_parser.py
-
   scorecards:
     name: Scorecards analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/third_party_scan.yml
+++ b/.github/workflows/third_party_scan.yml
@@ -1,56 +1,26 @@
-name: Third party dependency scan
+name: Third party deps scan
 on:
   # Only the default branch is supported.
   branch_protection_rule:
+  push:
     branches: [ main ]
-    schedule:
-      - cron: "0 8 * * *" # runs daily at 08:00
-
 
 # Declare default permissions as read only.
 permissions: read-all
 
 jobs:
-  analysis:
-    name: Third party dependency scan
-    runs-on: ubuntu-latest
-    permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      actions: read
-      contents: read
-
+  vuln-scan:
+    name: Vulnerability scanning
+    runs-on: ubuntu-20.04
+    if: ${{ github.repository == 'flutter/engine' }}
     steps:
       - name: "Checkout code"
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           persist-credentials: false
-
-      - name: setup python
+      - name: "setup python"
         uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
         with:
           python-version: '3.7.7' # install the python version needed
-
-      - name: install dependency
-        run: pip install git+https://github.com/psf/requests.git@4d394574f5555a8ddcc38f707e0c9f57f55d9a3b
-
-      - name: execute py script
-        run: python ci/deps_parser.py 
-      
-      - name: parse deps_parser output.txt
-        run: python ci/scan_flattened_deps.py 
-
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
-        with:
-          name: SARIF file
-          path: osvReport.sarif
-          retention-days: 5
-
-      # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@d186a2a36cc67bfa1b860e6170d37fb9634742c7
-        with:
-          sarif_file: osvReport.sarif
+      - name: "execute py script"
+        run: python ci/deps_parser.py


### PR DESCRIPTION
This removes the vuln scanning action from the scorecards yaml and into its own file. The additional file already existed but was not updated.

Fixes:
b/246821537

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
