### PR TITLE
Revert "Move linux clang tidy to engine_v2."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -267,7 +267,6 @@ targets:
     timeout: 60
 
   - name: Linux Host clang-tidy
-    bringup: true
     recipe: engine/engine_lint
     properties:
       cores: "32"
@@ -288,7 +287,6 @@ targets:
       - "**.vert"
 
   - name: Linux Android clang-tidy
-    bringup: true
     recipe: engine/engine_lint
     properties:
       cores: "32"
@@ -327,6 +325,7 @@ targets:
       - os=Linux
 
   - name: Linux linux_clang_tidy
+    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:


### PR DESCRIPTION
Reverts flutter/engine#42112

Try jobs appear to be running mysteriously slow and timing out: https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20Engine%20Drone/922165/overview

I'm guessing that the sharding might not be working quite right.