### PR TITLE
Register codecs with Skia explicitly

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -30,6 +30,7 @@
 #include "rapidjson/writer.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "third_party/skia/include/codec/SkBmpDecoder.h"
+#include "third_party/skia/include/codec/SkCodec.h"
 #include "third_party/skia/include/codec/SkGifDecoder.h"
 #include "third_party/skia/include/codec/SkIcoDecoder.h"
 #include "third_party/skia/include/codec/SkJpegDecoder.h"
@@ -76,18 +77,18 @@ std::unique_ptr<Engine> CreateEngine(
                                   volatile_path_tracker);
 }
 
-void InitSkiaEventTracer() {
+void RegisterCodecsWithSkia() {
   // These are in the order they will be attempted to be decoded from.
   // If we have data to back it up, we can order these by "frequency used in
   // the wild" for a very small performance bump, but for now we mirror the
   // order Skia had them in.
-  decoders->push_back(SkPngDecoder::Decoder());
-  decoders->push_back(SkJpegDecoder::Decoder());
-  decoders->push_back(SkWebpDecoder::Decoder());
-  decoders->push_back(SkGifDecoder::Decoder());
-  decoders->push_back(SkBmpDecoder::Decoder());
-  decoders->push_back(SkWbmpDecoder::Decoder());
-  decoders->push_back(SkIcoDecoder::Decoder());
+  SkCodecs::Register(SkPngDecoder::Decoder());
+  SkCodecs::Register(SkJpegDecoder::Decoder());
+  SkCodecs::Register(SkWebpDecoder::Decoder());
+  SkCodecs::Register(SkGifDecoder::Decoder());
+  SkCodecs::Register(SkBmpDecoder::Decoder());
+  SkCodecs::Register(SkWbmpDecoder::Decoder());
+  SkCodecs::Register(SkIcoDecoder::Decoder());
 }
 
 // Though there can be multiple shells, some settings apply to all components in

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -29,6 +29,13 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
+#include "third_party/skia/include/codec/SkBmpDecoder.h"
+#include "third_party/skia/include/codec/SkGifDecoder.h"
+#include "third_party/skia/include/codec/SkIcoDecoder.h"
+#include "third_party/skia/include/codec/SkJpegDecoder.h"
+#include "third_party/skia/include/codec/SkPngDecoder.h"
+#include "third_party/skia/include/codec/SkWbmpDecoder.h"
+#include "third_party/skia/include/codec/SkWebpDecoder.h"
 #include "third_party/skia/include/core/SkGraphics.h"
 #include "third_party/skia/include/utils/SkBase64.h"
 #include "third_party/tonic/common/log.h"
@@ -69,6 +76,20 @@ std::unique_ptr<Engine> CreateEngine(
                                   volatile_path_tracker);
 }
 
+void InitSkiaEventTracer() {
+  // These are in the order they will be attempted to be decoded from.
+  // If we have data to back it up, we can order these by "frequency used in
+  // the wild" for a very small performance bump, but for now we mirror the
+  // order Skia had them in.
+  decoders->push_back(SkPngDecoder::Decoder());
+  decoders->push_back(SkJpegDecoder::Decoder());
+  decoders->push_back(SkWebpDecoder::Decoder());
+  decoders->push_back(SkGifDecoder::Decoder());
+  decoders->push_back(SkBmpDecoder::Decoder());
+  decoders->push_back(SkWbmpDecoder::Decoder());
+  decoders->push_back(SkIcoDecoder::Decoder());
+}
+
 // Though there can be multiple shells, some settings apply to all components in
 // the process. These have to be set up before the shell or any of its
 // sub-components can be initialized. In a perfect world, this would be empty.
@@ -101,6 +122,7 @@ void PerformInitializationTasks(Settings& settings) {
     } else {
       FML_DLOG(INFO) << "Skia deterministic rendering is enabled.";
     }
+    RegisterCodecsWithSkia();
 
     if (settings.icu_initialization_required) {
       if (!settings.icu_data_path.empty()) {


### PR DESCRIPTION
In http://review.skia.org/689016, Skia added an option to explicitly register codecs to use (instead of relying on #defines set by BUILD.gn rules.

This uses that mechanism to explicitly register all the codecs that Flutter was currently using from Skia (at least by my read of [tools/gn](https://github.com/flutter/engine/blob/195009b91abdc3ff7af598d77cb3ab275145da6d/tools/gn#L292).

I'm not sure if there is another place I need to put this sort of code, e.g. for Fuchsia things.

To really test this out, we would want to add a define of SK_DISABLE_LEGACY_INIT_DECODERS when compiling Skia, but I'm not sure the best place to do this.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
