### PR TITLE
[Impeller] Add generic path for mask blurring

### DIFF
--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -3,7 +3,12 @@
 // found in the LICENSE file.
 
 #include "impeller/aiks/paint.h"
+
+#include <memory>
+
 #include "impeller/entity/contents/color_source_contents.h"
+#include "impeller/entity/contents/filters/color_filter_contents.h"
+#include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/contents/solid_color_contents.h"
 #include "impeller/entity/geometry/geometry.h"
 
@@ -30,6 +35,9 @@ std::shared_ptr<Contents> Paint::CreateContentsForGeometry(
     std::shared_ptr<Geometry> geometry) const {
   auto contents = color_source.GetContents(*this);
   contents->SetGeometry(std::move(geometry));
+  if (mask_blur_descriptor.has_value()) {
+    return mask_blur_descriptor->CreateMaskBlur(contents);
+  }
   return contents;
 }
 
@@ -40,7 +48,7 @@ std::shared_ptr<Contents> Paint::WithFilters(
                                                     ColorSource::Type::kColor);
   input = WithColorFilter(input, /*absorb_opacity=*/true);
   input = WithInvertFilter(input);
-  input = WithMaskBlur(input, is_solid_color_val, Matrix());
+  input = WithMaskBlur(input, is_solid_color_val);
   input = WithImageFilter(input, Matrix(), /*is_subpass=*/false);
   return input;
 }
@@ -53,13 +61,11 @@ std::shared_ptr<Contents> Paint::WithFiltersForSubpassTarget(
   return input;
 }
 
-std::shared_ptr<Contents> Paint::WithMaskBlur(
-    std::shared_ptr<Contents> input,
-    bool is_solid_color,
-    const Matrix& effect_transform) const {
+std::shared_ptr<Contents> Paint::WithMaskBlur(std::shared_ptr<Contents> input,
+                                              bool is_solid_color) const {
   if (mask_blur_descriptor.has_value()) {
-    input = mask_blur_descriptor->CreateMaskBlur(
-        FilterInput::Make(input), is_solid_color, effect_transform);
+    input = mask_blur_descriptor->CreateMaskBlur(FilterInput::Make(input),
+                                                 is_solid_color);
   }
   return input;
 }
@@ -117,15 +123,46 @@ std::shared_ptr<Contents> Paint::WithInvertFilter(
 }
 
 std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
+    std::shared_ptr<ColorSourceContents> color_source_contents) const {
+  /// 1. Create an opaque white mask of the original geometry.
+
+  auto mask = std::make_shared<SolidColorContents>();
+  mask->SetColor(Color::White());
+  mask->SetGeometry(color_source_contents->GetGeometry());
+
+  /// 2. Blur the mask.
+
+  auto blurred_mask = FilterContents::MakeGaussianBlur(
+      FilterInput::Make(mask), sigma, sigma, style, Entity::TileMode::kDecal,
+      Matrix());
+
+  /// 3. Replace the geometry of the original color source with a rectangle that
+  ///    covers the full region of the blurred mask. Note that geometry is in
+  ///    local bounds.
+
+  auto expanded_local_bounds = blurred_mask->GetCoverage({});
+  if (!expanded_local_bounds.has_value()) {
+    return nullptr;
+  }
+  color_source_contents->SetGeometry(
+      Geometry::MakeRect(*expanded_local_bounds));
+
+  /// 4. Composite the color source and mask together.
+
+  return ColorFilterContents::MakeBlend(
+      BlendMode::kSourceIn, {FilterInput::Make(blurred_mask),
+                             FilterInput::Make(color_source_contents)});
+}
+
+std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
     const FilterInput::Ref& input,
-    bool is_solid_color,
-    const Matrix& effect_transform) const {
+    bool is_solid_color) const {
   if (is_solid_color) {
-    return FilterContents::MakeGaussianBlur(
-        input, sigma, sigma, style, Entity::TileMode::kDecal, effect_transform);
+    return FilterContents::MakeGaussianBlur(input, sigma, sigma, style,
+                                            Entity::TileMode::kDecal, Matrix());
   }
   return FilterContents::MakeBorderMaskBlur(input, sigma, sigma, style,
-                                            effect_transform);
+                                            Matrix());
 }
 
 bool Paint::HasColorFilter() const {

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -43,9 +43,11 @@ struct Paint {
     Sigma sigma;
 
     std::shared_ptr<FilterContents> CreateMaskBlur(
+        std::shared_ptr<ColorSourceContents> color_source_contents) const;
+
+    std::shared_ptr<FilterContents> CreateMaskBlur(
         const FilterInput::Ref& input,
-        bool is_solid_color,
-        const Matrix& effect_matrix) const;
+        bool is_solid_color) const;
   };
 
   Color color = Color::Black();
@@ -101,8 +103,7 @@ struct Paint {
 
  private:
   std::shared_ptr<Contents> WithMaskBlur(std::shared_ptr<Contents> input,
-                                         bool is_solid_color,
-                                         const Matrix& effect_transform) const;
+                                         bool is_solid_color) const;
 
   std::shared_ptr<Contents> WithImageFilter(std::shared_ptr<Contents> input,
                                             const Matrix& effect_transform,

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -41,7 +41,6 @@ class ColorSourceContents : public Contents {
 
   Scalar GetOpacity() const;
 
- protected:
   const std::shared_ptr<Geometry>& GetGeometry() const;
 
  private:


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/127013.

Makes mask blurs work for most color source + geometry combinations. Crucially, this doesn't interfere with the fast paths for solid color RRect blurs (used for shadows).

I'll be addressing mask blurs for text in a follow-up.

Before:

![Screenshot 2023-05-24 at 9 58 20 PM](https://github.com/flutter/engine/assets/919017/9ee2e7d3-6d54-4c3b-abe4-3b0dfd06668c)


After:

![Screenshot 2023-05-24 at 9 55 09 PM](https://github.com/flutter/engine/assets/919017/7b0e28d4-5c32-4b7f-8fc8-44b44a27de93)
