### PR TITLE
[macOS] Add platformview creation parameter support

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h
@@ -22,10 +22,10 @@
  * FlutterResult is updated to contain nil for success or to contain
  * a FlutterError if there is an error.
  */
-- (void)onCreateWithViewID:(int64_t)viewId
-                  viewType:(nonnull NSString*)viewType
-                 arguments:(id _Nullable)args
-                    result:(nonnull FlutterResult)result;
+- (void)onCreateWithViewIdentifier:(int64_t)viewId
+                          viewType:(nonnull NSString*)viewType
+                         arguments:(nullable id)args
+                            result:(nonnull FlutterResult)result;
 
 /**
  * Disposes the platform view with `viewId`.

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h
@@ -17,12 +17,14 @@
 @interface FlutterPlatformViewController ()
 
 /**
- * Creates a platform view of viewType with viewId.
+ * Creates a platform view of viewType with viewId and arguments passed from
+ * the framework's creationParams constructor parameter.
  * FlutterResult is updated to contain nil for success or to contain
  * a FlutterError if there is an error.
  */
 - (void)onCreateWithViewID:(int64_t)viewId
                   viewType:(nonnull NSString*)viewType
+                 arguments:(id _Nullable)args
                     result:(nonnull FlutterResult)result;
 
 /**

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
@@ -25,10 +25,10 @@
   return self;
 }
 
-- (void)onCreateWithViewID:(int64_t)viewId
-                  viewType:(nonnull NSString*)viewType
-                 arguments:(id _Nullable)args
-                    result:(nonnull FlutterResult)result {
+- (void)onCreateWithViewIdentifier:(int64_t)viewId
+                          viewType:(nonnull NSString*)viewType
+                         arguments:(nullable id)args
+                            result:(nonnull FlutterResult)result {
   if (_platformViews.count(viewId) != 0) {
     result([FlutterError errorWithCode:@"recreating_view"
                                message:@"trying to create an already created view"
@@ -94,16 +94,19 @@
       int64_t viewId = [args[@"id"] longLongValue];
       NSString* viewType = [NSString stringWithUTF8String:([args[@"viewType"] UTF8String])];
 
-      id params = nil;
+      id creationArgs = nil;
       NSObject<FlutterPlatformViewFactory>* factory = _platformViewFactories[viewType];
       if ([factory respondsToSelector:@selector(createArgsCodec)]) {
         NSObject<FlutterMessageCodec>* codec = [factory createArgsCodec];
         if (codec != nil && args[@"params"] != nil) {
-          FlutterStandardTypedData* paramsData = args[@"params"];
-          params = [codec decode:paramsData.data];
+          FlutterStandardTypedData* creationArgsData = args[@"params"];
+          creationArgs = [codec decode:creationArgsData.data];
         }
       }
-      [self onCreateWithViewID:viewId viewType:viewType arguments:params result:result];
+      [self onCreateWithViewIdentifier:viewId
+                              viewType:viewType
+                             arguments:creationArgs
+                                result:result];
     } else {
       result([FlutterError errorWithCode:@"unknown_view"
                                  message:@"'id' argument must be passed to create a platform view."

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
@@ -43,11 +43,22 @@ TEST(FlutterPlatformViewController, TestRegisterPlatformViewFactoryAndCreate) {
 
   [platformViewController registerViewFactory:factory withId:@"MockPlatformView"];
 
+  NSDictionary* params = @{
+    @"album" : @"スコットとリバース",
+    @"releaseYear" : @2013,
+    @"artists" : @[ @"Scott Murphy", @"Rivers Cuomo" ],
+    @"playlist" : @[ @"おかしいやつ", @"ほどけていたんだ" ],
+  };
+  NSObject<FlutterMessageCodec>* codec = [factory createArgsCodec];
+  FlutterStandardTypedData* paramData =
+      [FlutterStandardTypedData typedDataWithBytes:[codec encode:params]];
+
   FlutterMethodCall* methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"create"
                                         arguments:@{
                                           @"id" : @2,
-                                          @"viewType" : @"MockPlatformView"
+                                          @"viewType" : @"MockPlatformView",
+                                          @"params" : paramData,
                                         }];
 
   __block bool success = false;
@@ -58,8 +69,33 @@ TEST(FlutterPlatformViewController, TestRegisterPlatformViewFactoryAndCreate) {
     }
   };
   [platformViewController handleMethodCall:methodCall result:result];
-
   EXPECT_TRUE(success);
+
+  // Verify PlatformView parameters are decoded correctly.
+  TestFlutterPlatformView* view =
+      (TestFlutterPlatformView*)[platformViewController platformViewWithID:2];
+  ASSERT_TRUE(view != nil);
+  ASSERT_TRUE(view.args != nil);
+
+  // Verify string type.
+  NSString* album = [view.args objectForKey:@"album"];
+  EXPECT_TRUE([album isEqualToString:@"スコットとリバース"]);
+
+  // Verify int type.
+  NSNumber* releaseYear = [view.args objectForKey:@"releaseYear"];
+  EXPECT_EQ(releaseYear.intValue, 2013);
+
+  // Verify list/array types.
+  NSArray* artists = [view.args objectForKey:@"artists"];
+  ASSERT_TRUE(artists != nil);
+  ASSERT_EQ(artists.count, 2ul);
+  EXPECT_TRUE([artists[0] isEqualToString:@"Scott Murphy"]);
+  EXPECT_TRUE([artists[1] isEqualToString:@"Rivers Cuomo"]);
+
+  NSArray* playlist = [view.args objectForKey:@"playlist"];
+  ASSERT_EQ(playlist.count, 2ul);
+  EXPECT_TRUE([playlist[0] isEqualToString:@"おかしいやつ"]);
+  EXPECT_TRUE([playlist[1] isEqualToString:@"ほどけていたんだ"]);
 }
 
 TEST(FlutterPlatformViewController, TestCreateAndDispose) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
@@ -43,22 +43,22 @@ TEST(FlutterPlatformViewController, TestRegisterPlatformViewFactoryAndCreate) {
 
   [platformViewController registerViewFactory:factory withId:@"MockPlatformView"];
 
-  NSDictionary* params = @{
+  NSDictionary* creationArgs = @{
     @"album" : @"スコットとリバース",
     @"releaseYear" : @2013,
     @"artists" : @[ @"Scott Murphy", @"Rivers Cuomo" ],
     @"playlist" : @[ @"おかしいやつ", @"ほどけていたんだ" ],
   };
   NSObject<FlutterMessageCodec>* codec = [factory createArgsCodec];
-  FlutterStandardTypedData* paramData =
-      [FlutterStandardTypedData typedDataWithBytes:[codec encode:params]];
+  FlutterStandardTypedData* creationArgsData =
+      [FlutterStandardTypedData typedDataWithBytes:[codec encode:creationArgs]];
 
   FlutterMethodCall* methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"create"
                                         arguments:@{
                                           @"id" : @2,
                                           @"viewType" : @"MockPlatformView",
-                                          @"params" : paramData,
+                                          @"params" : creationArgsData,
                                         }];
 
   __block bool success = false;

--- a/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.h
+++ b/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.h
@@ -7,6 +7,10 @@
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
 
 @interface TestFlutterPlatformView : NSView
+
+/// Arguments passed via the params value in the create method call.
+@property(nonatomic, copy) id args;
+
 @end
 
 @interface TestFlutterPlatformViewFactory : NSObject <FlutterPlatformViewFactory>

--- a/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.mm
+++ b/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.mm
@@ -9,8 +9,9 @@
 
 @implementation TestFlutterPlatformView
 
-- (instancetype)initWithFrame:(CGRect)frame {
+- (instancetype)initWithFrame:(CGRect)frame arguments:(nullable NSDictionary*)args {
   self = [super initWithFrame:frame];
+  _args = args;
   return self;
 }
 
@@ -18,7 +19,7 @@
 
 @implementation TestFlutterPlatformViewFactory
 - (NSView*)createWithViewIdentifier:(int64_t)viewId arguments:(nullable id)args {
-  return [[TestFlutterPlatformView alloc] initWithFrame:CGRectZero];
+  return [[TestFlutterPlatformView alloc] initWithFrame:CGRectZero arguments:args];
 }
 
 - (NSObject<FlutterMessageCodec>*)createArgsCodec {


### PR DESCRIPTION
Previously, when creating native platform views on macOS, we ignored any parameters passed via the framework side "params" argument in the "create" method call, and instead always passed a nil value to the FlutterPlatformViewFactory. This made it impossible for users of macOS platform views to pass constructor arguments to the NSView subclass implementing the platform view.

We now decode the arguments data using the codec specified by the `FlutterPlatformViewFactory` and pass them through to the `[FlutterPlatformViewFactory createWithIdentifier:arguments:]` method where the platform view author can make use of them.

Fixes: https://github.com/flutter/flutter/issues/124723

This is a part of the broader macOS platform view support effort: https://github.com/flutter/flutter/issues/41722

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
