### PR TITLE
Fix: invalid time-point comparison between each from different clock source

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -5,9 +5,11 @@
 #define FML_USED_ON_EMBEDDER
 
 #include <algorithm>
+#include <chrono>
 #include <ctime>
 #include <future>
 #include <memory>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -50,6 +52,8 @@
 #ifdef SHELL_ENABLE_VULKAN
 #include "flutter/vulkan/vulkan_application.h"  // nogncheck
 #endif
+
+using namespace std::chrono_literals;
 
 // CREATE_NATIVE_ENTRY is leaky by design
 // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
@@ -732,6 +736,9 @@ TEST_F(ShellTest, ReportTimingsIsCalled) {
 TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Wait to make |start| bigger than zero
+  std::this_thread::sleep_for(1ms);
 
   // We MUST put |start| after |CreateShell()| because the clock source will be
   // reset through |TimePoint::SetClockSource()| in

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -53,8 +53,6 @@
 #include "flutter/vulkan/vulkan_application.h"  // nogncheck
 #endif
 
-using namespace std::chrono_literals;
-
 // CREATE_NATIVE_ENTRY is leaky by design
 // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
 
@@ -747,6 +745,7 @@ TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
   std::unique_ptr<Shell> shell = CreateShell(settings);
 
   // Wait to make |start| bigger than zero
+  using namespace std::chrono_literals;
   std::this_thread::sleep_for(1ms);
 
   // We MUST put |start| after |CreateShell()| because the clock source will be

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -676,9 +676,13 @@ static void CheckFrameTimings(const std::vector<FrameTiming>& timings,
 }
 
 TEST_F(ShellTest, ReportTimingsIsCalled) {
-  fml::TimePoint start = fml::TimePoint::Now();
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // We MUST put |start| after |CreateShell| because the clock source will be
+  // reset through |TimePoint::SetClockSource()| in
+  // |DartVMInitializer::Initialize()| within |CreateShell()|.
+  fml::TimePoint start = fml::TimePoint::Now();
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());
@@ -726,9 +730,14 @@ TEST_F(ShellTest, ReportTimingsIsCalled) {
 }
 
 TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // We MUST put |start| after |CreateShell()| because the clock source will be
+  // reset through |TimePoint::SetClockSource()| in
+  // |DartVMInitializer::Initialize()| within |CreateShell()|.
   fml::TimePoint start = fml::TimePoint::Now();
 
-  auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent timingLatch;
   FrameTiming timing;
 
@@ -744,8 +753,6 @@ TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
     timing = t;
     timingLatch.Signal();
   };
-
-  std::unique_ptr<Shell> shell = CreateShell(settings);
 
   // Create the surface needed by rasterizer
   PlatformViewNotifyCreated(shell.get());


### PR DESCRIPTION
Sometimes the time point created late will less than the time point create earlier since the CLOCK SOURCE has changed.

We must make sure the  CLOCK SOURCE (fml::TimePoint) is always keep the same while we are testing. 
Corrects the test case is needed before we fix the problem completely.
