### PR TITLE
[macOS] Remove view ID from public 

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h
@@ -17,17 +17,6 @@
 
 // TODO: Merge this file with the iOS FlutterEngine.h.
 
-/**
- * The view ID for APIs that don't support multi-view.
- *
- * Some single-view APIs will eventually be replaced by their multi-view
- * variant. During the deprecation period, the single-view APIs will coexist with
- * and work with the multi-view APIs as if the other views don't exist.  For
- * backward compatibility, single-view APIs will always operate on the view with
- * this ID. Also, the first view assigned to the engine will also have this ID.
- */
-extern const uint64_t kFlutterDefaultViewId;
-
 @class FlutterViewController;
 
 /**

--- a/shell/platform/darwin/macos/framework/Headers/FlutterPluginRegistrarMacOS.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterPluginRegistrarMacOS.h
@@ -45,11 +45,6 @@ FLUTTER_DARWIN_EXPORT
 @property(nullable, readonly) NSView* view;
 
 /**
- * The `NSView` associated with the given view ID, if any.
- */
-- (nullable NSView*)viewForId:(uint64_t)viewId;
-
-/**
  * Registers |delegate| to receive handleMethodCall:result: callbacks for the given |channel|.
  */
 - (void)addMethodCallDelegate:(nonnull id<FlutterPlugin>)delegate

--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -54,16 +54,6 @@ FLUTTER_DARWIN_EXPORT
 @property(nonatomic, nonnull, readonly) FlutterEngine* engine;
 
 /**
- * The identifier for this view controller.
- *
- * The ID is assigned by FlutterEngine when the view controller is attached.
- *
- * If the view controller is unattached (see FlutterViewController#attached),
- * reading this property throws an assertion.
- */
-@property(nonatomic, readonly) uint64_t viewId;
-
-/**
  * The style of mouse tracking to use for the view. Defaults to
  * FlutterMouseTrackingModeInKeyWindow.
  */

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -13,6 +13,16 @@
 
 @interface FlutterViewController () <FlutterKeyboardViewDelegate>
 
+/**
+ * The identifier for this view controller.
+ *
+ * The ID is assigned by FlutterEngine when the view controller is attached.
+ *
+ * If the view controller is unattached (see FlutterViewController#attached),
+ * reading this property throws an assertion.
+ */
+@property(nonatomic, readonly) uint64_t viewId;
+
 // The FlutterView for this view controller.
 @property(nonatomic, readonly, nullable) FlutterView* flutterView;
 


### PR DESCRIPTION
This is a reland of https://github.com/flutter/engine/pull/39958, but only contains the minimal changes that removes all references to viewId from public interfaces, reverting these changes from https://github.com/flutter/engine/pull/39576.

Flutter doesn't really support multi-view anyway. These methods currently only works for view 0. We better remove them until we mark multi-view stable. It was a mistake that I decided to add them to public interfaces.

For the reason why https://github.com/flutter/engine/pull/39958 failed, I'm pretty sure it's the change to [platform_dispatcher.dart](https://github.com/flutter/engine/pull/39958/files#diff-57d6953e215d0e5dd7260ee60b665c812aa730566ef0b30f7ff1e3d661143585) that mysteriously and unintentionally appeared in the change list.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
