### PR TITLE
allow supplying custom gn args in gn wrapper

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -1119,6 +1119,14 @@ def parse_args(args):
   # Verbose output.
   parser.add_argument('--verbose', default=False, action='store_true')
 
+  parser.add_argument(
+      '--gn-args',
+      action='append',
+      help='Additional gn args to be passed to gn. If you '
+      'need to use this, it should probably be another switch '
+      'in //flutter/tools/gn.',
+  )
+
   return parser.parse_args(args)
 
 
@@ -1174,6 +1182,7 @@ def main(argv):
   command.append('--export-compile-commands=default')
 
   gn_args = to_command_line(to_gn_args(args))
+  gn_args.extend(args.gn_args or [])
   out_dir = get_out_dir(args)
   command.append(out_dir)
   command.append('--args=%s' % ' '.join(gn_args))


### PR DESCRIPTION
allows to supply gn args that do not have their cli switches (yet), like this:
```sh
python3 ./tools/gn --gn-args 'use_default_linux_sysroot=false'
```

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/126197

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
