### PR TITLE
Use moved SkImage procs

### DIFF
--- a/lib/ui/painting/image_decoder_skia.cc
+++ b/lib/ui/painting/image_decoder_skia.cc
@@ -189,7 +189,7 @@ static SkiaGPUObject<SkImage> UploadRasterImage(
             SkSafeRef(image.get());
             sk_sp<SkImage> texture_image = SkImages::RasterFromPixmap(
                 pixmap,
-                [](const void* pixels, SkImage::ReleaseContext context) {
+                [](const void* pixels, SkImages::ReleaseContext context) {
                   SkSafeUnref(static_cast<SkImage*>(context));
                 },
                 image.get());

--- a/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -79,7 +79,7 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTexture(
 
   GrBackendTexture gr_backend_texture(width, height, GrMipMapped::kNo,
                                       gr_texture_info);
-  SkImage::TextureReleaseProc release_proc = texture->destruction_callback;
+  SkImages::TextureReleaseProc release_proc = texture->destruction_callback;
   auto image =
       SkImages::BorrowTextureFrom(context,                   // context
                                   gr_backend_texture,        // texture handle


### PR DESCRIPTION
Use relocated SkImages context typedefs

In http://review.skia.org/661059, we moved many SkImage related methods, including these typedefs. This updates Flutter to use the moved types.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
