### PR TITLE
add dart_internal override where necessary

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -49,6 +49,8 @@ dependency_overrides:
     path: ../../third_party/dart/pkg/compiler
   crypto:
     path: ../../third_party/dart/third_party/pkg/crypto
+  dart_internal:
+    path: ../../third_party/dart/pkg/dart_internal
   dart2js_info:
     path: ../../third_party/dart/pkg/dart2js_info
   dev_compiler:

--- a/tools/api_check/pubspec.yaml
+++ b/tools/api_check/pubspec.yaml
@@ -52,6 +52,8 @@ dependency_overrides:
     path: ../../../third_party/dart/third_party/pkg/convert
   crypto:
     path: ../../../third_party/dart/third_party/pkg/crypto
+  dart_internal:
+    path: ../../../third_party/dart/pkg/dart_internal
   expect:
     path: ../../../third_party/dart/pkg/expect
   file:

--- a/web_sdk/pubspec.yaml
+++ b/web_sdk/pubspec.yaml
@@ -28,6 +28,8 @@ dependency_overrides: # Must include all transitive dependencies from the "any" 
     path: ../../third_party/dart/third_party/pkg/convert
   crypto:
     path: ../../third_party/dart/third_party/pkg/crypto
+  dart_internal:
+    path: ../../third_party/dart/pkg/dart_internal
   file:
     path: ../../third_party/pkg/file/packages/file
   glob:


### PR DESCRIPTION
A dependency to dart_internal was added in https://dart-review.googlesource.com/c/sdk/+/309460/6 and all transitive deps need to have overrides.