### PR TITLE
[Impeller] switches the wide gamut surface to f16

### DIFF
--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -208,6 +208,10 @@ Surface::SurfaceData GPUSurfaceMetalImpeller::GetSurfaceData() const {
       bytesPerPixel = 4;
       pixel_format = "MTLPixelFormatBGRA8Unorm";
       break;
+    case MTLPixelFormatRGBA16Float:
+      bytesPerPixel = 8;
+      pixel_format = "MTLPixelFormatRGBA16Float";
+      break;
     default:
       return {};
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -107,7 +107,11 @@
       CGColorSpaceRef srgb = CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB);
       layer.colorspace = srgb;
       CFRelease(srgb);
-      layer.pixelFormat = MTLPixelFormatBGRA10_XR;
+      // MTLPixelFormatRGBA16Float was chosen since it is compatible with
+      // impeller's offscreen buffers which need to have transparency.  Also,
+      // F16 was chosen over BGRA10_XR since Skia does not support decoding
+      // BGRA10_XR.
+      layer.pixelFormat = MTLPixelFormatRGBA16Float;
     }
   }
 


### PR DESCRIPTION
**requires https://github.com/flutter/flutter/pull/126712 to land first**

fixes https://github.com/flutter/flutter/issues/126620
integration test at: https://github.com/flutter/flutter/pull/126715

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
