### PR TITLE
[Android] Lifecycle defaults to focused instead of unfocused

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java
@@ -30,7 +30,7 @@ public class LifecycleChannel {
 
   private String lastAndroidState = "";
   private String lastFlutterState = "";
-  private boolean lastFocus = false;
+  private boolean lastFocus = true;
 
   @NonNull private final BasicMessageChannel<String> channel;
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/LifecycleChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/LifecycleChannelTest.java
@@ -31,29 +31,29 @@ public class LifecycleChannelTest {
     lifecycleChannel.appIsResumed();
     ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
     verify(mockChannel, times(1)).send(stringArgumentCaptor.capture());
-    assertEquals("AppLifecycleState.inactive", stringArgumentCaptor.getValue());
-
-    lifecycleChannel.aWindowIsFocused();
-    stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
-    verify(mockChannel, times(2)).send(stringArgumentCaptor.capture());
     assertEquals("AppLifecycleState.resumed", stringArgumentCaptor.getValue());
 
     lifecycleChannel.noWindowsAreFocused();
     stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
-    verify(mockChannel, times(3)).send(stringArgumentCaptor.capture());
+    verify(mockChannel, times(2)).send(stringArgumentCaptor.capture());
     assertEquals("AppLifecycleState.inactive", stringArgumentCaptor.getValue());
-
-    // Stays inactive, so no event is sent.
-    lifecycleChannel.appIsInactive();
-    verify(mockChannel, times(3)).send(any(String.class));
-
-    // Stays inactive, so no event is sent.
-    lifecycleChannel.appIsResumed();
-    verify(mockChannel, times(3)).send(any(String.class));
 
     lifecycleChannel.aWindowIsFocused();
     stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
-    verify(mockChannel, times(4)).send(stringArgumentCaptor.capture());
+    verify(mockChannel, times(3)).send(stringArgumentCaptor.capture());
+    assertEquals("AppLifecycleState.resumed", stringArgumentCaptor.getValue());
+
+    // Stays inactive, so no event is sent.
+    lifecycleChannel.appIsInactive();
+    verify(mockChannel, times(4)).send(any(String.class));
+
+    // Stays inactive, so no event is sent.
+    lifecycleChannel.appIsResumed();
+    verify(mockChannel, times(5)).send(any(String.class));
+
+    lifecycleChannel.aWindowIsFocused();
+    stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockChannel, times(5)).send(stringArgumentCaptor.capture());
     assertEquals("AppLifecycleState.resumed", stringArgumentCaptor.getValue());
   }
 


### PR DESCRIPTION
## Description

In https://github.com/flutter/engine/pull/41702, the default state of "the focus bit is "false", assuming that Android will send an `onWindowFocusChanged(true)` when the window is first focused, but there appear to be some cases where that doesn't happen.

This change puts the initial state back to what it used to be: in the absence of focus change events, entering the "onResume" Android state will report the `resumed` state in Flutter. Before this PR, if no focus events were received, it would default to `inactive`.

## Tests
 - Updated tests to match.