### PR TITLE
Add pkg:protobuf as a dependency for testing/dart

### DIFF
--- a/testing/dart/pubspec.yaml
+++ b/testing/dart/pubspec.yaml
@@ -26,14 +26,20 @@ dependencies:
 dependency_overrides:
   async_helper:
     path: ../../../third_party/dart/pkg/async_helper
+  collection:
+    path: ../../../third_party/dart/third_party/pkg/collection
   expect:
     path: ../../../third_party/dart/pkg/expect
+  fixnum:
+    path: ../../../third_party/dart/third_party/pkg/fixnum
   litetest:
     path: ../litetest
   meta:
     path: ../../../third_party/dart/pkg/meta
   path:
     path: ../../../third_party/dart/third_party/pkg/path
+  protobuf:
+    path: ../../../third_party/dart/third_party/pkg/protobuf/protobuf
   smith:
     path: ../../../third_party/dart/pkg/smith
   sky_engine:


### PR DESCRIPTION
Package vm_service added dependencies on protobuf and fixnum. Adding these, and transitive dependency on collections, to the path overrides in the testing/dart package's pubspec.yaml.

This is needed to roll https://github.com/dart-lang/sdk/commit/6c3c34560e6fdac211e362078557fdda254baf