### PR TITLE
Apply the drawShadow bounds workaround to the Web HTML backend

### DIFF
--- a/lib/web_ui/lib/src/engine/shadow.dart
+++ b/lib/web_ui/lib/src/engine/shadow.dart
@@ -73,12 +73,19 @@ ui.Rect computePenumbraBounds(ui.Rect shape, double elevation) {
   final double dx = elevation * tx;
   final double dy = elevation * ty;
   final ui.Offset offset = computeShadowOffset(elevation);
-  return ui.Rect.fromLTRB(
+  final ui.Rect bounds = ui.Rect.fromLTRB(
     shape.left - dx,
     shape.top - dy,
     shape.right + dx,
     shape.bottom + dy,
   ).shift(offset);
+
+  // Expand the bounds rectangle to compensate for inaccuracy in the shadow
+  // calculation.  This is similar to a workaround that had previously been
+  // used in the Flutter framework to adjust the bounds for shadows drawn
+  // by Skia.
+  // (See https://github.com/flutter/flutter/pull/127052)
+  return bounds.inflate(20);
 }
 
 /// Information needed to render a shadow using CSS or canvas.

--- a/lib/web_ui/test/html/recording_canvas_golden_test.dart
+++ b/lib/web_ui/test/html/recording_canvas_golden_test.dart
@@ -416,7 +416,7 @@ Future<void> testMain() async {
     expect(
       rc.pictureBounds,
       within(
-          distance: 0.05, from: const Rect.fromLTRB(17.9, 28.5, 103.5, 114.1)),
+          distance: 0.05, from: const Rect.fromLTRB(0.0, 8.5, 123.5, 134.1)),
     );
     await checkScreenshot(rc, 'path_with_shadow');
   });


### PR DESCRIPTION
Previously the Flutter framework had been inflating the rectangle computed for the bounds of a drawShadow operation in order to work around potential inaccuracies in the SkPicture's bounds calculation.

That workaround is now obsolete for most platforms and was removed from the framework (see https://github.com/flutter/flutter/pull/127052). But the Web HTML backend is using different code for computing shadow bounds.  This PR restores the workaround for Web HTML for consistency with the old behavior.
