### PR TITLE
Remove legacy xcode properties/dependencies

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -54,7 +54,6 @@ platform_properties:
       device_type: none
       cpu: x86
       os: Mac-12
-      xcode: 14e222b
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e222b"
@@ -498,10 +497,6 @@ targets:
         [
           {"dependency": "goldctl", "version": "git_revision:f808dcff91b221ae313e540c09d79696cd08b8de"}
         ]
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "14e222b"
-        }
     drone_dimensions:
       - os=Mac-12
 
@@ -516,11 +511,6 @@ targets:
     bringup: true
     recipe: engine/engine_unopt
     properties:
-      runtime_versions: >-
-        [
-          "ios-16-4_14e222b",
-          "ios-16-2_14c18"
-        ]
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e222b",
@@ -593,10 +583,6 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: mac_ios_engine
-      $flutter/osx_sdk : >-
-        {
-          "sdk_version": "14e222b"
-        }
       dependencies: >-
         [
           {"dependency": "jazzy", "version": "0.14.1"}


### PR DESCRIPTION
Now only $flutter/osx_sdk property is being used, and it's safe to remove deprecated entries from ci.yaml.

Part of https://github.com/flutter/flutter/issues/127534