### PR TITLE
Add missing #include of SkCFObject.h

### DIFF
--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -14,6 +14,7 @@
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/GrYUVABackendTextures.h"
 #include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
+#include "third_party/skia/include/ports/SkCFObject.h"
 
 FLUTTER_ASSERT_ARC
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -69,6 +69,7 @@ extern const intptr_t kPlatformStrongDillSize;
 
 #ifdef SHELL_ENABLE_METAL
 #include "flutter/shell/platform/embedder/embedder_surface_metal.h"
+#include "third_party/skia/include/ports/SkCFObject.h"
 #endif
 
 const int32_t kFlutterSemanticsNodeIdBatchEnd = -1;

--- a/testing/test_metal_context.h
+++ b/testing/test_metal_context.h
@@ -9,6 +9,7 @@
 #include <mutex>
 
 #include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/ports/SkCFObject.h"
 
 namespace flutter {
 


### PR DESCRIPTION
Another follow-on to http://review.skia.org/704942 which removed some #includes that Flutter had been transitively depending on.

Note that SkCFObject is mac-only, so I included it the appropriate #ifdef in embedder.cc, but the other two files are already mac-only so they do not need that guard.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
