### PR TITLE
Allow default out_dir for fuchsia symbols upload.

### DIFF
--- a/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -17,6 +17,13 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
+
+# Path to the engine root checkout. This is used to calculate absolute
+# paths if relative ones are passed to the script.
+BUILD_ROOT_DIR = os.path.abspath(
+    os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
+)
 
 
 def IsLinux():
@@ -145,6 +152,16 @@ def HardlinkContents(dirA, dirB):
   return internal_symbol_dirs
 
 
+def CalculateAbsoluteDirs(dirs):
+  results = []
+  for directory in dirs:
+    if os.path.isabs(directory):
+      results.append(directory)
+    else:
+      results.append(os.path.join(BUILD_ROOT_DIR, directory))
+  return results
+
+
 def main():
   parser = argparse.ArgumentParser()
 
@@ -156,10 +173,13 @@ def main():
   )
   parser.add_argument(
       '--out-dir',
-      required=True,
       action='store',
       dest='out_dir',
-      help='Output directory where the executables will be placed.'
+      default=tempfile.mkdtemp(),
+      help=(
+          'Output directory where the executables will be placed defaults to an '
+          'empty temp directory'
+      )
   )
   parser.add_argument(
       '--target-arch', type=str, choices=['x64', 'arm64'], required=True
@@ -174,7 +194,7 @@ def main():
 
   args = parser.parse_args()
 
-  symbol_dirs = args.symbol_dirs
+  symbol_dirs = CalculateAbsoluteDirs(args.symbol_dirs)
   for symbol_dir in symbol_dirs:
     assert os.path.exists(symbol_dir) and os.path.isdir(symbol_dir)
 


### PR DESCRIPTION
This also allows passing target files as relative to the src folder. This is required for migrating the fuchsia builds to engine_v2.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
