### PR TITLE
Turned back on debug unit tests

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -52,7 +52,7 @@
                         "--variant",
                         "host_debug",
                         "--type",
-                        "dart",
+                        "dart,engine",
                         "--engine-capture-core-dump"
                     ],
                     "script": "flutter/testing/run_tests.py"

--- a/flow/frame_timings.h
+++ b/flow/frame_timings.h
@@ -10,6 +10,7 @@
 #include "flutter/common/settings.h"
 #include "flutter/flow/raster_cache.h"
 #include "flutter/fml/macros.h"
+#include "flutter/fml/status.h"
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"
 
@@ -114,6 +115,16 @@ class FrameTimingsRecorder {
   FrameTiming GetRecordedTime() const;
 
  private:
+  FML_FRIEND_TEST(FrameTimingsRecorderTest, ThrowWhenRecordBuildBeforeVsync);
+  FML_FRIEND_TEST(FrameTimingsRecorderTest,
+                  ThrowWhenRecordRasterBeforeBuildEnd);
+
+  [[nodiscard]] fml::Status RecordVsyncImpl(fml::TimePoint vsync_start,
+                                            fml::TimePoint vsync_target);
+  [[nodiscard]] fml::Status RecordBuildStartImpl(fml::TimePoint build_start);
+  [[nodiscard]] fml::Status RecordBuildEndImpl(fml::TimePoint build_end);
+  [[nodiscard]] fml::Status RecordRasterStartImpl(fml::TimePoint raster_start);
+
   static std::atomic<uint64_t> frame_number_gen_;
 
   mutable std::mutex state_mutex_;

--- a/flow/frame_timings_recorder_unittests.cc
+++ b/flow/frame_timings_recorder_unittests.cc
@@ -2,13 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <thread>
 #include "flutter/flow/frame_timings.h"
 #include "flutter/flow/testing/layer_test.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/flow/testing/mock_raster_cache.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
-
-#include <thread>
 
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"
@@ -16,7 +15,8 @@
 #include "gtest/gtest.h"
 
 namespace flutter {
-namespace testing {
+
+using testing::MockRasterCache;
 
 TEST(FrameTimingsRecorderTest, RecordVsync) {
   auto recorder = std::make_unique<FrameTimingsRecorder>();
@@ -130,9 +130,9 @@ TEST(FrameTimingsRecorderTest, ThrowWhenRecordBuildBeforeVsync) {
   auto recorder = std::make_unique<FrameTimingsRecorder>();
 
   const auto build_start = fml::TimePoint::Now();
-  EXPECT_EXIT(recorder->RecordBuildStart(build_start),
-              ::testing::KilledBySignal(SIGABRT),
-              "Check failed: state_ == State::kVsync.");
+  fml::Status status = recorder->RecordBuildStartImpl(build_start);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.message(), "Check failed: state_ == State::kVsync.");
 }
 
 TEST(FrameTimingsRecorderTest, ThrowWhenRecordRasterBeforeBuildEnd) {
@@ -143,9 +143,9 @@ TEST(FrameTimingsRecorderTest, ThrowWhenRecordRasterBeforeBuildEnd) {
   recorder->RecordVsync(st, en);
 
   const auto raster_start = fml::TimePoint::Now();
-  EXPECT_EXIT(recorder->RecordRasterStart(raster_start),
-              ::testing::KilledBySignal(SIGABRT),
-              "Check failed: state_ == State::kBuildEnd.");
+  fml::Status status = recorder->RecordRasterStartImpl(raster_start);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.message(), "Check failed: state_ == State::kBuildEnd.");
 }
 
 #endif
@@ -297,5 +297,4 @@ TEST(FrameTimingsRecorderTest, FrameNumberTraceArgIsValid) {
   ASSERT_EQ(actual_arg, expected_arg);
 }
 
-}  // namespace testing
 }  // namespace flutter

--- a/fml/macros.h
+++ b/fml/macros.h
@@ -38,4 +38,7 @@
   TypeName() = delete;                               \
   FML_DISALLOW_COPY_ASSIGN_AND_MOVE(TypeName)
 
+#define FML_FRIEND_TEST(test_case_name, test_name) \
+  friend class test_case_name##_##test_name##_Test
+
 #endif  // FLUTTER_FML_MACROS_H_

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -472,6 +472,8 @@ def run_cc_tests(build_dir, executable_filter, coverage, capture_core_dump):
     # correctly by gtest-parallel.
     # https://github.com/flutter/flutter/issues/104789
     if not os.path.basename(build_dir).startswith('host_debug'):
+      # Test is disabled for flaking in debug runs:
+      # https://github.com/flutter/flutter/issues/127441
       run_engine_executable(
           build_dir,
           'flutter_desktop_darwin_unittests',

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -471,13 +471,14 @@ def run_cc_tests(build_dir, executable_filter, coverage, capture_core_dump):
     # flutter_desktop_darwin_unittests uses global state that isn't handled
     # correctly by gtest-parallel.
     # https://github.com/flutter/flutter/issues/104789
-    run_engine_executable(
-        build_dir,
-        'flutter_desktop_darwin_unittests',
-        executable_filter,
-        shuffle_flags,
-        coverage=coverage
-    )
+    if not os.path.basename(build_dir).startswith('host_debug'):
+      run_engine_executable(
+          build_dir,
+          'flutter_desktop_darwin_unittests',
+          executable_filter,
+          shuffle_flags,
+          coverage=coverage
+      )
     extra_env = {
         # pylint: disable=line-too-long
         # See https://developer.apple.com/documentation/metal/diagnosing_metal_programming_issues_early?language=objc


### PR DESCRIPTION
I refactored the `EXPECT_EXIT` tests since they are unsafe to execute in a process with multiple threads.

This leaves `flutter_desktop_darwin_unittests` disabled since it has existing issues.

fixes https://github.com/flutter/flutter/issues/103757

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
