### PR TITLE
[Impeller] Makes validation layers flag work for android

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -257,7 +257,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '859e7ccc38f55f89dac8aea49367b7a4c1656490',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'fabb92f0ada787444ad0be22638c80a6d5927a2c',
 
    # Fuchsia compatibility
    #

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -10,6 +10,7 @@ declare_args() {
   shell_enable_vulkan = false
 
   shell_enable_software = true
+  enable_vulkan_validation_layers = false
 }
 
 declare_args() {

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -10,7 +10,6 @@ declare_args() {
   shell_enable_vulkan = false
 
   shell_enable_software = true
-  enable_vulkan_validation_layers = false
 }
 
 declare_args() {

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -478,6 +478,24 @@ action("android_jar") {
     ":pom_libflutter",
   ]
 
+  if (enable_vulkan_validation_layers) {
+    deps += [ "//third_party/vulkan_validation_layers" ]
+    args += [
+      "--native_lib",
+      rebase_path("libVkLayer_khronos_validation.so",
+                  root_build_dir,
+                  root_build_dir),
+    ]
+    if (current_cpu == "arm64") {
+      args += [
+        "--native_lib",
+        rebase_path("$android_libcpp_root/libs/arm64-v8a/libc++_shared.so", root_build_dir),
+    ]
+    } else {
+      assert(false, "Validation layers not supported for arch.")
+    }
+  }
+
   if (flutter_runtime_mode == "profile") {
     deps += [ "//flutter/shell/vmservice:vmservice_snapshot" ]
     args += [

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -489,8 +489,9 @@ action("android_jar") {
     if (current_cpu == "arm64") {
       args += [
         "--native_lib",
-        rebase_path("$android_libcpp_root/libs/arm64-v8a/libc++_shared.so", root_build_dir),
-    ]
+        rebase_path("$android_libcpp_root/libs/arm64-v8a/libc++_shared.so",
+                    root_build_dir),
+      ]
     } else {
       assert(false, "Validation layers not supported for arch.")
     }

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -6,9 +6,11 @@ import("//build/config/android/config.gni")
 import("//build/toolchain/clang.gni")
 import("//flutter/build/zip_bundle.gni")
 import("//flutter/common/config.gni")
+import("//flutter/impeller/tools/impeller.gni")
 import("//flutter/shell/config.gni")
 import("//flutter/shell/gpu/gpu.gni")
 import("//flutter/shell/version/version.gni")
+import("//flutter/vulkan/config.gni")
 
 shell_gpu_configuration("android_gpu_configuration") {
   enable_software = true
@@ -479,6 +481,7 @@ action("android_jar") {
   ]
 
   if (enable_vulkan_validation_layers) {
+    assert(impeller_enable_vulkan)
     deps += [ "//third_party/vulkan_validation_layers" ]
     args += [
       "--native_lib",

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -330,9 +330,7 @@ public class FlutterLoader {
         String backend = metaData.getString(IMPELLER_BACKEND_META_DATA_KEY, "opengles");
         shellArgs.add("--impeller-backend=" + backend);
 
-        Log.d(TAG, "foobar has metadata");
         if (metaData.getBoolean(ENABLE_VULKAN_VALIDATION_META_DATA_KEY, false)) {
-          Log.d(TAG, "foobar has validation flag");
           shellArgs.add("--enable-vulkan-validation");
         }
       }

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -41,13 +41,8 @@ public class FlutterLoader {
       "io.flutter.embedding.android.OldGenHeapSize";
   private static final String ENABLE_IMPELLER_META_DATA_KEY =
       "io.flutter.embedding.android.EnableImpeller";
-<<<<<<< HEAD
-=======
-  private static final String IMPELLER_BACKEND_META_DATA_KEY =
-      "io.flutter.embedding.android.ImpellerBackend";
   private static final String ENABLE_VULKAN_VALIDATION_META_DATA_KEY =
       "io.flutter.embedding.android.EnableVulkanValidation";
->>>>>>> 2e93fc1cf8 ([Impeller] made a switch for turning on validation layers)
 
   /**
    * Set whether leave or clean up the VM after the last shell shuts down. It can be set from app's
@@ -327,9 +322,6 @@ public class FlutterLoader {
         if (metaData.getBoolean(ENABLE_IMPELLER_META_DATA_KEY, false)) {
           shellArgs.add("--enable-impeller");
         }
-        String backend = metaData.getString(IMPELLER_BACKEND_META_DATA_KEY, "opengles");
-        shellArgs.add("--impeller-backend=" + backend);
-
         if (metaData.getBoolean(ENABLE_VULKAN_VALIDATION_META_DATA_KEY, false)) {
           shellArgs.add("--enable-vulkan-validation");
         }

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -41,6 +41,13 @@ public class FlutterLoader {
       "io.flutter.embedding.android.OldGenHeapSize";
   private static final String ENABLE_IMPELLER_META_DATA_KEY =
       "io.flutter.embedding.android.EnableImpeller";
+<<<<<<< HEAD
+=======
+  private static final String IMPELLER_BACKEND_META_DATA_KEY =
+      "io.flutter.embedding.android.ImpellerBackend";
+  private static final String ENABLE_VULKAN_VALIDATION_META_DATA_KEY =
+      "io.flutter.embedding.android.EnableVulkanValidation";
+>>>>>>> 2e93fc1cf8 ([Impeller] made a switch for turning on validation layers)
 
   /**
    * Set whether leave or clean up the VM after the last shell shuts down. It can be set from app's
@@ -316,8 +323,18 @@ public class FlutterLoader {
 
       shellArgs.add("--prefetched-default-font-manager");
 
-      if (metaData != null && metaData.getBoolean(ENABLE_IMPELLER_META_DATA_KEY, false)) {
-        shellArgs.add("--enable-impeller");
+      if (metaData != null) {
+        if (metaData.getBoolean(ENABLE_IMPELLER_META_DATA_KEY, false)) {
+          shellArgs.add("--enable-impeller");
+        }
+        String backend = metaData.getString(IMPELLER_BACKEND_META_DATA_KEY, "opengles");
+        shellArgs.add("--impeller-backend=" + backend);
+
+        Log.d(TAG, "foobar has metadata");
+        if (metaData.getBoolean(ENABLE_VULKAN_VALIDATION_META_DATA_KEY, false)) {
+          Log.d(TAG, "foobar has validation flag");
+          shellArgs.add("--enable-vulkan-validation");
+        }
       }
 
       final String leakVM = isLeakVM(metaData) ? "true" : "false";

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -6,6 +6,7 @@ assert(is_fuchsia)
 
 import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
+import("//flutter/shell/config.gni")
 import("//flutter/shell/gpu/gpu.gni")
 import("//flutter/testing/testing.gni")
 import("//flutter/tools/fuchsia/dart.gni")

--- a/testing/scenario_app/android/gradle.properties
+++ b/testing/scenario_app/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx2048M
 android.useAndroidX=true
 android.enableJetifier=true
 android.builder.sdkDownload=false

--- a/tools/gn
+++ b/tools/gn
@@ -80,7 +80,7 @@ def to_command_line(gn_args):
   def merge(key, value):
     if isinstance(value, bool):
       return '%s=%s' % (key, 'true' if value else 'false')
-    elif isinstance(value, int):
+    if isinstance(value, int):
       return '%s=%d' % (key, value)
     return '%s="%s"' % (key, value)
 

--- a/tools/gn
+++ b/tools/gn
@@ -80,6 +80,8 @@ def to_command_line(gn_args):
   def merge(key, value):
     if isinstance(value, bool):
       return '%s=%s' % (key, 'true' if value else 'false')
+    elif isinstance(value, int):
+      return '%s=%d' % (key, value)
     return '%s="%s"' % (key, value)
 
   return [merge(x, y) for x, y in gn_args.items()]
@@ -548,11 +550,8 @@ def to_gn_args(args):
     gn_args['use_fstack_protector'] = True
 
   if args.enable_vulkan_validation_layers:
-    if args.target_os != 'fuchsia':
-      print(
-          'Vulkan validation layers are currently only supported on Fuchsia targets.'
-      )
-      sys.exit(1)
+    if args.target_os == 'android':
+      gn_args['android_api_level'] = int(26)
     gn_args['enable_vulkan_validation_layers'] = True
 
   # Enable pointer compression on 64-bit mobile targets. iOS is excluded due to

--- a/tools/gn
+++ b/tools/gn
@@ -551,7 +551,7 @@ def to_gn_args(args):
 
   if args.enable_vulkan_validation_layers:
     if args.target_os == 'android':
-      gn_args['android_api_level'] = int(26)
+      gn_args['android_api_level'] = 26
     gn_args['enable_vulkan_validation_layers'] = True
 
   # Enable pointer compression on 64-bit mobile targets. iOS is excluded due to

--- a/vulkan/config.gni
+++ b/vulkan/config.gni
@@ -3,4 +3,6 @@
 # found in the LICENSE file.
 
 declare_args() {
+  # Whether to include vulkan validation layers.
+  enable_vulkan_validation_layers = false
 }

--- a/vulkan/config.gni
+++ b/vulkan/config.gni
@@ -3,10 +3,4 @@
 # found in the LICENSE file.
 
 declare_args() {
-  # Whether to include vulkan validation layers, if available.
-  #
-  # Currently these are only supported on Fuchsia, where by default they are
-  # disabled, to enable them pass `--enable-vulkan-validation-layers` to your
-  # gn args.
-  enable_vulkan_validation_layers = false
 }


### PR DESCRIPTION
This builds and links in the validation layers for android.  They then can be turned on or off with a manifest field.

fixes https://github.com/flutter/flutter/issues/123788
depends on https://github.com/flutter/buildroot/pull/741

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
