### PR TITLE
Revert "Move clang tidy v2 build to prod."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -466,23 +466,11 @@ targets:
       - os=Linux
 
   - name: Mac mac_clang_tidy
+    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
       config_name: mac_clang_tidy
-    runIf:
-      - DEPS
-      - .ci.yaml
-      - tools/**
-      - ci/**
-      - "**.h"
-      - "**.c"
-      - "**.cc"
-      - "**.fbs"
-      - "**.frag"
-      - "**.vert"
-      - "**.m"
-      - "**.mm"
 
   - name: Mac mac_host_engine
     recipe: engine_v2/engine_v2
@@ -522,7 +510,6 @@ targets:
     timeout: 75
 
   - name: Mac Host clang-tidy
-    bringup: true
     recipe: engine/engine_lint
     properties:
       cpu: arm64
@@ -545,7 +532,6 @@ targets:
       - "**.mm"
 
   - name: Mac iOS clang-tidy
-    bringup: true
     recipe: engine/engine_lint
     properties:
       cpu: arm64


### PR DESCRIPTION
Reverts flutter/engine#41985

This is also suffering some the same issue as the Linux clang-tidy shards reverted in https://github.com/flutter/engine/pull/42434.