### PR TITLE
[web:a11y] support dialogs described by descendants

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -84,6 +84,7 @@ class Checkable extends RoleManager {
 
   @override
   void dispose() {
+    super.dispose();
     switch (_kind) {
       case _CheckableKind.checkbox:
         semanticsObject.setAriaRole('checkbox', false);

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -25,7 +25,7 @@ class Dialog extends RoleManager {
             'namesRoute set, indicating a self-labelled dialog, but it is '
             'missing the label. A dialog should be labelled either by setting '
             'namesRoute on itself and providing a label, or by containing a '
-            'child node with namesRoute that can describe it with it content.'
+            'child node with namesRoute that can describe it with its content.'
           );
         }
         return true;

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -77,8 +77,10 @@ class RouteName extends RoleManager {
         // Setting the label for the first time. Wait for the DOM tree to be
         // established, then find the nearest dialog and update its label.
         semanticsObject.owner.addOneTimePostUpdateCallback(() {
-          _lookUpNearestAncestorDialog();
-          _dialog?.describeBy(this);
+          if (!isDisposed) {
+            _lookUpNearestAncestorDialog();
+            _dialog?.describeBy(this);
+          }
         });
       }
     }

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -13,26 +13,84 @@ class Dialog extends RoleManager {
   Dialog(SemanticsObject semanticsObject) : super(Role.dialog, semanticsObject);
 
   @override
-  void dispose() {
-    semanticsObject.element.removeAttribute('aria-label');
-    semanticsObject.clearAriaRole();
+  void update() {
+    // If semantic object corresponding to the dialog also provides the label
+    // for itself it is applied as `aria-label`. See also [describeBy].
+    if (semanticsObject.namesRoute) {
+      final String? label = semanticsObject.label;
+      assert(() {
+        if (label == null || label.trim().isEmpty) {
+          printWarning(
+            'Semantic node ${semanticsObject.id} had both scopesRoute and '
+            'namesRoute set, indicating a self-labelled dialog, but it is '
+            'missing the label. A dialog should be labelled either by setting '
+            'namesRoute on itself and providing a label, or by containing a '
+            'child node with namesRoute that can describe it with it content.'
+          );
+        }
+        return true;
+      }());
+      semanticsObject.element.setAttribute('aria-label', label ?? '');
+      semanticsObject.setAriaRole('dialog', true);
+    }
   }
+
+  /// Sets the description of this dialog based on a [RouteName] descendant
+  /// node, unless the dialog provides its own label.
+  void describeBy(RouteName routeName) {
+    if (semanticsObject.namesRoute) {
+      // The dialog provides its own label, which takes precedence.
+      return;
+    }
+
+    semanticsObject.setAriaRole('dialog', true);
+    semanticsObject.element.setAttribute(
+      'aria-describedby',
+      routeName.semanticsObject.element.id,
+    );
+  }
+}
+
+/// Supplies a description for the nearest ancestor [Dialog].
+class RouteName extends RoleManager {
+  RouteName(SemanticsObject semanticsObject) : super(Role.routeName, semanticsObject);
+
+  Dialog? _dialog;
 
   @override
   void update() {
-    final String? label = semanticsObject.label;
-    assert(() {
-      if (label == null || label.trim().isEmpty) {
-        printWarning(
-          'Semantic node ${semanticsObject.id} was assigned dialog role, but '
-          'is missing a label. A dialog should contain a label so that a '
-          'screen reader can communicate to the user that a dialog appeared '
-          'and a user action is requested.'
-        );
+    // NOTE(yjbanov): this does not handle the case when the node structure
+    // changes such that this RouteName is no longer attached to the same
+    // dialog. While this is technically expressible using the semantics API,
+    // after discussing this case with customers I decided that this case is not
+    // interesting enough to support. A tree restructure like this is likely to
+    // confuse screen readers, and it would add complexity to the engine's
+    // semantics code. Since reparenting can be done with no update to either
+    // the Dialog or RouteName we'd have to scan intermediate nodes for
+    // structural changes.
+    if (semanticsObject.isLabelDirty) {
+      final Dialog? dialog = _dialog;
+      if (dialog != null) {
+        // Already attached to a dialog, just update the description.
+        dialog.describeBy(this);
+      } else {
+        // Setting the label for the first time. Wait for the DOM tree to be
+        // established, then find the nearest dialog and update its label.
+        semanticsObject.owner.addOneTimePostUpdateCallback(() {
+          _lookUpNearestAncestorDialog();
+          _dialog?.describeBy(this);
+        });
       }
-      return true;
-    }());
-    semanticsObject.element.setAttribute('aria-label', label ?? '');
-    semanticsObject.setAriaRole('dialog', true);
+    }
+  }
+
+  void _lookUpNearestAncestorDialog() {
+    SemanticsObject? parent = semanticsObject.parent;
+    while (parent != null && !parent.hasRole(Role.dialog)) {
+      parent = parent.parent;
+    }
+    if (parent != null && parent.hasRole(Role.dialog)) {
+      _dialog = parent.getRole<Dialog>(Role.dialog);
+    }
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -43,6 +43,7 @@ class Focusable extends RoleManager {
 
   @override
   void dispose() {
+    super.dispose();
     _focusManager.stopManaging();
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/image.dart
+++ b/lib/web_ui/lib/src/engine/semantics/image.dart
@@ -73,6 +73,7 @@ class ImageRoleManager extends RoleManager {
 
   @override
   void dispose() {
+    super.dispose();
     _cleanUpAuxiliaryElement();
     _cleanupElement();
   }

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -140,6 +140,7 @@ class Incrementable extends RoleManager {
   @override
   void dispose() {
     assert(_gestureModeListener != null);
+    super.dispose();
     _focusManager.stopManaging();
     semanticsObject.owner.removeGestureModeListener(_gestureModeListener);
     _gestureModeListener = null;

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -102,6 +102,7 @@ class LabelAndValue extends RoleManager {
 
   @override
   void dispose() {
+    super.dispose();
     _cleanUpDom();
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/live_region.dart
+++ b/lib/web_ui/lib/src/engine/semantics/live_region.dart
@@ -31,8 +31,4 @@ class LiveRegion extends RoleManager {
       }
     }
   }
-
-  @override
-  void dispose() {
-  }
 }

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -224,6 +224,7 @@ class Scrollable extends RoleManager {
 
   @override
   void dispose() {
+    super.dispose();
     final DomCSSStyleDeclaration style = semanticsObject.element.style;
     assert(_gestureModeListener != null);
     style.removeProperty('overflowY');

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -1557,7 +1557,7 @@ enum GestureMode {
 enum SemanticsUpdatePhase {
   /// No update is in progress.
   ///
-  /// The the semantics owner receives an update, it enters the [updating]
+  /// When the semantics owner receives an update, it enters the [updating]
   /// phase from the idle phase.
   idle,
 

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
 
 import '../../engine.dart'  show registerHotRestartListener;
@@ -437,6 +438,10 @@ abstract class RoleManager {
   /// minimum DOM updates.
   void update();
 
+  /// Whether this role manager was disposed of.
+  bool get isDisposed => _isDisposed;
+  bool _isDisposed = false;
+
   /// Called when [semanticsObject] is removed, or when it changes its role such
   /// that this role is no longer relevant.
   ///
@@ -444,7 +449,10 @@ abstract class RoleManager {
   /// DOM. In particular, this method is the appropriate place to call
   /// [EngineSemanticsOwner.removeGestureModeListener] if this role reponds to
   /// gesture mode changes.
-  void dispose() {}
+  @mustCallSuper
+  void dispose() {
+    _isDisposed = true;
+  }
 }
 
 /// Instantiation of a framework-side semantics node in the DOM.

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -376,9 +376,9 @@ enum Role {
   ///   `aria-label` attribute.
   /// * A descendant node has the `namesRoute` bit set. This means that the
   ///   child's content describes the dialog. The child may simply be labelled,
-  ///   or it may be a subtree of nodes that describe the dialog together. In
-  ///   this case the nearest HTML equivalent is `aria-labelledby`. In this case
-  ///   the child acquires the [routeName] role.
+  ///   or it may be a subtree of nodes that describe the dialog together. The
+  ///   nearest HTML equivalent is `aria-describedby`. The child acquires the
+  ///   [routeName] role, which manages the relevant ARIA attributes.
   /// * There is no `namesRoute` bit anywhere in the sub-tree rooted at the
   ///   current node. In this case it's likely not a dialog at all, and the node
   ///   should not get a label or the "dialog" role. It's just a group of
@@ -386,10 +386,13 @@ enum Role {
   ///   it as a dialog would be wrong.
   dialog,
 
-  /// Provides a description for an ancestor [dialog].
+  /// Provides a description for an ancestor dialog.
   ///
   /// This role is assigned to nodes that have `namesRoute` set but not
-  /// `scopesRoute`.
+  /// `scopesRoute`. When both flags are set the node only gets the dialog
+  /// role (see [dialog]).
+  ///
+  /// If the ancestor dialog is missing, this role does nothing useful.
   routeName,
 }
 

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -66,6 +66,7 @@ class Tappable extends RoleManager {
 
   @override
   void dispose() {
+    super.dispose();
     _stopListening();
     semanticsObject.setAriaRole('button', false);
   }

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -450,6 +450,7 @@ class TextField extends RoleManager {
 
   @override
   void dispose() {
+    super.dispose();
     _positionInputElementTimer?.cancel();
     _positionInputElementTimer = null;
     // on iOS, the `blur` event listener callback will remove the element.

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -2365,8 +2365,8 @@ void _testDialog() {
 
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
-<sem role="dialog" aria-label="this is a dialog label" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
-''');
+      <sem role="dialog" aria-label="this is a dialog label" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
+    ''');
 
     expect(
       semantics().debugSemanticsTree![0]!.debugRoleManagerFor(Role.dialog),
@@ -2404,14 +2404,14 @@ void _testDialog() {
     expect(
       warnings,
       <String>[
-        'Semantic node 0 had both scopesRoute and namesRoute set, indicating a self-labelled dialog, but it is missing the label. A dialog should be labelled either by setting namesRoute on itself and providing a label, or by containing a child node with namesRoute that can describe it with it content.',
+        'Semantic node 0 had both scopesRoute and namesRoute set, indicating a self-labelled dialog, but it is missing the label. A dialog should be labelled either by setting namesRoute on itself and providing a label, or by containing a child node with namesRoute that can describe it with its content.',
       ],
     );
 
     // But still sets the dialog role.
     expectSemanticsTree('''
-<sem role="dialog" aria-label="" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
-''');
+      <sem role="dialog" aria-label="" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
+    ''');
 
     expect(
       semantics().debugSemanticsTree![0]!.debugRoleManagerFor(Role.dialog),
@@ -2447,18 +2447,17 @@ void _testDialog() {
       );
       tester.apply();
 
-
-    expectSemanticsTree('''
-<sem aria-describedby="flt-semantic-node-2" style="$rootSemanticStyle">
-  <sem-c>
-    <sem>
-      <sem-c>
-        <sem aria-label="$label"></sem>
-      </sem-c>
-    </sem>
-  </sem-c>
-</sem>
-''');
+      expectSemanticsTree('''
+        <sem aria-describedby="flt-semantic-node-2" style="$rootSemanticStyle">
+          <sem-c>
+            <sem>
+              <sem-c>
+                <sem aria-label="$label"></sem>
+              </sem-c>
+            </sem>
+          </sem-c>
+        </sem>
+      ''');
     }
 
     pumpSemantics(label: 'Dialog label');
@@ -2493,7 +2492,9 @@ void _testDialog() {
     );
     tester.apply();
 
-    expectSemanticsTree('''<sem style="$rootSemanticStyle"></sem>''');
+    expectSemanticsTree('''
+      <sem style="$rootSemanticStyle"></sem>
+    ''');
 
     expect(
       semantics().debugSemanticsTree![0]!.debugRoleManagerFor(Role.dialog),
@@ -2532,16 +2533,16 @@ void _testDialog() {
     tester.apply();
 
     expectSemanticsTree('''
-<sem style="$rootSemanticStyle">
-  <sem-c>
-    <sem>
-      <sem-c>
-        <sem aria-label="Hello"></sem>
-      </sem-c>
-    </sem>
-  </sem-c>
-</sem>
-''');
+      <sem style="$rootSemanticStyle">
+        <sem-c>
+          <sem>
+            <sem-c>
+              <sem aria-label="Hello"></sem>
+            </sem-c>
+          </sem>
+        </sem-c>
+      </sem>
+    ''');
 
     expect(
       semantics().debugSemanticsTree![0]!.debugRoleManagerFor(Role.dialog),


### PR DESCRIPTION
Add a new `RouteName` semantic role for nodes with `namesRoute` set without a `scopesRoute`. Such nodes provide a description for the nearest ancestor dialog node. The web equivalent of this is when an element `role="dialog"` is described by pointing to one of its children using `aria-labelledby` and `aria-describedby`. Here's an example:

```
<div
  role="dialog"
  aria-labelledby="dialog1Title"
  aria-describedby="dialog1Desc">
  <h2 id="dialog1Title">Your personal details were successfully updated</h2>
  <p id="dialog1Desc">
    You can change your details at any time in the user account section.
  </p>
  <button>Close</button>
</div>
```

([Source](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role))

Flutter currently does not distinguish between "labelled by" and "described by". In my testing, only `aria-describedby` resulted in an announcement of the dialog's description upon opening. `aria-labelledby` required that the dialog element itself be focusable, which is not the case. So I went with `aria-describedby`.

Fixes https://github.com/flutter/flutter/issues/126030