### PR TITLE
switch MockTexture off of MockCanvas calls

### DIFF
--- a/common/graphics/texture.h
+++ b/common/graphics/texture.h
@@ -60,7 +60,7 @@ class Texture : public ContextListener {
   // Called on raster thread.
   virtual void OnTextureUnregistered() = 0;
 
-  int64_t Id() const { return id_; }
+  int64_t Id() { return id_; }
 
  private:
   int64_t id_;

--- a/common/graphics/texture.h
+++ b/common/graphics/texture.h
@@ -60,7 +60,7 @@ class Texture : public ContextListener {
   // Called on raster thread.
   virtual void OnTextureUnregistered() = 0;
 
-  int64_t Id() { return id_; }
+  int64_t Id() const { return id_; }
 
  private:
   int64_t id_;

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -199,6 +199,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
       DlImageSampling sampling,
       const DlPaint* paint = nullptr,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
+  using DlCanvas::DrawImageRect;
   // |DlCanvas|
   void DrawImageNine(const sk_sp<DlImage>& image,
                      const SkIRect& center,

--- a/flow/layers/texture_layer_unittests.cc
+++ b/flow/layers/texture_layer_unittests.cc
@@ -9,7 +9,7 @@
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/flow/testing/mock_texture.h"
 #include "flutter/fml/macros.h"
-#include "flutter/testing/mock_canvas.h"
+#include "flutter/testing/display_list_testing.h"
 
 namespace flutter {
 namespace testing {
@@ -28,8 +28,8 @@ TEST_F(TextureLayerTest, InvalidTexture) {
                  .makeOffset(layer_offset.fX, layer_offset.fY)));
   EXPECT_TRUE(layer->needs_painting(paint_context()));
 
-  layer->Paint(paint_context());
-  EXPECT_EQ(mock_canvas().draw_calls(), std::vector<MockCanvas::DrawCall>());
+  layer->Paint(display_list_paint_context());
+  EXPECT_TRUE(display_list()->Equals(DisplayList()));
 }
 
 #ifndef NDEBUG
@@ -72,6 +72,8 @@ TEST_F(TextureLayerTest, PaintBeforePrerollDies) {
 TEST_F(TextureLayerTest, PaintingWithLinearSampling) {
   const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
   const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
+  const SkRect layer_bounds =
+      SkRect::MakeSize(layer_size).makeOffset(layer_offset.fX, layer_offset.fY);
   const int64_t texture_id = 0;
   auto mock_texture = std::make_shared<MockTexture>(texture_id);
   auto layer = std::make_shared<TextureLayer>(
@@ -81,17 +83,18 @@ TEST_F(TextureLayerTest, PaintingWithLinearSampling) {
   preroll_context()->texture_registry->RegisterTexture(mock_texture);
 
   layer->Preroll(preroll_context());
-  EXPECT_EQ(layer->paint_bounds(),
-            (SkRect::MakeSize(layer_size)
-                 .makeOffset(layer_offset.fX, layer_offset.fY)));
+  EXPECT_EQ(layer->paint_bounds(), layer_bounds);
   EXPECT_TRUE(layer->needs_painting(paint_context()));
 
-  layer->Paint(paint_context());
-  EXPECT_EQ(mock_texture->paint_calls(),
-            std::vector({MockTexture::PaintCall{
-                mock_canvas(), layer->paint_bounds(), false, nullptr,
-                DlImageSampling::kLinear}}));
-  EXPECT_EQ(mock_canvas().draw_calls(), std::vector<MockCanvas::DrawCall>());
+  DlPaint mock_paint(
+      mock_texture->mockColor(0xff, false, DlImageSampling::kLinear));
+
+  layer->Paint(display_list_paint_context());
+  DisplayListBuilder expected_builder;
+  /* (Texture)layer::Paint */ {
+    expected_builder.DrawRect(layer_bounds, mock_paint);
+  }
+  EXPECT_TRUE(DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
 }
 
 using TextureLayerDiffTest = DiffContextTest;
@@ -118,24 +121,47 @@ TEST_F(TextureLayerDiffTest, TextureInRetainedLayer) {
 TEST_F(TextureLayerTest, OpacityInheritance) {
   const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
   const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
+  const SkRect layer_bounds =
+      SkRect::MakeSize(layer_size).makeOffset(layer_offset.fX, layer_offset.fY);
   const int64_t texture_id = 0;
   auto mock_texture = std::make_shared<MockTexture>(texture_id);
-  auto layer = std::make_shared<TextureLayer>(
+  SkAlpha alpha = 0x7f;
+  auto texture_layer = std::make_shared<TextureLayer>(
       layer_offset, layer_size, texture_id, false, DlImageSampling::kLinear);
+  auto layer = std::make_shared<OpacityLayer>(alpha, SkPoint::Make(0.0f, 0.0f));
+  layer->Add(texture_layer);
 
   // Ensure the texture is located by the Layer.
-  preroll_context()->texture_registry->RegisterTexture(mock_texture);
-
-  // The texture layer always reports opacity compatibility.
   PrerollContext* context = preroll_context();
   context->texture_registry->RegisterTexture(mock_texture);
+
+  // The texture layer always reports opacity compatibility.
+  texture_layer->Preroll(context);
+  EXPECT_EQ(context->renderable_state_flags,
+            LayerStateStack::kCallerCanApplyOpacity);
+
+  // Reset has_texture_layer since it is not supposed to be sent as we
+  // descend a tree in Preroll, but it was set by the previous test.
+  context->has_texture_layer = false;
   layer->Preroll(context);
   EXPECT_EQ(context->renderable_state_flags,
             LayerStateStack::kCallerCanApplyOpacity);
 
-  // MockTexture has no actual textur to render into the
-  // PaintContext canvas so we have no way to verify its
-  // rendering.
+  DlPaint mock_paint(
+      mock_texture->mockColor(alpha, false, DlImageSampling::kLinear));
+
+  layer->Paint(display_list_paint_context());
+  DisplayListBuilder expected_builder;
+  /* (Opacity)layer::Paint */ {
+    expected_builder.Save();
+    {
+      /* texture_layer::Paint */ {
+        expected_builder.DrawRect(layer_bounds, mock_paint);
+      }
+    }
+    expected_builder.Restore();
+  }
+  EXPECT_TRUE(DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
 }
 
 }  // namespace testing

--- a/flow/testing/mock_texture.cc
+++ b/flow/testing/mock_texture.cc
@@ -14,22 +14,22 @@ MockTexture::MockTexture(int64_t textureId) : Texture(textureId) {}
 void MockTexture::Paint(PaintContext& context,
                         const SkRect& bounds,
                         bool freeze,
-                        const DlImageSampling sampling) {
-  paint_calls_.emplace_back(PaintCall{*(context.canvas), bounds, freeze,
-                                      context.gr_context, sampling,
-                                      context.paint});
+                        DlImageSampling sampling) {
+  DlPaint paint;
+  if (context.paint) {
+    paint = *context.paint;
+  }
+  paint.setColor(mockColor(paint.getAlpha(), freeze, sampling));
+  context.canvas->DrawRect(bounds, paint);
 }
 
-bool operator==(const MockTexture::PaintCall& a,
-                const MockTexture::PaintCall& b) {
-  return &a.canvas == &b.canvas && a.bounds == b.bounds &&
-         a.context == b.context && a.freeze == b.freeze &&
-         a.sampling == b.sampling && a.paint == b.paint;
-}
-
-std::ostream& operator<<(std::ostream& os, const MockTexture::PaintCall& data) {
-  return os << &data.canvas << " " << data.bounds << " " << data.context << " "
-            << data.freeze << " " << data.sampling << " " << data.paint;
+DlColor MockTexture::mockColor(uint8_t alpha,
+                               bool freeze,
+                               DlImageSampling sampling) const {
+  uint8_t red = Id() & 0xff;
+  uint8_t green = freeze ? 1 : 0;
+  uint8_t blue = static_cast<uint8_t>(sampling);
+  return DlColor(alpha << 24 | red << 16 | green << 8 | blue);
 }
 
 }  // namespace testing

--- a/flow/testing/mock_texture.cc
+++ b/flow/testing/mock_texture.cc
@@ -34,7 +34,7 @@ MockTexture::MockTexture(int64_t textureId, const sk_sp<DlImage>& texture)
 void MockTexture::Paint(PaintContext& context,
                         const SkRect& bounds,
                         bool freeze,
-                        DlImageSampling sampling) {
+                        const DlImageSampling sampling) {
   // MockTexture objects that are not painted are allowed to have a null
   // texture, but when we get to this method we must have a non-null texture.
   FML_DCHECK(texture_ != nullptr);

--- a/flow/testing/mock_texture.cc
+++ b/flow/testing/mock_texture.cc
@@ -9,27 +9,41 @@
 namespace flutter {
 namespace testing {
 
-MockTexture::MockTexture(int64_t textureId) : Texture(textureId) {}
+sk_sp<DlImage> MockTexture::MakeTestTexture(int w, int h, int checker_size) {
+  sk_sp<SkSurface> surface = SkSurface::MakeRasterN32Premul(w, h);
+  SkCanvas* canvas = surface->getCanvas();
+  SkPaint p0, p1;
+  p0.setStyle(SkPaint::kFill_Style);
+  p0.setColor(SK_ColorGREEN);
+  p1.setStyle(SkPaint::kFill_Style);
+  p1.setColor(SK_ColorBLUE);
+  p1.setAlpha(128);
+  for (int y = 0; y < w; y += checker_size) {
+    for (int x = 0; x < h; x += checker_size) {
+      SkPaint& cellp = ((x + y) & 1) == 0 ? p0 : p1;
+      canvas->drawRect(SkRect::MakeXYWH(x, y, checker_size, checker_size),
+                       cellp);
+    }
+  }
+  return DlImage::Make(surface->makeImageSnapshot());
+}
+
+MockTexture::MockTexture(int64_t textureId, const sk_sp<DlImage>& texture)
+    : Texture(textureId), texture_(texture) {}
 
 void MockTexture::Paint(PaintContext& context,
                         const SkRect& bounds,
                         bool freeze,
                         DlImageSampling sampling) {
-  DlPaint paint;
-  if (context.paint) {
-    paint = *context.paint;
+  // MockTexture objects that are not painted are allowed to have a null
+  // texture, but when we get to this method we must have a non-null texture.
+  FML_DCHECK(texture_ != nullptr);
+  SkRect src = SkRect::Make(texture_->bounds());
+  if (freeze) {
+    FML_DCHECK(src.width() > 2.0f && src.height() > 2.0f);
+    src = src.makeInset(1.0f, 1.0f);
   }
-  paint.setColor(mockColor(paint.getAlpha(), freeze, sampling));
-  context.canvas->DrawRect(bounds, paint);
-}
-
-DlColor MockTexture::mockColor(uint8_t alpha,
-                               bool freeze,
-                               DlImageSampling sampling) const {
-  uint8_t red = Id() & 0xff;
-  uint8_t green = freeze ? 1 : 0;
-  uint8_t blue = static_cast<uint8_t>(sampling);
-  return DlColor(alpha << 24 | red << 16 | green << 8 | blue);
+  context.canvas->DrawImageRect(texture_, src, bounds, sampling, context.paint);
 }
 
 }  // namespace testing

--- a/flow/testing/mock_texture.h
+++ b/flow/testing/mock_texture.h
@@ -19,15 +19,16 @@ namespace testing {
 // later verify them against expected data.
 class MockTexture : public Texture {
  public:
-  explicit MockTexture(int64_t textureId);
+  static sk_sp<DlImage> MakeTestTexture(int w, int h, int checker_size);
+
+  explicit MockTexture(int64_t textureId,
+                       const sk_sp<DlImage>& texture = nullptr);
 
   // Called from raster thread.
   void Paint(PaintContext& context,
              const SkRect& bounds,
              bool freeze,
              DlImageSampling sampling) override;
-
-  DlColor mockColor(uint8_t alpha, bool freeze, DlImageSampling sampling) const;
 
   void OnGrContextCreated() override { gr_context_created_ = true; }
   void OnGrContextDestroyed() override { gr_context_destroyed_ = true; }
@@ -39,6 +40,7 @@ class MockTexture : public Texture {
   bool unregistered() { return unregistered_; }
 
  private:
+  sk_sp<DlImage> texture_;
   bool gr_context_created_ = false;
   bool gr_context_destroyed_ = false;
   bool unregistered_ = false;

--- a/flow/testing/mock_texture.h
+++ b/flow/testing/mock_texture.h
@@ -19,44 +19,30 @@ namespace testing {
 // later verify them against expected data.
 class MockTexture : public Texture {
  public:
-  struct PaintCall {
-    DlCanvas& canvas;
-    SkRect bounds;
-    bool freeze;
-    GrDirectContext* context;
-    DlImageSampling sampling;
-    const DlPaint* paint;
-  };
-
   explicit MockTexture(int64_t textureId);
 
   // Called from raster thread.
   void Paint(PaintContext& context,
              const SkRect& bounds,
              bool freeze,
-             const DlImageSampling sampling) override;
+             DlImageSampling sampling) override;
+
+  DlColor mockColor(uint8_t alpha, bool freeze, DlImageSampling sampling) const;
 
   void OnGrContextCreated() override { gr_context_created_ = true; }
   void OnGrContextDestroyed() override { gr_context_destroyed_ = true; }
   void MarkNewFrameAvailable() override {}
   void OnTextureUnregistered() override { unregistered_ = true; }
 
-  const std::vector<PaintCall>& paint_calls() { return paint_calls_; }
   bool gr_context_created() { return gr_context_created_; }
   bool gr_context_destroyed() { return gr_context_destroyed_; }
   bool unregistered() { return unregistered_; }
 
  private:
-  std::vector<PaintCall> paint_calls_;
   bool gr_context_created_ = false;
   bool gr_context_destroyed_ = false;
   bool unregistered_ = false;
 };
-
-extern bool operator==(const MockTexture::PaintCall& a,
-                       const MockTexture::PaintCall& b);
-extern std::ostream& operator<<(std::ostream& os,
-                                const MockTexture::PaintCall& data);
 
 }  // namespace testing
 }  // namespace flutter

--- a/flow/testing/mock_texture.h
+++ b/flow/testing/mock_texture.h
@@ -28,7 +28,7 @@ class MockTexture : public Texture {
   void Paint(PaintContext& context,
              const SkRect& bounds,
              bool freeze,
-             DlImageSampling sampling) override;
+             const DlImageSampling sampling) override;
 
   void OnGrContextCreated() override { gr_context_created_ = true; }
   void OnGrContextDestroyed() override { gr_context_destroyed_ = true; }

--- a/flow/testing/mock_texture_unittests.cc
+++ b/flow/testing/mock_texture_unittests.cc
@@ -6,7 +6,6 @@
 
 #include "flutter/display_list/dl_builder.h"
 #include "flutter/testing/display_list_testing.h"
-#include "flutter/testing/mock_canvas.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
@@ -29,7 +28,6 @@ TEST(MockTextureTest, Callbacks) {
 }
 
 TEST(MockTextureTest, PaintCalls) {
-  MockCanvas canvas;
   DisplayListBuilder builder;
   const SkRect paint_bounds1 = SkRect::MakeWH(1.0f, 1.0f);
   const SkRect paint_bounds2 = SkRect::MakeWH(2.0f, 2.0f);
@@ -54,7 +52,6 @@ TEST(MockTextureTest, PaintCalls) {
 }
 
 TEST(MockTextureTest, PaintCallsWithLinearSampling) {
-  MockCanvas canvas;
   DisplayListBuilder builder;
   const SkRect paint_bounds1 = SkRect::MakeWH(1.0f, 1.0f);
   const SkRect paint_bounds2 = SkRect::MakeWH(2.0f, 2.0f);

--- a/flow/testing/mock_texture_unittests.cc
+++ b/flow/testing/mock_texture_unittests.cc
@@ -34,9 +34,8 @@ TEST(MockTextureTest, PaintCalls) {
   const SkRect paint_bounds1 = SkRect::MakeWH(1.0f, 1.0f);
   const SkRect paint_bounds2 = SkRect::MakeWH(2.0f, 2.0f);
   const DlImageSampling sampling = DlImageSampling::kNearestNeighbor;
-  auto texture = std::make_shared<MockTexture>(0);
-  DlPaint paint1 = DlPaint(texture->mockColor(0xff, false, sampling));
-  DlPaint paint2 = DlPaint(texture->mockColor(0xff, true, sampling));
+  const auto texture_image = MockTexture::MakeTestTexture(20, 20, 5);
+  auto texture = std::make_shared<MockTexture>(0, texture_image);
 
   Texture::PaintContext context{
       .canvas = &builder,
@@ -44,9 +43,12 @@ TEST(MockTextureTest, PaintCalls) {
   texture->Paint(context, paint_bounds1, false, sampling);
   texture->Paint(context, paint_bounds2, true, sampling);
 
+  SkRect src1 = SkRect::Make(texture_image->bounds());
+  SkRect src2 = src1.makeInset(1.0, 1.0f);
+
   DisplayListBuilder expected_builder;
-  expected_builder.DrawRect(paint_bounds1, paint1);
-  expected_builder.DrawRect(paint_bounds2, paint2);
+  expected_builder.DrawImageRect(texture_image, src1, paint_bounds1, sampling);
+  expected_builder.DrawImageRect(texture_image, src2, paint_bounds2, sampling);
   EXPECT_TRUE(
       DisplayListsEQ_Verbose(builder.Build(), expected_builder.Build()));
 }
@@ -57,9 +59,8 @@ TEST(MockTextureTest, PaintCallsWithLinearSampling) {
   const SkRect paint_bounds1 = SkRect::MakeWH(1.0f, 1.0f);
   const SkRect paint_bounds2 = SkRect::MakeWH(2.0f, 2.0f);
   const auto sampling = DlImageSampling::kLinear;
-  auto texture = std::make_shared<MockTexture>(0);
-  DlPaint paint1 = DlPaint(texture->mockColor(0xff, false, sampling));
-  DlPaint paint2 = DlPaint(texture->mockColor(0xff, true, sampling));
+  const auto texture_image = MockTexture::MakeTestTexture(20, 20, 5);
+  auto texture = std::make_shared<MockTexture>(0, texture_image);
 
   Texture::PaintContext context{
       .canvas = &builder,
@@ -67,9 +68,12 @@ TEST(MockTextureTest, PaintCallsWithLinearSampling) {
   texture->Paint(context, paint_bounds1, false, sampling);
   texture->Paint(context, paint_bounds2, true, sampling);
 
+  SkRect src1 = SkRect::Make(texture_image->bounds());
+  SkRect src2 = src1.makeInset(1.0, 1.0f);
+
   DisplayListBuilder expected_builder;
-  expected_builder.DrawRect(paint_bounds1, paint1);
-  expected_builder.DrawRect(paint_bounds2, paint2);
+  expected_builder.DrawImageRect(texture_image, src1, paint_bounds1, sampling);
+  expected_builder.DrawImageRect(texture_image, src2, paint_bounds2, sampling);
   EXPECT_TRUE(
       DisplayListsEQ_Verbose(builder.Build(), expected_builder.Build()));
 }


### PR DESCRIPTION
Part of an ongoing set of efforts to address https://github.com/flutter/flutter/issues/106448

MockTexture now executes a call on the supplied DlCanvas object rather than creating its own list of MockCanvas-style draw calls. The TextureLayer tests now no longer use MockCanvas.