### PR TITLE
[Impeller] Simplify CreateContentsForGeometry overloads

### DIFF
--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -27,16 +27,9 @@ std::shared_ptr<Contents> Paint::CreateContentsForEntity(const Path& path,
 }
 
 std::shared_ptr<Contents> Paint::CreateContentsForGeometry(
-    std::unique_ptr<Geometry> geometry) const {
+    std::shared_ptr<Geometry> geometry) const {
   auto contents = color_source.GetContents(*this);
   contents->SetGeometry(std::move(geometry));
-  return contents;
-}
-
-std::shared_ptr<Contents> Paint::CreateContentsForGeometry(
-    const std::shared_ptr<Geometry>& geometry) const {
-  auto contents = color_source.GetContents(*this);
-  contents->SetGeometry(geometry);
   return contents;
 }
 

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -94,10 +94,7 @@ struct Paint {
                                                     bool cover = false) const;
 
   std::shared_ptr<Contents> CreateContentsForGeometry(
-      std::unique_ptr<Geometry> geometry) const;
-
-  std::shared_ptr<Contents> CreateContentsForGeometry(
-      const std::shared_ptr<Geometry>& geometry) const;
+      std::shared_ptr<Geometry> geometry) const;
 
   /// @brief   Whether this paint has a color filter that can apply opacity
   bool HasColorFilter() const;


### PR DESCRIPTION
Came across this while working on generic fallbacks for mask blurs. For the unique_ptr case, we always capture ownership and convert to a shared_ptr anyhow. For the shared_ptr case, we always need to capture a copy, and so better to not take a const ref and allow the caller to move if possible.