### PR TITLE
Implement union and intersection for DlRegion

### DIFF
--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -90,7 +90,7 @@ class DlRegionAdapter {
 };
 
 template <typename Region>
-void RunAddRectsBenchmark(benchmark::State& state, int maxSize) {
+void RunFromRectsBenchmark(benchmark::State& state, int maxSize) {
   std::random_device d;
   std::seed_seq seed{2, 1, 3};
   std::mt19937 rng(seed);
@@ -232,12 +232,12 @@ void RunIntersectsSingleRectBenchmark(benchmark::State& state, int maxSize) {
 
 namespace flutter {
 
-static void BM_DlRegion_AddRects(benchmark::State& state, int maxSize) {
-  RunAddRectsBenchmark<DlRegionAdapter>(state, maxSize);
+static void BM_DlRegion_FromRects(benchmark::State& state, int maxSize) {
+  RunFromRectsBenchmark<DlRegionAdapter>(state, maxSize);
 }
 
-static void BM_SkRegion_AddRects(benchmark::State& state, int maxSize) {
-  RunAddRectsBenchmark<SkRegionAdapter>(state, maxSize);
+static void BM_SkRegion_FromRects(benchmark::State& state, int maxSize) {
+  RunFromRectsBenchmark<SkRegionAdapter>(state, maxSize);
 }
 
 static void BM_DlRegion_GetRects(benchmark::State& state, int maxSize) {
@@ -370,21 +370,21 @@ BENCHMARK_CAPTURE(BM_SkRegion_Operation,
                   1500)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_CAPTURE(BM_DlRegion_AddRects, Tiny, 30)
+BENCHMARK_CAPTURE(BM_DlRegion_FromRects, Tiny, 30)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Tiny, 30)
+BENCHMARK_CAPTURE(BM_SkRegion_FromRects, Tiny, 30)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_DlRegion_AddRects, Small, 100)
+BENCHMARK_CAPTURE(BM_DlRegion_FromRects, Small, 100)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Small, 100)
+BENCHMARK_CAPTURE(BM_SkRegion_FromRects, Small, 100)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_DlRegion_AddRects, Medium, 400)
+BENCHMARK_CAPTURE(BM_DlRegion_FromRects, Medium, 400)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Medium, 400)
+BENCHMARK_CAPTURE(BM_SkRegion_FromRects, Medium, 400)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_DlRegion_AddRects, Large, 1500)
+BENCHMARK_CAPTURE(BM_DlRegion_FromRects, Large, 1500)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Large, 1500)
+BENCHMARK_CAPTURE(BM_SkRegion_FromRects, Large, 1500)
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_DlRegion_GetRects, Tiny, 30)

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -567,56 +567,56 @@ BENCHMARK_CAPTURE(BM_DlRegion_Operation,
                   false,
                   30,
                   kSizeFactorSmall)
-    ->Unit(benchmark::kNanosecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
                   Intersection_TinyAssymetric,
                   RegionOp::kIntersection,
                   false,
                   30,
                   kSizeFactorSmall)
-    ->Unit(benchmark::kNanosecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
                   Intersection_SmallAssymetric,
                   RegionOp::kIntersection,
                   false,
                   100,
                   kSizeFactorSmall)
-    ->Unit(benchmark::kNanosecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
                   Intersection_SmallAssymetric,
                   RegionOp::kIntersection,
                   false,
                   100,
                   kSizeFactorSmall)
-    ->Unit(benchmark::kNanosecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
                   Intersection_MediumAssymetric,
                   RegionOp::kIntersection,
                   false,
                   400,
                   kSizeFactorSmall)
-    ->Unit(benchmark::kNanosecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
                   Intersection_MediumAssymetric,
                   RegionOp::kIntersection,
                   false,
                   400,
                   kSizeFactorSmall)
-    ->Unit(benchmark::kNanosecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
                   Intersection_LargeAssymetric,
                   RegionOp::kIntersection,
                   false,
                   1500,
                   kSizeFactorSmall)
-    ->Unit(benchmark::kNanosecond);
+    ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
                   Intersection_LargeAssymetric,
                   RegionOp::kIntersection,
                   false,
                   1500,
                   kSizeFactorSmall)
-    ->Unit(benchmark::kNanosecond);
+    ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
                   Intersection_SingleRect_Tiny,

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -9,9 +9,27 @@
 
 #include <random>
 
+namespace {
+
 class SkRegionAdapter {
  public:
-  void addRect(const SkIRect& rect) { region_.op(rect, SkRegion::kUnion_Op); }
+  void addRects(std::vector<SkIRect>&& rects) {
+    for (const auto& rect : rects) {
+      region_.op(rect, SkRegion::kUnion_Op);
+    }
+  }
+
+  SkIRect getBounds() { return region_.getBounds(); }
+
+  void addRegion(const SkRegionAdapter& region) {
+    region_.op(region.region_, SkRegion::kUnion_Op);
+  }
+
+  bool intersects(const SkRegionAdapter& region) {
+    return region_.intersects(region.region_);
+  }
+
+  bool intersects(const SkIRect& rect) { return region_.intersects(rect); }
 
   std::vector<SkIRect> getRects() {
     std::vector<SkIRect> rects;
@@ -29,64 +47,260 @@ class SkRegionAdapter {
 
 class DlRegionAdapter {
  public:
-  void addRect(const SkIRect& rect) { rects_.push_back(rect); }
-
-  std::vector<SkIRect> getRects() {
-    flutter::DlRegion region(std::move(rects_));
-    return region.getRects(false);
+  void addRects(std::vector<SkIRect>&& rects) {
+    region_.addRects(std::move(rects));
   }
 
+  void addRegion(const DlRegionAdapter& region) {
+    region_.addRegion(region.region_);
+  }
+
+  SkIRect getBounds() { return region_.bounds(); }
+
+  bool intersects(const DlRegionAdapter& region) {
+    return region_.intersects(region.region_);
+  }
+
+  bool intersects(const SkIRect& rect) { return region_.intersects(rect); }
+
+  std::vector<SkIRect> getRects() { return region_.getRects(false); }
+
+  DlRegionAdapter() {}
+
+  DlRegionAdapter(const DlRegionAdapter& copy) : region_(copy.region_, true) {}
+
  private:
-  std::vector<SkIRect> rects_;
+  flutter::DlRegion region_;
 };
 
 template <typename Region>
-void RunRegionBenchmark(benchmark::State& state, int maxSize) {
+void RunAddRectsBenchmark(benchmark::State& state, int maxSize) {
+  std::random_device d;
+  std::seed_seq seed{2, 1, 3};
+  std::mt19937 rng(seed);
+
+  std::uniform_int_distribution pos(0, 4000);
+  std::uniform_int_distribution size(1, maxSize);
+
+  std::vector<SkIRect> rects;
+  for (int i = 0; i < 2000; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    rects.push_back(rect);
+  }
+
   while (state.KeepRunning()) {
-    std::random_device d;
-    std::seed_seq seed{2, 1, 3};
-    std::mt19937 rng(seed);
-
-    std::uniform_int_distribution pos(0, 4000);
-    std::uniform_int_distribution size(1, maxSize);
-
     Region region;
-
-    for (int i = 0; i < 2000; ++i) {
-      SkIRect rect =
-          SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
-      region.addRect(rect);
-    }
-
+    region.addRects(std::move(rects));
     auto vec2 = region.getRects();
   }
 }
 
+template <typename Region>
+void RunAddRegionBenchmark(benchmark::State& state, int maxSize) {
+  std::random_device d;
+  std::seed_seq seed{2, 1, 3};
+  std::mt19937 rng(seed);
+
+  std::uniform_int_distribution pos(0, 4000);
+  std::uniform_int_distribution size(1, maxSize);
+
+  std::vector<SkIRect> rects;
+  for (int i = 0; i < 500; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    rects.push_back(rect);
+  }
+
+  Region base;
+
+  Region region1(base);
+  region1.addRects(std::move(rects));
+
+  rects.clear();
+  for (int i = 0; i < 500; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    rects.push_back(rect);
+  }
+  Region region2(base);
+  region2.addRects(std::move(rects));
+
+  while (state.KeepRunning()) {
+    Region copy_of_region1(region1);
+    copy_of_region1.addRegion(region2);
+    // Region copy_of_region2(region2);
+    // copy_of_region2.addRegion(region1);
+  }
+}
+
+template <typename Region>
+void RunIntersectsRegionBenchmark(benchmark::State& state, int maxSize) {
+  std::random_device d;
+  std::seed_seq seed{2, 1, 3};
+  std::mt19937 rng(seed);
+
+  std::uniform_int_distribution pos(0, 4000);
+  std::uniform_int_distribution size(1, maxSize);
+
+  std::vector<SkIRect> rects;
+  for (int i = 0; i < 500; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    rects.push_back(rect);
+  }
+
+  Region base;
+
+  Region region1(base);
+  region1.addRects(std::move(rects));
+
+  rects.clear();
+  for (int i = 0; i < 500; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    rects.push_back(rect);
+  }
+  Region region2(base);
+  region2.addRects(std::move(rects));
+
+  while (state.KeepRunning()) {
+    region1.intersects(region2);
+  }
+}
+
+template <typename Region>
+void RunIntersectsSingleRectBenchmark(benchmark::State& state, int maxSize) {
+  std::random_device d;
+  std::seed_seq seed{2, 1, 3};
+  std::mt19937 rng(seed);
+
+  std::uniform_int_distribution pos(0, 4000);
+  std::uniform_int_distribution size(1, maxSize);
+
+  std::vector<SkIRect> rects;
+  for (int i = 0; i < 500; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    rects.push_back(rect);
+  }
+
+  Region base;
+
+  Region region1(base);
+  region1.addRects(std::move(rects));
+
+  rects.clear();
+  for (int i = 0; i < 100; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    rects.push_back(rect);
+  }
+
+  while (state.KeepRunning()) {
+    for (auto& rect : rects) {
+      region1.intersects(rect);
+    }
+  }
+}
+
+}  // namespace
+
 namespace flutter {
 
-static void BM_RegionBenchmarkSkRegion(benchmark::State& state, int maxSize) {
-  RunRegionBenchmark<SkRegionAdapter>(state, maxSize);
+static void BM_DlRegion_AddRects(benchmark::State& state, int maxSize) {
+  RunAddRectsBenchmark<DlRegionAdapter>(state, maxSize);
 }
 
-static void BM_RegionBenchmarkDlRegion(benchmark::State& state, int maxSize) {
-  RunRegionBenchmark<DlRegionAdapter>(state, maxSize);
+static void BM_SkRegion_AddRects(benchmark::State& state, int maxSize) {
+  RunAddRectsBenchmark<SkRegionAdapter>(state, maxSize);
 }
 
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Tiny, 30)
+static void BM_DlRegion_AddRegion(benchmark::State& state, int maxSize) {
+  RunAddRegionBenchmark<DlRegionAdapter>(state, maxSize);
+}
+
+static void BM_SkRegion_AddRegion(benchmark::State& state, int maxSize) {
+  RunAddRegionBenchmark<SkRegionAdapter>(state, maxSize);
+}
+
+static void BM_DlRegion_IntersectsRegion(benchmark::State& state, int maxSize) {
+  RunIntersectsRegionBenchmark<DlRegionAdapter>(state, maxSize);
+}
+
+static void BM_SkRegion_IntersectsRegion(benchmark::State& state, int maxSize) {
+  RunIntersectsRegionBenchmark<SkRegionAdapter>(state, maxSize);
+}
+
+static void BM_DlRegion_IntersectsSingleRect(benchmark::State& state,
+                                             int maxSize) {
+  RunIntersectsSingleRectBenchmark<DlRegionAdapter>(state, maxSize);
+}
+
+static void BM_SkRegion_IntersectsSingleRect(benchmark::State& state,
+                                             int maxSize) {
+  RunIntersectsSingleRectBenchmark<SkRegionAdapter>(state, maxSize);
+}
+
+BENCHMARK_CAPTURE(BM_DlRegion_IntersectsSingleRect, Tiny, 30)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_IntersectsSingleRect, Tiny, 30)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_IntersectsSingleRect, Small, 100)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_IntersectsSingleRect, Small, 100)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_IntersectsSingleRect, Medium, 400)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_IntersectsSingleRect, Medium, 400)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_IntersectsSingleRect, Large, 1500)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_IntersectsSingleRect, Large, 1500)
+    ->Unit(benchmark::kNanosecond);
+
+BENCHMARK_CAPTURE(BM_DlRegion_IntersectsRegion, Tiny, 30)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_IntersectsRegion, Tiny, 30)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_IntersectsRegion, Small, 100)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_IntersectsRegion, Small, 100)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_IntersectsRegion, Medium, 400)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_IntersectsRegion, Medium, 400)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_IntersectsRegion, Large, 1500)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_IntersectsRegion, Large, 1500)
+    ->Unit(benchmark::kNanosecond);
+
+BENCHMARK_CAPTURE(BM_DlRegion_AddRegion, Tiny, 30)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Tiny, 30)
+BENCHMARK_CAPTURE(BM_SkRegion_AddRegion, Tiny, 30)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Small, 100)
+BENCHMARK_CAPTURE(BM_DlRegion_AddRegion, Small, 100)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Small, 100)
+BENCHMARK_CAPTURE(BM_SkRegion_AddRegion, Small, 100)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Medium, 400)
+BENCHMARK_CAPTURE(BM_DlRegion_AddRegion, Medium, 400)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Medium, 400)
+BENCHMARK_CAPTURE(BM_SkRegion_AddRegion, Medium, 400)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkDlRegion, Large, 1500)
+BENCHMARK_CAPTURE(BM_DlRegion_AddRegion, Large, 1500)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_RegionBenchmarkSkRegion, Large, 1500)
+BENCHMARK_CAPTURE(BM_SkRegion_AddRegion, Large, 1500)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_CAPTURE(BM_DlRegion_AddRects, Tiny, 30)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Tiny, 30)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_AddRects, Small, 100)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Small, 100)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_AddRects, Medium, 400)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Medium, 400)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_AddRects, Large, 1500)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Large, 1500)
     ->Unit(benchmark::kMicrosecond);
 
 }  // namespace flutter

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -134,7 +134,10 @@ void RunGetRectsBenchmark(benchmark::State& state, int maxSize) {
 enum RegionOp { kUnion, kIntersection };
 
 template <typename Region>
-void RunRegionOpBenchmark(benchmark::State& state, RegionOp op, int maxSize) {
+void RunRegionOpBenchmark(benchmark::State& state,
+                          RegionOp op,
+                          bool withSingleRect,
+                          int maxSize) {
   std::random_device d;
   std::seed_seq seed{2, 1, 3};
   std::mt19937 rng(seed);
@@ -151,7 +154,7 @@ void RunRegionOpBenchmark(benchmark::State& state, RegionOp op, int maxSize) {
   Region region1(rects);
 
   rects.clear();
-  for (int i = 0; i < 500; ++i) {
+  for (int i = 0; i < (withSingleRect ? 1 : 500); ++i) {
     SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
     rects.push_back(rect);
   }
@@ -250,14 +253,16 @@ static void BM_SkRegion_GetRects(benchmark::State& state, int maxSize) {
 
 static void BM_DlRegion_Operation(benchmark::State& state,
                                   RegionOp op,
+                                  bool withSingleRect,
                                   int maxSize) {
-  RunRegionOpBenchmark<DlRegionAdapter>(state, op, maxSize);
+  RunRegionOpBenchmark<DlRegionAdapter>(state, op, withSingleRect, maxSize);
 }
 
 static void BM_SkRegion_Operation(benchmark::State& state,
                                   RegionOp op,
+                                  bool withSingleRect,
                                   int maxSize) {
-  RunRegionOpBenchmark<SkRegionAdapter>(state, op, maxSize);
+  RunRegionOpBenchmark<SkRegionAdapter>(state, op, withSingleRect, maxSize);
 }
 
 static void BM_DlRegion_IntersectsRegion(benchmark::State& state, int maxSize) {
@@ -312,61 +317,150 @@ BENCHMARK_CAPTURE(BM_DlRegion_IntersectsRegion, Large, 1500)
 BENCHMARK_CAPTURE(BM_SkRegion_IntersectsRegion, Large, 1500)
     ->Unit(benchmark::kNanosecond);
 
-BENCHMARK_CAPTURE(BM_DlRegion_Operation, Union_Tiny, RegionOp::kUnion, 30)
+BENCHMARK_CAPTURE(BM_DlRegion_Operation,
+                  Union_Tiny,
+                  RegionOp::kUnion,
+                  false,
+                  30)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_SkRegion_Operation, Union_Tiny, RegionOp::kUnion, 30)
+BENCHMARK_CAPTURE(BM_SkRegion_Operation,
+                  Union_Tiny,
+                  RegionOp::kUnion,
+                  false,
+                  30)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_DlRegion_Operation, Union_Small, RegionOp::kUnion, 100)
+BENCHMARK_CAPTURE(BM_DlRegion_Operation,
+                  Union_Small,
+                  RegionOp::kUnion,
+                  false,
+                  100)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_SkRegion_Operation, Union_Small, RegionOp::kUnion, 100)
+BENCHMARK_CAPTURE(BM_SkRegion_Operation,
+                  Union_Small,
+                  RegionOp::kUnion,
+                  false,
+                  100)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_DlRegion_Operation, Union_Medium, RegionOp::kUnion, 400)
+BENCHMARK_CAPTURE(BM_DlRegion_Operation,
+                  Union_Medium,
+                  RegionOp::kUnion,
+                  false,
+                  400)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_SkRegion_Operation, Union_Medium, RegionOp::kUnion, 400)
+BENCHMARK_CAPTURE(BM_SkRegion_Operation,
+                  Union_Medium,
+                  RegionOp::kUnion,
+                  false,
+                  400)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_DlRegion_Operation, Union_Large, RegionOp::kUnion, 1500)
+BENCHMARK_CAPTURE(BM_DlRegion_Operation,
+                  Union_Large,
+                  RegionOp::kUnion,
+                  false,
+                  1500)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_CAPTURE(BM_SkRegion_Operation, Union_Large, RegionOp::kUnion, 1500)
+BENCHMARK_CAPTURE(BM_SkRegion_Operation,
+                  Union_Large,
+                  RegionOp::kUnion,
+                  false,
+                  1500)
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
                   Intersection_Tiny,
                   RegionOp::kIntersection,
+                  false,
                   30)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
                   Intersection_Tiny,
                   RegionOp::kIntersection,
+                  false,
                   30)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
                   Intersection_Small,
                   RegionOp::kIntersection,
+                  false,
                   100)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
                   Intersection_Small,
                   RegionOp::kIntersection,
+                  false,
                   100)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
                   Intersection_Medium,
                   RegionOp::kIntersection,
+                  false,
                   400)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
                   Intersection_Medium,
                   RegionOp::kIntersection,
+                  false,
                   400)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
                   Intersection_Large,
                   RegionOp::kIntersection,
+                  false,
                   1500)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
                   Intersection_Large,
                   RegionOp::kIntersection,
+                  false,
+                  1500)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_CAPTURE(BM_DlRegion_Operation,
+                  Intersection_SingleRect_Tiny,
+                  RegionOp::kIntersection,
+                  true,
+                  30)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_Operation,
+                  Intersection_SingleRect_Tiny,
+                  RegionOp::kIntersection,
+                  true,
+                  30)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_Operation,
+                  Intersection_SingleRect_Small,
+                  RegionOp::kIntersection,
+                  true,
+                  100)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_Operation,
+                  Intersection_SingleRect_Small,
+                  RegionOp::kIntersection,
+                  true,
+                  100)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_Operation,
+                  Intersection_SingleRect_Medium,
+                  RegionOp::kIntersection,
+                  true,
+                  400)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_Operation,
+                  Intersection_SingleRect_Medium,
+                  RegionOp::kIntersection,
+                  true,
+                  400)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_Operation,
+                  Intersection_SingleRect_Large,
+                  RegionOp::kIntersection,
+                  true,
+                  1500)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_Operation,
+                  Intersection_SingleRect_Large,
+                  RegionOp::kIntersection,
+                  true,
                   1500)
     ->Unit(benchmark::kMicrosecond);
 

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -93,6 +93,27 @@ void RunAddRectsBenchmark(benchmark::State& state, int maxSize) {
 
   while (state.KeepRunning()) {
     Region region(rects);
+  }
+}
+
+template <typename Region>
+void RunGetRectsBenchmark(benchmark::State& state, int maxSize) {
+  std::random_device d;
+  std::seed_seq seed{2, 1, 3};
+  std::mt19937 rng(seed);
+
+  std::uniform_int_distribution pos(0, 4000);
+  std::uniform_int_distribution size(1, maxSize);
+
+  std::vector<SkIRect> rects;
+  for (int i = 0; i < 2000; ++i) {
+    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    rects.push_back(rect);
+  }
+
+  Region region(rects);
+
+  while (state.KeepRunning()) {
     auto vec2 = region.getRects();
   }
 }
@@ -195,6 +216,14 @@ static void BM_SkRegion_AddRects(benchmark::State& state, int maxSize) {
   RunAddRectsBenchmark<SkRegionAdapter>(state, maxSize);
 }
 
+static void BM_DlRegion_GetRects(benchmark::State& state, int maxSize) {
+  RunGetRectsBenchmark<DlRegionAdapter>(state, maxSize);
+}
+
+static void BM_SkRegion_GetRects(benchmark::State& state, int maxSize) {
+  RunGetRectsBenchmark<SkRegionAdapter>(state, maxSize);
+}
+
 static void BM_DlRegion_MakeUnion(benchmark::State& state, int maxSize) {
   RunUnionRegionBenchmark<DlRegionAdapter>(state, maxSize);
 }
@@ -287,6 +316,23 @@ BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Medium, 400)
 BENCHMARK_CAPTURE(BM_DlRegion_AddRects, Large, 1500)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_AddRects, Large, 1500)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_CAPTURE(BM_DlRegion_GetRects, Tiny, 30)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_GetRects, Tiny, 30)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_GetRects, Small, 100)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_GetRects, Small, 100)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_GetRects, Medium, 400)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_GetRects, Medium, 400)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DlRegion_GetRects, Large, 1500)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_SkRegion_GetRects, Large, 1500)
     ->Unit(benchmark::kMicrosecond);
 
 }  // namespace flutter

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -14,9 +14,7 @@ namespace {
 class SkRegionAdapter {
  public:
   explicit SkRegionAdapter(const std::vector<SkIRect>& rects) {
-    for (const auto& rect : rects) {
-      region_.op(rect, SkRegion::kUnion_Op);
-    }
+    region_.setRects(rects.data(), rects.size());
   }
 
   SkIRect getBounds() { return region_.getBounds(); }

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -140,7 +140,6 @@ void RunIntersectsRegionBenchmark(benchmark::State& state, int maxSize) {
     SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
     rects.push_back(rect);
   }
-
   Region region1(rects);
 
   rects.clear();
@@ -169,7 +168,6 @@ void RunIntersectsSingleRectBenchmark(benchmark::State& state, int maxSize) {
     SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
     rects.push_back(rect);
   }
-
   Region region1(rects);
 
   rects.clear();

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -562,56 +562,56 @@ BENCHMARK_CAPTURE(BM_SkRegion_Operation,
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
-                  Intersection_TinyAssymetric,
+                  Intersection_TinyAsymmetric,
                   RegionOp::kIntersection,
                   false,
                   30,
                   kSizeFactorSmall)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
-                  Intersection_TinyAssymetric,
+                  Intersection_TinyAsymmetric,
                   RegionOp::kIntersection,
                   false,
                   30,
                   kSizeFactorSmall)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
-                  Intersection_SmallAssymetric,
+                  Intersection_SmallAsymmetric,
                   RegionOp::kIntersection,
                   false,
                   100,
                   kSizeFactorSmall)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
-                  Intersection_SmallAssymetric,
+                  Intersection_SmallAsymmetric,
                   RegionOp::kIntersection,
                   false,
                   100,
                   kSizeFactorSmall)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
-                  Intersection_MediumAssymetric,
+                  Intersection_MediumAsymmetric,
                   RegionOp::kIntersection,
                   false,
                   400,
                   kSizeFactorSmall)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
-                  Intersection_MediumAssymetric,
+                  Intersection_MediumAsymmetric,
                   RegionOp::kIntersection,
                   false,
                   400,
                   kSizeFactorSmall)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DlRegion_Operation,
-                  Intersection_LargeAssymetric,
+                  Intersection_LargeAsymmetric,
                   RegionOp::kIntersection,
                   false,
                   1500,
                   kSizeFactorSmall)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_SkRegion_Operation,
-                  Intersection_LargeAssymetric,
+                  Intersection_LargeAsymmetric,
                   RegionOp::kIntersection,
                   false,
                   1500,

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -630,9 +630,9 @@ bool DlRegion::intersects(const SkIRect& rect) const {
     return false;
   }
 
-  auto it = std::upper_bound(
+  auto it = std::lower_bound(
       lines_.begin(), lines_.end(), rect.fTop,
-      [](int32_t i, const SpanLine& line) { return i < line.bottom; });
+      [](const SpanLine& line, int32_t i) { return line.bottom <= i; });
 
   while (it != lines_.end() && it->top < rect.fBottom) {
     FML_DCHECK(rect.fTop < it->bottom && it->top < rect.fBottom);

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -236,6 +236,9 @@ size_t DlRegion::intersectLineSpans(std::vector<Span>& res,
 }
 
 void DlRegion::addRects(const std::vector<SkIRect>& unsorted_rects) {
+  // addRects can only be called on empty regions.
+  FML_DCHECK(lines_.empty());
+
   size_t count = unsorted_rects.size();
   std::vector<const SkIRect*> rects(count);
   for (size_t i = 0; i < count; i++) {

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -37,7 +37,7 @@ DlRegion::SpanChunkHandle DlRegion::SpanBuffer::storeChunk(const Span* begin,
   }
   SpanChunkHandle res = size_;
   size_ += chunk_size + 1;
-  spans_[res].left = chunk_size;
+  setChunkSize(res, chunk_size);
 
   auto* dst = spans_ + res + 1;
   memmove(dst, begin, chunk_size * sizeof(Span));
@@ -50,13 +50,17 @@ size_t DlRegion::SpanBuffer::getChunkSize(SpanChunkHandle handle) const {
   return spans_[handle].left;
 }
 
+void DlRegion::SpanBuffer::setChunkSize(SpanChunkHandle handle, size_t size) {
+  FML_DCHECK(handle < size_);
+  spans_[handle].left = size;
+}
+
 void DlRegion::SpanBuffer::getSpans(SpanChunkHandle handle,
                                     const DlRegion::Span*& begin,
                                     const DlRegion::Span*& end) const {
   FML_DCHECK(handle < size_);
-  auto& info = spans_[handle];
   begin = spans_ + handle + 1;
-  end = begin + info.left;
+  end = begin + getChunkSize(handle);
 }
 
 DlRegion::DlRegion(const std::vector<SkIRect>& rects) {

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -8,473 +8,107 @@
 
 namespace flutter {
 
-class SpanBuffer {
- public:
-  static const uint32_t kDefaultCapacity;
-
-  SpanBuffer() {
-    free_handles_.reserve(256);
-    chunks_.reserve(256);
-    data_.reserve(2048);
-  }
-
-  ~SpanBuffer() {
-    // fprintf(stderr, "Allocated size %zu, Handles: %zu, Free handles: %zu\n",
-    // data_.size(), chunks_.size(), free_handles_.size());
-  }
-
-  SpanChunkHandle allocateChunk(uint32_t capacity = kDefaultCapacity) {
-    for (auto it = free_handles_.rbegin(); it != free_handles_.rend(); ++it) {
-      SpanChunkInfo& info = chunks_[*it];
-      if (info.capacity >= capacity) {
-        SpanChunkHandle handle = *it;
-        if (free_handles_.size() > 1) {
-          *it = free_handles_.back();
-          free_handles_.pop_back();
-        } else {
-          free_handles_.clear();
-        }
-        ++info.ref_count;
-        info.size = 0;
-        return handle;
-      }
-    }
-    return allocateWithCapacity(capacity);
-  }
-
-  SpanChunkHandle duplicateChunk(SpanChunkHandle handle) {
-    SpanChunkInfo& info = chunks_[handle];
-    ++info.ref_count;
-    return handle;
-  }
-
-  SpanChunkHandle copyChunk(DlRegion::Span* begin, DlRegion::Span* end) {
-    size_t size = end - begin;
-    SpanChunkHandle new_handle = allocateChunk(size * 2);
-    SpanChunkInfo& info = chunks_[new_handle];
-    std::memcpy(&data_[info.offset], begin, size * sizeof(DlRegion::Span));
-    info.size = size;
-    return new_handle;
-  }
-
-  void freeChunk(SpanChunkHandle handle) {
-    SpanChunkInfo& info = chunks_[handle];
-    FML_DCHECK(info.ref_count > 0);
-    --info.ref_count;
-    if (info.ref_count == 0) {
-      free_handles_.push_back(handle);
-    }
-  }
-
-  size_t getChunkSize(SpanChunkHandle handle) { return chunks_[handle].size; }
-
-  void updateChunkSize(SpanChunkHandle handle, size_t size) {
-    FML_DCHECK(chunks_[handle].ref_count == 1);
-    SpanChunkInfo& info = chunks_[handle];
-    FML_DCHECK(size <= info.capacity);
-    info.size = size;
-  }
-
-  void getSpans(SpanChunkHandle handle,
-                DlRegion::Span*& begin,
-                DlRegion::Span*& end) {
-    const SpanChunkInfo& info = chunks_[handle];
-    begin = &data_[info.offset];
-    end = begin + info.size;
-  }
-
-  void eraseSpans(SpanChunkHandle handle, size_t begin, size_t end) {
-    FML_DCHECK(chunks_[handle].ref_count == 1);
-    SpanChunkInfo& info = chunks_[handle];
-
-    if (end == info.size) {
-      info.size = begin;
-      return;
-    }
-
-    DlRegion::Span* span_begin = &data_[info.offset];
-    DlRegion::Span* span_end = span_begin + info.size;
-    DlRegion::Span* erase_begin = span_begin + begin;
-    DlRegion::Span* erase_end = span_begin + end;
-    std::memmove(erase_begin, erase_end,
-                 (span_end - erase_end) * sizeof(DlRegion::Span));
-    info.size -= end - begin;
-  }
-
-  void appendSpan(SpanChunkHandle handle, const DlRegion::Span& span) {
-    FML_DCHECK(chunks_[handle].ref_count == 1);
-    ensureSpace(handle);
-    SpanChunkInfo& info = chunks_[handle];
-    DlRegion::Span* begin = &data_[info.offset];
-    DlRegion::Span* end = begin + info.size;
-    *end = span;
-    ++info.size;
-  }
-
-  void insertSpan(SpanChunkHandle handle,
-                  size_t index,
-                  const DlRegion::Span& span) {
-    FML_DCHECK(chunks_[handle].ref_count == 1);
-    ensureSpace(handle);
-    SpanChunkInfo& info = chunks_[handle];
-    DlRegion::Span* begin = &data_[info.offset];
-    DlRegion::Span* end = begin + info.size;
-    DlRegion::Span* insert = begin + index;
-    std::memmove(insert + 1, insert, (end - insert) * sizeof(DlRegion::Span));
-    *insert = span;
-    ++info.size;
-  }
-
-  SpanChunkHandle ensureChunkWritable(SpanChunkHandle handle) {
-    SpanChunkInfo info = chunks_[handle];
-    FML_DCHECK(info.ref_count > 0);
-    if (info.ref_count == 1) {
-      return handle;
-    } else {
-      SpanChunkHandle new_handle = allocateChunk(info.capacity);
-      SpanChunkInfo& new_info = chunks_[new_handle];
-      new_info.size = info.size;
-      std::memmove(&data_[new_info.offset], &data_[info.offset],
-                   info.size * sizeof(DlRegion::Span));
-      --chunks_[handle].ref_count;
-      return new_handle;
-    }
-  }
-
- private:
-  static size_t round_to_8(size_t x) { return ((x + 7) & (-8)); }
-
-  SpanChunkHandle allocateWithCapacity(uint32_t capacity) {
-    capacity = round_to_8(std::max(capacity, kDefaultCapacity));
-    chunks_.push_back({static_cast<uint32_t>(data_.size()), 0, capacity, 1});
-    data_.resize(data_.size() + capacity);
-    return chunks_.size() - 1;
-  }
-
-  void ensureSpace(SpanChunkHandle handle) {
-    SpanChunkInfo& info = chunks_[handle];
-    if (info.size == info.capacity) {
-      auto previous_info = info;
-      info.capacity *= 2;
-      auto prev_offset = info.offset;
-      info.offset = data_.size();
-      data_.resize(data_.size() + info.capacity);
-      std::memmove(&data_[info.offset], &data_[prev_offset],
-                   info.size * sizeof(DlRegion::Span));
-      chunks_.push_back({
-          previous_info.offset,
-          0,
-          previous_info.capacity,
-          0,
-      });
-      free_handles_.push_back(chunks_.size() - 1);
-    }
-  }
-
-  struct SpanChunkInfo {
-    /// Offset from the beginning of the buffer.
-    uint32_t offset;
-    uint32_t size;
-    uint32_t capacity;
-    int32_t ref_count;
-  };
-
-  std::vector<DlRegion::Span> data_;
-  std::vector<SpanChunkInfo> chunks_;
-  std::vector<SpanChunkHandle> free_handles_;
+DlRegion::SpanBuffer::SpanBuffer(DlRegion::SpanBuffer&& m)
+    : capacity_(m.capacity_), size_(m.size_), spans_(m.spans_) {
+  m.size_ = 0;
+  m.capacity_ = 0;
+  m.spans_ = nullptr;
 };
 
-const uint32_t SpanBuffer::kDefaultCapacity = 16;
+DlRegion::SpanBuffer::~SpanBuffer() {
+  free(spans_);
+}
 
-DlRegion::DlRegion() : span_buffer_(std::make_shared<SpanBuffer>()) {}
+void DlRegion::SpanBuffer::reserve(size_t capacity) {
+  if (capacity_ < capacity) {
+    spans_ = static_cast<Span*>(std::realloc(spans_, capacity * sizeof(Span)));
+    capacity_ = capacity;
+  }
+}
 
-DlRegion::DlRegion(const std::vector<SkIRect>& rects)
-    : span_buffer_(std::make_shared<SpanBuffer>()) {
-  // If SpanLines can not be memmoved `addRect` would be significantly slower
-  // due to cost of inserting and removing elements from the `lines_` vector.
-  static_assert(std::is_trivially_constructible<SpanLine>::value,
-                "SpanLine must be trivially constructible.");
+DlRegion::SpanChunkHandle DlRegion::SpanBuffer::storeChunk(const Span* begin,
+                                                           const Span* end) {
+  size_t chunk_size = end - begin;
+  size_t min_capacity = size_ + chunk_size + 1;
+  if (capacity_ < min_capacity) {
+    size_t new_capacity = std::max(min_capacity, capacity_ * 2);
+    new_capacity = std::max(new_capacity, size_t(512));
+    reserve(new_capacity);
+  }
+  SpanChunkHandle res = size_;
+  size_ += chunk_size + 1;
+  spans_[res].left = chunk_size;
+
+  auto* dst = spans_ + res + 1;
+  memmove(dst, begin, chunk_size * sizeof(Span));
+
+  return res;
+}
+
+size_t DlRegion::SpanBuffer::getChunkSize(SpanChunkHandle handle) const {
+  FML_DCHECK(handle < size_);
+  return spans_[handle].left;
+}
+
+void DlRegion::SpanBuffer::getSpans(SpanChunkHandle handle,
+                                    const DlRegion::Span*& begin,
+                                    const DlRegion::Span*& end) const {
+  FML_DCHECK(handle < size_);
+  auto& info = spans_[handle];
+  begin = spans_ + handle + 1;
+  end = begin + info.left;
+}
+
+DlRegion::DlRegion(const std::vector<SkIRect>& rects) {
   addRects(rects);
 }
 
-DlRegion::~DlRegion() {
-  for (auto& line : lines_) {
-    span_buffer_->freeChunk(line.chunk_handle);
-  }
-}
+DlRegion::DlRegion() {}
 
-DlRegion::DlRegion(const DlRegion& region, bool share_buffer)
-    : span_buffer_(share_buffer
-                       ? region.span_buffer_
-                       : std::make_shared<SpanBuffer>(*region.span_buffer_)) {
-  lines_ = region.lines_;
-  for (auto& line : lines_) {
-    line.chunk_handle = span_buffer_->duplicateChunk(line.chunk_handle);
-  }
-  bounds_ = region.bounds_;
-}
-
-bool DlRegion::spansIntersect(const Span* begin1,
-                              const Span* end1,
-                              const Span* begin2,
-                              const Span* end2) const {
-  while (begin1 != end1 && begin2 != end2) {
-    if (begin1->right <= begin2->left) {
-      ++begin1;
-    } else if (begin2->right <= begin1->left) {
-      ++begin2;
-    } else {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool DlRegion::intersects(const SkIRect& rect) const {
-  if (isEmpty()) {
-    return false;
-  }
-
-  auto bounds_intersect = SkIRect::Intersects(bounds_, rect);
-
-  if (!isComplex()) {
-    return bounds_intersect;
-  }
-
-  if (!bounds_intersect) {
-    return false;
-  }
-
-  auto it = std::upper_bound(
-      lines_.begin(), lines_.end(), rect.fTop,
-      [](int32_t i, const SpanLine& line) { return i < line.bottom; });
-
-  while (it != lines_.end() && it->top < rect.fBottom) {
-    FML_DCHECK(rect.fTop < it->bottom || it->top < rect.fBottom);
-    Span *begin, *end;
-    span_buffer_->getSpans(it->chunk_handle, begin, end);
-    while (begin != end && begin->left < rect.fRight) {
-      if (begin->right > rect.fLeft && begin->left < rect.fRight) {
-        return true;
-      }
-      ++begin;
-    }
-    ++it;
-  }
-
-  return false;
-}
-
-bool DlRegion::intersects(const DlRegion& region) const {
-  if (isEmpty() || region.isEmpty()) {
-    return false;
-  }
-
-  auto our_complex = isComplex();
-  auto their_complex = region.isComplex();
-  auto bounds_intersect = SkIRect::Intersects(bounds_, region.bounds_);
-
-  if (!our_complex && !their_complex) {
-    return bounds_intersect;
-  }
-
-  if (!bounds_intersect) {
-    return false;
-  }
-
-  if (!our_complex) {
-    return region.intersects(bounds_);
-  }
-
-  if (!their_complex) {
-    return intersects(region.bounds_);
-  }
-
-  auto ours = lines_.begin();
-  auto theirs = region.lines_.begin();
-
-  while (ours != lines_.end() && theirs != region.lines_.end()) {
-    if (ours->bottom <= theirs->top) {
-      ++ours;
-    } else if (theirs->bottom <= ours->top) {
-      ++theirs;
-    } else {
-      FML_DCHECK(ours->top < theirs->bottom || theirs->top < ours->bottom);
-      Span *ours_begin, *ours_end;
-      span_buffer_->getSpans(ours->chunk_handle, ours_begin, ours_end);
-      Span *theirs_begin, *theirs_end;
-      region.span_buffer_->getSpans(theirs->chunk_handle, theirs_begin,
-                                    theirs_end);
-      if (spansIntersect(ours_begin, ours_end, theirs_begin, theirs_end)) {
-        return true;
-      }
-      if (ours->bottom < theirs->bottom) {
-        ++ours;
-      } else {
-        ++theirs;
-      }
-    }
-  }
-  return false;
-}
-
-std::vector<SkIRect> DlRegion::getRects(bool deband) const {
-  std::vector<SkIRect> rects;
-  size_t rect_count = 0;
-  size_t previous_span_end = 0;
-  for (const auto& line : lines_) {
-    rect_count += span_buffer_->getChunkSize(line.chunk_handle);
-  }
-  rects.reserve(rect_count);
-
-  for (const auto& line : lines_) {
-    Span *span_begin, *span_end;
-    span_buffer_->getSpans(line.chunk_handle, span_begin, span_end);
-    for (const auto* span = span_begin; span < span_end; ++span) {
-      SkIRect rect{span->left, line.top, span->right, line.bottom};
-      if (deband) {
-        auto iter = rects.begin() + previous_span_end;
-        // If there is rectangle previously in rects on which this one is a
-        // vertical continuation, remove the previous rectangle and expand
-        // this one vertically to cover the area.
-        while (iter != rects.begin()) {
-          --iter;
-          if (iter->bottom() < rect.top()) {
-            // Went all the way to previous span line.
-            break;
-          } else if (iter->left() == rect.left() &&
-                     iter->right() == rect.right()) {
-            FML_DCHECK(iter->bottom() == rect.top());
-            rect.fTop = iter->fTop;
-            rects.erase(iter);
-            --previous_span_end;
-            break;
-          }
-        }
-      }
-      rects.push_back(rect);
-    }
-    previous_span_end = rects.size();
-  }
-  return rects;
-}
-
-void DlRegion::SpanLine::insertSpan(SpanBuffer& span_buffer,
-                                    int32_t left,
-                                    int32_t right) {
-  Span *span_begin, *span_end;
-  chunk_handle = span_buffer.ensureChunkWritable(chunk_handle);
-  span_buffer.getSpans(chunk_handle, span_begin, span_end);
-  size_t size = span_end - span_begin;
-  for (size_t i = 0; i < size; ++i) {
-    Span& span = span_begin[i];
-    if (right < span.left) {
-      span_buffer.insertSpan(chunk_handle, i, {left, right});
-      return;
-    }
-    if (left > span.right) {
-      continue;
-    }
-    size_t last_index = i;
-    while (last_index + 1 < size && right >= span_begin[last_index + 1].left) {
-      ++last_index;
-    }
-    span.left = std::min(span.left, left);
-    span.right = std::max(span_begin[last_index].right, right);
-    if (last_index > i) {
-      span_buffer.eraseSpans(chunk_handle, i + 1, last_index + 1);
-    }
-    return;
-  }
-
-  span_buffer.appendSpan(chunk_handle, {left, right});
-}
-
-void DlRegion::SpanLine::insertSpans(SpanBuffer& buffer,
-                                     const Span* begin,
-                                     const Span* end) {
-  for (auto* span = begin; span != end; ++span) {
-    insertSpan(buffer, span->left, span->right);
-  }
-}
-
-bool DlRegion::SpanLine::spansEqual(SpanBuffer& buffer,
-                                    const DlRegion::SpanVec& vec) const {
-  Span *our_begin, *our_end;
-  buffer.getSpans(chunk_handle, our_begin, our_end);
+bool DlRegion::spansEqual(SpanLine& line,
+                          const Span* begin,
+                          const Span* end) const {
+  const Span *our_begin, *our_end;
+  span_buffer_.getSpans(line.chunk_handle, our_begin, our_end);
   size_t our_size = our_end - our_begin;
-  if (our_size != vec.size()) {
+  size_t their_size = end - begin;
+  if (our_size != their_size) {
     return false;
   }
-  return memcmp(our_begin, vec.data(), our_size * sizeof(Span)) == 0;
-}
 
-bool DlRegion::SpanLine::spansEqual(SpanBuffer& buffer,
-                                    const SpanLine& l2) const {
-  FML_DCHECK(this != &l2);
-
-  if (chunk_handle == l2.chunk_handle) {
-    return true;
-  }
-
-  Span *our_begin, *our_end, *outher_begin, *other_end;
-  buffer.getSpans(chunk_handle, our_begin, our_end);
-  buffer.getSpans(l2.chunk_handle, outher_begin, other_end);
-
-  size_t our_size = our_end - our_begin;
-  size_t other_size = other_end - outher_begin;
-
-  if (our_size != other_size) {
-    return false;
-  }
-  return memcmp(our_begin, outher_begin, our_size * sizeof(Span)) == 0;
-}
-
-void DlRegion::insertLine(size_t position, SpanLine line) {
-  lines_.insert(lines_.begin() + position, line);
-}
-
-DlRegion::LineVec::iterator DlRegion::removeLine(
-    DlRegion::LineVec::iterator line) {
-  span_buffer_->freeChunk(line->chunk_handle);
-  return lines_.erase(line);
+  return memcmp(our_begin, begin, our_size * sizeof(Span)) == 0;
 }
 
 DlRegion::SpanLine DlRegion::makeLine(int32_t top,
                                       int32_t bottom,
-                                      int32_t spanLeft,
-                                      int32_t spanRight) {
-  auto handle = span_buffer_->allocateChunk();
-  span_buffer_->appendSpan(handle, {spanLeft, spanRight});
-  return {top, bottom, handle};
+                                      const SpanVec& v) {
+  return makeLine(top, bottom, v.data(), v.data() + v.size());
 }
 
 DlRegion::SpanLine DlRegion::makeLine(int32_t top,
                                       int32_t bottom,
-                                      const DlRegion::SpanVec& v) {
-  auto handle = span_buffer_->allocateChunk(v.capacity());
-  Span *begin, *end;
-  span_buffer_->getSpans(handle, begin, end);
-  memcpy(begin, v.data(), v.size() * sizeof(Span));
-  span_buffer_->updateChunkSize(handle, v.size());
+                                      const Span* begin,
+                                      const Span* end) {
+  auto handle = span_buffer_.storeChunk(begin, end);
   return {top, bottom, handle};
 }
 
-DlRegion::SpanLine DlRegion::mergeLines(int32_t top,
-                                        int32_t bottom,
-                                        SpanChunkHandle our_handle,
-                                        SpanBuffer* their_span_buffer,
-                                        SpanChunkHandle their_handle) {
-  Span *begin2, *end2;
-  their_span_buffer->getSpans(their_handle, begin2, end2);
+size_t DlRegion::mergeLines(std::vector<Span>& res,
+                            const SpanBuffer& a_buffer,
+                            SpanChunkHandle a_handle,
+                            const SpanBuffer& b_buffer,
+                            SpanChunkHandle b_handle) {
+  const Span *begin1, *end1;
+  a_buffer.getSpans(a_handle, begin1, end1);
 
-  auto handle = span_buffer_->allocateChunk(
-      span_buffer_->getChunkSize(our_handle) + (end2 - begin2));
-  Span *begin1, *end1;
-  span_buffer_->getSpans(our_handle, begin1, end1);
+  const Span *begin2, *end2;
+  b_buffer.getSpans(b_handle, begin2, end2);
 
-  Span *begin, *end;
-  span_buffer_->getSpans(handle, begin, end);
+  size_t min_size = (end1 - begin1) + (end2 - begin2);
+  if (res.size() < min_size) {
+    res.resize(min_size);
+  }
+  Span* end = res.data();
 
   while (true) {
     if (begin1->right < begin2->left - 1) {
@@ -562,30 +196,7 @@ DlRegion::SpanLine DlRegion::mergeLines(int32_t top,
     ++end;
   }
 
-  span_buffer_->updateChunkSize(handle, end - begin);
-
-  return {top, bottom, handle};
-}
-
-DlRegion::SpanLine DlRegion::duplicateLine(int32_t top,
-                                           int32_t bottom,
-                                           SpanBuffer* span_buffer,
-                                           SpanChunkHandle handle) {
-  if (span_buffer == span_buffer_.get()) {
-    return {top, bottom, span_buffer_->duplicateChunk(handle)};
-  } else {
-    SpanChunkHandle new_handle;
-    Span *span_begin, *span_end;
-    span_buffer->getSpans(handle, span_begin, span_end);
-    new_handle = span_buffer_->copyChunk(span_begin, span_end);
-    return {top, bottom, new_handle};
-  }
-}
-
-DlRegion::SpanLine DlRegion::duplicateLine(int32_t top,
-                                           int32_t bottom,
-                                           SpanChunkHandle handle) {
-  return {top, bottom, span_buffer_->duplicateChunk(handle)};
+  return end - res.data();
 }
 
 void DlRegion::addRects(const std::vector<SkIRect>& unsorted_rects) {
@@ -610,7 +221,7 @@ void DlRegion::addRects(const std::vector<SkIRect>& unsorted_rects) {
   int32_t cur_y = std::numeric_limits<int32_t>::min();
   SpanVec working_spans;
 
-#ifdef DLREGION2_DO_STATS
+#ifdef DlRegion_DO_STATS
   size_t active_rect_count = 0;
   size_t span_count = 0;
   int pass_count = 0;
@@ -666,7 +277,7 @@ void DlRegion::addRects(const std::vector<SkIRect>& unsorted_rects) {
     working_spans.clear();
     FML_DCHECK(working_spans.empty());
 
-#ifdef DLREGION2_DO_STATS
+#ifdef DlRegion_DO_STATS
     active_rect_count += active_end;
     pass_count++;
 #endif
@@ -679,7 +290,7 @@ void DlRegion::addRects(const std::vector<SkIRect>& unsorted_rects) {
     for (size_t i = 1; i < active_end; i++) {
       const SkIRect* r = rects[i];
       if (r->left() > end_x) {
-        working_spans.push_back({start_x, end_x});
+        working_spans.emplace_back(start_x, end_x);
         start_x = r->left();
         end_x = r->right();
       } else if (end_x < r->right()) {
@@ -689,7 +300,7 @@ void DlRegion::addRects(const std::vector<SkIRect>& unsorted_rects) {
         end_y = r->bottom();
       }
     }
-    working_spans.push_back({start_x, end_x});
+    working_spans.emplace_back(start_x, end_x);
 
     // end_y must not pass by the top of the next input rect
     if (next_rect < count && end_y > rects[next_rect]->top()) {
@@ -701,20 +312,20 @@ void DlRegion::addRects(const std::vector<SkIRect>& unsorted_rects) {
     FML_DCHECK(end_y > cur_y);
 
     if (!lines_.empty() && lines_.back().bottom == cur_y &&
-        lines_.back().spansEqual(*span_buffer_, working_spans)) {
+        spansEqual(lines_.back(), working_spans.data(),
+                   working_spans.data() + working_spans.size())) {
       lines_.back().bottom = end_y;
     } else {
-#ifdef DLREGION2_DO_STATS
+#ifdef DlRegion_DO_STATS
       span_count += working_spans.size();
       line_count++;
 #endif
-      // lines_.emplace_back(cur_y, end_y, working_spans);
       lines_.push_back(makeLine(cur_y, end_y, working_spans));
     }
     cur_y = end_y;
   }
 
-#ifdef DLREGION2_DO_STATS
+#ifdef DlRegion_DO_STATS
   double span_avg = ((double)span_count) / line_count;
   double active_avg = ((double)active_rect_count) / pass_count;
   FML_LOG(ERROR) << lines_.size() << " lines for " << count
@@ -724,95 +335,254 @@ void DlRegion::addRects(const std::vector<SkIRect>& unsorted_rects) {
 #endif
 }
 
-bool DlRegion::isComplex() const {
-  return lines_.size() > 1 ||
-         (lines_.size() == 1 &&
-          span_buffer_->getChunkSize(lines_.front().chunk_handle) > 1);
-}
+DlRegion DlRegion::MakeUnion(const DlRegion& a, const DlRegion& b) {
+  DlRegion res;
 
-void DlRegion::addRegion(const DlRegion& region) {
-  bounds_.join(region.bounds_);
+  res.span_buffer_.reserve(a.span_buffer_.capacity() +
+                           b.span_buffer_.capacity());
+  res.bounds_ = a.bounds_;
+  res.bounds_.join(b.bounds_);
 
-  LineVec res;
-  res.reserve(lines_.size() + region.lines_.size());
+  auto& lines = res.lines_;
+  lines.reserve(a.lines_.size() + b.lines_.size());
 
-  auto append_line = [&](SpanLine line) {
-    if (res.empty()) {
-      res.push_back(line);
+  auto append_spans = [&](int32_t top, int32_t bottom, const Span* begin,
+                          const Span* end) {
+    if (lines.empty()) {
+      lines.push_back(res.makeLine(top, bottom, begin, end));
     } else {
-      if (res.back().bottom == line.top &&
-          res.back().spansEqual(*span_buffer_, line)) {
-        res.back().bottom = line.bottom;
-        span_buffer_->freeChunk(line.chunk_handle);
+      if (lines.back().bottom == top &&
+          res.spansEqual(lines.back(), begin, end)) {
+        lines.back().bottom = bottom;
       } else {
-        res.push_back(line);
+        lines.push_back(res.makeLine(top, bottom, begin, end));
       }
     }
   };
 
-  LineVec::iterator ours = lines_.begin();
-  auto theirs_copy = region.lines_;
-  LineVec::iterator theirs = theirs_copy.begin();
+  auto append_line = [&](int32_t top, int32_t bottom, const SpanBuffer& buffer,
+                         SpanChunkHandle chunk_handle) {
+    const Span *begin, *end;
+    buffer.getSpans(chunk_handle, begin, end);
+    append_spans(top, bottom, begin, end);
+  };
 
-  auto their_span_buffer = region.span_buffer_.get();
+  auto a_lines = a.lines_;
+  auto b_lines = b.lines_;
 
-  while (ours != lines_.end() && theirs != theirs_copy.end()) {
-    if (ours->bottom <= theirs->top) {
-      append_line(*ours);
-      ++ours;
-    } else if (theirs->bottom <= ours->top) {
-      append_line(duplicateLine(theirs->top, theirs->bottom, their_span_buffer,
-                                theirs->chunk_handle));
-      ++theirs;
+  auto a_it = a_lines.begin();
+  auto b_it = b_lines.begin();
+
+  auto& a_buffer = a.span_buffer_;
+  auto& b_buffer = b.span_buffer_;
+
+  std::vector<Span> tmp;
+
+  while (a_it != a_lines.end() && b_it != b_lines.end()) {
+    if (a_it->bottom <= b_it->top) {
+      append_line(a_it->top, a_it->bottom, a_buffer, a_it->chunk_handle);
+      ++a_it;
+    } else if (b_it->bottom <= a_it->top) {
+      append_line(b_it->top, b_it->bottom, b_buffer, b_it->chunk_handle);
+      ++b_it;
     } else {
-      if (ours->top < theirs->top) {
-        append_line(duplicateLine(ours->top, theirs->top, ours->chunk_handle));
-        ours->top = theirs->top;
-        if (ours->top == ours->bottom) {
-          span_buffer_->freeChunk(ours->chunk_handle);
-          ++ours;
+      if (a_it->top < b_it->top) {
+        append_line(a_it->top, b_it->top, a_buffer, a_it->chunk_handle);
+        a_it->top = b_it->top;
+        if (a_it->top == b_it->bottom) {
+          ++a_it;
         }
-      } else if (theirs->top < ours->top) {
-        append_line(duplicateLine(theirs->top, ours->top, their_span_buffer,
-                                  theirs->chunk_handle));
-        theirs->top = ours->top;
-        if (theirs->top == theirs->bottom) {
-          ++theirs;
+      } else if (b_it->top < a_it->top) {
+        append_line(b_it->top, a_it->top, b_buffer, b_it->chunk_handle);
+        b_it->top = a_it->top;
+        if (b_it->top == a_it->bottom) {
+          ++b_it;
         }
       } else {
-        auto new_bottom = std::min(ours->bottom, theirs->bottom);
-        FML_DCHECK(ours->top == theirs->top);
-        FML_DCHECK(new_bottom > ours->top);
-        FML_DCHECK(new_bottom > theirs->top);
-        append_line(mergeLines(ours->top, new_bottom, ours->chunk_handle,
-                               their_span_buffer, theirs->chunk_handle));
-        ours->top = new_bottom;
-        if (ours->top == ours->bottom) {
-          span_buffer_->freeChunk(ours->chunk_handle);
-          ++ours;
+        auto new_bottom = std::min(a_it->bottom, b_it->bottom);
+        FML_DCHECK(a_it->top == b_it->top);
+        FML_DCHECK(new_bottom > a_it->top);
+        FML_DCHECK(new_bottom > b_it->top);
+        auto size = mergeLines(tmp, a_buffer, a_it->chunk_handle, b_buffer,
+                               b_it->chunk_handle);
+        append_spans(a_it->top, new_bottom, tmp.data(), tmp.data() + size);
+        a_it->top = b_it->top = new_bottom;
+        if (a_it->top == a_it->bottom) {
+          ++a_it;
         }
-        theirs->top = new_bottom;
-        if (theirs->top == theirs->bottom) {
-          ++theirs;
+        if (b_it->top == b_it->bottom) {
+          ++b_it;
         }
       }
     }
   }
 
-  FML_DCHECK(ours == lines_.end() || theirs == theirs_copy.end());
+  FML_DCHECK(a_it == a_lines.end() || b_it == b_lines.end());
 
-  while (ours != lines_.end()) {
-    append_line(*ours);
-    ++ours;
+  while (a_it != a_lines.end()) {
+    append_line(a_it->top, a_it->bottom, a_buffer, a_it->chunk_handle);
+    ++a_it;
   }
 
-  while (theirs != theirs_copy.end()) {
-    append_line(duplicateLine(theirs->top, theirs->bottom, their_span_buffer,
-                              theirs->chunk_handle));
-    ++theirs;
+  while (b_it != b_lines.end()) {
+    append_line(b_it->top, b_it->bottom, b_buffer, b_it->chunk_handle);
+    ++b_it;
   }
 
-  lines_ = std::move(res);
+  return res;
+}
+
+std::vector<SkIRect> DlRegion::getRects(bool deband) const {
+  std::vector<SkIRect> rects;
+  size_t rect_count = 0;
+  size_t previous_span_end = 0;
+  for (const auto& line : lines_) {
+    rect_count += span_buffer_.getChunkSize(line.chunk_handle);
+  }
+  rects.reserve(rect_count);
+
+  for (const auto& line : lines_) {
+    const Span *span_begin, *span_end;
+    span_buffer_.getSpans(line.chunk_handle, span_begin, span_end);
+    for (const auto* span = span_begin; span < span_end; ++span) {
+      SkIRect rect{span->left, line.top, span->right, line.bottom};
+      if (deband) {
+        auto iter = rects.begin() + previous_span_end;
+        // If there is rectangle previously in rects on which this one is a
+        // vertical continuation, remove the previous rectangle and expand
+        // this one vertically to cover the area.
+        while (iter != rects.begin()) {
+          --iter;
+          if (iter->bottom() < rect.top()) {
+            // Went all the way to previous span line.
+            break;
+          } else if (iter->left() == rect.left() &&
+                     iter->right() == rect.right()) {
+            FML_DCHECK(iter->bottom() == rect.top());
+            rect.fTop = iter->fTop;
+            rects.erase(iter);
+            --previous_span_end;
+            break;
+          }
+        }
+      }
+      rects.push_back(rect);
+    }
+    previous_span_end = rects.size();
+  }
+  return rects;
+}
+
+DlRegion::~DlRegion() {}
+
+bool DlRegion::isComplex() const {
+  return lines_.size() > 1 ||
+         (lines_.size() == 1 &&
+          span_buffer_.getChunkSize(lines_.front().chunk_handle) > 1);
+}
+
+bool DlRegion::intersects(const SkIRect& rect) const {
+  if (isEmpty()) {
+    return false;
+  }
+
+  auto bounds_intersect = SkIRect::Intersects(bounds_, rect);
+
+  if (!isComplex()) {
+    return bounds_intersect;
+  }
+
+  if (!bounds_intersect) {
+    return false;
+  }
+
+  auto it = std::upper_bound(
+      lines_.begin(), lines_.end(), rect.fTop,
+      [](int32_t i, const SpanLine& line) { return i < line.bottom; });
+
+  while (it != lines_.end() && it->top < rect.fBottom) {
+    FML_DCHECK(rect.fTop < it->bottom || it->top < rect.fBottom);
+    const Span *begin, *end;
+    span_buffer_.getSpans(it->chunk_handle, begin, end);
+    while (begin != end && begin->left < rect.fRight) {
+      if (begin->right > rect.fLeft && begin->left < rect.fRight) {
+        return true;
+      }
+      ++begin;
+    }
+    ++it;
+  }
+
+  return false;
+}
+
+bool DlRegion::spansIntersect(const Span* begin1,
+                              const Span* end1,
+                              const Span* begin2,
+                              const Span* end2) {
+  while (begin1 != end1 && begin2 != end2) {
+    if (begin1->right <= begin2->left) {
+      ++begin1;
+    } else if (begin2->right <= begin1->left) {
+      ++begin2;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool DlRegion::intersects(const DlRegion& region) const {
+  if (isEmpty() || region.isEmpty()) {
+    return false;
+  }
+
+  auto our_complex = isComplex();
+  auto their_complex = region.isComplex();
+  auto bounds_intersect = SkIRect::Intersects(bounds_, region.bounds_);
+
+  if (!our_complex && !their_complex) {
+    return bounds_intersect;
+  }
+
+  if (!bounds_intersect) {
+    return false;
+  }
+
+  if (!our_complex) {
+    return region.intersects(bounds_);
+  }
+
+  if (!their_complex) {
+    return intersects(region.bounds_);
+  }
+
+  auto ours = lines_.begin();
+  auto theirs = region.lines_.begin();
+
+  while (ours != lines_.end() && theirs != region.lines_.end()) {
+    if (ours->bottom <= theirs->top) {
+      ++ours;
+    } else if (theirs->bottom <= ours->top) {
+      ++theirs;
+    } else {
+      FML_DCHECK(ours->top < theirs->bottom || theirs->top < ours->bottom);
+      const Span *ours_begin, *ours_end;
+      span_buffer_.getSpans(ours->chunk_handle, ours_begin, ours_end);
+      const Span *theirs_begin, *theirs_end;
+      region.span_buffer_.getSpans(theirs->chunk_handle, theirs_begin,
+                                   theirs_end);
+      if (spansIntersect(ours_begin, ours_end, theirs_begin, theirs_end)) {
+        return true;
+      }
+      if (ours->bottom < theirs->bottom) {
+        ++ours;
+      } else {
+        ++theirs;
+      }
+    }
+  }
+  return false;
 }
 
 }  // namespace flutter

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -93,11 +93,11 @@ DlRegion::SpanLine DlRegion::makeLine(int32_t top,
   return {top, bottom, handle};
 }
 
-size_t DlRegion::mergeLines(std::vector<Span>& res,
-                            const SpanBuffer& a_buffer,
-                            SpanChunkHandle a_handle,
-                            const SpanBuffer& b_buffer,
-                            SpanChunkHandle b_handle) {
+size_t DlRegion::unionLineSpans(std::vector<Span>& res,
+                                const SpanBuffer& a_buffer,
+                                SpanChunkHandle a_handle,
+                                const SpanBuffer& b_buffer,
+                                SpanChunkHandle b_handle) {
   const Span *begin1, *end1;
   a_buffer.getSpans(a_handle, begin1, end1);
 
@@ -394,8 +394,8 @@ DlRegion DlRegion::MakeUnion(const DlRegion& a, const DlRegion& b) {
         FML_DCHECK(a_it->top == b_it->top);
         FML_DCHECK(new_bottom > a_it->top);
         FML_DCHECK(new_bottom > b_it->top);
-        auto size = mergeLines(tmp, a_buffer, a_it->chunk_handle, b_buffer,
-                               b_it->chunk_handle);
+        auto size = unionLineSpans(tmp, a_buffer, a_it->chunk_handle, b_buffer,
+                                   b_it->chunk_handle);
         append_spans(a_it->top, new_bottom, tmp.data(), tmp.data() + size);
         a_it->top = b_it->top = new_bottom;
         if (a_it->top == a_it->bottom) {

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -509,6 +509,7 @@ DlRegion DlRegion::MakeIntersection(const DlRegion& a, const DlRegion& b) {
     } else {
       auto top = std::max(a_top, b_top);
       auto bottom = std::min(a_it->bottom, b_it->bottom);
+      FML_DCHECK(top < bottom);
       auto size = intersectLineSpans(tmp, a_buffer, a_it->chunk_handle,
                                      b_buffer, b_it->chunk_handle);
       if (size > 0) {

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -632,7 +632,7 @@ bool DlRegion::intersects(const SkIRect& rect) const {
 
   auto it = std::lower_bound(
       lines_.begin(), lines_.end(), rect.fTop,
-      [](const SpanLine& line, int32_t i) { return line.bottom <= i; });
+      [](const SpanLine& line, int32_t top) { return line.bottom <= top; });
 
   while (it != lines_.end() && it->top < rect.fBottom) {
     FML_DCHECK(rect.fTop < it->bottom && it->top < rect.fBottom);

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -507,6 +507,7 @@ DlRegion DlRegion::MakeIntersection(const DlRegion& a, const DlRegion& b) {
   } else if (a.isSimple() && b.isSimple()) {
     SkIRect r(a.bounds_);
     auto res = r.intersect(b.bounds_);
+    (void)res;  // Suppress unused variable warning in release builds.
     FML_DCHECK(res);
     return DlRegion(r);
   } else if (a.isSimple() && a.bounds_.contains(b.bounds_)) {

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -8,31 +8,330 @@
 
 namespace flutter {
 
-DlRegion::DlRegion(std::vector<SkIRect>&& rects) {
-  // If SpanLines can not be memmoved `addRect` would be signifantly slower
+class SpanBuffer {
+ public:
+  static const uint32_t kDefaultCapacity;
+
+  SpanBuffer() {
+    free_handles_.reserve(256);
+    chunks_.reserve(256);
+    data_.reserve(2048);
+  }
+
+  ~SpanBuffer() {
+    // fprintf(stderr, "Allocated size %zu, Handles: %zu, Free handles: %zu\n",
+    // data_.size(), chunks_.size(), free_handles_.size());
+  }
+
+  SpanChunkHandle allocateChunk(uint32_t capacity = kDefaultCapacity) {
+    for (auto it = free_handles_.rbegin(); it != free_handles_.rend(); ++it) {
+      SpanChunkInfo& info = chunks_[*it];
+      if (info.capacity >= capacity) {
+        SpanChunkHandle handle = *it;
+        if (free_handles_.size() > 1) {
+          *it = free_handles_.back();
+          free_handles_.pop_back();
+        } else {
+          free_handles_.clear();
+        }
+        ++info.ref_count;
+        info.size = 0;
+        return handle;
+      }
+    }
+    return allocateWithCapacity(capacity);
+  }
+
+  SpanChunkHandle duplicateChunk(SpanChunkHandle handle) {
+    SpanChunkInfo& info = chunks_[handle];
+    ++info.ref_count;
+    return handle;
+  }
+
+  SpanChunkHandle copyChunk(DlRegion::Span* begin, DlRegion::Span* end) {
+    size_t size = end - begin;
+    SpanChunkHandle new_handle = allocateChunk(size * 2);
+    SpanChunkInfo& info = chunks_[new_handle];
+    std::memcpy(&data_[info.offset], begin, size * sizeof(DlRegion::Span));
+    info.size = size;
+    return new_handle;
+  }
+
+  void freeChunk(SpanChunkHandle handle) {
+    SpanChunkInfo& info = chunks_[handle];
+    FML_DCHECK(info.ref_count > 0);
+    --info.ref_count;
+    if (info.ref_count == 0) {
+      free_handles_.push_back(handle);
+    }
+  }
+
+  size_t getChunkSize(SpanChunkHandle handle) { return chunks_[handle].size; }
+
+  void updateChunkSize(SpanChunkHandle handle, size_t size) {
+    FML_DCHECK(chunks_[handle].ref_count == 1);
+    SpanChunkInfo& info = chunks_[handle];
+    FML_DCHECK(size <= info.capacity);
+    info.size = size;
+  }
+
+  void getSpans(SpanChunkHandle handle,
+                DlRegion::Span*& begin,
+                DlRegion::Span*& end) {
+    const SpanChunkInfo& info = chunks_[handle];
+    begin = &data_[info.offset];
+    end = begin + info.size;
+  }
+
+  void eraseSpans(SpanChunkHandle handle, size_t begin, size_t end) {
+    FML_DCHECK(chunks_[handle].ref_count == 1);
+    SpanChunkInfo& info = chunks_[handle];
+
+    if (end == info.size) {
+      info.size = begin;
+      return;
+    }
+
+    DlRegion::Span* span_begin = &data_[info.offset];
+    DlRegion::Span* span_end = span_begin + info.size;
+    DlRegion::Span* erase_begin = span_begin + begin;
+    DlRegion::Span* erase_end = span_begin + end;
+    std::memmove(erase_begin, erase_end,
+                 (span_end - erase_end) * sizeof(DlRegion::Span));
+    info.size -= end - begin;
+  }
+
+  void appendSpan(SpanChunkHandle handle, const DlRegion::Span& span) {
+    FML_DCHECK(chunks_[handle].ref_count == 1);
+    ensureSpace(handle);
+    SpanChunkInfo& info = chunks_[handle];
+    DlRegion::Span* begin = &data_[info.offset];
+    DlRegion::Span* end = begin + info.size;
+    *end = span;
+    ++info.size;
+  }
+
+  void insertSpan(SpanChunkHandle handle,
+                  size_t index,
+                  const DlRegion::Span& span) {
+    FML_DCHECK(chunks_[handle].ref_count == 1);
+    ensureSpace(handle);
+    SpanChunkInfo& info = chunks_[handle];
+    DlRegion::Span* begin = &data_[info.offset];
+    DlRegion::Span* end = begin + info.size;
+    DlRegion::Span* insert = begin + index;
+    std::memmove(insert + 1, insert, (end - insert) * sizeof(DlRegion::Span));
+    *insert = span;
+    ++info.size;
+  }
+
+  SpanChunkHandle ensureChunkWritable(SpanChunkHandle handle) {
+    SpanChunkInfo info = chunks_[handle];
+    FML_DCHECK(info.ref_count > 0);
+    if (info.ref_count == 1) {
+      return handle;
+    } else {
+      SpanChunkHandle new_handle = allocateChunk(info.capacity);
+      SpanChunkInfo& new_info = chunks_[new_handle];
+      new_info.size = info.size;
+      std::memmove(&data_[new_info.offset], &data_[info.offset],
+                   info.size * sizeof(DlRegion::Span));
+      --chunks_[handle].ref_count;
+      return new_handle;
+    }
+  }
+
+ private:
+  static size_t round_to_8(size_t x) { return ((x + 7) & (-8)); }
+
+  SpanChunkHandle allocateWithCapacity(uint32_t capacity) {
+    capacity = round_to_8(std::max(capacity, kDefaultCapacity));
+    chunks_.push_back({static_cast<uint32_t>(data_.size()), 0, capacity, 1});
+    data_.resize(data_.size() + capacity);
+    return chunks_.size() - 1;
+  }
+
+  void ensureSpace(SpanChunkHandle handle) {
+    SpanChunkInfo& info = chunks_[handle];
+    if (info.size == info.capacity) {
+      auto previous_info = info;
+      info.capacity *= 2;
+      auto prev_offset = info.offset;
+      info.offset = data_.size();
+      data_.resize(data_.size() + info.capacity);
+      std::memmove(&data_[info.offset], &data_[prev_offset],
+                   info.size * sizeof(DlRegion::Span));
+      chunks_.push_back({
+          previous_info.offset,
+          0,
+          previous_info.capacity,
+          0,
+      });
+      free_handles_.push_back(chunks_.size() - 1);
+    }
+  }
+
+  struct SpanChunkInfo {
+    /// Offset from the beginning of the buffer.
+    uint32_t offset;
+    uint32_t size;
+    uint32_t capacity;
+    int32_t ref_count;
+  };
+
+  std::vector<DlRegion::Span> data_;
+  std::vector<SpanChunkInfo> chunks_;
+  std::vector<SpanChunkHandle> free_handles_;
+};
+
+const uint32_t SpanBuffer::kDefaultCapacity = 16;
+
+DlRegion::DlRegion() : span_buffer_(std::make_shared<SpanBuffer>()) {}
+
+DlRegion::DlRegion(std::vector<SkIRect>&& rects)
+    : span_buffer_(std::make_shared<SpanBuffer>()) {
+  // If SpanLines can not be memmoved `addRect` would be significantly slower
   // due to cost of inserting and removing elements from the `lines_` vector.
   static_assert(std::is_trivially_constructible<SpanLine>::value,
                 "SpanLine must be trivially constructible.");
   addRects(std::move(rects));
-
-  for (auto& spanvec : spanvec_pool_) {
-    delete spanvec;
-  }
-  spanvec_pool_.clear();
 }
 
 DlRegion::~DlRegion() {
   for (auto& line : lines_) {
-    delete line.spans;
+    span_buffer_->freeChunk(line.chunk_handle);
   }
+}
+
+DlRegion::DlRegion(const DlRegion& region, bool share_buffer)
+    : span_buffer_(share_buffer
+                       ? region.span_buffer_
+                       : std::make_shared<SpanBuffer>(*region.span_buffer_)) {
+  lines_ = region.lines_;
+  for (auto& line : lines_) {
+    line.chunk_handle = span_buffer_->duplicateChunk(line.chunk_handle);
+  }
+  bounds_ = region.bounds_;
+}
+
+bool DlRegion::spansIntersect(const Span* begin1,
+                              const Span* end1,
+                              const Span* begin2,
+                              const Span* end2) const {
+  while (begin1 != end1 && begin2 != end2) {
+    if (begin1->right <= begin2->left) {
+      ++begin1;
+    } else if (begin2->right <= begin1->left) {
+      ++begin2;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool DlRegion::intersects(const SkIRect& rect) const {
+  if (isEmpty()) {
+    return false;
+  }
+
+  auto bounds_intersect = SkIRect::Intersects(bounds_, rect);
+
+  if (!isComplex()) {
+    return bounds_intersect;
+  }
+
+  if (!bounds_intersect) {
+    return false;
+  }
+
+  auto it = std::upper_bound(
+      lines_.begin(), lines_.end(), rect.fTop,
+      [](int32_t i, const SpanLine& line) { return i < line.bottom; });
+
+  while (it != lines_.end() && it->top < rect.fBottom) {
+    FML_DCHECK(rect.fTop < it->bottom || it->top < rect.fBottom);
+    Span *begin, *end;
+    span_buffer_->getSpans(it->chunk_handle, begin, end);
+    while (begin != end && begin->left < rect.fRight) {
+      if (begin->right > rect.fLeft && begin->left < rect.fRight) {
+        return true;
+      }
+      ++begin;
+    }
+    ++it;
+  }
+
+  return false;
+}
+
+bool DlRegion::intersects(const DlRegion& region) const {
+  if (isEmpty() || region.isEmpty()) {
+    return false;
+  }
+
+  auto our_complex = isComplex();
+  auto their_complex = region.isComplex();
+  auto bounds_intersect = SkIRect::Intersects(bounds_, region.bounds_);
+
+  if (!our_complex && !their_complex) {
+    return bounds_intersect;
+  }
+
+  if (!bounds_intersect) {
+    return false;
+  }
+
+  if (!our_complex) {
+    return region.intersects(bounds_);
+  }
+
+  if (!their_complex) {
+    return intersects(region.bounds_);
+  }
+
+  auto ours = lines_.begin();
+  auto theirs = region.lines_.begin();
+
+  while (ours != lines_.end() && theirs != region.lines_.end()) {
+    if (ours->bottom <= theirs->top) {
+      ++ours;
+    } else if (theirs->bottom <= ours->top) {
+      ++theirs;
+    } else {
+      FML_DCHECK(ours->top < theirs->bottom || theirs->top < ours->bottom);
+      Span *ours_begin, *ours_end;
+      span_buffer_->getSpans(ours->chunk_handle, ours_begin, ours_end);
+      Span *theirs_begin, *theirs_end;
+      region.span_buffer_->getSpans(theirs->chunk_handle, theirs_begin,
+                                    theirs_end);
+      if (spansIntersect(ours_begin, ours_end, theirs_begin, theirs_end)) {
+        return true;
+      }
+      if (ours->bottom < theirs->bottom) {
+        ++ours;
+      } else {
+        ++theirs;
+      }
+    }
+  }
+  return false;
 }
 
 std::vector<SkIRect> DlRegion::getRects(bool deband) const {
   std::vector<SkIRect> rects;
+  size_t rect_count = 0;
   size_t previous_span_end = 0;
   for (const auto& line : lines_) {
-    for (const Span& span : *line.spans) {
-      SkIRect rect{span.left, line.top, span.right, line.bottom};
+    rect_count += span_buffer_->getChunkSize(line.chunk_handle);
+  }
+  rects.reserve(rect_count);
+
+  for (const auto& line : lines_) {
+    Span *span_begin, *span_end;
+    span_buffer_->getSpans(line.chunk_handle, span_begin, span_end);
+    for (const auto* span = span_begin; span < span_end; ++span) {
+      SkIRect rect{span->left, line.top, span->right, line.bottom};
       if (deband) {
         auto iter = rects.begin() + previous_span_end;
         // If there is rectangle previously in rects on which this one is a
@@ -60,43 +359,64 @@ std::vector<SkIRect> DlRegion::getRects(bool deband) const {
   return rects;
 }
 
-void DlRegion::SpanLine::insertSpan(int32_t left, int32_t right) {
-  auto& spans = *this->spans;
-  auto size = spans.size();
+void DlRegion::SpanLine::insertSpan(SpanBuffer& span_buffer,
+                                    int32_t left,
+                                    int32_t right) {
+  Span *span_begin, *span_end;
+  chunk_handle = span_buffer.ensureChunkWritable(chunk_handle);
+  span_buffer.getSpans(chunk_handle, span_begin, span_end);
+  size_t size = span_end - span_begin;
   for (size_t i = 0; i < size; ++i) {
-    Span& span = spans[i];
+    Span& span = span_begin[i];
     if (right < span.left) {
-      spans.insert(spans.begin() + i, {left, right});
+      span_buffer.insertSpan(chunk_handle, i, {left, right});
       return;
     }
     if (left > span.right) {
       continue;
     }
     size_t last_index = i;
-    while (last_index + 1 < size && right >= spans[last_index + 1].left) {
+    while (last_index + 1 < size && right >= span_begin[last_index + 1].left) {
       ++last_index;
     }
     span.left = std::min(span.left, left);
-    span.right = std::max(spans[last_index].right, right);
+    span.right = std::max(span_begin[last_index].right, right);
     if (last_index > i) {
-      spans.erase(spans.begin() + i + 1, spans.begin() + last_index + 1);
+      span_buffer.eraseSpans(chunk_handle, i + 1, last_index + 1);
     }
     return;
   }
 
-  spans.push_back({left, right});
+  span_buffer.appendSpan(chunk_handle, {left, right});
 }
 
-bool DlRegion::SpanLine::spansEqual(const SpanLine& l2) const {
-  SpanVec& spans = *this->spans;
-  SpanVec& otherSpans = *l2.spans;
+void DlRegion::SpanLine::insertSpans(SpanBuffer& buffer,
+                                     const Span* begin,
+                                     const Span* end) {
+  for (auto* span = begin; span != end; ++span) {
+    insertSpan(buffer, span->left, span->right);
+  }
+}
+
+bool DlRegion::SpanLine::spansEqual(SpanBuffer& buffer,
+                                    const SpanLine& l2) const {
   FML_DCHECK(this != &l2);
 
-  if (spans.size() != otherSpans.size()) {
+  if (chunk_handle == l2.chunk_handle) {
+    return true;
+  }
+
+  Span *our_begin, *our_end, *outher_begin, *other_end;
+  buffer.getSpans(chunk_handle, our_begin, our_end);
+  buffer.getSpans(l2.chunk_handle, outher_begin, other_end);
+
+  size_t our_size = our_end - our_begin;
+  size_t other_size = other_end - outher_begin;
+
+  if (our_size != other_size) {
     return false;
   }
-  return memcmp(spans.data(), otherSpans.data(), spans.size() * sizeof(Span)) ==
-         0;
+  return memcmp(our_begin, outher_begin, our_size * sizeof(Span)) == 0;
 }
 
 void DlRegion::insertLine(size_t position, SpanLine line) {
@@ -105,7 +425,7 @@ void DlRegion::insertLine(size_t position, SpanLine line) {
 
 DlRegion::LineVec::iterator DlRegion::removeLine(
     DlRegion::LineVec::iterator line) {
-  spanvec_pool_.push_back(line->spans);
+  span_buffer_->freeChunk(line->chunk_handle);
   return lines_.erase(line);
 }
 
@@ -113,30 +433,137 @@ DlRegion::SpanLine DlRegion::makeLine(int32_t top,
                                       int32_t bottom,
                                       int32_t spanLeft,
                                       int32_t spanRight) {
-  SpanVec* span_vec;
-  if (!spanvec_pool_.empty()) {
-    span_vec = spanvec_pool_.back();
-    spanvec_pool_.pop_back();
-    span_vec->clear();
-  } else {
-    span_vec = new SpanVec();
-  }
-  span_vec->push_back({spanLeft, spanRight});
-  return {top, bottom, span_vec};
+  auto handle = span_buffer_->allocateChunk();
+  span_buffer_->appendSpan(handle, {spanLeft, spanRight});
+  return {top, bottom, handle};
 }
 
-DlRegion::SpanLine DlRegion::makeLine(int32_t top,
-                                      int32_t bottom,
-                                      const SpanVec& spans) {
-  SpanVec* span_vec;
-  if (!spanvec_pool_.empty()) {
-    span_vec = spanvec_pool_.back();
-    spanvec_pool_.pop_back();
-  } else {
-    span_vec = new SpanVec();
+DlRegion::SpanLine DlRegion::mergeLines(int32_t top,
+                                        int32_t bottom,
+                                        SpanChunkHandle our_handle,
+                                        SpanBuffer* their_span_buffer,
+                                        SpanChunkHandle their_handle) {
+  Span *begin2, *end2;
+  their_span_buffer->getSpans(their_handle, begin2, end2);
+
+  auto handle = span_buffer_->allocateChunk(
+      span_buffer_->getChunkSize(our_handle) + (end2 - begin2));
+  Span *begin1, *end1;
+  span_buffer_->getSpans(our_handle, begin1, end1);
+
+  Span *begin, *end;
+  span_buffer_->getSpans(handle, begin, end);
+
+  while (true) {
+    if (begin1->right < begin2->left - 1) {
+      *end = *begin1;
+      ++begin1;
+      ++end;
+      if (begin1 == end1) {
+        break;
+      }
+    } else if (begin2->right < begin1->left) {
+      *end = *begin2;
+      ++begin2;
+      ++end;
+      if (begin2 == end2) {
+        break;
+      }
+    } else {
+      break;
+    }
   }
-  *span_vec = spans;
-  return {top, bottom, span_vec};
+
+  Span currentSpan{0, 0};
+  while (begin1 != end1 && begin2 != end2) {
+    if (currentSpan.left == currentSpan.right) {
+      if (begin1->right < begin2->left - 1) {
+        *end = *begin1;
+        ++begin1;
+        ++end;
+      } else if (begin2->right < begin1->left) {
+        *end = *begin2;
+        ++begin2;
+        ++end;
+      } else if (begin1->left == begin2->left) {
+        currentSpan.left = begin1->left;
+        currentSpan.right = std::max(begin1->right, begin2->right);
+        ++begin1;
+        ++begin2;
+      } else if (begin1->left < begin2->left) {
+        currentSpan.left = begin1->left;
+        currentSpan.right = begin1->right;
+        ++begin1;
+      } else {
+        currentSpan.left = begin2->left;
+        currentSpan.right = begin2->right;
+        ++begin2;
+      }
+    } else if (currentSpan.right >= begin1->left) {
+      currentSpan.right = std::max(currentSpan.right, begin1->right);
+      ++begin1;
+    } else if (currentSpan.right >= begin2->left) {
+      currentSpan.right = std::max(currentSpan.right, begin2->right);
+      ++begin2;
+    } else {
+      *end = currentSpan;
+      ++end;
+      currentSpan.left = currentSpan.right = 0;
+    }
+  }
+
+  if (currentSpan.left != currentSpan.right) {
+    while (begin1 != end1 && currentSpan.right >= begin1->left) {
+      currentSpan.right = std::max(currentSpan.right, begin1->right);
+      ++begin1;
+    }
+    while (begin2 != end2 && currentSpan.right >= begin2->left) {
+      currentSpan.right = std::max(currentSpan.right, begin2->right);
+      ++begin2;
+    }
+
+    *end = currentSpan;
+    ++end;
+  }
+
+  FML_DCHECK(begin1 == end1 || begin2 == end2);
+
+  while (begin1 != end1) {
+    *end = *begin1;
+    ++begin1;
+    ++end;
+  }
+
+  while (begin2 != end2) {
+    *end = *begin2;
+    ++begin2;
+    ++end;
+  }
+
+  span_buffer_->updateChunkSize(handle, end - begin);
+
+  return {top, bottom, handle};
+}
+
+DlRegion::SpanLine DlRegion::duplicateLine(int32_t top,
+                                           int32_t bottom,
+                                           SpanBuffer* span_buffer,
+                                           SpanChunkHandle handle) {
+  if (span_buffer == span_buffer_.get()) {
+    return {top, bottom, span_buffer_->duplicateChunk(handle)};
+  } else {
+    SpanChunkHandle new_handle;
+    Span *span_begin, *span_end;
+    span_buffer->getSpans(handle, span_begin, span_end);
+    new_handle = span_buffer_->copyChunk(span_begin, span_end);
+    return {top, bottom, new_handle};
+  }
+}
+
+DlRegion::SpanLine DlRegion::duplicateLine(int32_t top,
+                                           int32_t bottom,
+                                           SpanChunkHandle handle) {
+  return {top, bottom, span_buffer_->duplicateChunk(handle)};
 }
 
 void DlRegion::addRects(std::vector<SkIRect>&& rects) {
@@ -163,6 +590,8 @@ void DlRegion::addRects(std::vector<SkIRect>&& rects) {
     if (rect.isEmpty()) {
       continue;
     }
+
+    bounds_.join(rect);
 
     int32_t y1 = rect.fTop;
     int32_t y2 = rect.fBottom;
@@ -193,22 +622,22 @@ void DlRegion::addRects(std::vector<SkIRect>&& rects) {
         auto prevLineEnd = line.bottom;
         line.bottom = y1;
         mark_dirty(i);
-        insertLine(i + 1, makeLine(y1, prevLineEnd, *line.spans));
+        insertLine(i + 1, duplicateLine(y1, prevLineEnd, line.chunk_handle));
         continue;
       }
       FML_DCHECK(y1 == line.top);
       if (y2 < line.bottom) {
         // duplicate line
-        auto newLine = makeLine(y2, line.bottom, *line.spans);
+        auto new_line = duplicateLine(y2, line.bottom, line.chunk_handle);
         line.bottom = y2;
-        line.insertSpan(rect.fLeft, rect.fRight);
-        insertLine(i + 1, newLine);
+        line.insertSpan(*span_buffer_, rect.fLeft, rect.fRight);
+        insertLine(i + 1, new_line);
         y1 = y2;
         mark_dirty(i);
         break;
       }
       FML_DCHECK(y2 >= line.bottom);
-      line.insertSpan(rect.fLeft, rect.fRight);
+      line.insertSpan(*span_buffer_, rect.fLeft, rect.fRight);
       mark_dirty(i);
       y1 = line.bottom;
     }
@@ -231,7 +660,7 @@ void DlRegion::addRects(std::vector<SkIRect>&& rects) {
            i < lines_.begin() + dirty_end;) {
         auto& line = *i;
         auto& next = *(i + 1);
-        if (line.bottom == next.top && line.spansEqual(next)) {
+        if (line.bottom == next.top && line.spansEqual(*span_buffer_, next)) {
           --dirty_end;
           next.top = line.top;
           i = removeLine(i);
@@ -243,6 +672,97 @@ void DlRegion::addRects(std::vector<SkIRect>&& rects) {
     dirty_start = std::numeric_limits<size_t>::max();
     dirty_end = 0;
   }
+}
+
+bool DlRegion::isComplex() const {
+  return lines_.size() > 1 ||
+         (lines_.size() == 1 &&
+          span_buffer_->getChunkSize(lines_.front().chunk_handle) > 1);
+}
+
+void DlRegion::addRegion(const DlRegion& region) {
+  bounds_.join(region.bounds_);
+
+  LineVec res;
+  res.reserve(lines_.size() + region.lines_.size());
+
+  auto append_line = [&](SpanLine line) {
+    if (res.empty()) {
+      res.push_back(line);
+    } else {
+      if (res.back().bottom == line.top &&
+          res.back().spansEqual(*span_buffer_, line)) {
+        res.back().bottom = line.bottom;
+        span_buffer_->freeChunk(line.chunk_handle);
+      } else {
+        res.push_back(line);
+      }
+    }
+  };
+
+  LineVec::iterator ours = lines_.begin();
+  auto theirs_copy = region.lines_;
+  LineVec::iterator theirs = theirs_copy.begin();
+
+  auto their_span_buffer = region.span_buffer_.get();
+
+  while (ours != lines_.end() && theirs != theirs_copy.end()) {
+    if (ours->bottom <= theirs->top) {
+      append_line(*ours);
+      ++ours;
+    } else if (theirs->bottom <= ours->top) {
+      append_line(duplicateLine(theirs->top, theirs->bottom, their_span_buffer,
+                                theirs->chunk_handle));
+      ++theirs;
+    } else {
+      if (ours->top < theirs->top) {
+        append_line(duplicateLine(ours->top, theirs->top, ours->chunk_handle));
+        ours->top = theirs->top;
+        if (ours->top == ours->bottom) {
+          span_buffer_->freeChunk(ours->chunk_handle);
+          ++ours;
+        }
+      } else if (theirs->top < ours->top) {
+        append_line(duplicateLine(theirs->top, ours->top, their_span_buffer,
+                                  theirs->chunk_handle));
+        theirs->top = ours->top;
+        if (theirs->top == theirs->bottom) {
+          ++theirs;
+        }
+      } else {
+        auto new_bottom = std::min(ours->bottom, theirs->bottom);
+        FML_DCHECK(ours->top == theirs->top);
+        FML_DCHECK(new_bottom > ours->top);
+        FML_DCHECK(new_bottom > theirs->top);
+        append_line(mergeLines(ours->top, new_bottom, ours->chunk_handle,
+                               their_span_buffer, theirs->chunk_handle));
+        ours->top = new_bottom;
+        if (ours->top == ours->bottom) {
+          span_buffer_->freeChunk(ours->chunk_handle);
+          ++ours;
+        }
+        theirs->top = new_bottom;
+        if (theirs->top == theirs->bottom) {
+          ++theirs;
+        }
+      }
+    }
+  }
+
+  FML_DCHECK(ours == lines_.end() || theirs == theirs_copy.end());
+
+  while (ours != lines_.end()) {
+    append_line(*ours);
+    ++ours;
+  }
+
+  while (theirs != theirs_copy.end()) {
+    append_line(duplicateLine(theirs->top, theirs->bottom, their_span_buffer,
+                              theirs->chunk_handle));
+    ++theirs;
+  }
+
+  lines_ = std::move(res);
 }
 
 }  // namespace flutter

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -25,6 +25,21 @@ DlRegion::SpanBuffer::SpanBuffer(const DlRegion::SpanBuffer& m)
   }
 };
 
+DlRegion::SpanBuffer& DlRegion::SpanBuffer::operator=(
+    const DlRegion::SpanBuffer& buffer) {
+  SpanBuffer copy(buffer);
+  std::swap(*this, copy);
+  return *this;
+}
+
+DlRegion::SpanBuffer& DlRegion::SpanBuffer::operator=(
+    DlRegion::SpanBuffer&& buffer) {
+  std::swap(capacity_, buffer.capacity_);
+  std::swap(size_, buffer.size_);
+  std::swap(spans_, buffer.spans_);
+  return *this;
+}
+
 DlRegion::SpanBuffer::~SpanBuffer() {
   free(spans_);
 }
@@ -78,8 +93,6 @@ void DlRegion::SpanBuffer::getSpans(SpanChunkHandle handle,
 DlRegion::DlRegion(const std::vector<SkIRect>& rects) {
   setRects(rects);
 }
-
-DlRegion::DlRegion() {}
 
 DlRegion::DlRegion(const SkIRect& rect) : bounds_(rect) {
   Span span{rect.left(), rect.right()};

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -603,7 +603,7 @@ bool DlRegion::intersects(const SkIRect& rect) const {
     const Span *begin, *end;
     span_buffer_.getSpans(it->chunk_handle, begin, end);
     while (begin != end && begin->left < rect.fRight) {
-      if (begin->right > rect.fLeft && begin->left < rect.fRight) {
+      if (begin->right > rect.fLeft) {
         return true;
       }
       ++begin;

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -62,6 +62,8 @@ size_t DlRegion::SpanBuffer::getChunkSize(SpanChunkHandle handle) const {
 
 void DlRegion::SpanBuffer::setChunkSize(SpanChunkHandle handle, size_t size) {
   FML_DCHECK(handle < size_);
+  FML_DCHECK(spans_ != nullptr);
+  // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
   spans_[handle].left = size;
 }
 

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -139,18 +139,11 @@ size_t DlRegion::unionLineSpans(std::vector<Span>& res,
         *new_span++ = *begin1++;
       } else if (begin2->right < begin1->left) {
         *new_span++ = *begin2++;
-      } else if (begin1->left < begin2->left) {
-        current_span = *begin1;
-        ++begin1;
-      } else if (begin2->left < begin1->left) {
-        current_span = *begin2;
-        ++begin2;
       } else {
-        FML_DCHECK(begin1->left == begin2->left);
-        current_span.left = begin1->left;
-        current_span.right = std::max(begin1->right, begin2->right);
-        ++begin1;
-        ++begin2;
+        current_span = {std::min(begin1->left, begin2->left),
+                        std::max(begin1->right, begin2->right)};
+        begin1++;
+        begin2++;
       }
     } else if (current_span.right >= begin1->left) {
       current_span.right = std::max(current_span.right, begin1->right);
@@ -159,8 +152,7 @@ size_t DlRegion::unionLineSpans(std::vector<Span>& res,
       current_span.right = std::max(current_span.right, begin2->right);
       ++begin2;
     } else {
-      *new_span = current_span;
-      ++new_span;
+      *new_span++ = current_span;
       current_span.left = current_span.right = 0;
     }
   }

--- a/display_list/geometry/dl_region.cc
+++ b/display_list/geometry/dl_region.cc
@@ -161,6 +161,8 @@ size_t DlRegion::unionLineSpans(std::vector<Span>& res,
     }
   }
 
+  FML_DCHECK(begin1 == end1 || begin2 == end2);
+
   if (current_span.left != current_span.right) {
     while (begin1 != end1 && current_span.right >= begin1->left) {
       current_span.right = std::max(current_span.right, begin1->right);
@@ -174,8 +176,6 @@ size_t DlRegion::unionLineSpans(std::vector<Span>& res,
     *new_span = current_span;
     ++new_span;
   }
-
-  FML_DCHECK(begin1 == end1 || begin2 == end2);
 
   // At most one of these loops will execute
   while (begin1 != end1) {

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -58,7 +58,15 @@ class DlRegion {
   /// Returns whether this region intersects with another region.
   bool intersects(const DlRegion& region) const;
 
-  ~DlRegion();
+  /// Returns true if region is empty (contains no rectangles).
+  bool isEmpty() const { return lines_.empty(); }
+
+  /// Returns true if region is not empty and contains more than one rectangle.
+  bool isComplex() const;
+
+  /// Returns true if region can be represented by single rectangle (or is
+  /// empty).
+  bool isSimple() const { return !isComplex(); }
 
  private:
   typedef std::uint32_t SpanChunkHandle;
@@ -103,10 +111,6 @@ class DlRegion {
     // chunk size.
     Span* spans_ = nullptr;
   };
-
-  bool isEmpty() const { return lines_.empty(); }
-  bool isComplex() const;
-  bool isSimple() const { return !isComplex(); }
 
   struct SpanLine {
     int32_t top;

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -82,6 +82,8 @@ class DlRegion {
     ~SpanBuffer();
 
    private:
+    void setChunkSize(SpanChunkHandle handle, size_t size);
+
     size_t capacity_ = 0;
     size_t size_ = 0;
 

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -64,8 +64,8 @@ class DlRegion {
   /// Returns true if region is not empty and contains more than one rectangle.
   bool isComplex() const;
 
-  /// Returns true if region can be represented by single rectangle (or is
-  /// empty).
+  /// Returns true if region can be represented by single rectangle or is
+  /// empty.
   bool isSimple() const { return !isComplex(); }
 
  private:

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -25,7 +25,7 @@ class DlRegion {
 
   /// Creates region by bulk adding the rectangles.
   /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
-  explicit DlRegion(std::vector<SkIRect>&& rects);
+  explicit DlRegion(const std::vector<SkIRect>& rects);
 
   /// Creates copy of the region.
   DlRegion(const DlRegion& r) : flutter::DlRegion(r, false) {}
@@ -37,10 +37,6 @@ class DlRegion {
   DlRegion(const DlRegion&, bool share_buffer);
 
   ~DlRegion();
-
-  /// Adds group of rectangles to the region.
-  /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
-  void addRects(std::vector<SkIRect>&& rects);
 
   /// Adds another region to this region.
   /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
@@ -64,6 +60,8 @@ class DlRegion {
   const SkIRect& bounds() const { return bounds_; }
 
  private:
+  void addRects(const std::vector<SkIRect>& rects);
+
   friend class SpanBuffer;
   struct Span {
     int32_t left;
@@ -80,6 +78,7 @@ class DlRegion {
                      const Span* begin,
                      const Span* end);
     bool spansEqual(SpanBuffer& span_buffer, const SpanLine& l2) const;
+    bool spansEqual(SpanBuffer& span_buffer, const SpanVec& vec) const;
   };
 
   typedef std::vector<SpanLine> LineVec;
@@ -98,6 +97,7 @@ class DlRegion {
                     int32_t bottom,
                     int32_t spanLeft,
                     int32_t spanRight);
+  SpanLine makeLine(int32_t top, int32_t bottom, const SpanVec&);
   SpanLine duplicateLine(int32_t top, int32_t bottom, SpanChunkHandle handle);
   SpanLine duplicateLine(int32_t top,
                          int32_t bottom,

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -23,11 +23,11 @@ class DlRegion {
 
   DlRegion(DlRegion&&) = default;
 
-  /// Creates union region of region a and be.
+  /// Creates union region of region a and b.
   /// Matches SkRegion a; a.op(b, SkRegion::kUnion_Op) behavior.
   static DlRegion MakeUnion(const DlRegion& a, const DlRegion& b);
 
-  /// Creates intersection region of region a and be.
+  /// Creates intersection region of region a and b.
   /// Matches SkRegion a; a.op(b, SkRegion::kIntersect_Op) behavior.
   static DlRegion MakeIntersection(const DlRegion& a, const DlRegion& b);
 

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -57,7 +57,7 @@ class DlRegion {
     Span(int32_t left, int32_t right) : left(left), right(right) {}
   };
 
-  /// Holds spands for the region. Having custom allocated memory that doesn't
+  /// Holds spans for the region. Having custom allocated memory that doesn't
   /// do zero initialization every time the buffer gets resized improves
   /// performance measurably.
   class SpanBuffer {

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -27,6 +27,10 @@ class DlRegion {
   /// Matches SkRegion a; a.op(b, SkRegion::kUnion_Op) behavior.
   static DlRegion MakeUnion(const DlRegion& a, const DlRegion& b);
 
+  /// Creates intersection region of region a and be.
+  /// Matches SkRegion a; a.op(b, SkRegion::kIntersect_Op) behavior.
+  static DlRegion MakeIntersection(const DlRegion& a, const DlRegion& b);
+
   /// Returns list of non-overlapping rectangles that cover current region.
   /// If |deband| is false, each span line will result in separate rectangles,
   /// closely matching SkRegion::Iterator behavior.
@@ -99,6 +103,19 @@ class DlRegion {
 
   void addRects(const std::vector<SkIRect>& rects);
 
+  void appendLine(int32_t top,
+                  int32_t bottom,
+                  const Span* begin,
+                  const Span* end);
+  void appendLine(int32_t top,
+                  int32_t bottom,
+                  const SpanBuffer& buffer,
+                  SpanChunkHandle handle) {
+    const Span *begin, *end;
+    buffer.getSpans(handle, begin, end);
+    appendLine(top, bottom, begin, end);
+  }
+
   typedef std::vector<Span> SpanVec;
   SpanLine makeLine(int32_t top, int32_t bottom, const SpanVec&);
   SpanLine makeLine(int32_t top,
@@ -110,6 +127,11 @@ class DlRegion {
                                SpanChunkHandle a_handle,
                                const SpanBuffer& b_buffer,
                                SpanChunkHandle b_handle);
+  static size_t intersectLineSpans(std::vector<Span>& res,
+                                   const SpanBuffer& a_buffer,
+                                   SpanChunkHandle a_handle,
+                                   const SpanBuffer& b_buffer,
+                                   SpanChunkHandle b_handle);
 
   bool spansEqual(SpanLine& line, const Span* begin, const Span* end) const;
 

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -17,6 +17,9 @@ namespace flutter {
 /// converting set of overlapping rectangles to non-overlapping rectangles.
 class DlRegion {
  public:
+  /// Creates an empty region.
+  DlRegion() = default;
+
   /// Creates region by bulk adding the rectangles.
   /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
   explicit DlRegion(const std::vector<SkIRect>& rects);
@@ -26,6 +29,9 @@ class DlRegion {
 
   DlRegion(const DlRegion&) = default;
   DlRegion(DlRegion&&) = default;
+
+  DlRegion& operator=(const DlRegion&) = default;
+  DlRegion& operator=(DlRegion&&) = default;
 
   /// Creates union region of region a and b.
   /// Matches SkRegion a; a.op(b, SkRegion::kUnion_Op) behavior.
@@ -73,6 +79,8 @@ class DlRegion {
     SpanBuffer() = default;
     SpanBuffer(const SpanBuffer&);
     SpanBuffer(SpanBuffer&& m);
+    SpanBuffer& operator=(const SpanBuffer&);
+    SpanBuffer& operator=(SpanBuffer&& m);
 
     void reserve(size_t capacity);
     size_t capacity() const { return capacity_; }
@@ -95,8 +103,6 @@ class DlRegion {
     // chunk size.
     Span* spans_ = nullptr;
   };
-
-  DlRegion();
 
   bool isEmpty() const { return lines_.empty(); }
   bool isComplex() const;

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -7,19 +7,44 @@
 
 #include "third_party/skia/include/core/SkRect.h"
 
+#include <memory>
 #include <vector>
 
 namespace flutter {
+
+typedef std::uint32_t SpanChunkHandle;
+class SpanBuffer;
 
 /// Represents a region as a collection of non-overlapping rectangles.
 /// Implements a subset of SkRegion functionality optimized for quickly
 /// converting set of overlapping rectangles to non-overlapping rectangles.
 class DlRegion {
  public:
-  /// Creates region by bulk adding the rectangles./// Matches
-  /// SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
+  /// Creates empty region.
+  DlRegion();
+
+  /// Creates region by bulk adding the rectangles.
+  /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
   explicit DlRegion(std::vector<SkIRect>&& rects);
+
+  /// Creates copy of the region.
+  DlRegion(const DlRegion& r) : flutter::DlRegion(r, false) {}
+
+  /// Creates copy of the region.
+  /// If |share_buffer| is true, the new region will share the same internal
+  /// span buffer as the original region. This means that both region must
+  /// be used on the same thread.
+  DlRegion(const DlRegion&, bool share_buffer);
+
   ~DlRegion();
+
+  /// Adds group of rectangles to the region.
+  /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
+  void addRects(std::vector<SkIRect>&& rects);
+
+  /// Adds another region to this region.
+  /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
+  void addRegion(const DlRegion& region);
 
   /// Returns list of non-overlapping rectangles that cover current region.
   /// If |deband| is false, each span line will result in separate rectangles,
@@ -28,9 +53,18 @@ class DlRegion {
   /// merged into single rectange.
   std::vector<SkIRect> getRects(bool deband = true) const;
 
- private:
-  void addRects(std::vector<SkIRect>&& rects);
+  /// Returns whether this region intersects with a rectangle.
+  bool intersects(const SkIRect& rect) const;
 
+  /// Returns whether this region intersects with another region.
+  bool intersects(const DlRegion& region) const;
+
+  /// Returns maximum and minimum axis values of rectangles in this region.
+  /// If region is empty returns SKIRect::MakeEmpty().
+  const SkIRect& bounds() const { return bounds_; }
+
+ private:
+  friend class SpanBuffer;
   struct Span {
     int32_t left;
     int32_t right;
@@ -39,16 +73,23 @@ class DlRegion {
   struct SpanLine {
     int32_t top;
     int32_t bottom;
-    SpanVec* spans;
+    SpanChunkHandle chunk_handle;
 
-    void insertSpan(int32_t left, int32_t right);
-    bool spansEqual(const SpanLine& l2) const;
+    void insertSpan(SpanBuffer& span_buffer, int32_t left, int32_t right);
+    void insertSpans(SpanBuffer& span_buffer,
+                     const Span* begin,
+                     const Span* end);
+    bool spansEqual(SpanBuffer& span_buffer, const SpanLine& l2) const;
   };
 
   typedef std::vector<SpanLine> LineVec;
 
+  bool isEmpty() const { return lines_.empty(); }
+  bool isComplex() const;
+
   std::vector<SpanLine> lines_;
-  std::vector<SpanVec*> spanvec_pool_;
+
+  SkIRect bounds_ = SkIRect::MakeEmpty();
 
   void insertLine(size_t position, SpanLine line);
   LineVec::iterator removeLine(LineVec::iterator position);
@@ -57,7 +98,23 @@ class DlRegion {
                     int32_t bottom,
                     int32_t spanLeft,
                     int32_t spanRight);
-  SpanLine makeLine(int32_t top, int32_t bottom, const SpanVec& spans);
+  SpanLine duplicateLine(int32_t top, int32_t bottom, SpanChunkHandle handle);
+  SpanLine duplicateLine(int32_t top,
+                         int32_t bottom,
+                         SpanBuffer* span_buffer,
+                         SpanChunkHandle handle);
+  SpanLine mergeLines(int32_t top,
+                      int32_t bottom,
+                      SpanChunkHandle our_handle,
+                      SpanBuffer* their_span_buffer,
+                      SpanChunkHandle their_handle);
+
+  bool spansIntersect(const Span* begin1,
+                      const Span* end1,
+                      const Span* begin2,
+                      const Span* end2) const;
+
+  std::shared_ptr<SpanBuffer> span_buffer_;
 };
 
 }  // namespace flutter

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -157,6 +157,12 @@ class DlRegion {
                              const Span* begin2,
                              const Span* end2);
 
+  static void getIntersectionIterators(
+      const std::vector<SpanLine>& a_lines,
+      const std::vector<SpanLine>& b_lines,
+      std::vector<SpanLine>::const_iterator& a_it,
+      std::vector<SpanLine>::const_iterator& b_it);
+
   std::vector<SpanLine> lines_;
   SkIRect bounds_ = SkIRect::MakeEmpty();
   SpanBuffer span_buffer_;

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -35,7 +35,7 @@ class DlRegion {
   /// If |deband| is false, each span line will result in separate rectangles,
   /// closely matching SkRegion::Iterator behavior.
   /// If |deband| is true, matching rectangles from adjacent span lines will be
-  /// merged into single rectange.
+  /// merged into single rectangle.
   std::vector<SkIRect> getRects(bool deband = true) const;
 
   /// Returns maximum and minimum axis values of rectangles in this region.

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -21,6 +21,10 @@ class DlRegion {
   /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
   explicit DlRegion(const std::vector<SkIRect>& rects);
 
+  /// Creates region covering area of a rectangle.
+  explicit DlRegion(const SkIRect& rect);
+
+  DlRegion(const DlRegion&) = default;
   DlRegion(DlRegion&&) = default;
 
   /// Creates union region of region a and b.
@@ -67,7 +71,7 @@ class DlRegion {
   class SpanBuffer {
    public:
     SpanBuffer() = default;
-    SpanBuffer(const SpanBuffer&) = delete;
+    SpanBuffer(const SpanBuffer&);
     SpanBuffer(SpanBuffer&& m);
 
     void reserve(size_t capacity);
@@ -96,6 +100,7 @@ class DlRegion {
 
   bool isEmpty() const { return lines_.empty(); }
   bool isComplex() const;
+  bool isSimple() const { return !isComplex(); }
 
   struct SpanLine {
     int32_t top;
@@ -103,7 +108,7 @@ class DlRegion {
     SpanChunkHandle chunk_handle;
   };
 
-  void addRects(const std::vector<SkIRect>& rects);
+  void setRects(const std::vector<SkIRect>& rects);
 
   void appendLine(int32_t top,
                   int32_t bottom,

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -105,11 +105,11 @@ class DlRegion {
                     int32_t bottom,
                     const Span* begin,
                     const Span* end);
-  static size_t mergeLines(std::vector<Span>& res,
-                           const SpanBuffer& a_buffer,
-                           SpanChunkHandle a_handle,
-                           const SpanBuffer& b_buffer,
-                           SpanChunkHandle b_handle);
+  static size_t unionLineSpans(std::vector<Span>& res,
+                               const SpanBuffer& a_buffer,
+                               SpanChunkHandle a_handle,
+                               const SpanBuffer& b_buffer,
+                               SpanChunkHandle b_handle);
 
   bool spansEqual(SpanLine& line, const Span* begin, const Span* end) const;
 

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -373,8 +373,12 @@ TEST(DisplayListRegion, TestAgainstSkRegion) {
     DlRegion dl_union = DlRegion::MakeUnion(region1, region2);
     SkRegion sk_union(sk_region1);
     sk_union.op(sk_region2, SkRegion::kUnion_Op);
-
     CheckEquality(dl_union, sk_union);
+
+    DlRegion dl_intersection = DlRegion::MakeIntersection(region1, region2);
+    SkRegion sk_intersection(sk_region1);
+    sk_intersection.op(sk_region2, SkRegion::kIntersect_Op);
+    CheckEquality(dl_intersection, sk_intersection);
   }
 }
 

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -13,7 +13,7 @@ namespace flutter {
 namespace testing {
 
 TEST(DisplayListRegion, EmptyRegion) {
-  DlRegion region(std::vector<SkIRect>{});
+  DlRegion region;
   EXPECT_TRUE(region.getRects().empty());
 }
 
@@ -256,6 +256,7 @@ TEST(DisplayListRegion, Union1) {
   });
   DlRegion u = DlRegion::MakeUnion(region1, region2);
   EXPECT_EQ(u.bounds(), SkIRect::MakeXYWH(0, 0, 40, 40));
+  EXPECT_TRUE(u.isSimple());
   auto rects = u.getRects();
   std::vector<SkIRect> expected{
       SkIRect::MakeXYWH(0, 0, 40, 40),  //
@@ -309,8 +310,7 @@ TEST(DisplayListRegion, UnionEmpty) {
     DlRegion u = DlRegion::MakeUnion(region1, region2);
     EXPECT_EQ(u.bounds(), SkIRect::MakeEmpty());
     auto rects = u.getRects();
-    std::vector<SkIRect> expected{};
-    EXPECT_EQ(rects, expected);
+    EXPECT_TRUE(rects.empty());
   }
   {
     DlRegion region1(std::vector<SkIRect>{});

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -193,6 +193,58 @@ TEST(DisplayListRegion, Intersects2) {
   EXPECT_TRUE(region2.intersects(region1));
 }
 
+TEST(DisplayListRegion, Intersection1) {
+  DlRegion region1({
+      SkIRect::MakeXYWH(0, 0, 20, 20),
+      SkIRect::MakeXYWH(20, 20, 20, 20),
+  });
+  DlRegion region2({
+      SkIRect::MakeXYWH(20, 0, 20, 20),
+      SkIRect::MakeXYWH(0, 20, 20, 20),
+  });
+  DlRegion i = DlRegion::MakeIntersection(region1, region2);
+  EXPECT_EQ(i.bounds(), SkIRect::MakeEmpty());
+  auto rects = i.getRects();
+  EXPECT_TRUE(rects.empty());
+}
+
+TEST(DisplayListRegion, Intersection2) {
+  DlRegion region1({
+      SkIRect::MakeXYWH(0, 0, 20, 20),
+      SkIRect::MakeXYWH(20, 20, 20, 20),
+  });
+  DlRegion region2({
+      SkIRect::MakeXYWH(0, 0, 20, 20),
+      SkIRect::MakeXYWH(20, 20, 20, 20),
+  });
+  DlRegion i = DlRegion::MakeIntersection(region1, region2);
+  EXPECT_EQ(i.bounds(), SkIRect::MakeXYWH(0, 0, 40, 40));
+  auto rects = i.getRects();
+  std::vector<SkIRect> expected{
+      SkIRect::MakeXYWH(0, 0, 20, 20),
+      SkIRect::MakeXYWH(20, 20, 20, 20),
+  };
+  EXPECT_EQ(rects, expected);
+}
+
+TEST(DisplayListRegion, Intersection3) {
+  DlRegion region1({
+      SkIRect::MakeXYWH(0, 0, 20, 20),
+  });
+  DlRegion region2({
+      SkIRect::MakeXYWH(-10, -10, 20, 20),
+      SkIRect::MakeXYWH(10, 10, 20, 20),
+  });
+  DlRegion i = DlRegion::MakeIntersection(region1, region2);
+  EXPECT_EQ(i.bounds(), SkIRect::MakeXYWH(0, 0, 20, 20));
+  auto rects = i.getRects();
+  std::vector<SkIRect> expected{
+      SkIRect::MakeXYWH(0, 0, 10, 10),
+      SkIRect::MakeXYWH(10, 10, 10, 10),
+  };
+  EXPECT_EQ(rects, expected);
+}
+
 TEST(DisplayListRegion, Union1) {
   DlRegion region1({
       SkIRect::MakeXYWH(0, 0, 20, 20),
@@ -248,11 +300,6 @@ TEST(DisplayListRegion, Union3) {
       SkIRect::MakeXYWH(0, 10, 20, 10),
   };
   EXPECT_EQ(rects, expected);
-  // for (auto& rect : rects) {
-  //   printf("SkIRect::MakeXYWH(%d, %d, %d, %d,),\n", rect.fLeft, rect.fTop,
-  //   rect.width(),
-  //          rect.height());
-  // }
 }
 
 TEST(DisplayListRegion, UnionEmpty) {

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -391,17 +391,16 @@ TEST(DisplayListRegion, TestAgainstSkRegion) {
       SkIRect rect =
           SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
       rects_in1.push_back(rect);
-      sk_region1.op(rect, SkRegion::kUnion_Op);
-
       rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
       rects_in2.push_back(rect);
-      sk_region2.op(rect, SkRegion::kUnion_Op);
     }
 
     DlRegion region1(rects_in1);
+    sk_region1.setRects(rects_in1.data(), rects_in1.size());
     CheckEquality(region1, sk_region1);
 
     DlRegion region2(rects_in2);
+    sk_region2.setRects(rects_in2.data(), rects_in2.size());
     CheckEquality(region2, sk_region2);
 
     auto intersects_1 = region1.intersects(region2);

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -14,6 +14,7 @@ namespace testing {
 
 TEST(DisplayListRegion, EmptyRegion) {
   DlRegion region;
+  EXPECT_TRUE(region.isEmpty());
   EXPECT_TRUE(region.getRects().empty());
 }
 
@@ -204,6 +205,7 @@ TEST(DisplayListRegion, Intersection1) {
   });
   DlRegion i = DlRegion::MakeIntersection(region1, region2);
   EXPECT_EQ(i.bounds(), SkIRect::MakeEmpty());
+  EXPECT_TRUE(i.isEmpty());
   auto rects = i.getRects();
   EXPECT_TRUE(rects.empty());
 }
@@ -309,6 +311,7 @@ TEST(DisplayListRegion, UnionEmpty) {
     DlRegion region2(std::vector<SkIRect>{});
     DlRegion u = DlRegion::MakeUnion(region1, region2);
     EXPECT_EQ(u.bounds(), SkIRect::MakeEmpty());
+    EXPECT_TRUE(u.isEmpty());
     auto rects = u.getRects();
     EXPECT_TRUE(rects.empty());
   }

--- a/display_list/geometry/dl_rtree.cc
+++ b/display_list/geometry/dl_rtree.cc
@@ -173,7 +173,7 @@ std::list<SkRect> DlRTree::searchAndConsolidateRects(const SkRect& query,
     bounds(index).roundOut(&current_record_rect);
     rects.push_back(current_record_rect);
   }
-  DlRegion region(std::move(rects));
+  DlRegion region(rects);
 
   auto non_overlapping_rects = region.getRects(deband);
   std::list<SkRect> final_results;

--- a/display_list/geometry/dl_rtree.cc
+++ b/display_list/geometry/dl_rtree.cc
@@ -201,6 +201,18 @@ void DlRTree::search(const Node& parent,
   }
 }
 
+const DlRegion& DlRTree::region() const {
+  if (!region_) {
+    std::vector<SkIRect> rects;
+    rects.resize(leaf_count_);
+    for (int i = 0; i < leaf_count_; i++) {
+      nodes_[i].bounds.roundOut(&rects[i]);
+    }
+    region_.emplace(rects);
+  }
+  return *region_;
+}
+
 const SkRect& DlRTree::bounds() const {
   if (!nodes_.empty()) {
     return nodes_.back().bounds;

--- a/display_list/geometry/dl_rtree.h
+++ b/display_list/geometry/dl_rtree.h
@@ -6,8 +6,10 @@
 #define FLUTTER_DISPLAY_LIST_GEOMETRY_DL_RTREE_H_
 
 #include <list>
+#include <optional>
 #include <vector>
 
+#include "flutter/display_list/geometry/dl_region.h"
 #include "flutter/fml/logging.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
@@ -123,6 +125,16 @@ class DlRTree : public SkRefCnt {
   std::list<SkRect> searchAndConsolidateRects(const SkRect& query,
                                               bool deband = true) const;
 
+  /// Returns DlRegion that represents the union of all rectangles in the
+  /// R-Tree.
+  const DlRegion& region() const;
+
+  /// Returns DlRegion that represents the union of all rectangles in the
+  /// R-Tree intersected with the query rect.
+  DlRegion region(const SkRect& query) const {
+    return DlRegion::MakeIntersection(region(), DlRegion(query.roundOut()));
+  }
+
  private:
   static constexpr SkRect empty_ = SkRect::MakeEmpty();
 
@@ -133,6 +145,7 @@ class DlRTree : public SkRefCnt {
   std::vector<Node> nodes_;
   int leaf_count_;
   int invalid_id_;
+  mutable std::optional<DlRegion> region_;
 };
 
 }  // namespace flutter

--- a/display_list/geometry/dl_rtree.h
+++ b/display_list/geometry/dl_rtree.h
@@ -50,7 +50,7 @@ class DlRTree : public SkRefCnt {
   /// If an array of IDs is not specified then all leaf nodes will be
   /// represented by the |invalid_id| (which defaults to -1).
   ///
-  /// Invallid rects that are empty or contain a NaN value will not be
+  /// Invalid rects that are empty or contain a NaN value will not be
   /// stored in the R-Tree. And, if a |predicate| function is provided,
   /// that function will be called to query if the rectangle associated
   /// with the ID should be included.
@@ -73,8 +73,8 @@ class DlRTree : public SkRefCnt {
   /// The returned indices may not themselves be in numerical order,
   /// but they will represent the rectangles and IDs in the order in
   /// which they were passed into the constructor. The actual rectangle
-  /// and ID associated with each index can be retreived using the
-  /// |DlRTree::id| and |DlRTree::bouds| methods.
+  /// and ID associated with each index can be retrieved using the
+  /// |DlRTree::id| and |DlRTree::bounds| methods.
   void search(const SkRect& query, std::vector<int>* results) const;
 
   /// Return the ID for the indicated result of a query or

--- a/display_list/geometry/dl_rtree_unittests.cc
+++ b/display_list/geometry/dl_rtree_unittests.cc
@@ -301,5 +301,23 @@ TEST(DisplayListRTree, OverlappingRects) {
   EXPECT_EQ(list.front(), SkRect::MakeLTRB(0, 0, 70, 70));
 }
 
+TEST(DisplayListRTree, Region) {
+  SkRect rect[9];
+  for (int i = 0; i < 9; i++) {
+    rect[i] = SkRect::MakeXYWH(i * 10, i * 10, 20, 20);
+  }
+  DlRTree rtree(rect, 9);
+  auto region = rtree.region();
+  auto rects = region.getRects(true);
+  std::vector<SkIRect> expected_rects{
+      SkIRect::MakeLTRB(0, 0, 20, 10),    SkIRect::MakeLTRB(0, 10, 30, 20),
+      SkIRect::MakeLTRB(10, 20, 40, 30),  SkIRect::MakeLTRB(20, 30, 50, 40),
+      SkIRect::MakeLTRB(30, 40, 60, 50),  SkIRect::MakeLTRB(40, 50, 70, 60),
+      SkIRect::MakeLTRB(50, 60, 80, 70),  SkIRect::MakeLTRB(60, 70, 90, 80),
+      SkIRect::MakeLTRB(70, 80, 100, 90), SkIRect::MakeLTRB(80, 90, 100, 100),
+  };
+  EXPECT_EQ(rects.size(), expected_rects.size());
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -53,16 +53,17 @@ void RasterCacheResult::draw(DlCanvas& canvas,
     // On some platforms RTree from overlay layers is used for unobstructed
     // platform views and hit testing. To preserve the RTree raster cache must
     // paint individual rects instead of the whole image.
-    auto rects = rtree_->searchAndConsolidateRects(kGiantRect);
+    auto rects = rtree_->region().getRects(true);
 
     canvas.Translate(bounds.fLeft, bounds.fTop);
 
     SkRect rtree_bounds =
         RasterCacheUtil::GetRoundedOutDeviceBounds(rtree_->bounds(), matrix);
     for (auto rect : rects) {
-      rect = RasterCacheUtil::GetRoundedOutDeviceBounds(rect, matrix);
-      rect.offset(-rtree_bounds.fLeft, -rtree_bounds.fTop);
-      canvas.DrawImageRect(image_, rect, rect,
+      SkRect device_rect = RasterCacheUtil::GetRoundedOutDeviceBounds(
+          SkRect::Make(rect), matrix);
+      device_rect.offset(-rtree_bounds.fLeft, -rtree_bounds.fTop);
+      canvas.DrawImageRect(image_, device_rect, device_rect,
                            DlImageSampling::kNearestNeighbor, paint);
     }
   }

--- a/flow/rtree.cc
+++ b/flow/rtree.cc
@@ -54,7 +54,7 @@ std::list<SkRect> RTree::searchNonOverlappingDrawnRects(
     rects.push_back(current_record_rect);
   }
 
-  DlRegion region(std::move(rects));
+  DlRegion region(rects);
   auto non_overlapping_rects = region.getRects(true);
   std::list<SkRect> final_results;
   for (const auto& rect : non_overlapping_rects) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/128412

Adds 
- `DlRegion DlRegion::MakeUnion(const Region &, const DlRegion &)`
- `DlRegion DlRegion::MakeIntersection(const Region &, const DlRegion &)`
- `bool DlRegion::intersects(const DlRegion &)`
- `bool DlRegion::intersects(const SkIRect &)`

Instead of per span line vector all spans are stored in continuous buffer. 

Complete benchmarks:
```
-----------------------------------------------------------------------------------------------
Benchmark                                                     Time             CPU   Iterations
-----------------------------------------------------------------------------------------------
BM_DlRegion_IntersectsSingleRect/Tiny                      2688 ns         2687 ns       258580
BM_SkRegion_IntersectsSingleRect/Tiny                     85889 ns        85877 ns         8092
BM_DlRegion_IntersectsSingleRect/Small                     4814 ns         4813 ns       142874
BM_SkRegion_IntersectsSingleRect/Small                   101102 ns       101102 ns         6833
BM_DlRegion_IntersectsSingleRect/Medium                    2329 ns         2329 ns       302911
BM_SkRegion_IntersectsSingleRect/Medium                   60436 ns        60183 ns        11156
BM_DlRegion_IntersectsSingleRect/Large                     1243 ns         1243 ns       565209
BM_SkRegion_IntersectsSingleRect/Large                     2813 ns         2813 ns       252187
BM_DlRegion_IntersectsRegion/Tiny                          38.9 ns         38.9 ns     17913855
BM_SkRegion_IntersectsRegion/Tiny                           203 ns          203 ns      3480855
BM_DlRegion_IntersectsRegion/Small                          306 ns          306 ns      2295413
BM_SkRegion_IntersectsRegion/Small                         1057 ns         1057 ns       660826
BM_DlRegion_IntersectsRegion/Medium                        8.83 ns         8.83 ns     79128233
BM_SkRegion_IntersectsRegion/Medium                        43.3 ns         43.3 ns     16076912
BM_DlRegion_IntersectsRegion/Large                         6.96 ns         6.96 ns    101646676
BM_SkRegion_IntersectsRegion/Large                         31.8 ns         31.8 ns     22121517
BM_DlRegion_IntersectsRegion/TinyAsymmetric                54.2 ns         54.2 ns     12890870
BM_SkRegion_IntersectsRegion/TinyAsymmetric                4575 ns         4574 ns       155368
BM_DlRegion_IntersectsRegion/SmallAsymmetric                190 ns          189 ns      3748547
BM_SkRegion_IntersectsRegion/SmallAsymmetric               6157 ns         6157 ns       114403
BM_DlRegion_IntersectsRegion/MediumAsymmetric              20.9 ns         20.9 ns     33523941
BM_SkRegion_IntersectsRegion/MediumAsymmetric              3247 ns         3247 ns       214694
BM_DlRegion_IntersectsRegion/LargeAsymmetric               8.97 ns         8.97 ns     76827676
BM_SkRegion_IntersectsRegion/LargeAsymmetric                154 ns          154 ns      4757924
BM_DlRegion_Operation/Union_Tiny                           26.3 us         26.3 us        24534
BM_SkRegion_Operation/Union_Tiny                           37.9 us         37.9 us        17973
BM_DlRegion_Operation/Union_Small                          64.4 us         64.4 us        10657
BM_SkRegion_Operation/Union_Small                           105 us          105 us         6278
BM_DlRegion_Operation/Union_Medium                         22.0 us         22.0 us        31631
BM_SkRegion_Operation/Union_Medium                         64.8 us         64.8 us        10744
BM_DlRegion_Operation/Union_Large                          1.00 us         1.00 us       697406
BM_SkRegion_Operation/Union_Large                          1.29 us         1.29 us       547089
BM_DlRegion_Operation/Union_TinyAsymmetric                 10.3 us         10.3 us        68647
BM_SkRegion_Operation/Union_TinyAsymmetric                 20.6 us         20.6 us        33282
BM_DlRegion_Operation/Union_SmallAsymmetric                14.0 us         14.0 us        49944
BM_SkRegion_Operation/Union_SmallAsymmetric                34.4 us         34.4 us        19618
BM_DlRegion_Operation/Union_MediumAsymmetric               5.24 us         5.24 us       134097
BM_SkRegion_Operation/Union_MediumAsymmetric               12.7 us         12.7 us        55069
BM_DlRegion_Operation/Union_LargeAsymmetric               0.376 us        0.376 us      1808589
BM_SkRegion_Operation/Union_LargeAsymmetric               0.533 us        0.532 us      1283674
BM_DlRegion_Operation/Intersection_Tiny                    8.13 us         8.13 us        87199
BM_SkRegion_Operation/Intersection_Tiny                    31.8 us         31.8 us        21864
BM_DlRegion_Operation/Intersection_Small                   55.9 us         55.9 us        11888
BM_SkRegion_Operation/Intersection_Small                   98.4 us         98.3 us         6963
BM_DlRegion_Operation/Intersection_Medium                  40.0 us         40.0 us        17667
BM_SkRegion_Operation/Intersection_Medium                  69.8 us         69.8 us         9910
BM_DlRegion_Operation/Intersection_Large                   1.06 us         1.06 us       650957
BM_SkRegion_Operation/Intersection_Large                   1.26 us         1.26 us       559624
BM_DlRegion_Operation/Intersection_TinyAsymmetric          2.62 us         2.62 us       264565
BM_SkRegion_Operation/Intersection_TinyAsymmetric          15.3 us         15.3 us        45528
BM_DlRegion_Operation/Intersection_SmallAsymmetric         7.15 us         7.15 us        93482
BM_SkRegion_Operation/Intersection_SmallAsymmetric         27.5 us         27.5 us        24450
BM_DlRegion_Operation/Intersection_MediumAsymmetric        2.95 us         2.95 us       235133
BM_SkRegion_Operation/Intersection_MediumAsymmetric        10.5 us         10.5 us        65925
BM_DlRegion_Operation/Intersection_LargeAsymmetric        0.165 us        0.165 us      4016433
BM_SkRegion_Operation/Intersection_LargeAsymmetric        0.409 us        0.409 us      1719716
BM_DlRegion_Operation/Intersection_SingleRect_Tiny        0.105 us        0.105 us      7403099
BM_SkRegion_Operation/Intersection_SingleRect_Tiny         10.8 us         10.8 us        64185
BM_DlRegion_Operation/Intersection_SingleRect_Small       0.410 us        0.410 us      1724524
BM_SkRegion_Operation/Intersection_SingleRect_Small        16.2 us         16.2 us        43707
BM_DlRegion_Operation/Intersection_SingleRect_Medium      0.458 us        0.458 us      1540049
BM_SkRegion_Operation/Intersection_SingleRect_Medium       7.54 us         7.54 us        93407
BM_DlRegion_Operation/Intersection_SingleRect_Large       0.175 us        0.175 us      3984926
BM_SkRegion_Operation/Intersection_SingleRect_Large       0.351 us        0.351 us      1931946
BM_DlRegion_FromRects/Tiny                                  154 us          154 us         4383
BM_SkRegion_FromRects/Tiny                                69429 us        69419 us           10
BM_DlRegion_FromRects/Small                                 369 us          369 us         1932
BM_SkRegion_FromRects/Small                              117584 us       117578 us            6
BM_DlRegion_FromRects/Medium                                475 us          475 us         1477
BM_SkRegion_FromRects/Medium                              21611 us        21610 us           33
BM_DlRegion_FromRects/Large                                1329 us         1329 us          533
BM_SkRegion_FromRects/Large                                1409 us         1409 us          501
BM_DlRegion_GetRects/Tiny                                  39.2 us         39.2 us        18030
BM_SkRegion_GetRects/Tiny                                  84.2 us         84.2 us         9971
BM_DlRegion_GetRects/Small                                 88.9 us         88.9 us         7873
BM_SkRegion_GetRects/Small                                  212 us          212 us         3598
BM_DlRegion_GetRects/Medium                               0.845 us        0.813 us       881224
BM_SkRegion_GetRects/Medium                                3.10 us         3.09 us       223483
BM_DlRegion_GetRects/Large                                0.120 us        0.120 us      5954761
BM_SkRegion_GetRects/Large                                0.337 us        0.336 us      2068656
```

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
