### PR TITLE
[Impeller] Add UV compute shader.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1296,6 +1296,7 @@ ORIGIN: ../../../flutter/impeller/entity/shaders/gaussian_blur/gaussian_blur_alp
 ORIGIN: ../../../flutter/impeller/entity/shaders/gaussian_blur/gaussian_blur_noalpha_decal.frag + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/gaussian_blur/gaussian_blur_noalpha_nodecal.frag + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/geometry/points.comp + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/entity/shaders/geometry/uv.comp + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/glyph_atlas.frag + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/glyph_atlas.vert + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/glyph_atlas_color.frag + ../../../flutter/LICENSE
@@ -3922,6 +3923,7 @@ FILE: ../../../flutter/impeller/entity/shaders/gaussian_blur/gaussian_blur_alpha
 FILE: ../../../flutter/impeller/entity/shaders/gaussian_blur/gaussian_blur_noalpha_decal.frag
 FILE: ../../../flutter/impeller/entity/shaders/gaussian_blur/gaussian_blur_noalpha_nodecal.frag
 FILE: ../../../flutter/impeller/entity/shaders/geometry/points.comp
+FILE: ../../../flutter/impeller/entity/shaders/geometry/uv.comp
 FILE: ../../../flutter/impeller/entity/shaders/glyph_atlas.frag
 FILE: ../../../flutter/impeller/entity/shaders/glyph_atlas.vert
 FILE: ../../../flutter/impeller/entity/shaders/glyph_atlas_color.frag

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2373,5 +2373,35 @@ TEST_P(AiksTest, CanDrawPoints) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanDrawPointsWithTextureMap) {
+  auto texture = CreateTextureForFixture("table_mountain_nx.png",
+                                         /*enable_mipmapping=*/true);
+
+  std::vector<Point> points = {
+      {0, 0},      //
+      {100, 100},  //
+      {100, 0},    //
+      {0, 100},    //
+      {0, 0},      //
+      {48, 48},    //
+      {52, 52},    //
+  };
+  std::vector<PointStyle> caps = {
+      PointStyle::kRound,
+      PointStyle::kSquare,
+  };
+  Paint paint;
+  paint.color_source = ColorSource::MakeImage(texture, Entity::TileMode::kClamp,
+                                              Entity::TileMode::kClamp, {}, {});
+
+  Canvas canvas;
+  canvas.Translate({200, 200});
+  canvas.DrawPoints(points, 100, paint, PointStyle::kRound);
+  canvas.Translate({150, 0});
+  canvas.DrawPoints(points, 100, paint, PointStyle::kSquare);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -97,6 +97,7 @@ impeller_shaders("modern_entity_shaders") {
     "shaders/radial_gradient_ssbo_fill.frag",
     "shaders/sweep_gradient_ssbo_fill.frag",
     "shaders/geometry/points.comp",
+    "shaders/geometry/uv.comp",
   ]
 }
 

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -302,6 +302,11 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
         PointsComputeShaderPipeline::MakeDefaultPipelineDescriptor(*context_);
     point_field_compute_pipelines_ =
         context_->GetPipelineLibrary()->GetPipeline(pipeline_desc).Get();
+
+    auto uv_pipeline_desc =
+        UvComputeShaderPipeline::MakeDefaultPipelineDescriptor(*context_);
+    uv_compute_pipelines_ =
+        context_->GetPipelineLibrary()->GetPipeline(uv_pipeline_desc).Get();
   }
 
   if (solid_fill_pipelines_[{}]->GetDescriptor().has_value()) {

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -53,6 +53,7 @@
 #include "impeller/entity/texture_fill.vert.h"
 #include "impeller/entity/tiled_texture_fill.frag.h"
 #include "impeller/entity/tiled_texture_fill.vert.h"
+#include "impeller/entity/uv.comp.h"
 #include "impeller/entity/vertices.frag.h"
 #include "impeller/entity/yuv_to_rgb_filter.frag.h"
 #include "impeller/entity/yuv_to_rgb_filter.vert.h"
@@ -278,6 +279,7 @@ using FramebufferBlendSoftLightPipeline =
 
 /// Geometry Pipelines
 using PointsComputeShaderPipeline = ComputePipelineBuilder<PointsComputeShader>;
+using UvComputeShaderPipeline = ComputePipelineBuilder<UvComputeShader>;
 
 /// Pipeline state configuration.
 ///
@@ -670,6 +672,12 @@ class ContentContext {
     return point_field_compute_pipelines_;
   }
 
+  std::shared_ptr<Pipeline<ComputePipelineDescriptor>> GetUvComputePipeline()
+      const {
+    FML_DCHECK(GetDeviceCapabilities().SupportsCompute());
+    return uv_compute_pipelines_;
+  }
+
   std::shared_ptr<Context> GetContext() const;
 
   std::shared_ptr<GlyphAtlasContext> GetGlyphAtlasContext(
@@ -794,6 +802,8 @@ class ContentContext {
       framebuffer_blend_softlight_pipelines_;
   mutable std::shared_ptr<Pipeline<ComputePipelineDescriptor>>
       point_field_compute_pipelines_;
+  mutable std::shared_ptr<Pipeline<ComputePipelineDescriptor>>
+      uv_compute_pipelines_;
 
   template <class TypedPipeline>
   std::shared_ptr<Pipeline<PipelineDescriptor>> GetPipeline(

--- a/impeller/entity/geometry.h
+++ b/impeller/entity/geometry.h
@@ -291,10 +291,17 @@ class PointFieldGeometry : public Geometry {
   // |Geometry|
   std::optional<Rect> GetCoverage(const Matrix& transform) const override;
 
-  GeometryResult GetPositionBufferCPU(const ContentContext& renderer,
-                                      const Entity& entity,
-                                      RenderPass& pass,
-                                      Scalar radius);
+  GeometryResult GetPositionBufferGPU(
+      const ContentContext& renderer,
+      const Entity& entity,
+      RenderPass& pass,
+      std::optional<Rect> texture_coverage = std::nullopt,
+      std::optional<Matrix> effect_transform = std::nullopt);
+
+  std::optional<VertexBufferBuilder<SolidFillVertexShader::PerVertexData>>
+  GetPositionBufferCPU(const ContentContext& renderer,
+                       const Entity& entity,
+                       RenderPass& pass);
 
   std::vector<Point> points_;
   Scalar radius_;

--- a/impeller/entity/shaders/geometry/uv.comp
+++ b/impeller/entity/shaders/geometry/uv.comp
@@ -1,0 +1,60 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <impeller/texture.glsl>
+#include <impeller/types.glsl>
+
+// Unused, see See PointFieldGeometry::GetPositionBuffer
+layout(local_size_x = 16) in;
+
+layout(std430) readonly buffer GeometryData {
+  // Size of this input data is frame_info.count;
+  vec2 points[];
+}
+geometry_data;
+
+layout(std430) writeonly buffer GeometryUVData {
+  // Size of this output data is frame_info.count;
+  // x,y is the original geometry.
+  // u,v is the texture UV.
+  vec4 points_uv[];
+}
+geometry_uv_data;
+
+uniform FrameInfo {
+  uint count;
+  mat4 effect_transform;
+  vec2 texture_origin;
+  vec2 texture_size;
+}
+frame_info;
+
+vec2 project_point(mat4 m, vec2 v) {
+  float w = v.x * m[0][3] + v.y * m[1][3] + m[3][3];
+  vec2 result = vec2(v.x * m[0][0] + v.y * m[1][0] + m[3][0],
+                     v.x * m[0][1] + v.y * m[1][1] + m[3][1]);
+
+  // This is Skia's behavior, but it may be reasonable to allow UB for the w=0
+  // case.
+  if (w != 0) {
+    w = 1 / w;
+  }
+  return result * w;
+}
+
+void main() {
+  uint ident = gl_GlobalInvocationID.x;
+  if (ident >= frame_info.count) {
+    return;
+  }
+
+  vec2 point = geometry_data.points[ident];
+
+  vec2 coverage_coords =
+      (point - frame_info.texture_origin) / frame_info.texture_size;
+  vec2 texture_coords =
+      project_point(frame_info.effect_transform, coverage_coords);
+
+  geometry_uv_data.points_uv[ident] = vec4(point, texture_coords);
+}

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -13710,6 +13710,69 @@
       }
     }
   },
+  "flutter/impeller/entity/uv.comp.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/uv.comp.vkspv",
+      "has_uniform_computation": true,
+      "type": "Compute",
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": 100,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.1875,
+              0.1875,
+              0.1875,
+              0.0625,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.046875,
+              0.0,
+              0.046875,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.1875,
+              0.1875,
+              0.1875,
+              0.0625,
+              2.0,
+              0.0
+            ]
+          },
+          "shared_storage_used": 0,
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 14,
+          "work_registers_used": 10
+        }
+      }
+    }
+  },
   "flutter/impeller/entity/vertices.frag.vkspv": {
     "Mali-G78": {
       "core": "Mali-G78",


### PR DESCRIPTION
Adds a compute shader that computes the UV mapping for an arbitrary geometry. Use it with drawPoints since I didn't realize it was possible to use an image shader with this 😆 .
