### PR TITLE
Move benchmarks no upload to staging.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -196,6 +196,7 @@ targets:
 
   - name: Linux Benchmarks (no-upload)
     recipe: engine/engine_metrics
+    bringup: true
     properties:
       build_host: "true"
       upload_metrics: "false"


### PR DESCRIPTION
With the benchmarks and upload scripts running as tests within Linux_host_engine - host_release we can move this test to staging in preparation for its deprecation.

Example:
https://ci.chromium.org/p/flutter/builders/prod/Linux%20Production%20Engine%20Drone/191822?

Bug: https://github.com/flutter/flutter/issues/127678


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
