### PR TITLE
[Impeller] Corrected the 'texture_coords' computation in 'Geometry::GetPositionUVBuffer'

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -147,7 +147,9 @@ bool GenerateMipmap(const std::shared_ptr<Context>& context,
   return buffer->SubmitCommands();
 }
 
-void CanRenderTiledTexture(AiksTest* aiks_test, Entity::TileMode tile_mode) {
+void CanRenderTiledTexture(AiksTest* aiks_test,
+                           Entity::TileMode tile_mode,
+                           Matrix local_matrix = {}) {
   auto context = aiks_test->GetContext();
   ASSERT_TRUE(context);
   auto texture = aiks_test->CreateTextureForFixture("table_mountain_nx.png",
@@ -158,7 +160,7 @@ void CanRenderTiledTexture(AiksTest* aiks_test, Entity::TileMode tile_mode) {
   canvas.Translate({100.0f, 100.0f, 0});
   Paint paint;
   paint.color_source =
-      ColorSource::MakeImage(texture, tile_mode, tile_mode, {}, {});
+      ColorSource::MakeImage(texture, tile_mode, tile_mode, {}, local_matrix);
   paint.color = Color(1, 1, 1, 1);
   canvas.DrawRect({0, 0, 600, 600}, paint);
 
@@ -197,6 +199,11 @@ TEST_P(AiksTest, CanRenderTiledTextureMirror) {
 
 TEST_P(AiksTest, CanRenderTiledTextureDecal) {
   CanRenderTiledTexture(this, Entity::TileMode::kDecal);
+}
+
+TEST_P(AiksTest, CanRenderTiledTextureClampWithTranslate) {
+  CanRenderTiledTexture(this, Entity::TileMode::kClamp,
+                        Matrix::MakeTranslation({172.f, 172.f, 0.f}));
 }
 
 TEST_P(AiksTest, CanRenderImageRect) {

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -84,9 +84,9 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
     for (auto i = 0u; i < points.size(); i++) {
       VS::PerVertexData data;
       data.position = points[i];
-      auto coverage_coords =
-          (points[i] - texture_coverage.origin) / texture_coverage.size;
-      data.texture_coords = effect_transform * coverage_coords;
+      data.texture_coords = effect_transform *
+                            (points[i] - texture_coverage.origin) /
+                            texture_coverage.size;
       vertex_builder.AppendVertex(data);
     }
     for (auto i = 0u; i < indices.size(); i++) {
@@ -114,9 +114,9 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
           VS::PerVertexData data;
           Point vtx = {vertices[i], vertices[i + 1]};
           data.position = vtx;
-          auto coverage_coords =
-              (vtx - texture_coverage.origin) / texture_coverage.size;
-          data.texture_coords = effect_transform * coverage_coords;
+          data.texture_coords = effect_transform *
+                                (vtx - texture_coverage.origin) /
+                                texture_coverage.size;
           vertex_builder.AppendVertex(data);
         }
         FML_DCHECK(vertex_builder.GetVertexCount() == vertices_count / 2);

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -56,9 +56,9 @@ ComputeUVGeometryCPU(
        &texture_origin](SolidFillVertexShader::PerVertexData old_vtx) {
         TextureFillVertexShader::PerVertexData data;
         data.position = old_vtx.position;
-        auto coverage_coords =
-            (old_vtx.position - texture_origin) / texture_coverage;
-        data.texture_coords = effect_transform * coverage_coords;
+        data.texture_coords = effect_transform *
+                              (old_vtx.position - texture_origin) /
+                              texture_coverage;
         vertex_builder.AppendVertex(data);
       });
   return vertex_builder;
@@ -76,8 +76,8 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
   auto points = source_rect.GetPoints();
   for (auto i = 0u, j = 0u; i < 8; i += 2, j++) {
     data[i] = points[j];
-    data[i + 1] = effect_transform * ((points[j] - texture_coverage.origin) /
-                                      texture_coverage.size);
+    data[i + 1] = effect_transform * (points[j] - texture_coverage.origin) /
+                  texture_coverage.size;
   }
 
   return GeometryResult{


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/128328

We need to transform the 'position' first and then divide 'texture_coverage', otherwise the result will be incorrect.

without patch
![66WTKLw7fY](https://github.com/flutter/engine/assets/31977171/6d31138e-0595-4d9c-883e-70a50a5e228d)
with patch
![VAHrQB0HLk](https://github.com/flutter/engine/assets/31977171/0d75e2f8-126e-4ba0-8867-187a311249f4)


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

