### PR TITLE
Add relative path support for malioc_diff.

### DIFF
--- a/impeller/tools/malioc_diff.py
+++ b/impeller/tools/malioc_diff.py
@@ -44,6 +44,12 @@ CORES = [
     'Mali-T880',  # 2016
 ]
 
+# Path to the engine root checkout. This is used to calculate absolute
+# paths if relative ones are passed to the script.
+BUILD_ROOT_DIR = os.path.abspath(
+    os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
+)
+
 
 def parse_args(argv):
   parser = argparse.ArgumentParser(
@@ -277,6 +283,17 @@ def compare_shaders(malioc_tree, before_shader, after_shader):
 
 def main(argv):
   args = parse_args(argv[1:])
+
+  # Generate full paths if relative ones are provided.
+  args.before = (
+      args.before if os.path.isabs(args.before) else
+      os.path.join(BUILD_ROOT_DIR, args.before)
+  )
+  args.after = (
+      args.after if os.path.isabs(args.after) else
+      os.path.join(BUILD_ROOT_DIR, args.after)
+  )
+
   if not validate_args(args):
     return 1
 

--- a/impeller/tools/malioc_diff.py
+++ b/impeller/tools/malioc_diff.py
@@ -108,6 +108,23 @@ def parse_args(argv):
 
 
 def validate_args(args):
+  if not args.after and not args.after_relative_to_src:
+    print('--after argument or --after-relative-to-src must be specified.')
+    return False
+
+  if not args.before and not args.before_relative_to_src:
+    print('--before argument or --before-relative-to-src must be specified.')
+    return False
+
+  # Generate full paths if relative ones are provided with before and
+  # after taking precedence.
+  args.before = (
+      args.before or os.path.join(BUILD_ROOT_DIR, args.before_relative_to_src)
+  )
+  args.after = (
+      args.after or os.path.join(BUILD_ROOT_DIR, args.after_relative_to_src)
+  )
+
   if not args.after or not os.path.isdir(args.after):
     print('The --after argument must refer to a directory.')
     return False
@@ -299,15 +316,6 @@ def compare_shaders(malioc_tree, before_shader, after_shader):
 
 def main(argv):
   args = parse_args(argv[1:])
-
-  # Generate full paths if relative ones are provided with before and
-  # after taking precedence.
-  args.before = (
-      args.before or os.path.join(BUILD_ROOT_DIR, args.before_relative_to_src)
-  )
-  args.after = (
-      args.after or os.path.join(BUILD_ROOT_DIR, args.after_relative_to_src)
-  )
 
   if not validate_args(args):
     return 1

--- a/impeller/tools/malioc_diff.py
+++ b/impeller/tools/malioc_diff.py
@@ -68,6 +68,22 @@ def parse_args(argv):
       help='The path to a json file containing existing malioc results.',
   )
   parser.add_argument(
+      '--after-relative-to-checkout',
+      type=str,
+      help=(
+          'A relative path calculated from the checkout directory to '
+          'a directory tree containing new malioc results in json files'
+      ),
+  )
+  parser.add_argument(
+      '--before-relative-to-checkout',
+      type=str,
+      help=(
+          'A relative path calculated from the checkout directory to '
+          'a json file containing existing malioc results in json files'
+      ),
+  )
+  parser.add_argument(
       '--print-diff',
       '-p',
       default=False,
@@ -284,14 +300,15 @@ def compare_shaders(malioc_tree, before_shader, after_shader):
 def main(argv):
   args = parse_args(argv[1:])
 
-  # Generate full paths if relative ones are provided.
+  # Generate full paths if relative ones are provided with before and
+  # after taking precedence.
   args.before = (
-      args.before if os.path.isabs(args.before) else
-      os.path.join(BUILD_ROOT_DIR, args.before)
+      args.before or
+      os.path.join(BUILD_ROOT_DIR, args.before_relative_to_checkout)
   )
   args.after = (
-      args.after if os.path.isabs(args.after) else
-      os.path.join(BUILD_ROOT_DIR, args.after)
+      args.after or
+      os.path.join(BUILD_ROOT_DIR, args.after_relative_to_checkout)
   )
 
   if not validate_args(args):

--- a/impeller/tools/malioc_diff.py
+++ b/impeller/tools/malioc_diff.py
@@ -316,7 +316,6 @@ def compare_shaders(malioc_tree, before_shader, after_shader):
 
 def main(argv):
   args = parse_args(argv[1:])
-
   if not validate_args(args):
     return 1
 

--- a/impeller/tools/malioc_diff.py
+++ b/impeller/tools/malioc_diff.py
@@ -68,18 +68,18 @@ def parse_args(argv):
       help='The path to a json file containing existing malioc results.',
   )
   parser.add_argument(
-      '--after-relative-to-checkout',
+      '--after-relative-to-src',
       type=str,
       help=(
-          'A relative path calculated from the checkout directory to '
+          'A relative path calculated from the engine src directory to '
           'a directory tree containing new malioc results in json files'
       ),
   )
   parser.add_argument(
-      '--before-relative-to-checkout',
+      '--before-relative-to-src',
       type=str,
       help=(
-          'A relative path calculated from the checkout directory to '
+          'A relative path calculated from the engine src directory to '
           'a json file containing existing malioc results in json files'
       ),
   )
@@ -303,12 +303,10 @@ def main(argv):
   # Generate full paths if relative ones are provided with before and
   # after taking precedence.
   args.before = (
-      args.before or
-      os.path.join(BUILD_ROOT_DIR, args.before_relative_to_checkout)
+      args.before or os.path.join(BUILD_ROOT_DIR, args.before_relative_to_src)
   )
   args.after = (
-      args.after or
-      os.path.join(BUILD_ROOT_DIR, args.after_relative_to_checkout)
+      args.after or os.path.join(BUILD_ROOT_DIR, args.after_relative_to_src)
   )
 
   if not validate_args(args):


### PR DESCRIPTION
Relative paths are required for integrating this tool as a test in engine v2.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
