### PR TITLE
[Impeller] Always enable validation for goldens

### DIFF
--- a/impeller/aiks/BUILD.gn
+++ b/impeller/aiks/BUILD.gn
@@ -61,7 +61,10 @@ impeller_component("aiks_unittests") {
 impeller_component("aiks_unittests_golden") {
   testonly = true
 
-  defines = [ "IMPELLER_GOLDEN_TESTS" ]
+  defines = [
+    "IMPELLER_GOLDEN_TESTS",
+    "IMPELLER_ENABLE_VALIDATION=1",
+  ]
 
   sources = [ "aiks_unittests.cc" ]
   deps = [

--- a/impeller/base/validation.cc
+++ b/impeller/base/validation.cc
@@ -39,7 +39,7 @@ std::ostream& ValidationLog::GetStream() {
 
 void ImpellerValidationBreak(const char* message) {
 // Nothing to do. Exists for the debugger.
-#ifdef IMPELLER_DEBUG
+#ifdef IMPELLER_ENABLE_VALIDATION
   std::stringstream stream;
   stream << "Break on '" << __FUNCTION__
          << "' to inspect point of failure: " << message;

--- a/impeller/base/validation.h
+++ b/impeller/base/validation.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
+#ifndef IMPELLER_ENABLE_VALIDATION
+#ifdef IMPELLER_DEBUG
+#define IMPELLER_ENABLE_VALIDATION 1
+#endif
+#endif
+
 #include <sstream>
 
 #include "flutter/fml/macros.h"


### PR DESCRIPTION
Enable validation for release builds of the golden tests. The goldens hit a validation failure but didn't print anything in this PR: https://github.com/flutter/engine/pull/41563