### PR TITLE
Fix doc to fix engine roll

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -133,7 +133,7 @@ class FlutterView {
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
   ///  * [Display.devicePixelRatio], which reports the DPR of the display.
-  ///    The value here is equal to the value on the [display.devicePixelRatio].
+  ///    The value here is equal to the value exposed on [display].
   double get devicePixelRatio => _viewConfiguration.devicePixelRatio;
 
   /// The dimensions and location of the rectangle into which the scene rendered


### PR DESCRIPTION
The engine roll is currently failing (https://cirrus-ci.com/task/5475027185827840?logs=main#L172) because of a doc issue introduced by https://github.com/flutter/engine/pull/41685. This fixes the doc issue.