### PR TITLE
[Impeller] fix UV and color blending.

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -598,8 +598,7 @@ void Canvas::DrawVertices(const std::shared_ptr<VerticesGeometry>& vertices,
 
   std::shared_ptr<Contents> src_contents =
       src_paint.CreateContentsForGeometry(vertices);
-  if (vertices->HasTextureCoordinates() &&
-      paint.color_source.GetType() != ColorSource::Type::kImage) {
+  if (vertices->HasTextureCoordinates()) {
     // If the color source has an intrinsic size, then we use that to
     // create the src contents as a simplification. Otherwise we use
     // the extent of the texture coordinates to determine how large

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -107,13 +107,13 @@ bool VerticesUVContents::Render(const ContentContext& renderer,
 
   auto src_contents = parent_.GetSourceContents();
 
-  auto snapshot = src_contents->RenderToSnapshot(
-      renderer,                                    // renderer
-      entity,                                      // entity
-      Rect::MakeSize(pass.GetRenderTargetSize()),  // coverage_limit
-      std::nullopt,                                // sampler_descriptor
-      true,                                        // msaa_enabled
-      "VerticesUVContents Snapshot");              // label
+  auto snapshot =
+      src_contents->RenderToSnapshot(renderer,      // renderer
+                                     entity,        // entity
+                                     std::nullopt,  // coverage_limit
+                                     std::nullopt,  // sampler_descriptor
+                                     true,          // msaa_enabled
+                                     "VerticesUVContents Snapshot");  // label
   if (!snapshot.has_value()) {
     return false;
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/127486


Combinations of UV mapping and color blending would cause us to double apply the UV mapping which rendered either nothing or garbage.