### PR TITLE
[Impeller] Ignore the Z basis when scaling text

### DIFF
--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -1103,7 +1103,7 @@ void DlDispatcher::drawDisplayList(
 void DlDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                 SkScalar x,
                                 SkScalar y) {
-  Scalar scale = canvas_.GetCurrentTransformation().GetMaxBasisLength();
+  Scalar scale = canvas_.GetCurrentTransformation().GetMaxBasisLengthXY();
   canvas_.DrawTextFrame(TextFrameFromTextBlob(blob, scale),  //
                         impeller::Point{x, y},               //
                         paint_                               //

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -336,6 +336,21 @@ TEST(GeometryTest, MatrixGetMaxBasisLength) {
   }
 }
 
+TEST(GeometryTest, MatrixGetMaxBasisLengthXY) {
+  {
+    auto m = Matrix::MakeScale({3, 1, 1});
+    ASSERT_EQ(m.GetMaxBasisLengthXY(), 3);
+
+    m = m * Matrix::MakeSkew(0, 4);
+    ASSERT_EQ(m.GetMaxBasisLengthXY(), 5);
+  }
+
+  {
+    auto m = Matrix::MakeScale({-3, 4, 7});
+    ASSERT_EQ(m.GetMaxBasisLengthXY(), 4);
+  }
+}
+
 TEST(GeometryTest, MatrixMakeOrthographic) {
   {
     auto m = Matrix::MakeOrthographic(Size(100, 200));

--- a/impeller/geometry/matrix.cc
+++ b/impeller/geometry/matrix.cc
@@ -202,6 +202,14 @@ Scalar Matrix::GetMaxBasisLength() const {
   return std::sqrt(max);
 }
 
+Scalar Matrix::GetMaxBasisLengthXY() const {
+  Scalar max = 0;
+  for (int i = 0; i < 3; i++) {
+    max = std::max(max, e[i][0] * e[i][0] + e[i][1] * e[i][1]);
+  }
+  return std::sqrt(max);
+}
+
 /*
  *  Adapted for Impeller from Graphics Gems:
  *  http://www.realtimerendering.com/resources/GraphicsGems/gemsii/unmatrix.c

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -290,6 +290,8 @@ struct Matrix {
 
   Scalar GetMaxBasisLength() const;
 
+  Scalar GetMaxBasisLengthXY() const;
+
   constexpr Vector3 GetBasisX() const { return Vector3(m[0], m[1], m[2]); }
 
   constexpr Vector3 GetBasisY() const { return Vector3(m[4], m[5], m[6]); }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/126510.

`GetMaxBasisLength()` includes the Z basis vector, which happens to not be getting scaled down along with the X and Y for this reproduction case. And so given the 2D nature of text and the intent of this scale parameter, it's returning a value that's too large here.
We just haven't encountered this situation before because usually all dimensions of the matrix get scaled down, or point size of the text gets decreased instead

Before:
![Screenshot 2023-05-12 at 2 33 02 PM](https://github.com/flutter/engine/assets/919017/b39a6569-a550-4d5f-9c80-eb92765fcfc9)

After:
![Screenshot 2023-05-12 at 2 28 51 PM](https://github.com/flutter/engine/assets/919017/17780797-d91a-49cf-a871-102bc1bf9d58)
