### PR TITLE
Predictive back breakage fix

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -701,10 +701,10 @@ public class FlutterActivity extends Activity
           : null;
 
   @Override
-  public void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {
-    if (frameworkHandlesBacks && !hasRegisteredBackCallback) {
+  public void setFrameworkHandlesBack(boolean frameworkHandlesBack) {
+    if (frameworkHandlesBack && !hasRegisteredBackCallback) {
       registerOnBackInvokedCallback();
-    } else if (!frameworkHandlesBacks && hasRegisteredBackCallback) {
+    } else if (!frameworkHandlesBack && hasRegisteredBackCallback) {
       unregisterOnBackInvokedCallback();
     }
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -1689,11 +1689,6 @@ public class FlutterFragment extends Fragment
     return getArguments().getBoolean(ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW);
   }
 
-  @Override
-  public void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {
-    // Irrelevant to FlutterFragment.
-  }
-
   private boolean stillAttachedForEvent(String event) {
     if (delegate == null) {
       Log.w(TAG, "FlutterFragment " + hashCode() + " " + event + " called after release.");

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -517,7 +517,7 @@ public class PlatformChannel {
     void setSystemUiOverlayStyle(@NonNull SystemChromeStyle systemUiOverlayStyle);
 
     /** The Flutter application would or would not like to handle navigation pop events itself. */
-    void setFrameworkHandlesBack(boolean frameworkHandlesBack);
+    default void setFrameworkHandlesBack(boolean frameworkHandlesBack) {}
 
     /**
      * The Flutter application would like to pop the top item off of the Android app's navigation

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -516,7 +516,13 @@ public class PlatformChannel {
      */
     void setSystemUiOverlayStyle(@NonNull SystemChromeStyle systemUiOverlayStyle);
 
-    /** The Flutter application would or would not like to handle navigation pop events itself. */
+    /**
+     * The Flutter application would or would not like to handle navigation pop events itself.
+     *
+     * <p>Relevant for registering and unregistering the app's OnBackInvokedCallback for the
+     * Predictive Back feature, for example as in {@link
+     * io.flutter.embedding.android.FlutterActivity}.
+     */
     default void setFrameworkHandlesBack(boolean frameworkHandlesBack) {}
 
     /**

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -138,8 +138,8 @@ public class PlatformChannel {
                 break;
               case "SystemNavigator.setFrameworkHandlesBack":
                 {
-                  boolean frameworkHandlesBacks = (boolean) arguments;
-                  platformMessageHandler.setFrameworkHandlesBack(frameworkHandlesBacks);
+                  boolean frameworkHandlesBack = (boolean) arguments;
+                  platformMessageHandler.setFrameworkHandlesBack(frameworkHandlesBack);
                   result.success(null);
                   break;
                 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -63,7 +63,7 @@ public class PlatformPlugin {
      * <p>Relevant for registering and unregistering the app's OnBackInvokedCallback for the
      * Predictive Back feature.
      */
-    default void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {}
+    default void setFrameworkHandlesBack(boolean frameworkHandlesBack) {}
   }
 
   @VisibleForTesting
@@ -118,8 +118,8 @@ public class PlatformPlugin {
         }
 
         @Override
-        public void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {
-          PlatformPlugin.this.setFrameworkHandlesBack(frameworkHandlesBacks);
+        public void setFrameworkHandlesBack(boolean frameworkHandlesBack) {
+          PlatformPlugin.this.setFrameworkHandlesBack(frameworkHandlesBack);
         }
 
         @Override
@@ -488,8 +488,8 @@ public class PlatformPlugin {
     currentTheme = systemChromeStyle;
   }
 
-  private void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {
-    platformPluginDelegate.setFrameworkHandlesBack(frameworkHandlesBacks);
+  private void setFrameworkHandlesBack(boolean frameworkHandlesBack) {
+    platformPluginDelegate.setFrameworkHandlesBack(frameworkHandlesBack);
   }
 
   private void popSystemNavigator() {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -57,6 +57,12 @@ public class PlatformPlugin {
      */
     boolean popSystemNavigator();
 
+    /**
+     * The Flutter application would or would not like to handle navigation pop events itself.
+     *
+     * <p> Relevant for registering and unregistering the app's OnBackInvokedCallback for the
+     * Predictive Back feature.
+     */
     default void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {
     }
   }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -61,7 +61,8 @@ public class PlatformPlugin {
      * The Flutter application would or would not like to handle navigation pop events itself.
      *
      * <p>Relevant for registering and unregistering the app's OnBackInvokedCallback for the
-     * Predictive Back feature.
+     * Predictive Back feature, for example as in {@link
+     * io.flutter.embedding.android.FlutterActivity}.
      */
     default void setFrameworkHandlesBack(boolean frameworkHandlesBack) {}
   }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -57,7 +57,8 @@ public class PlatformPlugin {
      */
     boolean popSystemNavigator();
 
-    void setFrameworkHandlesBack(boolean frameworkHandlesBacks);
+    default void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {
+    }
   }
 
   @VisibleForTesting

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -60,11 +60,10 @@ public class PlatformPlugin {
     /**
      * The Flutter application would or would not like to handle navigation pop events itself.
      *
-     * <p> Relevant for registering and unregistering the app's OnBackInvokedCallback for the
+     * <p>Relevant for registering and unregistering the app's OnBackInvokedCallback for the
      * Predictive Back feature.
      */
-    default void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {
-    }
+    default void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {}
   }
 
   @VisibleForTesting

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -419,6 +419,6 @@ public class FlutterAndroidComponentTest {
     }
 
     @Override
-    public void setFrameworkHandlesBack(boolean frameworkHandlesBacks) {}
+    public void setFrameworkHandlesBack(boolean frameworkHandlesBack) {}
   }
 }


### PR DESCRIPTION
This PR attempts to fix breakage(s) caused by https://github.com/flutter/engine/pull/39208.

b/286627757

## Main problem

There were breakages in Google's code where classes that implemented PlatformMessageHandler did not provide an implementation of setFrameworkHandlesBack.

```
... is not abstract and does not override abstract method setFrameworkHandlesBack(boolean) in PlatformMessageHandler
```

I've tried to fix this by adding a default empty implementation to PlatformMessageHandler.  Is that ok to do there, even though other nearby methods don't have default implementations there?

Also, I noticed that I could probably do the same thing to avoid my empty implementation in FlutterFragment, so I added one to PlatformPluginDelegate as well.  That did allow me to remove the implementation in FlutterFragment.  Is that ok as well?  Do I need to provide both empty implementations?

## Other cleanup

I noticed that when I renamed frameworkHandlesBacks to frameworkHandlesBack, I forgot to rename some cases, which I've cleaned up here.