### PR TITLE
[Impeller] Correct attachment description for offscreen MSAA resolve.

### DIFF
--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -427,8 +427,7 @@ constexpr vk::AttachmentDescription CreateAttachmentDescription(
     SampleCount sample_count,
     LoadAction load_action,
     StoreAction store_action,
-    vk::ImageLayout current_layout,
-    bool resolve_texture = false) {
+    vk::ImageLayout current_layout) {
   vk::AttachmentDescription vk_attachment;
 
   vk_attachment.format = ToVKImageFormat(format);
@@ -467,9 +466,7 @@ constexpr vk::AttachmentDescription CreateAttachmentDescription(
   switch (kind) {
     case AttachmentKind::kColor:
       vk_attachment.initialLayout = current_layout;
-      vk_attachment.finalLayout =
-          resolve_texture ? vk::ImageLayout::eGeneral
-                          : vk::ImageLayout::eColorAttachmentOptimal;
+      vk_attachment.finalLayout = vk::ImageLayout::eGeneral;
       break;
     case AttachmentKind::kDepth:
     case AttachmentKind::kStencil:

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -468,7 +468,7 @@ constexpr vk::AttachmentDescription CreateAttachmentDescription(
     case AttachmentKind::kColor:
       vk_attachment.initialLayout = current_layout;
       vk_attachment.finalLayout =
-          resolve_texture ? vk::ImageLayout::ePresentSrcKHR
+          resolve_texture ? vk::ImageLayout::eGeneral
                           : vk::ImageLayout::eColorAttachmentOptimal;
       break;
     case AttachmentKind::kDepth:

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -427,7 +427,8 @@ constexpr vk::AttachmentDescription CreateAttachmentDescription(
     SampleCount sample_count,
     LoadAction load_action,
     StoreAction store_action,
-    vk::ImageLayout current_layout) {
+    vk::ImageLayout current_layout,
+    bool resolve_texture = false) {
   vk::AttachmentDescription vk_attachment;
 
   vk_attachment.format = ToVKImageFormat(format);
@@ -466,7 +467,9 @@ constexpr vk::AttachmentDescription CreateAttachmentDescription(
   switch (kind) {
     case AttachmentKind::kColor:
       vk_attachment.initialLayout = current_layout;
-      vk_attachment.finalLayout = vk::ImageLayout::eColorAttachmentOptimal;
+      vk_attachment.finalLayout =
+          resolve_texture ? vk::ImageLayout::ePresentSrcKHR
+                          : vk::ImageLayout::eColorAttachmentOptimal;
       break;
     case AttachmentKind::kDepth:
     case AttachmentKind::kStencil:

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -49,6 +49,8 @@ static vk::AttachmentDescription CreateAttachmentDescription(
 
   if (desc.storage_mode == StorageMode::kDeviceTransient) {
     store_action = StoreAction::kDontCare;
+  } else if (resolve_texture) {
+    store_action = StoreAction::kStore;
   }
 
   const auto attachment_desc =
@@ -95,7 +97,7 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
     if (color.resolve_texture) {
       resolve_refs[bind_point] =
           vk::AttachmentReference{static_cast<uint32_t>(attachments.size()),
-                                  vk::ImageLayout::eColorAttachmentOptimal};
+                                  vk::ImageLayout::ePresentSrcKHR};
       attachments.emplace_back(CreateAttachmentDescription(color, true));
     }
   }

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -58,8 +58,7 @@ static vk::AttachmentDescription CreateAttachmentDescription(
                                   desc.sample_count,  //
                                   load_action,        //
                                   store_action,       //
-                                  current_layout,     //
-                                  resolve_texture     //
+                                  current_layout      //
       );
 
   // Instead of transitioning layouts manually using barriers, we are going to

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -58,7 +58,8 @@ static vk::AttachmentDescription CreateAttachmentDescription(
                                   desc.sample_count,  //
                                   load_action,        //
                                   store_action,       //
-                                  current_layout      //
+                                  current_layout,     //
+                                  resolve_texture     //
       );
 
   // Instead of transitioning layouts manually using barriers, we are going to

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -96,9 +96,8 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
                                 vk::ImageLayout::eColorAttachmentOptimal};
     attachments.emplace_back(CreateAttachmentDescription(color));
     if (color.resolve_texture) {
-      resolve_refs[bind_point] =
-          vk::AttachmentReference{static_cast<uint32_t>(attachments.size()),
-                                  vk::ImageLayout::ePresentSrcKHR};
+      resolve_refs[bind_point] = vk::AttachmentReference{
+          static_cast<uint32_t>(attachments.size()), vk::ImageLayout::eGeneral};
       attachments.emplace_back(CreateAttachmentDescription(color, true));
     }
   }


### PR DESCRIPTION
Two issues:

1. The resolve texture is created from the same impeller attachment as the msaa attachment, so the store mode was getting set to dont care instead of store.

2. the image layout for the resolve attachment should be ePresentSrcKHR, at least from following the guide at https://vulkan-tutorial.com/Multisampling

Fixing both of these locally fixes all of the weird offscreen cursed rendering.

Fixes https://github.com/flutter/flutter/issues/128600