### PR TITLE
[Windows] Add force redraw to the C++ client wrapper

### DIFF
--- a/shell/platform/windows/client_wrapper/flutter_view_controller.cc
+++ b/shell/platform/windows/client_wrapper/flutter_view_controller.cc
@@ -29,6 +29,10 @@ FlutterViewController::~FlutterViewController() {
   }
 }
 
+void FlutterViewController::ForceRedraw() {
+  FlutterDesktopViewControllerForceRedraw(controller_);
+}
+
 std::optional<LRESULT> FlutterViewController::HandleTopLevelWindowProc(
     HWND hwnd,
     UINT message,

--- a/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc
@@ -46,7 +46,9 @@ class TestWindowsApi : public testing::StubFlutterWindowsApi {
 
   bool engine_destroyed() { return engine_destroyed_; }
   bool view_controller_destroyed() { return view_controller_destroyed_; }
-  bool view_controller_force_redrawed() { return view_controller_force_redrawed_; }
+  bool view_controller_force_redrawed() {
+    return view_controller_force_redrawed_;
+  }
 
  private:
   bool engine_destroyed_ = false;

--- a/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc
@@ -28,6 +28,11 @@ class TestWindowsApi : public testing::StubFlutterWindowsApi {
   void ViewControllerDestroy() override { view_controller_destroyed_ = true; }
 
   // |flutter::testing::StubFlutterWindowsApi|
+  void ViewControllerForceRedraw() override {
+    view_controller_force_redrawed_ = true;
+  }
+
+  // |flutter::testing::StubFlutterWindowsApi|
   FlutterDesktopEngineRef EngineCreate(
       const FlutterDesktopEngineProperties& engine_properties) override {
     return reinterpret_cast<FlutterDesktopEngineRef>(1);
@@ -41,10 +46,12 @@ class TestWindowsApi : public testing::StubFlutterWindowsApi {
 
   bool engine_destroyed() { return engine_destroyed_; }
   bool view_controller_destroyed() { return view_controller_destroyed_; }
+  bool view_controller_force_redrawed() { return view_controller_force_redrawed_; }
 
  private:
   bool engine_destroyed_ = false;
   bool view_controller_destroyed_ = false;
+  bool view_controller_force_redrawed_ = false;
 };
 
 }  // namespace
@@ -77,6 +84,17 @@ TEST(FlutterViewControllerTest, GetView) {
   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
   FlutterViewController controller(100, 100, project);
   EXPECT_NE(controller.view(), nullptr);
+}
+
+TEST(FlutterViewControllerTest, ForceRedraw) {
+  DartProject project(L"data");
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
+      std::make_unique<TestWindowsApi>());
+  auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
+  FlutterViewController controller(100, 100, project);
+
+  controller.ForceRedraw();
+  EXPECT_TRUE(test_api->view_controller_force_redrawed());
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
@@ -44,6 +44,9 @@ class FlutterViewController {
   // Returns the view managed by this controller.
   FlutterView* view() { return view_.get(); }
 
+  // Requests new frame from the engine and repaints the view.
+  void ForceRedraw();
+
   // Allows the Flutter engine and any interested plugins an opportunity to
   // handle the given message.
   //

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -65,7 +65,11 @@ FlutterDesktopViewRef FlutterDesktopViewControllerGetView(
 }
 
 void FlutterDesktopViewControllerForceRedraw(
-    FlutterDesktopViewControllerRef controller) {}
+    FlutterDesktopViewControllerRef controller) {
+  if (s_stub_implementation) {
+    s_stub_implementation->ViewControllerForceRedraw();
+  }
+}
 
 bool FlutterDesktopViewControllerHandleTopLevelWindowProc(
     FlutterDesktopViewControllerRef controller,

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
@@ -38,6 +38,9 @@ class StubFlutterWindowsApi {
   // Called for FlutterDesktopViewControllerDestroy.
   virtual void ViewControllerDestroy() {}
 
+  // Called for FlutterDesktopViewControllerForceRedraw.
+  virtual void ViewControllerForceRedraw() {}
+
   // Called for FlutterDesktopViewControllerHandleTopLevelWindowProc.
   virtual bool ViewControllerHandleTopLevelWindowProc(HWND hwnd,
                                                       UINT message,

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -107,7 +107,7 @@ FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopViewControllerGetEngine(
 FLUTTER_EXPORT FlutterDesktopViewRef
 FlutterDesktopViewControllerGetView(FlutterDesktopViewControllerRef controller);
 
-// Requests new frame from engine and repaints the view
+// Requests new frame from the engine and repaints the view.
 FLUTTER_EXPORT void FlutterDesktopViewControllerForceRedraw(
     FlutterDesktopViewControllerRef controller);
 


### PR DESCRIPTION
This change adds a C++ client wrapper to Windows's "force redraw" C API. This API can be used to schedule a frame.

Part of https://github.com/flutter/flutter/issues/119415

## Background

The Windows runner has a race at startup:

1. **Platform thread**: creates a hidden window
2. **Platform thread**: launches the Flutter engine
3. **UI/Raster threads**: renders the first frame
4. **Platform thread**: Registers a callback to show the window once the next frame has been rendered.

Steps 3 and 4 happen in parallel and it is possible for step 3 to complete before step 4 starts. In this scenario, the next frame callback is never called and the window is never shown.

The Windows runner will be updated to call the "force redraw" API after it registers the next frame callback. If step 3 hasn't completed yet, the "force redraw" will no-op as a frame is already scheduled. If step 3 has already completed, the "force redraw" will schedule another frame, which will call the next frame callback and show the window.

See this discussion below on why we cannot avoid changing the Windows runner to fix this issue: https://github.com/flutter/engine/pull/42061#issuecomment-1550080722

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
