### PR TITLE
[CP] [Impeller] Fix bounds when painting style is stroke width for image shaders (#42052)

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -165,6 +165,17 @@ void CanRenderTiledTexture(AiksTest* aiks_test, Entity::TileMode tile_mode) {
   };
   paint.color = Color(1, 1, 1, 1);
   canvas.DrawRect({0, 0, 600, 600}, paint);
+
+  // Should not change the image.
+  constexpr auto stroke_width = 64;
+  paint.style = Paint::Style::kStroke;
+  paint.stroke_width = stroke_width;
+  if (tile_mode == Entity::TileMode::kDecal) {
+    canvas.DrawRect({stroke_width, stroke_width, 600, 600}, paint);
+  } else {
+    canvas.DrawRect({0, 0, 600, 600}, paint);
+  }
+
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 }  // namespace

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -109,10 +109,9 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
 
   auto& host_buffer = pass.GetTransientsBuffer();
 
-  auto bounds_origin = GetGeometry()->GetCoverage(Matrix())->origin;
   auto geometry_result = GetGeometry()->GetPositionUVBuffer(
-      Rect(bounds_origin, Size(texture_size)), GetInverseMatrix(), renderer,
-      entity, pass);
+      Rect({0, 0}, Size(texture_size)), GetInverseMatrix(), renderer, entity,
+      pass);
   bool uses_emulated_tile_mode =
       UsesEmulatedTileMode(renderer.GetDeviceCapabilities());
 

--- a/impeller/entity/geometry.cc
+++ b/impeller/entity/geometry.cc
@@ -581,8 +581,7 @@ GeometryResult StrokePathGeometry::GetPositionUVBuffer(
        &effect_transform](SolidFillVertexShader::PerVertexData old_vtx) {
         TextureFillVertexShader::PerVertexData data;
         data.position = old_vtx.position;
-        auto coverage_coords = (old_vtx.position - texture_coverage.origin) /
-                               texture_coverage.size;
+        auto coverage_coords = old_vtx.position / texture_coverage.size;
         data.texture_coords = effect_transform * coverage_coords;
         vertex_builder.AppendVertex(data);
       });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/126739

When we're sampling from the texture, we need to sample from its origin regardless of how much offset the stroke width gives to the path.