### PR TITLE
[Impeller] Remove duplicate component in path.h

### DIFF
--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "impeller/geometry/path_component.h"
-#include "path_component.h"
 
 namespace impeller {
 


### PR DESCRIPTION
Noticed this while reading some code. I think an IDE plugin I have does this sometimes.
