### PR TITLE
[Impeller] Joined obligatory vulkan swapchain submits

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -19,6 +19,7 @@ struct FrameSynchronizer {
   vk::UniqueFence acquire;
   vk::UniqueSemaphore render_ready;
   vk::UniqueSemaphore present_ready;
+  std::shared_ptr<CommandBuffer> final_cmd_buffer;
   bool is_valid = false;
 
   explicit FrameSynchronizer(const vk::Device& device) {
@@ -382,18 +383,18 @@ bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
   //----------------------------------------------------------------------------
   /// Transition the image to color-attachment-optimal.
   ///
+  sync->final_cmd_buffer = context.CreateCommandBuffer();
+  if (!sync->final_cmd_buffer) {
+    return false;
+  }
+
+  auto vk_final_cmd_buffer = CommandBufferVK::Cast(*sync->final_cmd_buffer)
+                                 .GetEncoder()
+                                 ->GetCommandBuffer();
   {
-    auto cmd_buffer = context.CreateCommandBuffer();
-    if (!cmd_buffer) {
-      return false;
-    }
-
-    auto vk_cmd_buffer =
-        CommandBufferVK::Cast(*cmd_buffer).GetEncoder()->GetCommandBuffer();
-
     LayoutTransition transition;
     transition.new_layout = vk::ImageLayout::ePresentSrcKHR;
-    transition.cmd_buffer = vk_cmd_buffer;
+    transition.cmd_buffer = vk_final_cmd_buffer;
     transition.src_access = vk::AccessFlagBits::eColorAttachmentWrite;
     transition.src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
     transition.dst_access = {};
@@ -403,7 +404,7 @@ bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
       return false;
     }
 
-    if (!cmd_buffer->SubmitCommands()) {
+    if (vk_final_cmd_buffer.end() != vk::Result::eSuccess) {
       return false;
     }
   }
@@ -418,6 +419,7 @@ bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
     submit_info.setWaitDstStageMask(wait_stage);
     submit_info.setWaitSemaphores(*sync->render_ready);
     submit_info.setSignalSemaphores(*sync->present_ready);
+    submit_info.setCommandBuffers(vk_final_cmd_buffer);
     auto result =
         context.GetGraphicsQueue()->Submit(submit_info, *sync->acquire);
     if (result != vk::Result::eSuccess) {


### PR DESCRIPTION
Every frame we submit to the queue a layout transition and a notify to the `acquire` fence.  This joins those together into one `vkQueueSubmit` call.  Thus eliminating a fence that was happening after the layout transition.

issue https://github.com/flutter/flutter/issues/128838

## testing results from the gallery driver test
```
Before:
  "average_frame_build_time_millis": 1.379130952380952,
  "90th_percentile_frame_build_time_millis": 1.965,
  "99th_percentile_frame_build_time_millis": 20.246,
  "worst_frame_build_time_millis": 29.578,
  "missed_frame_build_budget_count": 7,
  "average_frame_rasterizer_time_millis": 20.447408955223867,
  "90th_percentile_frame_rasterizer_time_millis": 25.398,
  "99th_percentile_frame_rasterizer_time_millis": 160.198,
  "worst_frame_rasterizer_time_millis": 178.042,
  "missed_frame_rasterizer_budget_count": 122,
  "frame_count": 336,
  "frame_rasterizer_count": 335,
  "new_gen_gc_count": 0,
  "old_gen_gc_count": 0,
  "frame_build_times": [
after:
  "average_frame_build_time_millis": 1.1907232876712324,
  "90th_percentile_frame_build_time_millis": 1.926,
  "99th_percentile_frame_build_time_millis": 16.666,
  "worst_frame_build_time_millis": 27.39,
  "missed_frame_build_budget_count": 5,
  "average_frame_rasterizer_time_millis": 15.525100817438704,
  "90th_percentile_frame_rasterizer_time_millis": 20.116,
  "99th_percentile_frame_rasterizer_time_millis": 33.835,
  "worst_frame_rasterizer_time_millis": 56.075,
  "missed_frame_rasterizer_budget_count": 156,
  "frame_count": 365,
  "frame_rasterizer_count": 367,
  "new_gen_gc_count": 0,
  "old_gen_gc_count": 0,
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
