### PR TITLE
[Impeller] Use untransformed text bounds to calculate the size of ColorSourceTextContents

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -66,6 +66,10 @@ void TextContents::SetOffset(Vector2 offset) {
   offset_ = offset;
 }
 
+std::optional<Rect> TextContents::GetTextFrameBounds() const {
+  return frame_.GetBounds();
+}
+
 std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
   auto bounds = frame_.GetBounds();
   if (!bounds.has_value()) {

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -40,6 +40,8 @@ class TextContents final : public Contents {
 
   void SetOffset(Vector2 offset);
 
+  std::optional<Rect> GetTextFrameBounds() const;
+
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 


### PR DESCRIPTION
Previously this was attempting to invert the TransformBounds done by GetCoverage.  TransformBounds computes a bounding box of the transformed rectangle and can not be reversed.

Fixes https://github.com/flutter/flutter/issues/127103
