### PR TITLE
fix bounds of inverted rendered rectangles

### DIFF
--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -751,7 +751,7 @@ void DisplayListBuilder::DrawLine(const SkPoint& p0,
 void DisplayListBuilder::drawRect(const SkRect& rect) {
   Push<DrawRectOp>(0, 1, rect);
   CheckLayerOpacityCompatibility();
-  AccumulateOpBounds(rect, kDrawRectFlags);
+  AccumulateOpBounds(rect.makeSorted(), kDrawRectFlags);
 }
 void DisplayListBuilder::DrawRect(const SkRect& rect, const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawRectFlags);
@@ -760,7 +760,7 @@ void DisplayListBuilder::DrawRect(const SkRect& rect, const DlPaint& paint) {
 void DisplayListBuilder::drawOval(const SkRect& bounds) {
   Push<DrawOvalOp>(0, 1, bounds);
   CheckLayerOpacityCompatibility();
-  AccumulateOpBounds(bounds, kDrawOvalFlags);
+  AccumulateOpBounds(bounds.makeSorted(), kDrawOvalFlags);
 }
 void DisplayListBuilder::DrawOval(const SkRect& bounds, const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawOvalFlags);


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/128159

In diagnosing test failures for https://github.com/flutter/engine/pull/42330 we discovered that the DisplayList code was not always backwards compatible with computing the bounds of inverted rectangles (where left > right or top > bottom). Historically such rectangles were always rendered as if they were sorted (i.e. `SkRect::makeSorted()`), but we computed bounds as if the bounds only mattered if the supplied rectangle was ordered. So, we would sometimes render a rectangle for which we mis-computed the bounds.

This would rarely surface in the current code as most rendered rectangles would pass through `SkMatrix::mapRect()` which implicitly orders the rectangle as it transforms it, but any attributes applied to the bounds before that method may have been applied "in the wrong direction" - such as:

- stroke width padding
- mask blur padding
- image filter padding