### PR TITLE
[ios] view controller based status bar

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
@@ -23,8 +23,6 @@ extern const char* const kOrientationUpdateNotificationName;
 extern const char* const kOrientationUpdateNotificationKey;
 extern const char* const kOverlayStyleUpdateNotificationName;
 extern const char* const kOverlayStyleUpdateNotificationKey;
-extern const char* const kStatusBarHiddenUpdateNotificationName;
-extern const char* const kStatusBarHiddenUpdateNotificationKey;
 
 }  // namespace flutter
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
@@ -23,6 +23,8 @@ extern const char* const kOrientationUpdateNotificationName;
 extern const char* const kOrientationUpdateNotificationKey;
 extern const char* const kOverlayStyleUpdateNotificationName;
 extern const char* const kOverlayStyleUpdateNotificationKey;
+extern const char* const kStatusBarHiddenUpdateNotificationName;
+extern const char* const kStatusBarHiddenUpdateNotificationKey;
 
 }  // namespace flutter
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -63,13 +63,13 @@ using namespace flutter;
     NSObject* infoValue = [[NSBundle mainBundle]
         objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"];
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-    if (infoValue!= nil && ![infoValue isKindOfClass:[NSNumber class]]) {
-      FML_LOG(ERROR) << "The value of UIViewControllerBasedStatusBarAppearance in info.plist must be a Boolean type.";
+    if (infoValue != nil && ![infoValue isKindOfClass:[NSNumber class]]) {
+      FML_LOG(ERROR) << "The value of UIViewControllerBasedStatusBarAppearance in info.plist must "
+                        "be a Boolean type.";
     }
 #endif
-    NSNumber* infoValue = [[NSBundle mainBundle]
-        objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"];
-    _enableViewControllerBasedStatusBarAppearance = (infoValue == nil || [infoValue boolValue]);
+    _enableViewControllerBasedStatusBarAppearance =
+        (infoValue == nil || [(NSNumber*)infoValue boolValue]);
   }
 
   return self;
@@ -192,7 +192,7 @@ using namespace flutter;
                       object:nil];
   }
   if (self.enableViewControllerBasedStatusBarAppearance) {
-    [_engine.get() viewController].flutterPrefersStatusBarHidden = statusBarShouldBeHidden;
+    [_engine.get() viewController].prefersStatusBarHidden = statusBarShouldBeHidden;
   } else {
     // Checks if the top status bar should be visible. This platform ignores all
     // other overlays
@@ -207,7 +207,7 @@ using namespace flutter;
 - (void)setSystemChromeEnabledSystemUIMode:(NSString*)mode {
   BOOL edgeToEdge = [mode isEqualToString:@"SystemUiMode.edgeToEdge"];
   if (self.enableViewControllerBasedStatusBarAppearance) {
-    [_engine.get() viewController].flutterPrefersStatusBarHidden = !edgeToEdge;
+    [_engine.get() viewController].prefersStatusBarHidden = !edgeToEdge;
   } else {
     // Checks if the top status bar should be visible, reflected by edge to edge setting. This
     // platform ignores all other system ui modes.

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -40,7 +40,7 @@ using namespace flutter;
 /**
  * @brief Whether the status bar appearance is based on the style preferred for this ViewController.
  *
- *        The default value is true.
+ *        The default value is YES.
  *        Explicitly add `UIViewControllerBasedStatusBarAppearance` as `false` in
  *        info.plist makes this value to be false.
  */
@@ -60,6 +60,13 @@ using namespace flutter;
 
   if (self) {
     _engine = engine;
+    NSObject* infoValue = [[NSBundle mainBundle]
+        objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"];
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+    if (infoValue!= nil && ![infoValue isKindOfClass:[NSNumber class]]) {
+      FML_LOG(ERROR) << "The value of UIViewControllerBasedStatusBarAppearance in info.plist must be a Boolean type.";
+    }
+#endif
     NSNumber* infoValue = [[NSBundle mainBundle]
         objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"];
     _enableViewControllerBasedStatusBarAppearance = (infoValue == nil || [infoValue boolValue]);

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -146,6 +146,7 @@ typedef struct MouseState {
 }
 
 @synthesize displayingFlutterUI = _displayingFlutterUI;
+@synthesize prefersStatusBarHidden = _flutterPrefersStatusBarHidden;
 
 #pragma mark - Manage and override all designated initializers
 
@@ -2081,7 +2082,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   });
 }
 
-- (void)setFlutterPrefersStatusBarHidden:(BOOL)hidden {
+- (void)setPrefersStatusBarHidden:(BOOL)hidden {
   if (hidden != _flutterPrefersStatusBarHidden) {
     _flutterPrefersStatusBarHidden = hidden;
     [self setNeedsStatusBarAppearanceUpdate];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -103,13 +103,6 @@ typedef struct MouseState {
 @property(nonatomic, retain)
     UIRotationGestureRecognizer* rotationGestureRecognizer API_AVAILABLE(ios(13.4));
 
-// Whether the status bar is prefered hidden.
-//
-// The |UIViewController:prefersStatusBarHidden| of this ViewController is overriden and returns
-// `flutterPreferesStatusBarHidden`. Only works when `UIViewControllerBasedStatusBarAppearance` in
-// info.plist of the app project is `true`.
-@property(nonatomic, assign) BOOL flutterPreferesStatusBarHidden;
-
 /**
  * Creates and registers plugins used by this view controller.
  */
@@ -305,10 +298,6 @@ typedef struct MouseState {
   [center addObserver:self
              selector:@selector(onPreferredStatusBarStyleUpdated:)
                  name:@(flutter::kOverlayStyleUpdateNotificationName)
-               object:nil];
-  [center addObserver:self
-             selector:@selector(onPreferredStatusBarHiddenUpdated:)
-                 name:@(flutter::kStatusBarHiddenUpdateNotificationName)
                object:nil];
 
   [center addObserver:self
@@ -2092,29 +2081,15 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   });
 }
 
-- (void)onPreferredStatusBarHiddenUpdated:(NSNotification*)notification {
-  FML_DCHECK(
-      [notification.name isEqualToString:@(flutter::kStatusBarHiddenUpdateNotificationName)]);
-  // Notifications may not be on the iOS UI thread
-  fml::TaskRunner::RunNowOrPostTask([_engine.get() platformTaskRunner], [&]() {
-    NSDictionary* info = notification.userInfo;
-
-    NSNumber* update = info[@(flutter::kStatusBarHiddenUpdateNotificationKey)];
-
-    if (update == nil) {
-      return;
-    }
-
-    BOOL hidden = [update boolValue];
-    if (hidden != self.flutterPreferesStatusBarHidden) {
-      self.flutterPreferesStatusBarHidden = hidden;
-      [self setNeedsStatusBarAppearanceUpdate];
-    }
-  });
+- (void)setFlutterPrefersStatusBarHidden:(BOOL)hidden {
+  if (hidden != _flutterPrefersStatusBarHidden) {
+    _flutterPrefersStatusBarHidden = hidden;
+    [self setNeedsStatusBarAppearanceUpdate];
+  }
 }
 
 - (BOOL)prefersStatusBarHidden {
-  return self.flutterPreferesStatusBarHidden;
+  return _flutterPrefersStatusBarHidden;
 }
 
 #pragma mark - Platform views

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -43,9 +43,10 @@ typedef NS_ENUM(NSInteger, FlutterKeyboardMode) {
 /**
  * @brief Whether the status bar is preferred hidden.
  *
- *        The |UIViewController:prefersStatusBarHidden| of this ViewController is overriden and
- * returns `flutterPrefersStatusBarHidden`. This is ignored when
- * `UIViewControllerBasedStatusBarAppearance` in info.plist of the app project is `false`.
+ *        This overrides the |UIViewController:prefersStatusBarHidden| of this
+ *        ViewController is overriden.
+ *        This is ignored when `UIViewControllerBasedStatusBarAppearance` in info.plist
+ *        of the app project is `false`.
  */
 @property(nonatomic, assign, readwrite) BOOL prefersStatusBarHidden;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -43,8 +43,7 @@ typedef NS_ENUM(NSInteger, FlutterKeyboardMode) {
 /**
  * @brief Whether the status bar is preferred hidden.
  *
- *        This overrides the |UIViewController:prefersStatusBarHidden| of this
- *        ViewController is overriden.
+ *        This overrides the |UIViewController:prefersStatusBarHidden|.
  *        This is ignored when `UIViewControllerBasedStatusBarAppearance` in info.plist
  *        of the app project is `false`.
  */

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -39,6 +39,16 @@ typedef NS_ENUM(NSInteger, FlutterKeyboardMode) {
 @property(nonatomic, readonly) BOOL isPresentingViewController;
 @property(nonatomic, readonly) BOOL isVoiceOverRunning;
 @property(nonatomic, retain) FlutterKeyboardManager* keyboardManager;
+
+/**
+ * @brief Whether the status bar is preferred hidden.
+ *
+ *        The |UIViewController:prefersStatusBarHidden| of this ViewController is overriden and
+ * returns `flutterPrefersStatusBarHidden`. This is ignored when
+ * `UIViewControllerBasedStatusBarAppearance` in info.plist of the app project is `false`.
+ */
+@property(nonatomic, assign) BOOL flutterPrefersStatusBarHidden;
+
 - (fml::WeakPtr<FlutterViewController>)getWeakPtr;
 - (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
 - (FlutterRestorationPlugin*)restorationPlugin;
@@ -53,6 +63,7 @@ typedef NS_ENUM(NSInteger, FlutterKeyboardMode) {
 - (void)addInternalPlugins;
 - (void)deregisterNotifications;
 - (int32_t)accessibilityFlags;
+
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERVIEWCONTROLLER_INTERNAL_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSInteger, FlutterKeyboardMode) {
  * returns `flutterPrefersStatusBarHidden`. This is ignored when
  * `UIViewControllerBasedStatusBarAppearance` in info.plist of the app project is `false`.
  */
-@property(nonatomic, assign) BOOL flutterPrefersStatusBarHidden;
+@property(nonatomic, assign, readwrite) BOOL prefersStatusBarHidden;
 
 - (fml::WeakPtr<FlutterViewController>)getWeakPtr;
 - (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;


### PR DESCRIPTION
UIApplication based status bar API was deprecated.

This PR makes the ViewController based status bar appearance the default.
Still keep UIApplication based status bar for apps that explicitly sets `UIViewControllerBasedStatusBarAppearance` to NO in info.plist.

Part of https://github.com/flutter/flutter/issues/124289

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
