### PR TITLE
[web] generalize focusability in semantics

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1977,6 +1977,7 @@ ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics.dart + ../../../flu
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/accessibility.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/checkable.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/dialog.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/focusable.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/image.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/incrementable.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/semantics/label_and_value.dart + ../../../flutter/LICENSE
@@ -4592,6 +4593,7 @@ FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/accessibility.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/checkable.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/dialog.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/focusable.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/image.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/incrementable.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/semantics/label_and_value.dart

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -134,6 +134,7 @@ export 'engine/safe_browser_api.dart';
 export 'engine/semantics/accessibility.dart';
 export 'engine/semantics/checkable.dart';
 export 'engine/semantics/dialog.dart';
+export 'engine/semantics/focusable.dart';
 export 'engine/semantics/image.dart';
 export 'engine/semantics/incrementable.dart';
 export 'engine/semantics/label_and_value.dart';

--- a/lib/web_ui/lib/src/engine/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics.dart
@@ -4,6 +4,7 @@
 
 export 'semantics/accessibility.dart';
 export 'semantics/checkable.dart';
+export 'semantics/focusable.dart';
 export 'semantics/image.dart';
 export 'semantics/incrementable.dart';
 export 'semantics/label_and_value.dart';

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -1,0 +1,193 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:ui/ui.dart' as ui;
+
+import '../dom.dart';
+import '../platform_dispatcher.dart';
+import '../util.dart';
+import 'semantics.dart';
+
+/// Supplies generic accessibility focus features to semantics nodes that have
+/// [ui.SemanticsFlag.isFocusable] set.
+///
+/// Assumes that the element being focused on is [SemanticsObject.element]. Role
+/// managers with special needs can implement custom focus management and
+/// exclude this role manager.
+///
+/// `"tab-index=0"` is used because `<flt-semantics>` is not intrinsically
+/// focusable. Examples of intrinsically focusable elements include:
+///
+///   * <button>
+///   * <input> (of any type)
+///   * <a>
+///   * <textarea>
+///
+/// See also:
+///
+///   * https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets
+class Focusable extends RoleManager {
+  Focusable(SemanticsObject semanticsObject)
+      : _focusManager = AccessibilityFocusManager(semanticsObject.owner),
+        super(Role.focusable, semanticsObject) {
+    _focusManager.manage(semanticsObject.id, semanticsObject.element);
+  }
+
+  final AccessibilityFocusManager _focusManager;
+
+  @override
+  void update() {
+    _focusManager.changeFocus(semanticsObject.hasFocus && (!semanticsObject.hasEnabledState || semanticsObject.isEnabled));
+  }
+
+  @override
+  void dispose() {
+    _focusManager.stopManaging();
+  }
+}
+
+/// Objects associated with the element whose focus is being managed.
+typedef _FocusTarget = ({
+  /// [SemanticsObject.id] of the semantics node being managed.
+  int semanticsNodeId,
+
+  /// The element whose focus is being managed.
+  DomElement element,
+
+  /// The listener for the "focus" DOM event.
+  DomEventListener domFocusListener,
+
+  /// The listener for the "blur" DOM event.
+  DomEventListener domBlurListener,
+});
+
+/// Implements accessibility focus management for arbitrary elements.
+///
+/// Unlike [Focusable], which implements focus features on [SemanticsObject]s
+/// whose [SemanticsObject.element] is directly focusable, this class can help
+/// implementing focus features on custom elements. For example, [Incrementable]
+/// uses a custom `<input>` tag internally while its root-level element is not
+/// focusable. However, it can still use this class to managing the focus of the
+/// internal element.
+class AccessibilityFocusManager {
+  /// Creates a focus manager tied to a specific [EngineSemanticsOwner].
+  AccessibilityFocusManager(this._owner);
+
+  final EngineSemanticsOwner _owner;
+
+  _FocusTarget? _target;
+
+  /// Starts managing the focus of the given [element].
+  ///
+  /// The "focus" and "blur" DOM events are forwarded to the framework-side
+  /// semantics node with ID [semanticsNodeId] as [ui.SemanticsAction]s.
+  ///
+  /// If this manage was already managing a different element, stops managing
+  /// the old element and starts managing the new one.
+  ///
+  /// Calling this with the same element but a different [semanticsNodeId] will
+  /// cause any future focus/blur events to be forwarded to the new ID.
+  void manage(int semanticsNodeId, DomElement element) {
+    if (identical(element, _target?.element)) {
+      final _FocusTarget previousTarget = _target!;
+      if (semanticsNodeId == previousTarget.semanticsNodeId) {
+        return;
+      }
+
+      // No need to hook up new DOM listeners. The existing ones are good enough.
+      _target = (
+        semanticsNodeId: semanticsNodeId,
+        element: previousTarget.element,
+        domFocusListener: previousTarget.domFocusListener,
+        domBlurListener: previousTarget.domBlurListener,
+      );
+      return;
+    }
+
+    if (_target != null) {
+      // The element changed. Clear the old element before initializing the new one.
+      stopManaging();
+    }
+
+    final _FocusTarget newTarget = (
+      semanticsNodeId: semanticsNodeId,
+      element: element,
+      domFocusListener: createDomEventListener((_) => _setFocusFromDom(true)),
+      domBlurListener: createDomEventListener((_) => _setFocusFromDom(false)),
+    );
+    _target = newTarget;
+
+    element.tabIndex = 0;
+    element.addEventListener('focus', newTarget.domFocusListener);
+    element.addEventListener('blur', newTarget.domBlurListener);
+  }
+
+  /// Stops managing the focus of the current element, if any.
+  void stopManaging() {
+    final _FocusTarget? target = _target;
+
+    if (target == null) {
+      /// Nothing is being managed. Just return.
+      return;
+    }
+
+    target.element.removeEventListener('focus', target.domFocusListener);
+    target.element.removeEventListener('blur', target.domBlurListener);
+    _target = null;
+  }
+
+  void _setFocusFromDom(bool acquireFocus) {
+    final _FocusTarget? target = _target;
+
+    if (target == null) {
+      // DOM events can be asynchronous. By the time the event reaches here, the
+      // focus manager may have been disposed of.
+      return;
+    }
+
+    EnginePlatformDispatcher.instance.invokeOnSemanticsAction(
+      target.semanticsNodeId,
+      acquireFocus
+        ? ui.SemanticsAction.didGainAccessibilityFocus
+        : ui.SemanticsAction.didLoseAccessibilityFocus,
+      null,
+    );
+  }
+
+  /// Requests focus or blur on the DOM element.
+  void changeFocus(bool value) {
+    final _FocusTarget? target = _target;
+
+    if (target == null) {
+      // Nothing is being managed right now.
+      assert(() {
+        printWarning(
+          'Cannot change focus to $value. No element is being managed by this '
+          'AccessibilityFocusManager.'
+        );
+        return true;
+      }());
+      return;
+    }
+
+    // Delay the focus request until the final DOM structure is established
+    // because the element may not yet be attached to the DOM, or it may be
+    // reparented and lose focus again.
+    _owner.addOneTimePostUpdateCallback(() {
+      if (_target != target) {
+        // The element may have been swapped or the manager may have been disposed
+        // of between the focus change request and the post update callback
+        // invocation. So check again that the element is still the same and is
+        // not null.
+        return;
+      }
+
+      if (value) {
+        target.element.focus();
+      } else {
+        target.element.blur();
+      }
+    });
+  }
+}

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -68,7 +68,7 @@ typedef _FocusTarget = ({
 /// whose [SemanticsObject.element] is directly focusable, this class can help
 /// implementing focus features on custom elements. For example, [Incrementable]
 /// uses a custom `<input>` tag internally while its root-level element is not
-/// focusable. However, it can still use this class to managing the focus of the
+/// focusable. However, it can still use this class to manage the focus of the
 /// internal element.
 class AccessibilityFocusManager {
   /// Creates a focus manager tied to a specific [EngineSemanticsOwner].

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -6,6 +6,7 @@ import 'package:ui/ui.dart' as ui;
 
 import '../dom.dart';
 import '../platform_dispatcher.dart';
+import 'focusable.dart';
 import 'semantics.dart';
 
 /// Adds increment/decrement event handling to a semantics object.
@@ -19,7 +20,8 @@ import 'semantics.dart';
 /// gestures must be interpreted by the Flutter framework.
 class Incrementable extends RoleManager {
   Incrementable(SemanticsObject semanticsObject)
-      : super(Role.incrementable, semanticsObject) {
+      : _focusManager = AccessibilityFocusManager(semanticsObject.owner),
+        super(Role.incrementable, semanticsObject) {
     semanticsObject.element.append(_element);
     _element.type = 'range';
     _element.setAttribute('role', 'slider');
@@ -47,10 +49,13 @@ class Incrementable extends RoleManager {
       update();
     };
     semanticsObject.owner.addGestureModeListener(_gestureModeListener);
+    _focusManager.manage(semanticsObject.id, _element);
   }
 
   /// The HTML element used to render semantics to the browser.
   final DomHTMLInputElement _element = createDomHTMLInputElement();
+
+  final AccessibilityFocusManager _focusManager;
 
   /// The value used by the input element.
   ///
@@ -82,6 +87,7 @@ class Incrementable extends RoleManager {
       case GestureMode.pointerEvents:
         _disableBrowserGestureHandling();
     }
+    _focusManager.changeFocus(semanticsObject.hasFocus);
   }
 
   void _enableBrowserGestureHandling() {
@@ -134,6 +140,7 @@ class Incrementable extends RoleManager {
   @override
   void dispose() {
     assert(_gestureModeListener != null);
+    _focusManager.stopManaging();
     semanticsObject.owner.removeGestureModeListener(_gestureModeListener);
     _gestureModeListener = null;
     _disableBrowserGestureHandling();

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -24,10 +24,6 @@ class Tappable extends RoleManager {
   void update() {
     final DomElement element = semanticsObject.element;
 
-    // "tab-index=0" is used to allow keyboard traversal of non-form elements.
-    // See also: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets
-    element.tabIndex = 0;
-
     semanticsObject.setAriaRole(
         'button', semanticsObject.hasFlag(ui.SemanticsFlag.isButton));
 
@@ -56,13 +52,6 @@ class Tappable extends RoleManager {
       } else {
         _stopListening();
       }
-    }
-
-    // Request focus so that the AT shifts a11y focus to this node.
-    if (semanticsObject.isFlagsDirty && semanticsObject.hasFocus) {
-      semanticsObject.owner.addOneTimePostUpdateCallback(() {
-        element.focus();
-      });
     }
   }
 

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -111,7 +111,6 @@ void testMain() {
     expect(await logger.actionLog.first, ui.SemanticsAction.tap);
     }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
       // TODO(yjbanov): https://github.com/flutter/flutter/issues/50590
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50754
       skip: browserEngine != BrowserEngine.blink);
 
     test('Syncs semantic state from framework', () {


### PR DESCRIPTION
Introduce 2 new classes for a11y focus management:

* `AccessibilityFocusManager`: a generic class that attaches "focus" and "blur" event handlers, and forwards the events to the framework as `SemanticsAction.didGainAccessibilityFocus` and `SemanticsAction.didLoseAccessibilityFocus` respectively. Provides the `changeFocus` method for the framework to move a11y focus to the target element.
* `Focusable`: a role manager that provides generic focus management functionality to `SemanticsObject`s that don't need anything special.

Rewrites focus management using the above two classes as follows:

* All focusable nodes except text fields and incrementables get the `Focusable` role (all custom focus stuff in `Tappable` was removed and delegated to `Focusable`).
* `Incrementable` uses a custom `<input>` internally and so it cannot use the `Focusable` role. Instead, it uses `AccessibilityFocusManager` to manage the focus on the `<input>` element.

Behavioral changes:

* Fixes https://github.com/flutter/flutter/issues/118737, but more generally fixes all nodes that use the `isFocusable` and `hasFocus` bits.
* `Tappable` only partially implemented focusability (e.g. it didn't generate the respective `SemanticsAction` events). Now by delegating to `Focusable`, it will inherit all the functionality.
* `Incrementable` and `Checkable` (checkboxes, radios, switches) get focus management features for the first time.
* Elements that are not inherently focusable (text, images) can now be focused if semantics requires them to be.
* `TextField` is left alone for now as focus and on-screen keyboard interact with each other in non-obvious ways.