### PR TITLE
[Impeller] Switch back to shared buffer UI image uploading on iOS

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -452,13 +452,8 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
           // texture is implemented on other platforms.
           sk_sp<DlImage> image;
           std::string decode_error;
-#ifdef FML_OS_IOS
-          std::tie(image, decode_error) = UploadTextureToPrivate(
-              context, bitmap_result.device_buffer, bitmap_result.image_info);
-#else
           std::tie(image, decode_error) =
               UploadTextureToShared(context, bitmap_result.sk_bitmap);
-#endif
           result(image, decode_error);
         };
         // TODO(jonahwilliams): https://github.com/flutter/flutter/issues/123058


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/126878.

This is just a soft revert of the new blit upload path that was added in https://github.com/flutter/engine/pull/40410.

Switches back to uploading via `SetContents`. The blit pass that generates the mipmaps still fails if the app is backgrounded, but not writing all the mip levels is safe for Metal and Vulkan -- GLES is the problem child.

The downside of course is that we lose lossy compression for the time being (supported on Family 8/A15/iPhone 13 and above). Perhaps we can come back around to this and add, say, a command buffer queue that defers execution until apps are foregrounded.