### PR TITLE
Fix crash getting spell-check suggestions

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/SpellCheckPlugin.java
@@ -132,6 +132,11 @@ public class SpellCheckPlugin
     ArrayList<HashMap<String, Object>> spellCheckerSuggestionSpans =
         new ArrayList<HashMap<String, Object>>();
     SentenceSuggestionsInfo spellCheckResults = results[0];
+    if (spellCheckResults == null) {
+      pendingResult.success(new ArrayList<HashMap<String, Object>>());
+      pendingResult = null;
+      return;
+    }
 
     for (int i = 0; i < spellCheckResults.getSuggestionsCount(); i++) {
       SuggestionsInfo suggestionsInfo = spellCheckResults.getSuggestionsInfoAt(i);

--- a/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
@@ -247,4 +247,22 @@ public class SpellCheckPluginTest {
 
     verify(mockResult).success(new ArrayList<HashMap<String, Object>>());
   }
+
+  @Test
+  public void onGetSentenceSuggestionsResultsWithSuccessAndNoResultsWhenSuggestionsAreInvalid2() {
+    TextServicesManager fakeTextServicesManager = mock(TextServicesManager.class);
+    SpellCheckChannel fakeSpellCheckChannel = mock(SpellCheckChannel.class);
+    SpellCheckPlugin spellCheckPlugin =
+        spy(new SpellCheckPlugin(fakeTextServicesManager, fakeSpellCheckChannel));
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    spellCheckPlugin.pendingResult = mockResult;
+
+    spellCheckPlugin.onGetSentenceSuggestions(
+        new SentenceSuggestionsInfo[] {
+          // This "suggestion" may be provided by the Samsung spell checker:
+          null
+        });
+
+    verify(mockResult).success(new ArrayList<HashMap<String, Object>>());
+  }
 }


### PR DESCRIPTION
On some Samsung devices Flutter with spell-check enabled will crash when typing/moving near the ">" character. 

Stack trace is

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.view.textservice.SentenceSuggestionsInfo.getSuggestionsCount()' on a null object reference
       at io.flutter.plugin.editing.SpellCheckPlugin.onGetSentenceSuggestions(SpellCheckPlugin.java:26)
       at android.view.textservice.SpellCheckerSession.lambda$handleOnGetSentenceSuggestionsMultiple$1$android-view-textservice-SpellCheckerSession(SpellCheckerSession.java:224)
       at android.view.textservice.SpellCheckerSession$$ExternalSyntheticLambda0.run(:4)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8747)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

