### PR TITLE
[Android] Fix BasicMessageChannel.resizeChannelBuffer

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
@@ -11,8 +11,9 @@ import io.flutter.BuildConfig;
 import io.flutter.Log;
 import io.flutter.plugin.common.BinaryMessenger.BinaryMessageHandler;
 import io.flutter.plugin.common.BinaryMessenger.BinaryReply;
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Locale;
 
 /**
  * A named channel for communicating with the Flutter application using basic, asynchronous message
@@ -144,15 +145,12 @@ public final class BasicMessageChannel<T> {
 
   static void resizeChannelBuffer(
       @NonNull BinaryMessenger messenger, @NonNull String channel, int newSize) {
-    try {
-      final String content = String.format("resize\r%s\r%d", channel, newSize);
-      final byte[] bytes = content.getBytes("UTF-8");
-      ByteBuffer packet = ByteBuffer.allocateDirect(bytes.length);
-      packet.put(bytes);
-      messenger.send(BasicMessageChannel.CHANNEL_BUFFERS_CHANNEL, packet);
-    } catch (UnsupportedEncodingException e) {
-      Log.e(TAG, "Failed to resize channel buffer named " + channel, e);
-    }
+    Charset charset = Charset.forName("UTF-8");
+    String messageString = String.format(Locale.US, "resize\r%s\r%d", channel, newSize);
+    final byte[] bytes = messageString.getBytes(charset);
+    ByteBuffer packet = ByteBuffer.allocateDirect(bytes.length);
+    packet.put(bytes);
+    messenger.send(BasicMessageChannel.CHANNEL_BUFFERS_CHANNEL, packet);
   }
 
   /** A handler of incoming messages. */

--- a/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
@@ -1,0 +1,49 @@
+package io.flutter.embedding.engine.systemchannels;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import android.content.res.AssetManager;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.plugin.common.BasicMessageChannel;
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+@Config(manifest = Config.NONE)
+@RunWith(AndroidJUnit4.class)
+public class MethodChannelTest {
+  @Test
+  public void methodChannel_resizeChannelBuffer() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    DartExecutor dartExecutor = new DartExecutor(mockFlutterJNI, mock(AssetManager.class));
+    MethodChannel rawChannel = new MethodChannel(dartExecutor, "flutter/test");
+
+    BinaryMessenger messenger = dartExecutor.getBinaryMessenger();
+    rawChannel.resizeChannelBuffer(3);
+
+    ByteBuffer packet = null;
+    try {
+      final String content = String.format("resize\r%s\r%d", "flutter/test", 3);
+      final byte[] bytes = content.getBytes("UTF-8");
+      packet = ByteBuffer.allocateDirect(bytes.length);
+      packet.put(bytes);
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError("UTF-8 only");
+    }
+
+    // Verify that DartExecutor sent the correct message to FlutterJNI.
+    verify(mockFlutterJNI, times(1))
+        .dispatchPlatformMessage(
+            eq(BasicMessageChannel.CHANNEL_BUFFERS_CHANNEL), eq(packet), anyInt(), anyInt());
+  }
+}

--- a/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
@@ -1,4 +1,4 @@
-package io.flutter.embedding.engine.systemchannels;
+package io.flutter.plugin.common;
 
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -10,11 +10,9 @@ import android.content.res.AssetManager;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.plugin.common.BasicMessageChannel;
-import io.flutter.plugin.common.BinaryMessenger;
-import io.flutter.plugin.common.MethodChannel;
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Locale;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -26,20 +24,17 @@ public class MethodChannelTest {
   public void methodChannel_resizeChannelBuffer() {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = new DartExecutor(mockFlutterJNI, mock(AssetManager.class));
-    MethodChannel rawChannel = new MethodChannel(dartExecutor, "flutter/test");
+    String channel = "flutter/test";
+    MethodChannel rawChannel = new MethodChannel(dartExecutor, channel);
 
-    BinaryMessenger messenger = dartExecutor.getBinaryMessenger();
-    rawChannel.resizeChannelBuffer(3);
+    int newSize = 3;
+    rawChannel.resizeChannelBuffer(newSize);
 
-    ByteBuffer packet = null;
-    try {
-      final String content = String.format("resize\r%s\r%d", "flutter/test", 3);
-      final byte[] bytes = content.getBytes("UTF-8");
-      packet = ByteBuffer.allocateDirect(bytes.length);
-      packet.put(bytes);
-    } catch (UnsupportedEncodingException e) {
-      throw new AssertionError("UTF-8 only");
-    }
+    Charset charset = Charset.forName("UTF-8");
+    String messageString = String.format(Locale.US, "resize\r%s\r%d", channel, newSize);
+    final byte[] bytes = messageString.getBytes(charset);
+    ByteBuffer packet = ByteBuffer.allocateDirect(bytes.length);
+    packet.put(bytes);
 
     // Verify that DartExecutor sent the correct message to FlutterJNI.
     verify(mockFlutterJNI, times(1))


### PR DESCRIPTION
## Description

This PR updates `BasicMessageChannel.resizeChannelBuffer` implementation. Previous implementation builds a wrong `ByteBuffer` and was not tested so it is difficult to know when it stopped working.  

## Related Issue

Fixes https://github.com/flutter/flutter/issues/126632

## Tests

Adds 1 test.


