### PR TITLE
Move checkerboard unit tests onto DisplayList mechanism

### DIFF
--- a/display_list/benchmarking/dl_complexity_helper.h
+++ b/display_list/benchmarking/dl_complexity_helper.h
@@ -120,7 +120,7 @@ class ComplexityCalculatorHelper
 
   void setAntiAlias(bool aa) override { current_paint_.setAntiAlias(aa); }
 
-  void setStyle(DlDrawStyle style) override {
+  void setDrawStyle(DlDrawStyle style) override {
     current_paint_.setDrawStyle(style);
   }
 

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -247,6 +247,8 @@ class DisplayListBuilder final : public virtual DlCanvas,
       DisplayListBuilder& builder);
   friend DlOpReceiver& DisplayListBuilderTestingAccessor(
       DisplayListBuilder& builder);
+  friend DlPaint DisplayListBuilderTestingAttributes(
+      DisplayListBuilder& builder);
 
   void SetAttributesFromPaint(const DlPaint& paint,
                               const DisplayListAttributeFlags flags);
@@ -282,9 +284,9 @@ class DisplayListBuilder final : public virtual DlCanvas,
     }
   }
   // |DlOpReceiver|
-  void setStyle(DlDrawStyle style) override {
+  void setDrawStyle(DlDrawStyle style) override {
     if (current_.getDrawStyle() != style) {
-      onSetStyle(style);
+      onSetDrawStyle(style);
     }
   }
   // |DlOpReceiver|
@@ -341,6 +343,8 @@ class DisplayListBuilder final : public virtual DlCanvas,
       onSetMaskFilter(filter);
     }
   }
+
+  DlPaint CurrentAttributes() const { return current_; }
 
   // |DlOpReceiver|
   void save() override { Save(); }
@@ -654,7 +658,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void onSetInvertColors(bool invert);
   void onSetStrokeCap(DlStrokeCap cap);
   void onSetStrokeJoin(DlStrokeJoin join);
-  void onSetStyle(DlDrawStyle style);
+  void onSetDrawStyle(DlDrawStyle style);
   void onSetStrokeWidth(SkScalar width);
   void onSetStrokeMiter(SkScalar limit);
   void onSetColor(DlColor color);

--- a/display_list/dl_op_receiver.h
+++ b/display_list/dl_op_receiver.h
@@ -45,7 +45,7 @@ class DlOpReceiver {
   // attributes is not affected by |save| and |restore|.
   virtual void setAntiAlias(bool aa) = 0;
   virtual void setDither(bool dither) = 0;
-  virtual void setStyle(DlDrawStyle style) = 0;
+  virtual void setDrawStyle(DlDrawStyle style) = 0;
   virtual void setColor(DlColor color) = 0;
   virtual void setStrokeWidth(float width) = 0;
   virtual void setStrokeMiter(float limit) = 0;

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -145,7 +145,9 @@ struct SetStyleOp final : DLOp {
 
   const DlDrawStyle style;
 
-  void dispatch(DispatchContext& ctx) const { ctx.receiver.setStyle(style); }
+  void dispatch(DispatchContext& ctx) const {
+    ctx.receiver.setDrawStyle(style);
+  }
 };
 // 4 byte header + 4 byte payload packs into minimum 8 bytes
 struct SetStrokeWidthOp final : DLOp {

--- a/display_list/dl_paint.cc
+++ b/display_list/dl_paint.cc
@@ -32,7 +32,8 @@ bool DlPaint::operator==(DlPaint const& other) const {
          Equals(colorSource_, other.colorSource_) &&  //
          Equals(colorFilter_, other.colorFilter_) &&  //
          Equals(imageFilter_, other.imageFilter_) &&  //
-         Equals(maskFilter_, other.maskFilter_);
+         Equals(maskFilter_, other.maskFilter_) &&    //
+         Equals(pathEffect_, other.pathEffect_);
 }
 
 const DlPaint DlPaint::kDefault;

--- a/display_list/dl_paint_unittests.cc
+++ b/display_list/dl_paint_unittests.cc
@@ -27,6 +27,7 @@ TEST(DisplayListPaint, ConstructorDefaults) {
   EXPECT_EQ(paint.getColorFilter(), nullptr);
   EXPECT_EQ(paint.getImageFilter(), nullptr);
   EXPECT_EQ(paint.getMaskFilter(), nullptr);
+  EXPECT_EQ(paint.getPathEffect(), nullptr);
   EXPECT_TRUE(paint.isDefault());
   EXPECT_EQ(paint, DlPaint::kDefault);
 
@@ -68,6 +69,10 @@ TEST(DisplayListPaint, ConstructorDefaults) {
 
   DlBlurMaskFilter mask_filter(DlBlurStyle::kInner, 3.14);
   EXPECT_NE(paint, DlPaint().setMaskFilter(mask_filter.shared()));
+
+  SkScalar intervals[] = {1.0f, 2.0f};
+  auto path_effect = DlDashPathEffect::Make(intervals, 2, 0.0f);
+  EXPECT_NE(paint, DlPaint().setPathEffect(path_effect.get()));
 }
 
 TEST(DisplayListPaint, NullPointerSetGet) {
@@ -75,11 +80,13 @@ TEST(DisplayListPaint, NullPointerSetGet) {
   DlColorFilter* null_color_filter = nullptr;
   DlImageFilter* null_image_filter = nullptr;
   DlMaskFilter* null_mask_filter = nullptr;
+  DlPathEffect* null_path_effect = nullptr;
   DlPaint paint;
   EXPECT_EQ(paint.setColorSource(null_color_source).getColorSource(), nullptr);
   EXPECT_EQ(paint.setColorFilter(null_color_filter).getColorFilter(), nullptr);
   EXPECT_EQ(paint.setImageFilter(null_image_filter).getImageFilter(), nullptr);
   EXPECT_EQ(paint.setMaskFilter(null_mask_filter).getMaskFilter(), nullptr);
+  EXPECT_EQ(paint.setPathEffect(null_path_effect).getPathEffect(), nullptr);
 }
 
 TEST(DisplayListPaint, NullSharedPointerSetGet) {
@@ -87,14 +94,19 @@ TEST(DisplayListPaint, NullSharedPointerSetGet) {
   std::shared_ptr<DlColorFilter> null_color_filter;
   std::shared_ptr<DlImageFilter> null_image_filter;
   std::shared_ptr<DlMaskFilter> null_mask_filter;
+  std::shared_ptr<DlPathEffect> null_path_effect;
   DlPaint paint;
   EXPECT_EQ(paint.setColorSource(null_color_source).getColorSource(), nullptr);
   EXPECT_EQ(paint.setColorFilter(null_color_filter).getColorFilter(), nullptr);
   EXPECT_EQ(paint.setImageFilter(null_image_filter).getImageFilter(), nullptr);
   EXPECT_EQ(paint.setMaskFilter(null_mask_filter).getMaskFilter(), nullptr);
+  EXPECT_EQ(paint.setPathEffect(null_path_effect).getPathEffect(), nullptr);
 }
 
 TEST(DisplayListPaint, ChainingConstructor) {
+  SkScalar intervals[] = {1.0f, 2.0f};
+  auto path_effect = DlDashPathEffect::Make(intervals, 2, 0.0f);
+
   DlPaint paint =
       DlPaint()                                                              //
           .setAntiAlias(true)                                                //
@@ -114,7 +126,8 @@ TEST(DisplayListPaint, ChainingConstructor) {
                   .shared())
           .setImageFilter(
               DlBlurImageFilter(1.3, 4.7, DlTileMode::kClamp).shared())
-          .setMaskFilter(DlBlurMaskFilter(DlBlurStyle::kInner, 3.14).shared());
+          .setMaskFilter(DlBlurMaskFilter(DlBlurStyle::kInner, 3.14).shared())
+          .setPathEffect(path_effect);
   EXPECT_TRUE(paint.isAntiAlias());
   EXPECT_TRUE(paint.isDither());
   EXPECT_TRUE(paint.isInvertColors());
@@ -133,6 +146,7 @@ TEST(DisplayListPaint, ChainingConstructor) {
             DlBlurImageFilter(1.3, 4.7, DlTileMode::kClamp));
   EXPECT_EQ(*paint.getMaskFilter(),
             DlBlurMaskFilter(DlBlurStyle::kInner, 3.14));
+  EXPECT_EQ(*paint.getPathEffect(), *path_effect);
 
   EXPECT_NE(paint, DlPaint());
 }

--- a/display_list/skia/dl_sk_paint_dispatcher.cc
+++ b/display_list/skia/dl_sk_paint_dispatcher.cc
@@ -51,7 +51,7 @@ void DlSkPaintDispatchHelper::setStrokeCap(DlStrokeCap cap) {
 void DlSkPaintDispatchHelper::setStrokeJoin(DlStrokeJoin join) {
   paint_.setStrokeJoin(ToSk(join));
 }
-void DlSkPaintDispatchHelper::setStyle(DlDrawStyle style) {
+void DlSkPaintDispatchHelper::setDrawStyle(DlDrawStyle style) {
   paint_.setStyle(ToSk(style));
 }
 void DlSkPaintDispatchHelper::setStrokeWidth(SkScalar width) {

--- a/display_list/skia/dl_sk_paint_dispatcher.h
+++ b/display_list/skia/dl_sk_paint_dispatcher.h
@@ -23,7 +23,7 @@ class DlSkPaintDispatchHelper : public virtual DlOpReceiver {
 
   void setAntiAlias(bool aa) override;
   void setDither(bool dither) override;
-  void setStyle(DlDrawStyle style) override;
+  void setDrawStyle(DlDrawStyle style) override;
   void setColor(DlColor color) override;
   void setStrokeWidth(SkScalar width) override;
   void setStrokeMiter(SkScalar limit) override;

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -79,11 +79,13 @@ std::vector<DisplayListInvocationGroup> CreateAllAttributesOps() {
       {"SetStyle",
        {
            {0, 8, 0, 0,
-            [](DlOpReceiver& r) { r.setStyle(DlDrawStyle::kStroke); }},
+            [](DlOpReceiver& r) { r.setDrawStyle(DlDrawStyle::kStroke); }},
            {0, 8, 0, 0,
-            [](DlOpReceiver& r) { r.setStyle(DlDrawStyle::kStrokeAndFill); }},
+            [](DlOpReceiver& r) {
+              r.setDrawStyle(DlDrawStyle::kStrokeAndFill);
+            }},
            {0, 0, 0, 0,
-            [](DlOpReceiver& r) { r.setStyle(DlDrawStyle::kFill); }},
+            [](DlOpReceiver& r) { r.setDrawStyle(DlDrawStyle::kFill); }},
        }},
       {"SetStrokeWidth",
        {

--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -108,6 +108,7 @@ DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
   SkRect cull = cull_rect.isEmpty() ? SkRect::MakeEmpty() : cull_rect;
   saved_.emplace_back(std::make_unique<Data3x3>(matrix, cull));
   current_ = saved_.back().get();
+  save();  // saved_[0] will always be the initial settings
 }
 
 DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
@@ -121,6 +122,7 @@ DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
     saved_.emplace_back(std::make_unique<Data4x4>(m44, cull));
   }
   current_ = saved_.back().get();
+  save();  // saved_[0] will always be the initial settings
 }
 
 // clang-format off
@@ -172,8 +174,18 @@ void DisplayListMatrixClipTracker::save() {
 }
 
 void DisplayListMatrixClipTracker::restore() {
-  saved_.pop_back();
-  current_ = saved_.back().get();
+  if (saved_.size() > 2) {
+    saved_.pop_back();
+    current_ = saved_.back().get();
+  }
+}
+
+void DisplayListMatrixClipTracker::reset() {
+  while (saved_.size() > 1) {
+    saved_.pop_back();
+    current_ = saved_.back().get();
+  }
+  save();  // saved_[0] will always be the initial settings
 }
 
 void DisplayListMatrixClipTracker::restoreToCount(int restore_count) {

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -41,7 +41,12 @@ class DisplayListMatrixClipTracker {
 
   void save();
   void restore();
-  int getSaveCount() { return saved_.size(); }
+  void reset();
+  int getSaveCount() {
+    // saved_[0] is always the untouched initial conditions
+    // saved_[1] is the first editable stack entry
+    return saved_.size() - 1;
+  }
   void restoreToCount(int restore_count);
 
   void translate(SkScalar tx, SkScalar ty) { current_->translate(tx, ty); }

--- a/display_list/utils/dl_receiver_utils.h
+++ b/display_list/utils/dl_receiver_utils.h
@@ -28,7 +28,7 @@ class IgnoreAttributeDispatchHelper : public virtual DlOpReceiver {
   void setInvertColors(bool invert) override {}
   void setStrokeCap(DlStrokeCap cap) override {}
   void setStrokeJoin(DlStrokeJoin join) override {}
-  void setStyle(DlDrawStyle style) override {}
+  void setDrawStyle(DlDrawStyle style) override {}
   void setStrokeWidth(float width) override {}
   void setStrokeMiter(float limit) override {}
   void setColor(DlColor color) override {}

--- a/flow/layers/checkerboard_layertree_unittests.cc
+++ b/flow/layers/checkerboard_layertree_unittests.cc
@@ -46,43 +46,52 @@ TEST_F(CheckerBoardLayerTest, ClipRectSaveLayerCheckBoard) {
   EXPECT_EQ(mock_layer->parent_mutators(),
             std::vector({Mutator(layer_bounds)}));
 
-  layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector(
-          {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::ClipRectData{layer_bounds, ClipOp::kIntersect,
-                                           MockCanvas::kSoft_ClipEdgeStyle}},
-           MockCanvas::DrawCall{
-               1,
-               MockCanvas::SaveLayerData{child_bounds, DlPaint(), nullptr, 2}},
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawPathData{child_path, child_paint}},
-           MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  layer->Paint(display_list_paint_context());
+  {
+    DisplayListBuilder expected_builder;
+    /* (ClipRect)layer::Paint */ {
+      expected_builder.Save();
+      {
+        expected_builder.ClipRect(layer_bounds, DlCanvas::ClipOp::kIntersect,
+                                  true);
+        expected_builder.SaveLayer(&child_bounds);
+        {
+          /* mock_layer::Paint */ {
+            expected_builder.DrawPath(child_path, child_paint);
+          }
+        }
+        expected_builder.Restore();
+      }
+      expected_builder.Restore();
+    }
+    EXPECT_TRUE(
+        DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
+  }
 
-  mock_canvas().reset_draw_calls();
-
+  reset_display_list();
   layer->Paint(checkerboard_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector(
-          {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::ClipRectData{layer_bounds, ClipOp::kIntersect,
-                                           MockCanvas::kSoft_ClipEdgeStyle}},
-           MockCanvas::DrawCall{
-               1,
-               MockCanvas::SaveLayerData{child_bounds, DlPaint(), nullptr, 2}},
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawPathData{child_path, child_paint}},
-           // start DrawCheckerboard calls
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawRectData{child_bounds, checkerboard_paint()}},
-           // end DrawCheckerboard calls
-           MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  {
+    DisplayListBuilder expected_builder;
+    /* (ClipRect)layer::Paint */ {
+      expected_builder.Save();
+      {
+        expected_builder.ClipRect(layer_bounds, DlCanvas::ClipOp::kIntersect,
+                                  true);
+        expected_builder.SaveLayer(&child_bounds);
+        {
+          /* mock_layer::Paint */ {
+            expected_builder.DrawPath(child_path, child_paint);
+          }
+          expected_builder.DrawRect(child_path.getBounds(),
+                                    checkerboard_paint());
+        }
+        expected_builder.Restore();
+      }
+      expected_builder.Restore();
+    }
+    EXPECT_TRUE(
+        DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
+  }
 }
 
 TEST_F(CheckerBoardLayerTest, ClipPathSaveLayerCheckBoard) {
@@ -114,43 +123,52 @@ TEST_F(CheckerBoardLayerTest, ClipPathSaveLayerCheckBoard) {
   EXPECT_EQ(mock_layer->parent_matrix(), initial_matrix);
   EXPECT_EQ(mock_layer->parent_mutators(), std::vector({Mutator(layer_path)}));
 
-  layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector(
-          {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::ClipPathData{layer_path, ClipOp::kIntersect,
-                                           MockCanvas::kSoft_ClipEdgeStyle}},
-           MockCanvas::DrawCall{
-               1,
-               MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawPathData{child_path, child_paint}},
-           MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  layer->Paint(display_list_paint_context());
+  {
+    DisplayListBuilder expected_builder;
+    /* (ClipRect)layer::Paint */ {
+      expected_builder.Save();
+      {
+        expected_builder.ClipPath(layer_path, DlCanvas::ClipOp::kIntersect,
+                                  true);
+        expected_builder.SaveLayer(&child_bounds);
+        {
+          /* mock_layer::Paint */ {
+            expected_builder.DrawPath(child_path, child_paint);
+          }
+        }
+        expected_builder.Restore();
+      }
+      expected_builder.Restore();
+    }
+    EXPECT_TRUE(
+        DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
+  }
 
-  mock_canvas().reset_draw_calls();
-
+  reset_display_list();
   layer->Paint(checkerboard_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector(
-          {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::ClipPathData{layer_path, ClipOp::kIntersect,
-                                           MockCanvas::kSoft_ClipEdgeStyle}},
-           MockCanvas::DrawCall{
-               1,
-               MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawPathData{child_path, child_paint}},
-           // start DrawCheckerboard calls
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawRectData{child_bounds, checkerboard_paint()}},
-           // end DrawCheckerboard calls
-           MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  {
+    DisplayListBuilder expected_builder;
+    /* (ClipRect)layer::Paint */ {
+      expected_builder.Save();
+      {
+        expected_builder.ClipPath(layer_path, DlCanvas::ClipOp::kIntersect,
+                                  true);
+        expected_builder.SaveLayer(&child_bounds);
+        {
+          /* mock_layer::Paint */ {
+            expected_builder.DrawPath(child_path, child_paint);
+          }
+          expected_builder.DrawRect(child_path.getBounds(),
+                                    checkerboard_paint());
+        }
+        expected_builder.Restore();
+      }
+      expected_builder.Restore();
+    }
+    EXPECT_TRUE(
+        DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
+  }
 }
 
 TEST_F(CheckerBoardLayerTest, ClipRRectSaveLayerCheckBoard) {
@@ -181,43 +199,52 @@ TEST_F(CheckerBoardLayerTest, ClipRRectSaveLayerCheckBoard) {
   EXPECT_EQ(mock_layer->parent_matrix(), initial_matrix);
   EXPECT_EQ(mock_layer->parent_mutators(), std::vector({Mutator(layer_rrect)}));
 
-  layer->Paint(paint_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector(
-          {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::ClipRRectData{layer_rrect, ClipOp::kIntersect,
-                                            MockCanvas::kSoft_ClipEdgeStyle}},
-           MockCanvas::DrawCall{
-               1,
-               MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawPathData{child_path, child_paint}},
-           MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  layer->Paint(display_list_paint_context());
+  {
+    DisplayListBuilder expected_builder;
+    /* (ClipRect)layer::Paint */ {
+      expected_builder.Save();
+      {
+        expected_builder.ClipRRect(layer_rrect, DlCanvas::ClipOp::kIntersect,
+                                   true);
+        expected_builder.SaveLayer(&child_bounds);
+        {
+          /* mock_layer::Paint */ {
+            expected_builder.DrawPath(child_path, child_paint);
+          }
+        }
+        expected_builder.Restore();
+      }
+      expected_builder.Restore();
+    }
+    EXPECT_TRUE(
+        DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
+  }
 
-  mock_canvas().reset_draw_calls();
-
+  reset_display_list();
   layer->Paint(checkerboard_context());
-  EXPECT_EQ(
-      mock_canvas().draw_calls(),
-      std::vector(
-          {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-           MockCanvas::DrawCall{
-               1, MockCanvas::ClipRRectData{layer_rrect, ClipOp::kIntersect,
-                                            MockCanvas::kSoft_ClipEdgeStyle}},
-           MockCanvas::DrawCall{
-               1,
-               MockCanvas::SaveLayerData{child_bounds, clip_paint, nullptr, 2}},
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawPathData{child_path, child_paint}},
-           // start DrawCheckerboard calls
-           MockCanvas::DrawCall{
-               2, MockCanvas::DrawRectData{child_bounds, checkerboard_paint()}},
-           // end DrawCheckerboard calls
-           MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
-           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  {
+    DisplayListBuilder expected_builder;
+    /* (ClipRect)layer::Paint */ {
+      expected_builder.Save();
+      {
+        expected_builder.ClipRRect(layer_rrect, DlCanvas::ClipOp::kIntersect,
+                                   true);
+        expected_builder.SaveLayer(&child_bounds);
+        {
+          /* mock_layer::Paint */ {
+            expected_builder.DrawPath(child_path, child_paint);
+          }
+          expected_builder.DrawRect(child_path.getBounds(),
+                                    checkerboard_paint());
+        }
+        expected_builder.Restore();
+      }
+      expected_builder.Restore();
+    }
+    EXPECT_TRUE(
+        DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
+  }
 }
 
 #endif

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -88,7 +88,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
         checkerboard_context_{
             // clang-format off
             .state_stack                   = checkerboard_state_stack_,
-            .canvas                        = &TestT::mock_canvas(),
+            .canvas                        = &display_list_builder_,
             .gr_context                    = nullptr,
             .view_embedder                 = nullptr,
             .raster_time                   = raster_time_,
@@ -101,7 +101,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
     preroll_state_stack_.set_preroll_delegate(kGiantRect, SkMatrix::I());
     paint_state_stack_.set_delegate(&TestT::mock_canvas());
     display_list_state_stack_.set_delegate(&display_list_builder_);
-    checkerboard_state_stack_.set_delegate(&TestT::mock_canvas());
+    checkerboard_state_stack_.set_delegate(&display_list_builder_);
     checkerboard_state_stack_.set_checkerboard_func(draw_checkerboard);
     checkerboard_paint_.setColor(checkerboard_color_);
   }

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -201,7 +201,7 @@ static Paint::Style ToStyle(flutter::DlDrawStyle style) {
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcher::setStyle(flutter::DlDrawStyle style) {
+void DlDispatcher::setDrawStyle(flutter::DlDrawStyle style) {
   paint_.style = ToStyle(style);
 }
 

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -30,7 +30,7 @@ class DlDispatcher final : public flutter::DlOpReceiver {
   void setDither(bool dither) override;
 
   // |flutter::DlOpReceiver|
-  void setStyle(flutter::DlDrawStyle style) override;
+  void setDrawStyle(flutter::DlDrawStyle style) override;
 
   // |flutter::DlOpReceiver|
   void setColor(flutter::DlColor color) override;

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -354,7 +354,7 @@ void DisplayListStreamDispatcher::setAntiAlias(bool aa) {
 void DisplayListStreamDispatcher::setDither(bool dither) {
   startl() << "setDither(" << dither << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::setStyle(DlDrawStyle style) {
+void DisplayListStreamDispatcher::setDrawStyle(DlDrawStyle style) {
   startl() << "setStyle(" << style << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::setColor(DlColor color) {

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -59,7 +59,7 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
 
   void setAntiAlias(bool aa) override;
   void setDither(bool dither) override;
-  void setStyle(DlDrawStyle style) override;
+  void setDrawStyle(DlDrawStyle style) override;
   void setColor(DlColor color) override;
   void setStrokeWidth(SkScalar width) override;
   void setStrokeMiter(SkScalar limit) override;


### PR DESCRIPTION
Part of an ongoing set of efforts to address https://github.com/flutter/flutter/issues/106448

Move the checkerboard layer unit tests onto the DisplayList version of the paint contexts and fix some bugs in the reusability of the DisplayListBuilder that this migration uncovered.