### PR TITLE
Skip and ignore boringssl/src/rust when looking for the licenses.

### DIFF
--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 50e22428eba3a50279d65dfff9e10d67
+Signature: 4774da42a375d33f5195961a315026d6
 

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: cb8556d451f3040815fe5ee661d5dbad
+Signature: 50e22428eba3a50279d65dfff9e10d67
 

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 4774da42a375d33f5195961a315026d6
+Signature: 70f28de8b1b5d020e6870e2da16913ee
 

--- a/tools/licenses/lib/paths.dart
+++ b/tools/licenses/lib/paths.dart
@@ -58,6 +58,7 @@ final Set<String> skippedPaths = <String>{
   r'third_party/benchmark', // only used by tests
   r'third_party/boringssl/src/crypto/err/err_data_generate.go',
   r'third_party/boringssl/src/fuzz', // testing tools, not shipped
+  r'third_party/boringssl/src/rust', // rust-related code is not shipped
   r'third_party/boringssl/src/util', // code generators, not shipped
   r'third_party/colorama/src/demos',
   r'third_party/colorama/src/screenshots',
@@ -370,7 +371,6 @@ final Set<String> skippedCommonFiles = <String>{
   r'codereview.settings',
   r'coderules.txt',
   r'configure-ac-style.md',
-  r'deny.toml',
   r'doxygen.config',
   r'example.html',
   r'gerrit.md',

--- a/tools/licenses/lib/paths.dart
+++ b/tools/licenses/lib/paths.dart
@@ -370,6 +370,7 @@ final Set<String> skippedCommonFiles = <String>{
   r'codereview.settings',
   r'coderules.txt',
   r'configure-ac-style.md',
+  r'deny.toml',
   r'doxygen.config',
   r'example.html',
   r'gerrit.md',


### PR DESCRIPTION
third_party/boringssl/src/rust/bssl-crypto/deny.toml coming in as part of https://dart-review.googlesource.com/c/sdk/+/304210 triggers 'potential license' license script error.

Rust sources of boringssl are not included into flutter, don't need to be scanned for licenses.