### PR TITLE
Fix flaky FlutterChannelsTests, stop mocking `NSObject`

### DIFF
--- a/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// These tests are flaky on arm64.
-// TODO(dnfield): reenable after fixing https://github.com/flutter/flutter/issues/126013
-#if !defined(__aarch64__) && !defined(__arm64__)
-
 #if !__has_feature(objc_arc)
 #error ARC must be enabled!
 #endif
@@ -14,6 +10,9 @@
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+
+@protocol FlutterTaskQueue <NSObject>
+@end
 
 @interface MockBinaryMessenger : NSObject <FlutterBinaryMessenger>
 @property(nonatomic, copy) NSString* channel;
@@ -218,7 +217,7 @@
   FlutterBinaryMessengerConnection connection = 123;
   id binaryMessenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   id codec = OCMProtocolMock(@protocol(FlutterMethodCodec));
-  id taskQueue = OCMClassMock([NSObject class]);
+  id taskQueue = OCMProtocolMock(@protocol(FlutterTaskQueue));
   FlutterBasicMessageChannel* channel =
       [[FlutterBasicMessageChannel alloc] initWithName:channelName
                                        binaryMessenger:binaryMessenger
@@ -246,7 +245,7 @@
     FlutterBinaryMessengerConnection connection = 123;
     id binaryMessenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
     id codec = OCMProtocolMock(@protocol(FlutterMessageCodec));
-    id taskQueue = OCMClassMock([NSObject class]);
+    id taskQueue = OCMProtocolMock(@protocol(FlutterTaskQueue));
     FlutterBasicMessageChannel* channel =
         [[FlutterBasicMessageChannel alloc] initWithName:channelName
                                          binaryMessenger:binaryMessenger
@@ -283,7 +282,7 @@
   @autoreleasepool {
     id binaryMessenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
     id codec = OCMProtocolMock(@protocol(FlutterMethodCodec));
-    id taskQueue = OCMClassMock([NSObject class]);
+    id taskQueue = OCMProtocolMock(@protocol(FlutterTaskQueue));
     FlutterMethodChannel* channel = [[FlutterMethodChannel alloc] initWithName:channelName
                                                                binaryMessenger:binaryMessenger
                                                                          codec:codec
@@ -315,7 +314,7 @@
   FlutterBinaryMessengerConnection connection = 123;
   id binaryMessenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   id codec = OCMProtocolMock(@protocol(FlutterMethodCodec));
-  id taskQueue = OCMClassMock([NSObject class]);
+  id taskQueue = OCMProtocolMock(@protocol(FlutterTaskQueue));
   FlutterMethodChannel* channel = [[FlutterMethodChannel alloc] initWithName:channelName
                                                              binaryMessenger:binaryMessenger
                                                                        codec:codec
@@ -340,7 +339,7 @@
   FlutterBinaryMessengerConnection connection = 123;
   id binaryMessenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   id codec = OCMProtocolMock(@protocol(FlutterMethodCodec));
-  id taskQueue = OCMClassMock([NSObject class]);
+  id taskQueue = OCMProtocolMock(@protocol(FlutterTaskQueue));
   id handler = OCMProtocolMock(@protocol(FlutterStreamHandler));
   FlutterEventChannel* channel = [[FlutterEventChannel alloc] initWithName:channelName
                                                            binaryMessenger:binaryMessenger
@@ -360,5 +359,3 @@
 }
 
 @end
-
-#endif  // !defined(__arch64__) && !defined(__arm64__)


### PR DESCRIPTION
I don't know why this is only flaking on arm64 Macs, but instead of mocking out `NSObject` which seems to continue to be mocked on some background thread, instead mock out the more-specific `FlutterTaskQueue` protocol.  My suspicion is that the `no class for metaclass` is complaining when it tries to get the `isa` off an object's metaclass NSObject but the whole `NSObject` class is mocked out at that point?  Something like that.

Turn the tests back on.

Fixes https://github.com/flutter/flutter/issues/126013
Reverts https://github.com/flutter/engine/pull/41740

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
