### PR TITLE
Revert "Vuln scan on 3p deps triggered by label on PR"

### DIFF
--- a/.github/workflows/third_party_scan.yml
+++ b/.github/workflows/third_party_scan.yml
@@ -4,8 +4,6 @@ on:
   branch_protection_rule:
   push:
     branches: [ main ]
-  pull_request:
-    types: [ labeled ]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -14,9 +12,7 @@ jobs:
   vuln-scan:
     name: Vulnerability scanning
     runs-on: ubuntu-20.04
-    # run on flutter/engine push to main or PRs with 'vulnerability patch' label 
-    if: ${{  github.repository == 'flutter/engine' && (github.event_name == 'push' || github.event.label.name == 'vulnerability patch') }}
-
+    if: ${{ github.repository == 'flutter/engine' }}
     permissions:
       # Needed to upload the SARIF results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
Reverts flutter/engine#42247

Reverting in order to find solution which doesn't add a skipped test onto all PRs. Only PRs which address vuln scanning need to have this test showing at all. 