### PR TITLE
Turn @staticInterop tear-off into closure

### DIFF
--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -194,7 +194,12 @@ class FontManager {
     if (_downloadedFonts.isEmpty) {
       return;
     }
-    _downloadedFonts.forEach(domDocument.fonts!.add);
+    // Since we can't use tear-offs for interop members, this code is faster and
+    // easier to read with a for loop instead of forEach.
+    // ignore: prefer_foreach
+    for (final DomFontFace font in _downloadedFonts) {
+      domDocument.fonts!.add(font);
+    }
   }
 
 


### PR DESCRIPTION
@staticInterop members will start disallowing tear-offs, so this member should turn into a closure.

Unblocks a roll in the SDK that disallows tear-offs.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
