### PR TITLE
setupDefultFontManager correctly clear out cache

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -2063,6 +2063,7 @@ bool Shell::ReloadSystemFonts() {
   if (!engine_) {
     return false;
   }
+  engine_->SetupDefaultFontManager();
   engine_->GetFontCollection().GetFontCollection()->ClearFontFamilyCache();
   // After system fonts are reloaded, we send a system channel message
   // to notify flutter framework.

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -2063,7 +2063,6 @@ bool Shell::ReloadSystemFonts() {
   if (!engine_) {
     return false;
   }
-  engine_->SetupDefaultFontManager();
   engine_->GetFontCollection().GetFontCollection()->ClearFontFamilyCache();
   // After system fonts are reloaded, we send a system channel message
   // to notify flutter framework.

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -141,11 +141,17 @@ if (enable_unittests) {
   executable("txt_unittests") {
     testonly = true
 
-    sources = [ "tests/txt_run_all_unittests.cc" ]
+    sources = [
+      "tests/font_collection_tests.cc",
+      "tests/txt_run_all_unittests.cc",
+    ]
+
+    public_configs = [ ":txt_config" ]
 
     configs += [ ":allow_posix_names" ]
 
     deps = [
+      ":txt",
       ":txt_fixtures",
       "//flutter/fml",
       "//flutter/testing:testing_lib",

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -46,6 +46,7 @@ size_t FontCollection::GetFontManagersCount() const {
 void FontCollection::SetupDefaultFontManager(
     uint32_t font_initialization_data) {
   default_font_manager_ = GetDefaultFontManager(font_initialization_data);
+  skt_collection_.reset();
 }
 
 void FontCollection::SetDefaultFontManager(sk_sp<SkFontMgr> font_manager) {

--- a/third_party/txt/tests/font_collection_tests.cc
+++ b/third_party/txt/tests/font_collection_tests.cc
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include <sstream>
+
+#include "txt/font_collection.h"
+
+namespace txt {
+namespace testing {
+
+class FontCollectionTests : public ::testing::Test {
+ public:
+  FontCollectionTests() {}
+
+  void SetUp() override {}
+};
+
+TEST_F(FontCollectionTests, SettingUpDefaultFontManagerClearsCache) {
+  FontCollection font_collection;
+  sk_sp<skia::textlayout::FontCollection> sk_font_collection =
+      font_collection.CreateSktFontCollection();
+  ASSERT_EQ(sk_font_collection->getFallbackManager().get(), nullptr);
+  font_collection.SetupDefaultFontManager(0);
+  sk_font_collection = font_collection.CreateSktFontCollection();
+  ASSERT_NE(sk_font_collection->getFallbackManager().get(), nullptr);
+}
+}  // namespace testing
+}  // namespace txt

--- a/third_party/txt/tests/font_collection_tests.cc
+++ b/third_party/txt/tests/font_collection_tests.cc
@@ -1,6 +1,18 @@
-// Copyright 2013 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/123483

Not entirely sure if this really fix the flake as I can't reproduce locally. My guess to the flake is that the setDefaultfontmgr should only be called once during the life time of the app. The setDefaultfontmgr can be remove at the call site, since it is already called during setup

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
