### PR TITLE
[Impeller] Add golden repro for mask blur issues

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -544,6 +544,31 @@ TEST_P(AiksTest, CanRenderLinearGradientManyColorsUnevenStops) {
   ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
+TEST_P(AiksTest, CanRenderLinearGradientMaskBlur) {
+  Canvas canvas;
+
+  Paint paint = {
+      .color = Color::White(),
+      .color_source = ColorSource::MakeLinearGradient(
+          {200, 200}, {400, 400},
+          {Color::Red(), Color::White(), Color::Red(), Color::White(),
+           Color::Red(), Color::White(), Color::Red(), Color::White(),
+           Color::Red(), Color::White(), Color::Red()},
+          {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
+          Entity::TileMode::kClamp, {}),
+      .mask_blur_descriptor =
+          Paint::MaskBlurDescriptor{
+              .style = FilterContents::BlurStyle::kNormal,
+              .sigma = Sigma(20),
+          },
+  };
+
+  canvas.DrawCircle({300, 300}, 200, paint);
+  canvas.DrawRect(Rect::MakeLTRB(100, 300, 500, 600), paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, CanRenderRadialGradient) {
   auto callback = [&](AiksContext& renderer, RenderTarget& render_target) {
     const char* tile_mode_names[] = {"Clamp", "Repeat", "Mirror", "Decal"};


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/127013.

This is a repro to track the mask blur issues. If we accidentally trigger the wrong kind of blur, this golden will make it obvious because the gradient lines will become much more blurry.

Once this problem is fixed, the circle's mask should be fully blurred and the rounded rectangle should have no edge clamping (the diagonal lines should continue as the edges fade to black).

![image](https://github.com/flutter/engine/assets/919017/d08f607c-7cad-4f05-a663-4ae2316553e2)