### PR TITLE
Initial config for framework_smoke test

### DIFF
--- a/ci/builders/linux_framework_smoke.json
+++ b/ci/builders/linux_framework_smoke.json
@@ -22,7 +22,10 @@
             ],
             "name": "host_debug_unopt",
             "ninja": {
-                "config": "host_debug_unopt"
+                "config": "host_debug_unopt",
+                "targets": [
+                    "flutter/build/archives:dart_sdk_archive"
+                ]
             }
         }
     ],

--- a/ci/builders/linux_framework_smoke.json
+++ b/ci/builders/linux_framework_smoke.json
@@ -18,7 +18,7 @@
     ],
     "tests": [
         {
-            "name": "test: lint host_debug",
+            "name": "test: lint host_debug widgets",
             "drone_dimensions": [
                 "device_type=none",
                 "os=Linux"
@@ -29,6 +29,19 @@
             "local_engine": "host_debug_unopt",
             "shard": "framework_tests",
             "subshard": "widgets"
+        },
+        {
+            "name": "test: lint host_debug library",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "dependencies": [
+                "host_debug_unopt"
+            ],
+            "local_engine": "host_debug_unopt",
+            "shard": "framework_tests",
+            "subshard": "library"
         }
     ]
 }

--- a/ci/builders/linux_framework_smoke.json
+++ b/ci/builders/linux_framework_smoke.json
@@ -1,0 +1,50 @@
+{
+    "builds": [
+        {
+            "archives": [],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gn": [
+                "--unoptimized",
+                "--prebuilt-dart-sdk"
+            ],
+            "name": "host_debug_unopt",
+            "ninja": {
+                "config": "host_debug_unopt"
+            }
+        }
+    ],
+    "tests": [
+        {
+            "name": "test: lint host_debug",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "dependencies": [
+                "host_debug_unopt"
+            ],
+            "tasks": [
+                {
+                    "name": "Framework analyze",
+                    "parameters": [
+                        "analyze",
+                        "--flutter-repo",
+                        "--local-engine=host_debug_unopt"
+                    ],
+                    "script": "flutter/bin/flutter"
+                },
+                {
+                    "name": "test: frameowrk smoke",
+                    "parameters": [
+                        "--local-engine=host_debug_unopt"
+                    ],
+                    "script": "flutter/bin/dart/dev/bots/test.dart",
+                    "language": "dart"
+                }
+            ]
+        }
+    ]
+}

--- a/ci/builders/linux_framework_smoke.json
+++ b/ci/builders/linux_framework_smoke.json
@@ -41,7 +41,7 @@
             ],
             "local_engine": "host_debug_unopt",
             "shard": "framework_tests",
-            "subshard": "library"
+            "subshard": "libraries"
         }
     ]
 }

--- a/ci/builders/linux_framework_smoke.json
+++ b/ci/builders/linux_framework_smoke.json
@@ -51,6 +51,7 @@
             "dependencies": [
                 "host_debug_unopt"
             ],
+            "_comment": "shard/subshard strings are defined in framework test runner: dev/bots/test.dart, and are consistent with properties defined in framework .ciyaml targets",
             "shard": "framework_tests",
             "subshard": "libraries"
         },
@@ -63,6 +64,7 @@
             "dependencies": [
                 "host_debug_unopt"
             ],
+            "_comment": "validation strings are consistent with properties defined in framework .ciyaml targets",
             "validation": "analyze",
             "validation_name": "Analyze"
         }

--- a/ci/builders/linux_framework_smoke.json
+++ b/ci/builders/linux_framework_smoke.json
@@ -26,25 +26,9 @@
             "dependencies": [
                 "host_debug_unopt"
             ],
-            "tasks": [
-                {
-                    "name": "Framework analyze",
-                    "parameters": [
-                        "analyze",
-                        "--flutter-repo",
-                        "--local-engine=host_debug_unopt"
-                    ],
-                    "script": "flutter/bin/flutter"
-                },
-                {
-                    "name": "test: frameowrk smoke",
-                    "parameters": [
-                        "--local-engine=host_debug_unopt"
-                    ],
-                    "script": "flutter/bin/dart/dev/bots/test.dart",
-                    "language": "dart"
-                }
-            ]
+            "local_engine": "host_debug_unopt",
+            "shard": "framework_tests",
+            "subshard": "widgets"
         }
     ]
 }

--- a/ci/builders/linux_framework_smoke.json
+++ b/ci/builders/linux_framework_smoke.json
@@ -1,7 +1,17 @@
 {
     "builds": [
         {
-            "archives": [],
+            "archives": [
+                {
+                    "name": "host_debug_unopt",
+                    "base_path": "out/host_debug_unopt/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/host_debug_unopt/zip_archives/dart-sdk-linux-x64.zip"
+                    ],
+                    "realm": "production"
+                }
+            ],
             "drone_dimensions": [
                 "device_type=none",
                 "os=Linux"

--- a/ci/builders/linux_framework_smoke.json
+++ b/ci/builders/linux_framework_smoke.json
@@ -39,7 +39,6 @@
             "dependencies": [
                 "host_debug_unopt"
             ],
-            "local_engine": "host_debug_unopt",
             "shard": "framework_tests",
             "subshard": "widgets"
         },
@@ -52,9 +51,20 @@
             "dependencies": [
                 "host_debug_unopt"
             ],
-            "local_engine": "host_debug_unopt",
             "shard": "framework_tests",
             "subshard": "libraries"
+        },
+        {
+            "name": "test: flutter analyze",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "dependencies": [
+                "host_debug_unopt"
+            ],
+            "validation": "analyze",
+            "validation_name": "Analyze"
         }
     ]
 }


### PR DESCRIPTION
This is the initial config for framework_smoke_tests, preparing for v2 migration.

The v2 config consists of three targets from the framework to cover the v1 version. /cc @zanderso 

- `framework_tests_widget`
- `framework_tests_libraries`
- `analyze` adhoc validation test

An LED run based on this config: https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/keyonghan_google.com/6b3eb4603f1b478463cb36ac7d8a674ae24d4d3c7b9adb7c17eaf523ce8586ce/+/build.proto?server=chromium-swarm.appspot.com

Note the tests failures are being tracked in https://github.com/flutter/flutter/issues/127683