### PR TITLE
Use os_dimension in framework tests.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -298,7 +298,6 @@ targets:
       - main
       - master
     properties:
-      drone_dimensions: ["os=Linux"]
       add_recipes_cq: "true"
       cores: "32"
       gclient_variables: >-
@@ -311,7 +310,7 @@ targets:
       framework: "true"
       no_goma: "true"
       drone_dimensions: >
-        ["device_type=none"]
+        ["device_type=none", "os=Linux"]
       shard: web_tests
       subshards: >-
               ["0", "1", "2", "3", "4", "5", "6", "7_last"]

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -298,6 +298,7 @@ targets:
       - main
       - master
     properties:
+      drone_dimensions: ["os=Linux"]
       add_recipes_cq: "true"
       cores: "32"
       gclient_variables: >-


### PR DESCRIPTION
Dimensions are now used to detect the drone to use. Framework tests are using shard_util_v2 but not engine v2 builds and require to pass the drone dimension from the .ci.yaml file.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
