### PR TITLE
[Linux - TextInput] Do not add new line for send action

### DIFF
--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -47,6 +47,8 @@ static constexpr char kTextAffinityDownstream[] = "TextAffinity.downstream";
 static constexpr char kMultilineInputType[] = "TextInputType.multiline";
 static constexpr char kNoneInputType[] = "TextInputType.none";
 
+static constexpr char kFlTextInputActionSend[] = "TextInputAction.send";
+
 static constexpr int64_t kClientIdUnset = -1;
 
 typedef enum {
@@ -642,7 +644,8 @@ static gboolean fl_text_input_plugin_filter_keypress_default(
       case GDK_KEY_Return:
       case GDK_KEY_KP_Enter:
       case GDK_KEY_ISO_Enter:
-        if (priv->input_type == kFlTextInputTypeMultiline) {
+        if (priv->input_type == kFlTextInputTypeMultiline &&
+            strcmp(priv->input_action, kFlTextInputActionSend) != 0) {
           priv->text_model->AddCodePoint('\n');
           text = "\n";
           changed = TRUE;

--- a/shell/platform/linux/fl_text_input_plugin_test.cc
+++ b/shell/platform/linux/fl_text_input_plugin_test.cc
@@ -986,3 +986,63 @@ TEST(FlTextInputPluginTest, ComposingDelta) {
 
   g_signal_emit_by_name(context, "preedit-end", nullptr);
 }
+
+// Regression test for https://github.com/flutter/flutter/issues/125879.
+TEST(FlTextInputPluginTest, MultilineWithSendAction) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+  ::testing::NiceMock<flutter::testing::MockIMContext> context;
+  ::testing::NiceMock<flutter::testing::MockTextInputViewDelegate> delegate;
+
+  g_autoptr(FlTextInputPlugin) plugin =
+      fl_text_input_plugin_new(messenger, context, delegate);
+  EXPECT_NE(plugin, nullptr);
+
+  // Set input config.
+  g_autoptr(FlValue) config = build_input_config({
+      .client_id = 1,
+      .input_type = "TextInputType.multiline",
+      .input_action = "TextInputAction.send",
+  });
+  g_autoptr(FlJsonMethodCodec) codec = fl_json_method_codec_new();
+  g_autoptr(GBytes) set_client = fl_method_codec_encode_method_call(
+      FL_METHOD_CODEC(codec), "TextInput.setClient", config, nullptr);
+
+  g_autoptr(FlValue) null = fl_value_new_null();
+  EXPECT_CALL(messenger, fl_binary_messenger_send_response(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::_, SuccessResponse(null), ::testing::_))
+      .WillOnce(::testing::Return(true));
+
+  messenger.ReceiveMessage("flutter/textinput", set_client);
+
+  // Set editing state.
+  g_autoptr(FlValue) state = build_editing_state({
+      .text = "Flutter",
+      .selection_base = 7,
+      .selection_extent = 7,
+  });
+  g_autoptr(GBytes) set_state = fl_method_codec_encode_method_call(
+      FL_METHOD_CODEC(codec), "TextInput.setEditingState", state, nullptr);
+
+  EXPECT_CALL(messenger, fl_binary_messenger_send_response(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::_, SuccessResponse(null), ::testing::_))
+      .WillOnce(::testing::Return(true));
+
+  messenger.ReceiveMessage("flutter/textinput", set_state);
+
+  // Perform action.
+  g_autoptr(FlValue) action = build_list({
+      fl_value_new_int(1),  // client_id
+      fl_value_new_string("TextInputAction.send"),
+  });
+
+  EXPECT_CALL(messenger, fl_binary_messenger_send_on_channel(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::StrEq("flutter/textinput"),
+                             MethodCall("TextInputClient.performAction",
+                                        FlValueEq(action)),
+                             ::testing::_, ::testing::_, ::testing::_));
+
+  send_key_event(plugin, GDK_KEY_Return);
+}


### PR DESCRIPTION
## Description

This PR updates the Linux text input plugin to avoid adding a new line on a multiline text field when action is set to `TextInputAction.send`.

## Related Issue

Linux implementation for https://github.com/flutter/flutter/issues/125879

## Tests

Adds 1 test.

