### PR TITLE
ColorFilterLayer clips to its paint bounds

### DIFF
--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -82,6 +82,16 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
     }
   }
 
+  // If the color filter modifies transparent black, then when it's applied to
+  // a saveLayer, that layer will extend beyond the paint bounds provided in the
+  // SaveLayerRec (which defines the bounds of the content within the layer, not
+  // the extent of the layer during the restore()). ColorFilterLayer must clip
+  // before the saveLayer in these cases to ensure it doesn't go beyond its
+  // reported paint_bounds().
+  if (filter_ && filter_.affects_transparent_black()) {
+    mutator.applyClipRect(paint_bounds());
+  }
+
   // Now apply the color filter and then try rendering children either from
   // cache or directly.
   mutator.applyColorFilter(paint_bounds(), filter_);

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -88,8 +88,8 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   // the extent of the layer during the restore()). ColorFilterLayer must clip
   // before the saveLayer in these cases to ensure it doesn't go beyond its
   // reported paint_bounds().
-  if (filter_ && filter_.affects_transparent_black()) {
-    mutator.applyClipRect(paint_bounds());
+  if (filter_ && filter_.modifies_transparent_black()) {
+    mutator.clipRect(paint_bounds(), /*is_aa=*/false);
   }
 
   // Now apply the color filter and then try rendering children either from

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -88,7 +88,7 @@ void ColorFilterLayer::Paint(PaintContext& context) const {
   // the extent of the layer during the restore()). ColorFilterLayer must clip
   // before the saveLayer in these cases to ensure it doesn't go beyond its
   // reported paint_bounds().
-  if (filter_ && filter_.modifies_transparent_black()) {
+  if (filter_ && filter_->modifies_transparent_black()) {
     mutator.clipRect(paint_bounds(), /*is_aa=*/false);
   }
 

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -469,7 +469,6 @@ TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
       std::make_shared<DlMatrixColorFilter>(matrix));
   color_filter_layer->Add(mock_layer);
 
-  PrerollContext* context = preroll_context();
   color_filter_layer->Preroll(preroll_context());
 
   DisplayListBuilder expected_builder;

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -447,5 +447,50 @@ TEST_F(ColorFilterLayerTest, OpacityInheritance) {
   EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
 }
 
+TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
+  // In Skia, saveLayers with a color filter that modifies transparent black
+  // will fill all pixels within the clip, going beyond the user bounds hint.
+  // ColorFilterLayer must insert a clipRect before saveLayer to ensure it
+  // doesn't draw beyond its reported bounds.
+  // clang-format off
+  float matrix[20] = {
+    -1, 0, 0, 0, 1,
+     0,-1, 0, 0, 1,
+     0, 0,-1, 0, 1,
+     0, 0, 0,-1, 1,
+  };
+  // clang-format on
+  auto layer_filter = DlMatrixColorFilter(matrix);
+  ASSERT_TRUE(layer_filter.modifies_transparent_black());
+
+  const SkPath child_path = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
+  auto mock_layer = std::make_shared<MockLayer>(child_path);
+  auto color_filter_layer = std::make_shared<ColorFilterLayer>(
+      std::make_shared<DlMatrixColorFilter>(matrix));
+  color_filter_layer->Add(mock_layer);
+
+  PrerollContext* context = preroll_context();
+  context->subtree_can_inherit_opacity = false;
+  color_filter_layer->Preroll(preroll_context(), SkMatrix::I());
+
+  DisplayListBuilder expected_builder;
+  /* ColorFilterLayer::Paint() */ {
+    DlPaint dl_paint;
+    dl_paint.setColorFilter(&layer_filter);
+    expected_builder.save();
+    expected_builder.clipRect(child_path.getBounds(), SkClipOp::kIntersect,
+                              /*is_aa=*/false);
+    expected_builder.saveLayer(&child_path.getBounds(), &dl_paint);
+    /* MockLayer::Paint() */ {
+      expected_builder.drawPath(child_path, DlPaint().setColor(0xFF000000));
+    }
+    expected_builder.restore();
+    expected_builder.restore();
+  }
+
+  color_filter_layer->Paint(display_list_paint_context());
+  EXPECT_TRUE(DisplayListsEQ_Verbose(expected_builder.Build(), display_list()));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -478,8 +478,8 @@ TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
     DlPaint dl_paint;
     dl_paint.setColorFilter(&layer_filter);
     expected_builder.Save();
-    expected_builder.ClipRect(child_path.getBounds(), ClipOp::kIntersect,
-                              /*is_aa=*/false);
+    expected_builder.ClipRect(child_path.getBounds(),
+                              DlCanvas::ClipOp::kIntersect, /*is_aa=*/false);
     expected_builder.SaveLayer(&child_path.getBounds(), &dl_paint);
     /* MockLayer::Paint() */ {
       expected_builder.DrawPath(child_path, DlPaint(0xFF000000));

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -470,8 +470,7 @@ TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
   color_filter_layer->Add(mock_layer);
 
   PrerollContext* context = preroll_context();
-  context->subtree_can_inherit_opacity = false;
-  color_filter_layer->Preroll(preroll_context(), SkMatrix::I());
+  color_filter_layer->Preroll(preroll_context());
 
   DisplayListBuilder expected_builder;
   /* ColorFilterLayer::Paint() */ {

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -477,15 +477,15 @@ TEST_F(ColorFilterLayerTest, ModifiesTransparentBlack) {
   /* ColorFilterLayer::Paint() */ {
     DlPaint dl_paint;
     dl_paint.setColorFilter(&layer_filter);
-    expected_builder.save();
-    expected_builder.clipRect(child_path.getBounds(), SkClipOp::kIntersect,
+    expected_builder.Save();
+    expected_builder.ClipRect(child_path.getBounds(), ClipOp::kIntersect,
                               /*is_aa=*/false);
-    expected_builder.saveLayer(&child_path.getBounds(), &dl_paint);
+    expected_builder.SaveLayer(&child_path.getBounds(), &dl_paint);
     /* MockLayer::Paint() */ {
-      expected_builder.drawPath(child_path, DlPaint().setColor(0xFF000000));
+      expected_builder.DrawPath(child_path, DlPaint(0xFF000000));
     }
-    expected_builder.restore();
-    expected_builder.restore();
+    expected_builder.Restore();
+    expected_builder.Restore();
   }
 
   color_filter_layer->Paint(display_list_paint_context());

--- a/tools/gn
+++ b/tools/gn
@@ -300,8 +300,6 @@ def to_gn_args(args):
   gn_args['skia_use_wuffs'] = True
   gn_args['skia_use_expat'] = args.target_os == 'android'
   gn_args['skia_use_fontconfig'] = args.enable_fontconfig
-  gn_args['skia_use_legacy_layer_bounds'
-         ] = True  # Temporary: See skbug.com/12083, skbug.com/12303.
   gn_args['skia_use_legacy_colorfilter_imagefilter'] = True  # Temporary staging
   gn_args['skia_use_icu'] = True
   gn_args['is_official_build'] = True  # Disable Skia test utilities.


### PR DESCRIPTION
Removes use of staging flag skia_use_legacy_layer_bounds, and preserves previous behavior for ColorFilterLayers that affect transparent black by clipping before the saveLayer() to prevent the layer from changing all transparent black pixels on the canvas. Adds a unit test to make sure the display list is modified appropriately in that case.

https://bugs.chromium.org/p/skia/issues/detail?id=12083

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
