### PR TITLE
[Impeller] Use 32 bit Gaussian function in the 2-pass blur

### DIFF
--- a/impeller/compiler/shader_lib/impeller/gaussian.glsl
+++ b/impeller/compiler/shader_lib/impeller/gaussian.glsl
@@ -9,7 +9,13 @@
 #include <impeller/types.glsl>
 
 /// Gaussian distribution function.
-float16_t IPGaussian(float16_t x, float16_t sigma) {
+float IPGaussian(float x, float sigma) {
+  float variance = sigma * sigma;
+  return exp(-0.5f * x * x / variance) / (kSqrtTwoPi * sigma);
+}
+
+/// Gaussian distribution function.
+float16_t IPHalfGaussian(float16_t x, float16_t sigma) {
   float16_t variance = sigma * sigma;
   return exp(-0.5hf * x * x / variance) / (float16_t(kSqrtTwoPi) * sigma);
 }

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1004,7 +1004,8 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     static Color input_color = Color::Black();
     static int selected_blur_type = 0;
     static int selected_pass_variation = 0;
-    static float blur_amount[2] = {10, 10};
+    static float blur_amount_coarse[2] = {0, 0};
+    static float blur_amount_fine[2] = {10, 10};
     static int selected_blur_style = 0;
     static int selected_tile_mode = 3;
     static Color cover_color(1, 0, 0, 0.2);
@@ -1034,7 +1035,8 @@ TEST_P(EntityTest, GaussianBlurFilter) {
                      pass_variation_names,
                      sizeof(pass_variation_names) / sizeof(char*));
       }
-      ImGui::SliderFloat2("Sigma", blur_amount, 0, 10);
+      ImGui::SliderFloat2("Sigma (coarse)", blur_amount_coarse, 0, 1000);
+      ImGui::SliderFloat2("Sigma (fine)", blur_amount_fine, 0, 10);
       ImGui::Combo("Blur style", &selected_blur_style, blur_style_names,
                    sizeof(blur_style_names) / sizeof(char*));
       ImGui::Combo("Tile mode", &selected_tile_mode, tile_mode_names,
@@ -1050,6 +1052,9 @@ TEST_P(EntityTest, GaussianBlurFilter) {
       ImGui::SliderFloat4("Path XYWH", path_rect, -1000, 1000);
     }
     ImGui::End();
+
+    auto blur_sigma_x = Sigma{blur_amount_coarse[0] + blur_amount_fine[0]};
+    auto blur_sigma_y = Sigma{blur_amount_coarse[1] + blur_amount_fine[1]};
 
     std::shared_ptr<Contents> input;
     Size input_size;
@@ -1078,18 +1083,17 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     std::shared_ptr<FilterContents> blur;
     if (selected_pass_variation == 0) {
       blur = FilterContents::MakeGaussianBlur(
-          FilterInput::Make(input), Sigma{blur_amount[0]},
-          Sigma{blur_amount[1]}, blur_styles[selected_blur_style],
-          tile_modes[selected_tile_mode]);
+          FilterInput::Make(input), blur_sigma_x, blur_sigma_y,
+          blur_styles[selected_blur_style], tile_modes[selected_tile_mode]);
     } else {
-      Vector2 blur_vector(blur_amount[0], blur_amount[1]);
+      Vector2 blur_vector(blur_sigma_x.sigma, blur_sigma_y.sigma);
       blur = FilterContents::MakeDirectionalGaussianBlur(
           FilterInput::Make(input), Sigma{blur_vector.GetLength()},
           blur_vector.Normalize());
     }
 
     auto mask_blur = FilterContents::MakeBorderMaskBlur(
-        FilterInput::Make(input), Sigma{blur_amount[0]}, Sigma{blur_amount[1]},
+        FilterInput::Make(input), blur_sigma_x, blur_sigma_y,
         blur_styles[selected_blur_style]);
 
     auto ctm = Matrix::MakeScale(GetContentScale()) *

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -62,7 +62,7 @@ float16_t RRectShadow(f16vec2 sample_position, f16vec2 half_size) {
     float16_t y = begin_y + interval * (float16_t(sample_i) + 0.5hf);
     result += RRectShadowX(f16vec2(sample_position.x, sample_position.y - y),
                            half_size) *
-              IPGaussian(y, frag_info.blur_sigma) * interval;
+              IPHalfGaussian(y, frag_info.blur_sigma) * interval;
   }
 
   return result;


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/126487.

Increases the 2-pass blur quality and distribution limit.

It turns out sigma was breaking down beyond ~255 (moderately high, but not unreasonable for users to rely on). The Gaussian function computes sigma^2, and half precision floats only have 5 bit exponents and overflow for numbers above 65k.

Coincidentally, this also returns us to a state where we look a lot more like Skia's blurs for larger blur sigmas. Medium blurs have much less visual banding (although it's still there if you look closely). I suspect half precision isn't really enough for tracking the integral.

Unfortunately, this means our SIMD pipelining isn't going to be as good. I'll be interested in watching the blur-driven benchmarks for the perf hit.

Before Impeller:

![Screen Shot 2023-05-15 at 11 14 20 PM](https://github.com/flutter/engine/assets/919017/cc342954-4550-46ed-80d8-1e27acfd56ce)


After Impeller:

![Screen Shot 2023-05-15 at 11 12 18 PM](https://github.com/flutter/engine/assets/919017/f03fbd70-f21f-48e4-9a10-30aaad43bfa3)


Skia:

![Screen Shot 2023-05-15 at 11 16 58 PM](https://github.com/flutter/engine/assets/919017/c8ade876-4ea5-4d50-9bbe-a680d3921740)


