### PR TITLE
[macOS] Top-left origin for PlatformView container

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
@@ -34,7 +34,8 @@
 
 - (BOOL)isFlipped {
   // Flutter transforms assume a coordinate system with an upper-left corner origin, with y
-  // coordinate values increasing downwards.
+  // coordinate values increasing downwards. This affects the view, view transforms, and
+  // sublayerTransforms.
   return YES;
 }
 
@@ -58,7 +59,8 @@
 
 - (BOOL)isFlipped {
   // Flutter transforms assume a coordinate system with an upper-left corner origin, with y
-  // coordinate values increasing downwards.
+  // coordinate values increasing downwards. This affects the view, view transforms, and
+  // sublayerTransforms.
   return YES;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
@@ -12,8 +12,8 @@
 #include "flutter/shell/platform/embedder/embedder.h"
 
 @interface FlutterMutatorView () {
-  /// Each of these views clips to a CGPathRef. These views, if present,
-  /// are nested (first is child of FlutterMutatorView and last is parent of
+  // Each of these views clips to a CGPathRef. These views, if present,
+  // are nested (first is child of FlutterMutatorView and last is parent of
   // _platformView).
   NSMutableArray* _pathClipViews;
 
@@ -22,6 +22,20 @@
   NSView* _platformViewContainer;
 
   NSView* _platformView;
+}
+
+@end
+
+/// Superview container for platform views, to which sublayer transforms are applied.
+@interface FlutterPlatformViewContainer : NSView
+@end
+
+@implementation FlutterPlatformViewContainer
+
+- (BOOL)isFlipped {
+  // Flutter transforms assume a coordinate system with an upper-left corner origin, with y
+  // coordinate values increasing downwards.
+  return YES;
 }
 
 @end
@@ -43,6 +57,8 @@
 }
 
 - (BOOL)isFlipped {
+  // Flutter transforms assume a coordinate system with an upper-left corner origin, with y
+  // coordinate values increasing downwards.
   return YES;
 }
 
@@ -400,7 +416,7 @@ NSMutableArray* RoundedRectClipsFromMutations(CGRect master_clip, const Mutation
                             clipRect:(CGRect)clipRect {
   // Create the PlatformViewContainer view if necessary.
   if (_platformViewContainer == nil) {
-    _platformViewContainer = [[NSView alloc] initWithFrame:self.bounds];
+    _platformViewContainer = [[FlutterPlatformViewContainer alloc] initWithFrame:self.bounds];
     _platformViewContainer.wantsLayer = YES;
   }
 
@@ -409,14 +425,15 @@ NSMutableArray* RoundedRectClipsFromMutations(CGRect master_clip, const Mutation
   [containerSuperview addSubview:_platformViewContainer];
   _platformViewContainer.frame = self.bounds;
 
-  // Add the
+  // Nest the platform view in the PlatformViewContainer.
   [_platformViewContainer addSubview:_platformView];
   _platformView.frame = untransformedBounds;
 
   // Transform for the platform view is finalTransform adjusted for bounding rect origin.
-  _platformViewContainer.layer.sublayerTransform =
-      CATransform3DTranslate(transform, -transformedBounds.origin.x / transform.m11 /* scaleX */,
-                             -transformedBounds.origin.y / transform.m22 /* scaleY */, 0);
+  CATransform3D translation =
+      CATransform3DMakeTranslation(-transformedBounds.origin.x, -transformedBounds.origin.y, 0);
+  transform = CATransform3DConcat(transform, translation);
+  _platformViewContainer.layer.sublayerTransform = transform;
 
   // By default NSView clips children to frame. If masterClip is tighter than mutator view frame,
   // the frame is set to masterClip and child offset adjusted to compensate for the difference.


### PR DESCRIPTION
For consistency with Flutter (and all other platforms), Flutter views in the macOS embedder set `isFlipped` to ensure a co-ordinate system with the origin in the top-left, with y co-ordinates increasing towards the bottom edge of the view.

Previously, we were using a stock NSView as the container, which uses a bottom-left origin by default. Instead we extract the PlatformView container view as its own class with `isFlipped` true.

This doesn't correct the issue of the view anchorpoint/position but does correct rotation direction.

This also applies the transform back to origin prior to other transforms when adjusting the platformview position rather than after.

Issue: https://github.com/flutter/flutter/issues/124490

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
