### PR TITLE
[Impeller] take advantage of DisplayList culling

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -120,6 +120,7 @@
 ../../../flutter/impeller/.gitignore
 ../../../flutter/impeller/README.md
 ../../../flutter/impeller/aiks/aiks_unittests.cc
+../../../flutter/impeller/aiks/canvas_unittests.cc
 ../../../flutter/impeller/archivist/archivist_unittests.cc
 ../../../flutter/impeller/base/README.md
 ../../../flutter/impeller/base/base_unittests.cc

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -141,6 +141,11 @@ void DisplayList::Dispatch(DlOpReceiver& receiver) const {
 }
 
 void DisplayList::Dispatch(DlOpReceiver& receiver,
+                           const SkIRect& cull_rect) const {
+  Dispatch(receiver, SkRect::Make(cull_rect));
+}
+
+void DisplayList::Dispatch(DlOpReceiver& receiver,
                            const SkRect& cull_rect) const {
   if (cull_rect.isEmpty()) {
     return;

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -235,6 +235,7 @@ class DisplayList : public SkRefCnt {
 
   void Dispatch(DlOpReceiver& ctx) const;
   void Dispatch(DlOpReceiver& ctx, const SkRect& cull_rect) const;
+  void Dispatch(DlOpReceiver& ctx, const SkIRect& cull_rect) const;
 
   // From historical behavior, SkPicture always included nested bytes,
   // but nested ops are only included if requested. The defaults used

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -2532,81 +2532,79 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
   main_receiver.drawRect({20, 20, 30, 30});
   auto main = main_builder.Build();
 
+  auto test = [main](SkIRect cull_rect, const sk_sp<DisplayList>& expected) {
+    {  // Test SkIRect culling
+      DisplayListBuilder culling_builder;
+      main->Dispatch(ToReceiver(culling_builder), cull_rect);
+
+      EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected));
+    }
+
+    {  // Test SkRect culling
+      DisplayListBuilder culling_builder;
+      main->Dispatch(ToReceiver(culling_builder), SkRect::Make(cull_rect));
+
+      EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected));
+    }
+  };
+
   {  // No rects
-    SkRect cull_rect = {11, 11, 19, 19};
+    SkIRect cull_rect = {11, 11, 19, 19};
 
     DisplayListBuilder expected_builder;
     auto expected = expected_builder.Build();
 
-    DisplayListBuilder culling_builder(cull_rect);
-    main->Dispatch(ToReceiver(culling_builder), cull_rect);
-
-    EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected));
+    test(cull_rect, expected);
   }
 
   {  // Rect 1
-    SkRect cull_rect = {9, 9, 19, 19};
+    SkIRect cull_rect = {9, 9, 19, 19};
 
     DisplayListBuilder expected_builder;
     DlOpReceiver& expected_receiver = ToReceiver(expected_builder);
     expected_receiver.drawRect({0, 0, 10, 10});
     auto expected = expected_builder.Build();
 
-    DisplayListBuilder culling_builder(cull_rect);
-    main->Dispatch(ToReceiver(culling_builder), cull_rect);
-
-    EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected));
+    test(cull_rect, expected);
   }
 
   {  // Rect 2
-    SkRect cull_rect = {11, 9, 21, 19};
+    SkIRect cull_rect = {11, 9, 21, 19};
 
     DisplayListBuilder expected_builder;
     DlOpReceiver& expected_receiver = ToReceiver(expected_builder);
     expected_receiver.drawRect({20, 0, 30, 10});
     auto expected = expected_builder.Build();
 
-    DisplayListBuilder culling_builder(cull_rect);
-    main->Dispatch(ToReceiver(culling_builder), cull_rect);
-
-    EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected));
+    test(cull_rect, expected);
   }
 
   {  // Rect 3
-    SkRect cull_rect = {9, 11, 19, 21};
+    SkIRect cull_rect = {9, 11, 19, 21};
 
     DisplayListBuilder expected_builder;
     DlOpReceiver& expected_receiver = ToReceiver(expected_builder);
     expected_receiver.drawRect({0, 20, 10, 30});
     auto expected = expected_builder.Build();
 
-    DisplayListBuilder culling_builder(cull_rect);
-    main->Dispatch(ToReceiver(culling_builder), cull_rect);
-
-    EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected));
+    test(cull_rect, expected);
   }
 
   {  // Rect 4
-    SkRect cull_rect = {11, 11, 21, 21};
+    SkIRect cull_rect = {11, 11, 21, 21};
 
     DisplayListBuilder expected_builder;
     DlOpReceiver& expected_receiver = ToReceiver(expected_builder);
     expected_receiver.drawRect({20, 20, 30, 30});
     auto expected = expected_builder.Build();
 
-    DisplayListBuilder culling_builder(cull_rect);
-    main->Dispatch(ToReceiver(culling_builder), cull_rect);
-
-    EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected));
+    test(cull_rect, expected);
   }
 
   {  // All 4 rects
-    SkRect cull_rect = {9, 9, 21, 21};
+    SkIRect cull_rect = {9, 9, 21, 21};
 
-    DisplayListBuilder culling_builder(cull_rect);
-    main->Dispatch(ToReceiver(culling_builder), cull_rect);
-
-    EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), main));
+    test(cull_rect, main);
   }
 }
 

--- a/flow/surface_frame.cc
+++ b/flow/surface_frame.cc
@@ -31,7 +31,8 @@ SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
     canvas_ = &adapter_;
   } else if (display_list_fallback) {
     FML_DCHECK(!frame_size.isEmpty());
-    dl_builder_ = sk_make_sp<DisplayListBuilder>(SkRect::Make(frame_size));
+    dl_builder_ =
+        sk_make_sp<DisplayListBuilder>(SkRect::Make(frame_size), true);
     canvas_ = dl_builder_.get();
   }
 }

--- a/impeller/aiks/BUILD.gn
+++ b/impeller/aiks/BUILD.gn
@@ -47,7 +47,10 @@ impeller_component("aiks_playground") {
 
 impeller_component("aiks_unittests") {
   testonly = true
-  sources = [ "aiks_unittests.cc" ]
+  sources = [
+    "aiks_unittests.cc",
+    "canvas_unittests.cc",
+  ]
   deps = [
     ":aiks",
     ":aiks_playground",

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -40,6 +40,10 @@ class Canvas {
 
   Canvas();
 
+  explicit Canvas(Rect cull_rect);
+
+  explicit Canvas(IRect cull_rect);
+
   ~Canvas();
 
   void Save();
@@ -56,6 +60,8 @@ class Canvas {
   void RestoreToCount(size_t count);
 
   const Matrix& GetCurrentTransformation() const;
+
+  const Rect GetCurrentLocalClipBounds() const;
 
   void ResetTransform();
 
@@ -135,8 +141,9 @@ class Canvas {
   EntityPass* current_pass_ = nullptr;
   std::deque<CanvasStackEntry> xformation_stack_;
   std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas_;
+  Rect initial_cull_rect_;
 
-  void Initialize();
+  void Initialize(Rect cull_rect);
 
   void Reset();
 
@@ -145,7 +152,8 @@ class Canvas {
   size_t GetStencilDepth() const;
 
   void ClipGeometry(std::unique_ptr<Geometry> geometry,
-                    Entity::ClipOperation clip_op);
+                    Entity::ClipOperation clip_op,
+                    std::optional<Rect> geometry_bounds);
 
   void Save(bool create_subpass,
             BlendMode = BlendMode::kSourceOver,

--- a/impeller/aiks/canvas_unittests.cc
+++ b/impeller/aiks/canvas_unittests.cc
@@ -1,0 +1,337 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"
+#include "impeller/aiks/canvas.h"
+#include "impeller/geometry/path_builder.h"
+
+namespace impeller {
+namespace testing {
+
+using AiksCanvasTest = ::testing::Test;
+
+TEST(AiksCanvasTest, EmptyCullRect) {
+  Canvas canvas;
+
+  ASSERT_FALSE(canvas.GetCurrentLocalCullingBounds().has_value());
+}
+
+TEST(AiksCanvasTest, InitialCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+
+  Canvas canvas(initial_cull);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), initial_cull);
+}
+
+TEST(AiksCanvasTest, TranslatedCullRect) {
+  Rect initial_cull(5, 5, 10, 10);
+  Rect translated_cull(0, 0, 10, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.Translate(Vector3(5, 5, 0));
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), translated_cull);
+}
+
+TEST(AiksCanvasTest, ScaledCullRect) {
+  Rect initial_cull(5, 5, 10, 10);
+  Rect scaled_cull(10, 10, 20, 20);
+
+  Canvas canvas(initial_cull);
+  canvas.Scale(Vector2(0.5, 0.5));
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), scaled_cull);
+}
+
+TEST(AiksCanvasTest, RectClipIntersectAgainstEmptyCullRect) {
+  Rect rect_clip(5, 5, 10, 10);
+
+  Canvas canvas;
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kIntersect);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), rect_clip);
+}
+
+TEST(AiksCanvasTest, RectClipDiffAgainstEmptyCullRect) {
+  Rect rect_clip(5, 5, 10, 10);
+
+  Canvas canvas;
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
+
+  ASSERT_FALSE(canvas.GetCurrentLocalCullingBounds().has_value());
+}
+
+TEST(AiksCanvasTest, RectClipIntersectAgainstCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(5, 5, 10, 10);
+  Rect result_cull(5, 5, 5, 5);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kIntersect);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RectClipDiffAgainstNonCoveredCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(5, 5, 10, 10);
+  Rect result_cull(0, 0, 10, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RectClipDiffAboveCullRect) {
+  Rect initial_cull(5, 5, 10, 10);
+  Rect rect_clip(0, 0, 20, 4);
+  Rect result_cull(5, 5, 10, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RectClipDiffBelowCullRect) {
+  Rect initial_cull(5, 5, 10, 10);
+  Rect rect_clip(0, 16, 20, 4);
+  Rect result_cull(5, 5, 10, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RectClipDiffLeftOfCullRect) {
+  Rect initial_cull(5, 5, 10, 10);
+  Rect rect_clip(0, 0, 4, 20);
+  Rect result_cull(5, 5, 10, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RectClipDiffRightOfCullRect) {
+  Rect initial_cull(5, 5, 10, 10);
+  Rect rect_clip(16, 0, 4, 20);
+  Rect result_cull(5, 5, 10, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RectClipDiffAgainstVCoveredCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(5, 0, 10, 10);
+  Rect result_cull(0, 0, 5, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RectClipDiffAgainstHCoveredCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(0, 5, 10, 10);
+  Rect result_cull(0, 0, 10, 5);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RRectClipIntersectAgainstEmptyCullRect) {
+  Rect rect_clip(5, 5, 10, 10);
+
+  Canvas canvas;
+  canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kIntersect);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), rect_clip);
+}
+
+TEST(AiksCanvasTest, RRectClipDiffAgainstEmptyCullRect) {
+  Rect rect_clip(5, 5, 10, 10);
+
+  Canvas canvas;
+  canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
+
+  ASSERT_FALSE(canvas.GetCurrentLocalCullingBounds().has_value());
+}
+
+TEST(AiksCanvasTest, RRectClipIntersectAgainstCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(5, 5, 10, 10);
+  Rect result_cull(5, 5, 5, 5);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kIntersect);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RRectClipDiffAgainstNonCoveredCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(5, 5, 10, 10);
+  Rect result_cull(0, 0, 10, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RRectClipDiffAgainstVPartiallyCoveredCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(5, 0, 10, 10);
+  Rect result_cull(0, 0, 6, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RRectClipDiffAgainstVFullyCoveredCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(5, -2, 10, 14);
+  Rect result_cull(0, 0, 5, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RRectClipDiffAgainstHPartiallyCoveredCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(0, 5, 10, 10);
+  Rect result_cull(0, 0, 10, 6);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, RRectClipDiffAgainstHFullyCoveredCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  Rect rect_clip(-2, 5, 14, 10);
+  Rect result_cull(0, 0, 10, 5);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, PathClipIntersectAgainstEmptyCullRect) {
+  PathBuilder builder;
+  builder.AddRect({5, 5, 1, 1});
+  builder.AddRect({5, 14, 1, 1});
+  builder.AddRect({14, 5, 1, 1});
+  builder.AddRect({14, 14, 1, 1});
+  Path path = builder.TakePath();
+  Rect rect_clip(5, 5, 10, 10);
+
+  Canvas canvas;
+  canvas.ClipPath(path, Entity::ClipOperation::kIntersect);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), rect_clip);
+}
+
+TEST(AiksCanvasTest, PathClipDiffAgainstEmptyCullRect) {
+  PathBuilder builder;
+  builder.AddRect({5, 5, 1, 1});
+  builder.AddRect({5, 14, 1, 1});
+  builder.AddRect({14, 5, 1, 1});
+  builder.AddRect({14, 14, 1, 1});
+  Path path = builder.TakePath();
+
+  Canvas canvas;
+  canvas.ClipPath(path, Entity::ClipOperation::kDifference);
+
+  ASSERT_FALSE(canvas.GetCurrentLocalCullingBounds().has_value());
+}
+
+TEST(AiksCanvasTest, PathClipIntersectAgainstCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  PathBuilder builder;
+  builder.AddRect({5, 5, 1, 1});
+  builder.AddRect({5, 14, 1, 1});
+  builder.AddRect({14, 5, 1, 1});
+  builder.AddRect({14, 14, 1, 1});
+  Path path = builder.TakePath();
+  Rect result_cull(5, 5, 5, 5);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipPath(path, Entity::ClipOperation::kIntersect);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, PathClipDiffAgainstNonCoveredCullRect) {
+  Rect initial_cull(0, 0, 10, 10);
+  PathBuilder builder;
+  builder.AddRect({5, 5, 1, 1});
+  builder.AddRect({5, 14, 1, 1});
+  builder.AddRect({14, 5, 1, 1});
+  builder.AddRect({14, 14, 1, 1});
+  Path path = builder.TakePath();
+  Rect result_cull(0, 0, 10, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipPath(path, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+TEST(AiksCanvasTest, PathClipDiffAgainstFullyCoveredCullRect) {
+  Rect initial_cull(5, 5, 10, 10);
+  PathBuilder builder;
+  builder.AddRect({0, 0, 100, 100});
+  Path path = builder.TakePath();
+  // Diff clip of Paths is ignored due to complexity
+  Rect result_cull(5, 5, 10, 10);
+
+  Canvas canvas(initial_cull);
+  canvas.ClipPath(path, Entity::ClipOperation::kDifference);
+
+  ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
+  ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -15,6 +15,10 @@ class DlDispatcher final : public flutter::DlOpReceiver {
  public:
   DlDispatcher();
 
+  explicit DlDispatcher(Rect cull_rect);
+
+  explicit DlDispatcher(IRect cull_rect);
+
   ~DlDispatcher();
 
   Picture EndRecordingAsPicture();

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -234,12 +234,4 @@ class EntityPass {
   FML_DISALLOW_COPY_AND_ASSIGN(EntityPass);
 };
 
-struct CanvasStackEntry {
-  Matrix xformation;
-  Rect clip_bounds;
-  size_t stencil_depth = 0u;
-  bool is_subpass = false;
-  bool contains_clips = false;
-};
-
 }  // namespace impeller

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -236,6 +236,7 @@ class EntityPass {
 
 struct CanvasStackEntry {
   Matrix xformation;
+  Rect clip_bounds;
   size_t stencil_depth = 0u;
   bool is_subpass = false;
   bool contains_clips = false;

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -224,21 +224,21 @@ struct TRect {
         // Full cutout.
         return std::nullopt;
       }
-      if (b_top <= a_top) {
+      if (b_top <= a_top && b_bottom > a_top) {
         // Cuts off the top.
         return TRect::MakeLTRB(a_left, b_bottom, a_right, a_bottom);
       }
-      if (b_bottom >= b_bottom) {
+      if (b_bottom >= a_bottom && b_top < a_bottom) {
         // Cuts out the bottom.
         return TRect::MakeLTRB(a_left, a_top, a_right, b_top);
       }
     }
     if (b_top <= a_top && b_bottom >= a_bottom) {
-      if (b_left <= a_left) {
+      if (b_left <= a_left && b_right > a_left) {
         // Cuts out the left.
         return TRect::MakeLTRB(b_right, a_top, a_right, a_bottom);
       }
-      if (b_right >= a_right) {
+      if (b_right >= a_right && b_left < a_right) {
         // Cuts out the right.
         return TRect::MakeLTRB(a_left, a_top, b_left, a_bottom);
       }

--- a/impeller/renderer/backend/metal/surface_mtl.h
+++ b/impeller/renderer/backend/metal/surface_mtl.h
@@ -48,6 +48,9 @@ class SurfaceMTL final : public Surface {
 
   id<MTLDrawable> drawable() const { return drawable_; }
 
+  // Returns a Rect defining the area of the surface in device pixels
+  IRect coverage() const;
+
   // |Surface|
   bool Present() const override;
 

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -149,6 +149,11 @@ bool SurfaceMTL::ShouldPerformPartialRepaint(std::optional<IRect> damage_rect) {
 }
 
 // |Surface|
+IRect SurfaceMTL::coverage() const {
+  return IRect::MakeSize(resolve_texture_->GetSize());
+}
+
+// |Surface|
 bool SurfaceMTL::Present() const {
   if (drawable_ == nil) {
     return false;


### PR DESCRIPTION
Switching the calls to dispatch into an Impeller Dispatcher to use a cull rect to enable pre-culling of the out-of-bounds ops.

This change showed an improvement of around 2x on the rendering performance of the non-intersecting platform view benchmark, but that was measured without the recent changes to the destructive blend modes in Impeller renderer.