### PR TITLE
Roll buildroot to e522d38d629d7522f0589e754886ed2b82232d9e

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -256,7 +256,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'aee1094b10465e32972932e23b6799c3f8de244f',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e522d38d629d7522f0589e754886ed2b82232d9e',
 
    # Fuchsia compatibility
    #

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -38,11 +38,6 @@ config("allow_posix_names") {
 }
 
 source_set("txt") {
-  defines = []
-  if (flutter_use_fontconfig) {
-    defines += [ "FLUTTER_USE_FONTCONFIG" ]
-  }
-
   sources = [
     "src/skia/paragraph_builder_skia.cc",
     "src/skia/paragraph_builder_skia.h",
@@ -97,7 +92,7 @@ source_set("txt") {
   ]
 
   if (flutter_use_fontconfig) {
-    deps += [ "//third_party/fontconfig" ]
+    libs = [ "fontconfig" ]
   }
 
   if (is_mac || is_ios) {


### PR DESCRIPTION
Contains:
* Dynamically link against system fontconfig (flutter/buildroot#701)

Migrates from a statically-linked fontconfig to dyanmically linked. This is likely to fix various fontconfig-related issues such as:
* https://github.com/flutter/flutter/issues/118911
* Failures seen in https://github.com/flutter/engine/pull/38144

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
