### PR TITLE
Do not retry lint or clang tidy tests.

### DIFF
--- a/ci/builders/linux_clang_tidy.json
+++ b/ci/builders/linux_clang_tidy.json
@@ -61,6 +61,7 @@
                         "--shard-id=1",
                         "--shard-variants=android_debug_arm64"
                     ],
+		    "max_attempts": 1,
                     "script": "flutter/ci/lint.sh"
                 }
             ]
@@ -86,6 +87,7 @@
                         "--shard-id=0",
                         "--shard-variants=host_debug"
                     ],
+		    "max_attempts": 1,
                     "script": "flutter/ci/lint.sh"
                 }
             ]

--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -70,6 +70,7 @@
                         "--shard-id=1",
                         "--shard-variants=ios_debug_sim"
                     ],
+		    "max_attempts": 1,
                     "script": "flutter/ci/lint.sh"
                 }
             ]
@@ -99,6 +100,7 @@
                         "--shard-id=0",
                         "--shard-variants=host_debug"
                     ],
+		    "max_attempts": 1,
                     "script": "flutter/ci/lint.sh"
                 }
             ]

--- a/ci/builders/standalone/linux_license.json
+++ b/ci/builders/standalone/linux_license.json
@@ -11,6 +11,7 @@
     "tests": [
         {
             "name": "licenses check",
+	    "max_attempts": 1,
             "script": "flutter/ci/licenses.sh"
         }
     ]


### PR DESCRIPTION
Retries on lints and clang tidy were hiding the issues as timeouts rather than providing the fail signal right away.

Bug: https://github.com/flutter/flutter/issues/128083


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
