### PR TITLE
[web] dialog a11y fixes

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1976,6 +1976,7 @@ ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/safe_browser_api.dart + ../..
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/accessibility.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/checkable.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/dialog.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/image.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/incrementable.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/label_and_value.dart + ../../../flutter/LICENSE
@@ -4590,6 +4591,7 @@ FILE: ../../../flutter/lib/web_ui/lib/src/engine/safe_browser_api.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/accessibility.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/checkable.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/dialog.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/image.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/incrementable.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/label_and_value.dart

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -133,6 +133,7 @@ export 'engine/rrect_renderer.dart';
 export 'engine/safe_browser_api.dart';
 export 'engine/semantics/accessibility.dart';
 export 'engine/semantics/checkable.dart';
+export 'engine/semantics/dialog.dart';
 export 'engine/semantics/image.dart';
 export 'engine/semantics/incrementable.dart';
 export 'engine/semantics/label_and_value.dart';

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -20,8 +20,8 @@ class Dialog extends RoleManager {
 
   @override
   void update() {
+    final String? label = semanticsObject.label;
     assert(() {
-      final String? label = semanticsObject.label;
       if (label == null || label.trim().isEmpty) {
         printWarning(
           'Semantic node ${semanticsObject.id} was assigned dialog role, but '
@@ -32,7 +32,7 @@ class Dialog extends RoleManager {
       }
       return true;
     }());
-    semanticsObject.element.setAttribute('aria-label', semanticsObject.label ?? '');
+    semanticsObject.element.setAttribute('aria-label', label ?? '');
     semanticsObject.setAriaRole('dialog', true);
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../dom.dart';
+import '../semantics.dart';
+import '../util.dart';
+
+class Dialog extends RoleManager {
+  Dialog(SemanticsObject semanticsObject) : super(Role.dialog, semanticsObject);
+
+  @override
+  void dispose() {
+    semanticsObject.element.removeAttribute('aria-label');
+    semanticsObject.clearAriaRole();
+  }
+
+  @override
+  void update() {
+    assert(() {
+      final String? label = semanticsObject.label;
+      if (label == null || label.trim().isEmpty) {
+        printWarning(
+          'Semantic node ${semanticsObject.id} was assigned dialog role, but '
+          'is missing a label. A dialog should contain a label so that a '
+          'screen reader can communicate to the user that a dialog appeared '
+          'and a user action is requested.'
+        );
+      }
+      return true;
+    }());
+    semanticsObject.element.setAttribute('aria-label', semanticsObject.label ?? '');
+    semanticsObject.setAriaRole('dialog', true);
+  }
+}

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -6,6 +6,9 @@ import '../dom.dart';
 import '../semantics.dart';
 import '../util.dart';
 
+/// Provides accessibility for dialogs.
+///
+/// See also [Role.dialog].
 class Dialog extends RoleManager {
   Dialog(SemanticsObject semanticsObject) : super(Role.dialog, semanticsObject);
 

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -17,6 +17,7 @@ import '../platform_dispatcher.dart';
 import '../util.dart';
 import '../vector_math.dart';
 import 'checkable.dart';
+import 'dialog.dart';
 import 'image.dart';
 import 'incrementable.dart';
 import 'label_and_value.dart';
@@ -356,6 +357,18 @@ enum Role {
   /// with this role, they will be able to get the assistive technology's
   /// attention right away.
   liveRegion,
+
+  /// Adds the "dialog" ARIA role to the node.
+  ///
+  /// This corresponds to a semantics node that has both `scopesRoute` and
+  /// `namesRoute` bits set. While in Flutter a named route is not necessarily a
+  /// dialog, this is the closest analog on the web.
+  ///
+  /// Why is `scopesRoute` alone not sufficient? Because Flutter can create
+  /// routes that are not logically dialogs and there's nothing interesting to
+  /// announce to the user. For example, a modal barrier has `scopesRoute` set
+  /// but marking it as a dialog would be wrong.
+  dialog,
 }
 
 /// A function that creates a [RoleManager] for a [SemanticsObject].
@@ -370,6 +383,7 @@ final Map<Role, RoleManagerFactory> _roleFactories = <Role, RoleManagerFactory>{
   Role.checkable: (SemanticsObject object) => Checkable(object),
   Role.image: (SemanticsObject object) => ImageRoleManager(object),
   Role.liveRegion: (SemanticsObject object) => LiveRegion(object),
+  Role.dialog: (SemanticsObject object) => Dialog(object),
 };
 
 /// Provides the functionality associated with the role of the given
@@ -845,6 +859,15 @@ class SemanticsObject {
       !hasAction(ui.SemanticsAction.tap) &&
       !hasFlag(ui.SemanticsFlag.isButton);
 
+  /// Whether this node should be treated as an ARIA dialog.
+  ///
+  /// See also [Role.dialog].
+  bool get isDialog {
+    final bool scopesRoute = hasFlag(ui.SemanticsFlag.scopesRoute);
+    final bool namesRoute = hasFlag(ui.SemanticsFlag.namesRoute);
+    return scopesRoute && namesRoute;
+  }
+
   /// Whether this object carry enabled/disabled state (and if so whether it is
   /// enabled).
   ///
@@ -1241,7 +1264,11 @@ class SemanticsObject {
   /// Detects the roles that this semantics object corresponds to and manages
   /// the lifecycles of [SemanticsObjectRole] objects.
   void _updateRoles() {
-    _updateRole(Role.labelAndValue, (hasLabel || hasValue || hasTooltip) && !isTextField && !isVisualOnly);
+    // Some role managers manage labels themselves for various role-specific reasons.
+    final bool managesOwnLabel = isTextField || isDialog || isVisualOnly;
+    _updateRole(Role.labelAndValue, (hasLabel || hasValue || hasTooltip) && !managesOwnLabel);
+
+    _updateRole(Role.dialog, isDialog);
     _updateRole(Role.textField, isTextField);
 
     final bool shouldUseTappableRole =
@@ -1393,6 +1420,16 @@ class SemanticsObject {
     }
   }
 
+  /// Recursively visits the tree rooted at `this` node in depth-first fashion.
+  ///
+  /// Calls the [callback] for `this` node, then for all of its descendants.
+  void visitDepthFirst(void Function(SemanticsObject) callback) {
+    callback(this);
+    _currentChildrenInRenderOrder?.forEach((SemanticsObject child) {
+      child.visitDepthFirst(callback);
+    });
+  }
+
   @override
   String toString() {
     if (assertionsEnabled) {
@@ -1468,7 +1505,7 @@ class EngineSemanticsOwner {
 
   /// Map [SemanticsObject.id] to parent [SemanticsObject] it was attached to
   /// this frame.
-  Map<int?, SemanticsObject> _attachments = <int?, SemanticsObject>{};
+  Map<int, SemanticsObject> _attachments = <int, SemanticsObject>{};
 
   /// Declares that the [child] must be attached to the [parent].
   ///
@@ -1484,17 +1521,19 @@ class EngineSemanticsOwner {
   ///
   /// The objects in this list will be detached permanently unless they are
   /// reattached via the [_attachObject] method.
-  List<SemanticsObject?> _detachments = <SemanticsObject?>[];
+  List<SemanticsObject> _detachments = <SemanticsObject>[];
 
   /// Declares that the [SemanticsObject] with the given [id] was detached from
   /// its current parent object.
   ///
   /// The object will be detached permanently unless it is reattached via the
   /// [_attachObject] method.
-  void _detachObject(int? id) {
+  void _detachObject(int id) {
     assert(_semanticsTree.containsKey(id));
     final SemanticsObject? object = _semanticsTree[id];
-    _detachments.add(object);
+    if (object != null) {
+      _detachments.add(object);
+    }
   }
 
   /// Callbacks called after all objects in the tree have their properties
@@ -1513,20 +1552,30 @@ class EngineSemanticsOwner {
   /// the one-time callbacks scheduled via the [addOneTimePostUpdateCallback]
   /// method.
   void _finalizeTree() {
-    for (final SemanticsObject? object in _detachments) {
-      final SemanticsObject? parent = _attachments[object!.id];
-      if (parent == null) {
-        // Was not reparented and is removed permanently from the tree.
-        _semanticsTree.remove(object.id);
-        object._parent = null;
-        object.element.remove();
-      } else {
-        assert(object._parent == parent);
-        assert(object.element.parentNode == parent._childContainerElement);
+    for (final SemanticsObject detachmentRoot in _detachments) {
+      // A detached node may or may not have some of its descendants reattached
+      // elsewhere. Walk the descendant tree and find all descendants that were
+      // reattached to a parent. Those descendants need to be removed.
+      final List<SemanticsObject> removals = <SemanticsObject>[];
+      detachmentRoot.visitDepthFirst((SemanticsObject node) {
+        final SemanticsObject? parent = _attachments[node.id];
+        if (parent == null) {
+          // Was not reparented and is removed permanently from the tree.
+          removals.add(node);
+        } else {
+          assert(node._parent == parent);
+          assert(node.element.parentNode == parent._childContainerElement);
+        }
+      });
+
+      for (final SemanticsObject removal in removals) {
+        _semanticsTree.remove(removal.id);
+        removal._parent = null;
+        removal.element.remove();
       }
     }
-    _detachments = <SemanticsObject?>[];
-    _attachments = <int?, SemanticsObject>{};
+    _detachments = <SemanticsObject>[];
+    _attachments = <int, SemanticsObject>{};
 
     if (_oneTimePostUpdateCallbacks.isNotEmpty) {
       for (final ui.VoidCallback callback in _oneTimePostUpdateCallbacks) {
@@ -1595,7 +1644,7 @@ class EngineSemanticsOwner {
         _gestureMode = GestureMode.pointerEvents;
         _notifyGestureModeListeners();
       }
-      final List<int?> keys = _semanticsTree.keys.toList();
+      final List<int> keys = _semanticsTree.keys.toList();
       final int len = keys.length;
       for (int i = 0; i < len; i++) {
         _detachObject(keys[i]);
@@ -1828,7 +1877,23 @@ class EngineSemanticsOwner {
 
     assert(_semanticsTree.containsKey(0)); // must contain root node
     assert(() {
-      // Validate tree
+      // Validate that the node map only contains live elements, i.e. descendants
+      // of the root node. If a node is not reachable from the root, it should
+      // have been removed from the map.
+      final List<int> liveIds = <int>[];
+      final SemanticsObject root = _semanticsTree[0]!;
+      root.visitDepthFirst((SemanticsObject child) {
+        liveIds.add(child.id);
+      });
+      if (!_semanticsTree.keys.every(liveIds.contains)) {
+        throw AssertionError(
+          'The semantics node map is inconsistent:\n'
+          '  Nodes in tree: [${liveIds.join(', ')}]\n'
+          '  Nodes in map : [${_semanticsTree.keys.join(', ')}]'
+        );
+      }
+
+      // Validate that each node in the final tree is self-consistent.
       _semanticsTree.forEach((int? id, SemanticsObject object) {
         assert(id == object.id);
 

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -1529,8 +1529,8 @@ class EngineSemanticsOwner {
   /// The object will be detached permanently unless it is reattached via the
   /// [_attachObject] method.
   void _detachObject(int id) {
-    assert(_semanticsTree.containsKey(id));
     final SemanticsObject? object = _semanticsTree[id];
+    assert(object != null);
     if (object != null) {
       _detachments.add(object);
     }
@@ -1885,13 +1885,12 @@ class EngineSemanticsOwner {
       root.visitDepthFirst((SemanticsObject child) {
         liveIds.add(child.id);
       });
-      if (!_semanticsTree.keys.every(liveIds.contains)) {
-        throw AssertionError(
-          'The semantics node map is inconsistent:\n'
-          '  Nodes in tree: [${liveIds.join(', ')}]\n'
-          '  Nodes in map : [${_semanticsTree.keys.join(', ')}]'
-        );
-      }
+      assert(
+        _semanticsTree.keys.every(liveIds.contains),
+        'The semantics node map is inconsistent:\n'
+        '  Nodes in tree: [${liveIds.join(', ')}]\n'
+        '  Nodes in map : [${_semanticsTree.keys.join(', ')}]'
+      );
 
       // Validate that each node in the final tree is self-consistent.
       _semanticsTree.forEach((int? id, SemanticsObject object) {

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -2203,6 +2203,11 @@ void _testDialog() {
 <sem role="dialog" aria-label="this is a dialog label" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
 ''');
 
+    expect(
+      semantics().debugSemanticsTree![0]!.debugRoleManagerFor(Role.dialog),
+      isA<Dialog>(),
+    );
+
     semantics().semanticsEnabled = false;
   });
 
@@ -2236,6 +2241,16 @@ void _testDialog() {
       <String>[
         'Semantic node 0 was assigned dialog role, but is missing a label. A dialog should contain a label so that a screen reader can communicate to the user that a dialog appeared and a user action is requested.',
       ],
+    );
+
+    // But still sets the dialog role.
+    expectSemanticsTree('''
+<sem role="dialog" aria-label="" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
+''');
+
+    expect(
+      semantics().debugSemanticsTree![0]!.debugRoleManagerFor(Role.dialog),
+      isA<Dialog>(),
     );
 
     semantics().semanticsEnabled = false;

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -82,6 +82,9 @@ void runSemanticsTests() {
   group('group', () {
     _testGroup();
   });
+  group('dialog', () {
+    _testDialog();
+  });
 }
 
 void _testEngineAccessibilityBuilder() {
@@ -2167,6 +2170,73 @@ void _testGroup() {
     expectSemanticsTree('''
 <sem role="group" aria-label="this is a label for a group of elements" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
 ''');
+
+    semantics().semanticsEnabled = false;
+  });
+}
+
+void _testDialog() {
+  test('renders named and labeled routes', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
+    updateNode(
+      builder,
+      label: 'this is a dialog label',
+      flags: 0 | ui.SemanticsFlag.scopesRoute.index | ui.SemanticsFlag.namesRoute.index,
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      childrenInHitTestOrder: Int32List.fromList(<int>[1]),
+      childrenInTraversalOrder: Int32List.fromList(<int>[1]),
+    );
+    updateNode(
+      builder,
+      id: 1,
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+
+    semantics().updateSemantics(builder.build());
+    expectSemanticsTree('''
+<sem role="dialog" aria-label="this is a dialog label" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
+''');
+
+    semantics().semanticsEnabled = false;
+  });
+
+  test('warns about missing label', () {
+    final List<String> warnings = <String>[];
+    printWarning = warnings.add;
+
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
+    updateNode(
+      builder,
+      flags: 0 | ui.SemanticsFlag.scopesRoute.index | ui.SemanticsFlag.namesRoute.index,
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      childrenInHitTestOrder: Int32List.fromList(<int>[1]),
+      childrenInTraversalOrder: Int32List.fromList(<int>[1]),
+    );
+    updateNode(
+      builder,
+      id: 1,
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+
+    semantics().updateSemantics(builder.build());
+    expect(
+      warnings,
+      <String>[
+        'Semantic node 0 was assigned dialog role, but is missing a label. A dialog should contain a label so that a screen reader can communicate to the user that a dialog appeared and a user action is requested.',
+      ],
+    );
 
     semantics().semanticsEnabled = false;
   });

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -847,6 +847,92 @@ void _testContainer() {
 
     semantics().semanticsEnabled = false;
   });
+
+  test('descendant nodes are removed from the node map, unless reparented', () async {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    {
+      final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
+      updateNode(
+        builder,
+        childrenInTraversalOrder: Int32List.fromList(<int>[1, 2]),
+        childrenInHitTestOrder: Int32List.fromList(<int>[1, 2]),
+      );
+      updateNode(
+        builder,
+        id: 1,
+        childrenInTraversalOrder: Int32List.fromList(<int>[3, 4]),
+        childrenInHitTestOrder: Int32List.fromList(<int>[3, 4]),
+      );
+      updateNode(
+        builder,
+        id: 2,
+        childrenInTraversalOrder: Int32List.fromList(<int>[5, 6]),
+        childrenInHitTestOrder: Int32List.fromList(<int>[5, 6]),
+      );
+      updateNode(builder, id: 3);
+      updateNode(builder, id: 4);
+      updateNode(builder, id: 5);
+      updateNode(builder, id: 6);
+
+      semantics().updateSemantics(builder.build());
+      expectSemanticsTree('''
+  <sem style="$rootSemanticStyle">
+    <sem-c>
+      <sem style="z-index: 2">
+        <sem-c>
+          <sem style="z-index: 2"></sem>
+          <sem style="z-index: 1"></sem>
+        </sem-c>
+      </sem>
+      <sem style="z-index: 1">
+        <sem-c>
+          <sem style="z-index: 2"></sem>
+          <sem style="z-index: 1"></sem>
+        </sem-c>
+      </sem>
+    </sem-c>
+  </sem>''');
+
+      expect(EngineSemanticsOwner.instance.debugSemanticsTree!.keys.toList(), unorderedEquals(<int>[0, 1, 2, 3, 4, 5, 6]));
+    }
+
+    // Remove node #2 => expect nodes #2 and #5 to be removed and #6 reparented.
+    {
+      final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
+      updateNode(
+        builder,
+        childrenInTraversalOrder: Int32List.fromList(<int>[1]),
+        childrenInHitTestOrder: Int32List.fromList(<int>[1]),
+      );
+      updateNode(
+        builder,
+        id: 1,
+        childrenInTraversalOrder: Int32List.fromList(<int>[3, 4, 6]),
+        childrenInHitTestOrder: Int32List.fromList(<int>[3, 4, 6]),
+      );
+
+      semantics().updateSemantics(builder.build());
+      expectSemanticsTree('''
+  <sem style="$rootSemanticStyle">
+    <sem-c>
+      <sem style="z-index: 2">
+        <sem-c>
+          <sem style="z-index: 3"></sem>
+          <sem style="z-index: 2"></sem>
+          <sem style="z-index: 1"></sem>
+        </sem-c>
+      </sem>
+    </sem-c>
+  </sem>''');
+
+      expect(EngineSemanticsOwner.instance.debugSemanticsTree!.keys.toList(), unorderedEquals(<int>[0, 1, 3, 4, 6]));
+    }
+
+    semantics().semanticsEnabled = false;
+  });
 }
 
 void _testVerticalScrolling() {
@@ -951,7 +1037,7 @@ void _testVerticalScrolling() {
       childrenInTraversalOrder: Int32List.fromList(<int>[1, 2, 3]),
     );
 
-    for (int id = 1; id <= 5; id++) {
+    for (int id = 1; id <= 3; id++) {
       updateNode(
         builder,
         id: id,


### PR DESCRIPTION
Fixes two issues in dialog accessibility:

* Fixes https://github.com/flutter/flutter/issues/45207 by setting `role="dialog"` on nodes that have both `scopesRoute` and `namesRoute` set. There's no guarantee that this combination of flags is an actual dialog, but it's close enough, and it makes the screen reader announce the appearance of the dialog. Note that `scopesRoute` alone is not sufficient, because Flutter uses it for overlays that are not semantically dialogs, such as dismiss barriers.
* Fixes an issue with focus management, where focus fails to transfer to background content after the dialog is dismissed. This happened because `EngineSemanticsOwner._semanticsTree` retained descendants of parents that were removed. This is benign in many cases. However, for focus this is problematic because the HTML element can go away and come back (losing focus along the way), but its corresponding `SemanticsObject` is never marked as "dirty" and fails to update and request focus.

I'm hoping this is sufficient to fix b/251839784 as well. Will work with the relevant team to find out.