### PR TITLE
Fix crash with CJK keyboard with emoji at end of text field (#42539)

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1600,24 +1600,6 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
 }
 
 - (CGRect)caretRectForPosition:(UITextPosition*)position {
-<<<<<<< HEAD
-  // TODO(cbracken) Implement.
-
-  // As of iOS 14.4, this call is used by iOS's
-  // _UIKeyboardTextSelectionController to determine the position
-  // of the floating cursor when the user force touches the space
-  // bar to initiate floating cursor.
-  //
-  // It is recommended to return a value that's roughly the
-  // center of kSpacePanBounds to make sure the floating cursor
-  // has ample space in all directions and does not hit kSpacePanBounds.
-  // See the comments in beginFloatingCursorAtPoint.
-  return CGRectZero;
-}
-
-- (CGRect)bounds {
-  return _isFloatingCursorActive ? kSpacePanBounds : super.bounds;
-=======
   NSInteger index = ((FlutterTextPosition*)position).index;
   UITextStorageDirection affinity = ((FlutterTextPosition*)position).affinity;
   // Get the selectionRect of the characters before and after the requested caret position.
@@ -1677,7 +1659,6 @@ static BOOL IsSelectionRectCloserToPoint(CGPoint point,
     return CGRectMake(characterBeforeCaret.origin.x + characterBeforeCaret.size.width,
                       characterBeforeCaret.origin.y, 0, characterBeforeCaret.size.height);
   }
->>>>>>> de68fba093 (Fix crash with CJK keyboard with emoji at end of text field (#42540))
 }
 
 - (UITextPosition*)closestPositionToPoint:(CGPoint)point {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1429,6 +1429,29 @@ FLUTTER_ASSERT_ARC
       1U, ((FlutterTextPosition*)[inputView closestPositionToPoint:point withinRange:range]).index);
 }
 
+- (void)testClosestPositionToPointWithPartialSelectionRects {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [inputView setTextInputState:@{@"text" : @"COMPOSING"}];
+
+  [inputView setSelectionRects:@[ [FlutterTextSelectionRect
+                                   selectionRectWithRect:CGRectMake(0, 0, 100, 100)
+                                                position:0U] ]];
+  // Asking with a position at the end of selection rects should give you the trailing edge of
+  // the last rect.
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:1
+                                                   affinity:UITextStorageDirectionForward]],
+      CGRectMake(100, 0, 0, 100)));
+  // Asking with a position beyond the end of selection rects should return CGRectZero without
+  // crashing.
+  XCTAssertTrue(CGRectEqualToRect(
+      [inputView caretRectForPosition:[FlutterTextPosition
+                                          positionWithIndex:2
+                                                   affinity:UITextStorageDirectionForward]],
+      CGRectZero));
+}
+
 #pragma mark - Floating Cursor - Tests
 
 - (void)testFloatingCursorDoesNotThrow {


### PR DESCRIPTION
The `isRTLAtPosition` method had a bug, it used `NSInteger max = [_selectionRects count]` instead of `NSInteger max = [_selectionRects count] - 1`. But I realized we don't even need the function any more, it was used in a few places in previous iterations of #36643, but in the only place remaining, we actually already have the selection rect and don't need to search for it by position.

Btw as an explanation of the crash, I guess there is some mismatch between code point and character count somewhere. UIKit was asking for `caretRectForPosition:2` when we only had 1 character. This could have only crashed when floating cursor selection was used, but actually when switching to CJK keyboard, UIKit turns out to use `caretRectForPosition` to calculate something about the composing rect.

Fixes https://github.com/flutter/flutter/issues/128031

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
