### PR TITLE
[iOS] Fix TextInputAction.continueAction sends wrong action to framework

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -1009,7 +1009,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
       actionString = @"TextInputAction.next";
       break;
     case FlutterTextInputActionContinue:
-      actionString = @"TextInputAction.continue";
+      actionString = @"TextInputAction.continueAction";
       break;
     case FlutterTextInputActionJoin:
       actionString = @"TextInputAction.join";

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/common/shell.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h"
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 
@@ -31,4 +32,7 @@ class ThreadHost;
                        entrypointArgs:(/*nullable*/ NSArray<NSString*>*)entrypointArgs;
 - (const flutter::ThreadHost&)threadHost;
 - (void)updateDisplays;
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+               performAction:(FlutterTextInputAction)action
+                  withClient:(int)client;
 @end


### PR DESCRIPTION
## Description

This PR fixes an issue related to text input plugin, on IOS, sending a wrong action string to the engine for `FlutterTextInputActionContinue`.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/126922

## Tests

Adds 1 test.


