### PR TITLE
Roll buildroot to c96c9d4641714301fab450a5f3b0f3c42712e1e3

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -255,7 +255,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '5708f2051772fd02c949e5dc9397e54f8c7a4478',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'c96c9d4641714301fab450a5f3b0f3c42712e1e3',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
git log --date=short --format="%ad %ae %s" 5708f2051772fd02c949e5dc9397e54f8c7a4478..c96c9d4641714301fab450a5f3b0f3c42712e1e3 2023-04-28 maruel@gmail.com fuchsia: do not read json unless enabled (#725) 2023-04-28 49699333+dependabot[bot]@users.noreply.github.com Bump github/codeql-action from 2.3.1 to 2.3.2 (#724) 2023-04-27 49699333+dependabot[bot]@users.noreply.github.com Bump github/codeql-action from 2.3.0 to 2.3.1 (#723)"
