### PR TITLE
Fix lint failure in ImageDecoderImpeller

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -318,7 +318,7 @@ ImageDecoderImpeller::UploadTextureToPrivate(
     const std::shared_ptr<impeller::Context>& context,
     const std::shared_ptr<impeller::DeviceBuffer>& buffer,
     const SkImageInfo& image_info,
-    std::shared_ptr<SkBitmap> bitmap,
+    const std::shared_ptr<SkBitmap>& bitmap,
     const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch) {
   TRACE_EVENT0("impeller", __FUNCTION__);
   if (!context) {

--- a/lib/ui/painting/image_decoder_impeller.h
+++ b/lib/ui/painting/image_decoder_impeller.h
@@ -80,7 +80,7 @@ class ImageDecoderImpeller final : public ImageDecoder {
       const std::shared_ptr<impeller::Context>& context,
       const std::shared_ptr<impeller::DeviceBuffer>& buffer,
       const SkImageInfo& image_info,
-      std::shared_ptr<SkBitmap> bitmap,
+      const std::shared_ptr<SkBitmap>& bitmap,
       const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
 
   /// @brief Create a host visible texture from the provided bitmap.


### PR DESCRIPTION
This lint started failing on some builders a few hours ago.

https://ci.chromium.org/p/flutter/builders/prod/Linux%20Host%20clang-tidy