### PR TITLE
Migrate SkSurface::getBackend* methods to static functions

### DIFF
--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -11,6 +11,7 @@
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 
 #include <cstdlib>
 #include <memory>
@@ -97,8 +98,8 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
     return false;
   }
 
-  GrBackendRenderTarget render_target = surface->getBackendRenderTarget(
-      SkSurface::BackendHandleAccess::kDiscardWrite_BackendHandleAccess);
+  GrBackendRenderTarget render_target = SkSurfaces::GetBackendRenderTarget(
+      surface.get(), SkSurfaces::BackendHandleAccess::kDiscardWrite);
 
   if (!render_target.isValid()) {
     FML_LOG(ERROR) << "Backend render target was invalid.";
@@ -150,8 +151,8 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(
     return false;
   }
 
-  GrBackendTexture render_texture = surface->getBackendTexture(
-      SkSurface::BackendHandleAccess::kDiscardWrite_BackendHandleAccess);
+  GrBackendTexture render_texture = SkSurfaces::GetBackendTexture(
+      surface.get(), SkSurfaces::BackendHandleAccess::kDiscardWrite);
 
   if (!render_texture.isValid()) {
     FML_LOG(ERROR) << "Backend render texture was invalid.";

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -18,6 +18,7 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSemaphore.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
+#include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 #include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkExtensions.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
@@ -221,9 +222,9 @@ bool VulkanSurfaceProducer::TransitionSurfacesToExternal(
     if (!command_buffer->Begin())
       return false;
 
-    GrBackendRenderTarget backendRT =
-        vk_surface->GetSkiaSurface()->getBackendRenderTarget(
-            SkSurface::kFlushRead_BackendHandleAccess);
+    GrBackendRenderTarget backendRT = SkSurfaces::GetBackendRenderTarget(
+        vk_surface->GetSkiaSurface().get(),
+        SkSurfaces::BackendHandleAccess::kFlushRead);
     if (!backendRT.isValid()) {
       return false;
     }

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -10,6 +10,7 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 
 #include "vulkan_backbuffer.h"
@@ -476,8 +477,8 @@ VulkanSwapchain::AcquireResult VulkanSwapchain::AcquireSurface() {
     return error;
   }
 
-  GrBackendRenderTarget backendRT = surface->getBackendRenderTarget(
-      SkSurface::kFlushRead_BackendHandleAccess);
+  GrBackendRenderTarget backendRT = SkSurfaces::GetBackendRenderTarget(
+      surface.get(), SkSurfaces::BackendHandleAccess::kFlushRead);
   if (!backendRT.isValid()) {
     FML_DLOG(INFO) << "Could not get backend render target.";
     return error;


### PR DESCRIPTION
In https://skia-review.googlesource.com/c/skia/+/687642, Skia moved some gpu-related methods on SkSurface to be static functions in a different header. This updates those callsites in Flutter.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
