### PR TITLE
[Impeller] Print malioc errors on CI

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -257,7 +257,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'fabb92f0ada787444ad0be22638c80a6d5927a2c',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '84f3ac239e6872054d986085127bb5c3ff3f1ca8',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -257,7 +257,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '84f3ac239e6872054d986085127bb5c3ff3f1ca8',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '0ebf2593785cd440cbc35caced03fce2b99f750f',
 
    # Fuchsia compatibility
    #

--- a/impeller/tools/malioc.gni
+++ b/impeller/tools/malioc.gni
@@ -70,7 +70,7 @@ template("malioc_analyze_shaders") {
                                          "script",
                                        ])
 
-                script = "//build/gn_run_binary.py"
+                script = "//build/gn_run_malioc.py"
                 pool = "//flutter/impeller/tools:malioc_pool"
 
                 # Nest all malioc output under its own subdirectory of root_gen_dir
@@ -101,13 +101,12 @@ template("malioc_analyze_shaders") {
 
                 args = [
                   rebase_path(impeller_malioc_path, root_build_dir),
+                  rebase_path(output_file),
                   "--format",
                   "json",
                   shader_kind_flag,
                   "--core",
                   core.core,
-                  "--output",
-                  rebase_path(output_file),
                 ]
 
                 if (backend_ext == "vkspv") {

--- a/impeller/tools/malioc_cores.py
+++ b/impeller/tools/malioc_cores.py
@@ -40,7 +40,10 @@ def validate_args(args):
 
 
 def malioc_core_list(malioc):
-  malioc_cores = subprocess.check_output([malioc, '--list', '--format', 'json'])
+  malioc_cores = subprocess.check_output(
+      [malioc, '--list', '--format', 'json'],
+      stderr=subprocess.STDOUT,
+  )
   cores_json = json.loads(malioc_cores)
   cores = []
   for core in cores_json['cores']:
@@ -49,9 +52,10 @@ def malioc_core_list(malioc):
 
 
 def malioc_core_info(malioc, core):
-  malioc_info = subprocess.check_output([
-      malioc, '--info', '--core', core, '--format', 'json'
-  ])
+  malioc_info = subprocess.check_output(
+      [malioc, '--info', '--core', core, '--format', 'json'],
+      stderr=subprocess.STDOUT,
+  )
   info_json = json.loads(malioc_info)
 
   apis = info_json['apis']


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/128989.

Also bumps the buildroot to head for: https://github.com/flutter/buildroot/pull/744

Before:
```
[4876/5558] ACTION //flutter/impeller/entity:analyze_gles_entity_shaders_rrect_blur.frag_Mali-G78_malioc(//build/toolchain/android:clang_arm)
FAILED: gen/malioc/flutter/impeller/entity/rrect_blur.frag.gles.Mali-G78.json 
vpython3 ../../build/gn_run_binary.py ../../../../arm-tools/mali_offline_compiler/malioc --format json --fragment --core Mali-G78 --output /b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/malioc/flutter/impeller/entity/rrect_blur.frag.gles.Mali-G78.json /b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/flutter/impeller/entity/gles/rrect_blur.frag.gles

[4877/5558] ACTION //flutter/impeller/entity:analyze_gles_entity_shaders_radial_gradient_fill.frag_Mali-T880_malioc(//build/toolchain/android:clang_arm)
[4878/5558] ACTION //flutter/impeller/entity:analyze_gles_entity_shaders_rrect_blur.frag_Mali-T880_malioc(//build/toolchain/android:clang_arm)
FAILED: gen/malioc/flutter/impeller/entity/rrect_blur.frag.gles.Mali-T880.json 
vpython3 ../../build/gn_run_binary.py ../../../../arm-tools/mali_offline_compiler/malioc --format json --fragment --core Mali-T880 --output /b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/malioc/flutter/impeller/entity/rrect_blur.frag.gles.Mali-T880.json /b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/flutter/impeller/entity/gles/rrect_blur.frag.gles
```

After:
```
FAILED: gen/malioc/flutter/impeller/entity/rrect_blur.frag.gles.Mali-G78.json 
vpython3 ../../build/gn_run_malioc.py ../../../../arm-tools/mali_offline_compiler/malioc /b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/malioc/flutter/impeller/entity/rrect_blur.frag.gles.Mali-G78.json --format json --fragment --core Mali-G78 /b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/flutter/impeller/entity/gles/rrect_blur.frag.gles

malioc output:
{
  "producer": {
    "build": "aeadf0",
    "documentation": "https://developer.arm.com/tools-and-software/graphics-and-gaming/arm-mobile-studio/learn/mali-offline-compiler-documentation",
    "name": "Mali Offline Compiler",
    "version": [
      7,
      8,
      0
    ]
  },
  "schema": {
    "name": "error",
    "version": 0
  },
  "shaders": [
    {
      "driver": "r41p0-00rel0",
      "errors": [
        "0:60: L0002: Undeclared variable 'mp_copy_463_1_1'"
      ],
      "filename": "/b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/flutter/impeller/entity/gles/rrect_blur.frag.gles",
      "hardware": {
        "architecture": "Valhall",
        "core": "Mali-G78",
        "revision": "r1p1"
      },
      "shader": {
        "api": "OpenGL ES",
        "type": "Fragment"
      },
      "warnings": []
    }
  ]
}
[4737/5560] ACTION //flutter/impeller/entity:analyze_gles_entity_shaders_rrect_blur.frag_Mali-T880_malioc(//build/toolchain/android:clang_arm)
FAILED: gen/malioc/flutter/impeller/entity/rrect_blur.frag.gles.Mali-T880.json 
vpython3 ../../build/gn_run_malioc.py ../../../../arm-tools/mali_offline_compiler/malioc /b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/malioc/flutter/impeller/entity/rrect_blur.frag.gles.Mali-T880.json --format json --fragment --core Mali-T880 /b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/flutter/impeller/entity/gles/rrect_blur.frag.gles

malioc output:
{
  "producer": {
    "build": "aeadf0",
    "documentation": "https://developer.arm.com/tools-and-software/graphics-and-gaming/arm-mobile-studio/learn/mali-offline-compiler-documentation",
    "name": "Mali Offline Compiler",
    "version": [
      7,
      8,
      0
    ]
  },
  "schema": {
    "name": "error",
    "version": 0
  },
  "shaders": [
    {
      "driver": "r23p0-00rel0",
      "errors": [
        "0:60: L0002: Undeclared variable 'mp_copy_463_1_1'"
      ],
      "filename": "/b/s/w/ir/cache/builder/src/out/android_debug_unopt/gen/flutter/impeller/entity/gles/rrect_blur.frag.gles",
      "hardware": {
        "architecture": "Midgard",
        "core": "Mali-T880",
        "revision": "r2p0"
      },
      "shader": {
        "api": "OpenGL ES",
        "type": "Fragment"
      },
      "warnings": []
    }
  ]
}
```