### PR TITLE
[Impeller] Do not free a Vulkan command buffer if its command pool has already been destroyed

### DIFF
--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -37,6 +37,8 @@ class TrackedObjectsVK {
     if (!pool) {
       VALIDATION_LOG
           << "Command pool died before a command buffer could be recycled.";
+      // The buffer can not be freed if its command pool has been destroyed.
+      buffer_.release();
       return;
     }
     pool->CollectGraphicsCommandBuffer(std::move(buffer_));

--- a/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -123,6 +123,11 @@ vk::UniqueCommandBuffer CommandPoolVK::CreateGraphicsCommandBuffer() {
 void CommandPoolVK::CollectGraphicsCommandBuffer(
     vk::UniqueCommandBuffer buffer) {
   Lock lock(buffers_to_collect_mutex_);
+  if (!graphics_pool_) {
+    // If the command pool has already been destroyed, then its command buffers
+    // have been freed and are now invalid.
+    buffer.release();
+  }
   buffers_to_collect_.insert(MakeSharedVK(std::move(buffer)));
   GarbageCollectBuffersIfAble();
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/125519
