### PR TITLE
Generate android_release_arm64 treemap in engine v2

### DIFF
--- a/ci/builders/linux_android_aot_engine.json
+++ b/ci/builders/linux_android_aot_engine.json
@@ -235,6 +235,18 @@
                 ],
                 "script": "flutter/testing/symbols/verify_exported.dart",
                 "language": "dart"
+            },
+            {
+                "name": "Generate treemap for android_release_arm64",
+                "language": "python3",
+                "script": "third_party/dart/runtime/third_party/binary_size/src/run_binary_size_analysis.py",
+                "parameters": [
+                    "--library", "src/out/android_release_arm64/libflutter.so",
+                    "--destdir",
+                    "android-arm64-release",
+                    "--addr2line-binary",
+                    "src/third_party/android_tools/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-addr2line"
+                ]
             }
         ]
     }


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/128482

But not sure how to upload to match the behavior of:

https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/engine/engine.py#368

Which gives a clickable link to the treemap. cc @godofredoc for advice on how to achieve that.