### PR TITLE
[linux] Allow overriding aot_library_path

### DIFF
--- a/shell/platform/linux/fl_dart_project.cc
+++ b/shell/platform/linux/fl_dart_project.cc
@@ -62,6 +62,13 @@ G_MODULE_EXPORT FlDartProject* fl_dart_project_new() {
   return self;
 }
 
+G_MODULE_EXPORT void fl_dart_project_set_aot_library_path(FlDartProject* self,
+                                                          const gchar* path) {
+  g_return_if_fail(FL_IS_DART_PROJECT(self));
+  g_clear_pointer(&self->aot_library_path, g_free);
+  self->aot_library_path = g_strdup(path);
+}
+
 G_MODULE_EXPORT const gchar* fl_dart_project_get_aot_library_path(
     FlDartProject* self) {
   g_return_val_if_fail(FL_IS_DART_PROJECT(self), nullptr);

--- a/shell/platform/linux/fl_dart_project_test.cc
+++ b/shell/platform/linux/fl_dart_project_test.cc
@@ -28,6 +28,14 @@ TEST(FlDartProjectTest, GetPaths) {
                expected_icu_data_path);
 }
 
+TEST(FlDartProjectTest, OverrideAotLibraryPath) {
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+
+  char aot_library_path[] = "/normal/tuesday/night/for/shia/labeouf";
+  fl_dart_project_set_aot_library_path(project, aot_library_path);
+  EXPECT_STREQ(fl_dart_project_get_aot_library_path(project), aot_library_path);
+}
+
 TEST(FlDartProjectTest, OverrideAssetsPath) {
   g_autoptr(FlDartProject) project = fl_dart_project_new();
 

--- a/shell/platform/linux/public/flutter_linux/fl_dart_project.h
+++ b/shell/platform/linux/public/flutter_linux/fl_dart_project.h
@@ -36,6 +36,18 @@ G_DECLARE_FINAL_TYPE(FlDartProject, fl_dart_project, FL, DART_PROJECT, GObject)
 FlDartProject* fl_dart_project_new();
 
 /**
+ * fl_dart_project_set_aot_library_path:
+ * @project: an #FlDartProject.
+ * @path: the absolute path to the AOT library in the Flutter application.
+ *
+ * Sets the path to the AOT library in the Flutter application, which is
+ * the path to libapp.so. By default this is lib/libapp.so relative to the
+ * executable directory.
+ */
+void fl_dart_project_set_aot_library_path(FlDartProject* project,
+                                          const gchar* path);
+
+/**
  * fl_dart_project_get_aot_library_path:
  * @project: an #FlDartProject.
  *


### PR DESCRIPTION
Support overriding `aot_library_path` in `FLDartProject` on Linux.

Fixes: https://github.com/flutter/flutter/issues/128213

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
