### PR TITLE
Make validation logs ERROR level

### DIFF
--- a/impeller/base/validation.cc
+++ b/impeller/base/validation.cc
@@ -46,7 +46,7 @@ void ImpellerValidationBreak(const char* message) {
   if (sValidationLogsAreFatal) {
     FML_LOG(FATAL) << stream.str();
   } else {
-    FML_LOG(INFO) << stream.str();
+    FML_LOG(ERROR) << stream.str();
   }
 #endif  // IMPELLER_DEBUG
 }


### PR DESCRIPTION
INFO logs do not show up in normal logging unless an extra flag is passed by the tool (and it is a different flag from the "-v" flag).

This means bug reports that include logs about impeller are missing the validation errors, which makes them harder to triage and dedupe.

Fixes https://github.com/flutter/flutter/issues/128808
