### PR TITLE
[CP][codesign] Add pinned xcode version to mac android aot engine

### DIFF
--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -32,7 +32,11 @@
                     "flutter/shell/platform/android:gen_snapshot"
                 ]
             },
-            "tests": []
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14c18"
+                }
+            }
         },
         {
             "archives": [
@@ -67,7 +71,11 @@
                     "flutter/shell/platform/android:gen_snapshot"
                 ]
             },
-            "tests": []
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14c18"
+                }
+            }
         },
         {
             "archives": [
@@ -102,7 +110,11 @@
                     "flutter/shell/platform/android:gen_snapshot"
                 ]
             },
-            "tests": []
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14c18"
+                }
+            }
         },
         {
             "archives": [
@@ -136,7 +148,11 @@
                     "flutter/shell/platform/android:gen_snapshot"
                 ]
             },
-            "tests": []
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14c18"
+                }
+            }
         },
         {
             "archives": [
@@ -171,7 +187,11 @@
                     "flutter/shell/platform/android:gen_snapshot"
                 ]
             },
-            "tests": []
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14c18"
+                }
+            }
         },
         {
             "archives": [
@@ -206,7 +226,11 @@
                     "flutter/shell/platform/android:gen_snapshot"
                 ]
             },
-            "tests": []
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14c18"
+                }
+            }
         }
     ],
     "tests": [],


### PR DESCRIPTION
cherry picks https://github.com/flutter/engine/pull/41518
cp issue link: https://github.com/flutter/flutter/issues/125591

context: https://github.com/flutter/flutter/issues/125570#issuecomment-1523823942

Pin xcode version for the six sub builds in mac android aot engine

