### PR TITLE
[Impeller] Fix DrawPaint advanced blends on iOS.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1203,6 +1203,15 @@ TEST_P(AiksTest, CanDrawPaintMultipleTimes) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanDrawPaintWithAdvancedBlend) {
+  Canvas canvas;
+  canvas.Scale(Vector2(0.2, 0.2));
+  canvas.DrawPaint({.color = Color::MediumTurquoise()});
+  canvas.DrawPaint({.color = Color::Color::OrangeRed().WithAlpha(0.5),
+                    .blend_mode = BlendMode::kHue});
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, PaintBlendModeIsRespected) {
   Paint paint;
   Canvas canvas;

--- a/impeller/display_list/dl_image_impeller.cc
+++ b/impeller/display_list/dl_image_impeller.cc
@@ -31,8 +31,12 @@ sk_sp<DlImageImpeller> DlImageImpeller::MakeFromYUVTextures(
   impeller::Entity entity;
   entity.SetBlendMode(impeller::BlendMode::kSource);
   auto snapshot = yuv_to_rgb_filter_contents->RenderToSnapshot(
-      aiks_context->GetContentContext(), entity, std::nullopt, true,
-      "MakeYUVToRGBFilter Snapshot");
+      aiks_context->GetContentContext(),  // renderer
+      entity,                             // entity
+      std::nullopt,                       // coverage_limit
+      std::nullopt,                       // sampler_descriptor
+      true,                               // msaa_enabled
+      "MakeYUVToRGBFilter Snapshot");     // label
   return impeller::DlImageImpeller::Make(snapshot->texture);
 }
 

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -248,8 +248,13 @@ bool AtlasContents::Render(const ContentContext& renderer,
     auto contents = ColorFilterContents::MakeBlend(
         blend_mode_,
         {FilterInput::Make(dst_contents), FilterInput::Make(src_contents)});
-    auto snapshot = contents->RenderToSnapshot(renderer, entity, std::nullopt,
-                                               true, "AtlasContents Snapshot");
+    auto snapshot =
+        contents->RenderToSnapshot(renderer,      // renderer
+                                   entity,        // entity
+                                   std::nullopt,  // coverage_limit
+                                   std::nullopt,  // sampler_descriptor
+                                   true,          // msaa_enabled
+                                   "AtlasContents Snapshot");  // label
     if (!snapshot.has_value()) {
       return false;
     }

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -59,10 +59,14 @@ Contents::StencilCoverage Contents::GetStencilCoverage(
 std::optional<Snapshot> Contents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity,
+    std::optional<Rect> coverage_limit,
     const std::optional<SamplerDescriptor>& sampler_descriptor,
     bool msaa_enabled,
     const std::string& label) const {
   auto coverage = GetCoverage(entity);
+  if (coverage_limit.has_value()) {
+    coverage = coverage->Intersection(*coverage_limit);
+  }
   if (!coverage.has_value()) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -77,6 +77,7 @@ class Contents {
   virtual std::optional<Snapshot> RenderToSnapshot(
       const ContentContext& renderer,
       const Entity& entity,
+      std::optional<Rect> coverage_limit = std::nullopt,
       const std::optional<SamplerDescriptor>& sampler_descriptor = std::nullopt,
       bool msaa_enabled = true,
       const std::string& label = "Snapshot") const;

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -241,6 +241,7 @@ std::optional<Entity> FilterContents::GetEntity(const ContentContext& renderer,
 std::optional<Snapshot> FilterContents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity,
+    std::optional<Rect> coverage_limit,
     const std::optional<SamplerDescriptor>& sampler_descriptor,
     bool msaa_enabled,
     const std::string& label) const {
@@ -248,8 +249,13 @@ std::optional<Snapshot> FilterContents::RenderToSnapshot(
   // snapshot.
   if (std::optional<Entity> result = GetEntity(renderer, entity);
       result.has_value()) {
-    return result->GetContents()->RenderToSnapshot(renderer, result.value(),
-                                                   std::nullopt, true, label);
+    return result->GetContents()->RenderToSnapshot(
+        renderer,        // renderer
+        result.value(),  // entity
+        std::nullopt,    // coverage_limit
+        std::nullopt,    // sampler_descriptor
+        true,            // msaa_enabled
+        label);          // label
   }
 
   return std::nullopt;

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -125,6 +125,7 @@ class FilterContents : public Contents {
   std::optional<Snapshot> RenderToSnapshot(
       const ContentContext& renderer,
       const Entity& entity,
+      std::optional<Rect> coverage_limit = std::nullopt,
       const std::optional<SamplerDescriptor>& sampler_descriptor = std::nullopt,
       bool msaa_enabled = true,
       const std::string& label = "Filter Snapshot") const override;

--- a/impeller/entity/contents/filters/inputs/contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/contents_filter_input.cc
@@ -27,8 +27,12 @@ std::optional<Snapshot> ContentsFilterInput::GetSnapshot(
     const Entity& entity) const {
   if (!snapshot_.has_value()) {
     snapshot_ = contents_->RenderToSnapshot(
-        renderer, entity, std::nullopt, msaa_enabled_,
-        SPrintF("Contents to %s Filter Snapshot", label.c_str()));
+        renderer,       // renderer
+        entity,         // entity
+        std::nullopt,   // coverage_limit
+        std::nullopt,   // sampler_descriptor
+        msaa_enabled_,  // msaa_enabled
+        SPrintF("Contents to %s Filter Snapshot", label.c_str()));  // label
   }
   return snapshot_;
 }

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
@@ -27,8 +27,12 @@ std::optional<Snapshot> FilterContentsFilterInput::GetSnapshot(
     const Entity& entity) const {
   if (!snapshot_.has_value()) {
     snapshot_ = filter_->RenderToSnapshot(
-        renderer, entity, std::nullopt, true,
-        SPrintF("Filter to %s Filter Snapshot", label.c_str()));
+        renderer,      // renderer
+        entity,        // entity
+        std::nullopt,  // coverage_limit
+        std::nullopt,  // sampler_descriptor
+        true,          // msaa_enabled
+        SPrintF("Filter to %s Filter Snapshot", label.c_str()));  // label
   }
   return snapshot_;
 }

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -41,9 +41,13 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
-  auto src_snapshot =
-      child_contents_->RenderToSnapshot(renderer, entity, std::nullopt, true,
-                                        "FramebufferBlendContents Snapshot");
+  auto src_snapshot = child_contents_->RenderToSnapshot(
+      renderer,                                    // renderer
+      entity,                                      // entity
+      Rect::MakeSize(pass.GetRenderTargetSize()),  // coverage_limit
+      std::nullopt,                                // sampler_descriptor
+      true,                                        // msaa_enabled
+      "FramebufferBlendContents Snapshot");        // label
   if (!src_snapshot.has_value()) {
     return true;
   }

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -76,6 +76,7 @@ std::optional<Rect> TextureContents::GetCoverage(const Entity& entity) const {
 std::optional<Snapshot> TextureContents::RenderToSnapshot(
     const ContentContext& renderer,
     const Entity& entity,
+    std::optional<Rect> coverage_limit,
     const std::optional<SamplerDescriptor>& sampler_descriptor,
     bool msaa_enabled,
     const std::string& label) const {
@@ -95,8 +96,12 @@ std::optional<Snapshot> TextureContents::RenderToSnapshot(
         .opacity = opacity};
   }
   return Contents::RenderToSnapshot(
-      renderer, entity, sampler_descriptor.value_or(sampler_descriptor_), true,
-      label);
+      renderer,                                          // renderer
+      entity,                                            // entity
+      std::nullopt,                                      // coverage_limit
+      sampler_descriptor.value_or(sampler_descriptor_),  // sampler_descriptor
+      true,                                              // msaa_enabled
+      label);                                            // label
 }
 
 static TextureFillVertexShader::PerVertexData ComputeVertexData(

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -57,6 +57,7 @@ class TextureContents final : public Contents {
   std::optional<Snapshot> RenderToSnapshot(
       const ContentContext& renderer,
       const Entity& entity,
+      std::optional<Rect> coverage_limit = std::nullopt,
       const std::optional<SamplerDescriptor>& sampler_descriptor = std::nullopt,
       bool msaa_enabled = true,
       const std::string& label = "Texture Snapshot") const override;

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -66,7 +66,12 @@ TiledTextureContents::CreateFilterTexture(
   const ColorFilterProc& filter = color_filter_.value();
   auto color_filter_contents = filter(FilterInput::Make(texture_));
   auto snapshot = color_filter_contents->RenderToSnapshot(
-      renderer, Entity(), std::nullopt, true, "TiledTextureContents Snapshot");
+      renderer,                          // renderer
+      Entity(),                          // entity
+      std::nullopt,                      // coverage_limit
+      std::nullopt,                      // sampler_descriptor
+      true,                              // msaa_enabled
+      "TiledTextureContents Snapshot");  // label
   if (snapshot.has_value()) {
     return snapshot.value().texture;
   }

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -108,7 +108,12 @@ bool VerticesUVContents::Render(const ContentContext& renderer,
   auto src_contents = parent_.GetSourceContents();
 
   auto snapshot = src_contents->RenderToSnapshot(
-      renderer, entity, std::nullopt, true, "VerticesUVContents Snapshot");
+      renderer,                                    // renderer
+      entity,                                      // entity
+      Rect::MakeSize(pass.GetRenderTargetSize()),  // coverage_limit
+      std::nullopt,                                // sampler_descriptor
+      true,                                        // msaa_enabled
+      "VerticesUVContents Snapshot");              // label
   if (!snapshot.has_value()) {
     return false;
   }


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/126790.

Adds an optional coverage limit when taking a snapshot contents, used by FramebufferBlendContents.
Also makes advanced blends more efficient in cases where blended object lies partially outside the pass.

Before:

https://github.com/flutter/engine/assets/919017/865e91a6-92ff-4931-ab90-e25e0b511bbd

After:

https://github.com/flutter/engine/assets/919017/e5c6fe4d-2c81-4cbe-a39b-ff46130f4926


