### PR TITLE
[Impeller] Ensure vulkan offscreen pixelformat is the same as the onscreen format

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -263,7 +263,6 @@ bool EntityPass::Render(ContentContext& renderer,
             ->GetCapabilities()
             ->SupportsTextureToTextureBlits()) {
       auto blit_pass = command_buffer->CreateBlitPass();
-
       blit_pass->AddCopy(
           offscreen_target.GetRenderTarget().GetRenderTargetTexture(),
           root_render_target.GetRenderTargetTexture());

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -278,13 +278,11 @@ bool CapabilitiesVK::HasExtension(const std::string& ext) const {
   return false;
 }
 
-bool CapabilitiesVK::SetDevice(const vk::PhysicalDevice& device) {
-  if (HasSuitableColorFormat(device, vk::Format::eB8G8R8A8Unorm)) {
-    color_format_ = PixelFormat::kB8G8R8A8UNormInt;
-  } else {
-    return false;
-  }
+void CapabilitiesVK::SetOffscreenFormat(PixelFormat pixel_format) const {
+  color_format_ = pixel_format;
+}
 
+bool CapabilitiesVK::SetDevice(const vk::PhysicalDevice& device) {
   if (HasSuitableDepthStencilFormat(device, vk::Format::eS8Uint)) {
     depth_stencil_format_ = PixelFormat::kS8UInt;
   } else if (HasSuitableDepthStencilFormat(device,

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -46,6 +46,8 @@ class CapabilitiesVK final : public Capabilities,
 
   const vk::PhysicalDeviceProperties& GetPhysicalDeviceProperties() const;
 
+  void SetOffscreenFormat(PixelFormat pixel_format) const;
+
   // |Capabilities|
   bool HasThreadingRestrictions() const override;
 
@@ -88,7 +90,7 @@ class CapabilitiesVK final : public Capabilities,
  private:
   const bool enable_validations_;
   std::map<std::string, std::set<std::string>> exts_;
-  PixelFormat color_format_ = PixelFormat::kUnknown;
+  mutable PixelFormat color_format_ = PixelFormat::kUnknown;
   PixelFormat depth_stencil_format_ = PixelFormat::kUnknown;
   vk::PhysicalDeviceProperties device_properties_;
   bool supports_compute_subgroups_ = false;

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -408,6 +408,10 @@ void ContextVK::Setup(Settings settings) {
   SetDebugName(GetDevice(), device_holder_->device.get(), "ImpellerDevice");
 }
 
+void ContextVK::SetOffscreenFormat(PixelFormat pixel_format) {
+  CapabilitiesVK::Cast(*device_capabilities_).SetOffscreenFormat(pixel_format);
+}
+
 // |Context|
 std::string ContextVK::DescribeGpuModel() const {
   return device_name_;

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -78,6 +78,8 @@ class ContextVK final : public Context,
   // |Context|
   const std::shared_ptr<const Capabilities>& GetCapabilities() const override;
 
+  void SetOffscreenFormat(PixelFormat pixel_format);
+
   template <typename T>
   bool SetDebugName(T handle, std::string_view label) const {
     return SetDebugName(GetDevice(), handle, label);

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -135,7 +135,7 @@ SwapchainImplVK::SwapchainImplVK(const std::shared_ptr<Context>& context,
     return;
   }
 
-  const auto& vk_context = ContextVK::Cast(*context);
+  auto& vk_context = ContextVK::Cast(*context);
 
   auto [caps_result, caps] =
       vk_context.GetPhysicalDevice().getSurfaceCapabilitiesKHR(*surface);
@@ -159,6 +159,7 @@ SwapchainImplVK::SwapchainImplVK(const std::shared_ptr<Context>& context,
     VALIDATION_LOG << "Swapchain has no supported formats.";
     return;
   }
+  vk_context.SetOffscreenFormat(ToPixelFormat(format.value().format));
 
   const auto composite =
       ChooseAlphaCompositionMode(caps.supportedCompositeAlpha);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/128604

THe problem was that we were selecting kB8G8R8A8UNormInt for the offscreen and kR8G8B8A8UNormInt for the onscreen, so the blit was swapping the color channels.