### PR TITLE
[Impeller] Add an assert macro that can be used to satisfy the bugprone-unchecked-optional-access check

### DIFF
--- a/fml/logging.h
+++ b/fml/logging.h
@@ -95,4 +95,10 @@ bool ShouldCreateLogMessage(LogSeverity severity);
     ::fml::KillProcess();                          \
   }
 
+// Asserts that a std::optional contains a value.  This can be used to satisfy
+// the clang-tidy bugprone-unchecked-optional-access check.
+#define ASSERT_OPTIONAL_HAS_VALUE(opt) \
+  if (!opt.has_value())                \
+    FML_UNREACHABLE();
+
 #endif  // FLUTTER_FML_LOGGING_H_

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -50,6 +50,7 @@ static std::optional<RenderTarget> WrapTextureWithRenderTarget(
   // rendering but also creates smaller intermediate passes.
   ISize root_size;
   if (requires_blit) {
+    ASSERT_OPTIONAL_HAS_VALUE(clip_rect);
     root_size = ISize(clip_rect->size.width, clip_rect->size.height);
   } else {
     root_size = {static_cast<ISize::Type>(texture.width),
@@ -243,6 +244,7 @@ bool SurfaceMTL::Present() const {
       return false;
     }
     auto blit_pass = blit_command_buffer->CreateBlitPass();
+    ASSERT_OPTIONAL_HAS_VALUE(clip_rect_);
     blit_pass->AddCopy(source_texture_, destination_texture_, std::nullopt,
                        clip_rect_->origin);
     blit_pass->EncodeCommands(context->GetResourceAllocator());


### PR DESCRIPTION
In clang-tidy the bugprone-unchecked-optional-access linter will recognize Chromium's version of CHECK but does not know about Flutter's FML_CHECK macros.  This macro can be used to tell the linter that a std::optional is known to contain a value in a particular code path.
