### PR TITLE
[Impeller] Remove the DrawPaint->Clear optimization

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1818,18 +1818,6 @@ TEST_P(AiksTest, OpacityPeepHoleApplicationTest) {
   ASSERT_TRUE(delegate->CanCollapseIntoParentPass(entity_pass.get()));
 }
 
-TEST_P(AiksTest, DrawPaintAbsorbsClears) {
-  Canvas canvas;
-  canvas.DrawPaint({.color = Color::Red(), .blend_mode = BlendMode::kSource});
-  canvas.DrawPaint(
-      {.color = Color::CornflowerBlue(), .blend_mode = BlendMode::kSource});
-
-  Picture picture = canvas.EndRecordingAsPicture();
-
-  ASSERT_EQ(picture.pass->GetElementCount(), 0u);
-  ASSERT_EQ(picture.pass->GetClearColor(), Color::CornflowerBlue());
-}
-
 TEST_P(AiksTest, ForegroundBlendSubpassCollapseOptimization) {
   Canvas canvas;
 

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -172,16 +172,6 @@ void Canvas::DrawPath(const Path& path, const Paint& paint) {
 }
 
 void Canvas::DrawPaint(const Paint& paint) {
-  if (xformation_stack_.size() == 1 &&  // If we're recording the root pass,
-      GetCurrentPass().GetElementCount() == 0  // and this is the first item,
-  ) {
-    // Then we can absorb this drawPaint as the clear color of the pass.
-    auto color = Color::BlendColor(
-        paint.color, GetCurrentPass().GetClearColor(), paint.blend_mode);
-    GetCurrentPass().SetClearColor(color);
-    return;
-  }
-
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/125906.
Fixes https://github.com/flutter/flutter/issues/125908.

Going to add this back once I'm able to work out why the clear colors aren't working on GL/Vulkan. Stepping though with a debugger for both GLES and Vulkan, the clear colors seems to be getting piped through as expected. But the frame captures reveal that they're actually not.