### PR TITLE
switch from MockCanvas to DisplayListBuilder in layer unit tests

### DIFF
--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -92,6 +92,22 @@ class DisplayListTestBase : public BaseT {
 };
 using DisplayListTest = DisplayListTestBase<::testing::Test>;
 
+TEST_F(DisplayListTest, EmptyBuild) {
+  DisplayListBuilder builder;
+  auto dl = builder.Build();
+  EXPECT_EQ(dl->op_count(), 0u);
+  EXPECT_EQ(dl->bytes(), sizeof(DisplayList));
+}
+
+TEST_F(DisplayListTest, EmptyRebuild) {
+  DisplayListBuilder builder;
+  auto dl1 = builder.Build();
+  auto dl2 = builder.Build();
+  auto dl3 = builder.Build();
+  ASSERT_TRUE(dl1->Equals(dl2));
+  ASSERT_TRUE(dl2->Equals(dl3));
+}
+
 TEST_F(DisplayListTest, BuilderCanBeReused) {
   DisplayListBuilder builder(kTestBounds);
   builder.DrawRect(kTestBounds, DlPaint());

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -578,15 +578,18 @@ void DisplayListBuilder::Transform2DAffine(
     SkScalar myx, SkScalar myy, SkScalar myt) {
   if (SkScalarsAreFinite(mxx, myx) &&
       SkScalarsAreFinite(mxy, myy) &&
-      SkScalarsAreFinite(mxt, myt) &&
-      !(mxx == 1 && mxy == 0 && mxt == 0 &&
-        myx == 0 && myy == 1 && myt == 0)) {
-    checkForDeferredSave();
-    Push<Transform2DAffineOp>(0, 1,
-                              mxx, mxy, mxt,
-                              myx, myy, myt);
-    tracker_.transform2DAffine(mxx, mxy, mxt,
-                               myx, myy, myt);
+      SkScalarsAreFinite(mxt, myt)) {
+    if (mxx == 1 && mxy == 0 &&
+        myx == 0 && myy == 1) {
+      Translate(mxt, myt);
+    } else {
+      checkForDeferredSave();
+      Push<Transform2DAffineOp>(0, 1,
+                                mxx, mxy, mxt,
+                                myx, myy, myt);
+      tracker_.transform2DAffine(mxx, mxy, mxt,
+                                 myx, myy, myt);
+    }
   }
 }
 // full 4x4 transform in row major order

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -113,11 +113,17 @@ class DisplayListBuilder final : public virtual DlCanvas,
   SkMatrix GetTransform() const override { return tracker_.matrix_3x3(); }
 
   // |DlCanvas|
-  void ClipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
+  void ClipRect(const SkRect& rect,
+                ClipOp clip_op = ClipOp::kIntersect,
+                bool is_aa = false) override;
   // |DlCanvas|
-  void ClipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
+  void ClipRRect(const SkRRect& rrect,
+                 ClipOp clip_op = ClipOp::kIntersect,
+                 bool is_aa = false) override;
   // |DlCanvas|
-  void ClipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
+  void ClipPath(const SkPath& path,
+                ClipOp clip_op = ClipOp::kIntersect,
+                bool is_aa = false) override;
 
   /// Conservative estimate of the bounds of all outstanding clip operations
   /// measured in the coordinate space within which this DisplayList will

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -11,7 +11,6 @@
 #include "flutter/flow/testing/mock_embedder.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/fml/macros.h"
-#include "flutter/testing/mock_canvas.h"
 
 namespace flutter {
 namespace testing {
@@ -170,17 +169,19 @@ TEST_F(ClipRRectLayerTest, FullyContainedChild) {
   EXPECT_EQ(mock_layer->parent_matrix(), initial_matrix);
   EXPECT_EQ(mock_layer->parent_mutators(), std::vector({Mutator(layer_rrect)}));
 
-  layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector(
-          {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::ClipRRectData{layer_rrect, ClipOp::kIntersect,
-                                            MockCanvas::kHard_ClipEdgeStyle}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::DrawPathData{child_path, child_paint}},
-           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  layer->Paint(display_list_paint_context());
+  DisplayListBuilder expected_builder;
+  /* (ClipRRect)layer::Paint */ {
+    expected_builder.Save();
+    {
+      expected_builder.ClipRRect(layer_rrect);
+      /* mock_layer::Paint */ {
+        expected_builder.DrawPath(child_path, child_paint);
+      }
+    }
+    expected_builder.Restore();
+  }
+  EXPECT_TRUE(DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
 }
 
 TEST_F(ClipRRectLayerTest, PartiallyContainedChild) {
@@ -220,19 +221,19 @@ TEST_F(ClipRRectLayerTest, PartiallyContainedChild) {
   EXPECT_EQ(mock_layer->parent_matrix(), initial_matrix);
   EXPECT_EQ(mock_layer->parent_mutators(), std::vector({Mutator(clip_rrect)}));
 
-  EXPECT_TRUE(mock_layer->needs_painting(paint_context()));
-  EXPECT_TRUE(layer->needs_painting(paint_context()));
-  layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector(
-          {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::ClipRRectData{clip_rrect, ClipOp::kIntersect,
-                                            MockCanvas::kHard_ClipEdgeStyle}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::DrawPathData{child_path, child_paint}},
-           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  layer->Paint(display_list_paint_context());
+  DisplayListBuilder expected_builder;
+  /* (ClipRRect)layer::Paint */ {
+    expected_builder.Save();
+    {
+      expected_builder.ClipRRect(clip_rrect);
+      /* mock_layer::Paint */ {
+        expected_builder.DrawPath(child_path, child_paint);
+      }
+    }
+    expected_builder.Restore();
+  }
+  EXPECT_TRUE(DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
 }
 
 static bool ReadbackResult(PrerollContext* context,
@@ -503,8 +504,8 @@ TEST_F(ClipRRectLayerTest, LayerCached) {
 
   auto initial_transform = SkMatrix::Translate(50.0, 25.5);
   SkMatrix cache_ctm = initial_transform;
-  MockCanvas cache_canvas;
-  cache_canvas.SetTransform(cache_ctm);
+  DisplayListBuilder cache_canvas;
+  cache_canvas.Transform(cache_ctm);
 
   use_mock_raster_cache();
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);

--- a/flow/layers/layer_state_stack_unittests.cc
+++ b/flow/layers/layer_state_stack_unittests.cc
@@ -9,7 +9,6 @@
 #include "flutter/flow/layers/layer.h"
 #include "flutter/flow/layers/layer_state_stack.h"
 #include "flutter/testing/display_list_testing.h"
-#include "flutter/testing/mock_canvas.h"
 
 namespace flutter {
 namespace testing {
@@ -63,9 +62,10 @@ TEST(LayerStateStack, SingularDelegate) {
   LayerStateStack state_stack;
   ASSERT_EQ(state_stack.canvas_delegate(), nullptr);
 
-  // Two kinds of DlCanvas implementation
+  // Two different DlCanvas implementators
   DisplayListBuilder builder;
-  MockCanvas canvas;
+  DisplayListBuilder builder2;
+  DlCanvas& canvas = builder2;
 
   // no delegate -> builder delegate
   state_stack.set_delegate(&builder);
@@ -92,7 +92,8 @@ TEST(LayerStateStack, SingularDelegate) {
 TEST(LayerStateStack, OldDelegateIsRolledBack) {
   LayerStateStack state_stack;
   DisplayListBuilder builder;
-  MockCanvas canvas;
+  DisplayListBuilder builder2;
+  DlCanvas& canvas = builder2;
 
   ASSERT_TRUE(builder.GetTransform().isIdentity());
   ASSERT_TRUE(canvas.GetTransform().isIdentity());

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -172,13 +172,17 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
 
   sk_sp<DisplayList> display_list() {
     if (display_list_ == nullptr) {
-      // null out the canvas and recorder fields of the PaintContext
-      // and the delegate of the state_stack to prevent future use.
-      display_list_paint_context_.state_stack.clear_delegate();
-      display_list_paint_context_.canvas = nullptr;
       display_list_ = display_list_builder_.Build();
     }
     return display_list_;
+  }
+
+  void reset_display_list() {
+    display_list_ = nullptr;
+    // Build() will leave the builder in a state to start recording a new DL
+    display_list_builder_.Build();
+    // Make sure we are starting from a fresh state stack
+    FML_DCHECK(display_list_state_stack_.is_empty());
   }
 
   void enable_leaf_layer_tracing() {

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -159,8 +159,6 @@ class MockCanvas final : public DlCanvas {
   MockCanvas(int width, int height);
   ~MockCanvas();
 
-  // SkNWayCanvas* internal_canvas() { return &internal_canvas_; }
-
   const std::vector<DrawCall>& draw_calls() const { return draw_calls_; }
   void reset_draw_calls() { draw_calls_.clear(); }
 


### PR DESCRIPTION
Part of an ongoing set of efforts to address https://github.com/flutter/flutter/issues/106448

The layer unittests have been using a MockCanvas class to record the painting of trees of layers and then testing for the expected output.

A while back a similar mechanism was created to compare DisplayList output and to print out a human-friendly version of the differences found, but it was only used in a few tests written at the time it was created and a few since then.

This is the first in a series of PRs that will move all the rest of the unit tests onto the new DL comparison mechanism, starting with the layer types that just do basic drawing. Some of the remaining layers will require creating new hooks in, for instance, the Texture registry, the performance overlay TextBlob generation, etc.