### PR TITLE
[Web+Linux] Fix pressing Meta keys throws

### DIFF
--- a/lib/web_ui/lib/src/engine/raw_keyboard.dart
+++ b/lib/web_ui/lib/src/engine/raw_keyboard.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import '../engine.dart'  show registerHotRestartListener;
+import 'browser_detection.dart';
 import 'dom.dart';
 import 'keyboard_binding.dart';
 import 'platform_dispatcher.dart';
@@ -133,7 +134,7 @@ class RawKeyboard {
         _lastMetaState |= modifierNumLock;
       } else if (event.key == 'ScrollLock') {
         _lastMetaState |= modifierScrollLock;
-      } else if (event.key == 'Meta') {
+      } else if (event.key == 'Meta' && operatingSystem == OperatingSystem.linux) {
         // On Chrome Linux, metaState can be wrong when a Meta key is pressed.
         _lastMetaState |= _modifierMeta;
       }

--- a/lib/web_ui/lib/src/engine/raw_keyboard.dart
+++ b/lib/web_ui/lib/src/engine/raw_keyboard.dart
@@ -133,6 +133,9 @@ class RawKeyboard {
         _lastMetaState |= modifierNumLock;
       } else if (event.key == 'ScrollLock') {
         _lastMetaState |= modifierScrollLock;
+      } else if (event.key == 'Meta') {
+        // On Chrome Linux, metaState can be wrong when a Meta key is pressed.
+        _lastMetaState |= _modifierMeta;
       }
     }
     final Map<String, dynamic> eventData = <String, dynamic>{

--- a/lib/web_ui/test/engine/raw_keyboard_test.dart
+++ b/lib/web_ui/test/engine/raw_keyboard_test.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'package:quiver/testing/async.dart';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
+import 'package:ui/src/engine/browser_detection.dart';
 import 'package:ui/src/engine/dom.dart';
 import 'package:ui/src/engine/raw_keyboard.dart';
 import 'package:ui/src/engine/services.dart';
@@ -178,7 +179,7 @@ void testMain() {
         'keyCode': 0,
       });
       RawKeyboard.instance!.dispose();
-    });
+    }, skip: operatingSystem != OperatingSystem.linux);
 
     test('dispatches repeat events', () {
       RawKeyboard.initialize();


### PR DESCRIPTION
## Description

This PR fixes Meta keys throwing exception on Chrome Linux.

The assertions throws because the DOM event sent when Meta keys is pressed is not coherent when Meta is the only pressed key.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/125672

## Tests

Adds 1 test.


