### PR TITLE
[Impeller] Remove destructive blend mode check from Contents::ShouldRender

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2163,5 +2163,19 @@ TEST_P(AiksTest, OpaqueEntitiesGetCoercedToSource) {
   ASSERT_EQ(entity.GetBlendMode(), BlendMode::kSource);
 }
 
+TEST_P(AiksTest, CanRenderDestructiveSaveLayer) {
+  Canvas canvas;
+
+  canvas.DrawPaint({.color = Color::Red()});
+  // Draw an empty savelayer with a destructive blend mode, which will replace
+  // the entire red screen with fully transparent black, except for the green
+  // circle drawn within the layer.
+  canvas.SaveLayer({.blend_mode = BlendMode::kSource});
+  canvas.DrawCircle({300, 300}, 100, {.color = Color::Green()});
+  canvas.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -109,9 +109,6 @@ bool Contents::ShouldRender(const Entity& entity,
   if (!stencil_coverage.has_value()) {
     return false;
   }
-  if (Entity::IsBlendModeDestructive(entity.GetBlendMode())) {
-    return true;
-  }
 
   auto coverage = GetCoverage(entity);
   if (!coverage.has_value()) {

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -124,7 +124,7 @@ bool Entity::SetInheritedOpacity(Scalar alpha) {
   return true;
 }
 
-/// @brief  Returns true if the blend mode is "destrictive", meaning that even
+/// @brief  Returns true if the blend mode is "destructive", meaning that even
 ///         fully transparent source colors would result in the destination
 ///         getting changed.
 ///


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/125717.
The "destructive" check is only relevant for turning off SaveLayer shrinkwrapping (used for the `cover_whole_screen_` property in EntityPass), and shouldn't be used to avoid culling entities.