### PR TITLE
Fix analyzer warnings (prefer_final_in_for_each is now the default)

### DIFF
--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -237,13 +237,13 @@ class ClangTidy {
     final List<Command> totalCommands = <Command>[];
     if (sharedBuildCommandsData.isNotEmpty) {
       final List<Command> buildCommands = <Command>[
-        for (Object? data in buildCommandsData)
+        for (final Object? data in buildCommandsData)
           Command.fromMap((data as Map<String, Object?>?)!)
       ];
       final List<Set<String>> shardFilePaths = <Set<String>>[
-        for (List<Object?> list in sharedBuildCommandsData)
+        for (final List<Object?> list in sharedBuildCommandsData)
           <String>{
-            for (Object? data in list)
+            for (final Object? data in list)
               Command.fromMap((data as Map<String, Object?>?)!).filePath
           }
       ];
@@ -255,7 +255,7 @@ class ClangTidy {
         }
       }
       final List<Command> intersection = <Command>[
-        for (_SetStatusCommand result in intersectionResults)
+        for (final _SetStatusCommand result in intersectionResults)
           if (result.setStatus == _SetStatus.Intersection) result.command
       ];
       // Make sure to sort results so the sharding scheme is guaranteed to work
@@ -266,7 +266,7 @@ class ClangTidy {
           _takeShard(intersection, shardId!, 1 + sharedBuildCommandsData.length));
     } else {
       totalCommands.addAll(<Command>[
-        for (Object? data in buildCommandsData)
+        for (final Object? data in buildCommandsData)
           Command.fromMap((data as Map<String, Object?>?)!)
       ]);
     }

--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -192,7 +192,7 @@ class ClangTidy {
   /// Returns f(n) = value(n * [shardCount] + [id]).
   Iterable<T> _takeShard<T>(Iterable<T> values, int id, int shardCount) sync* {
     int count = 0;
-    for (final T val in values) {
+    for (T val in values) {
       if (count % shardCount == id) {
         yield val;
       }

--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -192,7 +192,7 @@ class ClangTidy {
   /// Returns f(n) = value(n * [shardCount] + [id]).
   Iterable<T> _takeShard<T>(Iterable<T> values, int id, int shardCount) sync* {
     int count = 0;
-    for (T val in values) {
+    for (final T val in values) {
       if (count % shardCount == id) {
         yield val;
       }


### PR DESCRIPTION
The analyzer option `prefer_final_in_for_each` has been made the default and this has triggered new warnings.