### PR TITLE
Set xcode explicitly on mac builds with release_build.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -514,6 +514,10 @@ targets:
         [
           {"dependency": "goldctl", "version": "git_revision:f808dcff91b221ae313e540c09d79696cd08b8de"}
         ]
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "14e222b"
+        }
     drone_dimensions:
       - os=Mac-12
 
@@ -604,6 +608,10 @@ targets:
         [
           {"dependency": "jazzy", "version": "0.14.1"}
         ]
+      $flutter/osx_sdk : >-
+        {
+          "sdk_version": "14e222b"
+        }
     drone_dimensions:
       - os=Mac-12
       - cpu=x86

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -45,6 +45,11 @@
                     "flutter:unittests"
                 ]
             },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
+            },
             "tests": [
                 {
                     "language": "python3",
@@ -98,6 +103,11 @@
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter:unittests"
                 ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
             },
             "tests": [
                 {
@@ -164,6 +174,11 @@
                     "flutter:unittests"
                 ]
             },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
+            },
             "tests": [
                 {
                     "language": "python3",
@@ -219,6 +234,11 @@
                     "flutter/build/archives:flutter_embedder_framework",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework"
                 ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
             }
         },
         {
@@ -257,6 +277,11 @@
                     "flutter/build/archives:artifacts",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework"
                 ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
             }
         },
         {
@@ -297,6 +322,11 @@
                     "flutter/build/archives:artifacts",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework"
                 ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
             }
         }
     ],

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -16,6 +16,11 @@
             "name": "ios_debug_sim",
             "ninja": {
                 "config": "ios_debug_sim"
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
             }
         },
         {
@@ -35,6 +40,11 @@
             "name": "ios_debug_sim_arm64",
             "ninja": {
                 "config": "ios_debug_sim_arm64"
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
             }
         },
         {
@@ -54,6 +64,11 @@
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework"
                 ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
             }
         },
         {
@@ -74,6 +89,11 @@
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
                 ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
             }
         },
         {
@@ -94,6 +114,11 @@
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
                 ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e222b"
+                }
             }
         }
     ],


### PR DESCRIPTION
Xcode version needs to be set explicitly for builds running on dart-internal.

Bug: https://github.com/flutter/flutter/issues/128977

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
