### PR TITLE
Reland "add non-rendering operation culling to DisplayListBuilder" (#41463)

### DIFF
--- a/display_list/benchmarking/dl_complexity_unittests.cc
+++ b/display_list/benchmarking/dl_complexity_unittests.cc
@@ -423,7 +423,7 @@ TEST(DisplayListComplexity, DrawAtlas) {
   std::vector<SkRSXform> xforms;
   for (int i = 0; i < 10; i++) {
     rects.push_back(SkRect::MakeXYWH(0, 0, 10, 10));
-    xforms.push_back(SkRSXform::Make(0, 0, 0, 0));
+    xforms.push_back(SkRSXform::Make(1, 0, 0, 0));
   }
 
   DisplayListBuilder builder;

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -22,7 +22,8 @@ DisplayList::DisplayList()
       unique_id_(0),
       bounds_({0, 0, 0, 0}),
       can_apply_group_opacity_(true),
-      is_ui_thread_safe_(true) {}
+      is_ui_thread_safe_(true),
+      modifies_transparent_black_(false) {}
 
 DisplayList::DisplayList(DisplayListStorage&& storage,
                          size_t byte_count,
@@ -32,6 +33,7 @@ DisplayList::DisplayList(DisplayListStorage&& storage,
                          const SkRect& bounds,
                          bool can_apply_group_opacity,
                          bool is_ui_thread_safe,
+                         bool modifies_transparent_black,
                          sk_sp<const DlRTree> rtree)
     : storage_(std::move(storage)),
       byte_count_(byte_count),
@@ -42,6 +44,7 @@ DisplayList::DisplayList(DisplayListStorage&& storage,
       bounds_(bounds),
       can_apply_group_opacity_(can_apply_group_opacity),
       is_ui_thread_safe_(is_ui_thread_safe),
+      modifies_transparent_black_(modifies_transparent_black),
       rtree_(std::move(rtree)) {}
 
 DisplayList::~DisplayList() {

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -265,6 +265,19 @@ class DisplayList : public SkRefCnt {
   bool can_apply_group_opacity() const { return can_apply_group_opacity_; }
   bool isUIThreadSafe() const { return is_ui_thread_safe_; }
 
+  /// @brief     Indicates if there are any rendering operations in this
+  ///            DisplayList that will modify a surface of transparent black
+  ///            pixels.
+  ///
+  /// This condition can be used to determine whether to create a cleared
+  /// surface, render a DisplayList into it, and then composite the
+  /// result into a scene. It is not uncommon for code in the engine to
+  /// come across such degenerate DisplayList objects when slicing up a
+  /// frame between platform views.
+  bool modifies_transparent_black() const {
+    return modifies_transparent_black_;
+  }
+
  private:
   DisplayList(DisplayListStorage&& ptr,
               size_t byte_count,
@@ -274,6 +287,7 @@ class DisplayList : public SkRefCnt {
               const SkRect& bounds,
               bool can_apply_group_opacity,
               bool is_ui_thread_safe,
+              bool modifies_transparent_black,
               sk_sp<const DlRTree> rtree);
 
   static uint32_t next_unique_id();
@@ -292,6 +306,8 @@ class DisplayList : public SkRefCnt {
 
   const bool can_apply_group_opacity_;
   const bool is_ui_thread_safe_;
+  const bool modifies_transparent_black_;
+
   const sk_sp<const DlRTree> rtree_;
 
   void Dispatch(DlOpReceiver& ctx,

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -22,6 +22,7 @@
 #include "flutter/testing/testing.h"
 
 #include "third_party/skia/include/core/SkPictureRecorder.h"
+#include "third_party/skia/include/core/SkRSXform.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
@@ -3014,6 +3015,165 @@ TEST_F(DisplayListTest, DrawUnorderedRoundRectPathCCW) {
     canvas.DrawPath(path, paint);
   };
   check_inverted_bounds(renderer, "DrawRoundRectPath Counter-Clockwise");
+}
+
+TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
+  auto run_tests = [](const std::string& name,
+                      void init(DisplayListBuilder & builder, DlPaint & paint),
+                      uint32_t expected_op_count = 0u) {
+    auto run_one_test =
+        [init](const std::string& name,
+               void build(DisplayListBuilder & builder, DlPaint & paint),
+               uint32_t expected_op_count = 0u) {
+          DisplayListBuilder builder;
+          DlPaint paint;
+          init(builder, paint);
+          build(builder, paint);
+          auto list = builder.Build();
+          if (list->op_count() != expected_op_count) {
+            FML_LOG(ERROR) << *list;
+          }
+          ASSERT_EQ(list->op_count(), expected_op_count) << name;
+          ASSERT_TRUE(list->bounds().isEmpty()) << name;
+        };
+    run_one_test(
+        name + " DrawColor",
+        [](DisplayListBuilder& builder, DlPaint& paint) {
+          builder.DrawColor(paint.getColor(), paint.getBlendMode());
+        },
+        expected_op_count);
+    run_one_test(
+        name + " DrawPaint",
+        [](DisplayListBuilder& builder, DlPaint& paint) {
+          builder.DrawPaint(paint);
+        },
+        expected_op_count);
+    run_one_test(
+        name + " DrawRect",
+        [](DisplayListBuilder& builder, DlPaint& paint) {
+          builder.DrawRect({10, 10, 20, 20}, paint);
+        },
+        expected_op_count);
+    run_one_test(
+        name + " Other Draw Ops",
+        [](DisplayListBuilder& builder, DlPaint& paint) {
+          builder.DrawLine({10, 10}, {20, 20}, paint);
+          builder.DrawOval({10, 10, 20, 20}, paint);
+          builder.DrawCircle({50, 50}, 20, paint);
+          builder.DrawRRect(SkRRect::MakeRectXY({10, 10, 20, 20}, 5, 5), paint);
+          builder.DrawDRRect(SkRRect::MakeRectXY({5, 5, 100, 100}, 5, 5),
+                             SkRRect::MakeRectXY({10, 10, 20, 20}, 5, 5),
+                             paint);
+          builder.DrawPath(kTestPath1, paint);
+          builder.DrawArc({10, 10, 20, 20}, 45, 90, true, paint);
+          SkPoint pts[] = {{10, 10}, {20, 20}};
+          builder.DrawPoints(PointMode::kLines, 2, pts, paint);
+          builder.DrawVertices(TestVertices1, DlBlendMode::kSrcOver, paint);
+          builder.DrawImage(TestImage1, {10, 10}, DlImageSampling::kLinear,
+                            &paint);
+          builder.DrawImageRect(TestImage1, SkRect{0.0f, 0.0f, 10.0f, 10.0f},
+                                SkRect{10.0f, 10.0f, 25.0f, 25.0f},
+                                DlImageSampling::kLinear, &paint);
+          builder.DrawImageNine(TestImage1, {10, 10, 20, 20},
+                                {10, 10, 100, 100}, DlFilterMode::kLinear,
+                                &paint);
+          SkRSXform xforms[] = {{1, 0, 10, 10}, {0, 1, 10, 10}};
+          SkRect rects[] = {{10, 10, 20, 20}, {10, 20, 30, 20}};
+          builder.DrawAtlas(TestImage1, xforms, rects, nullptr, 2,
+                            DlBlendMode::kSrcOver, DlImageSampling::kLinear,
+                            nullptr, &paint);
+          builder.DrawTextBlob(TestBlob1, 10, 10, paint);
+
+          // Dst mode eliminates most rendering ops except for
+          // the following two, so we'll prune those manually...
+          if (paint.getBlendMode() != DlBlendMode::kDst) {
+            builder.DrawDisplayList(TestDisplayList1, paint.getOpacity());
+            builder.DrawShadow(kTestPath1, paint.getColor(), 1, true, 1);
+          }
+        },
+        expected_op_count);
+    run_one_test(
+        name + " SaveLayer",
+        [](DisplayListBuilder& builder, DlPaint& paint) {
+          builder.SaveLayer(nullptr, &paint, nullptr);
+          builder.DrawRect({10, 10, 20, 20}, DlPaint());
+          builder.Restore();
+        },
+        expected_op_count);
+    run_one_test(
+        name + " inside Save",
+        [](DisplayListBuilder& builder, DlPaint& paint) {
+          builder.Save();
+          builder.DrawRect({10, 10, 20, 20}, paint);
+          builder.Restore();
+        },
+        expected_op_count);
+  };
+  run_tests("transparent color",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              paint.setColor(DlColor::kTransparent());
+            });
+  run_tests("0 alpha",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              // The transparent test above already tested transparent
+              // black (all 0s), we set White color here so we can test
+              // the case of all 1s with a 0 alpha
+              paint.setColor(DlColor::kWhite());
+              paint.setAlpha(0);
+            });
+  run_tests("BlendMode::kDst",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              paint.setBlendMode(DlBlendMode::kDst);
+            });
+  run_tests("Empty rect clip",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              builder.ClipRect(SkRect::MakeEmpty(), ClipOp::kIntersect, false);
+            });
+  run_tests("Empty rrect clip",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              builder.ClipRRect(SkRRect::MakeEmpty(), ClipOp::kIntersect,
+                                false);
+            });
+  run_tests("Empty path clip",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              builder.ClipPath(SkPath(), ClipOp::kIntersect, false);
+            });
+  run_tests("Transparent SaveLayer",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              DlPaint save_paint;
+              save_paint.setColor(DlColor::kTransparent());
+              builder.SaveLayer(nullptr, &save_paint);
+            });
+  run_tests("0 alpha SaveLayer",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              DlPaint save_paint;
+              // The transparent test above already tested transparent
+              // black (all 0s), we set White color here so we can test
+              // the case of all 1s with a 0 alpha
+              save_paint.setColor(DlColor::kWhite());
+              save_paint.setAlpha(0);
+              builder.SaveLayer(nullptr, &save_paint);
+            });
+  run_tests("Dst blended SaveLayer",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              DlPaint save_paint;
+              save_paint.setBlendMode(DlBlendMode::kDst);
+              builder.SaveLayer(nullptr, &save_paint);
+            });
+  run_tests(
+      "Nop inside SaveLayer",
+      [](DisplayListBuilder& builder, DlPaint& paint) {
+        builder.SaveLayer(nullptr, nullptr);
+        paint.setBlendMode(DlBlendMode::kDst);
+      },
+      2u);
+  run_tests("DrawImage inside Culled SaveLayer",  //
+            [](DisplayListBuilder& builder, DlPaint& paint) {
+              DlPaint save_paint;
+              save_paint.setColor(DlColor::kTransparent());
+              builder.SaveLayer(nullptr, &save_paint);
+              builder.DrawImage(TestImage1, {10, 10}, DlImageSampling::kLinear);
+            });
 }
 
 }  // namespace testing

--- a/display_list/dl_color.h
+++ b/display_list/dl_color.h
@@ -34,20 +34,20 @@ struct DlColor {
 
   uint32_t argb;
 
-  bool isOpaque() const { return getAlpha() == 0xFF; }
-  bool isTransparent() const { return getAlpha() == 0; }
+  constexpr bool isOpaque() const { return getAlpha() == 0xFF; }
+  constexpr bool isTransparent() const { return getAlpha() == 0; }
 
-  int getAlpha() const { return argb >> 24; }
-  int getRed() const { return (argb >> 16) & 0xFF; }
-  int getGreen() const { return (argb >> 8) & 0xFF; }
-  int getBlue() const { return argb & 0xFF; }
+  constexpr int getAlpha() const { return argb >> 24; }
+  constexpr int getRed() const { return (argb >> 16) & 0xFF; }
+  constexpr int getGreen() const { return (argb >> 8) & 0xFF; }
+  constexpr int getBlue() const { return argb & 0xFF; }
 
-  float getAlphaF() const { return toF(getAlpha()); }
-  float getRedF() const { return toF(getRed()); }
-  float getGreenF() const { return toF(getGreen()); }
-  float getBlueF() const { return toF(getBlue()); }
+  constexpr float getAlphaF() const { return toF(getAlpha()); }
+  constexpr float getRedF() const { return toF(getRed()); }
+  constexpr float getGreenF() const { return toF(getGreen()); }
+  constexpr float getBlueF() const { return toF(getBlue()); }
 
-  uint32_t premultipliedArgb() const {
+  constexpr uint32_t premultipliedArgb() const {
     if (isOpaque()) {
       return argb;
     }
@@ -58,20 +58,20 @@ struct DlColor {
            toC(getBlueF() * f);
   }
 
-  DlColor withAlpha(uint8_t alpha) const {  //
+  constexpr DlColor withAlpha(uint8_t alpha) const {  //
     return (argb & 0x00FFFFFF) | (alpha << 24);
   }
-  DlColor withRed(uint8_t red) const {  //
+  constexpr DlColor withRed(uint8_t red) const {  //
     return (argb & 0xFF00FFFF) | (red << 16);
   }
-  DlColor withGreen(uint8_t green) const {  //
+  constexpr DlColor withGreen(uint8_t green) const {  //
     return (argb & 0xFFFF00FF) | (green << 8);
   }
-  DlColor withBlue(uint8_t blue) const {  //
+  constexpr DlColor withBlue(uint8_t blue) const {  //
     return (argb & 0xFFFFFF00) | (blue << 0);
   }
 
-  DlColor modulateOpacity(float opacity) const {
+  constexpr DlColor modulateOpacity(float opacity) const {
     return opacity <= 0   ? withAlpha(0)
            : opacity >= 1 ? *this
                           : withAlpha(round(getAlpha() * opacity));

--- a/display_list/dl_paint.h
+++ b/display_list/dl_paint.h
@@ -83,6 +83,7 @@ class DlPaint {
     color_.argb = alpha << 24 | (color_.argb & 0x00FFFFFF);
     return *this;
   }
+  SkScalar getOpacity() const { return color_.getAlphaF(); }
   DlPaint& setOpacity(SkScalar opacity) {
     setAlpha(SkScalarRoundToInt(opacity * 0xff));
     return *this;

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -517,7 +517,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
             }},
            {1, 16, 1, 24,
             [](DlOpReceiver& r) {
-              r.drawColor(SK_ColorBLUE, DlBlendMode::kDstIn);
+              r.drawColor(SK_ColorBLUE, DlBlendMode::kDstOut);
             }},
            {1, 16, 1, 24,
             [](DlOpReceiver& r) {

--- a/display_list/testing/dl_test_snippets.h
+++ b/display_list/testing/dl_test_snippets.h
@@ -151,9 +151,9 @@ static const DlBlurImageFilter kTestBlurImageFilter4(5.0,
 static const DlDilateImageFilter kTestDilateImageFilter1(5.0, 5.0);
 static const DlDilateImageFilter kTestDilateImageFilter2(6.0, 5.0);
 static const DlDilateImageFilter kTestDilateImageFilter3(5.0, 6.0);
-static const DlErodeImageFilter kTestErodeImageFilter1(5.0, 5.0);
-static const DlErodeImageFilter kTestErodeImageFilter2(6.0, 5.0);
-static const DlErodeImageFilter kTestErodeImageFilter3(5.0, 6.0);
+static const DlErodeImageFilter kTestErodeImageFilter1(4.0, 4.0);
+static const DlErodeImageFilter kTestErodeImageFilter2(4.0, 3.0);
+static const DlErodeImageFilter kTestErodeImageFilter3(3.0, 4.0);
 static const DlMatrixImageFilter kTestMatrixImageFilter1(
     SkMatrix::RotateDeg(45),
     kNearestSampling);

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -38,6 +38,7 @@ class DisplayListMatrixClipTracker {
   bool content_culled(const SkRect& content_bounds) const {
     return current_->content_culled(content_bounds);
   }
+  bool is_cull_rect_empty() const { return current_->is_cull_rect_empty(); }
 
   void save();
   void restore();
@@ -86,9 +87,10 @@ class DisplayListMatrixClipTracker {
     virtual SkMatrix matrix_3x3() const = 0;
     virtual SkM44 matrix_4x4() const = 0;
 
-    virtual SkRect device_cull_rect() const { return cull_rect_; }
+    SkRect device_cull_rect() const { return cull_rect_; }
     virtual SkRect local_cull_rect() const = 0;
     virtual bool content_culled(const SkRect& content_bounds) const;
+    bool is_cull_rect_empty() const { return cull_rect_.isEmpty(); }
 
     virtual void translate(SkScalar tx, SkScalar ty) = 0;
     virtual void scale(SkScalar sx, SkScalar sy) = 0;

--- a/flow/diff_context_unittests.cc
+++ b/flow/diff_context_unittests.cc
@@ -10,7 +10,7 @@ namespace testing {
 TEST_F(DiffContextTest, ClipAlignment) {
   MockLayerTree t1;
   t1.root()->Add(CreateDisplayListLayer(
-      CreateDisplayList(SkRect::MakeLTRB(30, 30, 50, 50), 1)));
+      CreateDisplayList(SkRect::MakeLTRB(30, 30, 50, 50))));
   auto damage = DiffLayerTree(t1, MockLayerTree(), SkIRect::MakeEmpty(), 0, 0);
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(30, 30, 50, 50));
   EXPECT_EQ(damage.buffer_damage, SkIRect::MakeLTRB(30, 30, 50, 50));

--- a/flow/layers/container_layer_unittests.cc
+++ b/flow/layers/container_layer_unittests.cc
@@ -564,9 +564,9 @@ using ContainerLayerDiffTest = DiffContextTest;
 
 // Insert PictureLayer amongst container layers
 TEST_F(ContainerLayerDiffTest, PictureLayerInsertion) {
-  auto pic1 = CreateDisplayList(SkRect::MakeLTRB(0, 0, 50, 50), 1);
-  auto pic2 = CreateDisplayList(SkRect::MakeLTRB(100, 0, 150, 50), 1);
-  auto pic3 = CreateDisplayList(SkRect::MakeLTRB(200, 0, 250, 50), 1);
+  auto pic1 = CreateDisplayList(SkRect::MakeLTRB(0, 0, 50, 50));
+  auto pic2 = CreateDisplayList(SkRect::MakeLTRB(100, 0, 150, 50));
+  auto pic3 = CreateDisplayList(SkRect::MakeLTRB(200, 0, 250, 50));
 
   MockLayerTree t1;
 
@@ -616,9 +616,9 @@ TEST_F(ContainerLayerDiffTest, PictureLayerInsertion) {
 
 // Insert picture layer amongst other picture layers
 TEST_F(ContainerLayerDiffTest, PictureInsertion) {
-  auto pic1 = CreateDisplayList(SkRect::MakeLTRB(0, 0, 50, 50), 1);
-  auto pic2 = CreateDisplayList(SkRect::MakeLTRB(100, 0, 150, 50), 1);
-  auto pic3 = CreateDisplayList(SkRect::MakeLTRB(200, 0, 250, 50), 1);
+  auto pic1 = CreateDisplayList(SkRect::MakeLTRB(0, 0, 50, 50));
+  auto pic2 = CreateDisplayList(SkRect::MakeLTRB(100, 0, 150, 50));
+  auto pic3 = CreateDisplayList(SkRect::MakeLTRB(200, 0, 250, 50));
 
   MockLayerTree t1;
   t1.root()->Add(CreateDisplayListLayer(pic1));

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -297,7 +297,7 @@ TEST_F(DisplayListLayerTest, CachedIncompatibleDisplayListOpacityInheritance) {
 using DisplayListLayerDiffTest = DiffContextTest;
 
 TEST_F(DisplayListLayerDiffTest, SimpleDisplayList) {
-  auto display_list = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), 1);
+  auto display_list = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60));
 
   MockLayerTree tree1;
   tree1.root()->Add(CreateDisplayListLayer(display_list));
@@ -317,7 +317,7 @@ TEST_F(DisplayListLayerDiffTest, SimpleDisplayList) {
 }
 
 TEST_F(DisplayListLayerDiffTest, FractionalTranslation) {
-  auto display_list = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), 1);
+  auto display_list = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60));
 
   MockLayerTree tree1;
   tree1.root()->Add(
@@ -330,7 +330,7 @@ TEST_F(DisplayListLayerDiffTest, FractionalTranslation) {
 }
 
 TEST_F(DisplayListLayerDiffTest, FractionalTranslationWithRasterCache) {
-  auto display_list = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), 1);
+  auto display_list = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60));
 
   MockLayerTree tree1;
   tree1.root()->Add(
@@ -344,21 +344,25 @@ TEST_F(DisplayListLayerDiffTest, FractionalTranslationWithRasterCache) {
 
 TEST_F(DisplayListLayerDiffTest, DisplayListCompare) {
   MockLayerTree tree1;
-  auto display_list1 = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), 1);
+  auto display_list1 =
+      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), DlColor::kGreen());
   tree1.root()->Add(CreateDisplayListLayer(display_list1));
 
   auto damage = DiffLayerTree(tree1, MockLayerTree());
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 60, 60));
 
   MockLayerTree tree2;
-  auto display_list2 = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), 1);
+  // same DL, same offset
+  auto display_list2 =
+      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), DlColor::kGreen());
   tree2.root()->Add(CreateDisplayListLayer(display_list2));
 
   damage = DiffLayerTree(tree2, tree1);
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeEmpty());
 
   MockLayerTree tree3;
-  auto display_list3 = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), 1);
+  auto display_list3 =
+      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), DlColor::kGreen());
   // add offset
   tree3.root()->Add(
       CreateDisplayListLayer(display_list3, SkPoint::Make(10, 10)));
@@ -368,7 +372,8 @@ TEST_F(DisplayListLayerDiffTest, DisplayListCompare) {
 
   MockLayerTree tree4;
   // different color
-  auto display_list4 = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), 2);
+  auto display_list4 =
+      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), DlColor::kRed());
   tree4.root()->Add(
       CreateDisplayListLayer(display_list4, SkPoint::Make(10, 10)));
 

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -659,7 +659,7 @@ using OpacityLayerDiffTest = DiffContextTest;
 
 TEST_F(OpacityLayerDiffTest, FractionalTranslation) {
   auto picture = CreateDisplayListLayer(
-      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), 1));
+      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60)));
   auto layer = CreateOpacityLater({picture}, 128, SkPoint::Make(0.5, 0.5));
 
   MockLayerTree tree1;
@@ -672,7 +672,7 @@ TEST_F(OpacityLayerDiffTest, FractionalTranslation) {
 
 TEST_F(OpacityLayerDiffTest, FractionalTranslationWithRasterCache) {
   auto picture = CreateDisplayListLayer(
-      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), 1));
+      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60)));
   auto layer = CreateOpacityLater({picture}, 128, SkPoint::Make(0.5, 0.5));
 
   MockLayerTree tree1;

--- a/flow/testing/diff_context_test.cc
+++ b/flow/testing/diff_context_test.cc
@@ -30,7 +30,7 @@ Damage DiffContextTest::DiffLayerTree(MockLayerTree& layer_tree,
 }
 
 sk_sp<DisplayList> DiffContextTest::CreateDisplayList(const SkRect& bounds,
-                                                      SkColor color) {
+                                                      DlColor color) {
   DisplayListBuilder builder;
   builder.DrawRect(bounds, DlPaint().setColor(color));
   return builder.Build();

--- a/flow/testing/diff_context_test.h
+++ b/flow/testing/diff_context_test.h
@@ -47,7 +47,8 @@ class DiffContextTest : public LayerTest {
 
   // Create display list consisting of filled rect with given color; Being able
   // to specify different color is useful to test deep comparison of pictures
-  sk_sp<DisplayList> CreateDisplayList(const SkRect& bounds, uint32_t color);
+  sk_sp<DisplayList> CreateDisplayList(const SkRect& bounds,
+                                       DlColor color = DlColor::kBlack());
 
   std::shared_ptr<DisplayListLayer> CreateDisplayListLayer(
       const sk_sp<DisplayList>& display_list,

--- a/impeller/display_list/dl_unittests.cc
+++ b/impeller/display_list/dl_unittests.cc
@@ -830,18 +830,12 @@ TEST_P(DisplayListTest, CanDrawShadow) {
 }
 
 TEST_P(DisplayListTest, TransparentShadowProducesCorrectColor) {
-  flutter::DisplayListBuilder builder;
-  {
-    builder.Save();
-    builder.Scale(1.618, 1.618);
-    builder.DrawShadow(SkPath{}.addRect(SkRect::MakeXYWH(0, 0, 200, 100)),
-                       SK_ColorTRANSPARENT, 15, false, 1);
-    builder.Restore();
-  }
-  auto dl = builder.Build();
-
   DlDispatcher dispatcher;
-  dispatcher.drawDisplayList(dl, 1);
+  dispatcher.save();
+  dispatcher.scale(1.618, 1.618);
+  dispatcher.drawShadow(SkPath{}.addRect(SkRect::MakeXYWH(0, 0, 200, 100)),
+                        SK_ColorTRANSPARENT, 15, false, 1);
+  dispatcher.restore();
   auto picture = dispatcher.EndRecordingAsPicture();
 
   std::shared_ptr<SolidRRectBlurContents> rrect_blur;

--- a/shell/common/dl_op_spy_unittests.cc
+++ b/shell/common/dl_op_spy_unittests.cc
@@ -7,13 +7,38 @@
 #include "flutter/shell/common/dl_op_spy.h"
 #include "flutter/testing/testing.h"
 #include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkRSXform.h"
 
 namespace flutter {
 namespace testing {
 
+// The following macros demonstrate that the DlOpSpy class is equivalent
+// to DisplayList::affects_transparent_surface() now that DisplayListBuilder
+// implements operation culling.
+// See https://github.com/flutter/flutter/issues/125403
+#define ASSERT_DID_DRAW(spy, dl)                   \
+  do {                                             \
+    ASSERT_TRUE(spy.did_draw());                   \
+    ASSERT_TRUE(dl->modifies_transparent_black()); \
+  } while (0)
+
+#define ASSERT_NO_DRAW(spy, dl)                     \
+  do {                                              \
+    ASSERT_FALSE(spy.did_draw());                   \
+    ASSERT_FALSE(dl->modifies_transparent_black()); \
+  } while (0)
+
 TEST(DlOpSpy, DidDrawIsFalseByDefault) {
   DlOpSpy dl_op_spy;
   ASSERT_FALSE(dl_op_spy.did_draw());
+}
+
+TEST(DlOpSpy, EmptyDisplayList) {
+  DisplayListBuilder builder;
+  sk_sp<DisplayList> dl = builder.Build();
+  DlOpSpy dl_op_spy;
+  dl->Dispatch(dl_op_spy);
+  ASSERT_NO_DRAW(dl_op_spy, dl);
 }
 
 TEST(DlOpSpy, SetColor) {
@@ -24,7 +49,7 @@ TEST(DlOpSpy, SetColor) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // Set transparent color.
     DisplayListBuilder builder;
@@ -33,7 +58,7 @@ TEST(DlOpSpy, SetColor) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
   {  // Set black color.
     DisplayListBuilder builder;
@@ -42,7 +67,7 @@ TEST(DlOpSpy, SetColor) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
 }
 
@@ -55,7 +80,7 @@ TEST(DlOpSpy, SetColorSource) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // Set transparent color.
     DisplayListBuilder builder;
@@ -67,7 +92,7 @@ TEST(DlOpSpy, SetColorSource) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
   {  // Set black color.
     DisplayListBuilder builder;
@@ -79,7 +104,7 @@ TEST(DlOpSpy, SetColorSource) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
 }
 
@@ -91,16 +116,25 @@ TEST(DlOpSpy, DrawColor) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
-  {  // Transparent color source.
+  {  // Transparent color with kSrc.
     DisplayListBuilder builder;
     auto color = DlColor::kTransparent();
     builder.DrawColor(color, DlBlendMode::kSrc);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
+  }
+  {  // Transparent color with kSrcOver.
+    DisplayListBuilder builder;
+    auto color = DlColor::kTransparent();
+    builder.DrawColor(color, DlBlendMode::kSrcOver);
+    sk_sp<DisplayList> dl = builder.Build();
+    DlOpSpy dl_op_spy;
+    dl->Dispatch(dl_op_spy);
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
@@ -112,7 +146,7 @@ TEST(DlOpSpy, DrawPaint) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
   {  // black color in paint.
     DisplayListBuilder builder;
@@ -121,7 +155,7 @@ TEST(DlOpSpy, DrawPaint) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
 }
 
@@ -133,7 +167,7 @@ TEST(DlOpSpy, DrawLine) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent
     DisplayListBuilder builder;
@@ -142,7 +176,7 @@ TEST(DlOpSpy, DrawLine) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
@@ -154,7 +188,7 @@ TEST(DlOpSpy, DrawRect) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent
     DisplayListBuilder builder;
@@ -163,11 +197,11 @@ TEST(DlOpSpy, DrawRect) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
-TEST(DlOpSpy, drawOval) {
+TEST(DlOpSpy, DrawOval) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
@@ -175,7 +209,7 @@ TEST(DlOpSpy, drawOval) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent
     DisplayListBuilder builder;
@@ -184,11 +218,11 @@ TEST(DlOpSpy, drawOval) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
-TEST(DlOpSpy, drawCircle) {
+TEST(DlOpSpy, DrawCircle) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
@@ -196,7 +230,7 @@ TEST(DlOpSpy, drawCircle) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent
     DisplayListBuilder builder;
@@ -205,11 +239,11 @@ TEST(DlOpSpy, drawCircle) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
-TEST(DlOpSpy, drawRRect) {
+TEST(DlOpSpy, DrawRRect) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
@@ -217,7 +251,7 @@ TEST(DlOpSpy, drawRRect) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent
     DisplayListBuilder builder;
@@ -226,34 +260,49 @@ TEST(DlOpSpy, drawRRect) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
-TEST(DlOpSpy, drawPath) {
-  {  // black
+TEST(DlOpSpy, DrawPath) {
+  {  // black line
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
+    paint.setDrawStyle(DlDrawStyle::kStroke);
     builder.DrawPath(SkPath::Line(SkPoint::Make(0, 1), SkPoint::Make(1, 1)),
                      paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
-  {  // transparent
+  {  // triangle
+    DisplayListBuilder builder;
+    DlPaint paint(DlColor::kBlack());
+    SkPath path;
+    path.moveTo({0, 0});
+    path.lineTo({1, 0});
+    path.lineTo({0, 1});
+    builder.DrawPath(path, paint);
+    sk_sp<DisplayList> dl = builder.Build();
+    DlOpSpy dl_op_spy;
+    dl->Dispatch(dl_op_spy);
+    ASSERT_DID_DRAW(dl_op_spy, dl);
+  }
+  {  // transparent line
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
+    paint.setDrawStyle(DlDrawStyle::kStroke);
     builder.DrawPath(SkPath::Line(SkPoint::Make(0, 1), SkPoint::Make(1, 1)),
                      paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
-TEST(DlOpSpy, drawArc) {
+TEST(DlOpSpy, DrawArc) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
@@ -261,7 +310,7 @@ TEST(DlOpSpy, drawArc) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent
     DisplayListBuilder builder;
@@ -270,11 +319,11 @@ TEST(DlOpSpy, drawArc) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
-TEST(DlOpSpy, drawPoints) {
+TEST(DlOpSpy, DrawPoints) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
@@ -283,7 +332,7 @@ TEST(DlOpSpy, drawPoints) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent
     DisplayListBuilder builder;
@@ -293,38 +342,62 @@ TEST(DlOpSpy, drawPoints) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
-TEST(DlOpSpy, drawVertices) {
+TEST(DlOpSpy, DrawVertices) {
   {  // black
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
-    const SkPoint vertices[] = {SkPoint::Make(5, 5)};
-    const SkPoint texture_coordinates[] = {SkPoint::Make(5, 5)};
-    const DlColor colors[] = {DlColor::kBlack()};
-    auto dl_vertices = DlVertices::Make(DlVertexMode::kTriangles, 1, vertices,
+    const SkPoint vertices[] = {
+        SkPoint::Make(5, 5),
+        SkPoint::Make(5, 15),
+        SkPoint::Make(15, 5),
+    };
+    const SkPoint texture_coordinates[] = {
+        SkPoint::Make(5, 5),
+        SkPoint::Make(15, 5),
+        SkPoint::Make(5, 15),
+    };
+    const DlColor colors[] = {
+        DlColor::kBlack(),
+        DlColor::kRed(),
+        DlColor::kGreen(),
+    };
+    auto dl_vertices = DlVertices::Make(DlVertexMode::kTriangles, 3, vertices,
                                         texture_coordinates, colors, 0);
     builder.DrawVertices(dl_vertices.get(), DlBlendMode::kSrc, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
-    const SkPoint vertices[] = {SkPoint::Make(5, 5)};
-    const SkPoint texture_coordinates[] = {SkPoint::Make(5, 5)};
-    const DlColor colors[] = {DlColor::kBlack()};
-    auto dl_vertices = DlVertices::Make(DlVertexMode::kTriangles, 1, vertices,
+    const SkPoint vertices[] = {
+        SkPoint::Make(5, 5),
+        SkPoint::Make(5, 15),
+        SkPoint::Make(15, 5),
+    };
+    const SkPoint texture_coordinates[] = {
+        SkPoint::Make(5, 5),
+        SkPoint::Make(15, 5),
+        SkPoint::Make(5, 15),
+    };
+    const DlColor colors[] = {
+        DlColor::kBlack(),
+        DlColor::kRed(),
+        DlColor::kGreen(),
+    };
+    auto dl_vertices = DlVertices::Make(DlVertexMode::kTriangles, 3, vertices,
                                         texture_coordinates, colors, 0);
     builder.DrawVertices(dl_vertices.get(), DlBlendMode::kSrc, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
@@ -343,7 +416,7 @@ TEST(DlOpSpy, Images) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // DrawImageRect
     DisplayListBuilder builder;
@@ -359,7 +432,7 @@ TEST(DlOpSpy, Images) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // DrawImageNine
     DisplayListBuilder builder;
@@ -375,7 +448,7 @@ TEST(DlOpSpy, Images) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // DrawAtlas
     DisplayListBuilder builder;
@@ -386,20 +459,19 @@ TEST(DlOpSpy, Images) {
     SkBitmap bitmap;
     bitmap.allocPixels(info, 0);
     auto sk_image = SkImages::RasterFromBitmap(bitmap);
-    const SkRSXform xform[] = {};
-    const SkRect tex[] = {};
-    const DlColor colors[] = {};
+    const SkRSXform xform[] = {SkRSXform::Make(1, 0, 0, 0)};
+    const SkRect tex[] = {SkRect::MakeXYWH(10, 10, 10, 10)};
     SkRect cull_rect = SkRect::MakeWH(5, 5);
-    builder.DrawAtlas(DlImage::Make(sk_image), xform, tex, colors, 0,
+    builder.DrawAtlas(DlImage::Make(sk_image), xform, tex, nullptr, 1,
                       DlBlendMode::kSrc, DlImageSampling::kLinear, &cull_rect);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
 }
 
-TEST(DlOpSpy, drawDisplayList) {
+TEST(DlOpSpy, DrawDisplayList) {
   {  // Recursive Transparent DisplayList
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
@@ -414,7 +486,7 @@ TEST(DlOpSpy, drawDisplayList) {
 
     DlOpSpy dl_op_spy;
     dl2->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl2);
   }
   {  // Sub non-transparent DisplayList,
     DisplayListBuilder builder;
@@ -430,7 +502,7 @@ TEST(DlOpSpy, drawDisplayList) {
 
     DlOpSpy dl_op_spy;
     dl2->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl2);
   }
 
   {  // Sub non-transparent DisplayList, 0 opacity
@@ -447,7 +519,7 @@ TEST(DlOpSpy, drawDisplayList) {
 
     DlOpSpy dl_op_spy;
     dl2->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl2);
   }
 
   {  // Parent non-transparent DisplayList
@@ -464,11 +536,11 @@ TEST(DlOpSpy, drawDisplayList) {
 
     DlOpSpy dl_op_spy;
     dl2->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl2);
   }
 }
 
-TEST(DlOpSpy, drawTextBlob) {
+TEST(DlOpSpy, DrawTextBlob) {
   {  // Non-transparent color.
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
@@ -479,7 +551,7 @@ TEST(DlOpSpy, drawTextBlob) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent color.
     DisplayListBuilder builder;
@@ -491,11 +563,11 @@ TEST(DlOpSpy, drawTextBlob) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 
-TEST(DlOpSpy, drawShadow) {
+TEST(DlOpSpy, DrawShadow) {
   {  // valid shadow
     DisplayListBuilder builder;
     DlPaint paint;
@@ -505,7 +577,7 @@ TEST(DlOpSpy, drawShadow) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_TRUE(dl_op_spy.did_draw());
+    ASSERT_DID_DRAW(dl_op_spy, dl);
   }
   {  // transparent color
     DisplayListBuilder builder;
@@ -516,7 +588,7 @@ TEST(DlOpSpy, drawShadow) {
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
-    ASSERT_FALSE(dl_op_spy.did_draw());
+    ASSERT_NO_DRAW(dl_op_spy, dl);
   }
 }
 


### PR DESCRIPTION
This reverts commit 2553def911fa26e7ce69769e9e946c90bc023b98.

Fixes https://github.com/flutter/flutter/issues/125338

This PR should fix the blendmode/color analysis that caused failures for https://github.com/flutter/engine/pull/41463 as well as the bounds failures for inverted rectangles that caused failures for https://github.com/flutter/engine/pull/42330 (incorporating the fix from https://github.com/flutter/engine/pull/42556).

The description from the [previous PR](https://github.com/flutter/engine/pull/41463) updated with the new name of the DL property:

---------------------------------
This optimization avoids recording unnecessary render operations that will not affect the output and also eliminates the need for "draw detection" mechanisms like `DlOpSpy` and `CanvasSpy` by remembering if any non-transparent operations were included. The `DlOpSpy` unit tests were updated to check if the results from that object match the new `DisplayList::modifies_transparent_black()` method.

Fixes https://github.com/flutter/flutter/issues/125338

In addition, this change will unblock some other Issues:

- https://github.com/flutter/flutter/issues/125318
- https://github.com/flutter/flutter/issues/125403