### PR TITLE
Use engine_v2 builds on recipe testing.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -83,7 +83,6 @@ targets:
     recipe: engine/engine
     bringup: true
     properties:
-      add_recipes_cq: "true"
       build_android_aot: "true"
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
       android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
@@ -93,7 +92,6 @@ targets:
     recipe: engine/engine
     bringup: true
     properties:
-      add_recipes_cq: "true"
       build_android_debug: "true"
       build_android_jit_release: "true"
       build_android_vulkan: "true"
@@ -212,7 +210,6 @@ targets:
   - name: Linux Fuchsia arm64 FEMU
     recipe: engine/femu_test
     properties:
-      add_recipes_cq: "true"
       build_fuchsia: "true"
       fuchsia_ctl_version: version:0.0.27
       # ensure files from pre-production Fuchsia SDK tests are purged from cache
@@ -235,7 +232,6 @@ targets:
     properties:
       gclient_variables: >-
         {"download_emsdk": true}
-      add_recipes_cq: "true"
       build_host: "true"
       cores: "32"
     timeout: 60
@@ -244,7 +240,6 @@ targets:
     bringup: true
     recipe: engine/engine_unopt
     properties:
-      add_recipes_cq: "true"
       clobber: "true"
     timeout: 60
 
@@ -252,7 +247,6 @@ targets:
     bringup: true
     recipe: engine/engine_license
     properties:
-      add_recipes_cq: "true"
       clobber: "true"
     timeout: 60
 
@@ -299,7 +293,6 @@ targets:
     bringup: true
     recipe: engine/engine_arm
     properties:
-      add_recipes_cq: "true"
       build_host: "true"
     timeout: 90
 
@@ -325,6 +318,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_arm_host_engine
     drone_dimensions:
@@ -334,6 +328,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_host_engine
     drone_dimensions:
@@ -343,6 +338,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_host_desktop_engine
     drone_dimensions:
@@ -352,6 +348,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_android_aot_engine
     drone_dimensions:
@@ -361,6 +358,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_android_debug_engine
     drone_dimensions:
@@ -370,6 +368,7 @@ targets:
     recipe: engine_v2/builder
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       config_name: linux_license
       clobber: "true"
 
@@ -435,7 +434,6 @@ targets:
     properties:
       gclient_variables: >-
         {"download_emsdk": true}
-      add_recipes_cq: "true"
       build_host: "true"
     timeout: 75
 
@@ -443,6 +441,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: mac_android_aot_engine
     drone_dimensions:
@@ -471,6 +470,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       cpu: arm64
       config_name: mac_host_engine
@@ -494,7 +494,6 @@ targets:
     bringup: true
     recipe: engine/engine_unopt
     properties:
-      add_recipes_cq: "true"
       runtime_versions: >-
         [
           "ios-16-4_14e222b",
@@ -550,7 +549,6 @@ targets:
     bringup: true
     recipe: engine/engine
     properties:
-      add_recipes_cq: "true"
       build_ios: "true"
       ios_debug: "true"
     timeout: 60
@@ -559,6 +557,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: mac_ios_engine
       $flutter/osx_sdk : >-
@@ -594,13 +593,13 @@ targets:
     properties:
       gclient_variables: >-
         {"download_emsdk": true}
-      add_recipes_cq: "true"
       build_host: "true"
 
   - name: Windows windows_android_aot_engine
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: windows_android_aot_engine
     drone_dimensions:
@@ -610,6 +609,7 @@ targets:
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: windows_host_engine
     drone_dimensions:
@@ -622,6 +622,7 @@ targets:
       # Don't run this on release branches
       - main
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: windows_arm_host_engine
     drone_dimensions:


### PR DESCRIPTION
This is removing the legacy builds from recipes testing and adding the engine v2 ones.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
