### PR TITLE
[Impeller] Add interactive DrawPaint blend test

### DIFF
--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -16,6 +16,8 @@ namespace impeller {
 // If you add a new playground test to the aiks unittests and you do not want it
 // to also be a golden test, then add the test name here.
 static const std::vector<std::string> kSkipTests = {
+    "impeller_Play_AiksTest_CanDrawPaintMultipleTimesInteractive_Metal",
+    "impeller_Play_AiksTest_CanDrawPaintMultipleTimesInteractive_Vulkan",
     "impeller_Play_AiksTest_CanRenderLinearGradientManyColorsUnevenStops_Metal",
     "impeller_Play_AiksTest_CanRenderLinearGradientManyColorsUnevenStops_"
     "Vulkan",


### PR DESCRIPTION
Made this to help debugging clear color problems and I've had it sitting around in my stage for a few days. Today, it ended up leading me to discover several other issues. For example, advanced blends are doing nothing in this case...

![Screenshot 2023-05-14 at 7 14 43 PM](https://github.com/flutter/engine/assets/919017/9781ddbe-1e5c-4ee5-85e8-48e8ae538f71)
