### PR TITLE
[Impeller] Don't rely on zeroing of threadgroup shared memory, don't early return in quad decomp.

### DIFF
--- a/impeller/compiler/shader_lib/impeller/path.glsl
+++ b/impeller/compiler/shader_lib/impeller/path.glsl
@@ -121,7 +121,7 @@ QuadDecomposition DecomposeQuad(QuadData quad, float tolerance) {
   // This should never happen, but if it does happen be more defensive -
   // otherwise we'll get NaNs down the line.
   if (dd == vec2(0.)) {
-    return QuadDecomposition(0., 0., 0., 0., 0, 0.);
+    dd = vec2(1.0, 1.0);
   }
   float c = Cross(quad.p2 - quad.p1, dd);
   float x0 = dot(d01, dd) * 1. / c;

--- a/impeller/renderer/path_polyline.comp
+++ b/impeller/renderer/path_polyline.comp
@@ -72,10 +72,9 @@ void ProcessCubic(uint ident) {
   uint offset = 0;
   if (quad_count > 0) {
     scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
-
     offset = ComputePosition(ident) + quads.count;
   } else {
-    scratch_sum[ident] = 0;
+    scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
   }
 
   barrier();

--- a/impeller/renderer/path_polyline.comp
+++ b/impeller/renderer/path_polyline.comp
@@ -65,17 +65,17 @@ void ProcessCubic(uint ident) {
     cubic = cubics.data[ident];
     quad_count = EstimateQuadraticCount(cubic, config.cubic_accuracy);
     scratch_count[ident] = quad_count;
+  } else {
+    scratch_count[ident] = 0;
   }
 
   barrier();
 
   uint offset = 0;
   if (quad_count > 0) {
-    scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
     offset = ComputePosition(ident) + quads.count;
-  } else {
-    scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
   }
+  scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
 
   barrier();
   if (quad_count > 0) {
@@ -103,11 +103,9 @@ void ProcessQuad(uint ident) {
 
   uint offset = 0;
   if (decomposition.line_count > 0) {
-    scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
     offset = ComputePosition(ident) + lines.count;
-  } else {
-    scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
   }
+  scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
   barrier();
 
   if (decomposition.line_count > 0) {

--- a/impeller/renderer/path_polyline.comp
+++ b/impeller/renderer/path_polyline.comp
@@ -74,7 +74,10 @@ void ProcessCubic(uint ident) {
     scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
 
     offset = ComputePosition(ident) + quads.count;
+  } else {
+    scratch_sum[ident] = 0;
   }
+
   barrier();
   if (quad_count > 0) {
     atomicAdd(quads.count, quad_count);
@@ -83,6 +86,8 @@ void ProcessCubic(uint ident) {
     for (uint i = 0; i < quad_count; i++) {
       quads.data[offset + i] = GenerateQuadraticFromCubic(cubic, i, quad_count);
     }
+  } else {
+    cubic_ranges[ident] = uvec2(0, 0);
   }
 }
 
@@ -101,6 +106,8 @@ void ProcessQuad(uint ident) {
   if (decomposition.line_count > 0) {
     scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
     offset = ComputePosition(ident) + lines.count;
+  } else {
+    scratch_sum[ident] = subgroupExclusiveAdd(scratch_count[ident]);
   }
   barrier();
 
@@ -117,6 +124,8 @@ void ProcessQuad(uint ident) {
     }
     lines.data[offset + decomposition.line_count - 1] =
         LineData(last_point, quad.p2);
+  } else {
+    quad_ranges[ident] = uvec2(0, 0);
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/126960 . This doesn't reproduce on macOS as that appears to always zero threadgroup shared memory. On iOS this wasn't getting zero'd out, and so we'd just get whatever garbage was in the memory. This would end up as a huge number that would go far oob and cause a memory fault or something
