### PR TITLE
[linux] Wait for binding to be ready before requesting exits from framework

### DIFF
--- a/shell/platform/linux/fl_platform_plugin.cc
+++ b/shell/platform/linux/fl_platform_plugin.cc
@@ -244,6 +244,7 @@ static void request_app_exit(FlPlatformPlugin* self, const char* type) {
   if (!self->app_initialization_complete ||
       g_str_equal(type, kExitTypeRequired)) {
     quit_application();
+    return;
   }
 
   fl_value_set_string_take(args, kExitTypeKey, fl_value_new_string(type));

--- a/shell/platform/linux/fl_platform_plugin.cc
+++ b/shell/platform/linux/fl_platform_plugin.cc
@@ -260,7 +260,7 @@ static FlMethodResponse* system_intitialization_complete(
     FlPlatformPlugin* self,
     FlMethodCall* method_call) {
   self->app_initialization_complete = TRUE;
-  return nullptr;
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
 }
 
 // Called when Flutter wants to exit the application.

--- a/shell/platform/linux/fl_platform_plugin.cc
+++ b/shell/platform/linux/fl_platform_plugin.cc
@@ -237,9 +237,15 @@ static void request_app_exit_response_cb(GObject* object,
   }
 }
 
-// Send a request to Flutter to exit the application.
+// Send a request to Flutter to exit the application, but only if it's ready for
+// a request.
 static void request_app_exit(FlPlatformPlugin* self, const char* type) {
   g_autoptr(FlValue) args = fl_value_new_map();
+  if (!self->app_initialization_complete ||
+      g_str_equal(type, kExitTypeRequired)) {
+    quit_application();
+  }
+
   fl_value_set_string_take(args, kExitTypeKey, fl_value_new_string(type));
   fl_method_channel_invoke_method(self->channel, kRequestAppExitMethod, args,
                                   self->cancellable,

--- a/shell/platform/linux/fl_platform_plugin.cc
+++ b/shell/platform/linux/fl_platform_plugin.cc
@@ -353,16 +353,12 @@ static void method_call_cb(FlMethodChannel* channel,
     response = clipboard_has_strings_async(self, method_call);
   } else if (strcmp(method, kExitApplicationMethod) == 0) {
     response = system_exit_application(self, method_call);
-  } else if (strcmp(method, kInitializationComplete) == 0) {
+  } else if (strcmp(method, kInitializationCompleteMethod) == 0) {
     response = system_intitialization_complete(self, method_call);
   } else if (strcmp(method, kPlaySoundMethod) == 0) {
     response = system_sound_play(self, args);
   } else if (strcmp(method, kSystemNavigatorPopMethod) == 0) {
     response = system_navigator_pop(self);
-  } else if (strcmp(method, kInitializationCompleteMethod) == 0) {
-    // TODO(gspencergoog): Handle this message to enable exit message listening.
-    // https://github.com/flutter/flutter/issues/126033
-    response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
   } else {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
   }
@@ -403,6 +399,7 @@ FlPlatformPlugin* fl_platform_plugin_new(FlBinaryMessenger* messenger) {
       fl_method_channel_new(messenger, kChannelName, FL_METHOD_CODEC(codec));
   fl_method_channel_set_method_call_handler(self->channel, method_call_cb, self,
                                             nullptr);
+  self->app_initialization_complete = FALSE;
 
   return self;
 }

--- a/shell/platform/linux/fl_platform_plugin.cc
+++ b/shell/platform/linux/fl_platform_plugin.cc
@@ -255,7 +255,7 @@ static void request_app_exit(FlPlatformPlugin* self, const char* type) {
 
 // Called when the Dart app has finished initialization and is ready to handle
 // requests. For the Flutter framework, this means after the ServicesBinding has
-// been intialized and it sends a System.initializationComplete message.
+// been initialized and it sends a System.initializationComplete message.
 static FlMethodResponse* system_intitialization_complete(
     FlPlatformPlugin* self,
     FlMethodCall* method_call) {

--- a/shell/platform/linux/fl_platform_plugin.h
+++ b/shell/platform/linux/fl_platform_plugin.h
@@ -38,9 +38,12 @@ FlPlatformPlugin* fl_platform_plugin_new(FlBinaryMessenger* messenger);
  * @plugin: an #FlPlatformPlugin
  *
  * Request the application exits (i.e. due to the window being requested to be
- * closed). Will only actually send a request to the framework to ask if it
- * should exit if the framework has indicated that it is ready to receive
- * requests.
+ * closed).
+ *
+ * Calling this will only send an exit request to the framework if the framework
+ * has already indicated that it is ready to receive requests by sending a
+ * "System.initializationComplete" method call on the platform channel. Calls
+ * before initialization is complete will result in an immediate exit.
  */
 void fl_platform_plugin_request_app_exit(FlPlatformPlugin* plugin);
 

--- a/shell/platform/linux/fl_platform_plugin.h
+++ b/shell/platform/linux/fl_platform_plugin.h
@@ -38,7 +38,9 @@ FlPlatformPlugin* fl_platform_plugin_new(FlBinaryMessenger* messenger);
  * @plugin: an #FlPlatformPlugin
  *
  * Request the application exits (i.e. due to the window being requested to be
- * closed).
+ * closed). Will only actually send a request to the framework to ask if it
+ * should exit if the framework has indicated that it is ready to receive
+ * requests.
  */
 void fl_platform_plugin_request_app_exit(FlPlatformPlugin* plugin);
 

--- a/shell/platform/linux/fl_platform_plugin_test.cc
+++ b/shell/platform/linux/fl_platform_plugin_test.cc
@@ -114,21 +114,25 @@ TEST(FlPlatformPluginTest, ExitApplication) {
   EXPECT_NE(plugin, nullptr);
   g_autoptr(FlJsonMethodCodec) codec = fl_json_method_codec_new();
 
-  g_autoptr(FlValue) requestArgs = fl_value_new_map();
-  fl_value_set_string_take(requestArgs, "type",
-                           fl_value_new_string("cancelable"));
+  ON_CALL(messenger, fl_binary_messenger_send_response(
+                         ::testing::Eq<FlBinaryMessenger*>(messenger),
+                         ::testing::_, ::testing::_, ::testing::_))
+      .WillByDefault(testing::Return(TRUE));
 
   // Indicate that the binding is initialized.
+  g_autoptr(GError) error = nullptr;
   g_autoptr(GBytes) init_message = fl_method_codec_encode_method_call(
-      FL_METHOD_CODEC(codec), "System.initializationComplete", nullptr,
-      nullptr);
+      FL_METHOD_CODEC(codec), "System.initializationComplete", nullptr, &error);
   messenger.ReceiveMessage("flutter/platform", init_message);
 
+  g_autoptr(FlValue) request_args = fl_value_new_map();
+  fl_value_set_string_take(request_args, "type",
+                           fl_value_new_string("cancelable"));
   EXPECT_CALL(messenger,
               fl_binary_messenger_send_on_channel(
                   ::testing::Eq<FlBinaryMessenger*>(messenger),
                   ::testing::StrEq("flutter/platform"),
-                  MethodCall("System.requestAppExit", FlValueEq(requestArgs)),
+                  MethodCall("System.requestAppExit", FlValueEq(request_args)),
                   ::testing::_, ::testing::_, ::testing::_));
 
   g_autoptr(FlValue) args = fl_value_new_map();

--- a/shell/platform/linux/fl_platform_plugin_test.cc
+++ b/shell/platform/linux/fl_platform_plugin_test.cc
@@ -114,9 +114,10 @@ TEST(FlPlatformPluginTest, ExitApplication) {
   EXPECT_NE(plugin, nullptr);
   g_autoptr(FlJsonMethodCodec) codec = fl_json_method_codec_new();
 
+  g_autoptr(FlValue) null = fl_value_new_null();
   ON_CALL(messenger, fl_binary_messenger_send_response(
                          ::testing::Eq<FlBinaryMessenger*>(messenger),
-                         ::testing::_, ::testing::_, ::testing::_))
+                         ::testing::_, SuccessResponse(null), ::testing::_))
       .WillByDefault(testing::Return(TRUE));
 
   // Indicate that the binding is initialized.


### PR DESCRIPTION
## Description

Similar to https://github.com/flutter/engine/pull/41733 and https://github.com/flutter/engine/pull/41753 this causes the linux embedding to wait until it hears that the scheduler binding has registered itself before proceeding to send termination requests to the framework.

This allows applications that don't use the framework (just use `dart:ui` directly) to exit automatically when the last window is closed.  Without this change, the app does not exit when the window is closed.

Depends on framework PR https://github.com/flutter/flutter/pull/126075 landing first.

## Related PRs
 - https://github.com/flutter/engine/pull/41733
 - https://github.com/flutter/engine/pull/41753

## Related Issues
 - https://github.com/flutter/flutter/issues/126033.

## Tests
 - Added a test to make sure that it doesn't send a termination request if the binding hasn't notified that it is ready yet.