### PR TITLE
Windows unopt configuration.

### DIFF
--- a/ci/builders/standalone/windows_unopt.json
+++ b/ci/builders/standalone/windows_unopt.json
@@ -1,0 +1,39 @@
+{
+    "drone_dimensions": [
+        "device_type=none",
+        "os=Windows-10"
+    ],
+    "gclient_variables": {
+        "download_android_deps": false
+    },
+    "dependencies": [
+        {
+            "dependency": "certs",
+            "version": "version:9563bb"
+        }
+    ],
+    "gn": [
+        "--runtime-mode",
+        "debug",
+        "--unoptimized",
+        "--prebuilt-dart-sdk"
+    ],
+    "name": "host_debug",
+    "ninja": {
+        "config": "host_debug_unopt"
+    },
+    "tests": [
+        {
+            "language": "python3",
+            "name": "test: Host Tests for host_debug_unopt",
+            "parameters": [
+                "--variant",
+                "host_debug_unopt",
+                "--type",
+                "engine",
+                "--engine-capture-core-dump"
+            ],
+            "script": "flutter/testing/run_tests.py"
+        }
+    ]
+}


### PR DESCRIPTION
This PR also add a standalone folder to the build configurations folder. This is to separate configurations that require orchestrators from the ones the do not require them.

Bug: https://github.com/flutter/flutter/issues/126120

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
