### PR TITLE
Handle a11y focus event on Ios and android

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -24,8 +24,7 @@ public class AccessibilityChannel {
   @NonNull public final FlutterJNI flutterJNI;
   @Nullable private AccessibilityMessageHandler handler;
 
-  @VisibleForTesting
-  final BasicMessageChannel.MessageHandler<Object> parsingMessageHandler =
+  public final BasicMessageChannel.MessageHandler<Object> parsingMessageHandler =
       new BasicMessageChannel.MessageHandler<Object>() {
         @Override
         public void onMessage(

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -2,7 +2,6 @@ package io.flutter.embedding.engine.systemchannels;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -67,6 +67,14 @@ public class AccessibilityChannel {
                 }
                 break;
               }
+            case "focus":
+              {
+                Integer nodeId = (Integer) annotatedEvent.get("nodeId");
+                if (nodeId != null) {
+                  handler.onFocus(nodeId);
+                }
+                break;
+              }
             case "tooltip":
               {
                 String tooltipMessage = (String) data.get("message");
@@ -175,6 +183,9 @@ public class AccessibilityChannel {
 
     /** The user has long pressed on the widget with the given {@code nodeId}. */
     void onLongPress(int nodeId);
+
+    /** Focus on the widget with the given {@code nodeId}. */
+    void onFocus(int nodeId);
 
     /** The user has opened a tooltip. */
     void onTooltip(@NonNull String message);

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -178,10 +178,10 @@ public class AccessibilityChannel {
     /** The Dart application would like the given {@code message} to be announced. */
     void announce(@NonNull String message);
 
-    /** The user has tapped on the widget with the given {@code nodeId}. */
+    /** The user has tapped on the semantics node with the given {@code nodeId}. */
     void onTap(int nodeId);
 
-    /** The user has long pressed on the widget with the given {@code nodeId}. */
+    /** The user has long pressed on the semantics node with the given {@code nodeId}. */
     void onLongPress(int nodeId);
 
     /** The framework has requested focus on the semantics node with the given {@code nodeId}. */

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -184,7 +184,7 @@ public class AccessibilityChannel {
     /** The user has long pressed on the widget with the given {@code nodeId}. */
     void onLongPress(int nodeId);
 
-    /** Focus on the widget with the given {@code nodeId}. */
+    /** The framework has requested focus on the semantics node with the given {@code nodeId}. */
     void onFocus(int nodeId);
 
     /** The user has opened a tooltip. */

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -309,6 +309,13 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
           sendAccessibilityEvent(nodeId, AccessibilityEvent.TYPE_VIEW_LONG_CLICKED);
         }
 
+        /** The user has requested focus on the given {@code nodeId}. */
+        @Override
+        public void onFocus(int nodeId) {
+          sendAccessibilityEvent(nodeId, AccessibilityEvent.TYPE_VIEW_FOCUSED);
+          rootAccessibilityView.announceForAccessibility("hahaha");
+        }
+
         /** The user has opened a tooltip. */
         @Override
         public void onTooltip(@NonNull String message) {
@@ -655,6 +662,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     result.setClassName("android.view.View");
     result.setSource(rootAccessibilityView, virtualViewId);
     result.setFocusable(semanticsNode.isFocusable());
+    result.setUniqueId(Integer.toString(semanticsNode.id));
     if (inputFocusedSemanticsNode != null) {
       result.setFocused(inputFocusedSemanticsNode.id == virtualViewId);
     }

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1987,7 +1987,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   }
 
   @VisibleForTesting
-  public AccessibilityEvent obtainAccessibilityEvent(AccessibilityEvent event, int virtualViewId, int eventType) {
+  public AccessibilityEvent obtainAccessibilityEvent(
+      AccessibilityEvent event, int virtualViewId, int eventType) {
     event.setPackageName(rootAccessibilityView.getContext().getPackageName());
     event.setSource(rootAccessibilityView, virtualViewId);
     return event;

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1983,6 +1983,11 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
    */
   private AccessibilityEvent obtainAccessibilityEvent(int virtualViewId, int eventType) {
     AccessibilityEvent event = AccessibilityEvent.obtain(eventType);
+    return obtainAccessibilityEvent(event, virtualViewId, eventType);
+  }
+
+  @VisibleForTesting
+  public AccessibilityEvent obtainAccessibilityEvent(AccessibilityEvent event, int virtualViewId, int eventType) {
     event.setPackageName(rootAccessibilityView.getContext().getPackageName());
     event.setSource(rootAccessibilityView, virtualViewId);
     return event;

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1889,7 +1889,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
    * <p>The given {@code viewId} may either belong to {@link #rootAccessibilityView}, or any Flutter
    * {@link SemanticsNode}.
    */
-  private void sendAccessibilityEvent(int viewId, int eventType) {
+  @VisibleForTesting
+  public void sendAccessibilityEvent(int viewId, int eventType) {
     if (!accessibilityManager.isEnabled()) {
       return;
     }
@@ -1982,16 +1983,15 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
    * invoked to create an {@link AccessibilityEvent} for the {@link #rootAccessibilityView}.
    */
   private AccessibilityEvent obtainAccessibilityEvent(int virtualViewId, int eventType) {
-    AccessibilityEvent event = AccessibilityEvent.obtain(eventType);
-    return obtainAccessibilityEvent(event, virtualViewId, eventType);
-  }
-
-  @VisibleForTesting
-  public AccessibilityEvent obtainAccessibilityEvent(
-      AccessibilityEvent event, int virtualViewId, int eventType) {
+    AccessibilityEvent event = obtainAccessibilityEvent(eventType);
     event.setPackageName(rootAccessibilityView.getContext().getPackageName());
     event.setSource(rootAccessibilityView, virtualViewId);
     return event;
+  }
+
+  @VisibleForTesting
+  public AccessibilityEvent obtainAccessibilityEvent(int eventType) {
+        return AccessibilityEvent.obtain(eventType);
   }
 
   /**

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -289,7 +289,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   private boolean isReleased = false;
 
   // Handler for all messages received from Flutter via the {@code accessibilityChannel}
-  public final AccessibilityChannel.AccessibilityMessageHandler accessibilityMessageHandler =
+  private final AccessibilityChannel.AccessibilityMessageHandler accessibilityMessageHandler =
       new AccessibilityChannel.AccessibilityMessageHandler() {
         /** The Dart application would like the given {@code message} to be announced. */
         @Override

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1991,7 +1991,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
   @VisibleForTesting
   public AccessibilityEvent obtainAccessibilityEvent(int eventType) {
-        return AccessibilityEvent.obtain(eventType);
+    return AccessibilityEvent.obtain(eventType);
   }
 
   /**

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -309,7 +309,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
           sendAccessibilityEvent(nodeId, AccessibilityEvent.TYPE_VIEW_LONG_CLICKED);
         }
 
-        /** The user has requested focus on the given {@code nodeId}. */
+        /** The framework has requested focus on the given {@code nodeId}. */
         @Override
         public void onFocus(int nodeId) {
           sendAccessibilityEvent(nodeId, AccessibilityEvent.TYPE_VIEW_FOCUSED);

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -289,7 +289,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   private boolean isReleased = false;
 
   // Handler for all messages received from Flutter via the {@code accessibilityChannel}
-  private final AccessibilityChannel.AccessibilityMessageHandler accessibilityMessageHandler =
+  public final AccessibilityChannel.AccessibilityMessageHandler accessibilityMessageHandler =
       new AccessibilityChannel.AccessibilityMessageHandler() {
         /** The Dart application would like the given {@code message} to be announced. */
         @Override

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -313,7 +313,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         @Override
         public void onFocus(int nodeId) {
           sendAccessibilityEvent(nodeId, AccessibilityEvent.TYPE_VIEW_FOCUSED);
-          rootAccessibilityView.announceForAccessibility("hahaha");
         }
 
         /** The user has opened a tooltip. */
@@ -662,7 +661,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     result.setClassName("android.view.View");
     result.setSource(rootAccessibilityView, virtualViewId);
     result.setFocusable(semanticsNode.isFocusable());
-    result.setUniqueId(Integer.toString(semanticsNode.id));
     if (inputFocusedSemanticsNode != null) {
       result.setFocused(inputFocusedSemanticsNode.id == virtualViewId);
     }

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
@@ -38,7 +38,7 @@ public class AccessibilityChannelTest {
         new AccessibilityChannel(mock(DartExecutor.class), mock(FlutterJNI.class));
     HashMap<String, Object> arguments = new HashMap<>();
     arguments.put("type", "focus");
-    arguments.put("nodeId", "123");
+    arguments.put("nodeId", 123);
     AccessibilityChannel.AccessibilityMessageHandler handler =
         mock(AccessibilityChannel.AccessibilityMessageHandler.class);
     accessibilityChannel.setAccessibilityMessageHandler(handler);

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
@@ -7,6 +7,7 @@ import android.annotation.TargetApi;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.BasicMessageChannel;
+import java.util.HashMap;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -29,5 +30,20 @@ public class AccessibilityChannelTest {
     BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
     accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
     verify(reply).reply(null);
+  }
+
+  @Test
+  public void handleFocus() throws JSONException {
+    AccessibilityChannel accessibilityChannel =
+        new AccessibilityChannel(mock(DartExecutor.class), mock(FlutterJNI.class));
+    HashMap<String, Object> arguments = new HashMap<>();
+    arguments.put("type", "focus1");
+    arguments.put("nodeId", "123");
+    AccessibilityChannel.AccessibilityMessageHandler handler =
+        mock(AccessibilityChannel.AccessibilityMessageHandler.class);
+    accessibilityChannel.setAccessibilityMessageHandler(handler);
+    BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
+    accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
+    verify(handler).onFocus(123);
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/AccessibilityChannelTest.java
@@ -37,7 +37,7 @@ public class AccessibilityChannelTest {
     AccessibilityChannel accessibilityChannel =
         new AccessibilityChannel(mock(DartExecutor.class), mock(FlutterJNI.class));
     HashMap<String, Object> arguments = new HashMap<>();
-    arguments.put("type", "focus1");
+    arguments.put("type", "focus");
     arguments.put("nodeId", "123");
     AccessibilityChannel.AccessibilityMessageHandler handler =
         mock(AccessibilityChannel.AccessibilityMessageHandler.class);

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1845,9 +1845,8 @@ public class AccessibilityBridgeTest {
     ViewParent mockParent = mock(ViewParent.class);
     when(mockRootView.getParent()).thenReturn(mockParent);
     when(mockManager.isEnabled()).thenReturn(true);
-
-    AccessibilityBridge accessibilityBridge =
-        setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null, null);
+   
+    AccessibilityBridge spyAccessibilityBridge = spy(setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null, null));
 
     HashMap<String, Object> arguments = new HashMap<>();
     arguments.put("type", "focus");
@@ -1855,13 +1854,14 @@ public class AccessibilityBridgeTest {
     BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
     accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
 
+    verify(spyAccessibilityBridge).obtainAccessibilityNodeInfo(eq(mockRootView),123);
+
     // Check that focus event was sent.
     ArgumentCaptor<AccessibilityEvent> eventCaptor =
         ArgumentCaptor.forClass(AccessibilityEvent.class);
     verify(mockParent).requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
     AccessibilityEvent event = eventCaptor.getAllValues().get(0);
     assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_FOCUSED);
-    assertEquals(event.getSource().getSourceNodeId(), 123L);
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1846,8 +1846,8 @@ public class AccessibilityBridgeTest {
     when(mockRootView.getParent()).thenReturn(mockParent);
     when(mockManager.isEnabled()).thenReturn(true);
 
-    AccessibilityBridge spyAccessibilityBridge =
-        spy(setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null, null));
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null, null);
 
     HashMap<String, Object> arguments = new HashMap<>();
     arguments.put("type", "focus");
@@ -1855,14 +1855,33 @@ public class AccessibilityBridgeTest {
     BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
     accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
 
-    verify(spyAccessibilityBridge).obtainAccessibilityNodeInfo(eq(mockRootView), eq(123));
-
     // Check that focus event was sent.
     ArgumentCaptor<AccessibilityEvent> eventCaptor =
         ArgumentCaptor.forClass(AccessibilityEvent.class);
     verify(mockParent).requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
     AccessibilityEvent event = eventCaptor.getAllValues().get(0);
     assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_FOCUSED);
+    assertEquals(event.getSource(), null);
+  }
+
+  @Test
+  public void SetSourceAndPackageNameForAccessibilityEvent() {
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    ContentResolver mockContentResolver = mock(ContentResolver.class);
+    View mockRootView = mock(View.class);
+    Context context = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(context);
+    when(context.getPackageName()).thenReturn("test");
+    when(mockManager.isEnabled()).thenReturn(true);
+
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(mockRootView, null, mockManager, null, null, null);
+
+    AccessibilityEvent mockEvent = mock(AccessibilityEvent.class);
+    accessibilityBridge.obtainAccessibilityEvent(mockEvent, 123, AccessibilityEvent.TYPE_VIEW_FOCUSED);
+    verify(mockEvent).setSource(eq(mockRootView), eq(123));
+    verify(mockEvent).setPackageName("test");
+
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1880,14 +1880,12 @@ public class AccessibilityBridgeTest {
     AccessibilityBridge accessibilityBridge =
         setUpBridge(mockRootView, null, mockManager, null, null, null);
 
-
     AccessibilityBridge spyAccessibilityBridge = spy(accessibilityBridge);
 
     when(spyAccessibilityBridge.obtainAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED))
-    .thenReturn(mockEvent);
+        .thenReturn(mockEvent);
 
     spyAccessibilityBridge.sendAccessibilityEvent(123, AccessibilityEvent.TYPE_VIEW_FOCUSED);
-
 
     verify(mockEvent).setPackageName("test");
     verify(mockEvent).setSource(eq(mockRootView), eq(123));

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -44,23 +44,22 @@ import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
+import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.platform.PlatformViewsAccessibilityDelegate;
 import io.flutter.view.AccessibilityBridge.Flag;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.robolectric.annotation.Config;
-
-import io.flutter.embedding.engine.FlutterJNI;
-import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.plugin.common.BasicMessageChannel;
-import java.util.HashMap;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1843,7 +1843,7 @@ public class AccessibilityBridgeTest {
     when(mockRootView.getContext()).thenReturn(context);
     when(context.getPackageName()).thenReturn("test");
     AccessibilityBridge accessibilityBridge =
-        setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null);
+        setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null, null);
 
     ViewParent mockParent = mock(ViewParent.class);
     when(mockRootView.getParent()).thenReturn(mockParent);

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1873,18 +1873,24 @@ public class AccessibilityBridgeTest {
     when(mockRootView.getContext()).thenReturn(context);
     when(context.getPackageName()).thenReturn("test");
     when(mockManager.isEnabled()).thenReturn(true);
+    ViewParent mockParent = mock(ViewParent.class);
+    when(mockRootView.getParent()).thenReturn(mockParent);
+    AccessibilityEvent mockEvent = mock(AccessibilityEvent.class);
 
     AccessibilityBridge accessibilityBridge =
         setUpBridge(mockRootView, null, mockManager, null, null, null);
 
-    AccessibilityManager manager = accessibilityBridge.accessibilityMessageHandler;
+
+    AccessibilityBridge spyAccessibilityBridge = spy(accessibilityBridge);
+
+    when(spyAccessibilityBridge.obtainAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED))
+    .thenReturn(mockEvent);
+
+    spyAccessibilityBridge.sendAccessibilityEvent(123, AccessibilityEvent.TYPE_VIEW_FOCUSED);
 
 
-    AccessibilityEvent mockEvent = mock(AccessibilityEvent.class);
-    accessibilityBridge.obtainAccessibilityEvent(
-        mockEvent, 123, AccessibilityEvent.TYPE_VIEW_FOCUSED);
-    verify(mockEvent).setSource(eq(mockRootView), eq(123));
     verify(mockEvent).setPackageName("test");
+    verify(mockEvent).setSource(eq(mockRootView), eq(123));
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -57,6 +57,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.robolectric.annotation.Config;
 
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.plugin.common.BasicMessageChannel;
+import java.util.HashMap;
+
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
 @TargetApi(19)

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1855,7 +1855,7 @@ public class AccessibilityBridgeTest {
     BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
     accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
 
-    verify(spyAccessibilityBridge).obtainAccessibilityNodeInfo(eq(mockRootView), 123);
+    verify(spyAccessibilityBridge).obtainAccessibilityNodeInfo(eq(mockRootView), eq(123));
 
     // Check that focus event was sent.
     ArgumentCaptor<AccessibilityEvent> eventCaptor =

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1861,6 +1861,7 @@ public class AccessibilityBridgeTest {
     verify(mockParent).requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
     AccessibilityEvent event = eventCaptor.getAllValues().get(0);
     assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_FOCUSED);
+    assertEquals(event.getSource().getVirtualDescendantId(0), 123);
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1855,11 +1855,15 @@ public class AccessibilityBridgeTest {
     BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
     accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
 
-    AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_VIEW_FOCUSED);
-    event.setPackageName("test");
-    event.setSource(mockRootView, 123);
 
-    verify(mockParent).requestSendAccessibilityEvent(mockRootView, event);
+
+        // Check that focus event was sent.
+        ArgumentCaptor<AccessibilityEvent> eventCaptor =
+        ArgumentCaptor.forClass(AccessibilityEvent.class);
+    verify(mockParent)
+        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+    AccessibilityEvent event = eventCaptor.getAllValues().get(0);
+    assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_FOCUSED);
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1861,7 +1861,7 @@ public class AccessibilityBridgeTest {
     verify(mockParent).requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
     AccessibilityEvent event = eventCaptor.getAllValues().get(0);
     assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_FOCUSED);
-    assertEquals(event.getSourceNodeId(), 123L);
+    assertEquals(event.getSource().getSourceNodeId(), 123L);
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1861,7 +1861,7 @@ public class AccessibilityBridgeTest {
     verify(mockParent).requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
     AccessibilityEvent event = eventCaptor.getAllValues().get(0);
     assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_FOCUSED);
-    assertEquals(event.getSource().getVirtualDescendantId(0), 123);
+    assertEquals(event.getSource().getVirtualDescendantId(0L), 123);
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1877,6 +1877,9 @@ public class AccessibilityBridgeTest {
     AccessibilityBridge accessibilityBridge =
         setUpBridge(mockRootView, null, mockManager, null, null, null);
 
+    AccessibilityManager manager = accessibilityBridge.accessibilityMessageHandler;
+
+
     AccessibilityEvent mockEvent = mock(AccessibilityEvent.class);
     accessibilityBridge.obtainAccessibilityEvent(
         mockEvent, 123, AccessibilityEvent.TYPE_VIEW_FOCUSED);

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1827,6 +1827,38 @@ public class AccessibilityBridgeTest {
     verify(mockChannel, never()).setAccessibilityFeatures(anyInt());
   }
 
+  @Test
+  public void sendFocusAccessibilityEvent() {
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    AccessibilityChannel accessibilityChannel =
+    new AccessibilityChannel(mock(DartExecutor.class), mock(FlutterJNI.class));
+
+    ContentResolver mockContentResolver = mock(ContentResolver.class);
+    View mockRootView = mock(View.class);
+    Context context = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(context);
+    when(context.getPackageName()).thenReturn("test");
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(mockRootView, accessibilityChannel, mockManager, null,null);
+
+    ViewParent mockParent = mock(ViewParent.class);
+    when(mockRootView.getParent()).thenReturn(mockParent);
+    when(mockManager.isEnabled()).thenReturn(true);
+
+    HashMap<String, Object> arguments = new HashMap<>();
+    arguments.put("type", "focus");
+    arguments.put("nodeId", 123);
+    BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
+    accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
+
+
+    AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+    event.setPackageName("test");
+    event.setSource(mockRootView, 123);
+
+    verify(mockParent).requestSendAccessibilityEvent(mockRootView,event);
+  }
+
   AccessibilityBridge setUpBridge() {
     return setUpBridge(null, null, null, null, null, null);
   }

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1855,13 +1855,10 @@ public class AccessibilityBridgeTest {
     BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
     accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
 
-
-
-        // Check that focus event was sent.
-        ArgumentCaptor<AccessibilityEvent> eventCaptor =
+    // Check that focus event was sent.
+    ArgumentCaptor<AccessibilityEvent> eventCaptor =
         ArgumentCaptor.forClass(AccessibilityEvent.class);
-    verify(mockParent)
-        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+    verify(mockParent).requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
     AccessibilityEvent event = eventCaptor.getAllValues().get(0);
     assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_FOCUSED);
   }

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1845,8 +1845,9 @@ public class AccessibilityBridgeTest {
     ViewParent mockParent = mock(ViewParent.class);
     when(mockRootView.getParent()).thenReturn(mockParent);
     when(mockManager.isEnabled()).thenReturn(true);
-   
-    AccessibilityBridge spyAccessibilityBridge = spy(setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null, null));
+
+    AccessibilityBridge spyAccessibilityBridge =
+        spy(setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null, null));
 
     HashMap<String, Object> arguments = new HashMap<>();
     arguments.put("type", "focus");
@@ -1854,7 +1855,7 @@ public class AccessibilityBridgeTest {
     BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
     accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
 
-    verify(spyAccessibilityBridge).obtainAccessibilityNodeInfo(eq(mockRootView),123);
+    verify(spyAccessibilityBridge).obtainAccessibilityNodeInfo(eq(mockRootView), 123);
 
     // Check that focus event was sent.
     ArgumentCaptor<AccessibilityEvent> eventCaptor =

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1831,6 +1831,7 @@ public class AccessibilityBridgeTest {
     verify(mockChannel, never()).setAccessibilityFeatures(anyInt());
   }
 
+  @TargetApi(31)
   @Test
   public void sendFocusAccessibilityEvent() {
     AccessibilityManager mockManager = mock(AccessibilityManager.class);

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1842,12 +1842,12 @@ public class AccessibilityBridgeTest {
     Context context = mock(Context.class);
     when(mockRootView.getContext()).thenReturn(context);
     when(context.getPackageName()).thenReturn("test");
-    AccessibilityBridge accessibilityBridge =
-        setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null, null);
-
     ViewParent mockParent = mock(ViewParent.class);
     when(mockRootView.getParent()).thenReturn(mockParent);
     when(mockManager.isEnabled()).thenReturn(true);
+
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null, null);
 
     HashMap<String, Object> arguments = new HashMap<>();
     arguments.put("type", "focus");

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1831,7 +1831,7 @@ public class AccessibilityBridgeTest {
   public void sendFocusAccessibilityEvent() {
     AccessibilityManager mockManager = mock(AccessibilityManager.class);
     AccessibilityChannel accessibilityChannel =
-    new AccessibilityChannel(mock(DartExecutor.class), mock(FlutterJNI.class));
+        new AccessibilityChannel(mock(DartExecutor.class), mock(FlutterJNI.class));
 
     ContentResolver mockContentResolver = mock(ContentResolver.class);
     View mockRootView = mock(View.class);
@@ -1839,7 +1839,7 @@ public class AccessibilityBridgeTest {
     when(mockRootView.getContext()).thenReturn(context);
     when(context.getPackageName()).thenReturn("test");
     AccessibilityBridge accessibilityBridge =
-        setUpBridge(mockRootView, accessibilityChannel, mockManager, null,null);
+        setUpBridge(mockRootView, accessibilityChannel, mockManager, null, null);
 
     ViewParent mockParent = mock(ViewParent.class);
     when(mockRootView.getParent()).thenReturn(mockParent);
@@ -1851,12 +1851,11 @@ public class AccessibilityBridgeTest {
     BasicMessageChannel.Reply reply = mock(BasicMessageChannel.Reply.class);
     accessibilityChannel.parsingMessageHandler.onMessage(arguments, reply);
 
-
     AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_VIEW_FOCUSED);
     event.setPackageName("test");
     event.setSource(mockRootView, 123);
 
-    verify(mockParent).requestSendAccessibilityEvent(mockRootView,event);
+    verify(mockParent).requestSendAccessibilityEvent(mockRootView, event);
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1831,7 +1831,6 @@ public class AccessibilityBridgeTest {
     verify(mockChannel, never()).setAccessibilityFeatures(anyInt());
   }
 
-  @TargetApi(31)
   @Test
   public void sendFocusAccessibilityEvent() {
     AccessibilityManager mockManager = mock(AccessibilityManager.class);
@@ -1862,7 +1861,7 @@ public class AccessibilityBridgeTest {
     verify(mockParent).requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
     AccessibilityEvent event = eventCaptor.getAllValues().get(0);
     assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_FOCUSED);
-    assertEquals(event.getSource().getVirtualDescendantId(0L), 123);
+    assertEquals(event.getSourceNodeId(), 123L);
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -1878,10 +1878,10 @@ public class AccessibilityBridgeTest {
         setUpBridge(mockRootView, null, mockManager, null, null, null);
 
     AccessibilityEvent mockEvent = mock(AccessibilityEvent.class);
-    accessibilityBridge.obtainAccessibilityEvent(mockEvent, 123, AccessibilityEvent.TYPE_VIEW_FOCUSED);
+    accessibilityBridge.obtainAccessibilityEvent(
+        mockEvent, 123, AccessibilityEvent.TYPE_VIEW_FOCUSED);
     verify(mockEvent).setSource(eq(mockRootView), eq(123));
     verify(mockEvent).setPackageName("test");
-
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -57,6 +57,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
 
   void UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
                        const flutter::CustomAccessibilityActionUpdates& actions);
+  void HandleEvent(NSDictionary<NSString*, id>* annotatedEvent);
   void DispatchSemanticsAction(int32_t id, flutter::SemanticsAction action) override;
   void DispatchSemanticsAction(int32_t id,
                                flutter::SemanticsAction action,
@@ -88,7 +89,6 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   SemanticsObject* FindFirstFocusable(SemanticsObject* parent);
   void VisitObjectsRecursivelyAndRemove(SemanticsObject* object,
                                         NSMutableArray<NSNumber*>* doomed_uids);
-  void HandleEvent(NSDictionary<NSString*, id>* annotatedEvent);
 
   FlutterViewController* view_controller_;
   PlatformViewIOS* platform_view_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -362,6 +362,11 @@ void AccessibilityBridge::HandleEvent(NSDictionary<NSString*, id>* annotatedEven
     NSString* message = annotatedEvent[@"data"][@"message"];
     ios_delegate_->PostAccessibilityNotification(UIAccessibilityAnnouncementNotification, message);
   }
+  if ([type isEqualToString:@"focus"]) {
+    int32_t nodeId = [annotatedEvent[@"nodeId"] intValue];
+    ios_delegate_->PostAccessibilityNotification(UIAccessibilityLayoutChangedNotification,
+                                                 objects_.get()[@(nodeId)]);
+  }
 }
 
 fml::WeakPtr<AccessibilityBridge> AccessibilityBridge::GetWeakPtr() {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -363,7 +363,7 @@ void AccessibilityBridge::HandleEvent(NSDictionary<NSString*, id>* annotatedEven
     ios_delegate_->PostAccessibilityNotification(UIAccessibilityAnnouncementNotification, message);
   }
   if ([type isEqualToString:@"focus"]) {
-    SemanticsObject* node = objects_.get()[@([annotatedEvent[@"nodeId"] intValue])];
+    SemanticsObject* node = objects_.get()[annotatedEvent[@"nodeId"]];
     ios_delegate_->PostAccessibilityNotification(UIAccessibilityLayoutChangedNotification, node);
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -363,9 +363,9 @@ void AccessibilityBridge::HandleEvent(NSDictionary<NSString*, id>* annotatedEven
     ios_delegate_->PostAccessibilityNotification(UIAccessibilityAnnouncementNotification, message);
   }
   if ([type isEqualToString:@"focus"]) {
-    int32_t nodeId = [annotatedEvent[@"nodeId"] intValue];
+    SemanticsObject* node = objects_.get()[@([annotatedEvent[@"nodeId"] intValue])];
     ios_delegate_->PostAccessibilityNotification(UIAccessibilityLayoutChangedNotification,
-                                                 objects_.get()[@(nodeId)]);
+                                                 node);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -364,8 +364,7 @@ void AccessibilityBridge::HandleEvent(NSDictionary<NSString*, id>* annotatedEven
   }
   if ([type isEqualToString:@"focus"]) {
     SemanticsObject* node = objects_.get()[@([annotatedEvent[@"nodeId"] intValue])];
-    ios_delegate_->PostAccessibilityNotification(UIAccessibilityLayoutChangedNotification,
-                                                 node);
+    ios_delegate_->PostAccessibilityNotification(UIAccessibilityLayoutChangedNotification, node);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -1289,6 +1289,51 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                  UIAccessibilityScreenChangedNotification);
 }
 
+- (void)testHandleEvent {
+  flutter::MockDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*platform_views_controller=*/nil,
+      /*task_runners=*/runners);
+  id mockFlutterView = OCMClassMock([FlutterView class]);
+  id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
+
+  NSMutableArray<NSDictionary<NSString*, id>*>* accessibility_notifications =
+      [[[NSMutableArray alloc] init] autorelease];
+  auto ios_delegate = std::make_unique<flutter::MockIosDelegate>();
+  ios_delegate->on_PostAccessibilityNotification_ =
+      [accessibility_notifications](UIAccessibilityNotifications notification, id argument) {
+        [accessibility_notifications addObject:@{
+          @"notification" : @(notification),
+          @"argument" : argument ? argument : [NSNull null],
+        }];
+      };
+  __block auto bridge =
+      std::make_unique<flutter::AccessibilityBridge>(/*view_controller=*/mockFlutterViewController,
+                                                     /*platform_view=*/platform_view.get(),
+                                                     /*platform_views_controller=*/nil,
+                                                     /*ios_delegate=*/std::move(ios_delegate));
+
+  NSDictionary<NSString*, id>* annotatedEvent = @{@"type" : @"focus", @"nodeId" : @123};
+
+  bridge->HandleEvent(annotatedEvent);
+
+  XCTAssertEqual([accessibility_notifications count], 1ul);
+  // id focusObject = accessibility_notifications[0][@"argument"];
+  // XCTAssertTrue([focusObject isKindOfClass:[NSString class]]);
+  // XCTAssertEqualObjects(focusObject, @"node1");
+  XCTAssertEqual([accessibility_notifications[0][@"notification"] unsignedIntValue],
+                 UIAccessibilityLayoutChangedNotification);
+}
+
 - (void)testAnnouncesRouteChangesWhenNoNamesRoute {
   flutter::MockDelegate mock_delegate;
   auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -1301,7 +1301,9 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
       /*platform_views_controller=*/nil,
-      /*task_runners=*/runners);
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_sync_switch=*/nil);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
   OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -1327,9 +1327,6 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   bridge->HandleEvent(annotatedEvent);
 
   XCTAssertEqual([accessibility_notifications count], 1ul);
-  // id focusObject = accessibility_notifications[0][@"argument"];
-  // XCTAssertTrue([focusObject isKindOfClass:[NSString class]]);
-  // XCTAssertEqualObjects(focusObject, @"node1");
   XCTAssertEqual([accessibility_notifications[0][@"notification"] unsignedIntValue],
                  UIAccessibilityLayoutChangedNotification);
 }


### PR DESCRIPTION
framework change:https://github.com/flutter/flutter/pull/126171
issue: https://github.com/flutter/flutter/issues/94523
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
