### PR TITLE
Move clang tidy v2 build to prod.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -378,11 +378,23 @@ targets:
       config_name: mac_android_aot_engine
 
   - name: Mac mac_clang_tidy
-    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
       config_name: mac_clang_tidy
+    runIf:
+      - DEPS
+      - .ci.yaml
+      - tools/**
+      - ci/**
+      - "**.h"
+      - "**.c"
+      - "**.cc"
+      - "**.fbs"
+      - "**.frag"
+      - "**.vert"
+      - "**.m"
+      - "**.mm"
 
   - name: Mac mac_host_engine
     recipe: engine_v2/engine_v2
@@ -418,6 +430,7 @@ targets:
     timeout: 75
 
   - name: Mac Host clang-tidy
+    bringup: true
     recipe: engine/engine_lint
     properties:
       cpu: arm64
@@ -439,6 +452,7 @@ targets:
       - "**.mm"
 
   - name: Mac iOS clang-tidy
+    bringup: true
     recipe: engine/engine_lint
     properties:
       cpu: arm64


### PR DESCRIPTION
The mac clang tidy build has been running successfully on staging for several days. This is also moving the ios and host legacy clang tidy builds to staging.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
