### PR TITLE
[Impeller] check if path is Rect/RRect/Oval

### DIFF
--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -895,11 +895,15 @@ void DlDispatcher::drawDRRect(const SkRRect& outer, const SkRRect& inner) {
 void DlDispatcher::drawPath(const SkPath& path) {
   SkRect rect;
   SkRRect rrect;
+  SkRect oval;
   if (path.isRect(&rect)) {
     canvas_.DrawRect(skia_conversions::ToRect(rect), paint_);
   } else if (path.isRRect(&rrect) && rrect.isSimple()) {
     canvas_.DrawRRect(skia_conversions::ToRect(rrect.rect()),
                       rrect.getSimpleRadii().fX, paint_);
+  } else if (path.isOval(&oval) && oval.width() == oval.height()) {
+    canvas_.DrawCircle(skia_conversions::ToPoint(oval.center()),
+                       oval.width() * 0.5, paint_);
   } else {
     canvas_.DrawPath(skia_conversions::ToPath(path), paint_);
   }

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -893,7 +893,16 @@ void DlDispatcher::drawDRRect(const SkRRect& outer, const SkRRect& inner) {
 
 // |flutter::DlOpReceiver|
 void DlDispatcher::drawPath(const SkPath& path) {
-  canvas_.DrawPath(skia_conversions::ToPath(path), paint_);
+  SkRect rect;
+  SkRRect rrect;
+  if (path.isRect(&rect)) {
+    canvas_.DrawRect(skia_conversions::ToRect(rect), paint_);
+  } else if (path.isRRect(&rrect) && rrect.isSimple()) {
+    canvas_.DrawRRect(skia_conversions::ToRect(rrect.rect()),
+                      rrect.getSimpleRadii().fX, paint_);
+  } else {
+    canvas_.DrawPath(skia_conversions::ToPath(path), paint_);
+  }
 }
 
 // |flutter::DlOpReceiver|


### PR DESCRIPTION
This avoids tessellation if the application draws a Rect or RREct with Path.addRect or Path.addRREct.