### PR TITLE
[Impeller] Add tests for foreground blends with mask blurs

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2448,6 +2448,54 @@ TEST_P(AiksTest, CanRenderClippedBlur) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanRenderForegroundBlendWithMaskBlur) {
+  // This case triggers the ForegroundPorterDuffBlend path. The color filter
+  // should apply to the color only, and respect the alpha mask.
+  Canvas canvas;
+  canvas.ClipRect(Rect::MakeXYWH(100, 150, 400, 400));
+  canvas.DrawCircle({400, 400}, 200,
+                    {
+                        .color = Color::White(),
+                        .color_filter =
+                            [](const FilterInput::Ref& input) {
+                              return ColorFilterContents::MakeBlend(
+                                  BlendMode::kSource, {input}, Color::Green());
+                            },
+                        .mask_blur_descriptor =
+                            Paint::MaskBlurDescriptor{
+                                .style = FilterContents::BlurStyle::kNormal,
+                                .sigma = Radius(20),
+                            },
+                    });
+  canvas.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, CanRenderForegroundAdvancedBlendWithMaskBlur) {
+  // This case triggers the ForegroundAdvancedBlend path. The color filter
+  // should apply to the color only, and respect the alpha mask.
+  Canvas canvas;
+  canvas.ClipRect(Rect::MakeXYWH(100, 150, 400, 400));
+  canvas.DrawCircle({400, 400}, 200,
+                    {
+                        .color = Color::White(),
+                        .color_filter =
+                            [](const FilterInput::Ref& input) {
+                              return ColorFilterContents::MakeBlend(
+                                  BlendMode::kColor, {input}, Color::Green());
+                            },
+                        .mask_blur_descriptor =
+                            Paint::MaskBlurDescriptor{
+                                .style = FilterContents::BlurStyle::kNormal,
+                                .sigma = Radius(20),
+                            },
+                    });
+  canvas.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 // Regression test for https://github.com/flutter/flutter/issues/126701 .
 TEST_P(AiksTest, CanRenderClippedRuntimeEffects) {
   if (GetParam() != PlaygroundBackend::kMetal) {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/127232.

Both of these tests should be rendering as a clipped and blurred green circle. Making mask blurs interact correctly with color filters is not going to be trivial... These bugs extend beyond the filter graph itself. Want to get some goldens in to compare against.

ForegroundPorterDuffBlend:
![Screenshot 2023-06-08 at 4 58 54 PM](https://github.com/flutter/engine/assets/919017/e5592b35-1054-48f3-91e4-c97136a2ecfd)

ForegroundAdvancedBlend:
![Screenshot 2023-06-08 at 4 58 38 PM](https://github.com/flutter/engine/assets/919017/8de5d12a-6413-4436-aa35-f3a4ef09615f)
