### PR TITLE
Optimize Vertices.raw() indices check, fix CkVertices.raw() checks, add tests - addresses some of #123085

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4714,8 +4714,10 @@ class Vertices extends NativeFieldWrapperClass1 {
       throw ArgumentError('"positions" and "textureCoordinates" lengths must match.');
     }
     if (indices != null) {
+      final int halfPositions = positions.length>>1;  // len/2 - we already checked that positions.length is even
       for (int index = 0; index < indices.length; index += 1) {
-        if (indices[index] * 2 >= positions.length) {
+        // we need to check that `indices[index] * 2 >= positions.length`, so do it without multiplying
+        if (indices[index] >= halfPositions) {
           throw ArgumentError(
             '"indices" values must be valid indices in the positions list '
             '(i.e. numbers in the range 0..${positions.length ~/ 2 - 1}), '

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4714,7 +4714,7 @@ class Vertices extends NativeFieldWrapperClass1 {
       throw ArgumentError('"positions" and "textureCoordinates" lengths must match.');
     }
     if (indices != null) {
-      final int halfPositions = positions.length>>1;  // len/2 - we already checked that positions.length is even
+      final int halfPositions = positions.length >> 1;  // len/2 - we already checked that positions.length is even
       for (int index = 0; index < indices.length; index += 1) {
         // we need to check that `indices[index] * 2 >= positions.length`, so do it without multiplying
         if (indices[index] >= halfPositions) {

--- a/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
@@ -47,6 +47,9 @@ class CkVertices implements ui.Vertices {
     Int32List? colors,
     Uint16List? indices,
   }) {
+    if (positions.length % 2 != 0) {
+      throw ArgumentError('"positions" must have an even number of entries (each coordinate is an x,y pair).');
+    }
     if (textureCoordinates != null &&
         textureCoordinates.length != positions.length) {
       throw ArgumentError(

--- a/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
@@ -57,7 +57,7 @@ class CkVertices implements ui.Vertices {
     }
     // see ui.Vertices.raw() - all indices must be <(positions.length/2) because they refer to
     // pairs in the positions array.
-    final halfPositions = positions.length>>1;
+    final int halfPositions = positions.length >> 1;
     if (indices != null &&
         indices.any((int i) => i < 0 || i >= halfPositions)) {
       throw ArgumentError(

--- a/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
@@ -55,8 +55,11 @@ class CkVertices implements ui.Vertices {
     if (colors != null && colors.length * 2 != positions.length) {
       throw ArgumentError('"positions" and "colors" lengths must match.');
     }
+    // see ui.Vertices.raw() - all indices must be <(positions.length/2) because they refer to
+    // pairs in the positions array.
+    final halfPositions = positions.length>>1;
     if (indices != null &&
-        indices.any((int i) => i < 0 || i >= positions.length)) {
+        indices.any((int i) => i < 0 || i >= halfPositions)) {
       throw ArgumentError(
           '"indices" values must be valid indices in the positions list.');
     }

--- a/lib/web_ui/test/canvaskit/vertices_test.dart
+++ b/lib/web_ui/test/canvaskit/vertices_test.dart
@@ -66,6 +66,60 @@ void testMain() {
         .draw(builder.build().layerTree);
     await matchGoldenFile('canvaskit_vertices_antialiased.png', region: region);
   }, skip: isSafari);
+
+  test('Vertices checks', () {
+    try {
+      ui.Vertices(
+        ui.VertexMode.triangles,
+        const <ui.Offset>[ui.Offset.zero, ui.Offset.zero, ui.Offset.zero],
+        indices: Uint16List.fromList(const <int>[0, 2, 5]),
+      );
+      throw 'Vertices did not throw the expected error.';
+    } on ArgumentError catch (e) {
+      expect('$e', 'Invalid argument(s): "indices" values must be valid indices in the positions list.');
+    }
+    ui.Vertices( // This one does not throw.
+      ui.VertexMode.triangles,
+      const <ui.Offset>[ui.Offset.zero],
+    ).dispose();
+    ui.Vertices( // This one should not throw.
+      ui.VertexMode.triangles,
+      const <ui.Offset>[ui.Offset.zero, ui.Offset.zero, ui.Offset.zero],
+      indices: Uint16List.fromList(const <int>[0, 2, 1, 2, 0, 1, 2, 0]), // Uint16List implements List<int> so this is ok.
+    ).dispose();
+  });
+
+  test('Vertices.raw checks', () {
+    try {
+      ui.Vertices.raw(
+        ui.VertexMode.triangles,
+        Float32List.fromList(const <double>[0.0]),
+      );
+      throw 'Vertices.raw did not throw the expected error.';
+    } on ArgumentError catch (e) {
+      expect('$e', 'Invalid argument(s): "positions" must have an even number of entries (each coordinate is an x,y pair).');
+    }
+    try {
+      ui.Vertices.raw(
+        ui.VertexMode.triangles,
+        Float32List.fromList(const <double>[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        indices: Uint16List.fromList(const <int>[0, 2, 5]),
+      );
+      throw 'Vertices.raw did not throw the expected error.';
+    } on ArgumentError catch (e) {
+      expect('$e', '"indices" values must be valid indices in the positions list.');
+    }
+    ui.Vertices.raw( // This one does not throw.
+      ui.VertexMode.triangles,
+      Float32List.fromList(const <double>[0.0, 0.0]),
+    ).dispose();
+    ui.Vertices.raw( // This one should not throw.
+      ui.VertexMode.triangles,
+      Float32List.fromList(const <double>[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+      indices: Uint16List.fromList(const <int>[0, 2, 1, 2, 0, 1, 2, 0]),
+    ).dispose();
+  });
+
 }
 
 CkVertices _testVertices() {


### PR DESCRIPTION
This PR is the most conservative thing we can do to address some of https://github.com/flutter/flutter/issues/123085
This reduces the number of ops needed to check the `indices[n]*2 <= positions.length` by avoiding the *2 by simply comparing `indices[n] < halfPositionsLength`.

Additionally, this PR also fixes the indices[] checking within the canvaskit web_ui version of Vertices.raw() (CkVertices.raw())
This routine was incorrectly testing `indices[n] < positions.length` instead of `indices[n]*2 < positions.length`.  It was also missing a check to verify that positions.length was even (because it holds pairs of positions for the raw()).
One note is that the checks within CkVertice() and CkVertice.raw() are using indices.any() instead of looping, and their error messages are less informative their Vertices() counterparts because of this.  They also check for indices<0 where Vertices() does not.  Should these be changed to be identical to Vertices() ?

I also added tests of the CkVertices() and CkVertices.raw() parameter checking - this was completely missing and is how the ckVertices.raw() was getting away with doing incorrect parameter checking.  (These are essentially identical to the test that are done against Vertices() within `testing\dart\painting_test.dart` with the exception of the less informative error messages mentioned above).

https://github.com/flutter/flutter/issues/123085 is further discussing placing all of the Vertices.raw() parameter checks behind an assert() .  Removing all checks for non-debug mode has additional considerations, while this change only optimizes operations with no change to the verification being performed.

I would be happy to add the additional assert() wrapper discussed in https://github.com/flutter/flutter/issues/123085 to the checks for a real additional performance gain :wink:

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
