### PR TITLE
[Impeller] Disable the offscreen layer checkerboard drawing function on Impeller.

### DIFF
--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -111,7 +111,9 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
   }
 
   LayerStateStack state_stack;
-  if (checkerboard_offscreen_layers_) {
+
+  // DrawCheckerboard is not supported on Impeller.
+  if (checkerboard_offscreen_layers_ && !frame.aiks_context()) {
     state_stack.set_checkerboard_func(DrawCheckerboard);
   }
 


### PR DESCRIPTION
This function creates a Skia bitmap that can not be rendered by Impeller.

See https://github.com/flutter/flutter/issues/127080
