### PR TITLE
[Impeller] Improved numerical stability in cubic path boundary calculations

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -671,6 +671,16 @@ TEST(GeometryTest, BoundingBoxOfCompositePathIsCorrect) {
   ASSERT_RECT_NEAR(actual.value(), expected);
 }
 
+TEST(GeometryTest, ExtremaOfCubicPathComponentIsCorrect) {
+  CubicPathComponent cubic{{11.769268, 252.883148},
+                           {-6.2857933, 204.356461},
+                           {-4.53997231, 156.552902},
+                           {17.0067291, 109.472488}};
+  auto points = cubic.Extrema();
+  ASSERT_EQ(points.size(), static_cast<size_t>(3));
+  ASSERT_POINT_NEAR(points[2], cubic.Solve(0.455916));
+}
+
 TEST(GeometryTest, PathGetBoundingBoxForCubicWithNoDerivativeRootsIsCorrect) {
   PathBuilder builder;
   // Straight diagonal line.

--- a/impeller/geometry/path_component.cc
+++ b/impeller/geometry/path_component.cc
@@ -284,15 +284,23 @@ static void CubicPathBoundingPopulateValues(std::vector<Scalar>& values,
 
   Scalar rootB2Minus4AC = ::sqrt(b2Minus4AC);
 
+  /* From Numerical Recipes in C.
+   *
+   * q = -1/2 (b + sign(b) sqrt[b^2 - 4ac])
+   * x1 = q / a
+   * x2 = c / q
+   */
+  Scalar q = (b < 0) ? -(b - rootB2Minus4AC) / 2 : -(b + rootB2Minus4AC) / 2;
+
   {
-    Scalar t = (-b + rootB2Minus4AC) / (2.0 * a);
+    Scalar t = q / a;
     if (t >= 0.0 && t <= 1.0) {
       values.emplace_back(t);
     }
   }
 
   {
-    Scalar t = (-b - rootB2Minus4AC) / (2.0 * a);
+    Scalar t = c / q;
     if (t >= 0.0 && t <= 1.0) {
       values.emplace_back(t);
     }


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/128532

In this commit, we refined the method for calculating cubic path boundaries in CubicPathBoundingPopulateValues function. By adopting an alternative quadratic formula from Numerical Recipes in C (The code is ported from skia's `SkFindUnitQuadRoots`),  we mitigated numerical errors, hence boosting precision and reliability in handling cubic paths.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
