### PR TITLE
Increase timeout for clang-tidy on mac

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -390,7 +390,7 @@ targets:
       cpu: arm64
       lint_host: "true"
       lint_ios: "false"
-    timeout: 75
+    timeout: 120
     runIf:
       - DEPS
       - .ci.yaml
@@ -411,7 +411,7 @@ targets:
       cpu: arm64
       lint_host: "false"
       lint_ios: "true"
-    timeout: 75
+    timeout: 120
     runIf:
       - DEPS
       - .ci.yaml


### PR DESCRIPTION
These builds are affected by https://github.com/flutter/flutter/issues/119750

The timeout needs to be increased to avoid the autorollers closing PRs due to timeouts.