### PR TITLE
Overrides accessibilityScrollToVisible

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -569,6 +569,22 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return [self search:point];
 }
 
+// A private API iOS called when an item is swipe-to-focusd in VoiceOver.
+- (BOOL)accessibilityScrollToVisible {
+  [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
+  // There is no documentation on the return value. It doesn't appear
+  // to make a difference whether it returns YES or NO. Use Yes for now.
+  return YES;
+}
+
+// A private API iOS called when an item is swipe-to-focusd VoiceOver.
+//
+// There isn't a documentation on the input child, and the `child` appears always
+// the same object of `self`.
+- (BOOL)accessibilityScrollToVisibleWithChild:(id)child {
+  return [child accessibilityScrollToVisible];
+}
+
 - (NSAttributedString*)accessibilityAttributedLabel {
   NSString* label = [self accessibilityLabel];
   if (label.length == 0) {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -567,6 +567,11 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
 // iOS uses this method to determine the hittest results when users touch
 // explore in VoiceOver.
+//
+// For overlapping UIAccessibilityElements (e.g. a stack) in IOS, the focus
+// goes to the smallest object before IOS 16, but to the top-left object in
+// IOS 16. Overrides this method to focus the first eligiable semantics
+// object in hit test order.
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
   return [self search:point];
 }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -460,6 +460,10 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return attributedString;
 }
 
+- (void)showOnScreen {
+  [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
+}
+
 #pragma mark - UIAccessibility overrides
 
 - (BOOL)isAccessibilityElement {
@@ -567,10 +571,6 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return [self search:point];
 }
 
-- (void)showOnScreen {
-  [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
-}
-
 // iOS calls this method when this item is swipe-to-focusd in VoiceOver.
 - (BOOL)accessibilityScrollToVisible {
   [self showOnScreen];
@@ -579,7 +579,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
 // iOS calls this method when this item is swipe-to-focusd in VoiceOver.
 - (BOOL)accessibilityScrollToVisibleWithChild:(id)child {
-  if ([child isKindOfClass:[FlutterSemanticsObject class]]) {
+  if ([child isKindOfClass:[SemanticsObject class]]) {
     [child showOnScreen];
     return YES;
   }
@@ -767,7 +767,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   [self bridge]->AccessibilityObjectDidBecomeFocused([self uid]);
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden) ||
       [self node].HasFlag(flutter::SemanticsFlags::kIsHeader)) {
-    [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
+    [self showOnScreen];
   }
   if ([self node].HasAction(flutter::SemanticsAction::kDidGainAccessibilityFocus)) {
     [self bridge]->DispatchSemanticsAction([self uid],

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -93,7 +93,8 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
 @end
 
 @interface SemanticsObject (Tests)
-
+- (BOOL)accessibilityScrollToVisible;
+- (BOOL)accessibilityScrollToVisibleWithChild:(id)child;
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event;
 @end
 
@@ -200,6 +201,42 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   id hitTestResult = [object0 _accessibilityHitTest:point withEvent:nil];
 
   XCTAssertNil(hitTestResult);
+}
+
+- (void)testAccessibilityScrollToVisible {
+  fml::WeakPtrFactory<flutter::MockAccessibilityBridge> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
+  SemanticsObject* object3 = [[SemanticsObject alloc] initWithBridge:bridge uid:3];
+
+  flutter::SemanticsNode node3;
+  node3.id = 3;
+  node3.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  [object3 setSemanticsNode:&node3];
+
+  [object3 accessibilityScrollToVisible];
+
+  XCTAssertTrue(bridge->observations.size() == 1);
+  XCTAssertTrue(bridge->observations[0].id == 3);
+  XCTAssertTrue(bridge->observations[0].action == flutter::SemanticsAction::kShowOnScreen);
+}
+
+- (void)testAccessibilityScrollToVisibleWithChild {
+  fml::WeakPtrFactory<flutter::MockAccessibilityBridge> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
+  SemanticsObject* object3 = [[SemanticsObject alloc] initWithBridge:bridge uid:3];
+
+  flutter::SemanticsNode node3;
+  node3.id = 3;
+  node3.rect = SkRect::MakeXYWH(0, 0, 200, 200);
+  [object3 setSemanticsNode:&node3];
+
+  [object3 accessibilityScrollToVisibleWithChild:object3];
+
+  XCTAssertTrue(bridge->observations.size() == 1);
+  XCTAssertTrue(bridge->observations[0].id == 3);
+  XCTAssertTrue(bridge->observations[0].action == flutter::SemanticsAction::kShowOnScreen);
 }
 
 - (void)testAccessibilityHitTestOutOfRect {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/61624

Observed behavior is that this method is called when an item is swipe-to-focusd in VoiceOver.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
