### PR TITLE
Turn @staticInterop tear-off into closure

### DIFF
--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -130,7 +130,12 @@ class HtmlFontCollection implements FlutterFontCollection {
     }
 
     try {
-      fontFaces.forEach(domDocument.fonts!.add);
+      // Since we can't use tear-offs for interop members, this code is faster
+      // and easier to read with a for loop instead of forEach.
+      // ignore: prefer_foreach
+      for (final DomFontFace font in fontFaces) {
+        domDocument.fonts!.add(font);
+      }
     } catch (e) {
       return FontInvalidDataError(asset);
     }


### PR DESCRIPTION
@staticInterop members will start disallowing tear-offs, so this member should turn into a closure.

The static check wasn't added in time, so this is modifying the source code again.

https://github.com/flutter/engine/commit/ee3ce32c7c46a872fee2e5fd4d411bf2b9669d03 was the original change, but the static error didn't make it into the Dart SDK, so this is fixing another tear-off.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
