### PR TITLE
Switch to official Dart SDK CIPD packages.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -506,7 +506,7 @@ deps = {
   'src/flutter/prebuilts/linux-x64/dart-sdk': {
     'packages': [
       {
-        'package': 'flutter/dart-sdk/linux-amd64',
+        'package': 'dart/dart-sdk/linux-amd64',
         'version': 'git_revision:'+Var('dart_revision')
       }
     ],
@@ -516,7 +516,7 @@ deps = {
   'src/flutter/prebuilts/linux-arm64/dart-sdk': {
     'packages': [
       {
-        'package': 'flutter/dart-sdk/linux-arm64',
+        'package': 'dart/dart-sdk/linux-arm64',
         'version': 'git_revision:'+Var('dart_revision')
       }
     ],
@@ -526,7 +526,7 @@ deps = {
   'src/flutter/prebuilts/macos-x64/dart-sdk': {
     'packages': [
       {
-        'package': 'flutter/dart-sdk/mac-amd64',
+        'package': 'dart/dart-sdk/mac-amd64',
         'version': 'git_revision:'+Var('dart_revision')
       }
     ],
@@ -536,7 +536,7 @@ deps = {
   'src/flutter/prebuilts/macos-arm64/dart-sdk': {
     'packages': [
       {
-        'package': 'flutter/dart-sdk/mac-arm64',
+        'package': 'dart/dart-sdk/mac-arm64',
         'version': 'git_revision:'+Var('dart_revision')
       }
     ],
@@ -546,7 +546,7 @@ deps = {
   'src/flutter/prebuilts/windows-x64/dart-sdk': {
     'packages': [
       {
-        'package': 'flutter/dart-sdk/windows-amd64',
+        'package': 'dart/dart-sdk/windows-amd64',
         'version': 'git_revision:'+Var('dart_revision')
       }
     ],
@@ -556,7 +556,7 @@ deps = {
   'src/flutter/prebuilts/windows-arm64/dart-sdk': {
     'packages': [
       {
-        'package': 'flutter/dart-sdk/windows-arm64',
+        'package': 'dart/dart-sdk/windows-arm64',
         'version': 'git_revision:'+Var('dart_revision')
       }
     ],

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -164,26 +164,11 @@ zip_bundle("flutter_patched_sdk") {
   ]
 }
 
-generated_file("dart_sdk_entitlement_config") {
-  outputs = [ "$target_gen_dir/dart_sdk_entitlements.txt" ]
-
-  # Dart SDK is a prebuilt archive. The rule for building
-  # Dart SDK is https://github.com/flutter/engine/blob/main/BUILD.gn#L61
-  contents = [
-    "dart-sdk/bin/dart",
-    "dart-sdk/bin/dartaotruntime",
-    "dart-sdk/bin/utils/gen_snapshot",
-    "dart-sdk/bin/utils/wasm-opt",
-  ]
-
-  deps = []
-}
-
 # Flutter consumes the dart sdk as a prebuilt. Rather than regenerating
 # the zip file we are just copying the original file to the artifacts location.
 if (build_engine_artifacts && flutter_prebuilt_dart_sdk) {
   zip_bundle("dart_sdk_archive") {
-    deps = [ ":dart_sdk_entitlement_config" ]
+    deps = []
     output = "dart-sdk-$full_target_platform_name.zip"
     files = [
       {
@@ -195,12 +180,6 @@ if (build_engine_artifacts && flutter_prebuilt_dart_sdk) {
       # Mac artifacts sometimes use mac and sometimes darwin. Standardizing the
       # names will require changes in the list of artifacts the tool is downloading.
       output = "dart-sdk-darwin-$target_cpu.zip"
-      files += [
-        {
-          source = "$target_gen_dir/dart_sdk_entitlements.txt"
-          destination = "entitlements.txt"
-        },
-      ]
     }
   }
 }
@@ -218,13 +197,6 @@ if (build_engine_artifacts && !flutter_prebuilt_dart_sdk) {
     ]
     if (is_mac) {
       output = "dart-sdk-darwin-$target_cpu.zip"
-      deps += [ ":dart_sdk_entitlement_config" ]
-      files += [
-        {
-          source = "$target_gen_dir/dart_sdk_entitlements.txt"
-          destination = "entitlements.txt"
-        },
-      ]
     }
   }
 }


### PR DESCRIPTION
The dart/dart-sdk/ CIPD packages are now official and automatically built and signed when new releases are built. The flutter/dart-sdk/ CIPD packages were transitory and will no longer be updated.

Remove the logic for signing the artifacts in the Dart SDK as they are now already signed ahead of time with the Flutter signing key.

Bug: b/277727672
