### PR TITLE
Generate a unique temporary directory name in the iOS scenario test script

### DIFF
--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -45,7 +45,7 @@ SCENARIO_PATH=$SRC_DIR/out/$FLUTTER_ENGINE/scenario_app/Scenarios
 pushd .
 cd $SCENARIO_PATH
 
-RESULT_BUNDLE_FOLDER="ios_scenario_xcresult"
+RESULT_BUNDLE_FOLDER=$(mktemp -d ios_scenario_xcresult_XXX)
 RESULT_BUNDLE_PATH="${SCENARIO_PATH}/${RESULT_BUNDLE_FOLDER}"
 
 # Zip and upload xcresult to luci.
@@ -60,8 +60,6 @@ zip_and_upload_xcresult_to_luci () {
 
 echo "Running simulator tests with Skia"
 echo ""
-
-mktemp -d $RESULT_BUNDLE_PATH
 
 if set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme Scenarios \


### PR DESCRIPTION
This ensures that a retry of this script on CI will not collide with the output directory of a previous run.
