### PR TITLE
Fix clang tidy error and crash

### DIFF
--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -228,7 +228,7 @@ std::shared_ptr<ContextMTL> ContextMTL::Create(
   auto context = std::shared_ptr<ContextMTL>(new ContextMTL(
       device,
       MTLShaderLibraryFromFileData(device, shader_libraries_data, label),
-      worker_task_runner, std::move(is_gpu_disabled_sync_switch)));
+      std::move(worker_task_runner), std::move(is_gpu_disabled_sync_switch)));
   if (!context->IsValid()) {
     FML_LOG(ERROR) << "Could not create Metal context.";
     return nullptr;

--- a/impeller/renderer/backend/metal/formats_mtl.mm
+++ b/impeller/renderer/backend/metal/formats_mtl.mm
@@ -64,8 +64,13 @@ MTLDepthStencilDescriptor* ToMTLDepthStencilDescriptor(
 
   auto des = [[MTLDepthStencilDescriptor alloc] init];
 
-  des.depthCompareFunction = ToMTLCompareFunction(depth->depth_compare);
-  des.depthWriteEnabled = depth->depth_write_enabled;
+  // These temporary variables are necessary for clang-tidy (Fuchsia LLVM
+  // version 17.0.0git) to not crash.
+  auto compare_function = ToMTLCompareFunction(depth->depth_compare);
+  auto depth_write_enabled = depth->depth_write_enabled;
+
+  des.depthCompareFunction = compare_function;
+  des.depthWriteEnabled = depth_write_enabled;
 
   if (front.has_value()) {
     des.frontFaceStencil = ToMTLStencilDescriptor(front.value());


### PR DESCRIPTION
Clang tidy checks for https://github.com/flutter/engine/pull/42399 are failing for `formats_mtl.mm` and `context_mtl.mm`. Weirdly this happens even though none of these files where modified in the branch.

For `context_mtl.mm` the fix is straightforward, just a missing `std::move`.
For `formats_mtl.mm` clang-tidy actually crashes on the assignments to `des.depthCompareFunction` and `des.depth_write_enabled`. The crash doesn't happen if the assignment is done through a temporary variable. 

I'm not sure if we should have a workaround for the crash or disable clang-tidy on the file completely (FLUTTER_NOLINT).

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
