### PR TITLE
Revert "[Impeller] correct default PSO pixel format and sample count."

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -30,7 +30,7 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
   desc.SetSampleCount(sample_count);
 
   ColorAttachmentDescriptor color0 = *desc.GetColorAttachmentDescriptor(0u);
-  color0.format = color_attachment_pixel_format;
+  color0.format = color_attachment_pixel_format.value_or(PixelFormat::kUnknown);
   color0.alpha_blend_op = BlendOperation::kAdd;
   color0.color_blend_op = BlendOperation::kAdd;
 
@@ -165,139 +165,130 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
   if (!context_ || !context_->IsValid()) {
     return;
   }
-  auto default_options = ContentContextOptions{
-      .color_attachment_pixel_format =
-          context_->GetCapabilities()->GetDefaultColorFormat()};
 
 #ifdef IMPELLER_DEBUG
-  checkerboard_pipelines_[default_options] =
+  checkerboard_pipelines_[{}] =
       CreateDefaultPipeline<CheckerboardPipeline>(*context_);
 #endif  // IMPELLER_DEBUG
 
-  solid_fill_pipelines_[default_options] =
+  solid_fill_pipelines_[{}] =
       CreateDefaultPipeline<SolidFillPipeline>(*context_);
-
+  linear_gradient_fill_pipelines_[{}] =
+      CreateDefaultPipeline<LinearGradientFillPipeline>(*context_);
+  radial_gradient_fill_pipelines_[{}] =
+      CreateDefaultPipeline<RadialGradientFillPipeline>(*context_);
+  conical_gradient_fill_pipelines_[{}] =
+      CreateDefaultPipeline<ConicalGradientFillPipeline>(*context_);
   if (context_->GetCapabilities()->SupportsSSBO()) {
-    linear_gradient_ssbo_fill_pipelines_[default_options] =
+    linear_gradient_ssbo_fill_pipelines_[{}] =
         CreateDefaultPipeline<LinearGradientSSBOFillPipeline>(*context_);
-    radial_gradient_ssbo_fill_pipelines_[default_options] =
+    radial_gradient_ssbo_fill_pipelines_[{}] =
         CreateDefaultPipeline<RadialGradientSSBOFillPipeline>(*context_);
-    conical_gradient_ssbo_fill_pipelines_[default_options] =
+    conical_gradient_ssbo_fill_pipelines_[{}] =
         CreateDefaultPipeline<ConicalGradientSSBOFillPipeline>(*context_);
-    sweep_gradient_ssbo_fill_pipelines_[default_options] =
+    sweep_gradient_ssbo_fill_pipelines_[{}] =
         CreateDefaultPipeline<SweepGradientSSBOFillPipeline>(*context_);
-  } else {
-    linear_gradient_fill_pipelines_[default_options] =
-        CreateDefaultPipeline<LinearGradientFillPipeline>(*context_);
-    radial_gradient_fill_pipelines_[default_options] =
-        CreateDefaultPipeline<RadialGradientFillPipeline>(*context_);
-    conical_gradient_fill_pipelines_[default_options] =
-        CreateDefaultPipeline<ConicalGradientFillPipeline>(*context_);
-    sweep_gradient_fill_pipelines_[default_options] =
-        CreateDefaultPipeline<SweepGradientFillPipeline>(*context_);
   }
-
   if (context_->GetCapabilities()->SupportsFramebufferFetch()) {
-    framebuffer_blend_color_pipelines_[default_options] =
+    framebuffer_blend_color_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendColorPipeline>(*context_);
-    framebuffer_blend_colorburn_pipelines_[default_options] =
+    framebuffer_blend_colorburn_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendColorBurnPipeline>(*context_);
-    framebuffer_blend_colordodge_pipelines_[default_options] =
+    framebuffer_blend_colordodge_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendColorDodgePipeline>(*context_);
-    framebuffer_blend_darken_pipelines_[default_options] =
+    framebuffer_blend_darken_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendDarkenPipeline>(*context_);
-    framebuffer_blend_difference_pipelines_[default_options] =
+    framebuffer_blend_difference_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendDifferencePipeline>(*context_);
-    framebuffer_blend_exclusion_pipelines_[default_options] =
+    framebuffer_blend_exclusion_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendExclusionPipeline>(*context_);
-    framebuffer_blend_hardlight_pipelines_[default_options] =
+    framebuffer_blend_hardlight_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendHardLightPipeline>(*context_);
-    framebuffer_blend_hue_pipelines_[default_options] =
+    framebuffer_blend_hue_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendHuePipeline>(*context_);
-    framebuffer_blend_lighten_pipelines_[default_options] =
+    framebuffer_blend_lighten_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendLightenPipeline>(*context_);
-    framebuffer_blend_luminosity_pipelines_[default_options] =
+    framebuffer_blend_luminosity_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendLuminosityPipeline>(*context_);
-    framebuffer_blend_multiply_pipelines_[default_options] =
+    framebuffer_blend_multiply_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendMultiplyPipeline>(*context_);
-    framebuffer_blend_overlay_pipelines_[default_options] =
+    framebuffer_blend_overlay_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendOverlayPipeline>(*context_);
-    framebuffer_blend_saturation_pipelines_[default_options] =
+    framebuffer_blend_saturation_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendSaturationPipeline>(*context_);
-    framebuffer_blend_screen_pipelines_[default_options] =
+    framebuffer_blend_screen_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendScreenPipeline>(*context_);
-    framebuffer_blend_softlight_pipelines_[default_options] =
+    framebuffer_blend_softlight_pipelines_[{}] =
         CreateDefaultPipeline<FramebufferBlendSoftLightPipeline>(*context_);
   }
 
-  blend_color_pipelines_[default_options] =
+  blend_color_pipelines_[{}] =
       CreateDefaultPipeline<BlendColorPipeline>(*context_);
-  blend_colorburn_pipelines_[default_options] =
+  blend_colorburn_pipelines_[{}] =
       CreateDefaultPipeline<BlendColorBurnPipeline>(*context_);
-  blend_colordodge_pipelines_[default_options] =
+  blend_colordodge_pipelines_[{}] =
       CreateDefaultPipeline<BlendColorDodgePipeline>(*context_);
-  blend_darken_pipelines_[default_options] =
+  blend_darken_pipelines_[{}] =
       CreateDefaultPipeline<BlendDarkenPipeline>(*context_);
-  blend_difference_pipelines_[default_options] =
+  blend_difference_pipelines_[{}] =
       CreateDefaultPipeline<BlendDifferencePipeline>(*context_);
-  blend_exclusion_pipelines_[default_options] =
+  blend_exclusion_pipelines_[{}] =
       CreateDefaultPipeline<BlendExclusionPipeline>(*context_);
-  blend_hardlight_pipelines_[default_options] =
+  blend_hardlight_pipelines_[{}] =
       CreateDefaultPipeline<BlendHardLightPipeline>(*context_);
-  blend_hue_pipelines_[default_options] =
-      CreateDefaultPipeline<BlendHuePipeline>(*context_);
-  blend_lighten_pipelines_[default_options] =
+  blend_hue_pipelines_[{}] = CreateDefaultPipeline<BlendHuePipeline>(*context_);
+  blend_lighten_pipelines_[{}] =
       CreateDefaultPipeline<BlendLightenPipeline>(*context_);
-  blend_luminosity_pipelines_[default_options] =
+  blend_luminosity_pipelines_[{}] =
       CreateDefaultPipeline<BlendLuminosityPipeline>(*context_);
-  blend_multiply_pipelines_[default_options] =
+  blend_multiply_pipelines_[{}] =
       CreateDefaultPipeline<BlendMultiplyPipeline>(*context_);
-  blend_overlay_pipelines_[default_options] =
+  blend_overlay_pipelines_[{}] =
       CreateDefaultPipeline<BlendOverlayPipeline>(*context_);
-  blend_saturation_pipelines_[default_options] =
+  blend_saturation_pipelines_[{}] =
       CreateDefaultPipeline<BlendSaturationPipeline>(*context_);
-  blend_screen_pipelines_[default_options] =
+  blend_screen_pipelines_[{}] =
       CreateDefaultPipeline<BlendScreenPipeline>(*context_);
-  blend_softlight_pipelines_[default_options] =
+  blend_softlight_pipelines_[{}] =
       CreateDefaultPipeline<BlendSoftLightPipeline>(*context_);
-
-  rrect_blur_pipelines_[default_options] =
+  sweep_gradient_fill_pipelines_[{}] =
+      CreateDefaultPipeline<SweepGradientFillPipeline>(*context_);
+  rrect_blur_pipelines_[{}] =
       CreateDefaultPipeline<RRectBlurPipeline>(*context_);
-  texture_blend_pipelines_[default_options] =
+  texture_blend_pipelines_[{}] =
       CreateDefaultPipeline<BlendPipeline>(*context_);
-  texture_pipelines_[default_options] =
-      CreateDefaultPipeline<TexturePipeline>(*context_);
-  position_uv_pipelines_[default_options] =
+  texture_pipelines_[{}] = CreateDefaultPipeline<TexturePipeline>(*context_);
+  position_uv_pipelines_[{}] =
       CreateDefaultPipeline<PositionUVPipeline>(*context_);
-  tiled_texture_pipelines_[default_options] =
+  tiled_texture_pipelines_[{}] =
       CreateDefaultPipeline<TiledTexturePipeline>(*context_);
-  gaussian_blur_alpha_decal_pipelines_[default_options] =
+  gaussian_blur_alpha_decal_pipelines_[{}] =
       CreateDefaultPipeline<GaussianBlurAlphaDecalPipeline>(*context_);
-  gaussian_blur_alpha_nodecal_pipelines_[default_options] =
+  gaussian_blur_alpha_nodecal_pipelines_[{}] =
       CreateDefaultPipeline<GaussianBlurAlphaPipeline>(*context_);
-  gaussian_blur_noalpha_decal_pipelines_[default_options] =
+  gaussian_blur_noalpha_decal_pipelines_[{}] =
       CreateDefaultPipeline<GaussianBlurDecalPipeline>(*context_);
-  gaussian_blur_noalpha_nodecal_pipelines_[default_options] =
+  gaussian_blur_noalpha_nodecal_pipelines_[{}] =
       CreateDefaultPipeline<GaussianBlurPipeline>(*context_);
-  border_mask_blur_pipelines_[default_options] =
+  border_mask_blur_pipelines_[{}] =
       CreateDefaultPipeline<BorderMaskBlurPipeline>(*context_);
-  morphology_filter_pipelines_[default_options] =
+  morphology_filter_pipelines_[{}] =
       CreateDefaultPipeline<MorphologyFilterPipeline>(*context_);
-  color_matrix_color_filter_pipelines_[default_options] =
+  color_matrix_color_filter_pipelines_[{}] =
       CreateDefaultPipeline<ColorMatrixColorFilterPipeline>(*context_);
-  linear_to_srgb_filter_pipelines_[default_options] =
+  linear_to_srgb_filter_pipelines_[{}] =
       CreateDefaultPipeline<LinearToSrgbFilterPipeline>(*context_);
-  srgb_to_linear_filter_pipelines_[default_options] =
+  srgb_to_linear_filter_pipelines_[{}] =
       CreateDefaultPipeline<SrgbToLinearFilterPipeline>(*context_);
-  glyph_atlas_pipelines_[default_options] =
+  glyph_atlas_pipelines_[{}] =
       CreateDefaultPipeline<GlyphAtlasPipeline>(*context_);
-  glyph_atlas_color_pipelines_[default_options] =
+  glyph_atlas_color_pipelines_[{}] =
       CreateDefaultPipeline<GlyphAtlasColorPipeline>(*context_);
-  geometry_color_pipelines_[default_options] =
+  geometry_color_pipelines_[{}] =
       CreateDefaultPipeline<GeometryColorPipeline>(*context_);
-  yuv_to_rgb_filter_pipelines_[default_options] =
+  yuv_to_rgb_filter_pipelines_[{}] =
       CreateDefaultPipeline<YUVToRGBFilterPipeline>(*context_);
-  porter_duff_blend_pipelines_[default_options] =
+  porter_duff_blend_pipelines_[{}] =
       CreateDefaultPipeline<PorterDuffBlendPipeline>(*context_);
 
   if (context_->GetCapabilities()->SupportsCompute()) {
@@ -312,8 +303,7 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
         context_->GetPipelineLibrary()->GetPipeline(uv_pipeline_desc).Get();
   }
 
-  auto maybe_pipeline_desc =
-      solid_fill_pipelines_[default_options]->GetDescriptor();
+  auto maybe_pipeline_desc = solid_fill_pipelines_[{}]->GetDescriptor();
   if (maybe_pipeline_desc.has_value()) {
     auto clip_pipeline_descriptor = maybe_pipeline_desc.value();
     clip_pipeline_descriptor.SetLabel("Clip Pipeline");
@@ -326,7 +316,7 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
     }
     clip_pipeline_descriptor.SetColorAttachmentDescriptors(
         std::move(color_attachments));
-    clip_pipelines_[default_options] =
+    clip_pipelines_[{}] =
         std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor);
   } else {
     return;

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -291,12 +291,12 @@ using UvComputeShaderPipeline = ComputePipelineBuilder<UvComputeShader>;
 /// Flutter application may easily require building hundreds of PSOs in total,
 /// but they shouldn't require e.g. 10s of thousands.
 struct ContentContextOptions {
-  SampleCount sample_count = SampleCount::kCount4;
+  SampleCount sample_count = SampleCount::kCount1;
   BlendMode blend_mode = BlendMode::kSourceOver;
   CompareFunction stencil_compare = CompareFunction::kEqual;
   StencilOperation stencil_operation = StencilOperation::kKeep;
   PrimitiveType primitive_type = PrimitiveType::kTriangle;
-  PixelFormat color_attachment_pixel_format = PixelFormat::kUnknown;
+  std::optional<PixelFormat> color_attachment_pixel_format;
   bool has_stencil_attachment = true;
   bool wireframe = false;
 
@@ -820,9 +820,7 @@ class ContentContext {
       return found->second->WaitAndGet();
     }
 
-    auto prototype = container.find(
-        {.color_attachment_pixel_format =
-             context_->GetCapabilities()->GetDefaultColorFormat()});
+    auto prototype = container.find({});
 
     // The prototype must always be initialized in the constructor.
     FML_CHECK(prototype != container.end());

--- a/impeller/renderer/pipeline_descriptor.h
+++ b/impeller/renderer/pipeline_descriptor.h
@@ -133,7 +133,7 @@ class PipelineDescriptor final : public Comparable<PipelineDescriptor> {
 
  private:
   std::string label_;
-  SampleCount sample_count_ = SampleCount::kCount4;
+  SampleCount sample_count_ = SampleCount::kCount1;
   WindingOrder winding_order_ = WindingOrder::kClockwise;
   CullMode cull_mode_ = CullMode::kNone;
   std::map<ShaderStage, std::shared_ptr<const ShaderFunction>> entrypoints_;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -288,8 +288,6 @@ TEST_P(RendererTest, CanRenderToTexture) {
   using BoxPipelineBuilder = PipelineBuilder<VS, FS>;
   auto pipeline_desc =
       BoxPipelineBuilder::MakeDefaultPipelineDescriptor(*context);
-  pipeline_desc->SetSampleCount(SampleCount::kCount1);
-
   ASSERT_TRUE(pipeline_desc.has_value());
   auto box_pipeline =
       context->GetPipelineLibrary()->GetPipeline(pipeline_desc).Get();


### PR DESCRIPTION
Reverts flutter/engine#42902

This is breaking iOS builds:

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8778085761769326737/+/u/run_platform_views_scroll_perf_non_intersecting_impeller_ios__timeline_summary/test_stdout