### PR TITLE
Add configuration for automating release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    authors:
+      - skia-flutter-autoroll
+      - dependabot
+  categories:
+    - title: Impeller
+      labels:
+        - impeller
+    - title: Android
+      labels:
+        - platform-android
+    - title: iOS
+      labels:
+        - platform-ios
+    - title: Web
+      labels:
+        - platform-web
+    - title: Desktop
+      labels:
+        - platform-windows
+        - platform-macos


### PR DESCRIPTION
GitHub's automated changelog generation allows teams to setup a configuration file to determine how these changelogs will be generated.  

A similar file is available in flutter/flutter for release note generation.  As tags have been added to flutter/engine, we now have the ability to generate release notes in the same fashion. 