### PR TITLE
Fix the false failure caused by FlutterClippingMaskViewPool's random algorithm

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -2655,9 +2655,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   FlutterClippingMaskView* view3 = [pool getMaskViewWithFrame:newRect];
   FlutterClippingMaskView* view4 = [pool getMaskViewWithFrame:newRect];
   // view3 and view4 should randomly get either of view1 and view2.
-  XCTAssertTrue((view1 == view3) || (view1 == view4));
-  XCTAssertTrue((view2 == view3) || (view2 == view4));
-  XCTAssertNotEqual(view3, view4);
+  XCTAssertEqual(std::set<FlutterClippingMaskView*>({view1, view2}),
+                 std::set<FlutterClippingMaskView*>({view3, view4}));
   XCTAssertTrue(CGRectEqualToRect(view3.frame, newRect));
   XCTAssertTrue(CGRectEqualToRect(view4.frame, newRect));
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -2654,8 +2654,10 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   CGRect newRect = CGRectMake(0, 0, 10, 10);
   FlutterClippingMaskView* view3 = [pool getMaskViewWithFrame:newRect];
   FlutterClippingMaskView* view4 = [pool getMaskViewWithFrame:newRect];
-  XCTAssertEqual(view1, view3);
-  XCTAssertEqual(view2, view4);
+  // view3 and view4 should randomly get either of view1 and view2.
+  XCTAssertTrue((view1 == view3) || (view1 == view4));
+  XCTAssertTrue((view2 == view3) || (view2 == view4));
+  XCTAssertNotEqual(view3, view4);
   XCTAssertTrue(CGRectEqualToRect(view3.frame, newRect));
   XCTAssertTrue(CGRectEqualToRect(view4.frame, newRect));
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -2655,8 +2655,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   FlutterClippingMaskView* view3 = [pool getMaskViewWithFrame:newRect];
   FlutterClippingMaskView* view4 = [pool getMaskViewWithFrame:newRect];
   // view3 and view4 should randomly get either of view1 and view2.
-  XCTAssertEqual(std::set<FlutterClippingMaskView*>({view1, view2}),
-                 std::set<FlutterClippingMaskView*>({view3, view4}));
+  XCTAssertEqual([NSSet setWithObjects:view1, view2], [NSSet setWithObjects:view3, view4]);
   XCTAssertTrue(CGRectEqualToRect(view3.frame, newRect));
   XCTAssertTrue(CGRectEqualToRect(view4.frame, newRect));
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/126951

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
