### PR TITLE
Use the arm64 dsymutil on Mac M1 machines

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -39,7 +39,7 @@ vars = {
   # The list of revisions for these tools comes from Fuchsia, here:
   # https://fuchsia.googlesource.com/integration/+/HEAD/toolchain
   # If there are problems with the toolchain, contact fuchsia-toolchain@.
-  'clang_version': 'git_revision:5344d8e10bb7d8672d4bfae8adb010465470d51b',
+  'clang_version': 'git_revision:6d667d4b261e81f325756fdfd5bb43b3b3d2451d',
 
   # The goma version and the clang version can be tightly coupled. If goma
   # stops working on a clang roll, this may need to be updated using the value

--- a/DEPS
+++ b/DEPS
@@ -39,7 +39,7 @@ vars = {
   # The list of revisions for these tools comes from Fuchsia, here:
   # https://fuchsia.googlesource.com/integration/+/HEAD/toolchain
   # If there are problems with the toolchain, contact fuchsia-toolchain@.
-  'clang_version': 'git_revision:6d667d4b261e81f325756fdfd5bb43b3b3d2451d',
+  'clang_version': 'git_revision:5344d8e10bb7d8672d4bfae8adb010465470d51b',
 
   # The goma version and the clang version can be tightly coupled. If goma
   # stops working on a clang roll, this may need to be updated using the value

--- a/sky/tools/create_embedder_framework.py
+++ b/sky/tools/create_embedder_framework.py
@@ -15,7 +15,7 @@ buildroot_dir = os.path.abspath(
     os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
 )
 
-ARCH_SUBPATH = 'mac-arm64' if platform.processor()=='arm' else 'mac-x64'
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
     os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'

--- a/sky/tools/create_embedder_framework.py
+++ b/sky/tools/create_embedder_framework.py
@@ -15,7 +15,7 @@ buildroot_dir = os.path.abspath(
     os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
 )
 
-ARCH_SUBPATH = 'mac-arm64' if platform.processor() else 'mac-x64'
+ARCH_SUBPATH = 'mac-arm64' if platform.processor()=='arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
     os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'

--- a/sky/tools/create_embedder_framework.py
+++ b/sky/tools/create_embedder_framework.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 import argparse
+import platform
 import subprocess
 import shutil
 import sys

--- a/sky/tools/create_embedder_framework.py
+++ b/sky/tools/create_embedder_framework.py
@@ -14,8 +14,9 @@ buildroot_dir = os.path.abspath(
     os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
 )
 
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() else 'mac-x64'
 DSYMUTIL = os.path.join(
-    os.path.dirname(__file__), '..', '..', '..', 'buildtools', 'mac-x64',
+    os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'
 )
 

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -15,8 +15,9 @@ import sys
 
 from create_xcframework import create_xcframework  # pylint: disable=import-error
 
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() else 'mac-x64'
 DSYMUTIL = os.path.join(
-    os.path.dirname(__file__), '..', '..', '..', 'buildtools', 'mac-x64',
+    os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'
 )
 

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -16,7 +16,7 @@ import sys
 
 from create_xcframework import create_xcframework  # pylint: disable=import-error
 
-ARCH_SUBPATH = 'mac-arm64' if platform.processor() else 'mac-x64'
+ARCH_SUBPATH = 'mac-arm64' if platform.processor()=='arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
     os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -9,6 +9,7 @@
 
 import argparse
 import os
+import platform
 import shutil
 import subprocess
 import sys

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -16,7 +16,7 @@ import sys
 
 from create_xcframework import create_xcframework  # pylint: disable=import-error
 
-ARCH_SUBPATH = 'mac-arm64' if platform.processor()=='arm' else 'mac-x64'
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
     os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'

--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -13,7 +13,7 @@ import os
 
 from create_xcframework import create_xcframework  # pylint: disable=import-error
 
-ARCH_SUBPATH = 'mac-arm64' if platform.processor() else 'mac-x64'
+ARCH_SUBPATH = 'mac-arm64' if platform.processor()=='arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
     os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'

--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 import argparse
+import platform
 import subprocess
 import shutil
 import sys

--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -13,7 +13,7 @@ import os
 
 from create_xcframework import create_xcframework  # pylint: disable=import-error
 
-ARCH_SUBPATH = 'mac-arm64' if platform.processor()=='arm' else 'mac-x64'
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
     os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'

--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -12,8 +12,9 @@ import os
 
 from create_xcframework import create_xcframework  # pylint: disable=import-error
 
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() else 'mac-x64'
 DSYMUTIL = os.path.join(
-    os.path.dirname(__file__), '..', '..', '..', 'buildtools', 'mac-x64',
+    os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'
 )
 

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -15,7 +15,7 @@ buildroot_dir = os.path.abspath(
     os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
 )
 
-ARCH_SUBPATH = 'mac-arm64' if platform.processor()=='arm' else 'mac-x64'
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
     os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -15,7 +15,7 @@ buildroot_dir = os.path.abspath(
     os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
 )
 
-ARCH_SUBPATH = 'mac-arm64' if platform.processor() else 'mac-x64'
+ARCH_SUBPATH = 'mac-arm64' if platform.processor()=='arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
     os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 import argparse
+import platform
 import subprocess
 import shutil
 import sys
@@ -14,8 +15,9 @@ buildroot_dir = os.path.abspath(
     os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
 )
 
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() else 'mac-x64'
 DSYMUTIL = os.path.join(
-    os.path.dirname(__file__), '..', '..', '..', 'buildtools', 'mac-x64',
+    os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'
 )
 


### PR DESCRIPTION
Use the right binary architectures on scripts running dsymutil.

This is to fix the problem of bad architecture binary for builds running on dart internal: https://github.com/flutter/flutter/issues/128098

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
