### PR TITLE
[macOS] Return keyboard pressed state

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.h
@@ -39,4 +39,12 @@ typedef void (^FlutterSendEmbedderKeyEvent)(const FlutterKeyEvent& /* event */,
 - (void)syncModifiersIfNeeded:(NSEventModifierFlags)modifierFlags
                     timestamp:(NSTimeInterval)timestamp;
 
+/**
+ * Returns the keyboard pressed state.
+ *
+ * Returns the keyboard pressed state. The dictionary contains one entry per
+ * pressed keys, mapping from the logical key to the physical key.
+ */
+- (nonnull NSDictionary*)getPressedState;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -793,6 +793,9 @@ struct FlutterKeyPendingResponse {
                        guard:guardedCallback];
 }
 
+- (nonnull NSDictionary*)getPressedState {
+  return [NSDictionary dictionaryWithDictionary:_pressingRecords];
+}
 @end
 
 namespace {

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.h
@@ -57,4 +57,12 @@
 - (void)syncModifiersIfNeeded:(NSEventModifierFlags)modifierFlags
                     timestamp:(NSTimeInterval)timestamp;
 
+/**
+ * Returns the keyboard pressed state.
+ *
+ * Returns the keyboard pressed state. The dictionary contains one entry per
+ * pressed keys, mapping from the logical key to the physical key.
+ */
+- (nonnull NSDictionary*)getPressedState;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardViewDelegate.h
@@ -86,4 +86,12 @@ typedef struct {
  */
 - (flutter::LayoutClue)lookUpLayoutForKeyCode:(uint16_t)keyCode shift:(BOOL)shift;
 
+/**
+ * Returns the keyboard pressed state.
+ *
+ * Returns the keyboard pressed state. The dictionary contains one entry per
+ * pressed keys, mapping from the logical key to the physical key.
+ */
+- (nonnull NSDictionary*)getPressedState;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -955,6 +955,10 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
   return LayoutClue{0, false};
 }
 
+- (nonnull NSDictionary*)getPressedState {
+  return [_keyboardManager getPressedState];
+}
+
 #pragma mark - NSResponder
 
 - (BOOL)acceptsFirstResponder {


### PR DESCRIPTION
## Description

This PR updates the macOS engine in order to answer to keyboard pressed state queries from the framework (as implemented in https://github.com/flutter/flutter/pull/122885).

## Related Issue

macOS engine implementation for https://github.com/flutter/flutter/issues/87391
Similar to:
- Linux: https://github.com/flutter/engine/pull/42346
- Android: https://github.com/flutter/engine/pull/42758

## Tests

Adds 2 tests.


