### PR TITLE
[Impeller] delete special handling of RRect.

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -241,18 +241,22 @@ void Canvas::DrawRRect(Rect rect, Scalar corner_radius, const Paint& paint) {
   if (AttemptDrawBlurredRRect(rect, corner_radius, paint)) {
     return;
   }
+  auto path = PathBuilder{}
+                  .SetConvexity(Convexity::kConvex)
+                  .AddRoundedRect(rect, corner_radius)
+                  .TakePath();
   if (paint.style == Paint::Style::kFill) {
     Entity entity;
     entity.SetTransformation(GetCurrentTransformation());
     entity.SetStencilDepth(GetStencilDepth());
     entity.SetBlendMode(paint.blend_mode);
-    entity.SetContents(paint.WithFilters(paint.CreateContentsForGeometry(
-        Geometry::MakeRRect(rect, corner_radius))));
+    entity.SetContents(paint.WithFilters(
+        paint.CreateContentsForGeometry(Geometry::MakeFillPath(path))));
 
     GetCurrentPass().AddEntity(entity);
     return;
   }
-  DrawPath(PathBuilder{}.AddRoundedRect(rect, corner_radius).TakePath(), paint);
+  DrawPath(path, paint);
 }
 
 void Canvas::DrawCircle(Point center, Scalar radius, const Paint& paint) {
@@ -293,7 +297,11 @@ void Canvas::ClipRect(const Rect& rect, Entity::ClipOperation clip_op) {
 void Canvas::ClipRRect(const Rect& rect,
                        Scalar corner_radius,
                        Entity::ClipOperation clip_op) {
-  ClipGeometry(Geometry::MakeRRect(rect, corner_radius), clip_op);
+  auto path = PathBuilder{}
+                  .SetConvexity(Convexity::kConvex)
+                  .AddRoundedRect(rect, corner_radius)
+                  .TakePath();
+  ClipGeometry(Geometry::MakeFillPath(path), clip_op);
   switch (clip_op) {
     case Entity::ClipOperation::kIntersect:
       IntersectCulling(rect);

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -224,7 +224,11 @@ TEST_P(EntityTest, CanDrawRect) {
 
 TEST_P(EntityTest, CanDrawRRect) {
   auto contents = std::make_shared<SolidColorContents>();
-  contents->SetGeometry(Geometry::MakeRRect({100, 100, 100, 100}, 10.0));
+  auto path = PathBuilder{}
+                  .SetConvexity(Convexity::kConvex)
+                  .AddRoundedRect({100, 100, 100, 100}, 10.0)
+                  .TakePath();
+  contents->SetGeometry(Geometry::MakeFillPath(path));
   contents->SetColor(Color::Red());
 
   Entity entity;

--- a/impeller/entity/geometry.h
+++ b/impeller/entity/geometry.h
@@ -46,8 +46,6 @@ class Geometry {
 
   static std::unique_ptr<Geometry> MakeFillPath(const Path& path);
 
-  static std::unique_ptr<Geometry> MakeRRect(Rect rect, Scalar corner_radius);
-
   static std::unique_ptr<Geometry> MakeStrokePath(
       const Path& path,
       Scalar stroke_width = 0.0,
@@ -260,39 +258,6 @@ class RectGeometry : public Geometry {
   Rect rect_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RectGeometry);
-};
-
-class RRectGeometry : public Geometry {
- public:
-  explicit RRectGeometry(Rect rect, Scalar corner_radius);
-
-  ~RRectGeometry();
-
- private:
-  // |Geometry|
-  GeometryResult GetPositionBuffer(const ContentContext& renderer,
-                                   const Entity& entity,
-                                   RenderPass& pass) override;
-
-  // |Geometry|
-  GeometryResult GetPositionUVBuffer(Rect texture_coverage,
-                                     Matrix effect_transform,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     RenderPass& pass) override;
-
-  // |Geometry|
-  GeometryVertexType GetVertexType() const override;
-
-  // |Geometry|
-  std::optional<Rect> GetCoverage(const Matrix& transform) const override;
-
-  VertexBufferBuilder<Point> CreatePositionBuffer(const Entity& entity) const;
-
-  Rect rect_;
-  Scalar corner_radius_;
-
-  FML_DISALLOW_COPY_AND_ASSIGN(RRectGeometry);
 };
 
 }  // namespace impeller

--- a/impeller/geometry/path_builder.h
+++ b/impeller/geometry/path_builder.h
@@ -104,14 +104,6 @@ class PathBuilder {
 
   PathBuilder& AddRoundedRect(Rect rect, Scalar radius);
 
-  PathBuilder& AddRoundedRectTopLeft(Rect rect, RoundingRadii radii);
-
-  PathBuilder& AddRoundedRectTopRight(Rect rect, RoundingRadii radii);
-
-  PathBuilder& AddRoundedRectBottomRight(Rect rect, RoundingRadii radii);
-
-  PathBuilder& AddRoundedRectBottomLeft(Rect rect, RoundingRadii radii);
-
   PathBuilder& AddPath(const Path& path);
 
  private:
@@ -119,6 +111,14 @@ class PathBuilder {
   Point current_;
   Path prototype_;
   Convexity convexity_;
+
+  PathBuilder& AddRoundedRectTopLeft(Rect rect, RoundingRadii radii);
+
+  PathBuilder& AddRoundedRectTopRight(Rect rect, RoundingRadii radii);
+
+  PathBuilder& AddRoundedRectBottomRight(Rect rect, RoundingRadii radii);
+
+  PathBuilder& AddRoundedRectBottomLeft(Rect rect, RoundingRadii radii);
 
   Point ReflectedQuadraticControlPoint1() const;
 


### PR DESCRIPTION
The convex path tessellator is more general purpose than the RRect and shouldn't be any slower. BY removing this class, we make it easier to switch to GPU polyline generation and tessellation for convex shapes.
