### PR TITLE
Upload xcresults to LUCI cloud storage

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -17,6 +17,7 @@ import glob
 import multiprocessing
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -752,6 +753,12 @@ def run_objc_tests(ios_variant='ios_debug_sim_unopt', test_filter=None):
     ios_unit_test_dir = os.path.join(
         BUILDROOT_DIR, 'flutter', 'testing', 'ios', 'IosUnitTests'
     )
+
+    result_bundle_temp = tempfile.TemporaryDirectory(
+        suffix='ios_embedding_xcresult'
+    ).name
+    result_bundle_path = os.path.join(result_bundle_temp, 'ios_embedding')
+
     # Avoid using xcpretty unless the following can be addressed:
     # - Make sure all relevant failure output is printed on a failure.
     # - Make sure that a failing exit code is set for CI.
@@ -760,13 +767,27 @@ def run_objc_tests(ios_variant='ios_debug_sim_unopt', test_filter=None):
         'xcodebuild '
         '-sdk iphonesimulator '
         '-scheme IosUnitTests '
-        "-destination name='" + new_simulator_name + "' "
+        '-resultBundlePath ' + result_bundle_path + " -destination name='" +
+        new_simulator_name + "' "
         'test '
         'FLUTTER_ENGINE=' + ios_variant
     ]
     if test_filter is not None:
       test_command[0] = test_command[0] + ' -only-testing:%s' % test_filter
     run_cmd(test_command, cwd=ios_unit_test_dir, shell=True)
+
+    # except:
+    # The LUCI environment may provide a variable containing a directory path
+    # for additional output files that will be uploaded to cloud storage.
+    # Upload the xcresult when the tests fail.
+    luci_test_outputs_path = os.environ.get('FLUTTER_TEST_OUTPUTS_DIR')
+    xcresult_bundle = os.path.join(result_bundle_temp, 'ios_embedding.xcresult')
+    print(xcresult_bundle)
+    if luci_test_outputs_path and os.path.exists(xcresult_bundle):
+      dump_path = os.path.join(luci_test_outputs_path, 'ios_embedding.xcresult')
+      # xcresults contain many little files. Archive the bundle before upload.
+      shutil.make_archive(dump_path, 'zip', root_dir=xcresult_bundle)
+
   finally:
     delete_simulator(new_simulator_name)
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -754,39 +754,38 @@ def run_objc_tests(ios_variant='ios_debug_sim_unopt', test_filter=None):
         BUILDROOT_DIR, 'flutter', 'testing', 'ios', 'IosUnitTests'
     )
 
-    result_bundle_temp = tempfile.TemporaryDirectory(
+    with tempfile.TemporaryDirectory(
         suffix='ios_embedding_xcresult'
-    ).name
-    result_bundle_path = os.path.join(result_bundle_temp, 'ios_embedding')
+    ) as result_bundle_temp:
+      result_bundle_path = os.path.join(result_bundle_temp, 'ios_embedding')
 
-    # Avoid using xcpretty unless the following can be addressed:
-    # - Make sure all relevant failure output is printed on a failure.
-    # - Make sure that a failing exit code is set for CI.
-    # See https://github.com/flutter/flutter/issues/63742
-    test_command = [
-        'xcodebuild '
-        '-sdk iphonesimulator '
-        '-scheme IosUnitTests '
-        '-resultBundlePath ' + result_bundle_path + " -destination name='" +
-        new_simulator_name + "' "
-        'test '
-        'FLUTTER_ENGINE=' + ios_variant
-    ]
-    if test_filter is not None:
-      test_command[0] = test_command[0] + ' -only-testing:%s' % test_filter
-    run_cmd(test_command, cwd=ios_unit_test_dir, shell=True)
+      # Avoid using xcpretty unless the following can be addressed:
+      # - Make sure all relevant failure output is printed on a failure.
+      # - Make sure that a failing exit code is set for CI.
+      # See https://github.com/flutter/flutter/issues/63742
+      test_command = [
+          'xcodebuild '
+          '-sdk iphonesimulator '
+          '-scheme IosUnitTests '
+          '-resultBundlePath ' + result_bundle_path + ' '
+          '-destination name=' + new_simulator_name + ' '
+          'test '
+          'FLUTTER_ENGINE=' + ios_variant
+      ]
+      if test_filter is not None:
+        test_command[0] = test_command[0] + ' -only-testing:%s' % test_filter
+      run_cmd(test_command, cwd=ios_unit_test_dir, shell=True)
 
-    # except:
-    # The LUCI environment may provide a variable containing a directory path
-    # for additional output files that will be uploaded to cloud storage.
-    # Upload the xcresult when the tests fail.
-    luci_test_outputs_path = os.environ.get('FLUTTER_TEST_OUTPUTS_DIR')
-    xcresult_bundle = os.path.join(result_bundle_temp, 'ios_embedding.xcresult')
-    print(xcresult_bundle)
-    if luci_test_outputs_path and os.path.exists(xcresult_bundle):
-      dump_path = os.path.join(luci_test_outputs_path, 'ios_embedding.xcresult')
-      # xcresults contain many little files. Archive the bundle before upload.
-      shutil.make_archive(dump_path, 'zip', root_dir=xcresult_bundle)
+      # except:
+      # The LUCI environment may provide a variable containing a directory path
+      # for additional output files that will be uploaded to cloud storage.
+      # Upload the xcresult when the tests fail.
+      luci_test_outputs_path = os.environ.get('FLUTTER_TEST_OUTPUTS_DIR')
+      xcresult_bundle = os.path.join(result_bundle_temp, 'ios_embedding.xcresult')
+      if luci_test_outputs_path and os.path.exists(xcresult_bundle):
+        dump_path = os.path.join(luci_test_outputs_path, 'ios_embedding.xcresult')
+        # xcresults contain many little files. Archive the bundle before upload.
+        shutil.make_archive(dump_path, 'zip', root_dir=xcresult_bundle)
 
   finally:
     delete_simulator(new_simulator_name)

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -754,9 +754,8 @@ def run_objc_tests(ios_variant='ios_debug_sim_unopt', test_filter=None):
         BUILDROOT_DIR, 'flutter', 'testing', 'ios', 'IosUnitTests'
     )
 
-    with tempfile.TemporaryDirectory(
-        suffix='ios_embedding_xcresult'
-    ) as result_bundle_temp:
+    with tempfile.TemporaryDirectory(suffix='ios_embedding_xcresult'
+                                    ) as result_bundle_temp:
       result_bundle_path = os.path.join(result_bundle_temp, 'ios_embedding')
 
       # Avoid using xcpretty unless the following can be addressed:
@@ -781,9 +780,13 @@ def run_objc_tests(ios_variant='ios_debug_sim_unopt', test_filter=None):
       # for additional output files that will be uploaded to cloud storage.
       # Upload the xcresult when the tests fail.
       luci_test_outputs_path = os.environ.get('FLUTTER_TEST_OUTPUTS_DIR')
-      xcresult_bundle = os.path.join(result_bundle_temp, 'ios_embedding.xcresult')
+      xcresult_bundle = os.path.join(
+          result_bundle_temp, 'ios_embedding.xcresult'
+      )
       if luci_test_outputs_path and os.path.exists(xcresult_bundle):
-        dump_path = os.path.join(luci_test_outputs_path, 'ios_embedding.xcresult')
+        dump_path = os.path.join(
+            luci_test_outputs_path, 'ios_embedding.xcresult'
+        )
         # xcresults contain many little files. Archive the bundle before upload.
         shutil.make_archive(dump_path, 'zip', root_dir=xcresult_bundle)
 

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -50,9 +50,9 @@ RESULT_BUNDLE_PATH="${SCENARIO_PATH}/${RESULT_BUNDLE_FOLDER}"
 # Zip and upload xcresult to luci.
 # First parameter ($1) is the zip output name.
 zip_and_upload_xcresult_to_luci () {
-  # Using absolute directory causes the zip containing all the sub directories.
-  # So use relative directory (./$RESULT_BUNDLE_FOLDER) instead.
-  zip -q -r $1 $RESULT_BUNDLE_PATH
+  # We don't want the zip to contain the abusolute path,
+  # so use relative path (./$RESULT_BUNDLE_FOLDER) instead.
+  zip -q -r $1 "./$RESULT_BUNDLE_FOLDER"
   mv -f $1 $FLUTTER_TEST_OUTPUTS_DIR
   exit 1
 }

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -93,4 +93,3 @@ else
   zip_and_upload_xcresult_to_luci "ios_scenario_impeller_xcresult.zip"
 fi
 rm -rf $RESULT_BUNDLE_PATH
-

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -50,13 +50,11 @@ RESULT_BUNDLE_PATH="${SCENARIO_PATH}/${RESULT_BUNDLE_FOLDER}"
 # Zip and upload xcresult to luci.
 # First parameter ($1) is the zip output name.
 ZIP_AND_UPLOAD_XCRESULT_TO_LUCI () {
-  # Using RESULT_BUNDLE_PATH causes the zip containing all the sub directories.
-  # So use relative directory instead.
+  # Using absolute directory causes the zip containing all the sub directories.
+  # So use relative directory (./$RESULT_BUNDLE_FOLDER) instead.
   echo $1
   zip -q -r $1 "./$RESULT_BUNDLE_FOLDER"
-  if ( -z "$FLUTTER_TEST_OUTPUTS_DIR") then
-    mv -f $1 $FLUTTER_TEST_OUTPUTS_DIR
-  fi
+  mv -f $1 $FLUTTER_TEST_OUTPUTS_DIR
   exit 1
 }
 
@@ -95,3 +93,4 @@ else
   echo "test failed."
   ZIP_AND_UPLOAD_XCRESULT_TO_LUCI "ios_scenario_impeller_xcresult.zip"
 fi
+

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -55,6 +55,7 @@ ZIP_AND_UPLOAD_XCRESULT_TO_LUCI () {
   echo $1
   zip -q -r $1 "./$RESULT_BUNDLE_FOLDER"
   mv -f $1 $FLUTTER_TEST_OUTPUTS_DIR
+  rm -rf $RESULT_BUNDLE_PATH
   exit 1
 }
 
@@ -62,7 +63,6 @@ echo "Running simulator tests with Skia"
 echo ""
 
 mktemp -d $RESULT_BUNDLE_PATH
-trap 'rm -rf $RESULT_BUNDLE_PATH' EXIT
 
 if set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme Scenarios \

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -42,6 +42,7 @@ fi
 defaults write com.apple.iphonesimulator RotateWindowWhenSignaledByGuest -int 1
 
 SCENARIO_PATH=$SRC_DIR/out/$FLUTTER_ENGINE/scenario_app/Scenarios
+pushd .
 cd $SCENARIO_PATH
 
 RESULT_BUNDLE_FOLDER="ios_scenario_xcresult"
@@ -93,3 +94,5 @@ else
   zip_and_upload_xcresult_to_luci "ios_scenario_impeller_xcresult.zip"
 fi
 rm -rf $RESULT_BUNDLE_PATH
+
+popd

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -49,11 +49,10 @@ RESULT_BUNDLE_PATH="${SCENARIO_PATH}/${RESULT_BUNDLE_FOLDER}"
 
 # Zip and upload xcresult to luci.
 # First parameter ($1) is the zip output name.
-ZIP_AND_UPLOAD_XCRESULT_TO_LUCI () {
+zip_and_upload_xcresult_to_luci () {
   # Using absolute directory causes the zip containing all the sub directories.
   # So use relative directory (./$RESULT_BUNDLE_FOLDER) instead.
-  echo $1
-  zip -q -r $1 "./$RESULT_BUNDLE_FOLDER"
+  zip -q -r $1 $RESULT_BUNDLE_PATH
   mv -f $1 $FLUTTER_TEST_OUTPUTS_DIR
   exit 1
 }
@@ -72,7 +71,7 @@ if set -o pipefail && xcodebuild -sdk iphonesimulator \
   echo "test success."
 else
   echo "test failed."
-  ZIP_AND_UPLOAD_XCRESULT_TO_LUCI "ios_scenario_xcresult.zip"
+  zip_and_upload_xcresult_to_luci "ios_scenario_xcresult.zip"
 fi
 rm -rf $RESULT_BUNDLE_PATH
 
@@ -91,7 +90,7 @@ if set -o pipefail && xcodebuild -sdk iphonesimulator \
   echo "test success."
 else
   echo "test failed."
-  ZIP_AND_UPLOAD_XCRESULT_TO_LUCI "ios_scenario_impeller_xcresult.zip"
+  zip_and_upload_xcresult_to_luci "ios_scenario_impeller_xcresult.zip"
 fi
 rm -rf $RESULT_BUNDLE_PATH
 

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -55,7 +55,6 @@ ZIP_AND_UPLOAD_XCRESULT_TO_LUCI () {
   echo $1
   zip -q -r $1 "./$RESULT_BUNDLE_FOLDER"
   mv -f $1 $FLUTTER_TEST_OUTPUTS_DIR
-  rm -rf $RESULT_BUNDLE_PATH
   exit 1
 }
 
@@ -75,6 +74,7 @@ else
   echo "test failed."
   ZIP_AND_UPLOAD_XCRESULT_TO_LUCI "ios_scenario_xcresult.zip"
 fi
+rm -rf $RESULT_BUNDLE_PATH
 
 echo "Running simulator tests with Impeller"
 echo ""
@@ -93,4 +93,5 @@ else
   echo "test failed."
   ZIP_AND_UPLOAD_XCRESULT_TO_LUCI "ios_scenario_impeller_xcresult.zip"
 fi
+rm -rf $RESULT_BUNDLE_PATH
 


### PR DESCRIPTION
Taking over from https://github.com/flutter/engine/pull/41644

fixes: https://github.com/flutter/flutter/issues/125823

Steps to verify
- [x] CI should pass with only the test script change, no xcresults are uploaded.
- [x] https://github.com/flutter/engine/pull/41652 should fail and xcresult should be uploaded.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
