### PR TITLE
Add leak_tracker package from Dart DEPS to DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -180,6 +180,7 @@ vars = {
   "upstream_libtess2": "https://github.com/memononen/libtess2.git",
   "upstream_libwebp": "https://chromium.googlesource.com/webm/libwebp.git",
   "upstream_libxml": "https://gitlab.gnome.org/GNOME/libxml2.git",
+  "upstream_leak_tracker": "https://github.com/dart-lang/leak_tracker.git",
   "upstream_linter": "https://github.com/dart-lang/linter.git",
   "upstream_logging": "https://github.com/dart-lang/logging.git",
   "upstream_markdown": "https://github.com/dart-lang/markdown.git",
@@ -400,6 +401,9 @@ deps = {
 
   'src/third_party/dart/third_party/pkg/json_rpc_2':
    Var('dart_git') + '/json_rpc_2.git@800843e2aaf948ace35ddcab7037b9abc4222bfc',
+
+  'src/third_party/dart/third_party/pkg/leak_tracker':
+   Var('dart_git') + '/leak_tracker.git@571c24aeee986767e6a5b8eef4056278cf747850',
 
   'src/third_party/dart/third_party/pkg/linter':
    Var('dart_git') + '/linter.git@599b5288ee883393bf3a9ae4d2cfe90c168cce91',


### PR DESCRIPTION
The package leak_tracker was added to Dart DEPS, and analysis_server now depends on it.
This fixes a breakage when rolling Dart into Flutter engine.

Bug: https://github.com/flutter/devtools/issues/5606

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
