### PR TITLE
[web] Remove comment about dart:html migration

### DIFF
--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -212,8 +212,6 @@ class TextHeightRuler {
 
     _dimensions.appendToHost(host);
 
-    // [rulerHost] is not migrated yet so add a cast to [html.HtmlElement].
-    // This cast will be removed after the migration is complete.
     rulerHost.addElement(host);
     return host;
   }


### PR DESCRIPTION
Migration has already happened in [this PR](https://github.com/flutter/engine/pull/33370/files#diff-30cfc07b03caec6d1c915b40a9e50a23d1f1a1c54c670d5996199d805b077daeR213) so the comment is not relevant anymore.