### PR TITLE
Revert "Replace deprecated and internal Skia EncodedImage calls with public versions"

### DIFF
--- a/impeller/image/backends/skia/compressed_image_skia.cc
+++ b/impeller/image/backends/skia/compressed_image_skia.cc
@@ -9,9 +9,8 @@
 #include "impeller/base/validation.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkData.h"
-#include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/core/SkImageGenerator.h"
 #include "third_party/skia/include/core/SkPixmap.h"
-#include "third_party/skia/include/core/SkRefCnt.h"
 
 namespace impeller {
 
@@ -47,12 +46,12 @@ DecompressedImage CompressedImageSkia::Decode() const {
       },
       src);
 
-  auto image = SkImages::DeferredFromEncodedData(sk_data);
-  if (!image) {
+  auto generator = SkImageGenerator::MakeFromEncoded(sk_data);
+  if (!generator) {
     return {};
   }
 
-  const auto dims = image->imageInfo().dimensions();
+  const auto dims = generator->getInfo().dimensions();
   auto info = SkImageInfo::Make(dims.width(), dims.height(),
                                 kRGBA_8888_SkColorType, kPremul_SkAlphaType);
 
@@ -62,7 +61,7 @@ DecompressedImage CompressedImageSkia::Decode() const {
     return {};
   }
 
-  if (!image->readPixels(nullptr, bitmap->pixmap(), 0, 0)) {
+  if (!generator->getPixels(bitmap->pixmap())) {
     VALIDATION_LOG << "Could not decompress image into arena.";
     return {};
   }

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -838,8 +838,7 @@ TEST(ImageDecoderTest, VerifySimpleDecoding) {
   auto data = OpenFixtureAsSkData("Horizontal.jpg");
   auto image = SkImages::DeferredFromEncodedData(data);
   ASSERT_TRUE(image != nullptr);
-  ASSERT_EQ(600, image->width());
-  ASSERT_EQ(200, image->height());
+  ASSERT_EQ(SkISize::Make(600, 200), image->dimensions());
 
   ImageGeneratorRegistry registry;
   std::shared_ptr<ImageGenerator> generator =
@@ -848,10 +847,11 @@ TEST(ImageDecoderTest, VerifySimpleDecoding) {
 
   auto descriptor = fml::MakeRefCounted<ImageDescriptor>(std::move(data),
                                                          std::move(generator));
-  auto compressed_image = ImageDecoderSkia::ImageFromCompressedData(
-      descriptor.get(), 6, 2, fml::tracing::TraceFlow(""));
-  ASSERT_EQ(compressed_image->width(), 6);
-  ASSERT_EQ(compressed_image->height(), 2);
+
+  ASSERT_EQ(ImageDecoderSkia::ImageFromCompressedData(
+                descriptor.get(), 6, 2, fml::tracing::TraceFlow(""))
+                ->dimensions(),
+            SkISize::Make(6, 2));
 
 #if IMPELLER_SUPPORTS_RENDERING
   std::shared_ptr<impeller::Allocator> allocator =
@@ -859,14 +859,12 @@ TEST(ImageDecoderTest, VerifySimpleDecoding) {
   auto result_1 = ImageDecoderImpeller::DecompressTexture(
       descriptor.get(), SkISize::Make(6, 2), {100, 100},
       /*supports_wide_gamut=*/false, allocator);
-  ASSERT_EQ(result_1->sk_bitmap->width(), 6);
-  ASSERT_EQ(result_1->sk_bitmap->height(), 2);
+  ASSERT_EQ(result_1->sk_bitmap->dimensions(), SkISize::Make(6, 2));
 
   auto result_2 = ImageDecoderImpeller::DecompressTexture(
       descriptor.get(), SkISize::Make(60, 20), {10, 10},
       /*supports_wide_gamut=*/false, allocator);
-  ASSERT_EQ(result_2->sk_bitmap->width(), 10);
-  ASSERT_EQ(result_2->sk_bitmap->height(), 10);
+  ASSERT_EQ(result_2->sk_bitmap->dimensions(), SkISize::Make(10, 10));
 #endif  // IMPELLER_SUPPORTS_RENDERING
 }
 
@@ -880,15 +878,9 @@ TEST(ImageDecoderTest, VerifySubpixelDecodingPreservesExifOrientation) {
   auto descriptor =
       fml::MakeRefCounted<ImageDescriptor>(data, std::move(generator));
 
-  // If Exif metadata is ignored, the height and width will be swapped because
-  // "Rotate 90 CW" is what is encoded there.
-  ASSERT_EQ(600, descriptor->width());
-  ASSERT_EQ(200, descriptor->height());
-
   auto image = SkImages::DeferredFromEncodedData(data);
   ASSERT_TRUE(image != nullptr);
-  ASSERT_EQ(600, image->width());
-  ASSERT_EQ(200, image->height());
+  ASSERT_EQ(SkISize::Make(600, 200), image->dimensions());
 
   auto decode = [descriptor](uint32_t target_width, uint32_t target_height) {
     return ImageDecoderSkia::ImageFromCompressedData(
@@ -902,9 +894,8 @@ TEST(ImageDecoderTest, VerifySubpixelDecodingPreservesExifOrientation) {
 
   auto assert_image = [&](auto decoded_image) {
     ASSERT_EQ(decoded_image->dimensions(), SkISize::Make(300, 100));
-    sk_sp<SkData> encoded =
-        SkPngEncoder::Encode(nullptr, decoded_image.get(), {});
-    ASSERT_TRUE(encoded->equals(expected_data.get()));
+    ASSERT_TRUE(SkPngEncoder::Encode(nullptr, decoded_image.get(), {})
+                    ->equals(expected_data.get()));
   };
 
   assert_image(decode(300, 100));

--- a/lib/ui/painting/image_generator.h
+++ b/lib/ui/painting/image_generator.h
@@ -11,9 +11,9 @@
 #include "third_party/skia/include/codec/SkCodecAnimation.h"
 #include "third_party/skia/include/core/SkData.h"
 #include "third_party/skia/include/core/SkImage.h"
-#include "third_party/skia/include/core/SkImageGenerator.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkSize.h"
+#include "third_party/skia/src/codec/SkCodecImageGenerator.h"  // nogncheck
 
 namespace flutter {
 
@@ -213,8 +213,7 @@ class BuiltinSkiaCodecImageGenerator : public ImageGenerator {
 
  private:
   FML_DISALLOW_COPY_ASSIGN_AND_MOVE(BuiltinSkiaCodecImageGenerator);
-  std::unique_ptr<SkCodec> codec_;
-  SkImageInfo image_info_;
+  std::unique_ptr<SkCodecImageGenerator> codec_generator_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Reverts flutter/engine#41368

This is blocking rolls into the framework. Let's revert until we sort out whether there's a workaround for the change to the unpremultiplied alpha issue.