### PR TITLE
Improve getting non-overlapping rectangles from RTree

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -116,6 +116,7 @@ group("flutter") {
     public_deps += [
       "//flutter/display_list:display_list_benchmarks",
       "//flutter/display_list:display_list_builder_benchmarks",
+      "//flutter/display_list:display_list_region_benchmarks",
       "//flutter/fml:fml_benchmarks",
       "//flutter/impeller/geometry:geometry_benchmarks",
       "//flutter/lib/ui:ui_benchmarks",

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -39,6 +39,7 @@
 ../../../flutter/display_list/effects/dl_image_filter_unittests.cc
 ../../../flutter/display_list/effects/dl_mask_filter_unittests.cc
 ../../../flutter/display_list/effects/dl_path_effect_unittests.cc
+../../../flutter/display_list/geometry/dl_region_unittests.cc
 ../../../flutter/display_list/geometry/dl_rtree_unittests.cc
 ../../../flutter/display_list/skia/dl_sk_conversions_unittests.cc
 ../../../flutter/display_list/skia/dl_sk_paint_dispatcher_unittests.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -714,6 +714,7 @@ ORIGIN: ../../../flutter/display_list/benchmarking/dl_complexity_gl.h + ../../..
 ORIGIN: ../../../flutter/display_list/benchmarking/dl_complexity_helper.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/benchmarking/dl_complexity_metal.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/benchmarking/dl_complexity_metal.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/display_list/benchmarking/dl_region_benchmarks.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/display_list.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/display_list.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/dl_attributes.h + ../../../flutter/LICENSE
@@ -748,6 +749,8 @@ ORIGIN: ../../../flutter/display_list/effects/dl_path_effect.cc + ../../../flutt
 ORIGIN: ../../../flutter/display_list/effects/dl_path_effect.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/effects/dl_runtime_effect.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/effects/dl_runtime_effect.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/display_list/geometry/dl_region.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/display_list/geometry/dl_region.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/geometry/dl_rtree.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/geometry/dl_rtree.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/display_list/image/dl_image.cc + ../../../flutter/LICENSE
@@ -3380,6 +3383,7 @@ FILE: ../../../flutter/display_list/benchmarking/dl_complexity_gl.h
 FILE: ../../../flutter/display_list/benchmarking/dl_complexity_helper.h
 FILE: ../../../flutter/display_list/benchmarking/dl_complexity_metal.cc
 FILE: ../../../flutter/display_list/benchmarking/dl_complexity_metal.h
+FILE: ../../../flutter/display_list/benchmarking/dl_region_benchmarks.cc
 FILE: ../../../flutter/display_list/display_list.cc
 FILE: ../../../flutter/display_list/display_list.h
 FILE: ../../../flutter/display_list/dl_attributes.h
@@ -3414,6 +3418,8 @@ FILE: ../../../flutter/display_list/effects/dl_path_effect.cc
 FILE: ../../../flutter/display_list/effects/dl_path_effect.h
 FILE: ../../../flutter/display_list/effects/dl_runtime_effect.cc
 FILE: ../../../flutter/display_list/effects/dl_runtime_effect.h
+FILE: ../../../flutter/display_list/geometry/dl_region.cc
+FILE: ../../../flutter/display_list/geometry/dl_region.h
 FILE: ../../../flutter/display_list/geometry/dl_rtree.cc
 FILE: ../../../flutter/display_list/geometry/dl_rtree.h
 FILE: ../../../flutter/display_list/image/dl_image.cc

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -57,6 +57,8 @@ source_set("display_list") {
     "effects/dl_path_effect.h",
     "effects/dl_runtime_effect.cc",
     "effects/dl_runtime_effect.h",
+    "geometry/dl_region.cc",
+    "geometry/dl_region.h",
     "geometry/dl_rtree.cc",
     "geometry/dl_rtree.h",
     "image/dl_image.cc",
@@ -112,6 +114,7 @@ if (enable_unittests) {
       "effects/dl_image_filter_unittests.cc",
       "effects/dl_mask_filter_unittests.cc",
       "effects/dl_path_effect_unittests.cc",
+      "geometry/dl_region_unittests.cc",
       "geometry/dl_rtree_unittests.cc",
       "skia/dl_sk_conversions_unittests.cc",
       "skia/dl_sk_paint_dispatcher_unittests.cc",
@@ -179,6 +182,18 @@ if (enable_unittests) {
       ":display_list_fixtures",
       "//flutter/benchmarking",
       "//flutter/display_list/testing:display_list_testing",
+      "//flutter/testing:testing_lib",
+    ]
+  }
+
+  executable("display_list_region_benchmarks") {
+    testonly = true
+
+    sources = [ "benchmarking/dl_region_benchmarks.cc" ]
+
+    deps = [
+      ":display_list_fixtures",
+      "//flutter/benchmarking",
       "//flutter/testing:testing_lib",
     ]
   }

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -27,6 +27,34 @@ class SkRegionAdapter {
   SkRegion region_;
 };
 
+class DlRegion2Adapter {
+ public:
+  void addRect(const SkIRect& rect) { rects_.push_back(rect); }
+
+  std::vector<SkIRect> getRects() {
+    flutter::DlRegion2 region;
+    region.addRects(std::move(rects_));
+    return region.getRects(false);
+  }
+
+ private:
+  std::vector<SkIRect> rects_;
+};
+
+class DlRegionSortedAdapter {
+ public:
+  void addRect(const SkIRect& rect) { rects_.push_back(rect); }
+
+  std::vector<SkIRect> getRects() {
+    flutter::DlRegionSorted region;
+    region.addRects(std::move(rects_));
+    return region.getRects(false);
+  }
+
+ private:
+  std::vector<SkIRect> rects_;
+};
+
 template <typename Region>
 void RunRegionBenchmark(benchmark::State& state, int maxSize) {
   while (state.KeepRunning()) {
@@ -59,17 +87,47 @@ static void BM_RegionBenchmarkDlRegion(benchmark::State& state, int maxSize) {
   RunRegionBenchmark<DlRegion>(state, maxSize);
 }
 
+static void BM_RegionBenchmarkDlRegionSorted(benchmark::State& state,
+                                             int maxSize) {
+  RunRegionBenchmark<DlRegionSortedAdapter>(state, maxSize);
+}
+
+static void BM_RegionBenchmarkDlRegion2(benchmark::State& state, int maxSize) {
+  RunRegionBenchmark<DlRegion2Adapter>(state, maxSize);
+}
+
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Tiny, 30)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion2, Tiny, 30)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegionSorted, Tiny, 30)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Tiny, 30)
+    ->Unit(benchmark::kMicrosecond);
+
 BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Small, 100)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion2, Small, 100)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegionSorted, Small, 100)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Small, 100)
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Medium, 400)
     ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion2, Medium, 400)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegionSorted, Medium, 400)
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Medium, 400)
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Large, 1500)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion2, Large, 1500)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegionSorted, Large, 1500)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Large, 1500)
     ->Unit(benchmark::kMicrosecond);

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -1,0 +1,77 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/benchmarking/benchmarking.h"
+
+#include "flutter/display_list/geometry/dl_region.h"
+#include "third_party/skia/include/core/SkRegion.h"
+
+#include <random>
+
+class SkRegionAdapter {
+ public:
+  void addRect(const SkIRect& rect) { region_.op(rect, SkRegion::kUnion_Op); }
+
+  std::vector<SkIRect> getRects() {
+    std::vector<SkIRect> rects;
+    SkRegion::Iterator it(region_);
+    while (!it.done()) {
+      rects.push_back(it.rect());
+      it.next();
+    }
+    return rects;
+  }
+
+ private:
+  SkRegion region_;
+};
+
+template <typename Region>
+void RunRegionBenchmark(benchmark::State& state, int maxSize) {
+  while (state.KeepRunning()) {
+    std::random_device d;
+    std::seed_seq seed{2, 1, 3};
+    std::mt19937 rng(seed);
+
+    std::uniform_int_distribution pos(0, 4000);
+    std::uniform_int_distribution size(1, maxSize);
+
+    Region region;
+
+    for (int i = 0; i < 2000; ++i) {
+      SkIRect rect =
+          SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+      region.addRect(rect);
+    }
+
+    auto vec2 = region.getRects();
+  }
+}
+
+namespace flutter {
+
+static void BM_RegionBenchmarkSkRegion(benchmark::State& state, int maxSize) {
+  RunRegionBenchmark<SkRegionAdapter>(state, maxSize);
+}
+
+static void BM_RegionBenchmarkDlRegion(benchmark::State& state, int maxSize) {
+  RunRegionBenchmark<DlRegion>(state, maxSize);
+}
+
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Small, 100)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Small, 100)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Medium, 400)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Medium, 400)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Large, 1500)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Large, 1500)
+    ->Unit(benchmark::kMicrosecond);
+
+}  // namespace flutter

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -32,8 +32,7 @@ class DlRegionAdapter {
   void addRect(const SkIRect& rect) { rects_.push_back(rect); }
 
   std::vector<SkIRect> getRects() {
-    flutter::DlRegion region;
-    region.addRects(std::move(rects_));
+    flutter::DlRegion region(std::move(rects_));
     return region.getRects(false);
   }
 

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -27,26 +27,12 @@ class SkRegionAdapter {
   SkRegion region_;
 };
 
-class DlRegion2Adapter {
+class DlRegionAdapter {
  public:
   void addRect(const SkIRect& rect) { rects_.push_back(rect); }
 
   std::vector<SkIRect> getRects() {
-    flutter::DlRegion2 region;
-    region.addRects(std::move(rects_));
-    return region.getRects(false);
-  }
-
- private:
-  std::vector<SkIRect> rects_;
-};
-
-class DlRegionSortedAdapter {
- public:
-  void addRect(const SkIRect& rect) { rects_.push_back(rect); }
-
-  std::vector<SkIRect> getRects() {
-    flutter::DlRegionSorted region;
+    flutter::DlRegion region;
     region.addRects(std::move(rects_));
     return region.getRects(false);
   }
@@ -84,50 +70,22 @@ static void BM_RegionBenchmarkSkRegion(benchmark::State& state, int maxSize) {
 }
 
 static void BM_RegionBenchmarkDlRegion(benchmark::State& state, int maxSize) {
-  RunRegionBenchmark<DlRegion>(state, maxSize);
-}
-
-static void BM_RegionBenchmarkDlRegionSorted(benchmark::State& state,
-                                             int maxSize) {
-  RunRegionBenchmark<DlRegionSortedAdapter>(state, maxSize);
-}
-
-static void BM_RegionBenchmarkDlRegion2(benchmark::State& state, int maxSize) {
-  RunRegionBenchmark<DlRegion2Adapter>(state, maxSize);
+  RunRegionBenchmark<DlRegionAdapter>(state, maxSize);
 }
 
 BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Tiny, 30)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion2, Tiny, 30)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegionSorted, Tiny, 30)
-    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Tiny, 30)
     ->Unit(benchmark::kMicrosecond);
-
 BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Small, 100)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion2, Small, 100)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegionSorted, Small, 100)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Small, 100)
     ->Unit(benchmark::kMicrosecond);
-
 BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Medium, 400)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion2, Medium, 400)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegionSorted, Medium, 400)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Medium, 400)
     ->Unit(benchmark::kMicrosecond);
-
 BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Large, 1500)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion2, Large, 1500)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegionSorted, Large, 1500)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Large, 1500)
     ->Unit(benchmark::kMicrosecond);

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -1106,7 +1106,8 @@ void DisplayListBuilder::DrawDisplayList(const sk_sp<DisplayList> display_list,
     case BoundsAccumulatorType::kRTree:
       auto rtree = display_list->rtree();
       if (rtree) {
-        std::list<SkRect> rects = rtree->searchAndConsolidateRects(bounds);
+        std::list<SkRect> rects =
+            rtree->searchAndConsolidateRects(bounds, false);
         for (const SkRect& rect : rects) {
           // TODO (https://github.com/flutter/flutter/issues/114919): Attributes
           // are not necessarily `kDrawDisplayListFlags`.

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -48,6 +48,7 @@ std::vector<SkIRect> DlRegion::getRects(bool deband) const {
             FML_DCHECK(iter->bottom() == rect.top());
             rect.fTop = iter->fTop;
             rects.erase(iter);
+            --previous_span_end;
             break;
           }
         }

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -8,6 +8,22 @@
 
 namespace flutter {
 
+DlRegion::DlRegion() {
+  // If SpanLines can not be memmoved `addRect` would be signifantly slower
+  // due to cost of inserting and removing elements from the `lines_` vector.
+  static_assert(std::is_trivially_constructible<SpanLine>::value,
+                "SpanLine must be trivially constructible.");
+}
+
+DlRegion::~DlRegion() {
+  for (auto& spanvec : spanvec_pool_) {
+    delete spanvec;
+  }
+  for (auto& line : lines_) {
+    delete line.spans;
+  }
+}
+
 std::vector<SkIRect> DlRegion::getRects(bool deband) const {
   std::vector<SkIRect> rects;
   size_t previous_span_end = 0;

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -14,12 +14,14 @@ DlRegion::DlRegion(std::vector<SkIRect>&& rects) {
   static_assert(std::is_trivially_constructible<SpanLine>::value,
                 "SpanLine must be trivially constructible.");
   addRects(std::move(rects));
-}
 
-DlRegion::~DlRegion() {
   for (auto& spanvec : spanvec_pool_) {
     delete spanvec;
   }
+  spanvec_pool_.clear();
+}
+
+DlRegion::~DlRegion() {
   for (auto& line : lines_) {
     delete line.spans;
   }

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -148,19 +148,14 @@ void DlRegion::addRects(std::vector<SkIRect>&& rects) {
 
   size_t start_index = 0;
 
-  size_t dirty_start = -1;
-  size_t dirty_end = 1;
+  size_t dirty_start = std::numeric_limits<size_t>::max();
+  size_t dirty_end = 0;
 
   // Marks line as dirty. Dirty lines will be checked for equality
   // later and merged as needed.
   auto mark_dirty = [&](size_t line) {
-    if (dirty_start == static_cast<size_t>(-1)) {
-      dirty_start = line;
-      dirty_end = line;
-    } else {
-      dirty_start = std::min(dirty_start, line);
-      dirty_end = std::max(dirty_end, line);
-    }
+    dirty_start = std::min(dirty_start, line);
+    dirty_end = std::max(dirty_end, line);
   };
 
   for (const SkIRect& rect : rects) {
@@ -223,7 +218,7 @@ void DlRegion::addRects(std::vector<SkIRect>&& rects) {
     }
 
     // Check for duplicate lines and merge them.
-    if (dirty_start != static_cast<size_t>(-1)) {
+    if (dirty_start <= dirty_end) {
       // Expand the region by one if possible.
       if (dirty_start > 0) {
         --dirty_start;
@@ -244,8 +239,8 @@ void DlRegion::addRects(std::vector<SkIRect>&& rects) {
         }
       }
     }
-    dirty_start = -1;
-    dirty_end = -1;
+    dirty_start = std::numeric_limits<size_t>::max();
+    dirty_end = 0;
   }
 }
 

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -190,18 +190,19 @@ void DlRegion::addRect(const SkIRect& rect) {
 
 std::vector<SkIRect> DlRegion::getRects(bool deband) const {
   std::vector<SkIRect> rects;
+  size_t previous_span_end = 0;
   for (const auto& line : lines_) {
     for (const Span& span : *line.spans) {
       SkIRect rect{span.left, line.top, span.right, line.bottom};
       if (deband) {
-        auto iter = rects.end();
-        // If there is recangle previously in rects on which this one is a
+        auto iter = rects.begin() + previous_span_end;
+        // If there is rectangle previously in rects on which this one is a
         // vertical continuation, remove the previous rectangle and expand this
         // one vertically to cover the area.
         while (iter != rects.begin()) {
           --iter;
           if (iter->bottom() < rect.top()) {
-            // Went too far.
+            // Went all the way to previous span line.
             break;
           } else if (iter->bottom() == rect.top() &&
                      iter->left() == rect.left() &&
@@ -214,6 +215,7 @@ std::vector<SkIRect> DlRegion::getRects(bool deband) const {
       }
       rects.push_back(rect);
     }
+    previous_span_end = rects.size();
   }
   return rects;
 }

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -71,7 +71,8 @@ struct DlRegion::SpanLine {
 };
 
 DlRegion::DlRegion() {
-  // If we can't memmove SpanLines addRect would be signifantly slower.
+  // If SpanLines can not be memmoved `addRect` would be signifantly slower
+  // due to cost of inserting and removing elements from the `lines_` vector.
   static_assert(std::is_trivially_constructible<SpanLine>::value,
                 "SpanLine must be trivially constructible.");
 }
@@ -194,7 +195,7 @@ std::vector<SkIRect> DlRegion::getRects(bool deband) const {
       SkIRect rect{span.left, line.top, span.right, line.bottom};
       if (deband) {
         auto iter = rects.end();
-        // If there is recangle previously in rect on which this one is a
+        // If there is recangle previously in rects on which this one is a
         // vertical continuation, remove the previous rectangle and expand this
         // one vertically to cover the area.
         while (iter != rects.begin()) {

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -260,4 +260,339 @@ DlRegion::SpanLine DlRegion::makeLine(int32_t top,
   return {top, bottom, span_vec};
 }
 
+void DlRegion2::SpanLine::insertSpan(int32_t left, int32_t right) {
+  auto size = spans.size();
+  for (size_t i = 0; i < size; ++i) {
+    Span& span = spans[i];
+    if (right < span.left) {
+      spans.insert(spans.begin() + i, {left, right});
+      return;
+    }
+    if (left > span.right) {
+      continue;
+    }
+    size_t last_index = i;
+    while (last_index + 1 < size && right >= spans[last_index + 1].left) {
+      ++last_index;
+    }
+    span.left = std::min(span.left, left);
+    span.right = std::max(spans[last_index].right, right);
+    if (last_index > i) {
+      spans.erase(spans.begin() + i + 1, spans.begin() + last_index + 1);
+    }
+    return;
+  }
+
+  spans.push_back({left, right});
+}
+
+void DlRegion2::addRects(std::vector<SkIRect>&& rects) {
+  std::sort(rects.begin(), rects.end(), [](const SkIRect& a, const SkIRect& b) {
+    if (a.top() == b.top()) {
+      return a.left() < b.left();
+    } else {
+      return a.top() < b.top();
+    }
+  });
+
+  size_t span_start = 0;
+  while (span_start < rects.size()) {
+    size_t span_end = span_start;
+    int32_t span_top = rects[span_start].fTop;
+    int32_t span_bottom = rects[span_start].fBottom;
+    while (true) {
+      ++span_end;
+      if (span_end == rects.size()) {
+        break;
+      }
+      if (rects[span_end].fTop != span_top) {
+        span_bottom = std::min(span_bottom, rects[span_end].fTop);
+        break;
+      }
+      span_bottom = std::min(span_bottom, rects[span_end].fBottom);
+    }
+    SpanLine line;
+    line.top = span_top;
+    line.bottom = span_bottom;
+
+    for (size_t i = span_start; i < span_end; ++i) {
+      line.insertSpan(rects[i].fLeft, rects[i].fRight);
+      rects[i].fTop = span_bottom;
+      if (rects[i].fBottom == span_bottom) {
+        if (i > span_start) {
+          std::memmove(&rects[span_start + 1], &rects[span_start],
+                       (i - span_start) * sizeof(SkIRect));
+        }
+        ++span_start;
+      }
+    }
+
+    if (!lines_.empty() && lines_.back().bottom == line.top &&
+        lines_.back().spans.size() == line.spans.size() &&
+        memcmp(lines_.back().spans.data(), line.spans.data(),
+               line.spans.size() * sizeof(Span)) == 0) {
+      lines_.back().bottom = line.bottom;
+    } else {
+      lines_.push_back(std::move(line));
+    }
+  }
+}
+
+std::vector<SkIRect> DlRegion2::getRects(bool deband) const {
+  std::vector<SkIRect> rects;
+  size_t previous_span_end = 0;
+  for (const auto& line : lines_) {
+    for (const Span& span : line.spans) {
+      SkIRect rect{span.left, line.top, span.right, line.bottom};
+      if (deband) {
+        auto iter = rects.begin() + previous_span_end;
+        // If there is rectangle previously in rects on which this one is a
+        // vertical continuation, remove the previous rectangle and expand
+        // this one vertically to cover the area.
+        while (iter != rects.begin()) {
+          --iter;
+          if (iter->bottom() < rect.top()) {
+            // Went all the way to previous span line.
+            break;
+          } else if (iter->bottom() == rect.top() &&
+                     iter->left() == rect.left() &&
+                     iter->right() == rect.right()) {
+            rect.fTop = iter->fTop;
+            rects.erase(iter);
+            break;
+          }
+        }
+      }
+      rects.push_back(rect);
+    }
+    previous_span_end = rects.size();
+  }
+  return rects;
+}
+
+std::vector<SkIRect> DlRegionSorted::getRects(bool deband) const {
+  std::vector<SkIRect> rects;
+  size_t previous_span_end = 0;
+  for (const auto& line : lines_) {
+    for (const Span& span : *line.spans) {
+      SkIRect rect{span.left, line.top, span.right, line.bottom};
+      if (deband) {
+        auto iter = rects.begin() + previous_span_end;
+        // If there is rectangle previously in rects on which this one is a
+        // vertical continuation, remove the previous rectangle and expand
+        // this one vertically to cover the area.
+        while (iter != rects.begin()) {
+          --iter;
+          if (iter->bottom() < rect.top()) {
+            // Went all the way to previous span line.
+            break;
+          } else if (iter->bottom() == rect.top() &&
+                     iter->left() == rect.left() &&
+                     iter->right() == rect.right()) {
+            rect.fTop = iter->fTop;
+            rects.erase(iter);
+            break;
+          }
+        }
+      }
+      rects.push_back(rect);
+    }
+    previous_span_end = rects.size();
+  }
+  return rects;
+}
+
+void DlRegionSorted::SpanLine::insertSpan(int32_t left, int32_t right) {
+  auto& spans = *this->spans;
+  auto size = spans.size();
+  for (size_t i = 0; i < size; ++i) {
+    Span& span = spans[i];
+    if (right < span.left) {
+      spans.insert(spans.begin() + i, {left, right});
+      return;
+    }
+    if (left > span.right) {
+      continue;
+    }
+    size_t last_index = i;
+    while (last_index + 1 < size && right >= spans[last_index + 1].left) {
+      ++last_index;
+    }
+    span.left = std::min(span.left, left);
+    span.right = std::max(spans[last_index].right, right);
+    if (last_index > i) {
+      spans.erase(spans.begin() + i + 1, spans.begin() + last_index + 1);
+    }
+    return;
+  }
+
+  spans.push_back({left, right});
+}
+
+bool DlRegionSorted::SpanLine::spansEqual(const SpanLine& l2) const {
+  SpanVec& spans = *this->spans;
+  SpanVec& otherSpans = *l2.spans;
+  assert(this != &l2);
+
+  if (spans.size() != otherSpans.size()) {
+    return false;
+  }
+  return memcmp(spans.data(), otherSpans.data(), spans.size() * sizeof(Span)) ==
+         0;
+}
+
+void DlRegionSorted::insertLine(size_t position, SpanLine line) {
+  lines_.insert(lines_.begin() + position, line);
+}
+
+DlRegionSorted::LineVec::iterator DlRegionSorted::removeLine(
+    DlRegionSorted::LineVec::iterator line) {
+  spanvec_pool_.push_back(line->spans);
+  return lines_.erase(line);
+}
+
+DlRegionSorted::SpanLine DlRegionSorted::makeLine(int32_t top,
+                                                  int32_t bottom,
+                                                  int32_t spanLeft,
+                                                  int32_t spanRight) {
+  SpanVec* span_vec;
+  if (!spanvec_pool_.empty()) {
+    span_vec = spanvec_pool_.back();
+    spanvec_pool_.pop_back();
+    span_vec->clear();
+  } else {
+    span_vec = new SpanVec();
+  }
+  span_vec->push_back({spanLeft, spanRight});
+  return {top, bottom, span_vec};
+}
+
+DlRegionSorted::SpanLine DlRegionSorted::makeLine(int32_t top,
+                                                  int32_t bottom,
+                                                  const SpanVec& spans) {
+  SpanVec* span_vec;
+  if (!spanvec_pool_.empty()) {
+    span_vec = spanvec_pool_.back();
+    spanvec_pool_.pop_back();
+  } else {
+    span_vec = new SpanVec();
+  }
+  *span_vec = spans;
+  return {top, bottom, span_vec};
+}
+
+void DlRegionSorted::addRects(std::vector<SkIRect>&& rects) {
+  std::sort(rects.begin(), rects.end(), [](const SkIRect& a, const SkIRect& b) {
+    // Sort the rectangles by Y axis. Because the rectangles have varying
+    // height, they are added to span lines in non-deterministic order and thus
+    // it makes no difference if they are also sorted by the X axis.
+    return a.top() < b.top();
+  });
+
+  size_t start_index = 0;
+
+  size_t dirty_start = -1;
+  size_t dirty_end = 1;
+
+  // Marks line as dirty. Dirty lines will be checked for equality
+  // later and merged as needed.
+  auto mark_dirty = [&](size_t line) {
+    if (dirty_start == static_cast<size_t>(-1)) {
+      dirty_start = line;
+      dirty_end = line;
+    } else {
+      dirty_start = std::min(dirty_start, line);
+      dirty_end = std::max(dirty_end, line);
+    }
+  };
+
+  size_t processed_count = 0;
+
+  for (const SkIRect& rect : rects) {
+    ++processed_count;
+    if (rect.isEmpty()) {
+      continue;
+    }
+
+    int32_t y1 = rect.fTop;
+    int32_t y2 = rect.fBottom;
+
+    for (size_t i = start_index; i < lines_.size() && y1 < y2; ++i) {
+      SpanLine& line = lines_[i];
+
+      if (y1 >= line.bottom) {
+        start_index = i + 1;
+        continue;
+      }
+
+      if (y2 <= line.top) {
+        insertLine(i, makeLine(y1, y2, rect.fLeft, rect.fRight));
+        mark_dirty(i);
+        y1 = y2;
+        break;
+      }
+      if (y1 < line.top) {
+        auto prevLineStart = line.top;
+        insertLine(i, makeLine(y1, prevLineStart, rect.fLeft, rect.fRight));
+        mark_dirty(i);
+        y1 = prevLineStart;
+        continue;
+      }
+      if (y1 > line.top) {
+        // duplicate line
+        auto prevLineEnd = line.bottom;
+        line.bottom = y1;
+        mark_dirty(i);
+        insertLine(i + 1, makeLine(y1, prevLineEnd, *line.spans));
+        continue;
+      }
+      assert(y1 == line.top);
+      if (y2 < line.bottom) {
+        // duplicate line
+        auto newLine = makeLine(y2, line.bottom, *line.spans);
+        line.bottom = y2;
+        line.insertSpan(rect.fLeft, rect.fRight);
+        insertLine(i + 1, newLine);
+        y1 = y2;
+        mark_dirty(i);
+        break;
+      }
+      assert(y2 >= line.bottom);
+      line.insertSpan(rect.fLeft, rect.fRight);
+      mark_dirty(i);
+      y1 = line.bottom;
+    }
+
+    if (y1 < y2) {
+      lines_.push_back(makeLine(y1, y2, rect.fLeft, rect.fRight));
+      mark_dirty(lines_.size() - 1);
+    }
+
+    // Check for duplicate lines and merge them.
+    if (dirty_start != static_cast<size_t>(-1)) {
+      // Expand the region by one if possible.
+      if (dirty_start > 0) {
+        --dirty_start;
+      }
+      if (dirty_end + 1 < lines_.size()) {
+        ++dirty_end;
+      }
+      for (auto i = lines_.begin() + dirty_start;
+           i < lines_.begin() + dirty_end;) {
+        auto& line = *i;
+        auto& next = *(i + 1);
+        if (line.bottom == next.top && line.spansEqual(next)) {
+          --dirty_end;
+          next.top = line.top;
+          i = removeLine(i);
+        } else {
+          ++i;
+        }
+      }
+    }
+    dirty_start = -1;
+    dirty_end = -1;
+  }
+}
+
 }  // namespace flutter

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -52,7 +52,7 @@ struct DlRegion::SpanLine {
     spans.push_back({left, right});
   }
 
-  bool operator==(const SpanLine& l2) const {
+  bool spansEqual(const SpanLine& l2) const {
     SpanVec& spans = *this->spans;
     SpanVec& otherSpans = *l2.spans;
     assert(this != &l2);
@@ -176,7 +176,7 @@ void DlRegion::addRect(const SkIRect& rect) {
          i < lines_.begin() + dirty_end;) {
       auto& line = *i;
       auto& next = *(i + 1);
-      if (line == next) {
+      if (line.bottom == next.top && line.spansEqual(next)) {
         --dirty_end;
         next.top = line.top;
         i = removeLine(i);

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -8,186 +8,6 @@
 
 namespace flutter {
 
-struct DlRegion::Span {
-  int32_t left;
-  int32_t right;
-};
-
-struct DlRegion::SpanLine {
-  int32_t top;
-  int32_t bottom;
-  // For performance reasons SpanLine must be trivially constructible.
-  // DlRegion is responsible for allocating and deallocating the
-  // memory for spans.
-  SpanVec* spans;
-
-  /// Inserts span into this span line. If there are existing spans
-  /// that overlap with the new span, they will be merged into single
-  /// span.
-  void insertSpan(int32_t left, int32_t right) {
-    SpanVec& spans = *this->spans;
-
-    auto size = spans.size();
-    for (size_t i = 0; i < size; ++i) {
-      Span& span = spans[i];
-      if (right < span.left) {
-        _insertSpanAt(i, left, right);
-        return;
-      }
-      if (left > span.right) {
-        continue;
-      }
-      size_t last_index = i;
-      while (last_index + 1 < size && right >= spans[last_index + 1].left) {
-        ++last_index;
-      }
-      span.left = std::min(span.left, left);
-      span.right = std::max(spans[last_index].right, right);
-      if (last_index > i) {
-        spans.erase(spans.begin() + i + 1, spans.begin() + last_index + 1);
-      }
-      return;
-    }
-
-    spans.push_back({left, right});
-  }
-
-  bool spansEqual(const SpanLine& l2) const {
-    SpanVec& spans = *this->spans;
-    SpanVec& otherSpans = *l2.spans;
-    assert(this != &l2);
-
-    if (spans.size() != otherSpans.size()) {
-      return false;
-    }
-    return memcmp(spans.data(), otherSpans.data(),
-                  spans.size() * sizeof(Span)) == 0;
-  }
-
- private:
-  void _insertSpanAt(size_t index, int32_t x1, int32_t x2) {
-    spans->insert(spans->begin() + index, {x1, x2});
-  }
-};
-
-DlRegion::DlRegion() {
-  // If SpanLines can not be memmoved `addRect` would be signifantly slower
-  // due to cost of inserting and removing elements from the `lines_` vector.
-  static_assert(std::is_trivially_constructible<SpanLine>::value,
-                "SpanLine must be trivially constructible.");
-}
-
-DlRegion::~DlRegion() {
-  for (auto& spanvec : spanvec_pool_) {
-    delete spanvec;
-  }
-  for (auto& line : lines_) {
-    delete line.spans;
-  }
-}
-
-void DlRegion::addRect(const SkIRect& rect) {
-  if (rect.isEmpty()) {
-    return;
-  }
-
-  int32_t y1 = rect.fTop;
-  int32_t y2 = rect.fBottom;
-
-  size_t dirty_start = -1;
-  size_t dirty_end = 1;
-
-  // Marks line as dirty. Dirty lines will be checked for equality
-  // later and merged as needed.
-  auto mark_dirty = [&](size_t line) {
-    if (dirty_start == static_cast<size_t>(-1)) {
-      dirty_start = line;
-      dirty_end = line;
-    } else {
-      dirty_start = std::min(dirty_start, line);
-      dirty_end = std::max(dirty_end, line);
-    }
-  };
-
-  auto upper_bound = std::upper_bound(
-      lines_.begin(), lines_.end(), y1,
-      [](int32_t i, const SpanLine& line) { return i < line.bottom; });
-
-  auto start_index = upper_bound - lines_.begin();
-
-  for (size_t i = start_index; i < lines_.size() && y1 < y2; ++i) {
-    SpanLine& line = lines_[i];
-
-    // If this is false the start index is wrong.
-    assert(y1 < line.bottom);
-
-    if (y2 <= line.top) {
-      insertLine(i, makeLine(y1, y2, rect.fLeft, rect.fRight));
-      mark_dirty(i);
-      y1 = y2;
-      break;
-    }
-    if (y1 < line.top) {
-      auto prevLineStart = line.top;
-      insertLine(i, makeLine(y1, prevLineStart, rect.fLeft, rect.fRight));
-      mark_dirty(i);
-      y1 = prevLineStart;
-      continue;
-    }
-    if (y1 > line.top) {
-      // duplicate line
-      auto prevLineEnd = line.bottom;
-      line.bottom = y1;
-      mark_dirty(i);
-      insertLine(i + 1, makeLine(y1, prevLineEnd, *line.spans));
-      continue;
-    }
-    assert(y1 == line.top);
-    if (y2 < line.bottom) {
-      // duplicate line
-      auto newLine = makeLine(y2, line.bottom, *line.spans);
-      line.bottom = y2;
-      line.insertSpan(rect.fLeft, rect.fRight);
-      insertLine(i + 1, newLine);
-      y1 = y2;
-      mark_dirty(i);
-      break;
-    }
-    assert(y2 >= line.bottom);
-    line.insertSpan(rect.fLeft, rect.fRight);
-    mark_dirty(i);
-    y1 = line.bottom;
-  }
-
-  if (y1 < y2) {
-    lines_.push_back(makeLine(y1, y2, rect.fLeft, rect.fRight));
-    mark_dirty(lines_.size() - 1);
-  }
-
-  // Check for duplicate lines and merge them.
-  if (dirty_start != static_cast<size_t>(-1)) {
-    // Expand the region by one if possible.
-    if (dirty_start > 0) {
-      --dirty_start;
-    }
-    if (dirty_end + 1 < lines_.size()) {
-      ++dirty_end;
-    }
-    for (auto i = lines_.begin() + dirty_start;
-         i < lines_.begin() + dirty_end;) {
-      auto& line = *i;
-      auto& next = *(i + 1);
-      if (line.bottom == next.top && line.spansEqual(next)) {
-        --dirty_end;
-        next.top = line.top;
-        i = removeLine(i);
-      } else {
-        ++i;
-      }
-    }
-  }
-}
-
 std::vector<SkIRect> DlRegion::getRects(bool deband) const {
   std::vector<SkIRect> rects;
   size_t previous_span_end = 0;
@@ -197,8 +17,8 @@ std::vector<SkIRect> DlRegion::getRects(bool deband) const {
       if (deband) {
         auto iter = rects.begin() + previous_span_end;
         // If there is rectangle previously in rects on which this one is a
-        // vertical continuation, remove the previous rectangle and expand this
-        // one vertically to cover the area.
+        // vertical continuation, remove the previous rectangle and expand
+        // this one vertically to cover the area.
         while (iter != rects.begin()) {
           --iter;
           if (iter->bottom() < rect.top()) {
@@ -218,6 +38,45 @@ std::vector<SkIRect> DlRegion::getRects(bool deband) const {
     previous_span_end = rects.size();
   }
   return rects;
+}
+
+void DlRegion::SpanLine::insertSpan(int32_t left, int32_t right) {
+  auto& spans = *this->spans;
+  auto size = spans.size();
+  for (size_t i = 0; i < size; ++i) {
+    Span& span = spans[i];
+    if (right < span.left) {
+      spans.insert(spans.begin() + i, {left, right});
+      return;
+    }
+    if (left > span.right) {
+      continue;
+    }
+    size_t last_index = i;
+    while (last_index + 1 < size && right >= spans[last_index + 1].left) {
+      ++last_index;
+    }
+    span.left = std::min(span.left, left);
+    span.right = std::max(spans[last_index].right, right);
+    if (last_index > i) {
+      spans.erase(spans.begin() + i + 1, spans.begin() + last_index + 1);
+    }
+    return;
+  }
+
+  spans.push_back({left, right});
+}
+
+bool DlRegion::SpanLine::spansEqual(const SpanLine& l2) const {
+  SpanVec& spans = *this->spans;
+  SpanVec& otherSpans = *l2.spans;
+  assert(this != &l2);
+
+  if (spans.size() != otherSpans.size()) {
+    return false;
+  }
+  return memcmp(spans.data(), otherSpans.data(), spans.size() * sizeof(Span)) ==
+         0;
 }
 
 void DlRegion::insertLine(size_t position, SpanLine line) {
@@ -260,228 +119,7 @@ DlRegion::SpanLine DlRegion::makeLine(int32_t top,
   return {top, bottom, span_vec};
 }
 
-void DlRegion2::SpanLine::insertSpan(int32_t left, int32_t right) {
-  auto size = spans.size();
-  for (size_t i = 0; i < size; ++i) {
-    Span& span = spans[i];
-    if (right < span.left) {
-      spans.insert(spans.begin() + i, {left, right});
-      return;
-    }
-    if (left > span.right) {
-      continue;
-    }
-    size_t last_index = i;
-    while (last_index + 1 < size && right >= spans[last_index + 1].left) {
-      ++last_index;
-    }
-    span.left = std::min(span.left, left);
-    span.right = std::max(spans[last_index].right, right);
-    if (last_index > i) {
-      spans.erase(spans.begin() + i + 1, spans.begin() + last_index + 1);
-    }
-    return;
-  }
-
-  spans.push_back({left, right});
-}
-
-void DlRegion2::addRects(std::vector<SkIRect>&& rects) {
-  std::sort(rects.begin(), rects.end(), [](const SkIRect& a, const SkIRect& b) {
-    if (a.top() == b.top()) {
-      return a.left() < b.left();
-    } else {
-      return a.top() < b.top();
-    }
-  });
-
-  size_t span_start = 0;
-  while (span_start < rects.size()) {
-    size_t span_end = span_start;
-    int32_t span_top = rects[span_start].fTop;
-    int32_t span_bottom = rects[span_start].fBottom;
-    while (true) {
-      ++span_end;
-      if (span_end == rects.size()) {
-        break;
-      }
-      if (rects[span_end].fTop != span_top) {
-        span_bottom = std::min(span_bottom, rects[span_end].fTop);
-        break;
-      }
-      span_bottom = std::min(span_bottom, rects[span_end].fBottom);
-    }
-    SpanLine line;
-    line.top = span_top;
-    line.bottom = span_bottom;
-
-    for (size_t i = span_start; i < span_end; ++i) {
-      line.insertSpan(rects[i].fLeft, rects[i].fRight);
-      rects[i].fTop = span_bottom;
-      if (rects[i].fBottom == span_bottom) {
-        if (i > span_start) {
-          std::memmove(&rects[span_start + 1], &rects[span_start],
-                       (i - span_start) * sizeof(SkIRect));
-        }
-        ++span_start;
-      }
-    }
-
-    if (!lines_.empty() && lines_.back().bottom == line.top &&
-        lines_.back().spans.size() == line.spans.size() &&
-        memcmp(lines_.back().spans.data(), line.spans.data(),
-               line.spans.size() * sizeof(Span)) == 0) {
-      lines_.back().bottom = line.bottom;
-    } else {
-      lines_.push_back(std::move(line));
-    }
-  }
-}
-
-std::vector<SkIRect> DlRegion2::getRects(bool deband) const {
-  std::vector<SkIRect> rects;
-  size_t previous_span_end = 0;
-  for (const auto& line : lines_) {
-    for (const Span& span : line.spans) {
-      SkIRect rect{span.left, line.top, span.right, line.bottom};
-      if (deband) {
-        auto iter = rects.begin() + previous_span_end;
-        // If there is rectangle previously in rects on which this one is a
-        // vertical continuation, remove the previous rectangle and expand
-        // this one vertically to cover the area.
-        while (iter != rects.begin()) {
-          --iter;
-          if (iter->bottom() < rect.top()) {
-            // Went all the way to previous span line.
-            break;
-          } else if (iter->bottom() == rect.top() &&
-                     iter->left() == rect.left() &&
-                     iter->right() == rect.right()) {
-            rect.fTop = iter->fTop;
-            rects.erase(iter);
-            break;
-          }
-        }
-      }
-      rects.push_back(rect);
-    }
-    previous_span_end = rects.size();
-  }
-  return rects;
-}
-
-std::vector<SkIRect> DlRegionSorted::getRects(bool deband) const {
-  std::vector<SkIRect> rects;
-  size_t previous_span_end = 0;
-  for (const auto& line : lines_) {
-    for (const Span& span : *line.spans) {
-      SkIRect rect{span.left, line.top, span.right, line.bottom};
-      if (deband) {
-        auto iter = rects.begin() + previous_span_end;
-        // If there is rectangle previously in rects on which this one is a
-        // vertical continuation, remove the previous rectangle and expand
-        // this one vertically to cover the area.
-        while (iter != rects.begin()) {
-          --iter;
-          if (iter->bottom() < rect.top()) {
-            // Went all the way to previous span line.
-            break;
-          } else if (iter->bottom() == rect.top() &&
-                     iter->left() == rect.left() &&
-                     iter->right() == rect.right()) {
-            rect.fTop = iter->fTop;
-            rects.erase(iter);
-            break;
-          }
-        }
-      }
-      rects.push_back(rect);
-    }
-    previous_span_end = rects.size();
-  }
-  return rects;
-}
-
-void DlRegionSorted::SpanLine::insertSpan(int32_t left, int32_t right) {
-  auto& spans = *this->spans;
-  auto size = spans.size();
-  for (size_t i = 0; i < size; ++i) {
-    Span& span = spans[i];
-    if (right < span.left) {
-      spans.insert(spans.begin() + i, {left, right});
-      return;
-    }
-    if (left > span.right) {
-      continue;
-    }
-    size_t last_index = i;
-    while (last_index + 1 < size && right >= spans[last_index + 1].left) {
-      ++last_index;
-    }
-    span.left = std::min(span.left, left);
-    span.right = std::max(spans[last_index].right, right);
-    if (last_index > i) {
-      spans.erase(spans.begin() + i + 1, spans.begin() + last_index + 1);
-    }
-    return;
-  }
-
-  spans.push_back({left, right});
-}
-
-bool DlRegionSorted::SpanLine::spansEqual(const SpanLine& l2) const {
-  SpanVec& spans = *this->spans;
-  SpanVec& otherSpans = *l2.spans;
-  assert(this != &l2);
-
-  if (spans.size() != otherSpans.size()) {
-    return false;
-  }
-  return memcmp(spans.data(), otherSpans.data(), spans.size() * sizeof(Span)) ==
-         0;
-}
-
-void DlRegionSorted::insertLine(size_t position, SpanLine line) {
-  lines_.insert(lines_.begin() + position, line);
-}
-
-DlRegionSorted::LineVec::iterator DlRegionSorted::removeLine(
-    DlRegionSorted::LineVec::iterator line) {
-  spanvec_pool_.push_back(line->spans);
-  return lines_.erase(line);
-}
-
-DlRegionSorted::SpanLine DlRegionSorted::makeLine(int32_t top,
-                                                  int32_t bottom,
-                                                  int32_t spanLeft,
-                                                  int32_t spanRight) {
-  SpanVec* span_vec;
-  if (!spanvec_pool_.empty()) {
-    span_vec = spanvec_pool_.back();
-    spanvec_pool_.pop_back();
-    span_vec->clear();
-  } else {
-    span_vec = new SpanVec();
-  }
-  span_vec->push_back({spanLeft, spanRight});
-  return {top, bottom, span_vec};
-}
-
-DlRegionSorted::SpanLine DlRegionSorted::makeLine(int32_t top,
-                                                  int32_t bottom,
-                                                  const SpanVec& spans) {
-  SpanVec* span_vec;
-  if (!spanvec_pool_.empty()) {
-    span_vec = spanvec_pool_.back();
-    spanvec_pool_.pop_back();
-  } else {
-    span_vec = new SpanVec();
-  }
-  *span_vec = spans;
-  return {top, bottom, span_vec};
-}
-
-void DlRegionSorted::addRects(std::vector<SkIRect>&& rects) {
+void DlRegion::addRects(std::vector<SkIRect>&& rects) {
   std::sort(rects.begin(), rects.end(), [](const SkIRect& a, const SkIRect& b) {
     // Sort the rectangles by Y axis. Because the rectangles have varying
     // height, they are added to span lines in non-deterministic order and thus
@@ -506,10 +144,7 @@ void DlRegionSorted::addRects(std::vector<SkIRect>&& rects) {
     }
   };
 
-  size_t processed_count = 0;
-
   for (const SkIRect& rect : rects) {
-    ++processed_count;
     if (rect.isEmpty()) {
       continue;
     }
@@ -520,8 +155,8 @@ void DlRegionSorted::addRects(std::vector<SkIRect>&& rects) {
     for (size_t i = start_index; i < lines_.size() && y1 < y2; ++i) {
       SpanLine& line = lines_[i];
 
-      if (y1 >= line.bottom) {
-        start_index = i + 1;
+      if (rect.fTop >= line.bottom) {
+        start_index = i;
         continue;
       }
 

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -1,0 +1,260 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/geometry/dl_region.h"
+
+#include <cassert>
+
+namespace flutter {
+
+struct DlRegion::Span {
+  int32_t left;
+  int32_t right;
+};
+
+struct DlRegion::SpanLine {
+  int32_t top;
+  int32_t bottom;
+  // For performance reasons SpanLine must be trivially constructible.
+  // DlRegion is responsible for allocating and deallocating the
+  // memory for spans.
+  SpanVec* spans;
+
+  /// Inserts span into this span line. If there are existing spans
+  /// that overlap with the new span, they will be merged into single
+  /// span.
+  void insertSpan(int32_t left, int32_t right) {
+    SpanVec& spans = *this->spans;
+
+    auto size = spans.size();
+    for (size_t i = 0; i < size; ++i) {
+      Span& span = spans[i];
+      if (right < span.left) {
+        _insertSpanAt(i, left, right);
+        return;
+      }
+      if (left > span.right) {
+        continue;
+      }
+      size_t last_index = i;
+      while (last_index + 1 < size && right >= spans[last_index + 1].left) {
+        ++last_index;
+      }
+      span.left = std::min(span.left, left);
+      span.right = std::max(spans[last_index].right, right);
+      if (last_index > i) {
+        spans.erase(spans.begin() + i + 1, spans.begin() + last_index + 1);
+      }
+      return;
+    }
+
+    spans.push_back({left, right});
+  }
+
+  bool operator==(const SpanLine& l2) const {
+    SpanVec& spans = *this->spans;
+    SpanVec& otherSpans = *l2.spans;
+    assert(this != &l2);
+
+    if (spans.size() != otherSpans.size()) {
+      return false;
+    }
+    return memcmp(spans.data(), otherSpans.data(),
+                  spans.size() * sizeof(Span)) == 0;
+  }
+
+ private:
+  void _insertSpanAt(size_t index, int32_t x1, int32_t x2) {
+    spans->insert(spans->begin() + index, {x1, x2});
+  }
+};
+
+DlRegion::DlRegion() {
+  // If we can't memmove SpanLines addRect would be signifantly slower.
+  static_assert(std::is_trivially_constructible<SpanLine>::value,
+                "SpanLine must be trivially constructible.");
+}
+
+DlRegion::~DlRegion() {
+  for (auto& spanvec : spanvec_pool_) {
+    delete spanvec;
+  }
+  for (auto& line : lines_) {
+    delete line.spans;
+  }
+}
+
+void DlRegion::addRect(const SkIRect& rect) {
+  if (rect.isEmpty()) {
+    return;
+  }
+
+  int32_t i1 = rect.fTop;
+  int32_t i2 = rect.fBottom;
+
+  size_t dirty_start = -1;
+  size_t dirty_end = 1;
+
+  // Marks line as dirty. Dirty lines will be checked for equality
+  // later and merged as needed.
+  auto mark_dirty = [&](size_t line) {
+    if (dirty_start == static_cast<size_t>(-1)) {
+      dirty_start = line;
+      dirty_end = line;
+    } else {
+      dirty_start = std::min(dirty_start, line);
+      dirty_end = std::max(dirty_end, line);
+    }
+  };
+
+  auto upper_bound = std::upper_bound(
+      lines_.begin(), lines_.end(), i1,
+      [](int32_t i, const SpanLine& line) { return i < line.bottom; });
+
+  auto start_index = upper_bound - lines_.begin();
+
+  for (size_t i = start_index; i < lines_.size() && i1 < i2; ++i) {
+    SpanLine& line = lines_[i];
+
+    // If this is false the start index is wrong.
+    assert(i1 < line.bottom);
+
+    if (i2 <= line.top) {
+      insertLine(i, makeLine(i1, i2, rect.fLeft, rect.fRight));
+      mark_dirty(i);
+      i1 = i2;
+      break;
+    }
+    if (i1 < line.top) {
+      auto prevLineStart = line.top;
+      insertLine(i, makeLine(i1, prevLineStart, rect.fLeft, rect.fRight));
+      mark_dirty(i);
+      i1 = prevLineStart;
+      continue;
+    }
+    if (i1 > line.top) {
+      // duplicate line
+      auto prevLineEnd = line.bottom;
+      line.bottom = i1;
+      mark_dirty(i);
+      insertLine(i + 1, makeLine(i1, prevLineEnd, *line.spans));
+      continue;
+    }
+    assert(i1 == line.top);
+    if (i2 < line.bottom) {
+      // duplicate line
+      auto newLine = makeLine(i2, line.bottom, *line.spans);
+      line.bottom = i2;
+      line.insertSpan(rect.fLeft, rect.fRight);
+      insertLine(i + 1, newLine);
+      i1 = i2;
+      mark_dirty(i);
+      break;
+    }
+    assert(i2 >= line.bottom);
+    line.insertSpan(rect.fLeft, rect.fRight);
+    mark_dirty(i);
+    i1 = line.bottom;
+  }
+
+  if (i1 < i2) {
+    lines_.push_back(makeLine(i1, i2, rect.fLeft, rect.fRight));
+    mark_dirty(lines_.size() - 1);
+  }
+
+  // Check for duplicate lines and merge them.
+  if (dirty_start != static_cast<size_t>(-1)) {
+    // Expand the region by one if possible.
+    if (dirty_start > 0) {
+      --dirty_start;
+    }
+    if (dirty_end + 1 < lines_.size()) {
+      ++dirty_end;
+    }
+    for (auto i = lines_.begin() + dirty_start;
+         i < lines_.begin() + dirty_end;) {
+      auto& line = *i;
+      auto& next = *(i + 1);
+      if (line == next) {
+        --dirty_end;
+        next.top = line.top;
+        i = removeLine(i);
+      } else {
+        ++i;
+      }
+    }
+  }
+}
+
+std::vector<SkIRect> DlRegion::getRects(bool deband) const {
+  std::vector<SkIRect> rects;
+  for (const auto& line : lines_) {
+    for (const Span& span : *line.spans) {
+      SkIRect rect{span.left, line.top, span.right, line.bottom};
+      if (deband) {
+        auto iter = rects.end();
+        // If there is recangle previously in rect on which this one is a
+        // vertical continuation, remove the previous rectangle and expand this
+        // one vertically to cover the area.
+        while (iter != rects.begin()) {
+          --iter;
+          if (iter->bottom() < rect.top()) {
+            // Went too far.
+            break;
+          } else if (iter->bottom() == rect.top() &&
+                     iter->left() == rect.left() &&
+                     iter->right() == rect.right()) {
+            rect.fTop = iter->fTop;
+            rects.erase(iter);
+            break;
+          }
+        }
+      }
+      rects.push_back(rect);
+    }
+  }
+  return rects;
+}
+
+void DlRegion::insertLine(size_t position, SpanLine line) {
+  lines_.insert(lines_.begin() + position, line);
+}
+
+DlRegion::LineVec::iterator DlRegion::removeLine(
+    DlRegion::LineVec::iterator line) {
+  spanvec_pool_.push_back(line->spans);
+  return lines_.erase(line);
+}
+
+DlRegion::SpanLine DlRegion::makeLine(int32_t top,
+                                      int32_t bottom,
+                                      int32_t spanLeft,
+                                      int32_t spanRight) {
+  SpanVec* span_vec;
+  if (!spanvec_pool_.empty()) {
+    span_vec = spanvec_pool_.back();
+    spanvec_pool_.pop_back();
+    span_vec->clear();
+  } else {
+    span_vec = new SpanVec();
+  }
+  span_vec->push_back({spanLeft, spanRight});
+  return {top, bottom, span_vec};
+}
+
+DlRegion::SpanLine DlRegion::makeLine(int32_t top,
+                                      int32_t bottom,
+                                      const SpanVec& spans) {
+  SpanVec* span_vec;
+  if (!spanvec_pool_.empty()) {
+    span_vec = spanvec_pool_.back();
+    spanvec_pool_.pop_back();
+  } else {
+    span_vec = new SpanVec();
+  }
+  *span_vec = spans;
+  return {top, bottom, span_vec};
+}
+
+}  // namespace flutter

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -8,11 +8,12 @@
 
 namespace flutter {
 
-DlRegion::DlRegion() {
+DlRegion::DlRegion(std::vector<SkIRect>&& rects) {
   // If SpanLines can not be memmoved `addRect` would be signifantly slower
   // due to cost of inserting and removing elements from the `lines_` vector.
   static_assert(std::is_trivially_constructible<SpanLine>::value,
                 "SpanLine must be trivially constructible.");
+  addRects(std::move(rects));
 }
 
 DlRegion::~DlRegion() {

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -90,8 +90,8 @@ void DlRegion::addRect(const SkIRect& rect) {
     return;
   }
 
-  int32_t i1 = rect.fTop;
-  int32_t i2 = rect.fBottom;
+  int32_t y1 = rect.fTop;
+  int32_t y2 = rect.fBottom;
 
   size_t dirty_start = -1;
   size_t dirty_end = 1;
@@ -109,57 +109,57 @@ void DlRegion::addRect(const SkIRect& rect) {
   };
 
   auto upper_bound = std::upper_bound(
-      lines_.begin(), lines_.end(), i1,
+      lines_.begin(), lines_.end(), y1,
       [](int32_t i, const SpanLine& line) { return i < line.bottom; });
 
   auto start_index = upper_bound - lines_.begin();
 
-  for (size_t i = start_index; i < lines_.size() && i1 < i2; ++i) {
+  for (size_t i = start_index; i < lines_.size() && y1 < y2; ++i) {
     SpanLine& line = lines_[i];
 
     // If this is false the start index is wrong.
-    assert(i1 < line.bottom);
+    assert(y1 < line.bottom);
 
-    if (i2 <= line.top) {
-      insertLine(i, makeLine(i1, i2, rect.fLeft, rect.fRight));
+    if (y2 <= line.top) {
+      insertLine(i, makeLine(y1, y2, rect.fLeft, rect.fRight));
       mark_dirty(i);
-      i1 = i2;
+      y1 = y2;
       break;
     }
-    if (i1 < line.top) {
+    if (y1 < line.top) {
       auto prevLineStart = line.top;
-      insertLine(i, makeLine(i1, prevLineStart, rect.fLeft, rect.fRight));
+      insertLine(i, makeLine(y1, prevLineStart, rect.fLeft, rect.fRight));
       mark_dirty(i);
-      i1 = prevLineStart;
+      y1 = prevLineStart;
       continue;
     }
-    if (i1 > line.top) {
+    if (y1 > line.top) {
       // duplicate line
       auto prevLineEnd = line.bottom;
-      line.bottom = i1;
+      line.bottom = y1;
       mark_dirty(i);
-      insertLine(i + 1, makeLine(i1, prevLineEnd, *line.spans));
+      insertLine(i + 1, makeLine(y1, prevLineEnd, *line.spans));
       continue;
     }
-    assert(i1 == line.top);
-    if (i2 < line.bottom) {
+    assert(y1 == line.top);
+    if (y2 < line.bottom) {
       // duplicate line
-      auto newLine = makeLine(i2, line.bottom, *line.spans);
-      line.bottom = i2;
+      auto newLine = makeLine(y2, line.bottom, *line.spans);
+      line.bottom = y2;
       line.insertSpan(rect.fLeft, rect.fRight);
       insertLine(i + 1, newLine);
-      i1 = i2;
+      y1 = y2;
       mark_dirty(i);
       break;
     }
-    assert(i2 >= line.bottom);
+    assert(y2 >= line.bottom);
     line.insertSpan(rect.fLeft, rect.fRight);
     mark_dirty(i);
-    i1 = line.bottom;
+    y1 = line.bottom;
   }
 
-  if (i1 < i2) {
-    lines_.push_back(makeLine(i1, i2, rect.fLeft, rect.fRight));
+  if (y1 < y2) {
+    lines_.push_back(makeLine(y1, y2, rect.fLeft, rect.fRight));
     mark_dirty(lines_.size() - 1);
   }
 

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/display_list/geometry/dl_region.h"
 
-#include <cassert>
+#include "flutter/fml/logging.h"
 
 namespace flutter {
 
@@ -43,9 +43,9 @@ std::vector<SkIRect> DlRegion::getRects(bool deband) const {
           if (iter->bottom() < rect.top()) {
             // Went all the way to previous span line.
             break;
-          } else if (iter->bottom() == rect.top() &&
-                     iter->left() == rect.left() &&
+          } else if (iter->left() == rect.left() &&
                      iter->right() == rect.right()) {
+            FML_DCHECK(iter->bottom() == rect.top());
             rect.fTop = iter->fTop;
             rects.erase(iter);
             break;
@@ -89,7 +89,7 @@ void DlRegion::SpanLine::insertSpan(int32_t left, int32_t right) {
 bool DlRegion::SpanLine::spansEqual(const SpanLine& l2) const {
   SpanVec& spans = *this->spans;
   SpanVec& otherSpans = *l2.spans;
-  assert(this != &l2);
+  FML_DCHECK(this != &l2);
 
   if (spans.size() != otherSpans.size()) {
     return false;
@@ -195,7 +195,7 @@ void DlRegion::addRects(std::vector<SkIRect>&& rects) {
         insertLine(i + 1, makeLine(y1, prevLineEnd, *line.spans));
         continue;
       }
-      assert(y1 == line.top);
+      FML_DCHECK(y1 == line.top);
       if (y2 < line.bottom) {
         // duplicate line
         auto newLine = makeLine(y2, line.bottom, *line.spans);
@@ -206,7 +206,7 @@ void DlRegion::addRects(std::vector<SkIRect>&& rects) {
         mark_dirty(i);
         break;
       }
-      assert(y2 >= line.bottom);
+      FML_DCHECK(y2 >= line.bottom);
       line.insertSpan(rect.fLeft, rect.fRight);
       mark_dirty(i);
       y1 = line.bottom;

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -16,65 +16,6 @@ namespace flutter {
 /// converting set of overlapping rectangles to non-overlapping rectangles.
 class DlRegion {
  public:
-  DlRegion();
-  ~DlRegion();
-
-  /// Adds rectangle to current region.
-  /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
-  void addRect(const SkIRect& rect);
-
-  /// Returns list of non-overlapping rectangles that cover current region.
-  /// If |deband| is false, each span line will result in separate rectangles,
-  /// closely matching SkRegion::Iterator behavior.
-  /// If |deband| is true, matching rectangles from adjacent span lines will be
-  /// merged into single rectange.
-  std::vector<SkIRect> getRects(bool deband = true) const;
-
- private:
-  struct Span;
-  struct SpanLine;
-  typedef std::vector<Span> SpanVec;
-  typedef std::vector<SpanLine> LineVec;
-
-  void insertLine(size_t position, SpanLine line);
-  LineVec::iterator removeLine(LineVec::iterator position);
-
-  SpanLine makeLine(int32_t top,
-                    int32_t bottom,
-                    int32_t spanLeft,
-                    int32_t spanRight);
-  SpanLine makeLine(int32_t top, int32_t bottom, const SpanVec& spans);
-
-  LineVec lines_;
-  std::vector<SpanVec*> spanvec_pool_;
-};
-
-class DlRegion2 {
- public:
-  void addRects(std::vector<SkIRect>&& rects);
-  std::vector<SkIRect> getRects(bool deband = true) const;
-
- private:
-  struct Span {
-    int32_t left;
-    int32_t right;
-  };
-  struct SpanLine {
-    int32_t top;
-    int32_t bottom;
-    std::vector<Span> spans;
-
-    void insertSpan(int32_t left, int32_t right);
-  };
-
-  std::vector<SpanLine> lines_;
-};
-
-/// Represents a region as a collection of non-overlapping rectangles.
-/// Implements a subset of SkRegion functionality optimized for quickly
-/// converting set of overlapping rectangles to non-overlapping rectangles.
-class DlRegionSorted {
- public:
   /// Bulks adds rectangles to current region.
   /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
   void addRects(std::vector<SkIRect>&& rects);

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -1,0 +1,54 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_GEOMETRY_REGION_H_
+#define FLUTTER_DISPLAY_LIST_GEOMETRY_REGION_H_
+
+#include "third_party/skia/include/core/SkRect.h"
+
+#include <vector>
+
+namespace flutter {
+
+/// Represents a region as a collection of non-overlapping rectangles.
+/// Implements a subset of SkRegion functionality optimized for quickly
+/// converting set of overlapping rectangles to non-overlapping rectangles.
+class DlRegion {
+ public:
+  DlRegion();
+  ~DlRegion();
+
+  /// Adds rectangle to current region.
+  /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
+  void addRect(const SkIRect& rect);
+
+  /// Returns list of non-overlapping rectangles that cover current region.
+  /// If |deband| is false, each span line will result in separate rectangles,
+  /// closely matching SkRegion::Iterator behavior.
+  /// If |deband| is true, matching rectangles from adjacent span lines will be
+  /// merged into single rectange.
+  std::vector<SkIRect> getRects(bool deband = true) const;
+
+ private:
+  struct Span;
+  struct SpanLine;
+  typedef std::vector<Span> SpanVec;
+  typedef std::vector<SpanLine> LineVec;
+
+  void insertLine(size_t position, SpanLine line);
+  LineVec::iterator removeLine(LineVec::iterator position);
+
+  SpanLine makeLine(int32_t top,
+                    int32_t bottom,
+                    int32_t spanLeft,
+                    int32_t spanRight);
+  SpanLine makeLine(int32_t top, int32_t bottom, const SpanVec& spans);
+
+  LineVec lines_;
+  std::vector<SpanVec*> spanvec_pool_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_DISPLAY_LIST_GEOMETRY_REGION_H_

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -16,12 +16,10 @@ namespace flutter {
 /// converting set of overlapping rectangles to non-overlapping rectangles.
 class DlRegion {
  public:
-  DlRegion();
+  /// Creates region by bulk adding the rectangles./// Matches
+  /// SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
+  explicit DlRegion(std::vector<SkIRect>&& rects);
   ~DlRegion();
-
-  /// Bulks adds rectangles to current region.
-  /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
-  void addRects(std::vector<SkIRect>&& rects);
 
   /// Returns list of non-overlapping rectangles that cover current region.
   /// If |deband| is false, each span line will result in separate rectangles,
@@ -31,6 +29,8 @@ class DlRegion {
   std::vector<SkIRect> getRects(bool deband = true) const;
 
  private:
+  void addRects(std::vector<SkIRect>&& rects);
+
   struct Span {
     int32_t left;
     int32_t right;

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -16,6 +16,9 @@ namespace flutter {
 /// converting set of overlapping rectangles to non-overlapping rectangles.
 class DlRegion {
  public:
+  DlRegion();
+  ~DlRegion();
+
   /// Bulks adds rectangles to current region.
   /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
   void addRects(std::vector<SkIRect>&& rects);

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -49,6 +49,73 @@ class DlRegion {
   std::vector<SpanVec*> spanvec_pool_;
 };
 
+class DlRegion2 {
+ public:
+  void addRects(std::vector<SkIRect>&& rects);
+  std::vector<SkIRect> getRects(bool deband = true) const;
+
+ private:
+  struct Span {
+    int32_t left;
+    int32_t right;
+  };
+  struct SpanLine {
+    int32_t top;
+    int32_t bottom;
+    std::vector<Span> spans;
+
+    void insertSpan(int32_t left, int32_t right);
+  };
+
+  std::vector<SpanLine> lines_;
+};
+
+/// Represents a region as a collection of non-overlapping rectangles.
+/// Implements a subset of SkRegion functionality optimized for quickly
+/// converting set of overlapping rectangles to non-overlapping rectangles.
+class DlRegionSorted {
+ public:
+  /// Bulks adds rectangles to current region.
+  /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
+  void addRects(std::vector<SkIRect>&& rects);
+
+  /// Returns list of non-overlapping rectangles that cover current region.
+  /// If |deband| is false, each span line will result in separate rectangles,
+  /// closely matching SkRegion::Iterator behavior.
+  /// If |deband| is true, matching rectangles from adjacent span lines will be
+  /// merged into single rectange.
+  std::vector<SkIRect> getRects(bool deband = true) const;
+
+ private:
+  struct Span {
+    int32_t left;
+    int32_t right;
+  };
+  typedef std::vector<Span> SpanVec;
+  struct SpanLine {
+    int32_t top;
+    int32_t bottom;
+    SpanVec* spans;
+
+    void insertSpan(int32_t left, int32_t right);
+    bool spansEqual(const SpanLine& l2) const;
+  };
+
+  typedef std::vector<SpanLine> LineVec;
+
+  std::vector<SpanLine> lines_;
+  std::vector<SpanVec*> spanvec_pool_;
+
+  void insertLine(size_t position, SpanLine line);
+  LineVec::iterator removeLine(LineVec::iterator position);
+
+  SpanLine makeLine(int32_t top,
+                    int32_t bottom,
+                    int32_t spanLeft,
+                    int32_t spanRight);
+  SpanLine makeLine(int32_t top, int32_t bottom, const SpanVec& spans);
+};
+
 }  // namespace flutter
 
 #endif  // FLUTTER_DISPLAY_LIST_GEOMETRY_REGION_H_

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -169,8 +169,7 @@ TEST(DisplayListRegion, TestAgainstSkRegion) {
 
   for (const auto& settings : all_settings) {
     std::random_device d;
-    // std::seed_seq seed{::testing::UnitTest::GetInstance()->random_seed()};
-    std::seed_seq seed{4};
+    std::seed_seq seed{::testing::UnitTest::GetInstance()->random_seed()};
     std::mt19937 rng(seed);
 
     SkRegion sk_region;

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -25,7 +25,7 @@ TEST(DisplayListRegion, SingleRectangle) {
   EXPECT_EQ(rects.front(), SkIRect::MakeLTRB(10, 10, 50, 50));
 }
 
-TEST(DisplayListRegion, NonOverlappingRectangles) {
+TEST(DisplayListRegion, NonOverlappingRectangles1) {
   DlRegion region;
   for (int i = 0; i < 10; ++i) {
     SkIRect rect = SkIRect::MakeXYWH(50 * i, 50 * i, 50, 50);
@@ -37,6 +37,22 @@ TEST(DisplayListRegion, NonOverlappingRectangles) {
       {150, 150, 200, 200}, {200, 200, 250, 250}, {250, 250, 300, 300},
       {300, 300, 350, 350}, {350, 350, 400, 400}, {400, 400, 450, 450},
       {450, 450, 500, 500},
+  };
+  EXPECT_EQ(rects, expected);
+}
+
+TEST(DisplayListRegion, NonOverlappingRectangles2) {
+  DlRegion region;
+  region.addRect(SkIRect::MakeXYWH(5, 5, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(25, 5, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(5, 25, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(25, 25, 10, 10));
+  auto rects = region.getRects();
+  std::vector<SkIRect> expected{
+      SkIRect::MakeXYWH(5, 5, 10, 10),
+      SkIRect::MakeXYWH(25, 5, 10, 10),
+      SkIRect::MakeXYWH(5, 25, 10, 10),
+      SkIRect::MakeXYWH(25, 25, 10, 10),
   };
   EXPECT_EQ(rects, expected);
 }

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -57,6 +57,51 @@ TEST(DisplayListRegion, NonOverlappingRectangles2) {
   EXPECT_EQ(rects, expected);
 }
 
+TEST(DisplayListRegion, NonOverlappingRectangles3) {
+  DlRegion region;
+  region.addRect(SkIRect::MakeXYWH(0, 0, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(-11, -11, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(11, 11, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(-11, 0, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(0, 11, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(0, -11, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(11, 0, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(11, -11, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(-11, 11, 10, 10));
+  auto rects = region.getRects();
+  std::vector<SkIRect> expected{
+      SkIRect::MakeXYWH(-11, -11, 10, 10),  //
+      SkIRect::MakeXYWH(0, -11, 10, 10),    //
+      SkIRect::MakeXYWH(11, -11, 10, 10),   //
+      SkIRect::MakeXYWH(-11, 0, 10, 10),    //
+      SkIRect::MakeXYWH(0, 0, 10, 10),      //
+      SkIRect::MakeXYWH(11, 0, 10, 10),     //
+      SkIRect::MakeXYWH(-11, 11, 10, 10),   //
+      SkIRect::MakeXYWH(0, 11, 10, 10),     //
+      SkIRect::MakeXYWH(11, 11, 10, 10),
+  };
+  EXPECT_EQ(rects, expected);
+}
+
+TEST(DisplayListRegion, MergeTouchingRectangles) {
+  DlRegion region;
+  region.addRect(SkIRect::MakeXYWH(0, 0, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(-10, -10, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(10, 10, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(-10, 0, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(0, 10, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(0, -10, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(10, 0, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(10, -10, 10, 10));
+  region.addRect(SkIRect::MakeXYWH(-10, 10, 10, 10));
+
+  auto rects = region.getRects();
+  std::vector<SkIRect> expected{
+      SkIRect::MakeXYWH(-10, -10, 30, 30),
+  };
+  EXPECT_EQ(rects, expected);
+}
+
 TEST(DisplayListRegion, OverlappingRectangles) {
   DlRegion region;
   for (int i = 0; i < 10; ++i) {

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -1,0 +1,138 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/geometry/dl_region.h"
+#include "gtest/gtest.h"
+
+#include "third_party/skia/include/core/SkRegion.h"
+
+#include <random>
+
+namespace flutter {
+namespace testing {
+
+TEST(DisplayListRegion, EmptyRegion) {
+  DlRegion region;
+  EXPECT_TRUE(region.getRects().empty());
+}
+
+TEST(DisplayListRegion, SingleRectangle) {
+  DlRegion region;
+  region.addRect(SkIRect::MakeLTRB(10, 10, 50, 50));
+  auto rects = region.getRects();
+  ASSERT_EQ(rects.size(), 1u);
+  EXPECT_EQ(rects.front(), SkIRect::MakeLTRB(10, 10, 50, 50));
+}
+
+TEST(DisplayListRegion, NonOverlappingRectangles) {
+  DlRegion region;
+  for (int i = 0; i < 10; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(50 * i, 50 * i, 50, 50);
+    region.addRect(rect);
+  }
+  auto rects = region.getRects();
+  std::vector<SkIRect> expected{
+      {0, 0, 50, 50},       {50, 50, 100, 100},   {100, 100, 150, 150},
+      {150, 150, 200, 200}, {200, 200, 250, 250}, {250, 250, 300, 300},
+      {300, 300, 350, 350}, {350, 350, 400, 400}, {400, 400, 450, 450},
+      {450, 450, 500, 500},
+  };
+  EXPECT_EQ(rects, expected);
+}
+
+TEST(DisplayListRegion, OverlappingRectangles) {
+  DlRegion region;
+  for (int i = 0; i < 10; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(10 * i, 10 * i, 50, 50);
+    region.addRect(rect);
+  }
+  auto rects = region.getRects();
+  std::vector<SkIRect> expected{
+      {0, 0, 50, 10},      {0, 10, 60, 20},     {0, 20, 70, 30},
+      {0, 30, 80, 40},     {0, 40, 90, 50},     {10, 50, 100, 60},
+      {20, 60, 110, 70},   {30, 70, 120, 80},   {40, 80, 130, 90},
+      {50, 90, 140, 100},  {60, 100, 140, 110}, {70, 110, 140, 120},
+      {80, 120, 140, 130}, {90, 130, 140, 140},
+  };
+
+  EXPECT_EQ(rects, expected);
+}
+
+TEST(DisplayListRegion, Deband) {
+  DlRegion region;
+  region.addRect(SkIRect::MakeXYWH(0, 0, 50, 50));
+  region.addRect(SkIRect::MakeXYWH(60, 0, 20, 20));
+  region.addRect(SkIRect::MakeXYWH(90, 0, 50, 50));
+
+  auto rects_with_deband = region.getRects(true);
+  std::vector<SkIRect> expected{
+      SkIRect::MakeXYWH(60, 0, 20, 20),
+      SkIRect::MakeXYWH(0, 0, 50, 50),
+      SkIRect::MakeXYWH(90, 0, 50, 50),
+  };
+  EXPECT_EQ(rects_with_deband, expected);
+
+  auto rects_without_deband = region.getRects(false);
+  std::vector<SkIRect> expected_without_deband{
+      SkIRect::MakeXYWH(0, 0, 50, 20),   //
+      SkIRect::MakeXYWH(60, 0, 20, 20),  //
+      SkIRect::MakeXYWH(90, 0, 50, 20),  //
+      SkIRect::MakeXYWH(0, 20, 50, 30),  //
+      SkIRect::MakeXYWH(90, 20, 50, 30),
+  };
+  EXPECT_EQ(rects_without_deband, expected_without_deband);
+}
+
+TEST(DisplayListRegion, TestAgainstSkRegion) {
+  struct Settings {
+    int max_size;
+    size_t iteration_count;
+  };
+  std::vector<Settings> all_settings{
+      {100, 10},    //
+      {100, 100},   //
+      {100, 1000},  //
+      {400, 10},    //
+      {400, 100},   //
+      {400, 1000},  //
+      {800, 10},    //
+      {800, 100},   //
+      {800, 1000},
+  };
+
+  for (const auto& settings : all_settings) {
+    std::random_device d;
+    std::seed_seq seed{::testing::UnitTest::GetInstance()->random_seed()};
+    std::mt19937 rng(seed);
+
+    DlRegion region;
+    SkRegion sk_region;
+
+    std::uniform_int_distribution pos(0, 4000);
+    std::uniform_int_distribution size(1, settings.max_size);
+
+    for (size_t i = 0; i < settings.iteration_count; ++i) {
+      SkIRect rect =
+          SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+      region.addRect(rect);
+      sk_region.op(rect, SkRegion::kUnion_Op);
+    }
+
+    // Do not deband the rectangles - identical to SkRegion::Iterator
+    auto rects = region.getRects(false);
+
+    std::vector<SkIRect> skia_rects;
+
+    auto iterator = SkRegion::Iterator(sk_region);
+    while (!iterator.done()) {
+      skia_rects.push_back(iterator.rect());
+      iterator.next();
+    }
+
+    EXPECT_EQ(rects, skia_rects);
+  }
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -19,18 +19,20 @@ TEST(DisplayListRegion, EmptyRegion) {
 
 TEST(DisplayListRegion, SingleRectangle) {
   DlRegion region;
-  region.addRect(SkIRect::MakeLTRB(10, 10, 50, 50));
+  region.addRects({SkIRect::MakeLTRB(10, 10, 50, 50)});
   auto rects = region.getRects();
   ASSERT_EQ(rects.size(), 1u);
   EXPECT_EQ(rects.front(), SkIRect::MakeLTRB(10, 10, 50, 50));
 }
 
 TEST(DisplayListRegion, NonOverlappingRectangles1) {
-  DlRegion region;
+  std::vector<SkIRect> rects_in;
   for (int i = 0; i < 10; ++i) {
     SkIRect rect = SkIRect::MakeXYWH(50 * i, 50 * i, 50, 50);
-    region.addRect(rect);
+    rects_in.push_back(rect);
   }
+  DlRegion region;
+  region.addRects(std::move(rects_in));
   auto rects = region.getRects();
   std::vector<SkIRect> expected{
       {0, 0, 50, 50},       {50, 50, 100, 100},   {100, 100, 150, 150},
@@ -43,10 +45,12 @@ TEST(DisplayListRegion, NonOverlappingRectangles1) {
 
 TEST(DisplayListRegion, NonOverlappingRectangles2) {
   DlRegion region;
-  region.addRect(SkIRect::MakeXYWH(5, 5, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(25, 5, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(5, 25, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(25, 25, 10, 10));
+  region.addRects({
+      SkIRect::MakeXYWH(5, 5, 10, 10),
+      SkIRect::MakeXYWH(25, 5, 10, 10),
+      SkIRect::MakeXYWH(5, 25, 10, 10),
+      SkIRect::MakeXYWH(25, 25, 10, 10),
+  });
   auto rects = region.getRects();
   std::vector<SkIRect> expected{
       SkIRect::MakeXYWH(5, 5, 10, 10),
@@ -59,15 +63,17 @@ TEST(DisplayListRegion, NonOverlappingRectangles2) {
 
 TEST(DisplayListRegion, NonOverlappingRectangles3) {
   DlRegion region;
-  region.addRect(SkIRect::MakeXYWH(0, 0, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(-11, -11, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(11, 11, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(-11, 0, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(0, 11, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(0, -11, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(11, 0, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(11, -11, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(-11, 11, 10, 10));
+  region.addRects({
+      SkIRect::MakeXYWH(0, 0, 10, 10),
+      SkIRect::MakeXYWH(-11, -11, 10, 10),
+      SkIRect::MakeXYWH(11, 11, 10, 10),
+      SkIRect::MakeXYWH(-11, 0, 10, 10),
+      SkIRect::MakeXYWH(0, 11, 10, 10),
+      SkIRect::MakeXYWH(0, -11, 10, 10),
+      SkIRect::MakeXYWH(11, 0, 10, 10),
+      SkIRect::MakeXYWH(11, -11, 10, 10),
+      SkIRect::MakeXYWH(-11, 11, 10, 10),
+  });
   auto rects = region.getRects();
   std::vector<SkIRect> expected{
       SkIRect::MakeXYWH(-11, -11, 10, 10),  //
@@ -85,15 +91,17 @@ TEST(DisplayListRegion, NonOverlappingRectangles3) {
 
 TEST(DisplayListRegion, MergeTouchingRectangles) {
   DlRegion region;
-  region.addRect(SkIRect::MakeXYWH(0, 0, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(-10, -10, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(10, 10, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(-10, 0, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(0, 10, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(0, -10, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(10, 0, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(10, -10, 10, 10));
-  region.addRect(SkIRect::MakeXYWH(-10, 10, 10, 10));
+  region.addRects({
+      SkIRect::MakeXYWH(0, 0, 10, 10),
+      SkIRect::MakeXYWH(-10, -10, 10, 10),
+      SkIRect::MakeXYWH(10, 10, 10, 10),
+      SkIRect::MakeXYWH(-10, 0, 10, 10),
+      SkIRect::MakeXYWH(0, 10, 10, 10),
+      SkIRect::MakeXYWH(0, -10, 10, 10),
+      SkIRect::MakeXYWH(10, 0, 10, 10),
+      SkIRect::MakeXYWH(10, -10, 10, 10),
+      SkIRect::MakeXYWH(-10, 10, 10, 10),
+  });
 
   auto rects = region.getRects();
   std::vector<SkIRect> expected{
@@ -103,11 +111,13 @@ TEST(DisplayListRegion, MergeTouchingRectangles) {
 }
 
 TEST(DisplayListRegion, OverlappingRectangles) {
-  DlRegion region;
+  std::vector<SkIRect> rects_in;
   for (int i = 0; i < 10; ++i) {
     SkIRect rect = SkIRect::MakeXYWH(10 * i, 10 * i, 50, 50);
-    region.addRect(rect);
+    rects_in.push_back(rect);
   }
+  DlRegion region;
+  region.addRects(std::move(rects_in));
   auto rects = region.getRects();
   std::vector<SkIRect> expected{
       {0, 0, 50, 10},      {0, 10, 60, 20},     {0, 20, 70, 30},
@@ -122,9 +132,11 @@ TEST(DisplayListRegion, OverlappingRectangles) {
 
 TEST(DisplayListRegion, Deband) {
   DlRegion region;
-  region.addRect(SkIRect::MakeXYWH(0, 0, 50, 50));
-  region.addRect(SkIRect::MakeXYWH(60, 0, 20, 20));
-  region.addRect(SkIRect::MakeXYWH(90, 0, 50, 50));
+  region.addRects({
+      SkIRect::MakeXYWH(0, 0, 50, 50),
+      SkIRect::MakeXYWH(60, 0, 20, 20),
+      SkIRect::MakeXYWH(90, 0, 50, 50),
+  });
 
   auto rects_with_deband = region.getRects(true);
   std::vector<SkIRect> expected{
@@ -164,21 +176,26 @@ TEST(DisplayListRegion, TestAgainstSkRegion) {
 
   for (const auto& settings : all_settings) {
     std::random_device d;
-    std::seed_seq seed{::testing::UnitTest::GetInstance()->random_seed()};
+    // std::seed_seq seed{::testing::UnitTest::GetInstance()->random_seed()};
+    std::seed_seq seed{4};
     std::mt19937 rng(seed);
 
-    DlRegion region;
     SkRegion sk_region;
 
     std::uniform_int_distribution pos(0, 4000);
     std::uniform_int_distribution size(1, settings.max_size);
 
+    std::vector<SkIRect> rects_in;
+
     for (size_t i = 0; i < settings.iteration_count; ++i) {
       SkIRect rect =
           SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
-      region.addRect(rect);
+      rects_in.push_back(rect);
       sk_region.op(rect, SkRegion::kUnion_Op);
     }
+
+    DlRegion region;
+    region.addRects(std::move(rects_in));
 
     // Do not deband the rectangles - identical to SkRegion::Iterator
     auto rects = region.getRects(false);

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -13,13 +13,12 @@ namespace flutter {
 namespace testing {
 
 TEST(DisplayListRegion, EmptyRegion) {
-  DlRegion region;
+  DlRegion region({});
   EXPECT_TRUE(region.getRects().empty());
 }
 
 TEST(DisplayListRegion, SingleRectangle) {
-  DlRegion region;
-  region.addRects({SkIRect::MakeLTRB(10, 10, 50, 50)});
+  DlRegion region({SkIRect::MakeLTRB(10, 10, 50, 50)});
   auto rects = region.getRects();
   ASSERT_EQ(rects.size(), 1u);
   EXPECT_EQ(rects.front(), SkIRect::MakeLTRB(10, 10, 50, 50));
@@ -31,8 +30,7 @@ TEST(DisplayListRegion, NonOverlappingRectangles1) {
     SkIRect rect = SkIRect::MakeXYWH(50 * i, 50 * i, 50, 50);
     rects_in.push_back(rect);
   }
-  DlRegion region;
-  region.addRects(std::move(rects_in));
+  DlRegion region(std::move(rects_in));
   auto rects = region.getRects();
   std::vector<SkIRect> expected{
       {0, 0, 50, 50},       {50, 50, 100, 100},   {100, 100, 150, 150},
@@ -44,8 +42,7 @@ TEST(DisplayListRegion, NonOverlappingRectangles1) {
 }
 
 TEST(DisplayListRegion, NonOverlappingRectangles2) {
-  DlRegion region;
-  region.addRects({
+  DlRegion region({
       SkIRect::MakeXYWH(5, 5, 10, 10),
       SkIRect::MakeXYWH(25, 5, 10, 10),
       SkIRect::MakeXYWH(5, 25, 10, 10),
@@ -62,8 +59,7 @@ TEST(DisplayListRegion, NonOverlappingRectangles2) {
 }
 
 TEST(DisplayListRegion, NonOverlappingRectangles3) {
-  DlRegion region;
-  region.addRects({
+  DlRegion region({
       SkIRect::MakeXYWH(0, 0, 10, 10),
       SkIRect::MakeXYWH(-11, -11, 10, 10),
       SkIRect::MakeXYWH(11, 11, 10, 10),
@@ -90,8 +86,7 @@ TEST(DisplayListRegion, NonOverlappingRectangles3) {
 }
 
 TEST(DisplayListRegion, MergeTouchingRectangles) {
-  DlRegion region;
-  region.addRects({
+  DlRegion region({
       SkIRect::MakeXYWH(0, 0, 10, 10),
       SkIRect::MakeXYWH(-10, -10, 10, 10),
       SkIRect::MakeXYWH(10, 10, 10, 10),
@@ -116,8 +111,7 @@ TEST(DisplayListRegion, OverlappingRectangles) {
     SkIRect rect = SkIRect::MakeXYWH(10 * i, 10 * i, 50, 50);
     rects_in.push_back(rect);
   }
-  DlRegion region;
-  region.addRects(std::move(rects_in));
+  DlRegion region(std::move(rects_in));
   auto rects = region.getRects();
   std::vector<SkIRect> expected{
       {0, 0, 50, 10},      {0, 10, 60, 20},     {0, 20, 70, 30},
@@ -131,8 +125,7 @@ TEST(DisplayListRegion, OverlappingRectangles) {
 }
 
 TEST(DisplayListRegion, Deband) {
-  DlRegion region;
-  region.addRects({
+  DlRegion region({
       SkIRect::MakeXYWH(0, 0, 50, 50),
       SkIRect::MakeXYWH(60, 0, 20, 20),
       SkIRect::MakeXYWH(90, 0, 50, 50),
@@ -194,8 +187,7 @@ TEST(DisplayListRegion, TestAgainstSkRegion) {
       sk_region.op(rect, SkRegion::kUnion_Op);
     }
 
-    DlRegion region;
-    region.addRects(std::move(rects_in));
+    DlRegion region(std::move(rects_in));
 
     // Do not deband the rectangles - identical to SkRegion::Iterator
     auto rects = region.getRects(false);

--- a/display_list/geometry/dl_rtree.cc
+++ b/display_list/geometry/dl_rtree.cc
@@ -166,12 +166,15 @@ std::list<SkRect> DlRTree::searchAndConsolidateRects(const SkRect& query,
   std::vector<int> intermediary_results;
   search(query, &intermediary_results);
 
-  DlRegion region;
+  std::vector<SkIRect> rects;
+  rects.reserve(intermediary_results.size());
   for (int index : intermediary_results) {
     SkIRect current_record_rect;
     bounds(index).roundOut(&current_record_rect);
-    region.addRect(current_record_rect);
+    rects.push_back(current_record_rect);
   }
+  DlRegion region;
+  region.addRects(std::move(rects));
 
   auto non_overlapping_rects = region.getRects(deband);
   std::list<SkRect> final_results;

--- a/display_list/geometry/dl_rtree.cc
+++ b/display_list/geometry/dl_rtree.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/display_list/geometry/dl_rtree.h"
+#include "flutter/display_list/geometry/dl_region.h"
 
 #include "flutter/fml/logging.h"
 
@@ -165,38 +166,17 @@ std::list<SkRect> DlRTree::searchAndConsolidateRects(
   std::vector<int> intermediary_results;
   search(query, &intermediary_results);
 
-  std::list<SkRect> final_results;
+  DlRegion region;
   for (int index : intermediary_results) {
-    auto current_record_rect = bounds(index);
-    auto replaced_existing_rect = false;
-    // // If the current record rect intersects with any of the rects in the
-    // // result list, then join them, and update the rect in final_results.
-    std::list<SkRect>::iterator curr_rect_itr = final_results.begin();
-    std::list<SkRect>::iterator first_intersecting_rect_itr;
-    while (!replaced_existing_rect && curr_rect_itr != final_results.end()) {
-      if (SkRect::Intersects(*curr_rect_itr, current_record_rect)) {
-        replaced_existing_rect = true;
-        first_intersecting_rect_itr = curr_rect_itr;
-        curr_rect_itr->join(current_record_rect);
-      }
-      curr_rect_itr++;
-    }
-    // It's possible that the result contains duplicated rects at this point.
-    // For example, consider a result list that contains rects A, B. If a
-    // new rect C is a superset of A and B, then A and B are the same set after
-    // the merge. As a result, find such cases and remove them from the result
-    // list.
-    while (replaced_existing_rect && curr_rect_itr != final_results.end()) {
-      if (SkRect::Intersects(*curr_rect_itr, *first_intersecting_rect_itr)) {
-        first_intersecting_rect_itr->join(*curr_rect_itr);
-        curr_rect_itr = final_results.erase(curr_rect_itr);
-      } else {
-        curr_rect_itr++;
-      }
-    }
-    if (!replaced_existing_rect) {
-      final_results.push_back(current_record_rect);
-    }
+    SkIRect current_record_rect;
+    bounds(index).roundOut(&current_record_rect);
+    region.addRect(current_record_rect);
+  }
+
+  auto non_overlapping_rects = region.getRects(true);
+  std::list<SkRect> final_results;
+  for (const auto& rect : non_overlapping_rects) {
+    final_results.push_back(SkRect::Make(rect));
   }
   return final_results;
 }

--- a/display_list/geometry/dl_rtree.cc
+++ b/display_list/geometry/dl_rtree.cc
@@ -160,8 +160,8 @@ void DlRTree::search(const SkRect& query, std::vector<int>* results) const {
   }
 }
 
-std::list<SkRect> DlRTree::searchAndConsolidateRects(
-    const SkRect& query) const {
+std::list<SkRect> DlRTree::searchAndConsolidateRects(const SkRect& query,
+                                                     bool deband) const {
   // Get the indexes for the operations that intersect with the query rect.
   std::vector<int> intermediary_results;
   search(query, &intermediary_results);
@@ -173,7 +173,7 @@ std::list<SkRect> DlRTree::searchAndConsolidateRects(
     region.addRect(current_record_rect);
   }
 
-  auto non_overlapping_rects = region.getRects(true);
+  auto non_overlapping_rects = region.getRects(deband);
   std::list<SkRect> final_results;
   for (const auto& rect : non_overlapping_rects) {
     final_results.push_back(SkRect::Make(rect));

--- a/display_list/geometry/dl_rtree.cc
+++ b/display_list/geometry/dl_rtree.cc
@@ -173,8 +173,7 @@ std::list<SkRect> DlRTree::searchAndConsolidateRects(const SkRect& query,
     bounds(index).roundOut(&current_record_rect);
     rects.push_back(current_record_rect);
   }
-  DlRegion region;
-  region.addRects(std::move(rects));
+  DlRegion region(std::move(rects));
 
   auto non_overlapping_rects = region.getRects(deband);
   std::list<SkRect> final_results;

--- a/display_list/geometry/dl_rtree.h
+++ b/display_list/geometry/dl_rtree.h
@@ -109,8 +109,7 @@ class DlRTree : public SkRefCnt {
 
   /// Finds the rects in the tree that intersect with the query rect.
   ///
-  /// When two matching query results intersect with each other, they are
-  /// joined into a single rect which also intersects with the query rect.
+  /// The returned list of rectangles will be non-overlapping.
   /// In other words, the bounds of each rect in the result list are mutually
   /// exclusive.
   std::list<SkRect> searchAndConsolidateRects(const SkRect& query) const;

--- a/display_list/geometry/dl_rtree.h
+++ b/display_list/geometry/dl_rtree.h
@@ -112,7 +112,12 @@ class DlRTree : public SkRefCnt {
   /// The returned list of rectangles will be non-overlapping.
   /// In other words, the bounds of each rect in the result list are mutually
   /// exclusive.
-  std::list<SkRect> searchAndConsolidateRects(const SkRect& query) const;
+  ///
+  /// If |deband| is true, then matching rectangles from adjacent DlRegion
+  /// spanlines will be joined together. This reduces the number of
+  /// rectangles returned, but requires some extra computation.
+  std::list<SkRect> searchAndConsolidateRects(const SkRect& query,
+                                              bool deband = true) const;
 
  private:
   static constexpr SkRect empty_ = SkRect::MakeEmpty();

--- a/flow/rtree.cc
+++ b/flow/rtree.cc
@@ -6,6 +6,7 @@
 
 #include <list>
 
+#include "flutter/display_list/geometry/dl_region.h"
 #include "flutter/fml/logging.h"
 #include "third_party/skia/include/core/SkBBHFactory.h"
 #include "third_party/skia/include/core/SkRect.h"
@@ -41,43 +42,22 @@ std::list<SkRect> RTree::searchNonOverlappingDrawnRects(
   std::vector<int> intermediary_results;
   search(query, &intermediary_results);
 
-  std::list<SkRect> final_results;
+  DlRegion region;
   for (int index : intermediary_results) {
     auto draw_op = draw_op_.find(index);
     // Ignore records that don't draw anything.
     if (draw_op == draw_op_.end()) {
       continue;
     }
-    auto current_record_rect = draw_op->second;
-    auto replaced_existing_rect = false;
-    // // If the current record rect intersects with any of the rects in the
-    // // result list, then join them, and update the rect in final_results.
-    std::list<SkRect>::iterator curr_rect_itr = final_results.begin();
-    std::list<SkRect>::iterator first_intersecting_rect_itr;
-    while (!replaced_existing_rect && curr_rect_itr != final_results.end()) {
-      if (SkRect::Intersects(*curr_rect_itr, current_record_rect)) {
-        replaced_existing_rect = true;
-        first_intersecting_rect_itr = curr_rect_itr;
-        curr_rect_itr->join(current_record_rect);
-      }
-      curr_rect_itr++;
-    }
-    // It's possible that the result contains duplicated rects at this point.
-    // For example, consider a result list that contains rects A, B. If a
-    // new rect C is a superset of A and B, then A and B are the same set after
-    // the merge. As a result, find such cases and remove them from the result
-    // list.
-    while (replaced_existing_rect && curr_rect_itr != final_results.end()) {
-      if (SkRect::Intersects(*curr_rect_itr, *first_intersecting_rect_itr)) {
-        first_intersecting_rect_itr->join(*curr_rect_itr);
-        curr_rect_itr = final_results.erase(curr_rect_itr);
-      } else {
-        curr_rect_itr++;
-      }
-    }
-    if (!replaced_existing_rect) {
-      final_results.push_back(current_record_rect);
-    }
+    SkIRect current_record_rect;
+    draw_op->second.roundOut(&current_record_rect);
+    region.addRect(current_record_rect);
+  }
+
+  auto non_overlapping_rects = region.getRects(true);
+  std::list<SkRect> final_results;
+  for (const auto& rect : non_overlapping_rects) {
+    final_results.push_back(SkRect::Make(rect));
   }
   return final_results;
 }

--- a/flow/rtree.cc
+++ b/flow/rtree.cc
@@ -42,7 +42,7 @@ std::list<SkRect> RTree::searchNonOverlappingDrawnRects(
   std::vector<int> intermediary_results;
   search(query, &intermediary_results);
 
-  DlRegion region;
+  std::vector<SkIRect> rects;
   for (int index : intermediary_results) {
     auto draw_op = draw_op_.find(index);
     // Ignore records that don't draw anything.
@@ -51,9 +51,11 @@ std::list<SkRect> RTree::searchNonOverlappingDrawnRects(
     }
     SkIRect current_record_rect;
     draw_op->second.roundOut(&current_record_rect);
-    region.addRect(current_record_rect);
+    rects.push_back(current_record_rect);
   }
 
+  DlRegion region;
+  region.addRects(std::move(rects));
   auto non_overlapping_rects = region.getRects(true);
   std::list<SkRect> final_results;
   for (const auto& rect : non_overlapping_rects) {

--- a/flow/rtree.cc
+++ b/flow/rtree.cc
@@ -54,8 +54,7 @@ std::list<SkRect> RTree::searchNonOverlappingDrawnRects(
     rects.push_back(current_record_rect);
   }
 
-  DlRegion region;
-  region.addRects(std::move(rects));
+  DlRegion region(std::move(rects));
   auto non_overlapping_rects = region.getRects(true);
   std::list<SkRect> final_results;
   for (const auto& rect : non_overlapping_rects) {

--- a/flow/rtree_unittests.cc
+++ b/flow/rtree_unittests.cc
@@ -123,15 +123,15 @@ TEST(RTree, searchNonOverlappingDrawnRectsJoinRectsWhenIntersectedCase1) {
   rect_paint.setStyle(SkPaint::Style::kFill_Style);
 
   // Given the A, and B rects, which intersect with the query rect,
-  // the result list contains the rect resulting from the union of A and B.
+  // the result list contains the three rectangles covering same area.
   //
-  // +-----+
-  // |  A  |
-  // |   +-----+
-  // |   |  C  |
-  // |   +-----+
-  // |     |
-  // +-----+
+  // +-----+        +-----+
+  // |  A  |        |  A  |
+  // |   +-----+    +---------+
+  // |   |     |    |   B     |
+  // +---|  B  |    +---+-----+
+  //     |     |        |  C  |
+  //     +-----+        +-----+
 
   // A
   recording_canvas->drawRect(SkRect::MakeLTRB(100, 100, 150, 150), rect_paint);
@@ -142,8 +142,10 @@ TEST(RTree, searchNonOverlappingDrawnRectsJoinRectsWhenIntersectedCase1) {
 
   auto hits = rtree_factory.getInstance()->searchNonOverlappingDrawnRects(
       SkRect::MakeXYWH(120, 120, 126, 126));
-  ASSERT_EQ(1UL, hits.size());
-  ASSERT_EQ(*hits.begin(), SkRect::MakeLTRB(100, 100, 175, 175));
+  ASSERT_EQ(3UL, hits.size());
+  ASSERT_EQ(*hits.begin(), SkRect::MakeLTRB(100, 100, 150, 125));
+  ASSERT_EQ(*std::next(hits.begin(), 1), SkRect::MakeLTRB(100, 125, 175, 150));
+  ASSERT_EQ(*std::next(hits.begin(), 2), SkRect::MakeLTRB(125, 150, 175, 175));
 }
 
 TEST(RTree, searchNonOverlappingDrawnRectsJoinRectsWhenIntersectedCase2) {
@@ -198,7 +200,7 @@ TEST(RTree, searchNonOverlappingDrawnRectsJoinRectsWhenIntersectedCase3) {
   rect_paint.setStyle(SkPaint::Style::kFill_Style);
 
   // Given the A, B, C and D rects that intersect with the query rect,
-  // the result list contains a single rect, which is the union of
+  // the result list contains two rects - D and remainder of C
   // these four rects.
   //
   // +------------------------------+
@@ -227,8 +229,9 @@ TEST(RTree, searchNonOverlappingDrawnRectsJoinRectsWhenIntersectedCase3) {
 
   auto hits = rtree_factory.getInstance()->searchNonOverlappingDrawnRects(
       SkRect::MakeLTRB(30, 30, 550, 270));
-  ASSERT_EQ(1UL, hits.size());
-  ASSERT_EQ(*hits.begin(), SkRect::MakeLTRB(50, 50, 620, 300));
+  ASSERT_EQ(2UL, hits.size());
+  ASSERT_EQ(*hits.begin(), SkRect::MakeLTRB(50, 50, 620, 250));
+  ASSERT_EQ(*std::next(hits.begin(), 1), SkRect::MakeLTRB(500, 250, 600, 300));
 }
 
 }  // namespace testing

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/UnobstructedPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/UnobstructedPlatformViewTests.m
@@ -158,17 +158,14 @@ static const CGFloat kCompareAccuracy = 0.001;
 
   XCUIElement* overlay1 = app.otherElements[@"platform_view[0].overlay[0]"];
   XCTAssertTrue(overlay1.exists);
-  XCTAssertEqual(overlay1.frame.origin.x, 150);
+  XCTAssertEqual(overlay1.frame.origin.x, 75);
   XCTAssertEqual(overlay1.frame.origin.y, 150);
-  XCTAssertEqual(overlay1.frame.size.width, 75);
-  XCTAssertEqual(overlay1.frame.size.height, 75);
+  XCTAssertEqual(overlay1.frame.size.width, 150);
+  XCTAssertEqual(overlay1.frame.size.height, 100);
 
-  XCUIElement* overlay2 = app.otherElements[@"platform_view[0].overlay[1]"];
-  XCTAssertTrue(overlay2.exists);
-  XCTAssertEqual(overlay2.frame.origin.x, 75);
-  XCTAssertEqual(overlay2.frame.origin.y, 225);
-  XCTAssertEqual(overlay2.frame.size.width, 50);
-  XCTAssertEqual(overlay2.frame.size.height, 25);
+  // There are three non overlapping rects above platform view, which
+  // FlutterPlatformViewsController merges into one.
+  XCTAssertFalse(app.otherElements[@"platform_view[0].overlay[1]"].exists);
 
   XCUIElement* overlayView0 = app.otherElements[@"platform_view[0].overlay_view[0]"];
   XCTAssertTrue(overlayView0.exists);
@@ -177,15 +174,6 @@ static const CGFloat kCompareAccuracy = 0.001;
   XCTAssertEqualWithAccuracy(overlayView0.frame.origin.y, app.frame.origin.x, kCompareAccuracy);
   XCTAssertEqualWithAccuracy(overlayView0.frame.size.width, app.frame.size.width, kCompareAccuracy);
   XCTAssertEqualWithAccuracy(overlayView0.frame.size.height, app.frame.size.height,
-                             kCompareAccuracy);
-
-  XCUIElement* overlayView1 = app.otherElements[@"platform_view[0].overlay_view[1]"];
-  XCTAssertTrue(overlayView1.exists);
-  // Overlay should always be the same frame as the app.
-  XCTAssertEqualWithAccuracy(overlayView1.frame.origin.x, app.frame.origin.x, kCompareAccuracy);
-  XCTAssertEqualWithAccuracy(overlayView1.frame.origin.y, app.frame.origin.x, kCompareAccuracy);
-  XCTAssertEqualWithAccuracy(overlayView1.frame.size.width, app.frame.size.width, kCompareAccuracy);
-  XCTAssertEqualWithAccuracy(overlayView1.frame.size.height, app.frame.size.height,
                              kCompareAccuracy);
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/116070
Fixes https://github.com/flutter/flutter/issues/126202

Introduces `DlRegion` class which implements subset of `SkRegion` required to get non-overlapping rectangles from region.

The implementation is different and faster than `SkRegion` for this particular use-case (`display_list_region_benchmarks`):

Edit: Updated benchmark to latest revision and natively (initial run went through rosetta)
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_RegionBenchmarkDlRegion/Tiny          616 us          616 us          908
BM_RegionBenchmarkSkRegion/Tiny        70559 us        70557 us           10
BM_RegionBenchmarkDlRegion/Small        1315 us         1314 us          537
BM_RegionBenchmarkSkRegion/Small      121736 us       121717 us            6
BM_RegionBenchmarkDlRegion/Medium       1079 us         1079 us          650
BM_RegionBenchmarkSkRegion/Medium      22039 us        22035 us           32
BM_RegionBenchmarkDlRegion/Large         399 us          399 us         1763
BM_RegionBenchmarkSkRegion/Large        1510 us         1510 us          466
```

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
