### PR TITLE
[Impeller] Disable the wide gamut settings flag on iOS simulators

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -157,9 +157,15 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   settings.domain_network_policy = "";
 
   // Whether to enable wide gamut colors.
+#if TARGET_OS_SIMULATOR
+  // As of Xcode 14.1, the wide gamut surface pixel formats are not supported by
+  // the simulator.
+  settings.enable_wide_gamut = false;
+#else
   NSNumber* nsEnableWideGamut = [mainBundle objectForInfoDictionaryKey:@"FLTEnableWideGamut"];
   BOOL enableWideGamut = nsEnableWideGamut ? nsEnableWideGamut.boolValue : YES;
   settings.enable_wide_gamut = enableWideGamut;
+#endif
 
   // TODO(dnfield): We should reverse the order for all these settings so that command line options
   // are preferred to plist settings. https://github.com/flutter/flutter/issues/124049

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -44,12 +44,6 @@
 }
 
 - (BOOL)isWideGamutSupported {
-#if TARGET_OS_SIMULATOR
-  // As of Xcode 14.1, the wide gamut surface pixel formats are not supported by
-  // the simulator.
-  return NO;
-#endif
-
   if (![_delegate isUsingImpeller]) {
     return NO;
   }
@@ -74,7 +68,7 @@
   if (self) {
     _delegate = delegate;
     _isWideGamutEnabled = isWideGamutEnabled;
-    if (_isWideGamutEnabled && self.isWideGamutSupported) {
+    if (_isWideGamutEnabled && !self.isWideGamutSupported) {
       FML_DLOG(WARNING) << "Rendering wide gamut colors is turned on but isn't "
                            "supported, downgrading the color gamut to sRGB.";
     }


### PR DESCRIPTION
Wide gamut is not supported on the iOS simulator, and the iOS platform's FlutterView.isWideGamutSupported checked for this.  However, the ImageDecoder decides whether to enable wide gamut based on the engine's settings, so the flag in the settings needs to be modified for the simulator.
