### PR TITLE
[Impeller] correct default PSO pixel format and sample count.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -30,7 +30,7 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
   desc.SetSampleCount(sample_count);
 
   ColorAttachmentDescriptor color0 = *desc.GetColorAttachmentDescriptor(0u);
-  color0.format = color_attachment_pixel_format.value_or(PixelFormat::kUnknown);
+  color0.format = color_attachment_pixel_format;
   color0.alpha_blend_op = BlendOperation::kAdd;
   color0.color_blend_op = BlendOperation::kAdd;
 
@@ -165,130 +165,139 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
   if (!context_ || !context_->IsValid()) {
     return;
   }
+  auto default_options = ContentContextOptions{
+      .color_attachment_pixel_format =
+          context_->GetCapabilities()->GetDefaultColorFormat()};
 
 #ifdef IMPELLER_DEBUG
-  checkerboard_pipelines_[{}] =
+  checkerboard_pipelines_[default_options] =
       CreateDefaultPipeline<CheckerboardPipeline>(*context_);
 #endif  // IMPELLER_DEBUG
 
-  solid_fill_pipelines_[{}] =
+  solid_fill_pipelines_[default_options] =
       CreateDefaultPipeline<SolidFillPipeline>(*context_);
-  linear_gradient_fill_pipelines_[{}] =
-      CreateDefaultPipeline<LinearGradientFillPipeline>(*context_);
-  radial_gradient_fill_pipelines_[{}] =
-      CreateDefaultPipeline<RadialGradientFillPipeline>(*context_);
-  conical_gradient_fill_pipelines_[{}] =
-      CreateDefaultPipeline<ConicalGradientFillPipeline>(*context_);
+
   if (context_->GetCapabilities()->SupportsSSBO()) {
-    linear_gradient_ssbo_fill_pipelines_[{}] =
+    linear_gradient_ssbo_fill_pipelines_[default_options] =
         CreateDefaultPipeline<LinearGradientSSBOFillPipeline>(*context_);
-    radial_gradient_ssbo_fill_pipelines_[{}] =
+    radial_gradient_ssbo_fill_pipelines_[default_options] =
         CreateDefaultPipeline<RadialGradientSSBOFillPipeline>(*context_);
-    conical_gradient_ssbo_fill_pipelines_[{}] =
+    conical_gradient_ssbo_fill_pipelines_[default_options] =
         CreateDefaultPipeline<ConicalGradientSSBOFillPipeline>(*context_);
-    sweep_gradient_ssbo_fill_pipelines_[{}] =
+    sweep_gradient_ssbo_fill_pipelines_[default_options] =
         CreateDefaultPipeline<SweepGradientSSBOFillPipeline>(*context_);
+  } else {
+    linear_gradient_fill_pipelines_[default_options] =
+        CreateDefaultPipeline<LinearGradientFillPipeline>(*context_);
+    radial_gradient_fill_pipelines_[default_options] =
+        CreateDefaultPipeline<RadialGradientFillPipeline>(*context_);
+    conical_gradient_fill_pipelines_[default_options] =
+        CreateDefaultPipeline<ConicalGradientFillPipeline>(*context_);
+    sweep_gradient_fill_pipelines_[default_options] =
+        CreateDefaultPipeline<SweepGradientFillPipeline>(*context_);
   }
+
   if (context_->GetCapabilities()->SupportsFramebufferFetch()) {
-    framebuffer_blend_color_pipelines_[{}] =
+    framebuffer_blend_color_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendColorPipeline>(*context_);
-    framebuffer_blend_colorburn_pipelines_[{}] =
+    framebuffer_blend_colorburn_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendColorBurnPipeline>(*context_);
-    framebuffer_blend_colordodge_pipelines_[{}] =
+    framebuffer_blend_colordodge_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendColorDodgePipeline>(*context_);
-    framebuffer_blend_darken_pipelines_[{}] =
+    framebuffer_blend_darken_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendDarkenPipeline>(*context_);
-    framebuffer_blend_difference_pipelines_[{}] =
+    framebuffer_blend_difference_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendDifferencePipeline>(*context_);
-    framebuffer_blend_exclusion_pipelines_[{}] =
+    framebuffer_blend_exclusion_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendExclusionPipeline>(*context_);
-    framebuffer_blend_hardlight_pipelines_[{}] =
+    framebuffer_blend_hardlight_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendHardLightPipeline>(*context_);
-    framebuffer_blend_hue_pipelines_[{}] =
+    framebuffer_blend_hue_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendHuePipeline>(*context_);
-    framebuffer_blend_lighten_pipelines_[{}] =
+    framebuffer_blend_lighten_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendLightenPipeline>(*context_);
-    framebuffer_blend_luminosity_pipelines_[{}] =
+    framebuffer_blend_luminosity_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendLuminosityPipeline>(*context_);
-    framebuffer_blend_multiply_pipelines_[{}] =
+    framebuffer_blend_multiply_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendMultiplyPipeline>(*context_);
-    framebuffer_blend_overlay_pipelines_[{}] =
+    framebuffer_blend_overlay_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendOverlayPipeline>(*context_);
-    framebuffer_blend_saturation_pipelines_[{}] =
+    framebuffer_blend_saturation_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendSaturationPipeline>(*context_);
-    framebuffer_blend_screen_pipelines_[{}] =
+    framebuffer_blend_screen_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendScreenPipeline>(*context_);
-    framebuffer_blend_softlight_pipelines_[{}] =
+    framebuffer_blend_softlight_pipelines_[default_options] =
         CreateDefaultPipeline<FramebufferBlendSoftLightPipeline>(*context_);
   }
 
-  blend_color_pipelines_[{}] =
+  blend_color_pipelines_[default_options] =
       CreateDefaultPipeline<BlendColorPipeline>(*context_);
-  blend_colorburn_pipelines_[{}] =
+  blend_colorburn_pipelines_[default_options] =
       CreateDefaultPipeline<BlendColorBurnPipeline>(*context_);
-  blend_colordodge_pipelines_[{}] =
+  blend_colordodge_pipelines_[default_options] =
       CreateDefaultPipeline<BlendColorDodgePipeline>(*context_);
-  blend_darken_pipelines_[{}] =
+  blend_darken_pipelines_[default_options] =
       CreateDefaultPipeline<BlendDarkenPipeline>(*context_);
-  blend_difference_pipelines_[{}] =
+  blend_difference_pipelines_[default_options] =
       CreateDefaultPipeline<BlendDifferencePipeline>(*context_);
-  blend_exclusion_pipelines_[{}] =
+  blend_exclusion_pipelines_[default_options] =
       CreateDefaultPipeline<BlendExclusionPipeline>(*context_);
-  blend_hardlight_pipelines_[{}] =
+  blend_hardlight_pipelines_[default_options] =
       CreateDefaultPipeline<BlendHardLightPipeline>(*context_);
-  blend_hue_pipelines_[{}] = CreateDefaultPipeline<BlendHuePipeline>(*context_);
-  blend_lighten_pipelines_[{}] =
+  blend_hue_pipelines_[default_options] =
+      CreateDefaultPipeline<BlendHuePipeline>(*context_);
+  blend_lighten_pipelines_[default_options] =
       CreateDefaultPipeline<BlendLightenPipeline>(*context_);
-  blend_luminosity_pipelines_[{}] =
+  blend_luminosity_pipelines_[default_options] =
       CreateDefaultPipeline<BlendLuminosityPipeline>(*context_);
-  blend_multiply_pipelines_[{}] =
+  blend_multiply_pipelines_[default_options] =
       CreateDefaultPipeline<BlendMultiplyPipeline>(*context_);
-  blend_overlay_pipelines_[{}] =
+  blend_overlay_pipelines_[default_options] =
       CreateDefaultPipeline<BlendOverlayPipeline>(*context_);
-  blend_saturation_pipelines_[{}] =
+  blend_saturation_pipelines_[default_options] =
       CreateDefaultPipeline<BlendSaturationPipeline>(*context_);
-  blend_screen_pipelines_[{}] =
+  blend_screen_pipelines_[default_options] =
       CreateDefaultPipeline<BlendScreenPipeline>(*context_);
-  blend_softlight_pipelines_[{}] =
+  blend_softlight_pipelines_[default_options] =
       CreateDefaultPipeline<BlendSoftLightPipeline>(*context_);
-  sweep_gradient_fill_pipelines_[{}] =
-      CreateDefaultPipeline<SweepGradientFillPipeline>(*context_);
-  rrect_blur_pipelines_[{}] =
+
+  rrect_blur_pipelines_[default_options] =
       CreateDefaultPipeline<RRectBlurPipeline>(*context_);
-  texture_blend_pipelines_[{}] =
+  texture_blend_pipelines_[default_options] =
       CreateDefaultPipeline<BlendPipeline>(*context_);
-  texture_pipelines_[{}] = CreateDefaultPipeline<TexturePipeline>(*context_);
-  position_uv_pipelines_[{}] =
+  texture_pipelines_[default_options] =
+      CreateDefaultPipeline<TexturePipeline>(*context_);
+  position_uv_pipelines_[default_options] =
       CreateDefaultPipeline<PositionUVPipeline>(*context_);
-  tiled_texture_pipelines_[{}] =
+  tiled_texture_pipelines_[default_options] =
       CreateDefaultPipeline<TiledTexturePipeline>(*context_);
-  gaussian_blur_alpha_decal_pipelines_[{}] =
+  gaussian_blur_alpha_decal_pipelines_[default_options] =
       CreateDefaultPipeline<GaussianBlurAlphaDecalPipeline>(*context_);
-  gaussian_blur_alpha_nodecal_pipelines_[{}] =
+  gaussian_blur_alpha_nodecal_pipelines_[default_options] =
       CreateDefaultPipeline<GaussianBlurAlphaPipeline>(*context_);
-  gaussian_blur_noalpha_decal_pipelines_[{}] =
+  gaussian_blur_noalpha_decal_pipelines_[default_options] =
       CreateDefaultPipeline<GaussianBlurDecalPipeline>(*context_);
-  gaussian_blur_noalpha_nodecal_pipelines_[{}] =
+  gaussian_blur_noalpha_nodecal_pipelines_[default_options] =
       CreateDefaultPipeline<GaussianBlurPipeline>(*context_);
-  border_mask_blur_pipelines_[{}] =
+  border_mask_blur_pipelines_[default_options] =
       CreateDefaultPipeline<BorderMaskBlurPipeline>(*context_);
-  morphology_filter_pipelines_[{}] =
+  morphology_filter_pipelines_[default_options] =
       CreateDefaultPipeline<MorphologyFilterPipeline>(*context_);
-  color_matrix_color_filter_pipelines_[{}] =
+  color_matrix_color_filter_pipelines_[default_options] =
       CreateDefaultPipeline<ColorMatrixColorFilterPipeline>(*context_);
-  linear_to_srgb_filter_pipelines_[{}] =
+  linear_to_srgb_filter_pipelines_[default_options] =
       CreateDefaultPipeline<LinearToSrgbFilterPipeline>(*context_);
-  srgb_to_linear_filter_pipelines_[{}] =
+  srgb_to_linear_filter_pipelines_[default_options] =
       CreateDefaultPipeline<SrgbToLinearFilterPipeline>(*context_);
-  glyph_atlas_pipelines_[{}] =
+  glyph_atlas_pipelines_[default_options] =
       CreateDefaultPipeline<GlyphAtlasPipeline>(*context_);
-  glyph_atlas_color_pipelines_[{}] =
+  glyph_atlas_color_pipelines_[default_options] =
       CreateDefaultPipeline<GlyphAtlasColorPipeline>(*context_);
-  geometry_color_pipelines_[{}] =
+  geometry_color_pipelines_[default_options] =
       CreateDefaultPipeline<GeometryColorPipeline>(*context_);
-  yuv_to_rgb_filter_pipelines_[{}] =
+  yuv_to_rgb_filter_pipelines_[default_options] =
       CreateDefaultPipeline<YUVToRGBFilterPipeline>(*context_);
-  porter_duff_blend_pipelines_[{}] =
+  porter_duff_blend_pipelines_[default_options] =
       CreateDefaultPipeline<PorterDuffBlendPipeline>(*context_);
 
   if (context_->GetCapabilities()->SupportsCompute()) {
@@ -303,7 +312,8 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
         context_->GetPipelineLibrary()->GetPipeline(uv_pipeline_desc).Get();
   }
 
-  auto maybe_pipeline_desc = solid_fill_pipelines_[{}]->GetDescriptor();
+  auto maybe_pipeline_desc =
+      solid_fill_pipelines_[default_options]->GetDescriptor();
   if (maybe_pipeline_desc.has_value()) {
     auto clip_pipeline_descriptor = maybe_pipeline_desc.value();
     clip_pipeline_descriptor.SetLabel("Clip Pipeline");
@@ -316,7 +326,7 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
     }
     clip_pipeline_descriptor.SetColorAttachmentDescriptors(
         std::move(color_attachments));
-    clip_pipelines_[{}] =
+    clip_pipelines_[default_options] =
         std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor);
   } else {
     return;

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -291,12 +291,12 @@ using UvComputeShaderPipeline = ComputePipelineBuilder<UvComputeShader>;
 /// Flutter application may easily require building hundreds of PSOs in total,
 /// but they shouldn't require e.g. 10s of thousands.
 struct ContentContextOptions {
-  SampleCount sample_count = SampleCount::kCount1;
+  SampleCount sample_count = SampleCount::kCount4;
   BlendMode blend_mode = BlendMode::kSourceOver;
   CompareFunction stencil_compare = CompareFunction::kEqual;
   StencilOperation stencil_operation = StencilOperation::kKeep;
   PrimitiveType primitive_type = PrimitiveType::kTriangle;
-  std::optional<PixelFormat> color_attachment_pixel_format;
+  PixelFormat color_attachment_pixel_format = PixelFormat::kUnknown;
   bool has_stencil_attachment = true;
   bool wireframe = false;
 
@@ -820,7 +820,9 @@ class ContentContext {
       return found->second->WaitAndGet();
     }
 
-    auto prototype = container.find({});
+    auto prototype = container.find(
+        {.color_attachment_pixel_format =
+             context_->GetCapabilities()->GetDefaultColorFormat()});
 
     // The prototype must always be initialized in the constructor.
     FML_CHECK(prototype != container.end());

--- a/impeller/renderer/pipeline_descriptor.h
+++ b/impeller/renderer/pipeline_descriptor.h
@@ -133,7 +133,7 @@ class PipelineDescriptor final : public Comparable<PipelineDescriptor> {
 
  private:
   std::string label_;
-  SampleCount sample_count_ = SampleCount::kCount1;
+  SampleCount sample_count_ = SampleCount::kCount4;
   WindingOrder winding_order_ = WindingOrder::kClockwise;
   CullMode cull_mode_ = CullMode::kNone;
   std::map<ShaderStage, std::shared_ptr<const ShaderFunction>> entrypoints_;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -288,6 +288,8 @@ TEST_P(RendererTest, CanRenderToTexture) {
   using BoxPipelineBuilder = PipelineBuilder<VS, FS>;
   auto pipeline_desc =
       BoxPipelineBuilder::MakeDefaultPipelineDescriptor(*context);
+  pipeline_desc->SetSampleCount(SampleCount::kCount1);
+
   ASSERT_TRUE(pipeline_desc.has_value());
   auto box_pipeline =
       context->GetPipelineLibrary()->GetPipeline(pipeline_desc).Get();


### PR DESCRIPTION
Despite compiling an initial PSO variant for every shader, in practice these were completely useless as they had a sample count of 1 (instead of 4 for MSAA) and an invalid pixel format.

Correct the defaults so they may be usful.

Not enough to fix https://github.com/flutter/flutter/issues/128963 , because we still have far too much state for Vulkan to handle
