### PR TITLE
Remove single view assumption from pointer events

### DIFF
--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -330,6 +330,15 @@ class PlatformConfiguration final {
   void DispatchPlatformMessage(std::unique_ptr<PlatformMessage> message);
 
   //----------------------------------------------------------------------------
+  /// @brief      Notifies the PlatformConfiguration that the client has sent
+  ///             it pointer events. This call originates in the platform view
+  ///             and has been forwarded through the engine to here.
+  ///
+  /// @param[in]  packet  The pointer event(s) serialized into a packet.
+  ///
+  void DispatchPointerDataPacket(const PointerDataPacket& packet);
+
+  //----------------------------------------------------------------------------
   /// @brief      Notifies the framework that the embedder encountered an
   ///             accessibility related action on the specified node. This call
   ///             originates on the platform view and has been forwarded to the
@@ -440,6 +449,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue update_semantics_enabled_;
   tonic::DartPersistentValue update_accessibility_features_;
   tonic::DartPersistentValue dispatch_platform_message_;
+  tonic::DartPersistentValue dispatch_pointer_data_packet_;
   tonic::DartPersistentValue dispatch_semantics_action_;
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -21,23 +21,6 @@ Window::Window(int64_t window_id, ViewportMetrics metrics)
 
 Window::~Window() {}
 
-void Window::DispatchPointerDataPacket(const PointerDataPacket& packet) {
-  std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state) {
-    return;
-  }
-  tonic::DartState::Scope scope(dart_state);
-
-  const std::vector<uint8_t>& buffer = packet.data();
-  Dart_Handle data_handle =
-      tonic::DartByteData::Create(buffer.data(), buffer.size());
-  if (Dart_IsError(data_handle)) {
-    return;
-  }
-  tonic::CheckAndHandleError(tonic::DartInvokeField(
-      library_.value(), "_dispatchPointerDataPacket", {data_handle}));
-}
-
 void Window::UpdateWindowMetrics(const ViewportMetrics& metrics) {
   viewport_metrics_ = metrics;
 

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -28,9 +28,6 @@ class Window final {
 
   const ViewportMetrics& viewport_metrics() const { return viewport_metrics_; }
 
-  // Dispatch a packet to the framework that indicates one or a few pointer
-  // events.
-  void DispatchPointerDataPacket(const PointerDataPacket& packet);
   void UpdateWindowMetrics(const ViewportMetrics& metrics);
 
  private:

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -272,7 +272,7 @@ bool RuntimeController::DispatchPointerDataPacket(
     const PointerDataPacket& packet) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
     TRACE_EVENT0("flutter", "RuntimeController::DispatchPointerDataPacket");
-    platform_configuration->get_window(0)->DispatchPointerDataPacket(packet);
+    platform_configuration->DispatchPointerDataPacket(packet);
     return true;
   }
 

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -1206,3 +1206,17 @@ void draw_solid_green() {
 void draw_solid_blue() {
   drawSolidColor(const Color.fromARGB(255, 0, 0, 255));
 }
+
+@pragma('vm:entry-point')
+void pointer_data_packet() {
+  PlatformDispatcher.instance.onPointerDataPacket =
+    (PointerDataPacket packet) {
+    signalNativeCount(packet.data.length);
+
+    for (final pointerData in packet.data) {
+      signalNativeMessage(pointerData.toString());
+    }
+  };
+
+  signalNativeTest();
+}


### PR DESCRIPTION
This change removes the assumption that that all pointer events go to the view ID `0`. This change also adds a test for pointer events.

Part of: https://github.com/flutter/flutter/issues/112205

## Background

All pointer events are sent to [`PlatformDispatcher.onPointerDataPacket`](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onPointerDataPacket.html). In the future, a `viewId` property will be added [`PointerData`](https://api.flutter.dev/flutter/dart-ui/PointerData-class.html), which the framework (specifically, `GestureBinding`) will use to route the event to the proper view. This `viewId` property's value will be set by the embedders.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
