### PR TITLE
Roll watcher dependency for web_ui to 1.1.0.

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -43,7 +43,7 @@ dev_dependencies:
   test_core: any
   typed_data: any
   uuid: 3.0.6
-  watcher: 1.0.0
+  watcher: 1.1.0
   web_socket_channel: any
   webdriver: 3.0.1
   webkit_inspection_protocol: any


### PR DESCRIPTION
Incoming dart sdk change needs updated version of watcher
