### PR TITLE
[Impeller] track path convexity and use it to simplify fill tessellation.

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -261,8 +261,10 @@ void Canvas::DrawCircle(Point center, Scalar radius, const Paint& paint) {
                               paint)) {
     return;
   }
-  auto circle_path = PathBuilder{}.AddCircle(center, radius).TakePath();
-  circle_path.SetConvexity(Convexity::kConvex);
+  auto circle_path = PathBuilder{}
+                         .AddCircle(center, radius)
+                         .SetConvexity(Convexity::kConvex)
+                         .TakePath();
   DrawPath(circle_path, paint);
 }
 

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -251,10 +251,8 @@ void Canvas::DrawRRect(Rect rect, Scalar corner_radius, const Paint& paint) {
 
     GetCurrentPass().AddEntity(entity);
     return;
-  } else {
-    DrawPath(PathBuilder{}.AddRoundedRect(rect, corner_radius).TakePath(),
-             paint);
   }
+  DrawPath(PathBuilder{}.AddRoundedRect(rect, corner_radius).TakePath(), paint);
 }
 
 void Canvas::DrawCircle(Point center, Scalar radius, const Paint& paint) {
@@ -263,7 +261,9 @@ void Canvas::DrawCircle(Point center, Scalar radius, const Paint& paint) {
                               paint)) {
     return;
   }
-  DrawPath(PathBuilder{}.AddCircle(center, radius).TakePath(), paint);
+  auto circle_path = PathBuilder{}.AddCircle(center, radius).TakePath();
+  circle_path.SetConvexity(Convexity::kConvex);
+  DrawPath(circle_path, paint);
 }
 
 void Canvas::ClipPath(const Path& path, Entity::ClipOperation clip_op) {

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
@@ -846,6 +847,7 @@ void DlDispatcher::drawLine(const SkPoint& p0, const SkPoint& p1) {
       PathBuilder{}
           .AddLine(skia_conversions::ToPoint(p0), skia_conversions::ToPoint(p1))
           .TakePath();
+  path.SetConvexity(Convexity::kConvex);
   Paint paint = paint_;
   paint.style = Paint::Style::kStroke;
   canvas_.DrawPath(path, paint);
@@ -864,6 +866,7 @@ void DlDispatcher::drawOval(const SkRect& bounds) {
   } else {
     auto path =
         PathBuilder{}.AddOval(skia_conversions::ToRect(bounds)).TakePath();
+    path.SetConvexity(Convexity::kConvex);
     canvas_.DrawPath(path, paint_);
   }
 }
@@ -893,6 +896,7 @@ void DlDispatcher::drawDRRect(const SkRRect& outer, const SkRRect& inner) {
 
 // |flutter::DlOpReceiver|
 void DlDispatcher::drawPath(const SkPath& path) {
+  std::cerr << "DRAW PATH" << path.isConvex() << std::endl;
   canvas_.DrawPath(skia_conversions::ToPath(path), paint_);
 }
 

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -845,8 +845,8 @@ void DlDispatcher::drawLine(const SkPoint& p0, const SkPoint& p1) {
   auto path =
       PathBuilder{}
           .AddLine(skia_conversions::ToPoint(p0), skia_conversions::ToPoint(p1))
+          .SetConvexity(Convexity::kConvex)
           .TakePath();
-  path.SetConvexity(Convexity::kConvex);
   Paint paint = paint_;
   paint.style = Paint::Style::kStroke;
   canvas_.DrawPath(path, paint);
@@ -863,9 +863,10 @@ void DlDispatcher::drawOval(const SkRect& bounds) {
     canvas_.DrawCircle(skia_conversions::ToPoint(bounds.center()),
                        bounds.width() * 0.5, paint_);
   } else {
-    auto path =
-        PathBuilder{}.AddOval(skia_conversions::ToRect(bounds)).TakePath();
-    path.SetConvexity(Convexity::kConvex);
+    auto path = PathBuilder{}
+                    .AddOval(skia_conversions::ToRect(bounds))
+                    .SetConvexity(Convexity::kConvex)
+                    .TakePath();
     canvas_.DrawPath(path, paint_);
   }
 }

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <iostream>
 #include <memory>
 #include <optional>
 #include <unordered_map>

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -6,12 +6,12 @@
 
 #include <algorithm>
 #include <cstring>
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <iostream>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
@@ -896,7 +896,6 @@ void DlDispatcher::drawDRRect(const SkRRect& outer, const SkRRect& inner) {
 
 // |flutter::DlOpReceiver|
 void DlDispatcher::drawPath(const SkPath& path) {
-  std::cerr << "DRAW PATH" << path.isConvex() << std::endl;
   canvas_.DrawPath(skia_conversions::ToPath(path), paint_);
 }
 

--- a/impeller/display_list/skia_conversions.cc
+++ b/impeller/display_list/skia_conversions.cc
@@ -110,14 +110,16 @@ Path ToPath(const SkPath& path) {
       break;
   }
   auto result_path = builder.TakePath(fill_type);
-  result_path.SetConvexity(path.isConvex() ? Convexity::kConvex : Convexity::kUnknown);
+  result_path.SetConvexity(path.isConvex() ? Convexity::kConvex
+                                           : Convexity::kUnknown);
   return result_path;
 }
 
 Path ToPath(const SkRRect& rrect) {
-  auto result_path = PathBuilder{}
-      .AddRoundedRect(ToRect(rrect.getBounds()), ToRoundingRadii(rrect))
-      .TakePath();
+  auto result_path =
+      PathBuilder{}
+          .AddRoundedRect(ToRect(rrect.getBounds()), ToRoundingRadii(rrect))
+          .TakePath();
   result_path.SetConvexity(Convexity::kConvex);
   return result_path;
 }

--- a/impeller/display_list/skia_conversions.cc
+++ b/impeller/display_list/skia_conversions.cc
@@ -109,19 +109,16 @@ Path ToPath(const SkPath& path) {
       fill_type = FillType::kNonZero;
       break;
   }
-  auto result_path = builder.TakePath(fill_type);
-  result_path.SetConvexity(path.isConvex() ? Convexity::kConvex
-                                           : Convexity::kUnknown);
-  return result_path;
+  builder.SetConvexity(path.isConvex() ? Convexity::kConvex
+                                       : Convexity::kUnknown);
+  return builder.TakePath(fill_type);
 }
 
 Path ToPath(const SkRRect& rrect) {
-  auto result_path =
-      PathBuilder{}
-          .AddRoundedRect(ToRect(rrect.getBounds()), ToRoundingRadii(rrect))
-          .TakePath();
-  result_path.SetConvexity(Convexity::kConvex);
-  return result_path;
+  return PathBuilder{}
+      .AddRoundedRect(ToRect(rrect.getBounds()), ToRoundingRadii(rrect))
+      .SetConvexity(Convexity::kConvex)
+      .TakePath();
 }
 
 Point ToPoint(const SkPoint& point) {

--- a/impeller/display_list/skia_conversions.cc
+++ b/impeller/display_list/skia_conversions.cc
@@ -109,13 +109,17 @@ Path ToPath(const SkPath& path) {
       fill_type = FillType::kNonZero;
       break;
   }
-  return builder.TakePath(fill_type);
+  auto result_path = builder.TakePath(fill_type);
+  result_path.SetConvexity(path.isConvex() ? Convexity::kConvex : Convexity::kUnknown);
+  return result_path;
 }
 
 Path ToPath(const SkRRect& rrect) {
-  return PathBuilder{}
+  auto result_path = PathBuilder{}
       .AddRoundedRect(ToRect(rrect.getBounds()), ToRoundingRadii(rrect))
       .TakePath();
+  result_path.SetConvexity(Convexity::kConvex);
+  return result_path;
 }
 
 Point ToPoint(const SkPoint& point) {

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2605,19 +2605,18 @@ TEST_P(EntityTest, TessellateConvex) {
     // Sanity check simple rectangle.
     auto [pts, indices] =
         TessellateConvex(PathBuilder{}
-                            .AddRect(Rect::MakeLTRB(0, 0, 10, 10))
-                            .TakePath()
-                            .CreatePolyline(1.0));
+                             .AddRect(Rect::MakeLTRB(0, 0, 10, 10))
+                             .TakePath()
+                             .CreatePolyline(1.0));
 
     std::vector<Point> expected = {
-      {0, 0},   {10, 0},  {4, 4}, //
-      {10, 0},  {10, 10}, {4, 4}, //
-      {10, 10}, {0, 10},  {4, 4}, //
-      {0, 10},  {0, 0},   {4, 4}, //
+        {0, 0},   {10, 0},  {4, 4},  //
+        {10, 0},  {10, 10}, {4, 4},  //
+        {10, 10}, {0, 10},  {4, 4},  //
+        {0, 10},  {0, 0},   {4, 4},  //
     };
-    std::vector<uint16_t> expected_indices = {
-      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
-    };
+    std::vector<uint16_t> expected_indices = {0, 1, 2, 3, 4,  5,
+                                              6, 7, 8, 9, 10, 11};
     ASSERT_EQ(pts, expected);
     ASSERT_EQ(indices, expected_indices);
   }

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2600,5 +2600,28 @@ TEST_P(EntityTest, TiledTextureContentsIsOpaque) {
   ASSERT_FALSE(contents.IsOpaque());
 }
 
+TEST_P(EntityTest, TessellateConvex) {
+  {
+    // Sanity check simple rectangle.
+    auto [pts, indices] =
+        TessellateConvex(PathBuilder{}
+                            .AddRect(Rect::MakeLTRB(0, 0, 10, 10))
+                            .TakePath()
+                            .CreatePolyline(1.0));
+
+    std::vector<Point> expected = {
+      {0, 0},   {10, 0},  {4, 4}, //
+      {10, 0},  {10, 10}, {4, 4}, //
+      {10, 10}, {0, 10},  {4, 4}, //
+      {0, 10},  {0, 0},   {4, 4}, //
+    };
+    std::vector<uint16_t> expected_indices = {
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+    };
+    ASSERT_EQ(pts, expected);
+    ASSERT_EQ(indices, expected_indices);
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2610,13 +2610,27 @@ TEST_P(EntityTest, TessellateConvex) {
                              .CreatePolyline(1.0));
 
     std::vector<Point> expected = {
-        {0, 0},   {10, 0},  {4, 4},  //
-        {10, 0},  {10, 10}, {4, 4},  //
-        {10, 10}, {0, 10},  {4, 4},  //
-        {0, 10},  {0, 0},   {4, 4},  //
+        {0, 0}, {10, 0}, {10, 10}, {0, 10},  //
     };
-    std::vector<uint16_t> expected_indices = {0, 1, 2, 3, 4,  5,
-                                              6, 7, 8, 9, 10, 11};
+    std::vector<uint16_t> expected_indices = {0, 1, 2, 0, 2, 3};
+    ASSERT_EQ(pts, expected);
+    ASSERT_EQ(indices, expected_indices);
+  }
+
+  {
+    auto [pts, indices] =
+        TessellateConvex(PathBuilder{}
+                             .AddRect(Rect::MakeLTRB(0, 0, 10, 10))
+                             .AddRect(Rect::MakeLTRB(20, 20, 30, 30))
+                             .TakePath()
+                             .CreatePolyline(1.0));
+
+    std::vector<Point> expected = {
+        {0, 0},   {10, 0},  {10, 10}, {0, 10},  //
+        {20, 20}, {30, 20}, {30, 30}, {20, 30}  //
+    };
+    std::vector<uint16_t> expected_indices = {0, 1, 2, 0, 2, 3,
+                                              0, 6, 7, 0, 7, 8};
     ASSERT_EQ(pts, expected);
     ASSERT_EQ(indices, expected_indices);
   }

--- a/impeller/entity/geometry.cc
+++ b/impeller/entity/geometry.cc
@@ -103,6 +103,15 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
     const ContentContext& renderer,
     const Entity& entity,
     RenderPass& pass) {
+  if (path_.GetFillType() == FillType::kNonZero &&  //
+      path.GetConvexity() == Convexity::kConvex &&  //
+      renderer.GetDeviceCapabilities().SupportsDisabledRasterization()) {
+    auto polyline = path_.CreatePolyline(entity.GetTransformation().GetMaxBasisLength());
+    for (auto i = 0u; i < polyline.contours.size(); i++) {
+      auto [start, end] = polyline.GetContourPointBounds(i);
+    }
+  }
+
   VertexBuffer vertex_buffer;
   auto& host_buffer = pass.GetTransientsBuffer();
   auto tesselation_result = renderer.GetTessellator()->Tessellate(

--- a/impeller/entity/geometry.cc
+++ b/impeller/entity/geometry.cc
@@ -41,9 +41,12 @@ std::pair<std::vector<Point>, std::vector<uint16_t>> TessellateConvex(
       output.emplace_back(point_b);
       output.emplace_back(Point(center_x, center_y));
     }
-    output.emplace_back(polyline.points[end - 1]);
-    output.emplace_back(polyline.points[start]);
-    output.emplace_back(Point(center_x, center_y));
+    // Some shapes don't seem to self close?
+    if (polyline.points[end - 1] != polyline.points[start]) {
+      output.emplace_back(polyline.points[end - 1]);
+      output.emplace_back(polyline.points[start]);
+      output.emplace_back(Point(center_x, center_y));
+    }
   }
 
   std::vector<uint16_t> index(output.size());

--- a/impeller/entity/geometry.cc
+++ b/impeller/entity/geometry.cc
@@ -104,9 +104,9 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
     const Entity& entity,
     RenderPass& pass) {
   if (path_.GetFillType() == FillType::kNonZero &&  //
-      path.GetConvexity() == Convexity::kConvex &&  //
-      renderer.GetDeviceCapabilities().SupportsDisabledRasterization()) {
-    auto polyline = path_.CreatePolyline(entity.GetTransformation().GetMaxBasisLength());
+      path_.GetConvexity() == Convexity::kConvex) {
+    auto polyline =
+        path_.CreatePolyline(entity.GetTransformation().GetMaxBasisLength());
     for (auto i = 0u; i < polyline.contours.size(); i++) {
       auto [start, end] = polyline.GetContourPointBounds(i);
     }

--- a/impeller/entity/geometry.cc
+++ b/impeller/entity/geometry.cc
@@ -138,7 +138,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
   VertexBuffer vertex_buffer;
 
   if (path_.GetFillType() == FillType::kNonZero &&  //
-      path_.GetIsConvex()) {
+      path_.IsConvex()) {
     auto [points, indicies] = TessellateConvex(
         path_.CreatePolyline(entity.GetTransformation().GetMaxBasisLength()));
 

--- a/impeller/entity/geometry.h
+++ b/impeller/entity/geometry.h
@@ -33,6 +33,11 @@ enum GeometryVertexType {
   kUV,
 };
 
+/// @brief Given a polyline created from a convex filled path, perform a
+/// tessellation.
+std::pair<std::vector<Point>, std::vector<uint16_t>> TessellateConvex(
+    Path::Polyline polyline);
+
 class Geometry {
  public:
   Geometry();

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -53,6 +53,14 @@ FillType Path::GetFillType() const {
   return fill_;
 }
 
+void Path::SetConvexity(Convexity value) {
+  convexity_ = value;
+}
+
+Convexity Path::GetConvexity() const {
+  return convexity_;
+}
+
 Path& Path::AddLinearComponent(Point p1, Point p2) {
   linears_.emplace_back(p1, p2);
   components_.emplace_back(ComponentType::kLinear, linears_.size() - 1);

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -53,7 +53,7 @@ FillType Path::GetFillType() const {
   return fill_;
 }
 
-bool Path::GetIsConvex() const {
+bool Path::IsConvex() const {
   return convexity_ == Convexity::kConvex;
 }
 

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -53,12 +53,12 @@ FillType Path::GetFillType() const {
   return fill_;
 }
 
-void Path::SetConvexity(Convexity value) {
-  convexity_ = value;
+bool Path::GetIsConvex() const {
+  return convexity_ == Convexity::kConvex;
 }
 
-Convexity Path::GetConvexity() const {
-  return convexity_;
+void Path::SetConvexity(Convexity value) {
+  convexity_ = value;
 }
 
 Path& Path::AddLinearComponent(Point p1, Point p2) {

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -37,8 +37,6 @@ enum class FillType {
 enum class Convexity {
   kUnknown,
   kConvex,
-  kConcave,
-  kComplex,
 };
 
 //------------------------------------------------------------------------------
@@ -101,9 +99,7 @@ class Path {
 
   FillType GetFillType() const;
 
-  void SetConvexity(Convexity value);
-
-  Convexity GetConvexity() const;
+  bool GetIsConvex() const;
 
   Path& AddLinearComponent(Point p1, Point p2);
 
@@ -159,6 +155,10 @@ class Path {
   std::optional<std::pair<Point, Point>> GetMinMaxCoveragePoints() const;
 
  private:
+  friend class PathBuilder;
+
+  void SetConvexity(Convexity value);
+
   struct ComponentIndexPair {
     ComponentType type = ComponentType::kLinear;
     size_t index = 0;

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -34,6 +34,13 @@ enum class FillType {
   kAbsGeqTwo,
 };
 
+enum class Convexity {
+  kUnknown,
+  kConvex,
+  kConcave,
+  kComplex,
+};
+
 //------------------------------------------------------------------------------
 /// @brief      Paths are lightweight objects that describe a collection of
 ///             linear, quadratic, or cubic segments. These segments may be
@@ -93,6 +100,10 @@ class Path {
   void SetFillType(FillType fill);
 
   FillType GetFillType() const;
+
+  void SetConvexity(Convexity value);
+
+  Convexity GetConvexity() const;
 
   Path& AddLinearComponent(Point p1, Point p2);
 
@@ -159,6 +170,7 @@ class Path {
   };
 
   FillType fill_ = FillType::kNonZero;
+  Convexity convexity_ = Convexity::kUnknown;
   std::vector<ComponentIndexPair> components_;
   std::vector<LinearPathComponent> linears_;
   std::vector<QuadraticPathComponent> quads_;

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -99,7 +99,7 @@ class Path {
 
   FillType GetFillType() const;
 
-  bool GetIsConvex() const;
+  bool IsConvex() const;
 
   Path& AddLinearComponent(Point p1, Point p2);
 

--- a/impeller/geometry/path_builder.cc
+++ b/impeller/geometry/path_builder.cc
@@ -21,6 +21,7 @@ Path PathBuilder::CopyPath(FillType fill) const {
 Path PathBuilder::TakePath(FillType fill) {
   auto path = prototype_;
   path.SetFillType(fill);
+  path.SetConvexity(convexity_);
   return path;
 }
 
@@ -100,6 +101,11 @@ PathBuilder& PathBuilder::SmoothQuadraticCurveTo(Point point, bool relative) {
    *  too. So there the last argument is always false (i.e, not relative).
    */
   QuadraticCurveTo(point, ReflectedQuadraticControlPoint1(), false);
+  return *this;
+}
+
+PathBuilder& PathBuilder::SetConvexity(Convexity value) {
+  convexity_ = value;
   return *this;
 }
 

--- a/impeller/geometry/path_builder.h
+++ b/impeller/geometry/path_builder.h
@@ -31,6 +31,8 @@ class PathBuilder {
 
   const Path& GetCurrentPath() const;
 
+  PathBuilder& SetConvexity(Convexity value);
+
   PathBuilder& MoveTo(Point point, bool relative = false);
 
   PathBuilder& Close();
@@ -116,6 +118,7 @@ class PathBuilder {
   Point subpath_start_;
   Point current_;
   Path prototype_;
+  Convexity convexity_;
 
   Point ReflectedQuadraticControlPoint1() const;
 


### PR DESCRIPTION
We can do this on the GPU, but we'll need a fallback when we don't have polyline compute.

From experimentation, Skia has already computed this value when Impeller gets that path. Additionally, this will allow us to speed up tessellation of known convex shapes like ovals that we don't want to add special cases for in the API.