### PR TITLE
Revert "Reland: [Impeller] Use a device buffer for SkBitmap allocation, use Linear texture on Metal backend. "

### DIFF
--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -45,14 +45,6 @@ static bool DeviceSupportsComputeSubgroups(id<MTLDevice> device) {
   return supports_subgroups;
 }
 
-static constexpr bool SupportsLinearTexture() {
-#ifdef FML_OS_IOS_SIMULATOR
-  return false;
-#else
-  return true;
-#endif  // FML_OS_IOS_SIMULATOR
-}
-
 static std::unique_ptr<Capabilities> InferMetalCapabilities(
     id<MTLDevice> device,
     PixelFormat color_format) {
@@ -63,7 +55,6 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetSupportsBufferToTextureBlits(true)
       .SetSupportsTextureToTextureBlits(true)
       .SetSupportsDecalTileMode(true)
-      .SetSupportsSharedDeviceBufferTextureMemory(SupportsLinearTexture())
       .SetSupportsFramebufferFetch(DeviceSupportsFramebufferFetch(device))
       .SetDefaultColorFormat(color_format)
       .SetDefaultStencilFormat(PixelFormat::kS8UInt)

--- a/impeller/renderer/backend/metal/device_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/device_buffer_mtl.h
@@ -35,12 +35,10 @@ class DeviceBufferMTL final : public DeviceBuffer,
   // |DeviceBuffer|
   uint8_t* OnGetContents() const override;
 
-#ifndef FML_OS_IOS_SIMULATOR
   // |DeviceBuffer|
   std::shared_ptr<Texture> AsTexture(Allocator& allocator,
                                      const TextureDescriptor& descriptor,
                                      uint16_t row_bytes) const override;
-#endif  // FML_OS_IOS_SIMULATOR
 
   // |DeviceBuffer|
   bool OnCopyHostBuffer(const uint8_t* source,

--- a/impeller/renderer/backend/metal/device_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/device_buffer_mtl.mm
@@ -29,7 +29,6 @@ uint8_t* DeviceBufferMTL::OnGetContents() const {
   return reinterpret_cast<uint8_t*>(buffer_.contents);
 }
 
-#ifndef FML_OS_IOS_SIMULATOR
 std::shared_ptr<Texture> DeviceBufferMTL::AsTexture(
     Allocator& allocator,
     const TextureDescriptor& descriptor,
@@ -53,7 +52,6 @@ std::shared_ptr<Texture> DeviceBufferMTL::AsTexture(
   }
   return std::make_shared<TextureMTL>(descriptor, texture);
 }
-#endif  // FML_OS_IOS_SIMULATOR
 
 [[nodiscard]] bool DeviceBufferMTL::OnCopyHostBuffer(const uint8_t* source,
                                                      Range source_range,

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -348,14 +348,8 @@ bool CapabilitiesVK::SupportsReadFromOnscreenTexture() const {
   return false;
 }
 
-// |Capabilities|
 bool CapabilitiesVK::SupportsDecalTileMode() const {
   return true;
-}
-
-// |Capabilities|
-bool CapabilitiesVK::SupportsSharedDeviceBufferTextureMemory() const {
-  return false;
 }
 
 // |Capabilities|

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -80,9 +80,6 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsDecalTileMode() const override;
 
   // |Capabilities|
-  bool SupportsSharedDeviceBufferTextureMemory() const override;
-
-  // |Capabilities|
   PixelFormat GetDefaultColorFormat() const override;
 
   // |Capabilities|

--- a/impeller/renderer/capabilities.cc
+++ b/impeller/renderer/capabilities.cc
@@ -67,11 +67,6 @@ class StandardCapabilities final : public Capabilities {
   }
 
   // |Capabilities|
-  bool SupportsSharedDeviceBufferTextureMemory() const override {
-    return supports_shared_device_buffer_texture_memory_;
-  }
-
-  // |Capabilities|
   PixelFormat GetDefaultColorFormat() const override {
     return default_color_format_;
   }
@@ -93,7 +88,6 @@ class StandardCapabilities final : public Capabilities {
                        bool supports_read_from_onscreen_texture,
                        bool supports_read_from_resolve,
                        bool supports_decal_tile_mode,
-                       bool supports_shared_device_buffer_texture_memory,
                        PixelFormat default_color_format,
                        PixelFormat default_stencil_format)
       : has_threading_restrictions_(has_threading_restrictions),
@@ -108,8 +102,6 @@ class StandardCapabilities final : public Capabilities {
             supports_read_from_onscreen_texture),
         supports_read_from_resolve_(supports_read_from_resolve),
         supports_decal_tile_mode_(supports_decal_tile_mode),
-        supports_shared_device_buffer_texture_memory_(
-            supports_shared_device_buffer_texture_memory),
         default_color_format_(default_color_format),
         default_stencil_format_(default_stencil_format) {}
 
@@ -126,7 +118,6 @@ class StandardCapabilities final : public Capabilities {
   bool supports_read_from_onscreen_texture_ = false;
   bool supports_read_from_resolve_ = false;
   bool supports_decal_tile_mode_ = false;
-  bool supports_shared_device_buffer_texture_memory_ = false;
   PixelFormat default_color_format_ = PixelFormat::kUnknown;
   PixelFormat default_stencil_format_ = PixelFormat::kUnknown;
 
@@ -211,12 +202,6 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsDecalTileMode(bool value) {
   return *this;
 }
 
-CapabilitiesBuilder&
-CapabilitiesBuilder::SetSupportsSharedDeviceBufferTextureMemory(bool value) {
-  supports_shared_device_buffer_texture_memory_ = value;
-  return *this;
-}
-
 std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
   return std::unique_ptr<StandardCapabilities>(new StandardCapabilities(  //
       has_threading_restrictions_,                                        //
@@ -230,7 +215,6 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       supports_read_from_onscreen_texture_,                               //
       supports_read_from_resolve_,                                        //
       supports_decal_tile_mode_,                                          //
-      supports_shared_device_buffer_texture_memory_,                      //
       *default_color_format_,                                             //
       *default_stencil_format_                                            //
       ));

--- a/impeller/renderer/capabilities.h
+++ b/impeller/renderer/capabilities.h
@@ -37,8 +37,6 @@ class Capabilities {
 
   virtual bool SupportsDecalTileMode() const = 0;
 
-  virtual bool SupportsSharedDeviceBufferTextureMemory() const = 0;
-
   virtual PixelFormat GetDefaultColorFormat() const = 0;
 
   virtual PixelFormat GetDefaultStencilFormat() const = 0;
@@ -81,8 +79,6 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetSupportsDecalTileMode(bool value);
 
-  CapabilitiesBuilder& SetSupportsSharedDeviceBufferTextureMemory(bool value);
-
   std::unique_ptr<Capabilities> Build();
 
  private:
@@ -97,7 +93,6 @@ class CapabilitiesBuilder {
   bool supports_read_from_onscreen_texture_ = false;
   bool supports_read_from_resolve_ = false;
   bool supports_decal_tile_mode_ = false;
-  bool supports_shared_device_buffer_texture_memory_ = false;
   std::optional<PixelFormat> default_color_format_ = std::nullopt;
   std::optional<PixelFormat> default_stencil_format_ = std::nullopt;
 

--- a/impeller/renderer/capabilities_unittests.cc
+++ b/impeller/renderer/capabilities_unittests.cc
@@ -29,7 +29,6 @@ CAPABILITY_TEST(SupportsComputeSubgroups, false);
 CAPABILITY_TEST(SupportsReadFromOnscreenTexture, false);
 CAPABILITY_TEST(SupportsReadFromResolve, false);
 CAPABILITY_TEST(SupportsDecalTileMode, false);
-CAPABILITY_TEST(SupportsSharedDeviceBufferTextureMemory, false);
 
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/typographer/backends/skia/text_render_context_skia.h
+++ b/impeller/typographer/backends/skia/text_render_context_skia.h
@@ -6,36 +6,8 @@
 
 #include "flutter/fml/macros.h"
 #include "impeller/typographer/text_render_context.h"
-#include "third_party/skia/include/core/SkBitmap.h"
 
 namespace impeller {
-
-class DeviceBuffer;
-class Allocator;
-
-/// @brief An implementation of an SkBitmap allocator that deferrs allocation to
-///        an Impeller allocator. This allows usage of Skia software rendering
-///        to write to a host buffer or linear texture without an extra copy.
-///
-///        This class is an exact copy of the implementation in
-///        image_decode_impeller.cc due to the lack of a reasonable library
-///        that could be shared.
-class FontImpellerAllocator : public SkBitmap::Allocator {
- public:
-  explicit FontImpellerAllocator(
-      std::shared_ptr<impeller::Allocator> allocator);
-
-  ~FontImpellerAllocator() = default;
-
-  // |Allocator|
-  bool allocPixelRef(SkBitmap* bitmap) override;
-
-  std::optional<std::shared_ptr<DeviceBuffer>> GetDeviceBuffer() const;
-
- private:
-  std::shared_ptr<impeller::Allocator> allocator_;
-  std::optional<std::shared_ptr<DeviceBuffer>> buffer_;
-};
 
 class TextRenderContextSkia : public TextRenderContext {
  public:
@@ -47,7 +19,6 @@ class TextRenderContextSkia : public TextRenderContext {
   std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
       GlyphAtlas::Type type,
       std::shared_ptr<GlyphAtlasContext> atlas_context,
-      const std::shared_ptr<const Capabilities>& capabilities,
       FrameIterator iterator) const override;
 
  private:

--- a/impeller/typographer/glyph_atlas.cc
+++ b/impeller/typographer/glyph_atlas.cc
@@ -22,9 +22,8 @@ const ISize& GlyphAtlasContext::GetAtlasSize() const {
   return atlas_size_;
 }
 
-std::pair<std::shared_ptr<SkBitmap>, std::shared_ptr<DeviceBuffer>>
-GlyphAtlasContext::GetBitmap() const {
-  return std::make_pair(bitmap_, device_buffer_);
+std::shared_ptr<SkBitmap> GlyphAtlasContext::GetBitmap() const {
+  return bitmap_;
 }
 
 std::shared_ptr<skgpu::Rectanizer> GlyphAtlasContext::GetRectPacker() const {
@@ -37,11 +36,8 @@ void GlyphAtlasContext::UpdateGlyphAtlas(std::shared_ptr<GlyphAtlas> atlas,
   atlas_size_ = size;
 }
 
-void GlyphAtlasContext::UpdateBitmap(
-    std::shared_ptr<SkBitmap> bitmap,
-    std::shared_ptr<DeviceBuffer> device_buffer) {
+void GlyphAtlasContext::UpdateBitmap(std::shared_ptr<SkBitmap> bitmap) {
   bitmap_ = std::move(bitmap);
-  device_buffer_ = std::move(device_buffer);
 }
 
 void GlyphAtlasContext::UpdateRectPacker(

--- a/impeller/typographer/glyph_atlas.h
+++ b/impeller/typographer/glyph_atlas.h
@@ -10,7 +10,6 @@
 #include <unordered_map>
 
 #include "flutter/fml/macros.h"
-#include "impeller/core/device_buffer.h"
 #include "impeller/core/texture.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/renderer/pipeline.h"
@@ -154,8 +153,7 @@ class GlyphAtlasContext {
 
   //----------------------------------------------------------------------------
   /// @brief      Retrieve the previous (if any) SkBitmap instance.
-  std::pair<std::shared_ptr<SkBitmap>, std::shared_ptr<DeviceBuffer>>
-  GetBitmap() const;
+  std::shared_ptr<SkBitmap> GetBitmap() const;
 
   //----------------------------------------------------------------------------
   /// @brief      Retrieve the previous (if any) rect packer.
@@ -165,8 +163,7 @@ class GlyphAtlasContext {
   /// @brief      Update the context with a newly constructed glyph atlas.
   void UpdateGlyphAtlas(std::shared_ptr<GlyphAtlas> atlas, ISize size);
 
-  void UpdateBitmap(std::shared_ptr<SkBitmap> bitmap,
-                    std::shared_ptr<DeviceBuffer> device_buffer);
+  void UpdateBitmap(std::shared_ptr<SkBitmap> bitmap);
 
   void UpdateRectPacker(std::shared_ptr<skgpu::Rectanizer> rect_packer);
 
@@ -174,7 +171,6 @@ class GlyphAtlasContext {
   std::shared_ptr<GlyphAtlas> atlas_;
   ISize atlas_size_;
   std::shared_ptr<SkBitmap> bitmap_;
-  std::shared_ptr<DeviceBuffer> device_buffer_;
   std::shared_ptr<skgpu::Rectanizer> rect_packer_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(GlyphAtlasContext);

--- a/impeller/typographer/lazy_glyph_atlas.cc
+++ b/impeller/typographer/lazy_glyph_atlas.cc
@@ -37,7 +37,6 @@ std::shared_ptr<GlyphAtlas> LazyGlyphAtlas::CreateOrGetGlyphAtlas(
     }
   }
 
-  auto capabilities = context->GetCapabilities();
   auto text_context = TextRenderContext::Create(std::move(context));
   if (!text_context || !text_context->IsValid()) {
     return nullptr;
@@ -51,8 +50,8 @@ std::shared_ptr<GlyphAtlas> LazyGlyphAtlas::CreateOrGetGlyphAtlas(
     i++;
     return &result;
   };
-  auto atlas = text_context->CreateGlyphAtlas(type, std::move(atlas_context),
-                                              capabilities, iterator);
+  auto atlas =
+      text_context->CreateGlyphAtlas(type, std::move(atlas_context), iterator);
   if (!atlas || !atlas->IsValid()) {
     VALIDATION_LOG << "Could not create valid atlas.";
     return nullptr;

--- a/impeller/typographer/text_render_context.cc
+++ b/impeller/typographer/text_render_context.cc
@@ -29,7 +29,6 @@ const std::shared_ptr<Context>& TextRenderContext::GetContext() const {
 std::shared_ptr<GlyphAtlas> TextRenderContext::CreateGlyphAtlas(
     GlyphAtlas::Type type,
     std::shared_ptr<GlyphAtlasContext> atlas_context,
-    const std::shared_ptr<const Capabilities>& capabilities,
     const TextFrame& frame) const {
   size_t count = 0;
   FrameIterator iterator = [&]() -> const TextFrame* {
@@ -39,8 +38,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContext::CreateGlyphAtlas(
     }
     return nullptr;
   };
-  return CreateGlyphAtlas(type, std::move(atlas_context), capabilities,
-                          iterator);
+  return CreateGlyphAtlas(type, std::move(atlas_context), iterator);
 }
 
 }  // namespace impeller

--- a/impeller/typographer/text_render_context.h
+++ b/impeller/typographer/text_render_context.h
@@ -45,13 +45,11 @@ class TextRenderContext {
   virtual std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
       GlyphAtlas::Type type,
       std::shared_ptr<GlyphAtlasContext> atlas_context,
-      const std::shared_ptr<const Capabilities>& capabilities,
       FrameIterator iterator) const = 0;
 
   std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
       GlyphAtlas::Type type,
       std::shared_ptr<GlyphAtlasContext> atlas_context,
-      const std::shared_ptr<const Capabilities>& capabilities,
       const TextFrame& frame) const;
 
  protected:

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -4,7 +4,6 @@
 
 #include "flutter/testing/testing.h"
 #include "impeller/playground/playground_test.h"
-#include "impeller/renderer/capabilities.h"
 #include "impeller/typographer/backends/skia/text_frame_skia.h"
 #include "impeller/typographer/backends/skia/text_render_context_skia.h"
 #include "impeller/typographer/lazy_glyph_atlas.h"
@@ -42,9 +41,9 @@ TEST_P(TypographerTest, CanCreateGlyphAtlas) {
   SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("hello", sk_font);
   ASSERT_TRUE(blob);
-  auto atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-      CapabilitiesBuilder().Build(), TextFrameFromTextBlob(blob));
+  auto atlas =
+      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
+                                TextFrameFromTextBlob(blob));
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
   ASSERT_EQ(atlas->GetType(), GlyphAtlas::Type::kAlphaBitmap);
@@ -117,9 +116,9 @@ TEST_P(TypographerTest, GlyphAtlasWithOddUniqueGlyphSize) {
   SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("AGH", sk_font);
   ASSERT_TRUE(blob);
-  auto atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-      CapabilitiesBuilder().Build(), TextFrameFromTextBlob(blob));
+  auto atlas =
+      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
+                                TextFrameFromTextBlob(blob));
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
 
@@ -134,18 +133,18 @@ TEST_P(TypographerTest, GlyphAtlasIsRecycledIfUnchanged) {
   SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("spooky skellingtons", sk_font);
   ASSERT_TRUE(blob);
-  auto atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-      CapabilitiesBuilder().Build(), TextFrameFromTextBlob(blob));
+  auto atlas =
+      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
+                                TextFrameFromTextBlob(blob));
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
   ASSERT_EQ(atlas, atlas_context->GetGlyphAtlas());
 
   // now attempt to re-create an atlas with the same text blob.
 
-  auto next_atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-      CapabilitiesBuilder().Build(), TextFrameFromTextBlob(blob));
+  auto next_atlas =
+      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
+                                TextFrameFromTextBlob(blob));
   ASSERT_EQ(atlas, next_atlas);
   ASSERT_EQ(atlas_context->GetGlyphAtlas(), atlas);
 }
@@ -174,9 +173,8 @@ TEST_P(TypographerTest, GlyphAtlasWithLotsOfdUniqueGlyphSize) {
     }
     return nullptr;
   };
-  auto atlas =
-      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-                                CapabilitiesBuilder().Build(), iterator);
+  auto atlas = context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap,
+                                         atlas_context, iterator);
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
 
@@ -184,16 +182,18 @@ TEST_P(TypographerTest, GlyphAtlasWithLotsOfdUniqueGlyphSize) {
             atlas->GetTexture()->GetSize().height);
 }
 
-TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledIfUnchanged) {
+// TODO(jonahwilliams): Re-enable
+// https://github.com/flutter/flutter/issues/122839
+TEST_P(TypographerTest, DISABLED_GlyphAtlasTextureIsRecycledIfUnchanged) {
   auto context = TextRenderContext::Create(GetContext());
   auto atlas_context = std::make_shared<GlyphAtlasContext>();
   ASSERT_TRUE(context && context->IsValid());
   SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("spooky 1", sk_font);
   ASSERT_TRUE(blob);
-  auto atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-      CapabilitiesBuilder().Build(), TextFrameFromTextBlob(blob));
+  auto atlas =
+      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
+                                TextFrameFromTextBlob(blob));
   auto old_packer = atlas_context->GetRectPacker();
 
   ASSERT_NE(atlas, nullptr);
@@ -205,9 +205,9 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledIfUnchanged) {
   // Now create a new glyph atlas with a nearly identical blob.
 
   auto blob2 = SkTextBlob::MakeFromString("spooky 2", sk_font);
-  auto next_atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-      CapabilitiesBuilder().Build(), TextFrameFromTextBlob(blob2));
+  auto next_atlas =
+      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
+                                TextFrameFromTextBlob(blob2));
   ASSERT_EQ(atlas, next_atlas);
   auto* second_texture = next_atlas->GetTexture().get();
 
@@ -224,9 +224,9 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
   SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("spooky 1", sk_font);
   ASSERT_TRUE(blob);
-  auto atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-      CapabilitiesBuilder().Build(), TextFrameFromTextBlob(blob));
+  auto atlas =
+      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
+                                TextFrameFromTextBlob(blob));
   auto old_packer = atlas_context->GetRectPacker();
 
   ASSERT_NE(atlas, nullptr);
@@ -239,9 +239,9 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
   // but change the type.
 
   auto blob2 = SkTextBlob::MakeFromString("spooky 1", sk_font);
-  auto next_atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kColorBitmap, atlas_context,
-      CapabilitiesBuilder().Build(), TextFrameFromTextBlob(blob2));
+  auto next_atlas =
+      context->CreateGlyphAtlas(GlyphAtlas::Type::kColorBitmap, atlas_context,
+                                TextFrameFromTextBlob(blob2));
   ASSERT_NE(atlas, next_atlas);
   auto* second_texture = next_atlas->GetTexture().get();
 
@@ -249,54 +249,6 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
 
   ASSERT_NE(second_texture, first_texture);
   ASSERT_NE(old_packer, new_packer);
-}
-
-TEST_P(TypographerTest, GlyphAtlasUsesLinearTextureAlphaBitmap) {
-  if (!GetContext()
-           ->GetCapabilities()
-           ->SupportsSharedDeviceBufferTextureMemory()) {
-    GTEST_SKIP()
-        << "Skipping test that requires "
-           "SupportsSharedDeviceBufferTextureMemory on non metal platform";
-  }
-
-  auto context = TextRenderContext::Create(GetContext());
-  auto atlas_context = std::make_shared<GlyphAtlasContext>();
-  ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font;
-  auto blob = SkTextBlob::MakeFromString("s", sk_font);
-  ASSERT_TRUE(blob);
-  auto atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-      GetContext()->GetCapabilities(), TextFrameFromTextBlob(blob));
-
-  auto* first_texture = atlas->GetTexture().get();
-
-  ASSERT_TRUE(first_texture->IsValid());
-}
-
-TEST_P(TypographerTest, GlyphAtlasUsesLinearTextureColor) {
-  if (!GetContext()
-           ->GetCapabilities()
-           ->SupportsSharedDeviceBufferTextureMemory()) {
-    GTEST_SKIP()
-        << "Skipping test that requires "
-           "SupportsSharedDeviceBufferTextureMemory on non metal platform";
-  }
-
-  auto context = TextRenderContext::Create(GetContext());
-  auto atlas_context = std::make_shared<GlyphAtlasContext>();
-  ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font;
-  auto blob = SkTextBlob::MakeFromString("s", sk_font);
-  ASSERT_TRUE(blob);
-  auto atlas = context->CreateGlyphAtlas(
-      GlyphAtlas::Type::kColorBitmap, atlas_context,
-      GetContext()->GetCapabilities(), TextFrameFromTextBlob(blob));
-
-  auto* first_texture = atlas->GetTexture().get();
-
-  ASSERT_TRUE(first_texture->IsValid());
 }
 
 TEST_P(TypographerTest, FontGlyphPairTypeChangesHashAndEquals) {


### PR DESCRIPTION
Reverts flutter/engine#41538

Playground atlas text is broken for the Vulkan + OpenGLES backends with this change. Maybe something's not getting zero initialized?

Before revert:

![Screenshot 2023-04-27 at 7 56 34 PM](https://user-images.githubusercontent.com/919017/235044138-d658a414-24db-4afb-8516-b0154e556fc7.png)

After revert:

![Screenshot 2023-04-27 at 7 57 47 PM](https://user-images.githubusercontent.com/919017/235044149-88b9734f-42bc-48f0-9c0f-5fcb49af6c0e.png)
