### PR TITLE
Proper memory management in Skwasm

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2024,6 +2024,7 @@ ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.da
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/layers.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart + ../../../flutter/LICENSE
@@ -4679,6 +4680,7 @@ FILE: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/layers.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -3384,45 +3384,6 @@ extension JsConstructorExtension on JsConstructor {
   String get name => _name.toDart;
 }
 
-/// Attaches a weakly referenced object to another object and calls a finalizer
-/// with the latter when weakly referenced object is garbage collected.
-///
-/// We use this to delete Skia objects when their "Ck" wrapper is garbage
-/// collected.
-///
-/// Example sequence of events:
-///
-/// 1. A (CkPaint, SkPaint) pair created.
-/// 2. The paint is used to paint some picture.
-/// 3. CkPaint is dropped by the app.
-/// 4. GC decides to perform a GC cycle and collects CkPaint.
-/// 5. The finalizer function is called with the SkPaint as the sole argument.
-/// 6. We call `delete` on SkPaint.
-@JS('window.FinalizationRegistry')
-@staticInterop
-class SkObjectFinalizationRegistry {}
-
-SkObjectFinalizationRegistry createSkObjectFinalizationRegistry(JSFunction cleanup) {
-  return js_util.callConstructor(
-    _finalizationRegistryConstructor!.toObjectShallow,
-    <Object>[cleanup],
-  );
-}
-
-extension SkObjectFinalizationRegistryExtension on SkObjectFinalizationRegistry {
-  @JS('register')
-  external JSVoid _register(JSAny ckObject, JSAny skObject);
-  void register(Object ckObject, Object skObject) =>
-      _register(ckObject.toJSAnyShallow, skObject.toJSAnyShallow);
-}
-
-@JS('window.FinalizationRegistry')
-external JSAny? get _finalizationRegistryConstructor;
-
-/// Whether the current browser supports `FinalizationRegistry`.
-bool browserSupportsFinalizationRegistry =
-    _finalizationRegistryConstructor != null;
-
 @JS()
 @staticInterop
 class SkData {}

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -3435,3 +3435,35 @@ class DomTextDecoder {
 extension DomTextDecoderExtension on DomTextDecoder {
   external JSString decode(JSTypedArray buffer);
 }
+
+@JS('window.FinalizationRegistry')
+@staticInterop
+class DomFinalizationRegistry {
+  external factory DomFinalizationRegistry(JSFunction cleanup);
+}
+
+extension DomFinalizationRegistryExtension on DomFinalizationRegistry {
+  @JS('register')
+  external JSVoid _register1(JSAny target, JSAny value);
+
+  @JS('register')
+  external JSVoid _register2(JSAny target, JSAny value, JSAny token);
+  void register(Object target, Object value, [Object? token]) {
+      if (token != null) {
+        _register2(target.toJSAnyShallow, value.toJSAnyShallow, token.toJSAnyShallow);
+      } else {
+        _register1(target.toJSAnyShallow, value.toJSAnyShallow);
+      }
+  }
+
+  @JS('unregister')
+  external JSVoid _unregister(JSAny token);
+  void unregister(Object token) => _unregister(token.toJSAnyShallow);
+}
+
+@JS('window.FinalizationRegistry')
+external JSAny? get _finalizationRegistryConstructor;
+
+/// Whether the current browser supports `FinalizationRegistry`.
+bool browserSupportsFinalizationRegistry =
+    _finalizationRegistryConstructor != null;

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl.dart
@@ -15,6 +15,7 @@ export 'skwasm_impl/filters.dart';
 export 'skwasm_impl/font_collection.dart';
 export 'skwasm_impl/image.dart';
 export 'skwasm_impl/layers.dart';
+export 'skwasm_impl/memory.dart';
 export 'skwasm_impl/paint.dart';
 export 'skwasm_impl/paragraph.dart';
 export 'skwasm_impl/path.dart';

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
@@ -18,9 +18,9 @@ class SkwasmCanvas implements SceneCanvas {
   SkwasmCanvas.fromHandle(this._handle);
   CanvasHandle _handle;
 
-  void delete() {
-    canvasDestroy(_handle);
-  }
+  // Note that we do not need to deal with the finalizer registry here, because
+  // the underlying native skia object is tied directly to the lifetime of the 
+  // associated SkPictureRecorder.
 
   @override
   void save() {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
@@ -19,7 +19,7 @@ class SkwasmCanvas implements SceneCanvas {
   CanvasHandle _handle;
 
   // Note that we do not need to deal with the finalizer registry here, because
-  // the underlying native skia object is tied directly to the lifetime of the 
+  // the underlying native skia object is tied directly to the lifetime of the
   // associated SkPictureRecorder.
 
   @override

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
@@ -9,11 +9,11 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmImageFilter implements SceneImageFilter {
+class SkwasmImageFilter implements SceneImageFilter, SkwasmObjectWrapper<RawImageFilter> {
   SkwasmImageFilter._(this.handle) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
-  
+
   factory SkwasmImageFilter.blur({
     double sigmaX = 0.0,
     double sigmaY = 0.0,
@@ -62,9 +62,10 @@ class SkwasmImageFilter implements SceneImageFilter {
     return SkwasmImageFilter._(imageFilterCompose(nativeOuter.handle, nativeInner.handle));
   }
 
-  static final DomFinalizationRegistry _registry = 
-    DomFinalizationRegistry(createSkwasmFinalizer(imageFilterDispose));
+  static final SkwasmFinalizationRegistry<RawImageFilter> _registry =
+    SkwasmFinalizationRegistry<RawImageFilter>(imageFilterDispose);
 
+  @override
   final ImageFilterHandle handle;
   bool _isDisposed = false;
 
@@ -83,9 +84,9 @@ class SkwasmImageFilter implements SceneImageFilter {
   });
 }
 
-class SkwasmColorFilter {
+class SkwasmColorFilter implements SkwasmObjectWrapper<RawColorFilter> {
   SkwasmColorFilter._(this.handle) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
   factory SkwasmColorFilter.fromEngineColorFilter(EngineColorFilter colorFilter) =>
@@ -107,9 +108,10 @@ class SkwasmColorFilter {
     SkwasmColorFilter inner,
   ) => SkwasmColorFilter._(colorFilterCompose(outer.handle, inner.handle));
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(colorFilterDispose));
+  static final SkwasmFinalizationRegistry<RawColorFilter> _registry =
+    SkwasmFinalizationRegistry<RawColorFilter>(colorFilterDispose);
 
+  @override
   final ColorFilterHandle handle;
   bool _isDisposed = false;
 
@@ -121,9 +123,9 @@ class SkwasmColorFilter {
   }
 }
 
-class SkwasmMaskFilter {
+class SkwasmMaskFilter implements SkwasmObjectWrapper<RawMaskFilter> {
   SkwasmMaskFilter._(this.handle) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
   factory SkwasmMaskFilter.fromUiMaskFilter(ui.MaskFilter maskFilter) =>
@@ -132,9 +134,10 @@ class SkwasmMaskFilter {
       maskFilter.webOnlySigma
     ));
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(maskFilterDispose));
+  static final SkwasmFinalizationRegistry<RawMaskFilter> _registry =
+    SkwasmFinalizationRegistry<RawMaskFilter>(maskFilterDispose);
 
+  @override
   final MaskFilterHandle handle;
   bool _isDisposed = false;
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
@@ -10,8 +10,10 @@ import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
 class SkwasmImageFilter implements SceneImageFilter {
-  SkwasmImageFilter._(this.handle);
-
+  SkwasmImageFilter._(this.handle) {
+    _registry.register(this, handle.address, this);
+  }
+  
   factory SkwasmImageFilter.blur({
     double sigmaX = 0.0,
     double sigmaY = 0.0,
@@ -60,15 +62,18 @@ class SkwasmImageFilter implements SceneImageFilter {
     return SkwasmImageFilter._(imageFilterCompose(nativeOuter.handle, nativeInner.handle));
   }
 
-  void dispose() {
-    if (!_isDisposed) {
-      imageFilterDispose(handle);
-      _isDisposed = true;
-    }
-  }
+  static final DomFinalizationRegistry _registry = 
+    DomFinalizationRegistry(createSkwasmFinalizer(imageFilterDispose));
 
   final ImageFilterHandle handle;
   bool _isDisposed = false;
+
+  void dispose() {
+    assert(!_isDisposed);
+    _registry.unregister(this);
+    imageFilterDispose(handle);
+    _isDisposed = true;
+  }
 
   @override
   ui.Rect filterBounds(ui.Rect inputBounds) => withStackScope((StackScope scope) {
@@ -79,7 +84,9 @@ class SkwasmImageFilter implements SceneImageFilter {
 }
 
 class SkwasmColorFilter {
-  SkwasmColorFilter._(this.handle);
+  SkwasmColorFilter._(this.handle) {
+    _registry.register(this, handle.address, this);
+  }
 
   factory SkwasmColorFilter.fromEngineColorFilter(EngineColorFilter colorFilter) =>
     switch (colorFilter.type) {
@@ -100,19 +107,24 @@ class SkwasmColorFilter {
     SkwasmColorFilter inner,
   ) => SkwasmColorFilter._(colorFilterCompose(outer.handle, inner.handle));
 
-  void dispose() {
-    if (!_isDisposed) {
-      colorFilterDispose(handle);
-      _isDisposed = true;
-    }
-  }
+  static final DomFinalizationRegistry _registry =
+    DomFinalizationRegistry(createSkwasmFinalizer(colorFilterDispose));
 
   final ColorFilterHandle handle;
   bool _isDisposed = false;
+
+  void dispose() {
+    assert(!_isDisposed);
+    _registry.unregister(this);
+    colorFilterDispose(handle);
+    _isDisposed = true;
+  }
 }
 
 class SkwasmMaskFilter {
-  SkwasmMaskFilter._(this.handle);
+  SkwasmMaskFilter._(this.handle) {
+    _registry.register(this, handle.address, this);
+  }
 
   factory SkwasmMaskFilter.fromUiMaskFilter(ui.MaskFilter maskFilter) =>
     SkwasmMaskFilter._(maskFilterCreateBlur(
@@ -120,13 +132,16 @@ class SkwasmMaskFilter {
       maskFilter.webOnlySigma
     ));
 
+  static final DomFinalizationRegistry _registry =
+    DomFinalizationRegistry(createSkwasmFinalizer(maskFilterDispose));
+
   final MaskFilterHandle handle;
   bool _isDisposed = false;
 
   void dispose() {
-    if (!_isDisposed) {
-      maskFilterDispose(handle);
-      _isDisposed = true;
-    }
+    assert(!_isDisposed);
+    _registry.unregister(this);
+    maskFilterDispose(handle);
+    _isDisposed = true;
   }
 }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
@@ -9,10 +9,8 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmImageFilter implements SceneImageFilter, SkwasmObjectWrapper<RawImageFilter> {
-  SkwasmImageFilter._(this.handle) {
-    _registry.register(this);
-  }
+class SkwasmImageFilter extends SkwasmObjectWrapper<RawImageFilter> implements SceneImageFilter {
+  SkwasmImageFilter._(ImageFilterHandle handle) : super(handle, _registry);
 
   factory SkwasmImageFilter.blur({
     double sigmaX = 0.0,
@@ -66,17 +64,6 @@ class SkwasmImageFilter implements SceneImageFilter, SkwasmObjectWrapper<RawImag
     SkwasmFinalizationRegistry<RawImageFilter>(imageFilterDispose);
 
   @override
-  final ImageFilterHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    imageFilterDispose(handle);
-    _isDisposed = true;
-  }
-
-  @override
   ui.Rect filterBounds(ui.Rect inputBounds) => withStackScope((StackScope scope) {
     final RawIRect rawRect = scope.convertIRectToNative(inputBounds);
     imageFilterGetFilterBounds(handle, rawRect);
@@ -84,10 +71,8 @@ class SkwasmImageFilter implements SceneImageFilter, SkwasmObjectWrapper<RawImag
   });
 }
 
-class SkwasmColorFilter implements SkwasmObjectWrapper<RawColorFilter> {
-  SkwasmColorFilter._(this.handle) {
-    _registry.register(this);
-  }
+class SkwasmColorFilter extends SkwasmObjectWrapper<RawColorFilter> {
+  SkwasmColorFilter._(ColorFilterHandle handle) : super(handle, _registry);
 
   factory SkwasmColorFilter.fromEngineColorFilter(EngineColorFilter colorFilter) =>
     switch (colorFilter.type) {
@@ -110,23 +95,10 @@ class SkwasmColorFilter implements SkwasmObjectWrapper<RawColorFilter> {
 
   static final SkwasmFinalizationRegistry<RawColorFilter> _registry =
     SkwasmFinalizationRegistry<RawColorFilter>(colorFilterDispose);
-
-  @override
-  final ColorFilterHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    colorFilterDispose(handle);
-    _isDisposed = true;
-  }
 }
 
-class SkwasmMaskFilter implements SkwasmObjectWrapper<RawMaskFilter> {
-  SkwasmMaskFilter._(this.handle) {
-    _registry.register(this);
-  }
+class SkwasmMaskFilter extends SkwasmObjectWrapper<RawMaskFilter> {
+  SkwasmMaskFilter._(MaskFilterHandle handle) : super(handle, _registry);
 
   factory SkwasmMaskFilter.fromUiMaskFilter(ui.MaskFilter maskFilter) =>
     SkwasmMaskFilter._(maskFilterCreateBlur(
@@ -136,15 +108,4 @@ class SkwasmMaskFilter implements SkwasmObjectWrapper<RawMaskFilter> {
 
   static final SkwasmFinalizationRegistry<RawMaskFilter> _registry =
     SkwasmFinalizationRegistry<RawMaskFilter>(maskFilterDispose);
-
-  @override
-  final MaskFilterHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    maskFilterDispose(handle);
-    _isDisposed = true;
-  }
 }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
@@ -20,18 +20,22 @@ const String _robotoUrl =
     'https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf';
 
 class SkwasmTypeface {
-  SkwasmTypeface(SkDataHandle data) : handle = typefaceCreate(data);
+  SkwasmTypeface(SkDataHandle data) : handle = typefaceCreate(data) {
+    _registry.register(this, handle.address, this);
+  }
 
-  bool _isDisposed = false;
+  static final DomFinalizationRegistry _registry =
+    DomFinalizationRegistry(createSkwasmFinalizer(typefaceDispose));
 
   void dispose() {
-    if (!_isDisposed) {
-      _isDisposed = true;
-      typefaceDispose(handle);
-    }
+    assert(!_isDisposed);
+    _registry.unregister(this);
+    typefaceDispose(handle);
+    _isDisposed = true;
   }
 
   TypefaceHandle handle;
+  bool _isDisposed = false;
 }
 
 class SkwasmFontCollection implements FlutterFontCollection {
@@ -39,8 +43,13 @@ class SkwasmFontCollection implements FlutterFontCollection {
     setDefaultFontFamilies(<String>['Roboto']);
   }
 
+  // Most of the time, when an object deals with native handles to skwasm objects,
+  // we register it with a finalization registry so that it can clean up the handle
+  // when the dart side of object gets GC'd. However, this object is basically a
+  // singleton (the renderer creates one and just hangs onto it forever) so it's 
+  // not really worth it to do the finalization dance here.
   FontCollectionHandle handle = fontCollectionCreate();
-  TextStyleHandle defaultTextStyle = textStyleCreate();
+  SkwasmNativeTextStyle defaultTextStyle = SkwasmNativeTextStyle.defaultTextStyle();
   final Map<String, List<SkwasmTypeface>> registeredTypefaces = <String, List<SkwasmTypeface>>{};
 
   void setDefaultFontFamilies(List<String> families) => withStackScope((StackScope scope) {
@@ -49,8 +58,8 @@ class SkwasmFontCollection implements FlutterFontCollection {
     for (int i = 0; i < families.length; i++) {
       familyPointers[i] = skStringFromDartString(families[i]);
     }
-    textStyleClearFontFamilies(defaultTextStyle);
-    textStyleAddFontFamilies(defaultTextStyle, familyPointers, families.length);
+    textStyleClearFontFamilies(defaultTextStyle.handle);
+    textStyleAddFontFamilies(defaultTextStyle.handle, familyPointers, families.length);
     for (int i = 0; i < families.length; i++) {
       skStringFree(familyPointers[i]);
     }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
@@ -19,13 +19,13 @@ import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 const String _robotoUrl =
     'https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf';
 
-class SkwasmTypeface {
+class SkwasmTypeface implements SkwasmObjectWrapper<RawTypeface> {
   SkwasmTypeface(SkDataHandle data) : handle = typefaceCreate(data) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(typefaceDispose));
+  static final SkwasmFinalizationRegistry<RawTypeface> _registry =
+    SkwasmFinalizationRegistry<RawTypeface>(typefaceDispose);
 
   void dispose() {
     assert(!_isDisposed);
@@ -34,6 +34,7 @@ class SkwasmTypeface {
     _isDisposed = true;
   }
 
+  @override
   TypefaceHandle handle;
   bool _isDisposed = false;
 }
@@ -46,7 +47,7 @@ class SkwasmFontCollection implements FlutterFontCollection {
   // Most of the time, when an object deals with native handles to skwasm objects,
   // we register it with a finalization registry so that it can clean up the handle
   // when the dart side of object gets GC'd. However, this object is basically a
-  // singleton (the renderer creates one and just hangs onto it forever) so it's 
+  // singleton (the renderer creates one and just hangs onto it forever) so it's
   // not really worth it to do the finalization dance here.
   FontCollectionHandle handle = fontCollectionCreate();
   SkwasmNativeTextStyle defaultTextStyle = SkwasmNativeTextStyle.defaultTextStyle();

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
@@ -19,24 +19,11 @@ import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 const String _robotoUrl =
     'https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf';
 
-class SkwasmTypeface implements SkwasmObjectWrapper<RawTypeface> {
-  SkwasmTypeface(SkDataHandle data) : handle = typefaceCreate(data) {
-    _registry.register(this);
-  }
+class SkwasmTypeface extends SkwasmObjectWrapper<RawTypeface> {
+  SkwasmTypeface(SkDataHandle data) : super(typefaceCreate(data), _registry);
 
   static final SkwasmFinalizationRegistry<RawTypeface> _registry =
     SkwasmFinalizationRegistry<RawTypeface>(typefaceDispose);
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    typefaceDispose(handle);
-    _isDisposed = true;
-  }
-
-  @override
-  TypefaceHandle handle;
-  bool _isDisposed = false;
 }
 
 class SkwasmFontCollection implements FlutterFontCollection {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -10,7 +10,9 @@ import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
 class SkwasmImage implements ui.Image {
-  SkwasmImage(this.handle);
+  SkwasmImage(this.handle) {
+    _registry.register(this, handle.address, this);
+  }
 
   factory SkwasmImage.fromPixels(
     Uint8List pixels,
@@ -35,8 +37,19 @@ class SkwasmImage implements ui.Image {
     return SkwasmImage(imageHandle);
   }
 
+  static final DomFinalizationRegistry _registry =
+    DomFinalizationRegistry(createSkwasmFinalizer(imageDispose));
+
   final ImageHandle handle;
   bool _isDisposed = false;
+
+  @override
+  void dispose() {
+    assert(!_isDisposed);
+    _registry.unregister(this);
+    imageDispose(handle);
+    _isDisposed = true;
+  }
 
   @override
   int get width => imageGetWidth(handle);
@@ -52,14 +65,6 @@ class SkwasmImage implements ui.Image {
 
   @override
   ui.ColorSpace get colorSpace => ui.ColorSpace.sRGB;
-
-  @override
-  void dispose() {
-    if (!_isDisposed) {
-      imageDispose(handle);
-      _isDisposed = true;
-    }
-  }
 
   @override
   bool get debugDisposed => _isDisposed;

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -9,9 +9,9 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmImage implements ui.Image {
+class SkwasmImage implements SkwasmObjectWrapper<RawImage>, ui.Image {
   SkwasmImage(this.handle) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
   factory SkwasmImage.fromPixels(
@@ -37,9 +37,10 @@ class SkwasmImage implements ui.Image {
     return SkwasmImage(imageHandle);
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(imageDispose));
+  static final SkwasmFinalizationRegistry<RawImage> _registry =
+    SkwasmFinalizationRegistry<RawImage>(imageDispose);
 
+  @override
   final ImageHandle handle;
   bool _isDisposed = false;
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -10,7 +10,10 @@ import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
 class SkwasmImage extends SkwasmObjectWrapper<RawImage> implements ui.Image {
-  SkwasmImage(ImageHandle handle) : super(handle, _registry);
+  SkwasmImage(ImageHandle handle) : super(handle, _registry)
+  {
+    ui.Image.onCreate?.call(this);
+  }
 
   factory SkwasmImage.fromPixels(
     Uint8List pixels,
@@ -37,6 +40,12 @@ class SkwasmImage extends SkwasmObjectWrapper<RawImage> implements ui.Image {
 
   static final SkwasmFinalizationRegistry<RawImage> _registry =
     SkwasmFinalizationRegistry<RawImage>(imageDispose);
+
+  @override
+  void dispose() {
+    super.dispose();
+    ui.Image.onDispose?.call(this);
+  }
 
   @override
   int get width => imageGetWidth(handle);

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -9,10 +9,8 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmImage implements SkwasmObjectWrapper<RawImage>, ui.Image {
-  SkwasmImage(this.handle) {
-    _registry.register(this);
-  }
+class SkwasmImage extends SkwasmObjectWrapper<RawImage> implements ui.Image {
+  SkwasmImage(ImageHandle handle) : super(handle, _registry);
 
   factory SkwasmImage.fromPixels(
     Uint8List pixels,
@@ -41,18 +39,6 @@ class SkwasmImage implements SkwasmObjectWrapper<RawImage>, ui.Image {
     SkwasmFinalizationRegistry<RawImage>(imageDispose);
 
   @override
-  final ImageHandle handle;
-  bool _isDisposed = false;
-
-  @override
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    imageDispose(handle);
-    _isDisposed = true;
-  }
-
-  @override
   int get width => imageGetWidth(handle);
 
   @override
@@ -66,9 +52,6 @@ class SkwasmImage implements SkwasmObjectWrapper<RawImage>, ui.Image {
 
   @override
   ui.ColorSpace get colorSpace => ui.ColorSpace.sRGB;
-
-  @override
-  bool get debugDisposed => _isDisposed;
 
   @override
   SkwasmImage clone() {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi';
+import 'dart:js_interop';
+
+typedef DisposeFunction<T extends NativeType> = void Function(Pointer<T>);
+JSFunction createSkwasmFinalizer<T extends NativeType>(DisposeFunction<T> dispose) {
+  return ((JSNumber address) => 
+    dispose(Pointer<Void>.fromAddress(address.toDart.toInt()).cast<T>())
+  ).toJS;
+}

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
@@ -9,12 +9,24 @@ import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
 class SkwasmPaint implements ui.Paint {
-  factory SkwasmPaint() {
-    return SkwasmPaint._fromHandle(paintCreate());
+  factory SkwasmPaint() => SkwasmPaint._fromHandle(paintCreate());
+
+  SkwasmPaint._fromHandle(this._handle) {
+    _registry.register(this, _handle.address, this);
   }
 
-  SkwasmPaint._fromHandle(this._handle);
+  void dispose() {
+    assert(!_isDisposed);
+    _registry.unregister(this);
+    paintDispose(handle);
+    _isDisposed = true;
+  }
+
+  static final DomFinalizationRegistry _registry =
+    DomFinalizationRegistry(createSkwasmFinalizer(paintDispose));
+
   PaintHandle _handle;
+  bool _isDisposed = false;
 
   PaintHandle get handle => _handle;
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
@@ -8,11 +8,11 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmPaint implements ui.Paint {
+class SkwasmPaint implements SkwasmObjectWrapper<RawPaint>, ui.Paint {
   factory SkwasmPaint() => SkwasmPaint._fromHandle(paintCreate());
 
-  SkwasmPaint._fromHandle(this._handle) {
-    _registry.register(this, _handle.address, this);
+  SkwasmPaint._fromHandle(this.handle) {
+    _registry.register(this);
   }
 
   void dispose() {
@@ -22,13 +22,12 @@ class SkwasmPaint implements ui.Paint {
     _isDisposed = true;
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(paintDispose));
+  static final SkwasmFinalizationRegistry<RawPaint> _registry =
+    SkwasmFinalizationRegistry<RawPaint>(paintDispose);
 
-  PaintHandle _handle;
+  @override
+  PaintHandle handle;
   bool _isDisposed = false;
-
-  PaintHandle get handle => _handle;
 
   ui.BlendMode _cachedBlendMode = ui.BlendMode.srcOver;
 
@@ -59,51 +58,51 @@ class SkwasmPaint implements ui.Paint {
   set blendMode(ui.BlendMode blendMode) {
     if (_cachedBlendMode != blendMode) {
       _cachedBlendMode = blendMode;
-      paintSetBlendMode(_handle, blendMode.index);
+      paintSetBlendMode(handle, blendMode.index);
     }
   }
 
   @override
-  ui.PaintingStyle get style => ui.PaintingStyle.values[paintGetStyle(_handle)];
+  ui.PaintingStyle get style => ui.PaintingStyle.values[paintGetStyle(handle)];
 
   @override
-  set style(ui.PaintingStyle style) => paintSetStyle(_handle, style.index);
+  set style(ui.PaintingStyle style) => paintSetStyle(handle, style.index);
 
   @override
-  double get strokeWidth => paintGetStrokeWidth(_handle);
+  double get strokeWidth => paintGetStrokeWidth(handle);
 
   @override
-  set strokeWidth(double width) => paintSetStrokeWidth(_handle, width);
+  set strokeWidth(double width) => paintSetStrokeWidth(handle, width);
 
   @override
-  ui.StrokeCap get strokeCap => ui.StrokeCap.values[paintGetStrokeCap(_handle)];
+  ui.StrokeCap get strokeCap => ui.StrokeCap.values[paintGetStrokeCap(handle)];
 
   @override
-  set strokeCap(ui.StrokeCap cap) => paintSetStrokeCap(_handle, cap.index);
+  set strokeCap(ui.StrokeCap cap) => paintSetStrokeCap(handle, cap.index);
 
   @override
-  ui.StrokeJoin get strokeJoin => ui.StrokeJoin.values[paintGetStrokeJoin(_handle)];
+  ui.StrokeJoin get strokeJoin => ui.StrokeJoin.values[paintGetStrokeJoin(handle)];
 
   @override
-  set strokeJoin(ui.StrokeJoin join) => paintSetStrokeJoin(_handle, join.index);
+  set strokeJoin(ui.StrokeJoin join) => paintSetStrokeJoin(handle, join.index);
 
   @override
-  bool get isAntiAlias => paintGetAntiAlias(_handle);
+  bool get isAntiAlias => paintGetAntiAlias(handle);
 
   @override
-  set isAntiAlias(bool value) => paintSetAntiAlias(_handle, value);
+  set isAntiAlias(bool value) => paintSetAntiAlias(handle, value);
 
   @override
-  ui.Color get color => ui.Color(paintGetColorInt(_handle));
+  ui.Color get color => ui.Color(paintGetColorInt(handle));
 
   @override
-  set color(ui.Color color) => paintSetColorInt(_handle, color.value);
+  set color(ui.Color color) => paintSetColorInt(handle, color.value);
 
   @override
-  double get strokeMiterLimit => paintGetMiterLimit(_handle);
+  double get strokeMiterLimit => paintGetMiterLimit(handle);
 
   @override
-  set strokeMiterLimit(double limit) => paintSetMiterLimit(_handle, limit);
+  set strokeMiterLimit(double limit) => paintSetMiterLimit(handle, limit);
 
   @override
   ui.Shader? get shader => _shader;
@@ -114,7 +113,7 @@ class SkwasmPaint implements ui.Paint {
     _shader = skwasmShader;
     final ShaderHandle shaderHandle =
       skwasmShader != null ? skwasmShader.handle : nullptr;
-    paintSetShader(_handle, shaderHandle);
+    paintSetShader(handle, shaderHandle);
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
@@ -8,26 +8,11 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmPaint implements SkwasmObjectWrapper<RawPaint>, ui.Paint {
-  factory SkwasmPaint() => SkwasmPaint._fromHandle(paintCreate());
-
-  SkwasmPaint._fromHandle(this.handle) {
-    _registry.register(this);
-  }
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    paintDispose(handle);
-    _isDisposed = true;
-  }
+class SkwasmPaint extends SkwasmObjectWrapper<RawPaint> implements ui.Paint {
+  SkwasmPaint() : super(paintCreate(), _registry);
 
   static final SkwasmFinalizationRegistry<RawPaint> _registry =
     SkwasmFinalizationRegistry<RawPaint>(paintDispose);
-
-  @override
-  PaintHandle handle;
-  bool _isDisposed = false;
 
   ui.BlendMode _cachedBlendMode = ui.BlendMode.srcOver;
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -13,7 +13,7 @@ import 'package:ui/ui.dart' as ui;
 const int _kSoftLineBreak = 0;
 const int _kHardLineBreak = 100;
 
-class SkwasmLineMetrics implements ui.LineMetrics {
+class SkwasmLineMetrics implements SkwasmObjectWrapper<RawLineMetrics>, ui.LineMetrics {
   factory SkwasmLineMetrics({
     required bool hardBreak,
     required double ascent,
@@ -37,12 +37,13 @@ class SkwasmLineMetrics implements ui.LineMetrics {
   ));
 
   SkwasmLineMetrics._(this.handle) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(lineMetricsDispose));
+  static final SkwasmFinalizationRegistry<RawLineMetrics> _registry =
+    SkwasmFinalizationRegistry<RawLineMetrics>(lineMetricsDispose);
 
+  @override
   final LineMetricsHandle handle;
   bool _isDisposed = false;
 
@@ -81,14 +82,15 @@ class SkwasmLineMetrics implements ui.LineMetrics {
   int get lineNumber => lineMetricsGetLineNumber(handle);
 }
 
-class SkwasmParagraph implements ui.Paragraph {
+class SkwasmParagraph implements SkwasmObjectWrapper<RawParagraph>, ui.Paragraph {
   SkwasmParagraph(this.handle) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(paragraphDispose));
+  static final SkwasmFinalizationRegistry<RawParagraph> _registry =
+    SkwasmFinalizationRegistry<RawParagraph>(paragraphDispose);
 
+  @override
   final ParagraphHandle handle;
   bool _isDisposed = false;
   bool _hasCheckedForMissingCodePoints = false;
@@ -261,16 +263,17 @@ void withScopedFontList(
   });
 }
 
-class SkwasmNativeTextStyle {
+class SkwasmNativeTextStyle implements SkwasmObjectWrapper<RawTextStyle> {
   SkwasmNativeTextStyle(this.handle) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
   factory SkwasmNativeTextStyle.defaultTextStyle() => SkwasmNativeTextStyle(textStyleCreate());
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(textStyleDispose));
+  static final SkwasmFinalizationRegistry<RawTextStyle> _registry =
+    SkwasmFinalizationRegistry<RawTextStyle>(textStyleDispose);
 
+  @override
   final TextStyleHandle handle;
   bool _isDisposed = false;
 
@@ -445,7 +448,7 @@ class SkwasmTextStyle implements ui.TextStyle {
   final List<ui.FontVariation>? fontVariations;
 }
 
-class SkwasmStrutStyle implements ui.StrutStyle {
+class SkwasmStrutStyle implements SkwasmObjectWrapper<RawStrutStyle>, ui.StrutStyle {
   factory SkwasmStrutStyle({
     String? fontFamily,
     List<String>? fontFamilyFallback,
@@ -495,12 +498,13 @@ class SkwasmStrutStyle implements ui.StrutStyle {
   }
 
   SkwasmStrutStyle._(this.handle) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(strutStyleDispose));
+  static final SkwasmFinalizationRegistry<RawStrutStyle> _registry =
+    SkwasmFinalizationRegistry<RawStrutStyle>(strutStyleDispose);
 
+  @override
   final StrutStyleHandle handle;
   bool _isDisposed = false;
 
@@ -512,7 +516,7 @@ class SkwasmStrutStyle implements ui.StrutStyle {
   }
 }
 
-class SkwasmParagraphStyle implements ui.ParagraphStyle {
+class SkwasmParagraphStyle implements SkwasmObjectWrapper<RawParagraphStyle>, ui.ParagraphStyle {
   factory SkwasmParagraphStyle({
     ui.TextAlign? textAlign,
     ui.TextDirection? textDirection,
@@ -556,7 +560,7 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
       strutStyle as SkwasmStrutStyle;
       paragraphStyleSetStrutStyle(handle, strutStyle.handle);
     }
-    final SkwasmNativeTextStyle textStyle = 
+    final SkwasmNativeTextStyle textStyle =
       (renderer.fontCollection as SkwasmFontCollection).defaultTextStyle.copy();
     final TextStyleHandle textStyleHandle = textStyle.handle;
 
@@ -590,11 +594,11 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
   }
 
   SkwasmParagraphStyle._(this.handle, this.textStyle, this.defaultFontFamily) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(paragraphStyleDispose));
+  static final SkwasmFinalizationRegistry<RawParagraphStyle> _registry =
+    SkwasmFinalizationRegistry<RawParagraphStyle>(paragraphStyleDispose);
 
   void dispose() {
     assert(!_isDisposed);
@@ -603,13 +607,14 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
     _isDisposed = true;
   }
 
+  @override
   final ParagraphStyleHandle handle;
   bool _isDisposed = false;
   final SkwasmNativeTextStyle textStyle;
   final String? defaultFontFamily;
 }
 
-class SkwasmParagraphBuilder implements ui.ParagraphBuilder {
+class SkwasmParagraphBuilder implements SkwasmObjectWrapper<RawParagraphBuilder>, ui.ParagraphBuilder {
   factory SkwasmParagraphBuilder(
     SkwasmParagraphStyle style,
     SkwasmFontCollection collection,
@@ -619,12 +624,13 @@ class SkwasmParagraphBuilder implements ui.ParagraphBuilder {
     ), style);
 
   SkwasmParagraphBuilder._(this.handle, this.style) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(paragraphBuilderDispose));
+  static final SkwasmFinalizationRegistry<RawParagraphBuilder> _registry =
+    SkwasmFinalizationRegistry<RawParagraphBuilder>(paragraphBuilderDispose);
 
+  @override
   final ParagraphBuilderHandle handle;
   bool _isDisposed = false;
   final SkwasmParagraphStyle style;

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -13,7 +13,7 @@ import 'package:ui/ui.dart' as ui;
 const int _kSoftLineBreak = 0;
 const int _kHardLineBreak = 100;
 
-class SkwasmLineMetrics implements SkwasmObjectWrapper<RawLineMetrics>, ui.LineMetrics {
+class SkwasmLineMetrics extends SkwasmObjectWrapper<RawLineMetrics> implements ui.LineMetrics {
   factory SkwasmLineMetrics({
     required bool hardBreak,
     required double ascent,
@@ -36,23 +36,10 @@ class SkwasmLineMetrics implements SkwasmObjectWrapper<RawLineMetrics>, ui.LineM
     lineNumber,
   ));
 
-  SkwasmLineMetrics._(this.handle) {
-    _registry.register(this);
-  }
+  SkwasmLineMetrics._(LineMetricsHandle handle) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawLineMetrics> _registry =
     SkwasmFinalizationRegistry<RawLineMetrics>(lineMetricsDispose);
-
-  @override
-  final LineMetricsHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    lineMetricsDispose(handle);
-    _isDisposed = true;
-  }
 
   @override
   bool get hardBreak => lineMetricsGetHardBreak(handle);
@@ -82,29 +69,13 @@ class SkwasmLineMetrics implements SkwasmObjectWrapper<RawLineMetrics>, ui.LineM
   int get lineNumber => lineMetricsGetLineNumber(handle);
 }
 
-class SkwasmParagraph implements SkwasmObjectWrapper<RawParagraph>, ui.Paragraph {
-  SkwasmParagraph(this.handle) {
-    _registry.register(this);
-  }
+class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Paragraph {
+  SkwasmParagraph(ParagraphHandle handle) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawParagraph> _registry =
     SkwasmFinalizationRegistry<RawParagraph>(paragraphDispose);
 
-  @override
-  final ParagraphHandle handle;
-  bool _isDisposed = false;
   bool _hasCheckedForMissingCodePoints = false;
-
-  @override
-  bool get debugDisposed => _isDisposed;
-
-  @override
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    paragraphDispose(handle);
-    _isDisposed = true;
-  }
 
   @override
   double get width => paragraphGetWidth(handle);
@@ -263,26 +234,13 @@ void withScopedFontList(
   });
 }
 
-class SkwasmNativeTextStyle implements SkwasmObjectWrapper<RawTextStyle> {
-  SkwasmNativeTextStyle(this.handle) {
-    _registry.register(this);
-  }
+class SkwasmNativeTextStyle extends SkwasmObjectWrapper<RawTextStyle> {
+  SkwasmNativeTextStyle(TextStyleHandle handle) : super(handle, _registry);
 
   factory SkwasmNativeTextStyle.defaultTextStyle() => SkwasmNativeTextStyle(textStyleCreate());
 
   static final SkwasmFinalizationRegistry<RawTextStyle> _registry =
     SkwasmFinalizationRegistry<RawTextStyle>(textStyleDispose);
-
-  @override
-  final TextStyleHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    textStyleDispose(handle);
-    _isDisposed = true;
-  }
 
   SkwasmNativeTextStyle copy() {
     return SkwasmNativeTextStyle(textStyleCopy(handle));
@@ -448,7 +406,7 @@ class SkwasmTextStyle implements ui.TextStyle {
   final List<ui.FontVariation>? fontVariations;
 }
 
-class SkwasmStrutStyle implements SkwasmObjectWrapper<RawStrutStyle>, ui.StrutStyle {
+class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implements ui.StrutStyle {
   factory SkwasmStrutStyle({
     String? fontFamily,
     List<String>? fontFamilyFallback,
@@ -497,26 +455,13 @@ class SkwasmStrutStyle implements SkwasmObjectWrapper<RawStrutStyle>, ui.StrutSt
     return SkwasmStrutStyle._(handle);
   }
 
-  SkwasmStrutStyle._(this.handle) {
-    _registry.register(this);
-  }
+  SkwasmStrutStyle._(StrutStyleHandle handle) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawStrutStyle> _registry =
     SkwasmFinalizationRegistry<RawStrutStyle>(strutStyleDispose);
-
-  @override
-  final StrutStyleHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    strutStyleDispose(handle);
-    _isDisposed = true;
-  }
 }
 
-class SkwasmParagraphStyle implements SkwasmObjectWrapper<RawParagraphStyle>, ui.ParagraphStyle {
+class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle> implements ui.ParagraphStyle {
   factory SkwasmParagraphStyle({
     ui.TextAlign? textAlign,
     ui.TextDirection? textDirection,
@@ -593,28 +538,20 @@ class SkwasmParagraphStyle implements SkwasmObjectWrapper<RawParagraphStyle>, ui
     return SkwasmParagraphStyle._(handle, textStyle, fontFamily);
   }
 
-  SkwasmParagraphStyle._(this.handle, this.textStyle, this.defaultFontFamily) {
-    _registry.register(this);
-  }
+  SkwasmParagraphStyle._(
+    ParagraphStyleHandle handle,
+    this.textStyle,
+    this.defaultFontFamily
+  ) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawParagraphStyle> _registry =
     SkwasmFinalizationRegistry<RawParagraphStyle>(paragraphStyleDispose);
 
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    paragraphStyleDispose(handle);
-    _isDisposed = true;
-  }
-
-  @override
-  final ParagraphStyleHandle handle;
-  bool _isDisposed = false;
   final SkwasmNativeTextStyle textStyle;
   final String? defaultFontFamily;
 }
 
-class SkwasmParagraphBuilder implements SkwasmObjectWrapper<RawParagraphBuilder>, ui.ParagraphBuilder {
+class SkwasmParagraphBuilder extends SkwasmObjectWrapper<RawParagraphBuilder> implements ui.ParagraphBuilder {
   factory SkwasmParagraphBuilder(
     SkwasmParagraphStyle style,
     SkwasmFontCollection collection,
@@ -623,25 +560,13 @@ class SkwasmParagraphBuilder implements SkwasmObjectWrapper<RawParagraphBuilder>
       collection.handle,
     ), style);
 
-  SkwasmParagraphBuilder._(this.handle, this.style) {
-    _registry.register(this);
-  }
+  SkwasmParagraphBuilder._(ParagraphBuilderHandle handle, this.style) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawParagraphBuilder> _registry =
     SkwasmFinalizationRegistry<RawParagraphBuilder>(paragraphBuilderDispose);
 
-  @override
-  final ParagraphBuilderHandle handle;
-  bool _isDisposed = false;
   final SkwasmParagraphStyle style;
   final List<SkwasmNativeTextStyle> textStyleStack = <SkwasmNativeTextStyle>[];
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    paragraphBuilderDispose(handle);
-    _isDisposed = true;
-  }
 
   @override
   List<double> placeholderScales = <double>[];

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
@@ -28,13 +28,23 @@ class SkwasmPath implements ui.Path {
     return SkwasmPath.fromHandle(pathCopy(source._handle));
   }
 
-  SkwasmPath.fromHandle(this._handle);
+  SkwasmPath.fromHandle(this._handle) {
+    _registry.register(this, handle.address, this);
+  }
+
+  static final DomFinalizationRegistry _registry =
+    DomFinalizationRegistry(createSkwasmFinalizer(pathDispose));
+
   final PathHandle _handle;
+  bool _isDisposed = false;
 
   PathHandle get handle => _handle;
 
-  void delete() {
-    pathDestroy(_handle);
+  void dispose() {
+    assert(!_isDisposed);
+    _registry.unregister(this);
+    pathDispose(_handle);
+    _isDisposed = true;
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
@@ -19,59 +19,58 @@ enum PathArcSize {
   large,
 }
 
-class SkwasmPath implements ui.Path {
+class SkwasmPath implements SkwasmObjectWrapper<RawPath>, ui.Path {
   factory SkwasmPath() {
     return SkwasmPath.fromHandle(pathCreate());
   }
 
   factory SkwasmPath.from(SkwasmPath source) {
-    return SkwasmPath.fromHandle(pathCopy(source._handle));
+    return SkwasmPath.fromHandle(pathCopy(source.handle));
   }
 
-  SkwasmPath.fromHandle(this._handle) {
-    _registry.register(this, handle.address, this);
+  SkwasmPath.fromHandle(this.handle) {
+    _registry.register(this);
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(pathDispose));
+  static final SkwasmFinalizationRegistry<RawPath> _registry =
+    SkwasmFinalizationRegistry<RawPath>(pathDispose);
 
-  final PathHandle _handle;
+  @override
+  final PathHandle handle;
   bool _isDisposed = false;
-
-  PathHandle get handle => _handle;
 
   void dispose() {
     assert(!_isDisposed);
     _registry.unregister(this);
-    pathDispose(_handle);
+    pathDispose(handle);
     _isDisposed = true;
   }
 
   @override
-  ui.PathFillType get fillType => ui.PathFillType.values[pathGetFillType(_handle)];
+  ui.PathFillType get fillType => ui.PathFillType.values[pathGetFillType(handle)];
 
   @override
-  set fillType(ui.PathFillType fillType) => pathSetFillType(_handle, fillType.index);
+  set fillType(ui.PathFillType fillType) => pathSetFillType(handle, fillType.index);
 
   @override
-  void moveTo(double x, double y) => pathMoveTo(_handle, x, y);
+  void moveTo(double x, double y) => pathMoveTo(handle, x, y);
 
   @override
-  void relativeMoveTo(double x, double y) => pathRelativeMoveTo(_handle, x, y);
+  void relativeMoveTo(double x, double y) => pathRelativeMoveTo(handle, x, y);
 
   @override
-  void lineTo(double x, double y) => pathLineTo(_handle, x, y);
+  void lineTo(double x, double y) => pathLineTo(handle, x, y);
 
   @override
-  void relativeLineTo(double x, double y) => pathRelativeMoveTo(_handle, x, y);
+  void relativeLineTo(double x, double y) => pathRelativeMoveTo(handle, x, y);
 
   @override
   void quadraticBezierTo(double x1, double y1, double x2, double y2) =>
-    pathQuadraticBezierTo(_handle, x1, y1, x2, y2);
+    pathQuadraticBezierTo(handle, x1, y1, x2, y2);
 
   @override
   void relativeQuadraticBezierTo(double x1, double y1, double x2, double y2) =>
-    pathRelativeQuadraticBezierTo(_handle, x1, y1, x2, y2);
+    pathRelativeQuadraticBezierTo(handle, x1, y1, x2, y2);
 
   @override
   void cubicTo(
@@ -81,7 +80,7 @@ class SkwasmPath implements ui.Path {
     double y2,
     double x3,
     double y3) =>
-    pathCubicTo(_handle, x1, y1, x2, y2, x3, y3);
+    pathCubicTo(handle, x1, y1, x2, y2, x3, y3);
 
   @override
   void relativeCubicTo(
@@ -91,22 +90,22 @@ class SkwasmPath implements ui.Path {
       double y2,
       double x3,
       double y3) =>
-    pathRelativeCubicTo(_handle, x1, y1, x2, y2, x3, y3);
+    pathRelativeCubicTo(handle, x1, y1, x2, y2, x3, y3);
 
   @override
   void conicTo(double x1, double y1, double x2, double y2, double w) =>
-    pathConicTo(_handle, x1, y1, x2, y2, w);
+    pathConicTo(handle, x1, y1, x2, y2, w);
 
   @override
   void relativeConicTo(double x1, double y1, double x2, double y2, double w) =>
-    pathRelativeConicTo(_handle, x1, y1, x2, y2, w);
+    pathRelativeConicTo(handle, x1, y1, x2, y2, w);
 
   @override
   void arcTo(
       ui.Rect rect, double startAngle, double sweepAngle, bool forceMoveTo) {
     withStackScope((StackScope s) {
       pathArcToOval(
-          _handle,
+          handle,
           s.convertRectToNative(rect),
           ui.toDegrees(startAngle),
           ui.toDegrees(sweepAngle),
@@ -128,7 +127,7 @@ class SkwasmPath implements ui.Path {
     final PathDirection pathDirection =
         clockwise ? PathDirection.clockwise : PathDirection.counterClockwise;
     pathArcToRotated(
-        _handle,
+        handle,
         radius.x,
         radius.y,
         ui.toDegrees(rotation),
@@ -152,7 +151,7 @@ class SkwasmPath implements ui.Path {
     final PathDirection pathDirection =
         clockwise ? PathDirection.clockwise : PathDirection.counterClockwise;
     pathRelativeArcToRotated(
-        _handle,
+        handle,
         radius.x,
         radius.y,
         ui.toDegrees(rotation),
@@ -166,14 +165,14 @@ class SkwasmPath implements ui.Path {
   @override
   void addRect(ui.Rect rect) {
     withStackScope((StackScope s) {
-      pathAddRect(_handle, s.convertRectToNative(rect));
+      pathAddRect(handle, s.convertRectToNative(rect));
     });
   }
 
   @override
   void addOval(ui.Rect rect) {
     withStackScope((StackScope s) {
-      pathAddOval(_handle, s.convertRectToNative(rect));
+      pathAddOval(handle, s.convertRectToNative(rect));
     });
   }
 
@@ -181,7 +180,7 @@ class SkwasmPath implements ui.Path {
   void addArc(ui.Rect rect, double startAngle, double sweepAngle) {
     withStackScope((StackScope s) {
       pathAddArc(
-        _handle,
+        handle,
         s.convertRectToNative(rect),
         ui.toDegrees(startAngle),
         ui.toDegrees(sweepAngle)
@@ -192,14 +191,14 @@ class SkwasmPath implements ui.Path {
   @override
   void addPolygon(List<ui.Offset> points, bool close) {
     withStackScope((StackScope s) {
-      pathAddPolygon(_handle, s.convertPointArrayToNative(points), points.length, close);
+      pathAddPolygon(handle, s.convertPointArrayToNative(points), points.length, close);
     });
   }
 
   @override
   void addRRect(ui.RRect rrect) {
     withStackScope((StackScope s) {
-      pathAddRRect(_handle, s.convertRRectToNative(rrect));
+      pathAddRRect(handle, s.convertRRectToNative(rrect));
     });
   }
 
@@ -220,18 +219,18 @@ class SkwasmPath implements ui.Path {
           s.convertMatrix4toSkMatrix(matrix4 ?? Matrix4.identity().toFloat64());
       convertedMatrix[2] += offset.dx;
       convertedMatrix[5] += offset.dy;
-      pathAddPath(_handle, (path as SkwasmPath)._handle, convertedMatrix, extend);
+      pathAddPath(handle, (path as SkwasmPath).handle, convertedMatrix, extend);
     });
   }
 
   @override
-  void close() => pathClose(_handle);
+  void close() => pathClose(handle);
 
   @override
-  void reset() => pathReset(_handle);
+  void reset() => pathReset(handle);
 
   @override
-  bool contains(ui.Offset point) => pathContains(_handle, point.dx, point.dy);
+  bool contains(ui.Offset point) => pathContains(handle, point.dx, point.dy);
 
   @override
   ui.Path shift(ui.Offset offset) =>
@@ -240,7 +239,7 @@ class SkwasmPath implements ui.Path {
   @override
   ui.Path transform(Float64List matrix4) {
     return withStackScope((StackScope s) {
-      final PathHandle newPathHandle = pathCopy(_handle);
+      final PathHandle newPathHandle = pathCopy(handle);
       pathTransform(newPathHandle, s.convertMatrix4toSkMatrix(matrix4));
       return SkwasmPath.fromHandle(newPathHandle);
     });
@@ -250,7 +249,7 @@ class SkwasmPath implements ui.Path {
   ui.Rect getBounds() {
     return withStackScope((StackScope s) {
       final Pointer<Float> rectBuffer = s.allocFloatArray(4);
-      pathGetBounds(_handle, rectBuffer);
+      pathGetBounds(handle, rectBuffer);
       return s.convertRectFromNative(rectBuffer);
     });
   }
@@ -260,7 +259,7 @@ class SkwasmPath implements ui.Path {
     SkwasmPath path1,
     SkwasmPath path2) =>
     SkwasmPath.fromHandle(pathCombine(
-        operation.index, path1._handle, path2._handle));
+        operation.index, path1.handle, path2.handle));
 
   @override
   ui.PathMetrics computeMetrics({bool forceClosed = false}) {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path.dart
@@ -19,7 +19,7 @@ enum PathArcSize {
   large,
 }
 
-class SkwasmPath implements SkwasmObjectWrapper<RawPath>, ui.Path {
+class SkwasmPath extends SkwasmObjectWrapper<RawPath> implements ui.Path {
   factory SkwasmPath() {
     return SkwasmPath.fromHandle(pathCreate());
   }
@@ -28,23 +28,10 @@ class SkwasmPath implements SkwasmObjectWrapper<RawPath>, ui.Path {
     return SkwasmPath.fromHandle(pathCopy(source.handle));
   }
 
-  SkwasmPath.fromHandle(this.handle) {
-    _registry.register(this);
-  }
+  SkwasmPath.fromHandle(PathHandle handle) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawPath> _registry =
     SkwasmFinalizationRegistry<RawPath>(pathDispose);
-
-  @override
-  final PathHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    pathDispose(handle);
-    _isDisposed = true;
-  }
 
   @override
   ui.PathFillType get fillType => ui.PathFillType.values[pathGetFillType(handle)];

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/path_metrics.dart
@@ -19,27 +19,15 @@ class SkwasmPathMetrics extends IterableBase<ui.PathMetric>
   late Iterator<ui.PathMetric> iterator = SkwasmPathMetricIterator(path, forceClosed);
 }
 
-class SkwasmPathMetricIterator implements SkwasmObjectWrapper<RawContourMeasureIter>, Iterator<ui.PathMetric> {
+class SkwasmPathMetricIterator extends SkwasmObjectWrapper<RawContourMeasureIter> implements Iterator<ui.PathMetric> {
   SkwasmPathMetricIterator(SkwasmPath path, bool forceClosed)
-      : handle = contourMeasureIterCreate(path.handle, forceClosed, 1.0) {
-    _registry.register(this);
-  }
+      : super(contourMeasureIterCreate(path.handle, forceClosed, 1.0), _registry);
 
   static final SkwasmFinalizationRegistry<RawContourMeasureIter> _registry =
     SkwasmFinalizationRegistry<RawContourMeasureIter>(contourMeasureIterDispose);
 
-  @override
-  final ContourMeasureIterHandle handle;
-  bool _isDisposed = false;
   SkwasmPathMetric? _current;
   int _nextIndex = 0;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    contourMeasureIterDispose(handle);
-    _isDisposed = true;
-  }
 
   @override
   ui.PathMetric get current {
@@ -66,24 +54,11 @@ class SkwasmPathMetricIterator implements SkwasmObjectWrapper<RawContourMeasureI
   }
 }
 
-class SkwasmPathMetric implements SkwasmObjectWrapper<RawContourMeasure>, ui.PathMetric {
-  SkwasmPathMetric(this.handle, this.contourIndex) {
-    _registry.register(this);
-  }
+class SkwasmPathMetric extends SkwasmObjectWrapper<RawContourMeasure> implements ui.PathMetric {
+  SkwasmPathMetric(ContourMeasureHandle handle, this.contourIndex) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawContourMeasure> _registry =
     SkwasmFinalizationRegistry<RawContourMeasure>(contourMeasureDispose);
-
-  @override
-  final ContourMeasureHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    contourMeasureDispose(handle);
-    _isDisposed = true;
-  }
 
   @override
   final int contourIndex;

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
@@ -19,7 +19,10 @@ class SkwasmPicture extends SkwasmObjectWrapper<RawPicture> implements ScenePict
   int get approximateBytesUsed => pictureApproximateBytesUsed(handle);
 
   @override
-  bool debugDisposed = false;
+  void dispose() {
+    super.dispose();
+    ui.Picture.onDispose?.call(this);
+  }
 
   @override
   ui.Image toImageSync(int width, int height) =>

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/picture.dart
@@ -6,30 +6,14 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmPicture implements SkwasmObjectWrapper<RawPicture>, ScenePicture {
-  SkwasmPicture.fromHandle(this.handle) {
-    _registry.register(this);
-  }
+class SkwasmPicture extends SkwasmObjectWrapper<RawPicture> implements ScenePicture {
+  SkwasmPicture.fromHandle(PictureHandle handle) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawPicture> _registry =
     SkwasmFinalizationRegistry<RawPicture>(pictureDispose);
 
   @override
-  final PictureHandle handle;
-  bool _isDisposed = false;
-
-  @override
-  void dispose() {
-    assert(!_isDisposed);
-    ui.Picture.onDispose?.call(this);
-    _registry.unregister(this);
-    pictureDispose(handle);
-    _isDisposed = true;
-  }
-
-  @override
   Future<ui.Image> toImage(int width, int height) async => toImageSync(width, height);
-
 
   @override
   int get approximateBytesUsed => pictureApproximateBytesUsed(handle);
@@ -51,28 +35,11 @@ class SkwasmPicture implements SkwasmObjectWrapper<RawPicture>, ScenePicture {
   }
 }
 
-class SkwasmPictureRecorder implements SkwasmObjectWrapper<RawPictureRecorder>, ui.PictureRecorder {
-  factory SkwasmPictureRecorder() =>
-    SkwasmPictureRecorder._fromHandle(pictureRecorderCreate());
-
-  SkwasmPictureRecorder._fromHandle(this.handle) {
-    _registry.register(this);
-  }
-
+class SkwasmPictureRecorder extends SkwasmObjectWrapper<RawPictureRecorder> implements ui.PictureRecorder {
+  SkwasmPictureRecorder() : super(pictureRecorderCreate(), _registry);
 
   static final SkwasmFinalizationRegistry<RawPictureRecorder> _registry =
     SkwasmFinalizationRegistry<RawPictureRecorder>(pictureRecorderDispose);
-
-  @override
-  final PictureRecorderHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    pictureRecorderDispose(handle);
-    _isDisposed = true;
-  }
 
   @override
   SkwasmPicture endRecording() {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_canvas.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_canvas.dart
@@ -13,9 +13,6 @@ final class RawCanvas extends Opaque {}
 
 typedef CanvasHandle = Pointer<RawCanvas>;
 
-@Native<Void Function(CanvasHandle)>(symbol: 'canvas_destroy', isLeaf: true)
-external void canvasDestroy(CanvasHandle canvas);
-
 @Native<Void Function(CanvasHandle)>(symbol: 'canvas_save', isLeaf: true)
 external void canvasSave(CanvasHandle canvas);
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_paint.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_paint.dart
@@ -16,8 +16,8 @@ typedef PaintHandle = Pointer<RawPaint>;
 @Native<PaintHandle Function()>(symbol: 'paint_create', isLeaf: true)
 external PaintHandle paintCreate();
 
-@Native<Void Function(PaintHandle)>(symbol: 'paint_destroy', isLeaf: true)
-external void paintDestroy(PaintHandle paint);
+@Native<Void Function(PaintHandle)>(symbol: 'paint_dispose', isLeaf: true)
+external void paintDispose(PaintHandle paint);
 
 @Native<Void Function(PaintHandle, Int)>(symbol: 'paint_setBlendMode', isLeaf: true)
 external void paintSetBlendMode(PaintHandle paint, int blendMode);

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_path.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_path.dart
@@ -16,8 +16,8 @@ typedef PathHandle = Pointer<RawPath>;
 @Native<PathHandle Function()>(symbol: 'path_create', isLeaf: true)
 external PathHandle pathCreate();
 
-@Native<Void Function(PathHandle)>(symbol: 'path_destroy', isLeaf: true)
-external void pathDestroy(PathHandle path);
+@Native<Void Function(PathHandle)>(symbol: 'path_dispose', isLeaf: true)
+external void pathDispose(PathHandle path);
 
 @Native<PathHandle Function(PathHandle)>(symbol: 'path_copy', isLeaf: true)
 external PathHandle pathCopy(PathHandle path);

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_path_metrics.dart
@@ -30,7 +30,7 @@ external ContourMeasureHandle contourMeasureIterNext(
     symbol: 'contourMeasureIter_dispose')
 external void contourMeasureIterDispose(ContourMeasureIterHandle handle);
 
-@Native<Void Function(ContourMeasureHandle)>(symbol: 'contourMesaure_dispose')
+@Native<Void Function(ContourMeasureHandle)>(symbol: 'contourMeasure_dispose')
 external void contourMeasureDispose(ContourMeasureHandle handle);
 
 @Native<Float Function(ContourMeasureHandle)>(symbol: 'contourMeasure_length')

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_picture.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_picture.dart
@@ -21,9 +21,9 @@ typedef PictureHandle = Pointer<RawPicture>;
 external PictureRecorderHandle pictureRecorderCreate();
 
 @Native<Void Function(PictureRecorderHandle)>(
-  symbol: 'pictureRecorder_destroy',
+  symbol: 'pictureRecorder_dispose',
   isLeaf: true)
-external void pictureRecorderDestroy(PictureRecorderHandle picture);
+external void pictureRecorderDispose(PictureRecorderHandle picture);
 
 @Native<CanvasHandle Function(PictureRecorderHandle, RawRect)>(
   symbol: 'pictureRecorder_beginRecording',

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -24,7 +24,6 @@ class SkwasmRenderer implements Renderer {
     return SkwasmPath.combine(op, path1 as SkwasmPath, path2 as SkwasmPath);
   }
 
-
   @override
   ui.Path copyPath(ui.Path src) {
     return SkwasmPath.from(src as SkwasmPath);

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -17,28 +17,11 @@ abstract class SkwasmShader implements ui.Shader {
 
 // An implementation that handles the storage, disposal, and finalization of
 // a native shader handle.
-class SkwasmNativeShader implements SkwasmObjectWrapper<RawShader>, SkwasmShader {
-  SkwasmNativeShader(this.handle) {
-    _registry.register(this);
-  }
-
-  @override
-  final ShaderHandle handle;
-  bool _isDisposed = false;
+class SkwasmNativeShader extends SkwasmObjectWrapper<RawShader> implements SkwasmShader {
+  SkwasmNativeShader(ShaderHandle handle) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawShader> _registry =
     SkwasmFinalizationRegistry<RawShader>(shaderDispose);
-
-  @override
-  bool get debugDisposed => _isDisposed;
-
-  @override
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    shaderDispose(handle);
-    _isDisposed = true;
-  }
 }
 
 class SkwasmGradient extends SkwasmNativeShader implements ui.Gradient {
@@ -196,13 +179,14 @@ class SkwasmImageShader extends SkwasmNativeShader implements ui.ImageShader {
   }
 }
 
-class SkwasmFragmentProgram implements SkwasmObjectWrapper<RawRuntimeEffect>, ui.FragmentProgram {
+class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect> implements ui.FragmentProgram {
   SkwasmFragmentProgram._(
     this.name,
-    this.handle,
+    RuntimeEffectHandle handle,
     this.floatUniformCount,
     this.childShaderCount,
-  );
+  ) : super(handle, _registry);
+
   factory SkwasmFragmentProgram.fromBytes(String name, Uint8List bytes) {
     final ShaderData shaderData = ShaderData.fromBytes(bytes);
 
@@ -228,19 +212,9 @@ class SkwasmFragmentProgram implements SkwasmObjectWrapper<RawRuntimeEffect>, ui
   static final SkwasmFinalizationRegistry<RawRuntimeEffect> _registry =
     SkwasmFinalizationRegistry<RawRuntimeEffect>(runtimeEffectDispose);
 
-  @override
-  final RuntimeEffectHandle handle;
   final String name;
   final int floatUniformCount;
   final int childShaderCount;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    runtimeEffectDispose(handle);
-    _isDisposed = true;
-  }
 
   @override
   ui.FragmentShader fragmentShader() => SkwasmFragmentShader(this);
@@ -248,24 +222,11 @@ class SkwasmFragmentProgram implements SkwasmObjectWrapper<RawRuntimeEffect>, ui
   int get uniformSize => runtimeEffectGetUniformSize(handle);
 }
 
-class SkwasmShaderData implements SkwasmObjectWrapper<RawSkData> {
-  SkwasmShaderData(int size) : handle = skDataCreate(size) {
-    _registry.register(this);
-  }
+class SkwasmShaderData extends SkwasmObjectWrapper<RawSkData> {
+  SkwasmShaderData(int size) : super(skDataCreate(size), _registry);
 
   static final SkwasmFinalizationRegistry<RawSkData> _registry =
     SkwasmFinalizationRegistry<RawSkData>(skDataDispose);
-
-  @override
-  final SkDataHandle handle;
-  bool _isDisposed = false;
-
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    skDataDispose(handle);
-    _isDisposed = true;
-  }
 }
 
 // This class does not inherit from SkwasmNativeShader, as its handle might

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
@@ -7,11 +7,10 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 
-import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmVertices implements ui.Vertices {
+class SkwasmVertices implements SkwasmObjectWrapper<RawVertices>, ui.Vertices {
   factory SkwasmVertices(
     ui.VertexMode mode,
     List<ui.Offset> positions, {
@@ -71,12 +70,13 @@ class SkwasmVertices implements ui.Vertices {
   });
 
   SkwasmVertices._(this.handle) {
-    _registry.register(this, handle.address, this);
+    _registry.register(this);
   }
 
-  static final DomFinalizationRegistry _registry =
-    DomFinalizationRegistry(createSkwasmFinalizer(verticesDispose));
+  static final SkwasmFinalizationRegistry<RawVertices> _registry =
+    SkwasmFinalizationRegistry<RawVertices>(verticesDispose);
 
+  @override
   final VerticesHandle handle;
   bool _isDisposed = false;
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
@@ -7,6 +7,7 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 
+import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
@@ -69,7 +70,12 @@ class SkwasmVertices implements ui.Vertices {
     ));
   });
 
-  SkwasmVertices._(this.handle);
+  SkwasmVertices._(this.handle) {
+    _registry.register(this, handle.address, this);
+  }
+
+  static final DomFinalizationRegistry _registry =
+    DomFinalizationRegistry(createSkwasmFinalizer(verticesDispose));
 
   final VerticesHandle handle;
   bool _isDisposed = false;
@@ -79,9 +85,9 @@ class SkwasmVertices implements ui.Vertices {
 
   @override
   void dispose() {
-    if (!_isDisposed) {
-      verticesDispose(handle);
-      _isDisposed = true;
-    }
+    assert(!_isDisposed);
+    _registry.unregister(this);
+    verticesDispose(handle);
+    _isDisposed = true;
   }
 }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/vertices.dart
@@ -10,7 +10,7 @@ import 'dart:typed_data';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmVertices implements SkwasmObjectWrapper<RawVertices>, ui.Vertices {
+class SkwasmVertices extends SkwasmObjectWrapper<RawVertices> implements ui.Vertices {
   factory SkwasmVertices(
     ui.VertexMode mode,
     List<ui.Offset> positions, {
@@ -69,25 +69,8 @@ class SkwasmVertices implements SkwasmObjectWrapper<RawVertices>, ui.Vertices {
     ));
   });
 
-  SkwasmVertices._(this.handle) {
-    _registry.register(this);
-  }
+  SkwasmVertices._(VerticesHandle handle) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawVertices> _registry =
     SkwasmFinalizationRegistry<RawVertices>(verticesDispose);
-
-  @override
-  final VerticesHandle handle;
-  bool _isDisposed = false;
-
-  @override
-  bool get debugDisposed => _isDisposed;
-
-  @override
-  void dispose() {
-    assert(!_isDisposed);
-    _registry.unregister(this);
-    verticesDispose(handle);
-    _isDisposed = true;
-  }
 }

--- a/lib/web_ui/skwasm/contour_measure.cpp
+++ b/lib/web_ui/skwasm/contour_measure.cpp
@@ -23,6 +23,10 @@ SKWASM_EXPORT SkContourMeasure* contourMeasureIter_next(
   return next.get();
 }
 
+SKWASM_EXPORT void contourMeasureIter_dispose(SkContourMeasureIter* iter) {
+  delete iter;
+}
+
 SKWASM_EXPORT void contourMeasure_dispose(SkContourMeasure* measure) {
   measure->unref();
 }

--- a/lib/web_ui/skwasm/paint.cpp
+++ b/lib/web_ui/skwasm/paint.cpp
@@ -20,7 +20,7 @@ SKWASM_EXPORT SkPaint* paint_create() {
   return paint;
 }
 
-SKWASM_EXPORT void paint_destroy(SkPaint* paint) {
+SKWASM_EXPORT void paint_dispose(SkPaint* paint) {
   delete paint;
 }
 

--- a/lib/web_ui/skwasm/path.cpp
+++ b/lib/web_ui/skwasm/path.cpp
@@ -13,7 +13,7 @@ SKWASM_EXPORT SkPath* path_create() {
   return new SkPath();
 }
 
-SKWASM_EXPORT void path_destroy(SkPath* path) {
+SKWASM_EXPORT void path_dispose(SkPath* path) {
   delete path;
 }
 

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1907,7 +1907,7 @@ void _paragraphTests() {
     // FinalizationRegistry because it depends on GC, which cannot be controlled,
     // So the test simply tests that a FinalizationRegistry can be constructed
     // and its `register` method can be called.
-    final SkObjectFinalizationRegistry registry = createSkObjectFinalizationRegistry((String arg) {}.toJS);
+    final DomFinalizationRegistry registry = DomFinalizationRegistry((String arg) {}.toJS);
     registry.register(Object(), Object());
   });
 }


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/127243.

This ensures that native skwasm objects are cleaned up when their associated dart-side objects are garbage collected.