### PR TITLE
Revert "Cherry picks for image decoding in Impeller"

### DIFF
--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -383,13 +383,10 @@ static bool Bind(PassBindingsCache& pass,
   }
 
   if (texture.NeedsMipmapGeneration()) {
-    // TODO(127697): generate mips when the GPU is available on iOS.
-#if !FML_OS_IOS
     VALIDATION_LOG
         << "Texture at binding index " << bind_index
         << " has a mip count > 1, but the mipmap has not been generated.";
     return false;
-#endif  // !FML_OS_IOS
   }
 
   return pass.SetTexture(stage, bind_index,

--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -248,12 +248,12 @@ void createPath() {
 external void _validatePath(Path path);
 
 @pragma('vm:entry-point')
-void frameCallback(Object? image, int durationMilliseconds, String decodeError) {
-  validateFrameCallback(image, durationMilliseconds, decodeError);
+void frameCallback(Object? image, int durationMilliseconds) {
+  validateFrameCallback(image, durationMilliseconds);
 }
 
 @pragma('vm:external-name', 'ValidateFrameCallback')
-external void validateFrameCallback(Object? image, int durationMilliseconds, String decodeError);
+external void validateFrameCallback(Object? image, int durationMilliseconds);
 
 @pragma('vm:entry-point')
 void platformMessagePortResponseTest() async {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2105,12 +2105,9 @@ class Codec extends NativeFieldWrapperClass1 {
   /// [FrameInfo.image] on the returned object.
   Future<FrameInfo> getNextFrame() async {
     final Completer<FrameInfo> completer = Completer<FrameInfo>.sync();
-    final String? error = _getNextFrame((_Image? image, int durationMilliseconds, String decodeError) {
+    final String? error = _getNextFrame((_Image? image, int durationMilliseconds) {
       if (image == null) {
-        if (decodeError.isEmpty) {
-          decodeError = 'Codec failed to produce an image, possibly due to invalid image data.';
-        }
-        completer.completeError(Exception(decodeError));
+        completer.completeError(Exception('Codec failed to produce an image, possibly due to invalid image data.'));
       } else {
         completer.complete(FrameInfo._(
           image: Image._(image, image.width, image.height),
@@ -2126,7 +2123,7 @@ class Codec extends NativeFieldWrapperClass1 {
 
   /// Returns an error message on failure, null on success.
   @Native<Handle Function(Pointer<Void>, Handle)>(symbol: 'Codec::getNextFrame')
-  external String? _getNextFrame(void Function(_Image?, int, String) callback);
+  external String? _getNextFrame(void Function(_Image?, int) callback);
 
   /// Release the resources used by this object. The object is no longer usable
   /// after this method is called.

--- a/lib/ui/painting/image_decoder.cc
+++ b/lib/ui/painting/image_decoder.cc
@@ -16,16 +16,14 @@ std::unique_ptr<ImageDecoder> ImageDecoder::Make(
     const Settings& settings,
     const TaskRunners& runners,
     std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
-    fml::WeakPtr<IOManager> io_manager,
-    const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch) {
+    fml::WeakPtr<IOManager> io_manager) {
 #if IMPELLER_SUPPORTS_RENDERING
   if (settings.enable_impeller) {
     return std::make_unique<ImageDecoderImpeller>(
         runners,                            //
         std::move(concurrent_task_runner),  //
         std::move(io_manager),              //
-        settings.enable_wide_gamut,         //
-        gpu_disabled_switch);
+        settings.enable_wide_gamut);
   }
 #endif  // IMPELLER_SUPPORTS_RENDERING
   return std::make_unique<ImageDecoderSkia>(

--- a/lib/ui/painting/image_decoder.h
+++ b/lib/ui/painting/image_decoder.h
@@ -27,12 +27,11 @@ class ImageDecoder {
       const Settings& settings,
       const TaskRunners& runners,
       std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
-      fml::WeakPtr<IOManager> io_manager,
-      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
+      fml::WeakPtr<IOManager> io_manager);
 
   virtual ~ImageDecoder();
 
-  using ImageResult = std::function<void(sk_sp<DlImage>, std::string)>;
+  using ImageResult = std::function<void(sk_sp<DlImage>)>;
 
   // Takes an image descriptor and returns a handle to a texture resident on the
   // GPU. All image decompression and resizes are done on a worker thread

--- a/lib/ui/painting/image_decoder_impeller.h
+++ b/lib/ui/painting/image_decoder_impeller.h
@@ -41,7 +41,6 @@ struct DecompressResult {
   std::shared_ptr<impeller::DeviceBuffer> device_buffer;
   std::shared_ptr<SkBitmap> sk_bitmap;
   SkImageInfo image_info;
-  std::string decode_error;
 };
 
 class ImageDecoderImpeller final : public ImageDecoder {
@@ -50,8 +49,7 @@ class ImageDecoderImpeller final : public ImageDecoder {
       const TaskRunners& runners,
       std::shared_ptr<fml::ConcurrentTaskRunner> concurrent_task_runner,
       const fml::WeakPtr<IOManager>& io_manager,
-      bool supports_wide_gamut,
-      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
+      bool supports_wide_gamut);
 
   ~ImageDecoderImpeller() override;
 
@@ -61,7 +59,7 @@ class ImageDecoderImpeller final : public ImageDecoder {
               uint32_t target_height,
               const ImageResult& result) override;
 
-  static DecompressResult DecompressTexture(
+  static std::optional<DecompressResult> DecompressTexture(
       ImageDescriptor* descriptor,
       SkISize target_size,
       impeller::ISize max_texture_size,
@@ -73,35 +71,27 @@ class ImageDecoderImpeller final : public ImageDecoder {
   /// @param context    The Impeller graphics context.
   /// @param buffer     A host buffer containing the image to be uploaded.
   /// @param image_info Format information about the particular image.
-  /// @param bitmap      A bitmap containg the image to be uploaded.
-  /// @param gpu_disabled_switch Whether the GPU is available command encoding.
   /// @return           A DlImage.
-  static std::pair<sk_sp<DlImage>, std::string> UploadTextureToPrivate(
+  static sk_sp<DlImage> UploadTextureToPrivate(
       const std::shared_ptr<impeller::Context>& context,
       const std::shared_ptr<impeller::DeviceBuffer>& buffer,
-      const SkImageInfo& image_info,
-      std::shared_ptr<SkBitmap> bitmap,
-      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
+      const SkImageInfo& image_info);
 
   /// @brief Create a host visible texture from the provided bitmap.
   /// @param context     The Impeller graphics context.
   /// @param bitmap      A bitmap containg the image to be uploaded.
   /// @param create_mips Whether mipmaps should be generated for the given
   /// image.
-  /// @param gpu_disabled_switch Whether the GPU is available for mipmap
-  /// creation.
   /// @return            A DlImage.
-  static std::pair<sk_sp<DlImage>, std::string> UploadTextureToShared(
+  static sk_sp<DlImage> UploadTextureToShared(
       const std::shared_ptr<impeller::Context>& context,
       std::shared_ptr<SkBitmap> bitmap,
-      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch,
       bool create_mips = true);
 
  private:
   using FutureContext = std::shared_future<std::shared_ptr<impeller::Context>>;
   FutureContext context_;
   const bool supports_wide_gamut_;
-  std::shared_ptr<fml::SyncSwitch> gpu_disabled_switch_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ImageDecoderImpeller);
 };

--- a/lib/ui/painting/image_decoder_skia.cc
+++ b/lib/ui/painting/image_decoder_skia.cc
@@ -254,7 +254,7 @@ void ImageDecoderSkia::Decode(fml::RefPtr<ImageDescriptor> descriptor_ref_ptr,
               // terminate without a base trace. Add one explicitly.
               TRACE_EVENT0("flutter", "ImageDecodeCallback");
               flow.End();
-              callback(DlImageGPU::Make(std::move(image)), {});
+              callback(DlImageGPU::Make(std::move(image)));
               raw_descriptor->Release();
             }));
       };

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -136,11 +136,8 @@ class TestImpellerContext : public impeller::Context {
   }
 
   std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override {
-    command_buffer_count_ += 1;
     return nullptr;
   }
-
-  mutable size_t command_buffer_count_ = 0;
 
  private:
   std::shared_ptr<const Capabilities> capabilities_;
@@ -281,8 +278,7 @@ TEST_F(ImageDecoderFixtureTest, CanCreateImageDecoder) {
     TestIOManager manager(runners.GetIOTaskRunner());
     Settings settings;
     auto decoder = ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
-                                      manager.GetWeakIOManager(),
-                                      std::make_shared<fml::SyncSwitch>());
+                                      manager.GetWeakIOManager());
     ASSERT_NE(decoder, nullptr);
   });
 }
@@ -333,8 +329,7 @@ TEST_F(ImageDecoderFixtureTest, InvalidImageResultsError) {
     TestIOManager manager(runners.GetIOTaskRunner());
     Settings settings;
     auto decoder = ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
-                                      manager.GetWeakIOManager(),
-                                      std::make_shared<fml::SyncSwitch>());
+                                      manager.GetWeakIOManager());
 
     auto data = OpenFixtureAsSkData("ThisDoesNotExist.jpg");
     ASSERT_FALSE(data);
@@ -343,8 +338,7 @@ TEST_F(ImageDecoderFixtureTest, InvalidImageResultsError) {
         fml::MakeRefCounted<ImageDescriptor>(
             std::move(data), std::make_unique<UnknownImageGenerator>());
 
-    ImageDecoder::ImageResult callback = [&](const sk_sp<DlImage>& image,
-                                             const std::string& decode_error) {
+    ImageDecoder::ImageResult callback = [&](const sk_sp<DlImage>& image) {
       ASSERT_TRUE(runners.GetUITaskRunner()->RunsTasksOnCurrentThread());
       ASSERT_FALSE(image);
       latch.Signal();
@@ -373,9 +367,9 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
   };
   auto decode_image = [&]() {
     Settings settings;
-    std::unique_ptr<ImageDecoder> image_decoder = ImageDecoder::Make(
-        settings, runners, loop->GetTaskRunner(),
-        io_manager->GetWeakIOManager(), std::make_shared<fml::SyncSwitch>());
+    std::unique_ptr<ImageDecoder> image_decoder =
+        ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
+                           io_manager->GetWeakIOManager());
 
     auto data = OpenFixtureAsSkData("DashInNooglerHat.jpg");
 
@@ -390,8 +384,7 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
     auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
         std::move(data), std::move(generator));
 
-    ImageDecoder::ImageResult callback = [&](const sk_sp<DlImage>& image,
-                                             const std::string& decode_error) {
+    ImageDecoder::ImageResult callback = [&](const sk_sp<DlImage>& image) {
       ASSERT_TRUE(runners.GetUITaskRunner()->RunsTasksOnCurrentThread());
       ASSERT_TRUE(image && image->skia_image());
       EXPECT_TRUE(io_manager->did_access_is_gpu_disabled_sync_switch_);
@@ -428,34 +421,6 @@ float HalfToFloat(uint16_t half) {
   return (negative ? -1.f : 1.f) * pow_value * (1.0f + fFraction);
 }
 }  // namespace
-
-TEST_F(ImageDecoderFixtureTest, ImpellerUploadToSharedNoGpu) {
-#if !IMPELLER_SUPPORTS_RENDERING
-  GTEST_SKIP() << "Impeller only test.";
-#endif  // IMPELLER_SUPPORTS_RENDERING
-
-  auto no_gpu_access_context =
-      std::make_shared<impeller::TestImpellerContext>();
-  auto gpu_disabled_switch = std::make_shared<fml::SyncSwitch>(true);
-
-  auto info = SkImageInfo::Make(10, 10, SkColorType::kRGBA_8888_SkColorType,
-                                SkAlphaType::kPremul_SkAlphaType);
-  auto bitmap = std::make_shared<SkBitmap>();
-  bitmap->allocPixels(info, 10 * 4);
-  impeller::DeviceBufferDescriptor desc;
-  desc.size = bitmap->computeByteSize();
-  auto buffer = std::make_shared<impeller::TestImpellerDeviceBuffer>(desc);
-
-  auto result = ImageDecoderImpeller::UploadTextureToPrivate(
-      no_gpu_access_context, buffer, info, bitmap, gpu_disabled_switch);
-  ASSERT_EQ(no_gpu_access_context->command_buffer_count_, 0ul);
-  ASSERT_EQ(result.second, "");
-
-  result = ImageDecoderImpeller::UploadTextureToShared(
-      no_gpu_access_context, bitmap, gpu_disabled_switch, true);
-  ASSERT_EQ(no_gpu_access_context->command_buffer_count_, 0ul);
-  ASSERT_EQ(result.second, "");
-}
 
 TEST_F(ImageDecoderFixtureTest, ImpellerNullColorspace) {
   auto info = SkImageInfo::Make(10, 10, SkColorType::kRGBA_8888_SkColorType,
@@ -673,9 +638,9 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
   SkISize decoded_size = SkISize::MakeEmpty();
   auto decode_image = [&]() {
     Settings settings;
-    std::unique_ptr<ImageDecoder> image_decoder = ImageDecoder::Make(
-        settings, runners, loop->GetTaskRunner(),
-        io_manager->GetWeakIOManager(), std::make_shared<fml::SyncSwitch>());
+    std::unique_ptr<ImageDecoder> image_decoder =
+        ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
+                           io_manager->GetWeakIOManager());
 
     auto data = OpenFixtureAsSkData("Horizontal.jpg");
 
@@ -690,8 +655,7 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
     auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
         std::move(data), std::move(generator));
 
-    ImageDecoder::ImageResult callback = [&](const sk_sp<DlImage>& image,
-                                             const std::string& decode_error) {
+    ImageDecoder::ImageResult callback = [&](const sk_sp<DlImage>& image) {
       ASSERT_TRUE(runners.GetUITaskRunner()->RunsTasksOnCurrentThread());
       ASSERT_TRUE(image && image->skia_image());
       decoded_size = image->skia_image()->dimensions();
@@ -734,9 +698,9 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
 
   auto decode_image = [&]() {
     Settings settings;
-    std::unique_ptr<ImageDecoder> image_decoder = ImageDecoder::Make(
-        settings, runners, loop->GetTaskRunner(),
-        io_manager->GetWeakIOManager(), std::make_shared<fml::SyncSwitch>());
+    std::unique_ptr<ImageDecoder> image_decoder =
+        ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
+                           io_manager->GetWeakIOManager());
 
     auto data = OpenFixtureAsSkData("DashInNooglerHat.jpg");
 
@@ -751,8 +715,7 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
     auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
         std::move(data), std::move(generator));
 
-    ImageDecoder::ImageResult callback = [&](const sk_sp<DlImage>& image,
-                                             const std::string& decode_error) {
+    ImageDecoder::ImageResult callback = [&](const sk_sp<DlImage>& image) {
       ASSERT_TRUE(runners.GetUITaskRunner()->RunsTasksOnCurrentThread());
       ASSERT_TRUE(image && image->skia_image());
       runners.GetIOTaskRunner()->PostTask(release_io_manager);
@@ -802,8 +765,7 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   PostTaskSync(runners.GetUITaskRunner(), [&]() {
     Settings settings;
     image_decoder = ImageDecoder::Make(settings, runners, loop->GetTaskRunner(),
-                                       io_manager->GetWeakIOManager(),
-                                       std::make_shared<fml::SyncSwitch>());
+                                       io_manager->GetWeakIOManager());
   });
 
   // Setup a generic decoding utility that gives us the final decoded size.
@@ -824,13 +786,12 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
       auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
           std::move(data), std::move(generator));
 
-      ImageDecoder::ImageResult callback =
-          [&](const sk_sp<DlImage>& image, const std::string& decode_error) {
-            ASSERT_TRUE(runners.GetUITaskRunner()->RunsTasksOnCurrentThread());
-            ASSERT_TRUE(image && image->skia_image());
-            final_size = image->skia_image()->dimensions();
-            latch.Signal();
-          };
+      ImageDecoder::ImageResult callback = [&](const sk_sp<DlImage>& image) {
+        ASSERT_TRUE(runners.GetUITaskRunner()->RunsTasksOnCurrentThread());
+        ASSERT_TRUE(image && image->skia_image());
+        final_size = image->skia_image()->dimensions();
+        latch.Signal();
+      };
       image_decoder->Decode(descriptor, target_width, target_height, callback);
     });
     latch.Wait();
@@ -896,14 +857,12 @@ TEST(ImageDecoderTest, VerifySimpleDecoding) {
   auto result_1 = ImageDecoderImpeller::DecompressTexture(
       descriptor.get(), SkISize::Make(6, 2), {100, 100},
       /*supports_wide_gamut=*/false, allocator);
-  ASSERT_EQ(result_1.sk_bitmap->width(), 6);
-  ASSERT_EQ(result_1.sk_bitmap->height(), 2);
+  ASSERT_EQ(result_1->sk_bitmap->dimensions(), SkISize::Make(6, 2));
 
   auto result_2 = ImageDecoderImpeller::DecompressTexture(
       descriptor.get(), SkISize::Make(60, 20), {10, 10},
       /*supports_wide_gamut=*/false, allocator);
-  ASSERT_EQ(result_2.sk_bitmap->width(), 10);
-  ASSERT_EQ(result_2.sk_bitmap->height(), 10);
+  ASSERT_EQ(result_2->sk_bitmap->dimensions(), SkISize::Make(10, 10));
 #endif  // IMPELLER_SUPPORTS_RENDERING
 }
 
@@ -931,13 +890,13 @@ TEST(ImageDecoderTest, VerifySubpixelDecodingPreservesExifOrientation) {
   ASSERT_TRUE(expected_data != nullptr);
   ASSERT_FALSE(expected_data->isEmpty());
 
-  auto assert_image = [&](auto decoded_image, const std::string& decode_error) {
+  auto assert_image = [&](auto decoded_image) {
     ASSERT_EQ(decoded_image->dimensions(), SkISize::Make(300, 100));
     ASSERT_TRUE(decoded_image->encodeToData(SkEncodedImageFormat::kPNG, 100)
                     ->equals(expected_data.get()));
   };
 
-  assert_image(decode(300, 100), {});
+  assert_image(decode(300, 100));
 }
 
 TEST_F(ImageDecoderFixtureTest,

--- a/lib/ui/painting/multi_frame_codec.h
+++ b/lib/ui/painting/multi_frame_codec.h
@@ -9,8 +9,6 @@
 #include "flutter/lib/ui/painting/codec.h"
 #include "flutter/lib/ui/painting/image_generator.h"
 
-#include <utility>
-
 using tonic::DartPersistentValue;
 
 namespace flutter {
@@ -58,7 +56,7 @@ class MultiFrameCodec : public Codec {
     // The index of the last decoded required frame.
     int lastRequiredFrameIndex_ = -1;
 
-    std::pair<sk_sp<DlImage>, std::string> GetNextFrameImage(
+    sk_sp<DlImage> GetNextFrameImage(
         fml::WeakPtr<GrDirectContext> resourceContext,
         const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch,
         const std::shared_ptr<impeller::Context>& impeller_context,

--- a/lib/ui/painting/single_frame_codec.cc
+++ b/lib/ui/painting/single_frame_codec.cc
@@ -36,8 +36,8 @@ Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
     if (!cached_image_->image()) {
       return tonic::ToDart("Decoded image has been disposed");
     }
-    tonic::DartInvoke(callback_handle, {tonic::ToDart(cached_image_),
-                                        tonic::ToDart(0), tonic::ToDart("")});
+    tonic::DartInvoke(callback_handle,
+                      {tonic::ToDart(cached_image_), tonic::ToDart(0)});
     return Dart_Null();
   }
 
@@ -69,8 +69,7 @@ Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
       new fml::RefPtr<SingleFrameCodec>(this);
 
   decoder->Decode(
-      descriptor_, target_width_, target_height_,
-      [raw_codec_ref](auto image, auto decode_error) {
+      descriptor_, target_width_, target_height_, [raw_codec_ref](auto image) {
         std::unique_ptr<fml::RefPtr<SingleFrameCodec>> codec_ref(raw_codec_ref);
         fml::RefPtr<SingleFrameCodec> codec(std::move(*codec_ref));
 
@@ -98,9 +97,9 @@ Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
 
         // Invoke any callbacks that were provided before the frame was decoded.
         for (const DartPersistentValue& callback : codec->pending_callbacks_) {
-          tonic::DartInvoke(callback.value(),
-                            {tonic::ToDart(codec->cached_image_),
-                             tonic::ToDart(0), tonic::ToDart(decode_error)});
+          tonic::DartInvoke(
+              callback.value(),
+              {tonic::ToDart(codec->cached_image_), tonic::ToDart(0)});
         }
         codec->pending_callbacks_.clear();
       });

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -45,8 +45,7 @@ Engine::Engine(
     std::unique_ptr<Animator> animator,
     fml::WeakPtr<IOManager> io_manager,
     const std::shared_ptr<FontCollection>& font_collection,
-    std::unique_ptr<RuntimeController> runtime_controller,
-    const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch)
+    std::unique_ptr<RuntimeController> runtime_controller)
     : delegate_(delegate),
       settings_(settings),
       animator_(std::move(animator)),
@@ -55,8 +54,7 @@ Engine::Engine(
       image_decoder_(ImageDecoder::Make(settings_,
                                         task_runners,
                                         std::move(image_decoder_task_runner),
-                                        std::move(io_manager),
-                                        gpu_disabled_switch)),
+                                        std::move(io_manager))),
       task_runners_(task_runners),
       weak_factory_(this) {
   pointer_data_dispatcher_ = dispatcher_maker(*this);
@@ -73,8 +71,7 @@ Engine::Engine(Delegate& delegate,
                fml::WeakPtr<IOManager> io_manager,
                fml::RefPtr<SkiaUnrefQueue> unref_queue,
                fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
-               std::shared_ptr<VolatilePathTracker> volatile_path_tracker,
-               const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch)
+               std::shared_ptr<VolatilePathTracker> volatile_path_tracker)
     : Engine(delegate,
              dispatcher_maker,
              vm.GetConcurrentWorkerTaskRunner(),
@@ -83,8 +80,7 @@ Engine::Engine(Delegate& delegate,
              std::move(animator),
              io_manager,
              std::make_shared<FontCollection>(),
-             nullptr,
-             gpu_disabled_switch) {
+             nullptr) {
   runtime_controller_ = std::make_unique<RuntimeController>(
       *this,                                 // runtime delegate
       &vm,                                   // VM
@@ -116,8 +112,7 @@ std::unique_ptr<Engine> Engine::Spawn(
     std::unique_ptr<Animator> animator,
     const std::string& initial_route,
     const fml::WeakPtr<IOManager>& io_manager,
-    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
-    const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch) const {
+    fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate) const {
   auto result = std::make_unique<Engine>(
       /*delegate=*/delegate,
       /*dispatcher_maker=*/dispatcher_maker,
@@ -128,8 +123,7 @@ std::unique_ptr<Engine> Engine::Spawn(
       /*animator=*/std::move(animator),
       /*io_manager=*/io_manager,
       /*font_collection=*/font_collection_,
-      /*runtime_controller=*/nullptr,
-      /*gpu_disabled_switch=*/gpu_disabled_switch);
+      /*runtime_controller=*/nullptr);
   result->runtime_controller_ = runtime_controller_->Spawn(
       /*p_client=*/*result,
       /*advisory_script_uri=*/settings.advisory_script_uri,

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -309,8 +309,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
          std::unique_ptr<Animator> animator,
          fml::WeakPtr<IOManager> io_manager,
          const std::shared_ptr<FontCollection>& font_collection,
-         std::unique_ptr<RuntimeController> runtime_controller,
-         const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
+         std::unique_ptr<RuntimeController> runtime_controller);
 
   //----------------------------------------------------------------------------
   /// @brief      Creates an instance of the engine. This is done by the Shell
@@ -365,8 +364,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
          fml::WeakPtr<IOManager> io_manager,
          fml::RefPtr<SkiaUnrefQueue> unref_queue,
          fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
-         std::shared_ptr<VolatilePathTracker> volatile_path_tracker,
-         const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch);
+         std::shared_ptr<VolatilePathTracker> volatile_path_tracker);
 
   //----------------------------------------------------------------------------
   /// @brief      Create a Engine that shares as many resources as
@@ -384,8 +382,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
       std::unique_ptr<Animator> animator,
       const std::string& initial_route,
       const fml::WeakPtr<IOManager>& io_manager,
-      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
-      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch) const;
+      fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate) const;
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys the engine engine. Called by the shell on the UI task

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -162,8 +162,7 @@ TEST_F(EngineTest, Create) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(runtime_controller_),
-        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
+        /*runtime_controller=*/std::move(runtime_controller_));
     EXPECT_TRUE(engine);
   });
 }
@@ -184,8 +183,7 @@ TEST_F(EngineTest, DispatchPlatformMessageUnknown) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
+        /*runtime_controller=*/std::move(mock_runtime_controller));
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
@@ -211,8 +209,7 @@ TEST_F(EngineTest, DispatchPlatformMessageInitialRoute) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
+        /*runtime_controller=*/std::move(mock_runtime_controller));
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
@@ -245,8 +242,7 @@ TEST_F(EngineTest, DispatchPlatformMessageInitialRouteIgnored) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
+        /*runtime_controller=*/std::move(mock_runtime_controller));
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
@@ -278,12 +274,10 @@ TEST_F(EngineTest, SpawnSharesFontLibrary) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
+        /*runtime_controller=*/std::move(mock_runtime_controller));
 
-    auto spawn =
-        engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
-                      std::string(), io_manager_, snapshot_delegate_, nullptr);
+    auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
+                               std::string(), io_manager_, snapshot_delegate_);
     EXPECT_TRUE(spawn != nullptr);
     EXPECT_EQ(&engine->GetFontCollection(), &spawn->GetFontCollection());
   });
@@ -306,12 +300,10 @@ TEST_F(EngineTest, SpawnWithCustomInitialRoute) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
+        /*runtime_controller=*/std::move(mock_runtime_controller));
 
-    auto spawn =
-        engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr, "/foo",
-                      io_manager_, snapshot_delegate_, nullptr);
+    auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
+                               "/foo", io_manager_, snapshot_delegate_);
     EXPECT_TRUE(spawn != nullptr);
     ASSERT_EQ("/foo", spawn->InitialRoute());
   });
@@ -340,16 +332,14 @@ TEST_F(EngineTest, SpawnResetsViewportMetrics) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
+        /*runtime_controller=*/std::move(mock_runtime_controller));
 
     auto& old_platform_data = engine->GetRuntimeController()->GetPlatformData();
     EXPECT_EQ(old_platform_data.viewport_metrics.physical_width, kViewWidth);
     EXPECT_EQ(old_platform_data.viewport_metrics.physical_height, kViewHeight);
 
-    auto spawn =
-        engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
-                      std::string(), io_manager_, snapshot_delegate_, nullptr);
+    auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
+                               std::string(), io_manager_, snapshot_delegate_);
     EXPECT_TRUE(spawn != nullptr);
     auto& new_viewport_metrics =
         spawn->GetRuntimeController()->GetPlatformData().viewport_metrics;
@@ -375,15 +365,14 @@ TEST_F(EngineTest, SpawnWithCustomSettings) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
+        /*runtime_controller=*/std::move(mock_runtime_controller));
 
     Settings custom_settings = settings_;
     custom_settings.persistent_isolate_data =
         std::make_shared<fml::DataMapping>("foo");
     auto spawn =
         engine->Spawn(delegate_, dispatcher_maker_, custom_settings, nullptr,
-                      std::string(), io_manager_, snapshot_delegate_, nullptr);
+                      std::string(), io_manager_, snapshot_delegate_);
     EXPECT_TRUE(spawn != nullptr);
     auto new_persistent_isolate_data =
         const_cast<RuntimeController*>(spawn->GetRuntimeController())
@@ -416,8 +405,7 @@ TEST_F(EngineTest, PassesLoadDartDeferredLibraryErrorToRuntime) {
         /*animator=*/std::move(animator_),
         /*io_manager=*/io_manager_,
         /*font_collection=*/std::make_shared<FontCollection>(),
-        /*runtime_controller=*/std::move(mock_runtime_controller),
-        /*gpu_disabled_switch=*/std::make_shared<fml::SyncSwitch>());
+        /*runtime_controller=*/std::move(mock_runtime_controller));
 
     engine->LoadDartDeferredLibraryError(error_id, error_message, true);
   });

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -326,7 +326,7 @@ void onBeginFrameWithNotifyNativeMain() {
 }
 
 @pragma('vm:entry-point')
-void frameCallback(Object? image, int durationMilliseconds, String decodeError) {
+void frameCallback(Object? image, int durationMilliseconds) {
   if (image == null) {
     throw Exception('Expeccted image in frame callback to be non-null');
   }

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -54,21 +54,19 @@ std::unique_ptr<Engine> CreateEngine(
     const fml::WeakPtr<IOManager>& io_manager,
     const fml::RefPtr<SkiaUnrefQueue>& unref_queue,
     const fml::TaskRunnerAffineWeakPtr<SnapshotDelegate>& snapshot_delegate,
-    const std::shared_ptr<VolatilePathTracker>& volatile_path_tracker,
-    const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch) {
-  return std::make_unique<Engine>(delegate,               //
-                                  dispatcher_maker,       //
-                                  vm,                     //
-                                  isolate_snapshot,       //
-                                  task_runners,           //
-                                  platform_data,          //
-                                  settings,               //
-                                  std::move(animator),    //
-                                  io_manager,             //
-                                  unref_queue,            //
-                                  snapshot_delegate,      //
-                                  volatile_path_tracker,  //
-                                  gpu_disabled_switch);
+    const std::shared_ptr<VolatilePathTracker>& volatile_path_tracker) {
+  return std::make_unique<Engine>(delegate,             //
+                                  dispatcher_maker,     //
+                                  vm,                   //
+                                  isolate_snapshot,     //
+                                  task_runners,         //
+                                  platform_data,        //
+                                  settings,             //
+                                  std::move(animator),  //
+                                  io_manager,           //
+                                  unref_queue,          //
+                                  snapshot_delegate,    //
+                                  volatile_path_tracker);
 }
 
 // Though there can be multiple shells, some settings apply to all components in
@@ -303,8 +301,7 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
                              weak_io_manager_future.get(),    //
                              unref_queue_future.get(),        //
                              snapshot_delegate_future.get(),  //
-                             shell->volatile_path_tracker_,
-                             shell->is_gpu_disabled_sync_switch_));
+                             shell->volatile_path_tracker_));
       }));
 
   if (!shell->Setup(std::move(platform_view),  //
@@ -541,8 +538,7 @@ std::unique_ptr<Shell> Shell::Spawn(
           const fml::WeakPtr<IOManager>& io_manager,
           const fml::RefPtr<SkiaUnrefQueue>& unref_queue,
           fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
-          const std::shared_ptr<VolatilePathTracker>& volatile_path_tracker,
-          const std::shared_ptr<fml::SyncSwitch>& is_gpu_disabled_sync_switch) {
+          const std::shared_ptr<VolatilePathTracker>& volatile_path_tracker) {
         return engine->Spawn(
             /*delegate=*/delegate,
             /*dispatcher_maker=*/dispatcher_maker,
@@ -550,8 +546,7 @@ std::unique_ptr<Shell> Shell::Spawn(
             /*animator=*/std::move(animator),
             /*initial_route=*/initial_route,
             /*io_manager=*/io_manager,
-            /*snapshot_delegate=*/std::move(snapshot_delegate),
-            /*gpu_disabled_switch=*/is_gpu_disabled_sync_switch);
+            /*snapshot_delegate=*/std::move(snapshot_delegate));
       },
       is_gpu_disabled);
   result->RunEngine(std::move(run_configuration));

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -126,8 +126,7 @@ class Shell final : public PlatformView::Delegate,
       fml::WeakPtr<IOManager> io_manager,
       fml::RefPtr<SkiaUnrefQueue> unref_queue,
       fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
-      std::shared_ptr<VolatilePathTracker> volatile_path_tracker,
-      const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch)>
+      std::shared_ptr<VolatilePathTracker> volatile_path_tracker)>
       EngineCreateCallback;
 
   //----------------------------------------------------------------------------
@@ -357,7 +356,6 @@ class Shell final : public PlatformView::Delegate,
 
   //----------------------------------------------------------------------------
   /// @brief     Accessor for the disable GPU SyncSwitch.
-  // |Rasterizer::Delegate|
   std::shared_ptr<const fml::SyncSwitch> GetIsGpuDisabledSyncSwitch()
       const override;
 


### PR DESCRIPTION
Reverts flutter/engine#42362 which is causing [failures](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8779560985227054065/+/u/test:_lint_host_debug/stdout) in `Linux Host clang_tidy` blocking the release. 

