### PR TITLE
Remove onSemanticsAction

### DIFF
--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -826,27 +826,6 @@ void hooksTests() async {
     expectEquals(enabled, newValue);
   });
 
-  await test('onSemanticsAction preserves callback zone', () {
-    late Zone innerZone;
-    late Zone runZone;
-    late int id;
-    late int action;
-
-    runZoned(() {
-      innerZone = Zone.current;
-      window.onSemanticsAction = (int i, SemanticsAction a, ByteData? _) {
-        runZone = Zone.current;
-        action = a.index;
-        id = i;
-      };
-    });
-
-    _callHook('_dispatchSemanticsAction', 3, 1234, 4, null);
-    expectIdentical(runZone, innerZone);
-    expectEquals(id, 1234);
-    expectEquals(action, 4);
-  });
-
   await test('onSemanticsActionEvent preserves callback zone', () {
     late Zone innerZone;
     late Zone runZone;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -32,10 +32,6 @@ typedef PointerDataPacketCallback = void Function(PointerDataPacket packet);
 /// framework and should not be propagated further.
 typedef KeyDataCallback = bool Function(KeyData data);
 
-/// Signature for [PlatformDispatcher.onSemanticsAction].
-// TODO(goderbauer): Deprecate/remove this when the framework has migrated to SemanticsActionEventCallback.
-typedef SemanticsActionCallback = void Function(int nodeId, SemanticsAction action, ByteData? args);
-
 /// Signature for [PlatformDispatcher.onSemanticsActionEvent].
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
 
@@ -1159,23 +1155,6 @@ class PlatformDispatcher {
   ///
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.
-  // TODO(goderbauer): Deprecate/remove this when the framework has migrated to onSemanticsActionEvent.
-  SemanticsActionCallback? get onSemanticsAction => _onSemanticsAction;
-  SemanticsActionCallback? _onSemanticsAction;
-  Zone _onSemanticsActionZone = Zone.root;
-  set onSemanticsAction(SemanticsActionCallback? callback) {
-    _onSemanticsAction = callback;
-    _onSemanticsActionZone = Zone.current;
-  }
-
-  /// A callback that is invoked whenever the user requests an action to be
-  /// performed on a semantics node.
-  ///
-  /// This callback is used when the user expresses the action they wish to
-  /// perform based on the semantics node supplied by updateSemantics.
-  ///
-  /// The framework invokes this callback in the same zone in which the
-  /// callback was set.
   SemanticsActionEventCallback? get onSemanticsActionEvent => _onSemanticsActionEvent;
   SemanticsActionEventCallback? _onSemanticsActionEvent;
   Zone _onSemanticsActionEventZone = Zone.root;
@@ -1209,13 +1188,6 @@ class PlatformDispatcher {
 
   // Called from the engine, via hooks.dart
   void _dispatchSemanticsAction(int nodeId, int action, ByteData? args) {
-    _invoke3<int, SemanticsAction, ByteData?>(
-      onSemanticsAction,
-      _onSemanticsActionZone,
-      nodeId,
-      SemanticsAction.fromIndex(action)!,
-      args,
-    );
     _invoke1<SemanticsActionEvent>(
       onSemanticsActionEvent,
       _onSemanticsActionEventZone,

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -699,10 +699,11 @@ abstract class SemanticsUpdateBuilder {
   ///
   /// The `actions` are a bit field of [SemanticsAction]s that can be undertaken
   /// by this node. If the user wishes to undertake one of these actions on this
-  /// node, the [PlatformDispatcher.onSemanticsAction] will be called with `id`
-  /// and one of the possible [SemanticsAction]s. Because the semantics tree is
-  /// maintained asynchronously, the [PlatformDispatcher.onSemanticsAction]
-  /// callback might be called with an action that is no longer possible.
+  /// node, the [PlatformDispatcher.onSemanticsActionEvent] will be called with
+  /// a [SemanticsActionEvent] specifying the action to be performed. Because
+  /// the semantics tree is maintained asynchronously, the
+  /// [PlatformDispatcher.onSemanticsActionEvent] callback might be called with
+  /// an action that is no longer possible.
   ///
   /// The `label` is a string that describes this node. The `value` property
   /// describes the current value of the node as a string. The `increasedValue`

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -756,21 +756,6 @@ class SingletonFlutterWindow extends FlutterView {
     platformDispatcher.onFrameDataChanged = callback;
   }
 
-  /// A callback that is invoked whenever the user requests an action to be
-  /// performed.
-  ///
-  /// {@macro dart.ui.window.accessorForwardWarning}
-  ///
-  /// This callback is used when the user expresses the action they wish to
-  /// perform based on the semantics supplied by [updateSemantics].
-  ///
-  /// The framework invokes this callback in the same zone in which the
-  /// callback was set.
-  SemanticsActionCallback? get onSemanticsAction => platformDispatcher.onSemanticsAction;
-  set onSemanticsAction(SemanticsActionCallback? callback) {
-    platformDispatcher.onSemanticsAction = callback;
-  }
-
   /// Additional accessibility features that may be enabled by the platform.
   AccessibilityFeatures get accessibilityFeatures => platformDispatcher.accessibilityFeatures;
 

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -9,7 +9,6 @@ typedef FrameCallback = void Function(Duration duration);
 typedef TimingsCallback = void Function(List<FrameTiming> timings);
 typedef PointerDataPacketCallback = void Function(PointerDataPacket packet);
 typedef KeyDataCallback = bool Function(KeyData data);
-typedef SemanticsActionCallback = void Function(int nodeId, SemanticsAction action, ByteData? args);
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
 typedef PlatformMessageResponseCallback = void Function(ByteData? data);
 typedef PlatformMessageCallback = void Function(
@@ -134,9 +133,6 @@ abstract class PlatformDispatcher {
 
   VoidCallback? get onSemanticsEnabledChanged;
   set onSemanticsEnabledChanged(VoidCallback? callback);
-
-  SemanticsActionCallback? get onSemanticsAction;
-  set onSemanticsAction(SemanticsActionCallback? callback);
 
   SemanticsActionEventCallback? get onSemanticsActionEvent;
   set onSemanticsActionEvent(SemanticsActionEventCallback? callback);

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -1194,24 +1194,6 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   }
 
   /// A callback that is invoked whenever the user requests an action to be
-  /// performed.
-  ///
-  /// This callback is used when the user expresses the action they wish to
-  /// perform based on the semantics supplied by [updateSemantics].
-  ///
-  /// The framework invokes this callback in the same zone in which the
-  /// callback was set.
-  @override
-  ui.SemanticsActionCallback? get onSemanticsAction => _onSemanticsAction;
-  ui.SemanticsActionCallback? _onSemanticsAction;
-  Zone? _onSemanticsActionZone;
-  @override
-  set onSemanticsAction(ui.SemanticsActionCallback? callback) {
-    _onSemanticsAction = callback;
-    _onSemanticsActionZone = Zone.current;
-  }
-
-  /// A callback that is invoked whenever the user requests an action to be
   /// performed on a semantics node.
   ///
   /// This callback is used when the user expresses the action they wish to
@@ -1233,8 +1215,6 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// Otherwise zones won't work properly.
   void invokeOnSemanticsAction(
       int nodeId, ui.SemanticsAction action, ByteData? args) {
-    invoke3<int, ui.SemanticsAction, ByteData?>(
-        _onSemanticsAction, _onSemanticsActionZone, nodeId, action, args);
     invoke1<ui.SemanticsActionEvent>(
         _onSemanticsActionEvent, _onSemanticsActionEventZone, ui.SemanticsActionEvent(
           type: action,

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -114,11 +114,6 @@ abstract class SingletonFlutterWindow extends FlutterView {
     platformDispatcher.onSemanticsEnabledChanged = callback;
   }
 
-  SemanticsActionCallback? get onSemanticsAction => platformDispatcher.onSemanticsAction;
-  set onSemanticsAction(SemanticsActionCallback? callback) {
-    platformDispatcher.onSemanticsAction = callback;
-  }
-
   FrameData get frameData => const FrameData._();
 
   VoidCallback? get onFrameDataChanged => null;

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -1107,7 +1107,7 @@ void _testVerticalScrolling() {
       idLogController.add(event.nodeId);
       actionLogController.add(event.type);
       testZone.run(() {
-        expect(args, null);
+        expect(event.arguments, null);
       });
     };
     semantics()
@@ -2634,7 +2634,7 @@ void _testDialog() {
   });
 }
 
-typedef CapturedAction = (int nodeId, ui.SemanticsAction action, ByteData? args);
+typedef CapturedAction = (int nodeId, ui.SemanticsAction action, Object? args);
 
 void _testFocusable() {
   test('AccessibilityFocusManager can manage element focus', () async {

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -1102,10 +1102,10 @@ void _testVerticalScrolling() {
     // fired.
     final Zone testZone = Zone.current;
 
-    ui.window.onSemanticsAction =
-        (int id, ui.SemanticsAction action, ByteData? args) {
-      idLogController.add(id);
-      actionLogController.add(action);
+    ui.PlatformDispatcher.instance.onSemanticsActionEvent =
+        (ui.SemanticsActionEvent event) {
+      idLogController.add(event.nodeId);
+      actionLogController.add(event.type);
       testZone.run(() {
         expect(args, null);
       });
@@ -1459,8 +1459,8 @@ void _testIncrementables() {
     }
 
     final List<CapturedAction> capturedActions = <CapturedAction>[];
-    EnginePlatformDispatcher.instance.onSemanticsAction = (int nodeId, ui.SemanticsAction action, ByteData? args) {
-      capturedActions.add((nodeId, action, args));
+    EnginePlatformDispatcher.instance.onSemanticsActionEvent = (ui.SemanticsActionEvent event) {
+      capturedActions.add((event.nodeId, event.type, event.arguments));
     };
 
     pumpSemantics(isFocused: false);
@@ -1814,8 +1814,8 @@ void _testCheckables() {
     }
 
     final List<CapturedAction> capturedActions = <CapturedAction>[];
-    EnginePlatformDispatcher.instance.onSemanticsAction = (int nodeId, ui.SemanticsAction action, ByteData? args) {
-      capturedActions.add((nodeId, action, args));
+    EnginePlatformDispatcher.instance.onSemanticsActionEvent = (ui.SemanticsActionEvent event) {
+      capturedActions.add((event.nodeId, event.type, event.arguments));
     };
 
     pumpSemantics(isFocused: false);
@@ -1973,8 +1973,8 @@ void _testTappable() {
     }
 
     final List<CapturedAction> capturedActions = <CapturedAction>[];
-    EnginePlatformDispatcher.instance.onSemanticsAction = (int nodeId, ui.SemanticsAction action, ByteData? args) {
-      capturedActions.add((nodeId, action, args));
+    EnginePlatformDispatcher.instance.onSemanticsActionEvent = (ui.SemanticsActionEvent event) {
+      capturedActions.add((event.nodeId, event.type, event.arguments));
     };
 
     pumpSemantics(isFocused: false);
@@ -2656,8 +2656,8 @@ void _testFocusable() {
     }
 
     final List<CapturedAction> capturedActions = <CapturedAction>[];
-    EnginePlatformDispatcher.instance.onSemanticsAction = (int nodeId, ui.SemanticsAction action, ByteData? args) {
-      capturedActions.add((nodeId, action, args));
+    EnginePlatformDispatcher.instance.onSemanticsActionEvent = (ui.SemanticsActionEvent event) {
+      capturedActions.add((event.nodeId, event.type, event.arguments));
     };
     expect(capturedActions, isEmpty);
 

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -388,12 +388,12 @@ class SemanticsActionLogger {
     // fired.
     final Zone testZone = Zone.current;
 
-    ui.PlatformDispatcher.instance.onSemanticsAction =
+    ui.PlatformDispatcher.instance.onSemanticsActionEvent =
         (ui.SemanticsActionEvent event) {
       _idLogController.add(event.nodeId);
       _actionLogController.add(event.type);
       testZone.run(() {
-        expect(args, null);
+        expect(event.arguments, null);
       });
     };
   }

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -388,10 +388,10 @@ class SemanticsActionLogger {
     // fired.
     final Zone testZone = Zone.current;
 
-    ui.window.onSemanticsAction =
-        (int id, ui.SemanticsAction action, ByteData? args) {
-      _idLogController.add(id);
-      _actionLogController.add(action);
+    ui.PlatformDispatcher.instance.onSemanticsAction =
+        (ui.SemanticsActionEvent event) {
+      _idLogController.add(event.nodeId);
+      _actionLogController.add(event.type);
       testZone.run(() {
         expect(args, null);
       });

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -211,17 +211,17 @@ Future<void> testMain() async {
     EnginePlatformDispatcher.instance.invokeOnSemanticsEnabledChanged();
   });
 
-  test('onSemanticsAction preserves the zone', () {
+  test('onSemanticsActionEvent preserves the zone', () {
     final Zone innerZone = Zone.current.fork();
 
     innerZone.runGuarded(() {
-      void callback(int _, ui.SemanticsAction __, ByteData? ___) {
+      void callback(ui.SemanticsActionEvent _) {
         expect(Zone.current, innerZone);
       }
-      window.onSemanticsAction = callback;
+      ui.PlatformDispatcher.instance.onSemanticsActionEvent = callback;
 
       // Test that the getter returns the exact same callback, e.g. it doesn't wrap it.
-      expect(window.onSemanticsAction, same(callback));
+      expect(ui.PlatformDispatcher.instance.onSemanticsActionEvent, same(callback));
     });
 
     EnginePlatformDispatcher.instance.invokeOnSemanticsAction(0, ui.SemanticsAction.tap, null);


### PR DESCRIPTION
Follow-up to https://github.com/flutter/engine/pull/42493.

The framework has been migrated to the new onSemanticsActionEvent callback.