### PR TITLE
[macOS - TextInput] Insert new line only when TextInputAction.newline

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -61,6 +61,9 @@ static NSString* const kAutofillHints = @"hints";
 static NSString* const kTextAffinityDownstream = @"TextAffinity.downstream";
 static NSString* const kTextAffinityUpstream = @"TextAffinity.upstream";
 
+// TextInputAction types
+static NSString* const kInputActionNewline = @"TextInputAction.newline";
+
 #pragma mark - Enums
 /**
  * The affinity of the current cursor position. If the cursor is at a position representing
@@ -820,7 +823,8 @@ static char markerKey;
     _activeModel->CommitComposing();
     _activeModel->EndComposing();
   }
-  if ([self.inputType isEqualToString:kMultilineInputType]) {
+  if ([self.inputType isEqualToString:kMultilineInputType] &&
+      [self.inputAction isEqualToString:kInputActionNewline]) {
     [self insertText:@"\n" replacementRange:self.selectedRange];
   }
   [_channel invokeMethod:kPerformAction arguments:@[ self.clientID, self.inputAction ]];


### PR DESCRIPTION
## Description

This PR updates the macOS text input plugin to avoid adding a new line on a multiline text field when action is not set to `TextInputAction.newline`.

## Related Issue

macOS implementation for https://github.com/flutter/flutter/issues/125879.
(similar to the Linux implementation in https://github.com/flutter/engine/pull/41895).

## Tests

Adds 2 tests.

