### PR TITLE
Use ShellTest::Config struct to create Shell

### DIFF
--- a/shell/common/input_events_unittests.cc
+++ b/shell/common/input_events_unittests.cc
@@ -54,7 +54,10 @@ static void TestSimulatedInputEvents(
     bool restart_engine = false) {
   ///// Begin constructing shell ///////////////////////////////////////////////
   auto settings = fixture->CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = fixture->CreateShell(settings, true);
+  std::unique_ptr<Shell> shell = fixture->CreateShell({
+      .settings = settings,
+      .simulate_vsync = true,
+  });
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("onPointerDataPacketMain");
@@ -300,7 +303,10 @@ TEST_F(ShellTest, HandlesActualIphoneXsInputEvents) {
 TEST_F(ShellTest, CanCorrectlyPipePointerPacket) {
   // Sets up shell with test fixture.
   auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings, true);
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .simulate_vsync = true,
+  });
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("onPointerDataPacketMain");
@@ -361,7 +367,10 @@ TEST_F(ShellTest, CanCorrectlyPipePointerPacket) {
 TEST_F(ShellTest, CanCorrectlySynthesizePointerPacket) {
   // Sets up shell with test fixture.
   auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings, true);
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .simulate_vsync = true,
+  });
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("onPointerDataPacketMain");

--- a/shell/common/input_events_unittests.cc
+++ b/shell/common/input_events_unittests.cc
@@ -56,7 +56,9 @@ static void TestSimulatedInputEvents(
   auto settings = fixture->CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = fixture->CreateShell({
       .settings = settings,
-      .simulate_vsync = true,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .simulate_vsync = true,
+      }),
   });
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -305,7 +307,9 @@ TEST_F(ShellTest, CanCorrectlyPipePointerPacket) {
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
-      .simulate_vsync = true,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .simulate_vsync = true,
+      }),
   });
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -369,7 +373,9 @@ TEST_F(ShellTest, CanCorrectlySynthesizePointerPacket) {
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
-      .simulate_vsync = true,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .simulate_vsync = true,
+      }),
   });
 
   auto configuration = RunConfiguration::InferFromSettings(settings);

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -325,7 +325,7 @@ std::unique_ptr<Shell> ShellTest::CreateShell(
     std::optional<TaskRunners> task_runners) {
   return CreateShell({
       .settings = settings,
-      .task_runners = task_runners,
+      .task_runners = std::move(task_runners),
   });
 }
 

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -320,24 +320,23 @@ fml::TimePoint ShellTest::GetLatestFrameTargetTime(Shell* shell) const {
   return shell->GetLatestFrameTargetTime();
 }
 
-std::unique_ptr<Shell> ShellTest::CreateShell(const Settings& settings,
-                                              bool simulate_vsync) {
-  return CreateShell(settings, GetTaskRunnersForFixture(), simulate_vsync);
-}
-
 std::unique_ptr<Shell> ShellTest::CreateShell(
     const Settings& settings,
-    TaskRunners task_runners,
-    bool simulate_vsync,
-    const std::shared_ptr<ShellTestExternalViewEmbedder>&
-        shell_test_external_view_embedder,
-    bool is_gpu_disabled,
-    ShellTestPlatformView::BackendType rendering_backend,
-    Shell::CreateCallback<PlatformView> platform_view_create_callback) {
+    std::optional<TaskRunners> task_runners) {
+  return CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+  });
+}
+
+std::unique_ptr<Shell> ShellTest::CreateShell(const Config& config) {
   const auto vsync_clock = std::make_shared<ShellTestVsyncClock>();
 
+  TaskRunners task_runners = config.task_runners.has_value()
+                                 ? config.task_runners.value()
+                                 : GetTaskRunnersForFixture();
   CreateVsyncWaiter create_vsync_waiter = [&]() {
-    if (simulate_vsync) {
+    if (config.simulate_vsync) {
       return static_cast<std::unique_ptr<VsyncWaiter>>(
           std::make_unique<ShellTestVsyncWaiter>(task_runners, vsync_clock));
     } else {
@@ -346,23 +345,27 @@ std::unique_ptr<Shell> ShellTest::CreateShell(
     }
   };
 
+  Shell::CreateCallback<PlatformView> platform_view_create_callback =
+      std::move(config.platform_view_create_callback);
   if (!platform_view_create_callback) {
-    platform_view_create_callback = [vsync_clock,                        //
-                                     &create_vsync_waiter,               //
-                                     shell_test_external_view_embedder,  //
-                                     rendering_backend                   //
+    platform_view_create_callback =
+        [vsync_clock,           //
+         &create_vsync_waiter,  //
+         shell_test_external_view_embedder =
+             config.shell_test_external_view_embedder,  //
+         rendering_backend = config.rendering_backend   //
     ](Shell& shell) {
-      return ShellTestPlatformView::Create(
-          shell,                                  //
-          shell.GetTaskRunners(),                 //
-          vsync_clock,                            //
-          create_vsync_waiter,                    //
-          rendering_backend,                      //
-          shell_test_external_view_embedder,      //
-          shell.GetConcurrentWorkerTaskRunner(),  //
-          shell.GetIsGpuDisabledSyncSwitch()      //
-      );
-    };
+          return ShellTestPlatformView::Create(
+              shell,                                  //
+              shell.GetTaskRunners(),                 //
+              vsync_clock,                            //
+              create_vsync_waiter,                    //
+              rendering_backend,                      //
+              shell_test_external_view_embedder,      //
+              shell.GetConcurrentWorkerTaskRunner(),  //
+              shell.GetIsGpuDisabledSyncSwitch()      //
+          );
+        };
   }
 
   Shell::CreateCallback<Rasterizer> rasterizer_create_callback =
@@ -370,10 +373,10 @@ std::unique_ptr<Shell> ShellTest::CreateShell(
 
   return Shell::Create(flutter::PlatformData(),        //
                        task_runners,                   //
-                       settings,                       //
+                       config.settings,                //
                        platform_view_create_callback,  //
                        rasterizer_create_callback,     //
-                       is_gpu_disabled                 //
+                       config.is_gpu_disabled          //
   );
 }
 

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -334,7 +334,7 @@ std::unique_ptr<Shell> ShellTest::CreateShell(const Config& config) {
                                  ? config.task_runners.value()
                                  : GetTaskRunnersForFixture();
   Shell::CreateCallback<PlatformView> platform_view_create_callback =
-      std::move(config.platform_view_create_callback);
+      config.platform_view_create_callback;
   if (!platform_view_create_callback) {
     platform_view_create_callback = ShellTestPlatformViewBuilder({});
   }

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -31,22 +31,29 @@ namespace testing {
 
 class ShellTest : public FixtureTest {
  public:
+  struct Config {
+    // Required.
+    const Settings& settings;
+    // Defaults to GetTaskRunnersForFixture().
+    std::optional<TaskRunners> task_runners = {};
+    bool simulate_vsync = false;
+    std::shared_ptr<ShellTestExternalViewEmbedder>
+        shell_test_external_view_embedder = nullptr;
+    bool is_gpu_disabled = false;
+    ShellTestPlatformView::BackendType rendering_backend =
+        ShellTestPlatformView::BackendType::kDefaultBackend;
+    // Defaults to calling ShellTestPlatformView::Create with the provided
+    // arguments.
+    Shell::CreateCallback<PlatformView> platform_view_create_callback;
+  };
+
   ShellTest();
 
   Settings CreateSettingsForFixture() override;
-  std::unique_ptr<Shell> CreateShell(const Settings& settings,
-                                     bool simulate_vsync = false);
   std::unique_ptr<Shell> CreateShell(
       const Settings& settings,
-      TaskRunners task_runners,
-      bool simulate_vsync = false,
-      const std::shared_ptr<ShellTestExternalViewEmbedder>&
-          shell_test_external_view_embedder = nullptr,
-      bool is_gpu_disabled = false,
-      ShellTestPlatformView::BackendType rendering_backend =
-          ShellTestPlatformView::BackendType::kDefaultBackend,
-      Shell::CreateCallback<PlatformView> platform_view_create_callback =
-          nullptr);
+      std::optional<TaskRunners> task_runners = {});
+  std::unique_ptr<Shell> CreateShell(const Config& config);
   void DestroyShell(std::unique_ptr<Shell> shell);
   void DestroyShell(std::unique_ptr<Shell> shell,
                     const TaskRunners& task_runners);

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -36,12 +36,7 @@ class ShellTest : public FixtureTest {
     const Settings& settings;
     // Defaults to GetTaskRunnersForFixture().
     std::optional<TaskRunners> task_runners = {};
-    bool simulate_vsync = false;
-    std::shared_ptr<ShellTestExternalViewEmbedder>
-        shell_test_external_view_embedder = nullptr;
     bool is_gpu_disabled = false;
-    ShellTestPlatformView::BackendType rendering_backend =
-        ShellTestPlatformView::BackendType::kDefaultBackend;
     // Defaults to calling ShellTestPlatformView::Create with the provided
     // arguments.
     Shell::CreateCallback<PlatformView> platform_view_create_callback;

--- a/shell/common/shell_test_platform_view.cc
+++ b/shell/common/shell_test_platform_view.cc
@@ -66,8 +66,10 @@ std::unique_ptr<PlatformView> ShellTestPlatformViewBuilder::operator()(
     Shell& shell) {
   const TaskRunners& task_runners = shell.GetTaskRunners();
   const auto vsync_clock = std::make_shared<ShellTestVsyncClock>();
-  CreateVsyncWaiter create_vsync_waiter = [&]() {
-    if (config_.simulate_vsync) {
+  CreateVsyncWaiter create_vsync_waiter = [&task_runners, vsync_clock,
+                                           simulate_vsync =
+                                               config_.simulate_vsync]() {
+    if (simulate_vsync) {
       return static_cast<std::unique_ptr<VsyncWaiter>>(
           std::make_unique<ShellTestVsyncWaiter>(task_runners, vsync_clock));
     } else {

--- a/shell/common/shell_test_platform_view.cc
+++ b/shell/common/shell_test_platform_view.cc
@@ -60,7 +60,7 @@ std::unique_ptr<ShellTestPlatformView> ShellTestPlatformView::Create(
 }
 
 ShellTestPlatformViewBuilder::ShellTestPlatformViewBuilder(Config config)
-    : config_(config) {}
+    : config_(std::move(config)) {}
 
 std::unique_ptr<PlatformView> ShellTestPlatformViewBuilder::operator()(
     Shell& shell) {

--- a/shell/common/shell_test_platform_view.h
+++ b/shell/common/shell_test_platform_view.h
@@ -43,6 +43,24 @@ class ShellTestPlatformView : public PlatformView {
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTestPlatformView);
 };
 
+class ShellTestPlatformViewBuilder {
+ public:
+  struct Config {
+    bool simulate_vsync = false;
+    std::shared_ptr<ShellTestExternalViewEmbedder>
+        shell_test_external_view_embedder = nullptr;
+    ShellTestPlatformView::BackendType rendering_backend =
+        ShellTestPlatformView::BackendType::kDefaultBackend;
+  };
+
+  ShellTestPlatformViewBuilder(Config config);
+  ~ShellTestPlatformViewBuilder() = default;
+  std::unique_ptr<PlatformView> operator()(Shell& shell);
+
+ private:
+  Config config_;
+};
+
 }  // namespace testing
 }  // namespace flutter
 

--- a/shell/common/shell_test_platform_view.h
+++ b/shell/common/shell_test_platform_view.h
@@ -43,6 +43,7 @@ class ShellTestPlatformView : public PlatformView {
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTestPlatformView);
 };
 
+// Create a ShellTestPlatformView from configuration struct.
 class ShellTestPlatformViewBuilder {
  public:
   struct Config {
@@ -55,6 +56,8 @@ class ShellTestPlatformViewBuilder {
 
   ShellTestPlatformViewBuilder(Config config);
   ~ShellTestPlatformViewBuilder() = default;
+
+  // Override operator () to make this class assignable to std::function.
   std::unique_ptr<PlatformView> operator()(Shell& shell);
 
  private:

--- a/shell/common/shell_test_platform_view.h
+++ b/shell/common/shell_test_platform_view.h
@@ -15,10 +15,10 @@ namespace testing {
 class ShellTestPlatformView : public PlatformView {
  public:
   enum class BackendType {
+    kDefaultBackend = 0,
     kGLBackend,
     kVulkanBackend,
     kMetalBackend,
-    kDefaultBackend,
   };
 
   static std::unique_ptr<ShellTestPlatformView> Create(

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -811,7 +811,9 @@ TEST_F(ShellTest, ExternalEmbedderNoThreadMerger) {
       end_frame_callback, PostPrerollResult::kResubmitFrame, false);
   auto shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -870,7 +872,9 @@ TEST_F(ShellTest, PushBackdropFilterToVisitedPlatformViews) {
       end_frame_callback, PostPrerollResult::kResubmitFrame, false);
   auto shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -941,7 +945,9 @@ TEST_F(ShellTest,
       end_frame_callback, PostPrerollResult::kResubmitFrame, true);
   auto shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -984,7 +990,9 @@ TEST_F(ShellTest, OnPlatformViewDestroyDisablesThreadMerger) {
 
   auto shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -1048,7 +1056,9 @@ TEST_F(ShellTest, OnPlatformViewDestroyAfterMergingThreads) {
       PostPrerollResult::kResubmitFrame);
   auto shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -1114,7 +1124,9 @@ TEST_F(ShellTest, OnPlatformViewDestroyWhenThreadsAreMerging) {
 
   auto shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -1179,7 +1191,9 @@ TEST_F(ShellTest,
       end_frame_callback, PostPrerollResult::kSuccess, true);
   auto shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -1281,7 +1295,9 @@ TEST_F(ShellTest, OnPlatformViewDestroyWithStaticThreadMerging) {
   auto shell = CreateShell({
       .settings = settings,
       .task_runners = task_runners,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -1324,7 +1340,9 @@ TEST_F(ShellTest, GetUsedThisFrameShouldBeSetBeforeEndFrame) {
       end_frame_callback, PostPrerollResult::kSuccess, true);
   auto shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -1377,7 +1395,9 @@ TEST_F(ShellTest, DISABLED_SkipAndSubmitFrame) {
 
   auto shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   PlatformViewNotifyCreated(shell.get());
@@ -2651,7 +2671,9 @@ TEST_F(ShellTest, DISABLED_DiscardLayerTreeOnResize) {
       std::move(end_frame_callback), PostPrerollResult::kSuccess, false);
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -2726,7 +2748,9 @@ TEST_F(ShellTest, DISABLED_DiscardResubmittedLayerTreeOnResize) {
 
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
-      .shell_test_external_view_embedder = external_view_embedder,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .shell_test_external_view_embedder = external_view_embedder,
+      }),
   });
 
   // Create the surface needed by rasterizer
@@ -3582,7 +3606,9 @@ TEST_F(ShellTest, CanCreateShellsWithGLBackend) {
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
-      .rendering_backend = ShellTestPlatformView::BackendType::kGLBackend,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .rendering_backend = ShellTestPlatformView::BackendType::kGLBackend,
+      }),
   });
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
@@ -3602,7 +3628,10 @@ TEST_F(ShellTest, CanCreateShellsWithVulkanBackend) {
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
-      .rendering_backend = ShellTestPlatformView::BackendType::kVulkanBackend,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .rendering_backend =
+              ShellTestPlatformView::BackendType::kVulkanBackend,
+      }),
   });
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
@@ -3622,7 +3651,10 @@ TEST_F(ShellTest, CanCreateShellsWithMetalBackend) {
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
-      .rendering_backend = ShellTestPlatformView::BackendType::kMetalBackend,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .rendering_backend =
+              ShellTestPlatformView::BackendType::kMetalBackend,
+      }),
   });
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
@@ -3919,7 +3951,9 @@ TEST_F(ShellTest, PictureToImageSync) {
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
-      .rendering_backend = ShellTestPlatformView::BackendType::kGLBackend,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .rendering_backend = ShellTestPlatformView::BackendType::kGLBackend,
+      }),
   });
 
   AddNativeCallback("NativeOnBeforeToImageSync",
@@ -3958,7 +3992,10 @@ TEST_F(ShellTest, PictureToImageSyncImpellerNoSurface) {
   settings.enable_impeller = true;
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
-      .rendering_backend = ShellTestPlatformView::BackendType::kMetalBackend,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .rendering_backend =
+              ShellTestPlatformView::BackendType::kMetalBackend,
+      }),
   });
 
   AddNativeCallback("NativeOnBeforeToImageSync",
@@ -4007,7 +4044,9 @@ TEST_F(ShellTest, PictureToImageSyncWithTrampledContext) {
   std::unique_ptr<Shell> shell = CreateShell({
       .settings = settings,
       .task_runners = task_runners,
-      .rendering_backend = ShellTestPlatformView::BackendType::kGLBackend,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .rendering_backend = ShellTestPlatformView::BackendType::kGLBackend,
+      }),
   });
 
   AddNativeCallback(

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -430,9 +430,11 @@ TEST_F(ShellTest, InitializeWithDisabledGpu) {
   auto task_runner = thread_host.platform_thread->GetTaskRunner();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
-  auto shell = CreateShell(settings, task_runners, /*simulate_vsync=*/false,
-                           /*shell_test_external_view_embedder=*/nullptr,
-                           /*is_gpu_disabled=*/true);
+  auto shell = CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+      .is_gpu_disabled = true,
+  });
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   ASSERT_TRUE(ValidateShell(shell.get()));
 
@@ -807,8 +809,10 @@ TEST_F(ShellTest, ExternalEmbedderNoThreadMerger) {
       };
   auto external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       end_frame_callback, PostPrerollResult::kResubmitFrame, false);
-  auto shell = CreateShell(settings, GetTaskRunnersForFixture(), false,
-                           external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -864,8 +868,10 @@ TEST_F(ShellTest, PushBackdropFilterToVisitedPlatformViews) {
 
   external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       end_frame_callback, PostPrerollResult::kResubmitFrame, false);
-  auto shell = CreateShell(settings, GetTaskRunnersForFixture(), false,
-                           external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -933,8 +939,10 @@ TEST_F(ShellTest,
       };
   auto external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       end_frame_callback, PostPrerollResult::kResubmitFrame, true);
-  auto shell = CreateShell(settings, GetTaskRunnersForFixture(), false,
-                           external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -974,8 +982,10 @@ TEST_F(ShellTest, OnPlatformViewDestroyDisablesThreadMerger) {
   auto external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       end_frame_callback, PostPrerollResult::kSuccess, true);
 
-  auto shell = CreateShell(settings, GetTaskRunnersForFixture(), false,
-                           external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -1036,8 +1046,10 @@ TEST_F(ShellTest, OnPlatformViewDestroyAfterMergingThreads) {
   // Set resubmit once to trigger thread merging.
   external_view_embedder->UpdatePostPrerollResult(
       PostPrerollResult::kResubmitFrame);
-  auto shell = CreateShell(settings, GetTaskRunnersForFixture(), false,
-                           external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -1100,8 +1112,10 @@ TEST_F(ShellTest, OnPlatformViewDestroyWhenThreadsAreMerging) {
   auto external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       end_frame_callback, PostPrerollResult::kSuccess, true);
 
-  auto shell = CreateShell(settings, GetTaskRunnersForFixture(), false,
-                           external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -1163,8 +1177,10 @@ TEST_F(ShellTest,
       };
   auto external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       end_frame_callback, PostPrerollResult::kSuccess, true);
-  auto shell = CreateShell(settings, GetTaskRunnersForFixture(), false,
-                           external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -1202,8 +1218,7 @@ TEST_F(ShellTest,
 TEST_F(ShellTest, OnPlatformViewDestroyWithoutRasterThreadMerger) {
   auto settings = CreateSettingsForFixture();
 
-  auto shell =
-      CreateShell(settings, GetTaskRunnersForFixture(), false, nullptr);
+  auto shell = CreateShell(settings);
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -1263,8 +1278,11 @@ TEST_F(ShellTest, OnPlatformViewDestroyWithStaticThreadMerging) {
       thread_host.ui_thread->GetTaskRunner(),        // ui
       thread_host.io_thread->GetTaskRunner()         // io
   );
-  auto shell =
-      CreateShell(settings, task_runners, false, external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -1304,8 +1322,10 @@ TEST_F(ShellTest, GetUsedThisFrameShouldBeSetBeforeEndFrame) {
       };
   external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       end_frame_callback, PostPrerollResult::kSuccess, true);
-  auto shell = CreateShell(settings, GetTaskRunnersForFixture(), false,
-                           external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -1355,8 +1375,10 @@ TEST_F(ShellTest, DISABLED_SkipAndSubmitFrame) {
   external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       end_frame_callback, PostPrerollResult::kSkipAndRetryFrame, true);
 
-  auto shell = CreateShell(settings, GetTaskRunnersForFixture(), false,
-                           external_view_embedder);
+  auto shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   PlatformViewNotifyCreated(shell.get());
 
@@ -1581,15 +1603,11 @@ TEST_F(ShellTest, MultipleFluttersSetResourceCacheBytes) {
         return result;
       };
 
-  auto shell = CreateShell(
-      /*settings=*/settings,
-      /*task_runners=*/task_runners,
-      /*simulate_vsync=*/false,
-      /*shell_test_external_view_embedder=*/nullptr,
-      /*is_gpu_disabled=*/false,
-      /*rendering_backend=*/
-      ShellTestPlatformView::BackendType::kDefaultBackend,
-      /*platform_view_create_callback=*/platform_view_create_callback);
+  auto shell = CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+      .platform_view_create_callback = platform_view_create_callback,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -2631,8 +2649,10 @@ TEST_F(ShellTest, DISABLED_DiscardLayerTreeOnResize) {
       };
   auto external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       std::move(end_frame_callback), PostPrerollResult::kSuccess, false);
-  std::unique_ptr<Shell> shell = CreateShell(
-      settings, GetTaskRunnersForFixture(), false, external_view_embedder);
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -2704,8 +2724,10 @@ TEST_F(ShellTest, DISABLED_DiscardResubmittedLayerTreeOnResize) {
   external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
       std::move(end_frame_callback), PostPrerollResult::kResubmitFrame, true);
 
-  std::unique_ptr<Shell> shell = CreateShell(
-      settings, GetTaskRunnersForFixture(), false, external_view_embedder);
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .shell_test_external_view_embedder = external_view_embedder,
+  });
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -3558,14 +3580,10 @@ TEST_F(ShellTest, CanCreateShellsWithGLBackend) {
   GTEST_SKIP();
 #endif  // !SHELL_ENABLE_GL
   auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell =
-      CreateShell(settings,                                       //
-                  GetTaskRunnersForFixture(),                     //
-                  false,                                          //
-                  nullptr,                                        //
-                  false,                                          //
-                  ShellTestPlatformView::BackendType::kGLBackend  //
-      );
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .rendering_backend = ShellTestPlatformView::BackendType::kGLBackend,
+  });
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -3582,14 +3600,10 @@ TEST_F(ShellTest, CanCreateShellsWithVulkanBackend) {
   GTEST_SKIP();
 #endif  // !SHELL_ENABLE_VULKAN
   auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell =
-      CreateShell(settings,                                           //
-                  GetTaskRunnersForFixture(),                         //
-                  false,                                              //
-                  nullptr,                                            //
-                  false,                                              //
-                  ShellTestPlatformView::BackendType::kVulkanBackend  //
-      );
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .rendering_backend = ShellTestPlatformView::BackendType::kVulkanBackend,
+  });
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -3606,14 +3620,10 @@ TEST_F(ShellTest, CanCreateShellsWithMetalBackend) {
   GTEST_SKIP();
 #endif  // !SHELL_ENABLE_METAL
   auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell =
-      CreateShell(settings,                                          //
-                  GetTaskRunnersForFixture(),                        //
-                  false,                                             //
-                  nullptr,                                           //
-                  false,                                             //
-                  ShellTestPlatformView::BackendType::kMetalBackend  //
-      );
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .rendering_backend = ShellTestPlatformView::BackendType::kMetalBackend,
+  });
   ASSERT_NE(shell, nullptr);
   ASSERT_TRUE(shell->IsSetup());
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -3777,15 +3787,11 @@ TEST_F(ShellTest, UsesPlatformMessageHandler) {
             .WillOnce(Return(platform_message_handler));
         return result;
       };
-  auto shell = CreateShell(
-      /*settings=*/settings,
-      /*task_runners=*/task_runners,
-      /*simulate_vsync=*/false,
-      /*shell_test_external_view_embedder=*/nullptr,
-      /*is_gpu_disabled=*/false,
-      /*rendering_backend=*/
-      ShellTestPlatformView::BackendType::kDefaultBackend,
-      /*platform_view_create_callback=*/platform_view_create_callback);
+  auto shell = CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+      .platform_view_create_callback = platform_view_create_callback,
+  });
 
   EXPECT_EQ(platform_message_handler, shell->GetPlatformMessageHandler());
   PostSync(task_runners.GetUITaskRunner(), [&shell]() {
@@ -3911,14 +3917,10 @@ TEST_F(ShellTest, PictureToImageSync) {
   GTEST_SKIP();
 #endif  // !SHELL_ENABLE_GL
   auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell =
-      CreateShell(settings,                                       //
-                  GetTaskRunnersForFixture(),                     //
-                  false,                                          //
-                  nullptr,                                        //
-                  false,                                          //
-                  ShellTestPlatformView::BackendType::kGLBackend  //
-      );
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .rendering_backend = ShellTestPlatformView::BackendType::kGLBackend,
+  });
 
   AddNativeCallback("NativeOnBeforeToImageSync",
                     CREATE_NATIVE_ENTRY([&](auto args) {
@@ -3954,14 +3956,10 @@ TEST_F(ShellTest, PictureToImageSyncImpellerNoSurface) {
 #endif  // !SHELL_ENABLE_METAL
   auto settings = CreateSettingsForFixture();
   settings.enable_impeller = true;
-  std::unique_ptr<Shell> shell =
-      CreateShell(settings,                                          //
-                  GetTaskRunnersForFixture(),                        //
-                  false,                                             //
-                  nullptr,                                           //
-                  false,                                             //
-                  ShellTestPlatformView::BackendType::kMetalBackend  //
-      );
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .rendering_backend = ShellTestPlatformView::BackendType::kMetalBackend,
+  });
 
   AddNativeCallback("NativeOnBeforeToImageSync",
                     CREATE_NATIVE_ENTRY([&](auto args) {
@@ -4006,14 +4004,11 @@ TEST_F(ShellTest, PictureToImageSyncWithTrampledContext) {
                            task_runner);
 
   auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell =
-      CreateShell(settings,                                       //
-                  task_runners,                                   //
-                  false,                                          //
-                  nullptr,                                        //
-                  false,                                          //
-                  ShellTestPlatformView::BackendType::kGLBackend  //
-      );
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+      .rendering_backend = ShellTestPlatformView::BackendType::kGLBackend,
+  });
 
   AddNativeCallback(
       "NativeOnBeforeToImageSync", CREATE_NATIVE_ENTRY([&](auto args) {
@@ -4048,8 +4043,7 @@ TEST_F(ShellTest, PictureToImageSyncWithTrampledContext) {
 
 TEST_F(ShellTest, PluginUtilitiesCallbackHandleErrorHandling) {
   auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell =
-      CreateShell(settings, GetTaskRunnersForFixture());
+  std::unique_ptr<Shell> shell = CreateShell(settings);
 
   fml::AutoResetWaitableEvent latch;
   bool test_passed;

--- a/shell/platform/darwin/ios/platform_message_handler_ios_test.mm
+++ b/shell/platform/darwin/ios/platform_message_handler_ios_test.mm
@@ -44,8 +44,8 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
 
 @implementation PlatformMessageHandlerIosTest
 - (void)testCreate {
-  flutter::TaskRunners task_runners("test", GetCurrentTaskRunner(), CreateNewThread("raster"),
-                                    CreateNewThread("ui"), CreateNewThread("io"));
+  TaskRunners task_runners("test", GetCurrentTaskRunner(), CreateNewThread("raster"),
+                           CreateNewThread("ui"), CreateNewThread("io"));
   auto handler = std::make_unique<PlatformMessageHandlerIos>(task_runners.GetPlatformTaskRunner());
   XCTAssertTrue(handler);
 }


### PR DESCRIPTION
This PR refactors `ShellTest::CreateShell` so that instead of taking a list of optional parameters, it takes a `Config` struct, almost all fields of which have default values. This makes calling this method cleaner, and makes it easier to add more parameters. A short version is also kept that takes `settings` and `task_runners`, since this version is used so often.

Currently `ShellTest::CreateShell`'s full version has 2 mandatory parameters and 5 optional parameters. Many calls to this method have to list a long list of default parameters before going to the single one that needs overwriting, and adding new parameters to this call is even more tedious.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
