### PR TITLE
Delete WeakPtrFactory from GPUSurfaceVulkanImpeller

### DIFF
--- a/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -12,8 +12,7 @@
 namespace flutter {
 
 GPUSurfaceVulkanImpeller::GPUSurfaceVulkanImpeller(
-    std::shared_ptr<impeller::Context> context)
-    : weak_factory_(this) {
+    std::shared_ptr<impeller::Context> context) {
   if (!context || !context->IsValid()) {
     return;
   }

--- a/shell/gpu/gpu_surface_vulkan_impeller.h
+++ b/shell/gpu/gpu_surface_vulkan_impeller.h
@@ -29,7 +29,6 @@ class GPUSurfaceVulkanImpeller final : public Surface {
   std::shared_ptr<impeller::Renderer> impeller_renderer_;
   std::shared_ptr<impeller::AiksContext> aiks_context_;
   bool is_valid_ = false;
-  fml::WeakPtrFactory<GPUSurfaceVulkanImpeller> weak_factory_;
 
   // |Surface|
   std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) override;


### PR DESCRIPTION
Should fix https://github.com/flutter/flutter/issues/128618.

This is unused - if it were used we'd have to be careful about deleting the object on the same thread it's created on.