### PR TITLE
[CP] [Impeller] Fix the issue that 'coverage_coords' is incorrectly calculated in 'FillPathGeometry::GetPositionUVBuffer' #42155

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -177,6 +177,13 @@ void CanRenderTiledTexture(AiksTest* aiks_test, Entity::TileMode tile_mode) {
     canvas.DrawRect({0, 0, 600, 600}, paint);
   }
 
+  // Should not change the image.
+  PathBuilder path_builder;
+  path_builder.AddCircle({150, 150}, 150);
+  path_builder.AddRoundedRect(Rect::MakeLTRB(300, 300, 600, 600), 10);
+  paint.style = Paint::Style::kFill;
+  canvas.DrawPath(path_builder.TakePath(), paint);
+
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 }  // namespace

--- a/impeller/entity/geometry.cc
+++ b/impeller/entity/geometry.cc
@@ -152,8 +152,7 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
           Point vtx = {vertices[i], vertices[i + 1]};
           data.position = vtx;
           auto coverage_coords =
-              ((vtx - texture_coverage.origin) / texture_coverage.size) /
-              texture_coverage.size;
+              (vtx - texture_coverage.origin) / texture_coverage.size;
           data.texture_coords = effect_transform * coverage_coords;
           vertex_builder.AppendVertex(data);
         }


### PR DESCRIPTION
cp of https://github.com/flutter/engine/pull/42155

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
