### PR TITLE
[Impeller] Include AndroidSurfaceVulkanImpeller behind a flag

### DIFF
--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -51,9 +51,16 @@ std::unique_ptr<AndroidSurface> AndroidSurfaceFactoryImpl::CreateSurface() {
       }
     case AndroidRenderingAPI::kVulkan:
       FML_DCHECK(enable_impeller_);
-      return std::make_unique<AndroidSurfaceVulkanImpeller>(
+      // TODO(kaushikiska@): Enable this after wiring a preference for Vulkan
+      // backend.
+#if false
+    return std::make_unique<AndroidSurfaceVulkanImpeller>(
           std::static_pointer_cast<AndroidContextVulkanImpeller>(
               android_context_));
+#else
+      return std::make_unique<AndroidSurfaceGLImpeller>(
+          std::static_pointer_cast<AndroidContextGLImpeller>(android_context_));
+#endif
     default:
       FML_DCHECK(false);
       return nullptr;


### PR DESCRIPTION
Fixes b/282290672

Google Testing currently does not support vulkan, and constructors like this need to be behind a flag.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.