### PR TITLE
Allow for optional label to trigger vuln scan on patch PRs

### DIFF
--- a/.github/workflows/third_party_scan.yml
+++ b/.github/workflows/third_party_scan.yml
@@ -4,6 +4,8 @@ on:
   branch_protection_rule:
   push:
     branches: [ main ]
+  pull_request:
+    types: [ labeled ]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -12,7 +14,8 @@ jobs:
   vuln-scan:
     name: Vulnerability scanning
     runs-on: ubuntu-20.04
-    if: ${{ github.repository == 'flutter/engine' }}
+    # run on flutter/engine push to main or PRs with 'vulnerability patch' label 
+    if: ${{  github.repository == 'flutter/engine' && (github.event_name == 'push' || github.event.label.name == 'vulnerability patch') }}
     permissions:
       # Needed to upload the SARIF results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/third_party_scan.yml
+++ b/.github/workflows/third_party_scan.yml
@@ -15,7 +15,7 @@ jobs:
     name: Vulnerability scanning
     runs-on: ubuntu-20.04
     # run on flutter/engine push to main or PRs with 'vulnerability patch' label 
-    if: ${{  github.repository == 'flutter/engine' && (github.event_name == 'push' || github.event.label.name == 'vulnerability patch') }}
+    if: ${{  github.repository == 'flutter/engine' && (github.event_name == 'push' || github.event.label.name == 'vulnerability scan') }}
     permissions:
       # Needed to upload the SARIF results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
This change introduces the ability to allow for the vulnerability scanning workflow to be triggered by the 'vulnerability scan' label on PRs. If the label is not applied, the workflow is skipped completely on PRs. This will allow those working to patch a vulnerability to check for resolution before landing the change.

Testing this change: https://github.com/flutter/engine/actions/runs/5059129544

b/283970087

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
