### PR TITLE
Revert "Move linux fuchsia engine v2 build to prod."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -140,7 +140,6 @@ targets:
     timeout: 60
 
   - name: Linux Fuchsia
-    bringup: true
     recipe: engine/engine
     properties:
       add_recipes_cq: "true"
@@ -257,6 +256,7 @@ targets:
     timeout: 90
 
   - name: Linux linux_fuchsia
+    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:


### PR DESCRIPTION
Reverts flutter/engine#41865

Failing a framework test on presubmit: https://github.com/flutter/flutter/pull/126452