### PR TITLE
[floating_cursor_selection] a somewhat "design doc" for floating cursor feature

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1862,17 +1862,17 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 //
 // Notice that during the move gesture, the framework only animate the cursor visually. It's only
 // after the gesture is complete, will the framework update the selection to the cursor's
-// new position (with zero selection length). This means during the animation, the selection
-// in framework and the engine can be temporarily out of sync. But it will be in sync again
-// after the animation is complete.
+// new position (with zero selection length). This means during the animation, the visual effect
+// of the cursor is temporarily out of sync with the selection state in both framework and engine.
+// But it will be in sync again after the animation is complete.
 //
 // Floating cursor's "selection" gesture also starts with 1 finger to force press the space bar,
 // so exactly the same functions as the "move gesture" discussed above will be called. When the
-// second finger is pressed, `setSelectedText` will be called, which indicates the beginning of
-// the selection gesture. (This mechanism requires `closestPositionFromPoint` to be implemented, so
-// that UIKit can determine the selected text range based on points.) When the selection is
-// completed (i.e. when both of the 2 fingers are released), similar to "move" gesture,
-// the `endFloatingCursor` will be called.
+// second finger is pressed, `setSelectedText` will be called. This mechanism requires
+// `closestPositionFromPoint` to be implemented, so that UIKit can determine which text position
+// is the closest to any arbitrary screen point, hence determine the selected text range based on
+// those points. When the selection is completed (i.e. when both of the 2 fingers
+// are released), similar to "move" gesture, the `endFloatingCursor` will be called.
 //
 // Whenever a selection is updated, the engine sends the new selection to the framework. So unlike
 // the move gesture, the selections in the framework and the engine are always kept in sync.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1857,10 +1857,10 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 // Floating cursor's "move" gesture takes 1 finger to force press the space bar, and then move the
 // cursor. The process starts with `beginFloatingCursorAtPoint`. When the finger is moved,
 // `updateFloatingCursorAtPoint` will be called. When the finger is released, `endFloatingCursor`
-// will be called. In all cases, we send the relative point to the framework, so that framework
-// can animate the floating cursor.
+// will be called. In all cases, we send the point (relative to the initial point registered in
+// beginFloatingCursorAtPoint) to the framework, so that framework can animate the floating cursor.
 //
-// Notice that during the move gesture, the framework only animate the cursor visually. It's only
+// During the move gesture, the framework only animate the cursor visually. It's only
 // after the gesture is complete, will the framework update the selection to the cursor's
 // new position (with zero selection length). This means during the animation, the visual effect
 // of the cursor is temporarily out of sync with the selection state in both framework and engine.
@@ -1869,10 +1869,14 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 // Floating cursor's "selection" gesture also starts with 1 finger to force press the space bar,
 // so exactly the same functions as the "move gesture" discussed above will be called. When the
 // second finger is pressed, `setSelectedText` will be called. This mechanism requires
-// `closestPositionFromPoint` to be implemented, so that UIKit can determine which text position
-// is the closest to any arbitrary screen point, hence determine the selected text range based on
-// those points. When the selection is completed (i.e. when both of the 2 fingers
-// are released), similar to "move" gesture, the `endFloatingCursor` will be called.
+// `closestPositionFromPoint` to be implemented, to allow UIKit to translate the finger touch
+// location displacement to the text range to select. When the selection is completed
+// (i.e. when both of the 2 fingers are released), similar to "move" gesture,
+// the `endFloatingCursor` will be called.
+//
+// When the 2nd finger is pressed, it does not trigger another startFloatingCursor call. So
+// floating cursor move/selection logic has to be implemented in iOS embedder rather than
+// just the framework side.
 //
 // Whenever a selection is updated, the engine sends the new selection to the framework. So unlike
 // the move gesture, the selections in the framework and the engine are always kept in sync.


### PR DESCRIPTION
This PR gives an overview of how floating cursor feature works (including the new floating cursor selection gesture, and the existing floating cursor move gesture). It can serve as the missing design doc. 

I put it in the engine rather than the framework, since all logics are in one place, and it's closer to the UIKit behavior that I want to cover. 

Thanks @moffatman for helping me understanding it. 

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/30476

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
