### PR TITLE
[Impeller] Avoid encoding metal commands while the GPU is unavailable when decoding images.

### DIFF
--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -385,10 +385,13 @@ static bool Bind(PassBindingsCache& pass,
   }
 
   if (texture.NeedsMipmapGeneration()) {
+    // TODO(127697): generate mips when the GPU is available on iOS.
+#if !FML_OS_IOS
     VALIDATION_LOG
         << "Texture at binding index " << bind_index
         << " has a mip count > 1, but the mipmap has not been generated.";
     return false;
+#endif  // !FML_OS_IOS
   }
 
   return pass.SetTexture(stage, bind_index,

--- a/lib/ui/painting/image_decoder.cc
+++ b/lib/ui/painting/image_decoder.cc
@@ -16,14 +16,16 @@ std::unique_ptr<ImageDecoder> ImageDecoder::Make(
     const Settings& settings,
     const TaskRunners& runners,
     std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
-    fml::WeakPtr<IOManager> io_manager) {
+    fml::WeakPtr<IOManager> io_manager,
+    const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch) {
 #if IMPELLER_SUPPORTS_RENDERING
   if (settings.enable_impeller) {
     return std::make_unique<ImageDecoderImpeller>(
         runners,                            //
         std::move(concurrent_task_runner),  //
         std::move(io_manager),              //
-        settings.enable_wide_gamut);
+        settings.enable_wide_gamut,         //
+        gpu_disabled_switch);
   }
 #endif  // IMPELLER_SUPPORTS_RENDERING
   return std::make_unique<ImageDecoderSkia>(

--- a/lib/ui/painting/image_decoder.h
+++ b/lib/ui/painting/image_decoder.h
@@ -27,7 +27,8 @@ class ImageDecoder {
       const Settings& settings,
       const TaskRunners& runners,
       std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
-      fml::WeakPtr<IOManager> io_manager);
+      fml::WeakPtr<IOManager> io_manager,
+      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch = nullptr);
 
   virtual ~ImageDecoder();
 

--- a/lib/ui/painting/image_decoder.h
+++ b/lib/ui/painting/image_decoder.h
@@ -28,7 +28,7 @@ class ImageDecoder {
       const TaskRunners& runners,
       std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
       fml::WeakPtr<IOManager> io_manager,
-      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch = nullptr);
+      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
 
   virtual ~ImageDecoder();
 

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -492,7 +492,7 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
               bitmap_result.sk_bitmap, gpu_disabled_switch);
 #else
           std::tie(image, decode_error) = UploadTextureToShared(
-              context, bitmap_result.sk_bitmap, gpu_disabled_switch, true);
+              context, bitmap_result.sk_bitmap, gpu_disabled_switch, /*create_mips=*/true);
 #endif  // FML_OS_IOS
           result(image, decode_error);
         };

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -337,7 +337,7 @@ ImageDecoderImpeller::UploadTextureToPrivate(
           .SetIfTrue([&result, context, bitmap, gpu_disabled_switch] {
             // create_mips is false because we already know the GPU is disabled.
             result = UploadTextureToShared(context, bitmap, gpu_disabled_switch,
-                                           false);
+                                           /*create_mips=*/false);
           }));
   return result;
 }

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -491,8 +491,9 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
               context, bitmap_result.device_buffer, bitmap_result.image_info,
               bitmap_result.sk_bitmap, gpu_disabled_switch);
 #else
-          std::tie(image, decode_error) = UploadTextureToShared(
-              context, bitmap_result.sk_bitmap, gpu_disabled_switch, /*create_mips=*/true);
+          std::tie(image, decode_error) =
+              UploadTextureToShared(context, bitmap_result.sk_bitmap,
+                                    gpu_disabled_switch, /*create_mips=*/true);
 #endif  // FML_OS_IOS
           result(image, decode_error);
         };

--- a/lib/ui/painting/image_decoder_impeller.h
+++ b/lib/ui/painting/image_decoder_impeller.h
@@ -50,7 +50,8 @@ class ImageDecoderImpeller final : public ImageDecoder {
       const TaskRunners& runners,
       std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
       const fml::WeakPtr<IOManager>& io_manager,
-      bool supports_wide_gamut);
+      bool supports_wide_gamut,
+      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
 
   ~ImageDecoderImpeller() override;
 
@@ -83,16 +84,20 @@ class ImageDecoderImpeller final : public ImageDecoder {
   /// @param bitmap      A bitmap containg the image to be uploaded.
   /// @param create_mips Whether mipmaps should be generated for the given
   /// image.
+  /// @param gpu_disabled_switch Whether the GPU is available for mipmap
+  /// creation.
   /// @return            A DlImage.
   static std::pair<sk_sp<DlImage>, std::string> UploadTextureToShared(
       const std::shared_ptr<impeller::Context>& context,
       std::shared_ptr<SkBitmap> bitmap,
-      bool create_mips = true);
+      bool create_mips = true,
+      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch = nullptr);
 
  private:
   using FutureContext = std::shared_future<std::shared_ptr<impeller::Context>>;
   FutureContext context_;
   const bool supports_wide_gamut_;
+  std::shared_ptr<fml::SyncSwitch> gpu_disabled_switch_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ImageDecoderImpeller);
 };

--- a/lib/ui/painting/image_decoder_impeller.h
+++ b/lib/ui/painting/image_decoder_impeller.h
@@ -73,11 +73,15 @@ class ImageDecoderImpeller final : public ImageDecoder {
   /// @param context    The Impeller graphics context.
   /// @param buffer     A host buffer containing the image to be uploaded.
   /// @param image_info Format information about the particular image.
+  /// @param bitmap      A bitmap containg the image to be uploaded.
+  /// @param gpu_disabled_switch Whether the GPU is available command encoding.
   /// @return           A DlImage.
   static std::pair<sk_sp<DlImage>, std::string> UploadTextureToPrivate(
       const std::shared_ptr<impeller::Context>& context,
       const std::shared_ptr<impeller::DeviceBuffer>& buffer,
-      const SkImageInfo& image_info);
+      const SkImageInfo& image_info,
+      std::shared_ptr<SkBitmap> bitmap,
+      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
 
   /// @brief Create a host visible texture from the provided bitmap.
   /// @param context     The Impeller graphics context.
@@ -90,8 +94,8 @@ class ImageDecoderImpeller final : public ImageDecoder {
   static std::pair<sk_sp<DlImage>, std::string> UploadTextureToShared(
       const std::shared_ptr<impeller::Context>& context,
       std::shared_ptr<SkBitmap> bitmap,
-      bool create_mips = true,
-      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch = nullptr);
+      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch,
+      bool create_mips = true);
 
  private:
   using FutureContext = std::shared_future<std::shared_ptr<impeller::Context>>;

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -280,7 +280,8 @@ TEST_F(ImageDecoderFixtureTest, CanCreateImageDecoder) {
     TestIOManager manager(runners.GetIOTaskRunner());
     Settings settings;
     auto decoder = ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
-                                      manager.GetWeakIOManager());
+                                      manager.GetWeakIOManager(),
+                                      std::make_shared<fml::SyncSwitch>());
     ASSERT_NE(decoder, nullptr);
   });
 }
@@ -331,7 +332,8 @@ TEST_F(ImageDecoderFixtureTest, InvalidImageResultsError) {
     TestIOManager manager(runners.GetIOTaskRunner());
     Settings settings;
     auto decoder = ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
-                                      manager.GetWeakIOManager());
+                                      manager.GetWeakIOManager(),
+                                      std::make_shared<fml::SyncSwitch>());
 
     auto data = OpenFixtureAsSkData("ThisDoesNotExist.jpg");
     ASSERT_FALSE(data);
@@ -370,9 +372,9 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
   };
   auto decode_image = [&]() {
     Settings settings;
-    std::unique_ptr<ImageDecoder> image_decoder =
-        ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
-                           io_manager->GetWeakIOManager());
+    std::unique_ptr<ImageDecoder> image_decoder = ImageDecoder::Make(
+        settings, runners, loop->GetTaskRunner(),
+        io_manager->GetWeakIOManager(), std::make_shared<fml::SyncSwitch>());
 
     auto data = OpenFixtureAsSkData("DashInNooglerHat.jpg");
 
@@ -642,9 +644,9 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
   SkISize decoded_size = SkISize::MakeEmpty();
   auto decode_image = [&]() {
     Settings settings;
-    std::unique_ptr<ImageDecoder> image_decoder =
-        ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
-                           io_manager->GetWeakIOManager());
+    std::unique_ptr<ImageDecoder> image_decoder = ImageDecoder::Make(
+        settings, runners, loop->GetTaskRunner(),
+        io_manager->GetWeakIOManager(), std::make_shared<fml::SyncSwitch>());
 
     auto data = OpenFixtureAsSkData("Horizontal.jpg");
 
@@ -703,9 +705,9 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
 
   auto decode_image = [&]() {
     Settings settings;
-    std::unique_ptr<ImageDecoder> image_decoder =
-        ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
-                           io_manager->GetWeakIOManager());
+    std::unique_ptr<ImageDecoder> image_decoder = ImageDecoder::Make(
+        settings, runners, loop->GetTaskRunner(),
+        io_manager->GetWeakIOManager(), std::make_shared<fml::SyncSwitch>());
 
     auto data = OpenFixtureAsSkData("DashInNooglerHat.jpg");
 
@@ -771,7 +773,8 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   PostTaskSync(runners.GetUITaskRunner(), [&]() {
     Settings settings;
     image_decoder = ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
-                                       io_manager->GetWeakIOManager());
+                                       io_manager->GetWeakIOManager(),
+                                       std::make_shared<fml::SyncSwitch>());
   });
 
   // Setup a generic decoding utility that gives us the final decoded size.

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -159,6 +159,7 @@ MultiFrameCodec::State::GetNextFrameImage(
     // without mipmap creation there is no command buffer encoding done.
     return ImageDecoderImpeller::UploadTextureToShared(
         impeller_context, std::make_shared<SkBitmap>(bitmap),
+        std::make_shared<fml::SyncSwitch>(),
         /*create_mips=*/false);
   }
 #endif  // IMPELLER_SUPPORTS_RENDERING

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -309,7 +309,8 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
          std::unique_ptr<Animator> animator,
          fml::WeakPtr<IOManager> io_manager,
          const std::shared_ptr<FontCollection>& font_collection,
-         std::unique_ptr<RuntimeController> runtime_controller);
+         std::unique_ptr<RuntimeController> runtime_controller,
+         const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
 
   //----------------------------------------------------------------------------
   /// @brief      Creates an instance of the engine. This is done by the Shell
@@ -364,7 +365,8 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
          fml::WeakPtr<IOManager> io_manager,
          fml::RefPtr<SkiaUnrefQueue> unref_queue,
          fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
-         std::shared_ptr<VolatilePathTracker> volatile_path_tracker);
+         std::shared_ptr<VolatilePathTracker> volatile_path_tracker,
+         const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
 
   //----------------------------------------------------------------------------
   /// @brief      Create a Engine that shares as many resources as
@@ -382,7 +384,8 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
       std::unique_ptr<Animator> animator,
       const std::string& initial_route,
       const fml::WeakPtr<IOManager>& io_manager,
-      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate) const;
+      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
+      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch) const;
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys the engine engine. Called by the shell on the UI task

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -163,7 +163,7 @@ TEST_F(EngineTest, Create) {
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(runtime_controller_),
-        /*gpu_disabled_switch=*/nullptr);
+        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
     EXPECT_TRUE(engine);
   });
 }
@@ -185,7 +185,7 @@ TEST_F(EngineTest, DispatchPlatformMessageUnknown) {
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/nullptr);
+        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
@@ -212,7 +212,7 @@ TEST_F(EngineTest, DispatchPlatformMessageInitialRoute) {
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/nullptr);
+        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
@@ -246,7 +246,7 @@ TEST_F(EngineTest, DispatchPlatformMessageInitialRouteIgnored) {
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/nullptr);
+        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
@@ -279,7 +279,7 @@ TEST_F(EngineTest, SpawnSharesFontLibrary) {
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/nullptr);
+        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
 
     auto spawn =
         engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
@@ -307,7 +307,7 @@ TEST_F(EngineTest, SpawnWithCustomInitialRoute) {
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/nullptr);
+        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
 
     auto spawn =
         engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr, "/foo",
@@ -341,7 +341,7 @@ TEST_F(EngineTest, SpawnResetsViewportMetrics) {
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/nullptr);
+        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
 
     auto& old_platform_data = engine->GetRuntimeController()->GetPlatformData();
     EXPECT_EQ(old_platform_data.viewport_metrics.physical_width, kViewWidth);
@@ -376,7 +376,7 @@ TEST_F(EngineTest, SpawnWithCustomSettings) {
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/nullptr);
+        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
 
     Settings custom_settings = settings_;
     custom_settings.persistent_isolate_data =
@@ -417,7 +417,7 @@ TEST_F(EngineTest, PassesLoadDartDeferredLibraryErrorToRuntime) {
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/nullptr);
+        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
 
     engine->LoadDartDeferredLibraryError(error_id, error_message, true);
   });

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -162,7 +162,8 @@ TEST_F(EngineTest, Create) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(runtime_controller_));
+        /*runtime_controller=*/std::move(runtime_controller_),
+        /*gpu_disabled_switch=*/nullptr);
     EXPECT_TRUE(engine);
   });
 }
@@ -183,7 +184,8 @@ TEST_F(EngineTest, DispatchPlatformMessageUnknown) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller));
+        /*runtime_controller=*/std::move(mock_runtime_controller),
+        /*gpu_disabled_switch=*/nullptr);
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
@@ -209,7 +211,8 @@ TEST_F(EngineTest, DispatchPlatformMessageInitialRoute) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller));
+        /*runtime_controller=*/std::move(mock_runtime_controller),
+        /*gpu_disabled_switch=*/nullptr);
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
@@ -242,7 +245,8 @@ TEST_F(EngineTest, DispatchPlatformMessageInitialRouteIgnored) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller));
+        /*runtime_controller=*/std::move(mock_runtime_controller),
+        /*gpu_disabled_switch=*/nullptr);
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
@@ -274,10 +278,12 @@ TEST_F(EngineTest, SpawnSharesFontLibrary) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller));
+        /*runtime_controller=*/std::move(mock_runtime_controller),
+        /*gpu_disabled_switch=*/nullptr);
 
-    auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
-                               std::string(), io_manager_, snapshot_delegate_);
+    auto spawn =
+        engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
+                      std::string(), io_manager_, snapshot_delegate_, nullptr);
     EXPECT_TRUE(spawn != nullptr);
     EXPECT_EQ(&engine->GetFontCollection(), &spawn->GetFontCollection());
   });
@@ -300,10 +306,12 @@ TEST_F(EngineTest, SpawnWithCustomInitialRoute) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller));
+        /*runtime_controller=*/std::move(mock_runtime_controller),
+        /*gpu_disabled_switch=*/nullptr);
 
-    auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
-                               "/foo", io_manager_, snapshot_delegate_);
+    auto spawn =
+        engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr, "/foo",
+                      io_manager_, snapshot_delegate_, nullptr);
     EXPECT_TRUE(spawn != nullptr);
     ASSERT_EQ("/foo", spawn->InitialRoute());
   });
@@ -332,14 +340,16 @@ TEST_F(EngineTest, SpawnResetsViewportMetrics) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller));
+        /*runtime_controller=*/std::move(mock_runtime_controller),
+        /*gpu_disabled_switch=*/nullptr);
 
     auto& old_platform_data = engine->GetRuntimeController()->GetPlatformData();
     EXPECT_EQ(old_platform_data.viewport_metrics.physical_width, kViewWidth);
     EXPECT_EQ(old_platform_data.viewport_metrics.physical_height, kViewHeight);
 
-    auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
-                               std::string(), io_manager_, snapshot_delegate_);
+    auto spawn =
+        engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
+                      std::string(), io_manager_, snapshot_delegate_, nullptr);
     EXPECT_TRUE(spawn != nullptr);
     auto& new_viewport_metrics =
         spawn->GetRuntimeController()->GetPlatformData().viewport_metrics;
@@ -365,14 +375,15 @@ TEST_F(EngineTest, SpawnWithCustomSettings) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller));
+        /*runtime_controller=*/std::move(mock_runtime_controller),
+        /*gpu_disabled_switch=*/nullptr);
 
     Settings custom_settings = settings_;
     custom_settings.persistent_isolate_data =
         std::make_shared<fml::DataMapping>("foo");
     auto spawn =
         engine->Spawn(delegate_, dispatcher_maker_, custom_settings, nullptr,
-                      std::string(), io_manager_, snapshot_delegate_);
+                      std::string(), io_manager_, snapshot_delegate_, nullptr);
     EXPECT_TRUE(spawn != nullptr);
     auto new_persistent_isolate_data =
         const_cast<RuntimeController*>(spawn->GetRuntimeController())
@@ -405,7 +416,8 @@ TEST_F(EngineTest, PassesLoadDartDeferredLibraryErrorToRuntime) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller));
+        /*runtime_controller=*/std::move(mock_runtime_controller),
+        /*gpu_disabled_switch=*/nullptr);
 
     engine->LoadDartDeferredLibraryError(error_id, error_message, true);
   });

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -126,7 +126,8 @@ class Shell final : public PlatformView::Delegate,
       fml::WeakPtr<IOManager> io_manager,
       fml::RefPtr<SkiaUnrefQueue> unref_queue,
       fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
-      std::shared_ptr<VolatilePathTracker> volatile_path_tracker)>
+      std::shared_ptr<VolatilePathTracker> volatile_path_tracker,
+      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch)>
       EngineCreateCallback;
 
   //----------------------------------------------------------------------------
@@ -356,6 +357,7 @@ class Shell final : public PlatformView::Delegate,
 
   //----------------------------------------------------------------------------
   /// @brief     Accessor for the disable GPU SyncSwitch.
+  // |Rasterizer::Delegate|
   std::shared_ptr<const fml::SyncSwitch> GetIsGpuDisabledSyncSwitch()
       const override;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/126878

This disables device private upload on iOS when backgrounded, and disables mipmap generation when backgrounded.

We don't have a good way to test the core problem in this repo because it only reproduces on physical iOS hardware - simulators don't really care if you do this stuff in the background.

I'll write a devicelab test in the framework to capture this. In the mean time it can be reviewed.

We could consider making the IOManager a shared_ptr instead of having an fml::WeakPtr and that'd clean up some of the extra arguments to engine construction - or we could consider vending the sync switch from impeller::Context unconditionally, but it's pretty iOS specific...