### PR TITLE
[Impeller] Limit subpass textures and backdrop blurs to the current clip

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2174,5 +2174,52 @@ TEST_P(AiksTest, CanRenderDestructiveSaveLayer) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanRenderBackdropBlurInteractive) {
+  auto callback = [&](AiksContext& renderer, RenderTarget& render_target) {
+    auto [a, b] = IMPELLER_PLAYGROUND_LINE(Point(50, 50), Point(300, 200), 30,
+                                           Color::White(), Color::White());
+
+    Canvas canvas;
+    canvas.DrawCircle({100, 100}, 50, {.color = Color::CornflowerBlue()});
+    canvas.DrawCircle({300, 200}, 100, {.color = Color::GreenYellow()});
+    canvas.DrawCircle({140, 170}, 75, {.color = Color::DarkMagenta()});
+    canvas.DrawCircle({180, 120}, 100, {.color = Color::OrangeRed()});
+    canvas.ClipRRect(Rect::MakeLTRB(a.x, a.y, b.x, b.y), 20);
+    canvas.SaveLayer({.blend_mode = BlendMode::kSource}, std::nullopt,
+                     [](const FilterInput::Ref& input,
+                        const Matrix& effect_transform, bool is_subpass) {
+                       return FilterContents::MakeGaussianBlur(
+                           input, Sigma(20.0), Sigma(20.0),
+                           FilterContents::BlurStyle::kNormal,
+                           Entity::TileMode::kClamp, effect_transform);
+                     });
+    canvas.Restore();
+
+    return renderer.Render(canvas.EndRecordingAsPicture(), render_target);
+  };
+
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
+}
+
+TEST_P(AiksTest, CanRenderBackdropBlur) {
+  Canvas canvas;
+  canvas.DrawCircle({100, 100}, 50, {.color = Color::CornflowerBlue()});
+  canvas.DrawCircle({300, 200}, 100, {.color = Color::GreenYellow()});
+  canvas.DrawCircle({140, 170}, 75, {.color = Color::DarkMagenta()});
+  canvas.DrawCircle({180, 120}, 100, {.color = Color::OrangeRed()});
+  canvas.ClipRRect(Rect::MakeLTRB(75, 50, 375, 275), 20);
+  canvas.SaveLayer({.blend_mode = BlendMode::kSource}, std::nullopt,
+                   [](const FilterInput::Ref& input,
+                      const Matrix& effect_transform, bool is_subpass) {
+                     return FilterContents::MakeGaussianBlur(
+                         input, Sigma(30.0), Sigma(30.0),
+                         FilterContents::BlurStyle::kNormal,
+                         Entity::TileMode::kClamp, effect_transform);
+                   });
+  canvas.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -124,6 +124,14 @@ bool Contents::ShouldRender(const Entity& entity,
   return stencil_coverage->IntersectsWithRect(coverage.value());
 }
 
+void Contents::SetCoverageHint(std::optional<Rect> coverage_hint) {
+  coverage_hint_ = coverage_hint;
+}
+
+const std::optional<Rect>& Contents::GetCoverageHint() const {
+  return coverage_hint_;
+}
+
 std::optional<Size> Contents::GetColorSourceSize() const {
   return color_source_size_;
 };

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -56,6 +56,14 @@ class Contents {
   /// @brief Get the screen space bounding rectangle that this contents affects.
   virtual std::optional<Rect> GetCoverage(const Entity& entity) const = 0;
 
+  /// @brief  Hint that specifies the coverage area of this Contents that will
+  ///         actually be used during rendering. This is for optimization
+  ///         purposes only and can not be relied on as a clip. May optionally
+  ///         affect the result of `GetCoverage()`.
+  void SetCoverageHint(std::optional<Rect> coverage_hint);
+
+  const std::optional<Rect>& GetCoverageHint() const;
+
   /// @brief Whether this Contents only emits opaque source colors from the
   ///        fragment stage. This value does not account for any entity
   ///        properties (e.g. the blend mode), clips/visibility culling, or
@@ -110,6 +118,7 @@ class Contents {
   virtual void SetInheritedOpacity(Scalar opacity);
 
  private:
+  std::optional<Rect> coverage_hint_;
   std::optional<Size> color_source_size_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Contents);

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -649,7 +649,8 @@ std::optional<Entity> BlendFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   if (inputs.empty()) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/filters/blend_filter_contents.h
+++ b/impeller/entity/contents/filters/blend_filter_contents.h
@@ -32,11 +32,13 @@ class BlendFilterContents : public ColorFilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& inputs,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& inputs,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
 
   /// @brief Optimized advanced blend that avoids a second subpass when there is
   ///        only a single input and a foreground color.

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -53,7 +53,8 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   using VS = BorderMaskBlurPipeline::VertexShader;
   using FS = BorderMaskBlurPipeline::FragmentShader;
 

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
@@ -29,11 +29,13 @@ class BorderMaskBlurFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
 
   Sigma sigma_x_;
   Sigma sigma_y_;

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -29,7 +29,8 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   using VS = ColorMatrixColorFilterPipeline::VertexShader;
   using FS = ColorMatrixColorFilterPipeline::FragmentShader;
 

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.h
@@ -24,11 +24,13 @@ class ColorMatrixFilterContents final : public ColorFilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
 
   ColorMatrix matrix_;
 

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -102,16 +102,15 @@ class FilterContents : public Contents {
   ///         particular filter's implementation.
   void SetInputs(FilterInput::Vector inputs);
 
-  /// @brief  Screen space bounds to use for cropping the filter output.
-  void SetCoverageCrop(std::optional<Rect> coverage_crop);
-
   /// @brief  Sets the transform which gets appended to the effect of this
   ///         filter. Note that this is in addition to the entity's transform.
   void SetEffectTransform(Matrix effect_transform);
 
   /// @brief  Create an Entity that renders this filter's output.
-  std::optional<Entity> GetEntity(const ContentContext& renderer,
-                                  const Entity& entity) const;
+  std::optional<Entity> GetEntity(
+      const ContentContext& renderer,
+      const Entity& entity,
+      const std::optional<Rect>& coverage_hint) const;
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -141,16 +140,17 @@ class FilterContents : public Contents {
       const Matrix& effect_transform) const;
 
   /// @brief  Converts zero or more filter inputs into a render instruction.
-  virtual std::optional<Entity> RenderFilter(const FilterInput::Vector& inputs,
-                                             const ContentContext& renderer,
-                                             const Entity& entity,
-                                             const Matrix& effect_transform,
-                                             const Rect& coverage) const = 0;
+  virtual std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& inputs,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const = 0;
 
   std::optional<Rect> GetLocalCoverage(const Entity& local_entity) const;
 
   FilterInput::Vector inputs_;
-  std::optional<Rect> coverage_crop_;
   Matrix effect_transform_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FilterContents);

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -86,9 +86,12 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   using VS = GaussianBlurAlphaDecalPipeline::VertexShader;
   using FS = GaussianBlurAlphaDecalPipeline::FragmentShader;
+
+  bool is_first_pass = !source_override_;
 
   //----------------------------------------------------------------------------
   /// Handle inputs.
@@ -98,10 +101,20 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
     return std::nullopt;
   }
 
+  auto radius = Radius{blur_sigma_}.radius;
+
   // Input 0 snapshot.
 
-  auto input_snapshot =
-      inputs[0]->GetSnapshot("GaussianBlur", renderer, entity);
+  std::optional<Rect> expanded_coverage_hint;
+  if (coverage_hint.has_value()) {
+    auto r = Size(radius, radius).Abs();
+    expanded_coverage_hint =
+        is_first_pass ? Rect(coverage_hint.value().origin - r,
+                             Size(coverage_hint.value().size + r * 2))
+                      : coverage_hint;
+  }
+  auto input_snapshot = inputs[0]->GetSnapshot("GaussianBlur", renderer, entity,
+                                               expanded_coverage_hint);
   if (!input_snapshot.has_value()) {
     return std::nullopt;
   }
@@ -111,8 +124,6 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
         input_snapshot.value(), entity.GetBlendMode(),
         entity.GetStencilDepth());  // No blur to render.
   }
-
-  auto radius = Radius{blur_sigma_}.radius;
 
   auto transform = entity.GetTransformation() * effect_transform.Basis();
   auto transformed_blur_radius =
@@ -146,11 +157,21 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
   pass_texture_rect.origin.x -= transformed_blur_radius_length;
   pass_texture_rect.size.width += transformed_blur_radius_length * 2;
 
+  // Crop the pass texture with the rotated coverage hint if one was given.
+  if (expanded_coverage_hint.has_value()) {
+    auto maybe_pass_texture_rect = pass_texture_rect.Intersection(
+        expanded_coverage_hint->TransformBounds(texture_rotate));
+    if (!maybe_pass_texture_rect.has_value()) {
+      return std::nullopt;
+    }
+    pass_texture_rect = *maybe_pass_texture_rect;
+  }
+
   // Source override snapshot.
 
   auto source = source_override_ ? source_override_ : inputs[0];
-  auto source_snapshot =
-      source->GetSnapshot("GaussianBlur(Override)", renderer, entity);
+  auto source_snapshot = source->GetSnapshot("GaussianBlur(Override)", renderer,
+                                             entity, GetCoverageHint());
   if (!source_snapshot.has_value()) {
     return std::nullopt;
   }
@@ -172,8 +193,9 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
   /// Render to texture.
   ///
 
-  ContentContext::SubpassCallback callback = [&](const ContentContext& renderer,
-                                                 RenderPass& pass) {
+  ContentContext::SubpassCallback subpass_callback = [&](const ContentContext&
+                                                             renderer,
+                                                         RenderPass& pass) {
     auto& host_buffer = pass.GetTransientsBuffer();
 
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
@@ -294,8 +316,8 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
   {
     scale.x = scale_curve(transformed_blur_radius_length);
 
-    Scalar y_radius = std::abs(pass_transform.GetDirectionScale(Vector2(
-        0, source_override_ ? Radius{secondary_blur_sigma_}.radius : 1)));
+    Scalar y_radius = std::abs(pass_transform.GetDirectionScale(
+        Vector2(0, !is_first_pass ? Radius{secondary_blur_sigma_}.radius : 1)));
     scale.y = scale_curve(y_radius);
   }
 
@@ -303,7 +325,7 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
   ISize floored_size = ISize(scaled_size.x, scaled_size.y);
 
   auto out_texture = renderer.MakeSubpass("Directional Gaussian Blur Filter",
-                                          floored_size, callback);
+                                          floored_size, subpass_callback);
 
   if (!out_texture) {
     return std::nullopt;
@@ -339,7 +361,7 @@ std::optional<Rect> DirectionalGaussianBlurFilterContents::GetFilterCoverage(
 
   auto transform = inputs[0]->GetTransform(entity) * effect_transform.Basis();
   auto transformed_blur_vector =
-      transform.TransformDirection(blur_direction_* Radius{blur_sigma_}.radius)
+      transform.TransformDirection(blur_direction_ * Radius{blur_sigma_}.radius)
           .Abs();
   auto extent = coverage->size + transformed_blur_vector * 2;
   return Rect(coverage->origin - transformed_blur_vector,

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -37,11 +37,13 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
   Sigma blur_sigma_;
   Sigma secondary_blur_sigma_;
   Vector2 blur_direction_;

--- a/impeller/entity/contents/filters/inputs/contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/contents_filter_input.cc
@@ -24,14 +24,15 @@ FilterInput::Variant ContentsFilterInput::GetInput() const {
 std::optional<Snapshot> ContentsFilterInput::GetSnapshot(
     const std::string& label,
     const ContentContext& renderer,
-    const Entity& entity) const {
+    const Entity& entity,
+    std::optional<Rect> coverage_limit) const {
   if (!snapshot_.has_value()) {
     snapshot_ = contents_->RenderToSnapshot(
-        renderer,       // renderer
-        entity,         // entity
-        std::nullopt,   // coverage_limit
-        std::nullopt,   // sampler_descriptor
-        msaa_enabled_,  // msaa_enabled
+        renderer,        // renderer
+        entity,          // entity
+        coverage_limit,  // coverage_limit
+        std::nullopt,    // sampler_descriptor
+        msaa_enabled_,   // msaa_enabled
         SPrintF("Contents to %s Filter Snapshot", label.c_str()));  // label
   }
   return snapshot_;

--- a/impeller/entity/contents/filters/inputs/contents_filter_input.h
+++ b/impeller/entity/contents/filters/inputs/contents_filter_input.h
@@ -16,9 +16,11 @@ class ContentsFilterInput final : public FilterInput {
   Variant GetInput() const override;
 
   // |FilterInput|
-  std::optional<Snapshot> GetSnapshot(const std::string& label,
-                                      const ContentContext& renderer,
-                                      const Entity& entity) const override;
+  std::optional<Snapshot> GetSnapshot(
+      const std::string& label,
+      const ContentContext& renderer,
+      const Entity& entity,
+      std::optional<Rect> coverage_limit) const override;
 
   // |FilterInput|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
@@ -24,14 +24,15 @@ FilterInput::Variant FilterContentsFilterInput::GetInput() const {
 std::optional<Snapshot> FilterContentsFilterInput::GetSnapshot(
     const std::string& label,
     const ContentContext& renderer,
-    const Entity& entity) const {
+    const Entity& entity,
+    std::optional<Rect> coverage_limit) const {
   if (!snapshot_.has_value()) {
     snapshot_ = filter_->RenderToSnapshot(
-        renderer,      // renderer
-        entity,        // entity
-        std::nullopt,  // coverage_limit
-        std::nullopt,  // sampler_descriptor
-        true,          // msaa_enabled
+        renderer,        // renderer
+        entity,          // entity
+        coverage_limit,  // coverage_limit
+        std::nullopt,    // sampler_descriptor
+        true,            // msaa_enabled
         SPrintF("Filter to %s Filter Snapshot", label.c_str()));  // label
   }
   return snapshot_;

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
@@ -16,9 +16,11 @@ class FilterContentsFilterInput final : public FilterInput {
   Variant GetInput() const override;
 
   // |FilterInput|
-  std::optional<Snapshot> GetSnapshot(const std::string& label,
-                                      const ContentContext& renderer,
-                                      const Entity& entity) const override;
+  std::optional<Snapshot> GetSnapshot(
+      const std::string& label,
+      const ContentContext& renderer,
+      const Entity& entity,
+      std::optional<Rect> coverage_limit) const override;
 
   // |FilterInput|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;

--- a/impeller/entity/contents/filters/inputs/filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_input.h
@@ -45,9 +45,11 @@ class FilterInput {
 
   virtual Variant GetInput() const = 0;
 
-  virtual std::optional<Snapshot> GetSnapshot(const std::string& label,
-                                              const ContentContext& renderer,
-                                              const Entity& entity) const = 0;
+  virtual std::optional<Snapshot> GetSnapshot(
+      const std::string& label,
+      const ContentContext& renderer,
+      const Entity& entity,
+      std::optional<Rect> coverage_limit = std::nullopt) const = 0;
 
   std::optional<Rect> GetLocalCoverage(const Entity& entity) const;
 

--- a/impeller/entity/contents/filters/inputs/texture_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/texture_filter_input.cc
@@ -23,7 +23,8 @@ FilterInput::Variant TextureFilterInput::GetInput() const {
 std::optional<Snapshot> TextureFilterInput::GetSnapshot(
     const std::string& label,
     const ContentContext& renderer,
-    const Entity& entity) const {
+    const Entity& entity,
+    std::optional<Rect> coverage_limit) const {
   auto snapshot =
       Snapshot{.texture = texture_, .transform = GetTransform(entity)};
   if (texture_->GetMipCount() > 1) {

--- a/impeller/entity/contents/filters/inputs/texture_filter_input.h
+++ b/impeller/entity/contents/filters/inputs/texture_filter_input.h
@@ -18,9 +18,11 @@ class TextureFilterInput final : public FilterInput {
   Variant GetInput() const override;
 
   // |FilterInput|
-  std::optional<Snapshot> GetSnapshot(const std::string& label,
-                                      const ContentContext& renderer,
-                                      const Entity& entity) const override;
+  std::optional<Snapshot> GetSnapshot(
+      const std::string& label,
+      const ContentContext& renderer,
+      const Entity& entity,
+      std::optional<Rect> coverage_limit) const override;
 
   // |FilterInput|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -23,7 +23,8 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   if (inputs.empty()) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.h
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.h
@@ -17,11 +17,13 @@ class LinearToSrgbFilterContents final : public ColorFilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(LinearToSrgbFilterContents);
 };

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.cc
@@ -24,7 +24,8 @@ std::optional<Entity> LocalMatrixFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   return Entity::FromSnapshot(
       inputs[0]->GetSnapshot("LocalMatrix", renderer, entity),
       entity.GetBlendMode(), entity.GetStencilDepth());

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.h
@@ -22,11 +22,13 @@ class LocalMatrixFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
 
   Matrix matrix_;
 

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -27,7 +27,8 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   auto snapshot = inputs[0]->GetSnapshot("Matrix", renderer, entity);
   if (!snapshot.has_value()) {
     return std::nullopt;

--- a/impeller/entity/contents/filters/matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/matrix_filter_contents.h
@@ -29,11 +29,13 @@ class MatrixFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
 
   Matrix matrix_;
   SamplerDescriptor sampler_descriptor_ = {};

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -39,7 +39,8 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   using VS = MorphologyFilterPipeline::VertexShader;
   using FS = MorphologyFilterPipeline::FragmentShader;
 

--- a/impeller/entity/contents/filters/morphology_filter_contents.h
+++ b/impeller/entity/contents/filters/morphology_filter_contents.h
@@ -31,11 +31,13 @@ class DirectionalMorphologyFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
 
   Radius radius_;
   Vector2 direction_;

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -23,7 +23,8 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   if (inputs.empty()) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.h
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.h
@@ -17,11 +17,13 @@ class SrgbToLinearFilterContents final : public ColorFilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(SrgbToLinearFilterContents);
 };

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -42,7 +42,8 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     const ContentContext& renderer,
     const Entity& entity,
     const Matrix& effect_transform,
-    const Rect& coverage) const {
+    const Rect& coverage,
+    const std::optional<Rect>& coverage_hint) const {
   if (inputs.size() < 2) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.h
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.h
@@ -18,11 +18,13 @@ class YUVToRGBFilterContents final : public FilterContents {
 
  private:
   // |FilterContents|
-  std::optional<Entity> RenderFilter(const FilterInput::Vector& input_textures,
-                                     const ContentContext& renderer,
-                                     const Entity& entity,
-                                     const Matrix& effect_transform,
-                                     const Rect& coverage) const override;
+  std::optional<Entity> RenderFilter(
+      const FilterInput::Vector& input_textures,
+      const ContentContext& renderer,
+      const Entity& entity,
+      const Matrix& effect_transform,
+      const Rect& coverage,
+      const std::optional<Rect>& coverage_hint) const override;
 
   YUVColorSpace yuv_color_space_ = YUVColorSpace::kBT601LimitedRange;
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -75,7 +75,7 @@ size_t EntityPass::GetSubpassesDepth() const {
 }
 
 std::optional<Rect> EntityPass::GetElementsCoverage(
-    std::optional<Rect> coverage_crop) const {
+    std::optional<Rect> coverage_limit) const {
   std::optional<Rect> result;
   for (const auto& element : elements_) {
     std::optional<Rect> coverage;
@@ -83,12 +83,12 @@ std::optional<Rect> EntityPass::GetElementsCoverage(
     if (auto entity = std::get_if<Entity>(&element)) {
       coverage = entity->GetCoverage();
 
-      if (coverage.has_value() && coverage_crop.has_value()) {
-        coverage = coverage->Intersection(coverage_crop.value());
+      if (coverage.has_value() && coverage_limit.has_value()) {
+        coverage = coverage->Intersection(coverage_limit.value());
       }
     } else if (auto subpass =
                    std::get_if<std::unique_ptr<EntityPass>>(&element)) {
-      coverage = GetSubpassCoverage(*subpass->get(), coverage_crop);
+      coverage = GetSubpassCoverage(*subpass->get(), coverage_limit);
     } else {
       FML_UNREACHABLE();
     }
@@ -107,8 +107,8 @@ std::optional<Rect> EntityPass::GetElementsCoverage(
 
 std::optional<Rect> EntityPass::GetSubpassCoverage(
     const EntityPass& subpass,
-    std::optional<Rect> coverage_clip) const {
-  auto entities_coverage = subpass.GetElementsCoverage(coverage_clip);
+    std::optional<Rect> coverage_limit) const {
+  auto entities_coverage = subpass.GetElementsCoverage(coverage_limit);
   // The entities don't cover anything. There is nothing to do.
   if (!entities_coverage.has_value()) {
     return std::nullopt;
@@ -434,44 +434,47 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       pass_context.EndPass();
     }
 
-    auto subpass_coverage =
-        GetSubpassCoverage(*subpass, Rect::MakeSize(root_pass_size));
-    if (subpass->cover_whole_screen_) {
-      subpass_coverage =
-          Rect(global_pass_position, Size(pass_context.GetPassTarget()
-                                              .GetRenderTarget()
-                                              .GetRenderTargetSize()));
-    }
-    if (backdrop_filter_contents) {
-      auto backdrop_coverage = backdrop_filter_contents->GetCoverage(Entity{});
-      if (backdrop_coverage.has_value()) {
-        backdrop_coverage->origin += global_pass_position;
-
-        subpass_coverage =
-            subpass_coverage.has_value()
-                ? subpass_coverage->Union(backdrop_coverage.value())
-                : backdrop_coverage;
-      }
+    if (stencil_coverage_stack.empty() ||
+        !stencil_coverage_stack.back().coverage.has_value()) {
+      // The current clip is empty. This means the pass texture won't be
+      // visible, so skip it.
+      return EntityPass::EntityResult::Skip();
     }
 
+    // The maximum coverage of the subpass. Subpasses textures should never
+    // extend outside the parent pass texture or the current clip coverage.
+    auto coverage_limit =
+        Rect(global_pass_position, Size(pass_context.GetPassTarget()
+                                            .GetRenderTarget()
+                                            .GetRenderTargetSize()))
+            .Intersection(*stencil_coverage_stack.back().coverage);
+    if (!coverage_limit.has_value()) {
+      return EntityPass::EntityResult::Skip();
+    }
+
+    coverage_limit =
+        coverage_limit->Intersection(Rect::MakeSize(root_pass_size));
+    if (!coverage_limit.has_value()) {
+      return EntityPass::EntityResult::Skip();
+    }
+
+    auto subpass_coverage = (subpass->flood_clip_ || backdrop_filter_contents)
+                                ? coverage_limit
+                                : GetSubpassCoverage(*subpass, coverage_limit);
     if (!subpass_coverage.has_value()) {
-      // The subpass doesn't contain anything visible, so skip it.
       return EntityPass::EntityResult::Skip();
     }
 
-    subpass_coverage =
-        subpass_coverage->Intersection(Rect::MakeSize(root_pass_size));
-    if (!subpass_coverage.has_value() ||
-        ISize(subpass_coverage->size).IsEmpty()) {
-      // The subpass doesn't contain anything visible, so skip it.
+    auto subpass_size = ISize(subpass_coverage->size);
+    if (subpass_size.IsEmpty()) {
       return EntityPass::EntityResult::Skip();
     }
 
-    auto subpass_target =
-        CreateRenderTarget(renderer,                                  //
-                           ISize(subpass_coverage->size),             //
-                           subpass->GetTotalPassReads(renderer) > 0,  //
-                           clear_color_.Premultiply());
+    auto subpass_target = CreateRenderTarget(
+        renderer,                                  // renderer
+        subpass_size,                              // size
+        subpass->GetTotalPassReads(renderer) > 0,  // readable
+        clear_color_.Premultiply());               // clear_color
 
     if (!subpass_target.IsValid()) {
       VALIDATION_LOG << "Subpass render target is invalid.";
@@ -682,6 +685,12 @@ bool EntityPass::OnRender(
       return false;
     }
 
+    // Tell the backdrop contents which portion of the rendered output will
+    // actually be used. The contents may optionally use this hint to avoid
+    // unnecessary rendering work.
+    backdrop_filter_contents->SetCoverageHint(
+        stencil_coverage_stack.back().coverage);
+
     Entity backdrop_entity;
     backdrop_entity.SetContents(std::move(backdrop_filter_contents));
     backdrop_entity.SetTransformation(
@@ -758,7 +767,7 @@ bool EntityPass::OnRender(
             FilterInput::Make(result.entity.GetContents())};
         auto contents = ColorFilterContents::MakeBlend(
             result.entity.GetBlendMode(), inputs);
-        contents->SetCoverageCrop(result.entity.GetCoverage());
+        contents->SetCoverageHint(result.entity.GetCoverage());
         result.entity.SetContents(std::move(contents));
         result.entity.SetBlendMode(BlendMode::kSource);
       }
@@ -876,7 +885,7 @@ void EntityPass::SetStencilDepth(size_t stencil_depth) {
 
 void EntityPass::SetBlendMode(BlendMode blend_mode) {
   blend_mode_ = blend_mode;
-  cover_whole_screen_ = Entity::IsBlendModeDestructive(blend_mode);
+  flood_clip_ = Entity::IsBlendModeDestructive(blend_mode);
 }
 
 void EntityPass::SetClearColor(Color clear_color) {

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -96,10 +96,10 @@ class EntityPass {
 
   std::optional<Rect> GetSubpassCoverage(
       const EntityPass& subpass,
-      std::optional<Rect> coverage_crop) const;
+      std::optional<Rect> coverage_limit) const;
 
   std::optional<Rect> GetElementsCoverage(
-      std::optional<Rect> coverage_crop) const;
+      std::optional<Rect> coverage_limit) const;
 
  private:
   struct EntityResult {
@@ -209,7 +209,7 @@ class EntityPass {
   Matrix xformation_;
   size_t stencil_depth_ = 0u;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
-  bool cover_whole_screen_ = false;
+  bool flood_clip_ = false;
   Color clear_color_ = Color::BlackTransparent();
   bool enable_offscreen_debug_checkerboard_ = false;
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -202,7 +202,7 @@ TEST_P(EntityTest, FilterCoverageRespectsCropRect) {
   // With the crop rect.
   {
     auto expected = Rect::MakeLTRB(50, 50, 100, 100);
-    filter->SetCoverageCrop(expected);
+    filter->SetCoverageHint(expected);
     auto actual = filter->GetCoverage({});
 
     ASSERT_TRUE(actual.has_value());

--- a/impeller/geometry/size.h
+++ b/impeller/geometry/size.h
@@ -82,6 +82,8 @@ struct TSize {
     };
   }
 
+  constexpr TSize Abs() const { return {std::fabs(width), std::fabs(height)}; }
+
   constexpr TSize Floor() const {
     return {std::floor(width), std::floor(height)};
   }

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -23,6 +23,8 @@ static const std::vector<std::string> kSkipTests = {
     "impeller_Play_AiksTest_CanRenderRadialGradient_Vulkan",
     "impeller_Play_AiksTest_CanRenderRadialGradientManyColors_Metal",
     "impeller_Play_AiksTest_CanRenderRadialGradientManyColors_Vulkan",
+    "impeller_Play_AiksTest_CanRenderBackdropBlurInteractive_Metal",
+    "impeller_Play_AiksTest_CanRenderBackdropBlurInteractive_Vulkan",
     "impeller_Play_AiksTest_TextFrameSubpixelAlignment_Metal",
     "impeller_Play_AiksTest_TextFrameSubpixelAlignment_Vulkan",
     "impeller_Play_AiksTest_ColorWheel_Metal",


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/126696.

* Generalize the FilterContents coverage hint as a Contents property.
* Incorporates the stencil coverage when creating subpass textures.
* Set a coverage hint for backdrop filters.
* Incorporate the coverage hint in the 2-pass Gaussian blur.

New backdrop blur playground:

https://github.com/flutter/engine/assets/919017/9ce1f2c3-8cb8-4469-b12f-5063481830de

Frame capture showing the reduced pass sizes:

https://github.com/flutter/engine/assets/919017/c1b124cd-c35f-4872-b38e-4da82494a539

