### PR TITLE
[Impeller] add explicit VMA flush to device memory writes.

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -175,8 +175,7 @@ static constexpr VkMemoryPropertyFlags ToVKMemoryPropertyFlags(
       if (is_texture) {
         return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
       } else {
-        return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-               VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
       }
     case StorageMode::kDevicePrivate:
       return VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;

--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -168,15 +168,12 @@ static constexpr VmaMemoryUsage ToVMAMemoryUsage() {
 }
 
 static constexpr VkMemoryPropertyFlags ToVKMemoryPropertyFlags(
-    StorageMode mode,
-    bool is_texture) {
+    StorageMode mode) {
   switch (mode) {
     case StorageMode::kHostVisible:
-      if (is_texture) {
-        return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-      } else {
-        return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-      }
+      // See https://github.com/flutter/flutter/issues/128556 . Some devices do
+      // not have support for coherent host memory so we don't request it here.
+      return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
     case StorageMode::kDevicePrivate:
       return VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     case StorageMode::kDeviceTransient:
@@ -235,7 +232,7 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
     VmaAllocationCreateInfo alloc_nfo = {};
 
     alloc_nfo.usage = ToVMAMemoryUsage();
-    alloc_nfo.preferredFlags = ToVKMemoryPropertyFlags(desc.storage_mode, true);
+    alloc_nfo.preferredFlags = ToVKMemoryPropertyFlags(desc.storage_mode);
     alloc_nfo.flags = ToVmaAllocationCreateFlags(desc.storage_mode, true);
 
     auto create_info_native =
@@ -365,8 +362,7 @@ std::shared_ptr<DeviceBuffer> AllocatorVK::OnCreateBuffer(
 
   VmaAllocationCreateInfo allocation_info = {};
   allocation_info.usage = ToVMAMemoryUsage();
-  allocation_info.preferredFlags =
-      ToVKMemoryPropertyFlags(desc.storage_mode, false);
+  allocation_info.preferredFlags = ToVKMemoryPropertyFlags(desc.storage_mode);
   allocation_info.flags = ToVmaAllocationCreateFlags(desc.storage_mode, false);
 
   VkBuffer buffer = {};

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.cc
@@ -46,6 +46,8 @@ bool DeviceBufferVK::OnCopyHostBuffer(const uint8_t* source,
   if (source) {
     ::memmove(dest + offset, source + source_range.offset, source_range.length);
   }
+  // See https://github.com/flutter/flutter/issues/128556 . Some devices do not
+  // have support for coherent host memory and require an explicit flush.
   ::vmaFlushAllocation(allocator_, allocation_, offset, source_range.length);
 
   return true;

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.cc
@@ -46,6 +46,7 @@ bool DeviceBufferVK::OnCopyHostBuffer(const uint8_t* source,
   if (source) {
     ::memmove(dest + offset, source + source_range.offset, source_range.length);
   }
+  ::vmaFlushAllocation(allocator_, allocation_, offset, source_range.length);
 
   return true;
 }


### PR DESCRIPTION
According to my read of the documentation for VMA/Vulkan allocation docs, setting VK_MEMORY_PROPERTY_HOST_COHERENT_BIT means we shouldn't need to flush the memory. nevertheless, this fixes the corruption of host buffers observed in https://github.com/flutter/flutter/issues/124040


Fixes https://github.com/flutter/flutter/issues/124040

> VK_MEMORY_PROPERTY_HOST_COHERENT_BIT bit specifies that the host cache management commands [vkFlushMappedMemoryRanges](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkFlushMappedMemoryRanges.html) and [vkInvalidateMappedMemoryRanges](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkInvalidateMappedMemoryRanges.html) are not needed to flush host writes to the device or make device writes visible to the host, respectively.


🤷‍♂️ 


