### PR TITLE
[Impeller] Increase minimum size of alpha glyph atlas.

### DIFF
--- a/impeller/typographer/backends/skia/text_render_context_skia.cc
+++ b/impeller/typographer/backends/skia/text_render_context_skia.cc
@@ -135,13 +135,17 @@ namespace {
 ISize OptimumAtlasSizeForFontGlyphPairs(
     const FontGlyphPair::Set& pairs,
     std::vector<Rect>& glyph_positions,
-    const std::shared_ptr<GlyphAtlasContext>& atlas_context) {
+    const std::shared_ptr<GlyphAtlasContext>& atlas_context,
+    GlyphAtlas::Type type) {
   static constexpr auto kMinAtlasSize = 8u;
+  static constexpr auto kMinAlphaBitmapSize = 1024u;
   static constexpr auto kMaxAtlasSize = 4096u;
 
   TRACE_EVENT0("impeller", __FUNCTION__);
 
-  ISize current_size(kMinAtlasSize, kMinAtlasSize);
+  ISize current_size = type == GlyphAtlas::Type::kAlphaBitmap
+                           ? ISize(kMinAlphaBitmapSize, kMinAlphaBitmapSize)
+                           : ISize(kMinAtlasSize, kMinAtlasSize);
   size_t total_pairs = pairs.size() + 1;
   do {
     auto rect_packer = std::shared_ptr<GrRectanizer>(
@@ -403,7 +407,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   // ---------------------------------------------------------------------------
   auto glyph_atlas = std::make_shared<GlyphAtlas>(type);
   auto atlas_size = OptimumAtlasSizeForFontGlyphPairs(
-      font_glyph_pairs, glyph_positions, atlas_context);
+      font_glyph_pairs, glyph_positions, atlas_context, type);
 
   atlas_context->UpdateGlyphAtlas(glyph_atlas, atlas_size);
   if (atlas_size.IsEmpty()) {

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -189,9 +189,7 @@ TEST_P(TypographerTest, GlyphAtlasWithLotsOfdUniqueGlyphSize) {
             atlas->GetTexture()->GetSize().height);
 }
 
-// TODO(jonahwilliams): Re-enable
-// https://github.com/flutter/flutter/issues/122839
-TEST_P(TypographerTest, DISABLED_GlyphAtlasTextureIsRecycledIfUnchanged) {
+TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledIfUnchanged) {
   auto context = TextRenderContext::Create(GetContext());
   auto atlas_context = std::make_shared<GlyphAtlasContext>();
   ASSERT_TRUE(context && context->IsValid());


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/122839
Fixes https://github.com/flutter/flutter/issues/126103

Unlike Skia which starts with 2048x2048, I decreased the size of 1024x1024. Now that we'll never switch this to a color bitmap, the memory impact is dramatically lessened.