### PR TITLE
[web] Correct JS property name for baseUri

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -440,7 +440,7 @@ extension DomProgressEventExtension on DomProgressEvent {
 class DomNode extends DomEventTarget {}
 
 extension DomNodeExtension on DomNode {
-  @JS('baseUri')
+  @JS('baseURI')
   external JSString? get _baseUri;
   String? get baseUri => _baseUri?.toDart;
 

--- a/lib/web_ui/test/engine/history_test.dart
+++ b/lib/web_ui/test/engine/history_test.dart
@@ -717,6 +717,11 @@ void testMain() {
       // A listener that was never added.
       expect(() => location.removePopStateListener(myNonAddedListener), throwsAssertionError);
     });
+
+    test('returns a non-empty baseUri', () {
+      const BrowserPlatformLocation location = BrowserPlatformLocation();
+      expect(location.getBaseHref(), isNotNull);
+    });
   });
 }
 


### PR DESCRIPTION
Up to this point, whenever users use the `PathUrlStrategy`, they would be using `flutter_web_plugins`'s copy of `BrowserPlatformLocation` which has a [different implementation for `getBaseHref()`](https://github.com/flutter/flutter/blob/9376a2ac6003740c357688a376870dbe84a88883/packages/flutter_web_plugins/lib/src/navigation/url_strategy.dart#L235). So we never hit the [implementation in the engine](https://github.com/flutter/engine/blob/eed12f36f5956a37fb4ba13f1b670a5d41c37edb/lib/web_ui/lib/ui_web/src/ui_web/navigation/platform_location.dart#L138), meaning the bug was invisible.

Now that we are [removing](https://github.com/flutter/flutter/pull/126851) `BrowserPlatformLocation` from `flutter_web_plugins`, we are hitting the engine's implementation which contains the bug being solved in this PR.