### PR TITLE
[Impeller] [Vulkan] Make sure to set transfer flags

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -153,7 +153,7 @@ static constexpr vk::ImageUsageFlags ToVKImageUsageFlags(PixelFormat format,
     }
   }
 
-  if (mode != StorageMode::kDeviceTransient) {
+  if (!(vk_usage & vk::ImageUsageFlagBits::eTransientAttachment)) {
     // TODO (https://github.com/flutter/flutter/issues/121634):
     // Add transfer usage flags to support blit passes
     vk_usage |= vk::ImageUsageFlagBits::eTransferSrc |

--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -153,12 +153,10 @@ static constexpr vk::ImageUsageFlags ToVKImageUsageFlags(PixelFormat format,
     }
   }
 
-  if (!(vk_usage & vk::ImageUsageFlagBits::eTransientAttachment)) {
-    // TODO (https://github.com/flutter/flutter/issues/121634):
-    // Add transfer usage flags to support blit passes
-    vk_usage |= vk::ImageUsageFlagBits::eTransferSrc |
-                vk::ImageUsageFlagBits::eTransferDst;
-  }
+  // TODO (https://github.com/flutter/flutter/issues/121634):
+  // Add transfer usage flags to support blit passes
+  vk_usage |= vk::ImageUsageFlagBits::eTransferSrc |
+              vk::ImageUsageFlagBits::eTransferDst;
 
   return vk_usage;
 }


### PR DESCRIPTION
Even if device transient was requested, we might have decided it can't be device transient and may still put it through a blit pass.