### PR TITLE
[macOS] Wait for binding to be ready before requesting exits from framework

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate.mm
@@ -55,7 +55,7 @@
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication* _Nonnull)sender {
   // If the framework has already told us to terminate, terminate immediately.
-  if ([[self terminationHandler] shouldTerminate]) {
+  if ([self terminationHandler] == nil || [[self terminationHandler] shouldTerminate]) {
     return NSTerminateNow;
   }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -168,7 +168,7 @@ constexpr char kTextPlainFormat[] = "text/plain";
 - (instancetype)initWithEngine:(FlutterEngine*)engine
                     terminator:(FlutterTerminationCallback)terminator {
   self = [super init];
-  _bindingIsReady = NO;
+  _acceptingRequests = NO;
   _engine = engine;
   _terminator = terminator ? terminator : ^(id sender) {
     // Default to actually terminating the application. The terminator exists to
@@ -206,8 +206,8 @@ constexpr char kTextPlainFormat[] = "text/plain";
                              exitType:(FlutterAppExitType)type
                                result:(nullable FlutterResult)result {
   _shouldTerminate = YES;
-  if (![self bindingIsReady]) {
-    // Until the binding has signaled that it is ready to handle application
+  if (![self acceptingRequests]) {
+    // Until the Dart application has signaled that it is ready to handle
     // termination requests, the app will just terminate when asked.
     type = kFlutterAppExitTypeRequired;
   }
@@ -1038,7 +1038,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
   } else if ([call.method isEqualToString:@"System.exitApplication"]) {
     [[self terminationHandler] handleRequestAppExitMethodCall:call.arguments result:result];
   } else if ([call.method isEqualToString:@"System.initializationComplete"]) {
-    [self terminationHandler].bindingIsReady = YES;
+    [self terminationHandler].acceptingRequests = YES;
     result(nil);
   } else {
     result(FlutterMethodNotImplemented);

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -168,6 +168,7 @@ constexpr char kTextPlainFormat[] = "text/plain";
 - (instancetype)initWithEngine:(FlutterEngine*)engine
                     terminator:(FlutterTerminationCallback)terminator {
   self = [super init];
+  _bindingIsReady = NO;
   _engine = engine;
   _terminator = terminator ? terminator : ^(id sender) {
     // Default to actually terminating the application. The terminator exists to
@@ -205,6 +206,11 @@ constexpr char kTextPlainFormat[] = "text/plain";
                              exitType:(FlutterAppExitType)type
                                result:(nullable FlutterResult)result {
   _shouldTerminate = YES;
+  if (![self bindingIsReady]) {
+    // Until the binding has signaled that it is ready to handle application
+    // termination requests, the app will just terminate when asked.
+    type = kFlutterAppExitTypeRequired;
+  }
   switch (type) {
     case kFlutterAppExitTypeCancelable: {
       FlutterJSONMethodCodec* codec = [FlutterJSONMethodCodec sharedInstance];
@@ -1032,8 +1038,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
   } else if ([call.method isEqualToString:@"System.exitApplication"]) {
     [[self terminationHandler] handleRequestAppExitMethodCall:call.arguments result:result];
   } else if ([call.method isEqualToString:@"System.initializationComplete"]) {
-    // TODO(gspencergoog): Handle this message to enable exit message listening.
-    // https://github.com/flutter/flutter/issues/126033
+    [self terminationHandler].bindingIsReady = YES;
     result(nil);
   } else {
     result(FlutterMethodNotImplemented);

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -744,6 +744,16 @@ TEST_F(FlutterEngineTest, HandlesTerminationRequest) {
       [FlutterMethodCall methodCallWithMethodName:@"System.exitApplication"
                                         arguments:@{@"type" : @"cancelable"}];
 
+  // Always terminate when the binding isn't ready (which is the default).
+  triedToTerminate = FALSE;
+  calledAfterTerminate = @"";
+  nextResponse = @"cancel";
+  [engineMock handleMethodCall:methodExitApplication result:appExitResult];
+  EXPECT_STREQ([calledAfterTerminate UTF8String], "");
+  EXPECT_TRUE(triedToTerminate);
+
+  // Once the binding is ready, handle the request.
+  terminationHandler.bindingIsReady = YES;
   triedToTerminate = FALSE;
   calledAfterTerminate = @"";
   nextResponse = @"exit";

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -702,7 +702,7 @@ TEST_F(FlutterEngineTest, ManageControllersIfInitiatedByEngine) {
 TEST_F(FlutterEngineTest, HandlesTerminationRequest) {
   id engineMock = CreateMockFlutterEngine(nil);
   __block NSString* nextResponse = @"exit";
-  __block BOOL triedToTerminate = FALSE;
+  __block BOOL triedToTerminate = NO;
   FlutterEngineTerminationHandler* terminationHandler =
       [[FlutterEngineTerminationHandler alloc] initWithEngine:engineMock
                                                    terminator:^(id sender) {
@@ -745,7 +745,7 @@ TEST_F(FlutterEngineTest, HandlesTerminationRequest) {
                                         arguments:@{@"type" : @"cancelable"}];
 
   // Always terminate when the binding isn't ready (which is the default).
-  triedToTerminate = FALSE;
+  triedToTerminate = NO;
   calledAfterTerminate = @"";
   nextResponse = @"cancel";
   [engineMock handleMethodCall:methodExitApplication result:appExitResult];
@@ -754,14 +754,14 @@ TEST_F(FlutterEngineTest, HandlesTerminationRequest) {
 
   // Once the binding is ready, handle the request.
   terminationHandler.acceptingRequests = YES;
-  triedToTerminate = FALSE;
+  triedToTerminate = NO;
   calledAfterTerminate = @"";
   nextResponse = @"exit";
   [engineMock handleMethodCall:methodExitApplication result:appExitResult];
   EXPECT_STREQ([calledAfterTerminate UTF8String], "exit");
   EXPECT_TRUE(triedToTerminate);
 
-  triedToTerminate = FALSE;
+  triedToTerminate = NO;
   calledAfterTerminate = @"";
   nextResponse = @"cancel";
   [engineMock handleMethodCall:methodExitApplication result:appExitResult];
@@ -769,7 +769,7 @@ TEST_F(FlutterEngineTest, HandlesTerminationRequest) {
   EXPECT_FALSE(triedToTerminate);
 
   // Check that it doesn't crash on error.
-  triedToTerminate = FALSE;
+  triedToTerminate = NO;
   calledAfterTerminate = @"";
   nextResponse = @"error";
   [engineMock handleMethodCall:methodExitApplication result:appExitResult];
@@ -778,7 +778,7 @@ TEST_F(FlutterEngineTest, HandlesTerminationRequest) {
 }
 
 TEST_F(FlutterEngineTest, HandleAccessibilityEvent) {
-  __block BOOL announced = FALSE;
+  __block BOOL announced = NO;
   id engineMock = CreateMockFlutterEngine(nil);
 
   OCMStub([engineMock announceAccessibilityMessage:[OCMArg any]

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -753,7 +753,7 @@ TEST_F(FlutterEngineTest, HandlesTerminationRequest) {
   EXPECT_TRUE(triedToTerminate);
 
   // Once the binding is ready, handle the request.
-  terminationHandler.bindingIsReady = YES;
+  terminationHandler.acceptingRequests = YES;
   triedToTerminate = FALSE;
   calledAfterTerminate = @"";
   nextResponse = @"exit";

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
 @interface FlutterEngineTerminationHandler : NSObject
 
 @property(nonatomic, readonly) BOOL shouldTerminate;
-@property(nonatomic, readwrite) BOOL bindingIsReady;
+@property(nonatomic, readwrite) BOOL acceptingRequests;
 
 - (instancetype)initWithEngine:(FlutterEngine*)engine
                     terminator:(nullable FlutterTerminationCallback)terminator;

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -53,6 +53,7 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
 @interface FlutterEngineTerminationHandler : NSObject
 
 @property(nonatomic, readonly) BOOL shouldTerminate;
+@property(nonatomic, readwrite) BOOL bindingIsReady;
 
 - (instancetype)initWithEngine:(FlutterEngine*)engine
                     terminator:(nullable FlutterTerminationCallback)terminator;


### PR DESCRIPTION
## Description

Similar to https://github.com/flutter/engine/pull/41733 and https://github.com/flutter/engine/pull/41782, this causes the macos embedding to wait until it hears that the scheduler binding has registered itself before proceeding to send termination requests to the framework.

This allows applications that don't use the framework (just use `dart:ui` directly) to exit automatically when the last window is closed.  Without this change, the last window closes, but the app does not exit.

Depends on framework PR https://github.com/flutter/flutter/pull/126075 landing first.

## Related PRs
 - https://github.com/flutter/engine/pull/41733
 - https://github.com/flutter/engine/pull/41782

## Related Issues
 - https://github.com/flutter/flutter/issues/126033.

## Tests
 - Added a test to make sure that it doesn't send a termination request if the binding hasn't notified that it is ready yet.