### PR TITLE
Revert "[Impeller] use host image upload path on simulator"

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -417,7 +417,7 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
                                                      bitmap_result.value()]() {
 // TODO(jonahwilliams): remove ifdef once blit from buffer to texture is
 // implemented on other platforms.
-#if (FML_OS_IOS && !TARGET_IPHONE_SIMULATOR)
+#ifdef FML_OS_IOS
           result(UploadTextureToPrivate(context, bitmap_result.device_buffer,
                                         bitmap_result.image_info));
 #else


### PR DESCRIPTION
Reverts flutter/engine#42161

As reported by uses, this did not help with the issue.