### PR TITLE
[Impeller] Add 1 pixel border to snapshots of Contents

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1783,6 +1783,34 @@ TEST(GeometryTest, RectMakePointBounds) {
   }
 }
 
+TEST(GeometryTest, RectExpand) {
+  {
+    auto a = Rect::MakeLTRB(100, 100, 200, 200);
+    auto b = a.Expand(1);
+    auto expected = Rect::MakeLTRB(99, 99, 201, 201);
+    ASSERT_RECT_NEAR(b, expected);
+  }
+  {
+    auto a = Rect::MakeLTRB(100, 100, 200, 200);
+    auto b = a.Expand(-1);
+    auto expected = Rect::MakeLTRB(101, 101, 199, 199);
+    ASSERT_RECT_NEAR(b, expected);
+  }
+
+  {
+    auto a = Rect::MakeLTRB(100, 100, 200, 200);
+    auto b = a.Expand(1, 2, 3, 4);
+    auto expected = Rect::MakeLTRB(99, 98, 203, 204);
+    ASSERT_RECT_NEAR(b, expected);
+  }
+  {
+    auto a = Rect::MakeLTRB(100, 100, 200, 200);
+    auto b = a.Expand(-1, -2, -3, -4);
+    auto expected = Rect::MakeLTRB(101, 102, 197, 196);
+    ASSERT_RECT_NEAR(b, expected);
+  }
+}
+
 TEST(GeometryTest, RectGetPositive) {
   {
     Rect r{100, 200, 300, 400};

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -252,6 +252,24 @@ struct TRect {
     return TRect(origin.x + offset.x, origin.y + offset.y, size.width,
                  size.height);
   }
+
+  /// @brief  Returns a rectangle with expanded edges. Negative expansion
+  ///         results in shrinking.
+  constexpr TRect<T> Expand(T left, T top, T right, T bottom) {
+    return TRect(origin.x - left,            //
+                 origin.y - top,             //
+                 size.width + left + right,  //
+                 size.height + top + bottom);
+  }
+
+  /// @brief  Returns a rectangle with expanded edges in all directions.
+  ///         Negative expansion results in shrinking.
+  constexpr TRect<T> Expand(T amount) {
+    return TRect(origin.x - amount,        //
+                 origin.y - amount,        //
+                 size.width + amount * 2,  //
+                 size.height + amount * 2);
+  }
 };
 
 using Rect = TRect<Scalar>;


### PR DESCRIPTION
Everything in Impeller is theoretically treated as if being drawn to layers of infinite size. Without this change, there's a coverage leak that occurs in some filters due to the customizable sampling mode. I should be able to get rid of this 1 pixel padding by refactoring the way we do sampling in the filter inputs (we already have most of this infrastructure in place), but this is a correct, safe, and not-that-expensive solution for the time being.

Also, this fixes a potential segfault due to an unsafe optional access... (would really love if there was a static analysis check for this -- it's by far the number one way I push crashers).

Before:

![Screenshot 2023-05-23 at 10 51 43 PM](https://github.com/flutter/engine/assets/919017/13e0a994-d51b-4d4e-a9ba-57a20b16b59e)


After:

![Screenshot 2023-05-23 at 10 49 29 PM](https://github.com/flutter/engine/assets/919017/33dd008d-77d4-4571-a33f-5851160f5506)

