### PR TITLE
[Impeller] allow shader read for root resolve texture

### DIFF
--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -79,7 +79,8 @@ std::unique_ptr<SurfaceMTL> SurfaceMTL::WrapCurrentMetalLayerDrawable(
   TextureDescriptor resolve_tex_desc;
   resolve_tex_desc.format = color_format;
   resolve_tex_desc.size = msaa_tex_desc.size;
-  resolve_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
+  resolve_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget) |
+                           static_cast<uint64_t>(TextureUsage::kShaderRead);
   resolve_tex_desc.sample_count = SampleCount::kCount1;
   resolve_tex_desc.storage_mode = StorageMode::kDevicePrivate;
 


### PR DESCRIPTION
This fixes a validation error I see from Xcode running the backdrop filter benchmarks