### PR TITLE
[Impeller] Run DisplayList render tests on Impeller using Mac-host-Metal backend.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1391,8 +1391,8 @@ ORIGIN: ../../../flutter/impeller/golden_tests/golden_tests.cc + ../../../flutte
 ORIGIN: ../../../flutter/impeller/golden_tests/main.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshot.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshot.mm + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshoter.h + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshoter.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshotter.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshotter.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests/working_directory.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests/working_directory.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests_harvester/bin/golden_tests_harvester.dart + ../../../flutter/LICENSE
@@ -4069,8 +4069,8 @@ FILE: ../../../flutter/impeller/golden_tests/golden_tests.cc
 FILE: ../../../flutter/impeller/golden_tests/main.cc
 FILE: ../../../flutter/impeller/golden_tests/metal_screenshot.h
 FILE: ../../../flutter/impeller/golden_tests/metal_screenshot.mm
-FILE: ../../../flutter/impeller/golden_tests/metal_screenshoter.h
-FILE: ../../../flutter/impeller/golden_tests/metal_screenshoter.mm
+FILE: ../../../flutter/impeller/golden_tests/metal_screenshotter.h
+FILE: ../../../flutter/impeller/golden_tests/metal_screenshotter.mm
 FILE: ../../../flutter/impeller/golden_tests/working_directory.cc
 FILE: ../../../flutter/impeller/golden_tests/working_directory.h
 FILE: ../../../flutter/impeller/golden_tests_harvester/bin/golden_tests_harvester.dart

--- a/display_list/testing/BUILD.gn
+++ b/display_list/testing/BUILD.gn
@@ -66,9 +66,12 @@ source_set("display_list_surface_provider") {
 
   deps = [
     "//flutter/common/graphics",
-    "//flutter/impeller/golden_tests:metal_screenshot",
     "//flutter/testing:testing_lib",
   ]
+
+  if (is_mac) {
+    deps += [ "//flutter/impeller/golden_tests:metal_screenshot" ]
+  }
 
   public_configs = [ ":surface_provider_config" ]
 

--- a/display_list/testing/BUILD.gn
+++ b/display_list/testing/BUILD.gn
@@ -66,6 +66,7 @@ source_set("display_list_surface_provider") {
 
   deps = [
     "//flutter/common/graphics",
+    "//flutter/impeller/golden_tests:metal_screenshot",
     "//flutter/testing:testing_lib",
   ]
 

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -154,6 +154,63 @@ class SkImageSampling {
       SkSamplingOptions(SkCubicResampler{1 / 3.0f, 1 / 3.0f});
 };
 
+static void DrawCheckerboard(DlCanvas* canvas) {
+  DlPaint p0, p1;
+  p0.setDrawStyle(DlDrawStyle::kFill);
+  p0.setColor(SkColorSetARGB(0xff, 0x00, 0xfe, 0x00));  // off-green
+  p1.setDrawStyle(DlDrawStyle::kFill);
+  p1.setColor(SK_ColorBLUE);
+  // Some pixels need some transparency for DstIn testing
+  p1.setAlpha(128);
+  int cbdim = 5;
+  int width = canvas->GetBaseLayerSize().width();
+  int height = canvas->GetBaseLayerSize().height();
+  for (int y = 0; y < width; y += cbdim) {
+    for (int x = 0; x < height; x += cbdim) {
+      DlPaint& cellp = ((x + y) & 1) == 0 ? p0 : p1;
+      canvas->DrawRect(SkRect::MakeXYWH(x, y, cbdim, cbdim), cellp);
+    }
+  }
+}
+
+static void DrawCheckerboard(SkCanvas* canvas) {
+  DlSkCanvasAdapter dl_canvas(canvas);
+  DrawCheckerboard(&dl_canvas);
+}
+
+static std::shared_ptr<DlImageColorSource> MakeColorSource(
+    const sk_sp<DlImage>& image) {
+  return std::make_shared<DlImageColorSource>(image,                //
+                                              DlTileMode::kRepeat,  //
+                                              DlTileMode::kRepeat,  //
+                                              DlImageSampling::kLinear);
+}
+
+static sk_sp<SkShader> MakeColorSource(const sk_sp<SkImage>& image) {
+  return image->makeShader(SkTileMode::kRepeat,  //
+                           SkTileMode::kRepeat,  //
+                           SkImageSampling::kLinear);
+}
+
+// Used to show "INFO" warnings about tests that are omitted on certain
+// backends, but only once for the entire test run to avoid warning spam
+class OncePerBackendWarning {
+ public:
+  explicit OncePerBackendWarning(const std::string& warning)
+      : warning_(warning) {}
+
+  void warn(const std::string& name) {
+    if (warnings_sent_.find(name) == warnings_sent_.end()) {
+      warnings_sent_.insert(name);
+      FML_LOG(INFO) << warning_ << " on " << name;
+    }
+  }
+
+ private:
+  std::string warning_;
+  std::set<std::string> warnings_sent_;
+};
+
 // A class to specify how much tolerance to allow in bounds estimates.
 // For some attributes, the machinery must make some conservative
 // assumptions as to the extent of the bounds, but some of our test
@@ -269,22 +326,46 @@ class BoundsTolerance {
   SkScalar discrete_offset_ = 0;
 };
 
-using SkSetup = const std::function<void(SkCanvas*, SkPaint&)>;
-using SkRenderer = const std::function<void(SkCanvas*, const SkPaint&)>;
-using DlSetup = const std::function<void(DlCanvas*, DlPaint&)>;
-using DlRenderer = const std::function<void(DlCanvas*, const DlPaint&)>;
-static const SkSetup kEmptySkSetup = [](SkCanvas*, SkPaint&) {};
-static const SkRenderer kEmptySkRenderer = [](SkCanvas*, const SkPaint&) {};
-static const DlSetup kEmptyDlSetup = [](DlCanvas*, DlPaint&) {};
-static const DlRenderer kEmptyDlRenderer = [](DlCanvas*, const DlPaint&) {};
+template <typename C, typename P, typename I>
+struct RenderContext {
+  C canvas;
+  P paint;
+  I image;
+};
+using SkSetupContext = RenderContext<SkCanvas*, SkPaint&, sk_sp<SkImage>>;
+using DlSetupContext = RenderContext<DlCanvas*, DlPaint&, sk_sp<DlImage>>;
+using SkRenderContext =
+    RenderContext<SkCanvas*, const SkPaint&, sk_sp<SkImage>>;
+using DlRenderContext =
+    RenderContext<DlCanvas*, const DlPaint&, sk_sp<DlImage>>;
+
+using SkSetup = const std::function<void(const SkSetupContext&)>;
+using SkRenderer = const std::function<void(const SkRenderContext&)>;
+using DlSetup = const std::function<void(const DlSetupContext&)>;
+using DlRenderer = const std::function<void(const DlRenderContext&)>;
+static const SkSetup kEmptySkSetup = [](const SkSetupContext&) {};
+static const SkRenderer kEmptySkRenderer = [](const SkRenderContext&) {};
+static const DlSetup kEmptyDlSetup = [](const DlSetupContext&) {};
+static const DlRenderer kEmptyDlRenderer = [](const DlRenderContext&) {};
 
 using PixelFormat = DlSurfaceProvider::PixelFormat;
 using BackendType = DlSurfaceProvider::BackendType;
 
 class RenderResult {
  public:
-  explicit RenderResult(const sk_sp<SkSurface>& surface,
-                        bool take_snapshot = false) {
+  virtual ~RenderResult() = default;
+
+  virtual sk_sp<SkImage> image() const = 0;
+  virtual int width() const = 0;
+  virtual int height() const = 0;
+  virtual const uint32_t* addr32(int x, int y) const = 0;
+  virtual void write(const std::string& path) const {}
+};
+
+class SkRenderResult final : public RenderResult {
+ public:
+  explicit SkRenderResult(const sk_sp<SkSurface>& surface,
+                          bool take_snapshot = false) {
     SkImageInfo info = surface->imageInfo();
     info = SkImageInfo::MakeN32Premul(info.dimensions());
     addr_ = malloc(info.computeMinByteSize() * info.height());
@@ -294,17 +375,49 @@ class RenderResult {
       image_ = surface->makeImageSnapshot();
     }
   }
-  ~RenderResult() { free(addr_); }
+  ~SkRenderResult() override { free(addr_); }
 
-  sk_sp<SkImage> image() const { return image_; }
-  int width() const { return pixmap_.width(); }
-  int height() const { return pixmap_.height(); }
-  const uint32_t* addr32(int x, int y) const { return pixmap_.addr32(x, y); }
+  sk_sp<SkImage> image() const override { return image_; }
+  int width() const override { return pixmap_.width(); }
+  int height() const override { return pixmap_.height(); }
+  const uint32_t* addr32(int x, int y) const override {
+    return pixmap_.addr32(x, y);
+  }
 
  private:
   sk_sp<SkImage> image_;
   SkPixmap pixmap_;
   void* addr_ = nullptr;
+};
+
+class ImpellerRenderResult final : public RenderResult {
+ public:
+  explicit ImpellerRenderResult(std::unique_ptr<MetalScreenshot> screenshot,
+                                SkRect render_bounds)
+      : screenshot_(std::move(screenshot)),
+        render_bounds_(render_bounds),
+        addr_(reinterpret_cast<const uint32_t*>(screenshot_->GetBytes())),
+        ints_per_row_(screenshot_->GetBytesPerRow() / 4) {
+    FML_DCHECK(screenshot_->GetBytesPerRow() == ints_per_row_ * 4);
+  }
+  ~ImpellerRenderResult() override = default;
+
+  sk_sp<SkImage> image() const override { return nullptr; };
+  int width() const override { return screenshot_->GetWidth(); };
+  int height() const override { return screenshot_->GetHeight(); }
+  const uint32_t* addr32(int x, int y) const override {
+    return addr_ + (y * ints_per_row_) + x;
+  }
+  void write(const std::string& path) const override {
+    screenshot_->WriteToPNG(path);
+  }
+  const SkRect& render_bounds() const { return render_bounds_; }
+
+ private:
+  const std::unique_ptr<MetalScreenshot> screenshot_;
+  SkRect render_bounds_;
+  const uint32_t* addr_;
+  const uint32_t ints_per_row_;
 };
 
 struct RenderJobInfo {
@@ -338,21 +451,25 @@ struct MatrixClipJobRenderer : public JobRenderer {
 };
 
 struct SkJobRenderer : public MatrixClipJobRenderer {
-  explicit SkJobRenderer(const SkSetup& sk_setup = kEmptySkSetup,
-                         const SkRenderer& sk_render = kEmptySkRenderer,
-                         const SkRenderer& sk_restore = kEmptySkRenderer)
-      : sk_setup_(sk_setup), sk_render_(sk_render), sk_restore_(sk_restore) {}
+  explicit SkJobRenderer(const SkSetup& sk_setup,
+                         const SkRenderer& sk_render,
+                         const SkRenderer& sk_restore,
+                         const sk_sp<SkImage>& sk_image)
+      : sk_setup_(sk_setup),
+        sk_render_(sk_render),
+        sk_restore_(sk_restore),
+        sk_image_(sk_image) {}
 
   void Render(SkCanvas* canvas, const RenderJobInfo& info) override {
     FML_DCHECK(info.opacity == SK_Scalar1);
     SkPaint paint;
-    sk_setup_(canvas, paint);
+    sk_setup_({canvas, paint, sk_image_});
     setup_paint_ = paint;
     setup_matrix_ = canvas->getTotalMatrix();
     setup_clip_bounds_ = canvas->getDeviceClipBounds();
     is_setup_ = true;
-    sk_render_(canvas, paint);
-    sk_restore_(canvas, paint);
+    sk_render_({canvas, paint, sk_image_});
+    sk_restore_({canvas, paint, sk_image_});
   }
 
   sk_sp<SkPicture> MakePicture(const RenderJobInfo& info) {
@@ -372,14 +489,19 @@ struct SkJobRenderer : public MatrixClipJobRenderer {
   const SkSetup sk_setup_;
   const SkRenderer sk_render_;
   const SkRenderer sk_restore_;
+  sk_sp<SkImage> sk_image_;
   SkPaint setup_paint_;
 };
 
 struct DlJobRenderer : public MatrixClipJobRenderer {
-  explicit DlJobRenderer(const DlSetup& dl_setup = kEmptyDlSetup,
-                         const DlRenderer& dl_render = kEmptyDlRenderer,
-                         const DlRenderer& dl_restore = kEmptyDlRenderer)
-      : dl_setup_(dl_setup), dl_render_(dl_render), dl_restore_(dl_restore) {}
+  explicit DlJobRenderer(const DlSetup& dl_setup,
+                         const DlRenderer& dl_render,
+                         const DlRenderer& dl_restore,
+                         const sk_sp<DlImage>& dl_image)
+      : dl_setup_(dl_setup),
+        dl_render_(dl_render),
+        dl_restore_(dl_restore),
+        dl_image_(dl_image) {}
 
   void Render(SkCanvas* sk_canvas, const RenderJobInfo& info) override {
     DlSkCanvasAdapter canvas(sk_canvas);
@@ -389,13 +511,13 @@ struct DlJobRenderer : public MatrixClipJobRenderer {
   void Render(DlCanvas* canvas, const RenderJobInfo& info) {
     FML_DCHECK(info.opacity == SK_Scalar1);
     DlPaint paint;
-    dl_setup_(canvas, paint);
+    dl_setup_({canvas, paint, dl_image_});
     setup_paint_ = paint;
     setup_matrix_ = canvas->GetTransform();
     setup_clip_bounds_ = canvas->GetDestinationClipBounds().roundOut();
     is_setup_ = true;
-    dl_render_(canvas, paint);
-    dl_restore_(canvas, paint);
+    dl_render_({canvas, paint, dl_image_});
+    dl_restore_({canvas, paint, dl_image_});
   }
 
   sk_sp<DisplayList> MakeDisplayList(const RenderJobInfo& info) {
@@ -413,6 +535,7 @@ struct DlJobRenderer : public MatrixClipJobRenderer {
   const DlSetup dl_setup_;
   const DlRenderer dl_render_;
   const DlRenderer dl_restore_;
+  const sk_sp<DlImage> dl_image_;
   DlPaint setup_paint_;
 };
 
@@ -472,18 +595,24 @@ class RenderEnvironment {
                 DlSetup& dl_setup,
                 DlRenderer& dl_renderer,
                 DlColor bg = DlColor::kTransparent()) {
-    SkJobRenderer sk_job(sk_setup, sk_renderer);
+    SkJobRenderer sk_job(sk_setup, sk_renderer, kEmptySkRenderer, kTestSkImage);
     RenderJobInfo info = {
         .bg = bg,
     };
     ref_sk_result_ = getResult(info, sk_job);
-    DlJobRenderer dl_job(dl_setup, dl_renderer);
+    DlJobRenderer dl_job(dl_setup, dl_renderer, kEmptyDlRenderer, kTestDlImage);
     ref_dl_result_ = getResult(info, dl_job);
     ref_dl_paint_ = dl_job.setup_paint();
     ref_matrix_ = dl_job.setup_matrix();
     ref_clip_bounds_ = dl_job.setup_clip_bounds();
     ASSERT_EQ(sk_job.setup_matrix(), ref_matrix_);
     ASSERT_EQ(sk_job.setup_clip_bounds(), ref_clip_bounds_);
+    if (provider_->supports_impeller()) {
+      test_impeller_image_ = makeTestImpellerImage(provider_);
+      DlJobRenderer imp_job(dl_setup, dl_renderer, kEmptyDlRenderer,
+                            test_impeller_image_);
+      ref_impeller_result_ = getImpellerResult(info, imp_job);
+    }
   }
 
   std::unique_ptr<RenderResult> getResult(const RenderJobInfo& info,
@@ -503,7 +632,7 @@ class RenderEnvironment {
             GrAsDirectContext(surface->recordingContext())) {
       dContext->flushAndSubmit(surface, /*syncCpu=*/true);
     }
-    return std::make_unique<RenderResult>(surface);
+    return std::make_unique<SkRenderResult>(surface);
   }
 
   std::unique_ptr<RenderResult> getResult(sk_sp<DisplayList> dl) const {
@@ -512,9 +641,25 @@ class RenderEnvironment {
     return getResult(info, job);
   }
 
+  std::unique_ptr<ImpellerRenderResult> getImpellerResult(
+      const RenderJobInfo& info,
+      DlJobRenderer& renderer) const {
+    FML_DCHECK(info.scale == SK_Scalar1);
+
+    DisplayListBuilder builder;
+    builder.Clear(info.bg);
+    auto render_dl = renderer.MakeDisplayList(info);
+    builder.DrawDisplayList(render_dl);
+    auto dl = builder.Build();
+    auto snap = provider_->ImpellerSnapshot(dl, kTestWidth, kTestHeight);
+    return std::make_unique<ImpellerRenderResult>(std::move(snap),
+                                                  render_dl->bounds());
+  }
+
   const DlSurfaceProvider* provider() const { return provider_; }
   bool valid() const { return provider_->supports(format_); }
   const std::string backend_name() const { return provider_->backend_name(); }
+  bool supports_impeller() const { return provider_->supports_impeller(); }
 
   PixelFormat format() const { return format_; }
   const DlPaint& ref_dl_paint() const { return ref_dl_paint_; }
@@ -522,6 +667,13 @@ class RenderEnvironment {
   const SkIRect& ref_clip_bounds() const { return ref_clip_bounds_; }
   const RenderResult* ref_sk_result() const { return ref_sk_result_.get(); }
   const RenderResult* ref_dl_result() const { return ref_dl_result_.get(); }
+  const ImpellerRenderResult* ref_impeller_result() const {
+    return ref_impeller_result_.get();
+  }
+
+  const sk_sp<SkImage> sk_image() const { return kTestSkImage; }
+  const sk_sp<DlImage> dl_image() const { return kTestDlImage; }
+  const sk_sp<DlImage> impeller_image() const { return test_impeller_image_; }
 
  private:
   sk_sp<SkSurface> getSurface(int width, int height) const {
@@ -550,7 +702,30 @@ class RenderEnvironment {
   SkIRect ref_clip_bounds_;
   std::unique_ptr<RenderResult> ref_sk_result_;
   std::unique_ptr<RenderResult> ref_dl_result_;
+  std::unique_ptr<ImpellerRenderResult> ref_impeller_result_;
+  sk_sp<DlImage> test_impeller_image_;
+
+  static const sk_sp<SkImage> kTestSkImage;
+  static const sk_sp<DlImage> kTestDlImage;
+  static const sk_sp<SkImage> makeTestSkImage() {
+    sk_sp<SkSurface> surface = SkSurfaces::Raster(
+        SkImageInfo::MakeN32Premul(kRenderWidth, kRenderHeight));
+    DrawCheckerboard(surface->getCanvas());
+    return surface->makeImageSnapshot();
+  }
+  static const sk_sp<DlImage> makeTestImpellerImage(
+      const DlSurfaceProvider* provider) {
+    FML_DCHECK(provider->supports_impeller());
+    DisplayListBuilder builder(kRenderBounds);
+    DrawCheckerboard(&builder);
+    return provider->MakeImpellerImage(builder.Build(),  //
+                                       kRenderWidth, kRenderHeight);
+  }
 };
+
+const sk_sp<SkImage> RenderEnvironment::kTestSkImage = makeTestSkImage();
+const sk_sp<DlImage> RenderEnvironment::kTestDlImage =
+    DlImage::Make(kTestSkImage);
 
 class CaseParameters {
  public:
@@ -895,6 +1070,19 @@ class CanvasCompareTester {
       RenderEnvironment env = RenderEnvironment::MakeN32(provider.get());
       env.init_ref(params.sk_renderer(), params.dl_renderer());
       quickCompareToReference(env, "default");
+      if (env.supports_impeller()) {
+        auto impeller_result = env.ref_impeller_result();
+        if (!checkPixels(impeller_result, impeller_result->render_bounds(),
+                         "Impeller")) {
+          std::string test_name =
+              ::testing::UnitTest::GetInstance()->current_test_info()->name();
+          impeller_result->write(to_png_filename(test_name + " Impeller"));
+        }
+      } else {
+        static OncePerBackendWarning warnings("No Impeller output tests");
+        warnings.warn(env.backend_name());
+      }
+
       RenderWithTransforms(params, env, tolerance);
       RenderWithClips(params, env, tolerance);
       RenderWithSaveRestore(params, env, tolerance);
@@ -912,113 +1100,113 @@ class CanvasCompareTester {
         SkRect::MakeXYWH(kRenderCenterX - 1, kRenderCenterY - 1, 2, 2);
     SkRect rect = SkRect::MakeXYWH(kRenderCenterX, kRenderCenterY, 10, 10);
     DlColor alpha_layer_color = DlColor::kCyan().withAlpha(0x7f);
-    SkRenderer sk_safe_restore = [=](SkCanvas* cv, const SkPaint& p) {
+    SkRenderer sk_safe_restore = [=](const SkRenderContext& ctx) {
       // Draw another primitive to disable peephole optimizations
-      cv->drawRect(kRenderBounds.makeOffset(500, 500), SkPaint());
-      cv->restore();
+      ctx.canvas->drawRect(kRenderBounds.makeOffset(500, 500), SkPaint());
+      ctx.canvas->restore();
     };
-    DlRenderer dl_safe_restore = [=](DlCanvas* cv, const DlPaint& p) {
+    DlRenderer dl_safe_restore = [=](const DlRenderContext& ctx) {
       // Draw another primitive to disable peephole optimizations
       // As the rendering op rejection in the DisplayList Builder
       // gets smarter and smarter, this operation has had to get
       // sneakier and sneakier about specifying an operation that
       // won't practically show up in the output, but technically
       // can't be culled.
-      cv->DrawRect(
+      ctx.canvas->DrawRect(
           SkRect::MakeXYWH(kRenderCenterX, kRenderCenterY, 0.0001, 0.0001),
           DlPaint());
-      cv->Restore();
+      ctx.canvas->Restore();
     };
-    SkRenderer sk_opt_restore = [=](SkCanvas* cv, const SkPaint& p) {
+    SkRenderer sk_opt_restore = [=](const SkRenderContext& ctx) {
       // Just a simple restore to allow peephole optimizations to occur
-      cv->restore();
+      ctx.canvas->restore();
     };
-    DlRenderer dl_opt_restore = [=](DlCanvas* cv, const DlPaint& p) {
+    DlRenderer dl_opt_restore = [=](const DlRenderContext& ctx) {
       // Just a simple restore to allow peephole optimizations to occur
-      cv->Restore();
+      ctx.canvas->Restore();
     };
     SkRect layer_bounds = kRenderBounds.makeInset(15, 15);
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "With prior save/clip/restore",
-                   [=](SkCanvas* cv, SkPaint& p) {
-                     cv->save();
-                     cv->clipRect(clip, SkClipOp::kIntersect, false);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->save();
+                     ctx.canvas->clipRect(clip, SkClipOp::kIntersect, false);
                      SkPaint p2;
-                     cv->drawRect(rect, p2);
+                     ctx.canvas->drawRect(rect, p2);
                      p2.setBlendMode(SkBlendMode::kClear);
-                     cv->drawRect(rect, p2);
-                     cv->restore();
+                     ctx.canvas->drawRect(rect, p2);
+                     ctx.canvas->restore();
                    },
-                   [=](DlCanvas* cv, DlPaint& p) {
-                     cv->Save();
-                     cv->ClipRect(clip, ClipOp::kIntersect, false);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->Save();
+                     ctx.canvas->ClipRect(clip, ClipOp::kIntersect, false);
                      DlPaint p2;
-                     cv->DrawRect(rect, p2);
+                     ctx.canvas->DrawRect(rect, p2);
                      p2.setBlendMode(DlBlendMode::kClear);
-                     cv->DrawRect(rect, p2);
-                     cv->Restore();
+                     ctx.canvas->DrawRect(rect, p2);
+                     ctx.canvas->Restore();
                    }));
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "saveLayer no paint, no bounds",
-                   [=](SkCanvas* cv, SkPaint& p) {  //
-                     cv->saveLayer(nullptr, nullptr);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->saveLayer(nullptr, nullptr);
                    },
-                   [=](DlCanvas* cv, DlPaint& p) {  //
-                     cv->SaveLayer(nullptr, nullptr);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->SaveLayer(nullptr, nullptr);
                    })
                    .with_restore(sk_safe_restore, dl_safe_restore, false));
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "saveLayer no paint, with bounds",
-                   [=](SkCanvas* cv, SkPaint& p) {  //
-                     cv->saveLayer(layer_bounds, nullptr);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->saveLayer(layer_bounds, nullptr);
                    },
-                   [=](DlCanvas* cv, DlPaint& p) {  //
-                     cv->SaveLayer(&layer_bounds, nullptr);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->SaveLayer(&layer_bounds, nullptr);
                    })
                    .with_restore(sk_safe_restore, dl_safe_restore, true));
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "saveLayer with alpha, no bounds",
-                   [=](SkCanvas* cv, SkPaint& p) {
+                   [=](const SkSetupContext& ctx) {
                      SkPaint save_p;
                      save_p.setColor(alpha_layer_color);
-                     cv->saveLayer(nullptr, &save_p);
+                     ctx.canvas->saveLayer(nullptr, &save_p);
                    },
-                   [=](DlCanvas* cv, DlPaint& p) {
+                   [=](const DlSetupContext& ctx) {
                      DlPaint save_p;
                      save_p.setColor(alpha_layer_color);
-                     cv->SaveLayer(nullptr, &save_p);
+                     ctx.canvas->SaveLayer(nullptr, &save_p);
                    })
                    .with_restore(sk_safe_restore, dl_safe_restore, true));
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "saveLayer with peephole alpha, no bounds",
-                   [=](SkCanvas* cv, SkPaint& p) {
+                   [=](const SkSetupContext& ctx) {
                      SkPaint save_p;
                      save_p.setColor(alpha_layer_color);
-                     cv->saveLayer(nullptr, &save_p);
+                     ctx.canvas->saveLayer(nullptr, &save_p);
                    },
-                   [=](DlCanvas* cv, DlPaint& p) {
+                   [=](const DlSetupContext& ctx) {
                      DlPaint save_p;
                      save_p.setColor(alpha_layer_color);
-                     cv->SaveLayer(nullptr, &save_p);
+                     ctx.canvas->SaveLayer(nullptr, &save_p);
                    })
                    .with_restore(sk_opt_restore, dl_opt_restore, true, true));
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "saveLayer with alpha and bounds",
-                   [=](SkCanvas* cv, SkPaint& p) {
+                   [=](const SkSetupContext& ctx) {
                      SkPaint save_p;
                      save_p.setColor(alpha_layer_color);
-                     cv->saveLayer(layer_bounds, &save_p);
+                     ctx.canvas->saveLayer(layer_bounds, &save_p);
                    },
-                   [=](DlCanvas* cv, DlPaint& p) {
+                   [=](const DlSetupContext& ctx) {
                      DlPaint save_p;
                      save_p.setColor(alpha_layer_color);
-                     cv->SaveLayer(&layer_bounds, &save_p);
+                     ctx.canvas->SaveLayer(&layer_bounds, &save_p);
                    })
                    .with_restore(sk_safe_restore, dl_safe_restore, true));
     {
@@ -1031,21 +1219,17 @@ class CanvasCompareTester {
       // a non-opaque color to avoid that problem.
       RenderEnvironment backdrop_env =
           RenderEnvironment::MakeN32(env.provider());
-      SkSetup sk_backdrop_setup = [=](SkCanvas* cv, SkPaint& p) {
-        SkPaint setup_p;
-        setup_p.setShader(kTestSkImageColorSource);
-        cv->drawPaint(setup_p);
+      SkSetup sk_backdrop_setup = [=](const SkSetupContext& ctx) {
+        DrawCheckerboard(ctx.canvas);
       };
-      DlSetup dl_backdrop_setup = [=](DlCanvas* cv, DlPaint& p) {
-        DlPaint setup_p;
-        setup_p.setColorSource(&kTestDlImageColorSource);
-        cv->DrawPaint(setup_p);
+      DlSetup dl_backdrop_setup = [=](const DlSetupContext& ctx) {
+        DrawCheckerboard(ctx.canvas);
       };
-      SkSetup sk_content_setup = [=](SkCanvas* cv, SkPaint& p) {
-        p.setAlpha(p.getAlpha() / 2);
+      SkSetup sk_content_setup = [=](const SkSetupContext& ctx) {
+        ctx.paint.setAlpha(ctx.paint.getAlpha() / 2);
       };
-      DlSetup dl_content_setup = [=](DlCanvas* cv, DlPaint& p) {
-        p.setAlpha(p.getAlpha() / 2);
+      DlSetup dl_content_setup = [=](const DlSetupContext& ctx) {
+        ctx.paint.setAlpha(ctx.paint.getAlpha() / 2);
       };
       backdrop_env.init_ref(sk_backdrop_setup, testP.sk_renderer(),
                             dl_backdrop_setup, testP.dl_renderer());
@@ -1057,48 +1241,49 @@ class CanvasCompareTester {
       RenderWith(testP, backdrop_env, tolerance,
                  CaseParameters(
                      "saveLayer with backdrop",
-                     [=](SkCanvas* cv, SkPaint& p) {
-                       sk_backdrop_setup(cv, p);
-                       cv->saveLayer(SkCanvas::SaveLayerRec(
+                     [=](const SkSetupContext& ctx) {
+                       sk_backdrop_setup(ctx);
+                       ctx.canvas->saveLayer(SkCanvas::SaveLayerRec(
                            nullptr, nullptr, sk_backdrop.get(), 0));
-                       sk_content_setup(cv, p);
+                       sk_content_setup(ctx);
                      },
-                     [=](DlCanvas* cv, DlPaint& p) {
-                       dl_backdrop_setup(cv, p);
-                       cv->SaveLayer(nullptr, nullptr, &dl_backdrop);
-                       dl_content_setup(cv, p);
+                     [=](const DlSetupContext& ctx) {
+                       dl_backdrop_setup(ctx);
+                       ctx.canvas->SaveLayer(nullptr, nullptr, &dl_backdrop);
+                       dl_content_setup(ctx);
                      })
                      .with_restore(sk_safe_restore, dl_safe_restore, true));
       RenderWith(testP, backdrop_env, tolerance,
                  CaseParameters(
                      "saveLayer with bounds and backdrop",
-                     [=](SkCanvas* cv, SkPaint& p) {
-                       sk_backdrop_setup(cv, p);
-                       cv->saveLayer(SkCanvas::SaveLayerRec(
+                     [=](const SkSetupContext& ctx) {
+                       sk_backdrop_setup(ctx);
+                       ctx.canvas->saveLayer(SkCanvas::SaveLayerRec(
                            &layer_bounds, nullptr, sk_backdrop.get(), 0));
-                       sk_content_setup(cv, p);
+                       sk_content_setup(ctx);
                      },
-                     [=](DlCanvas* cv, DlPaint& p) {
-                       dl_backdrop_setup(cv, p);
-                       cv->SaveLayer(&layer_bounds, nullptr, &dl_backdrop);
-                       dl_content_setup(cv, p);
+                     [=](const DlSetupContext& ctx) {
+                       dl_backdrop_setup(ctx);
+                       ctx.canvas->SaveLayer(&layer_bounds, nullptr,
+                                             &dl_backdrop);
+                       dl_content_setup(ctx);
                      })
                      .with_restore(sk_safe_restore, dl_safe_restore, true));
       RenderWith(testP, backdrop_env, tolerance,
                  CaseParameters(
                      "clipped saveLayer with backdrop",
-                     [=](SkCanvas* cv, SkPaint& p) {
-                       sk_backdrop_setup(cv, p);
-                       cv->clipRect(layer_bounds);
-                       cv->saveLayer(SkCanvas::SaveLayerRec(
+                     [=](const SkSetupContext& ctx) {
+                       sk_backdrop_setup(ctx);
+                       ctx.canvas->clipRect(layer_bounds);
+                       ctx.canvas->saveLayer(SkCanvas::SaveLayerRec(
                            nullptr, nullptr, sk_backdrop.get(), 0));
-                       sk_content_setup(cv, p);
+                       sk_content_setup(ctx);
                      },
-                     [=](DlCanvas* cv, DlPaint& p) {
-                       dl_backdrop_setup(cv, p);
-                       cv->ClipRect(layer_bounds);
-                       cv->SaveLayer(nullptr, nullptr, &dl_backdrop);
-                       dl_content_setup(cv, p);
+                     [=](const DlSetupContext& ctx) {
+                       dl_backdrop_setup(ctx);
+                       ctx.canvas->ClipRect(layer_bounds);
+                       ctx.canvas->SaveLayer(nullptr, nullptr, &dl_backdrop);
+                       dl_content_setup(ctx);
                      })
                      .with_restore(sk_safe_restore, dl_safe_restore, true));
     }
@@ -1119,17 +1304,17 @@ class CanvasCompareTester {
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "saveLayer ColorFilter, no bounds",
-                       [=](SkCanvas* cv, SkPaint& p) {
+                       [=](const SkSetupContext& ctx) {
                          SkPaint save_p;
                          save_p.setColorFilter(sk_alpha_rotate_filter);
-                         cv->saveLayer(nullptr, &save_p);
-                         p.setStrokeWidth(5.0);
+                         ctx.canvas->saveLayer(nullptr, &save_p);
+                         ctx.paint.setStrokeWidth(5.0);
                        },
-                       [=](DlCanvas* cv, DlPaint& p) {
+                       [=](const DlSetupContext& ctx) {
                          DlPaint save_p;
                          save_p.setColorFilter(&dl_alpha_rotate_filter);
-                         cv->SaveLayer(nullptr, &save_p);
-                         p.setStrokeWidth(5.0);
+                         ctx.canvas->SaveLayer(nullptr, &save_p);
+                         ctx.paint.setStrokeWidth(5.0);
                        })
                        .with_restore(sk_safe_restore, dl_safe_restore, true));
       }
@@ -1137,17 +1322,17 @@ class CanvasCompareTester {
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "saveLayer ColorFilter and bounds",
-                       [=](SkCanvas* cv, SkPaint& p) {
+                       [=](const SkSetupContext& ctx) {
                          SkPaint save_p;
                          save_p.setColorFilter(sk_alpha_rotate_filter);
-                         cv->saveLayer(kRenderBounds, &save_p);
-                         p.setStrokeWidth(5.0);
+                         ctx.canvas->saveLayer(kRenderBounds, &save_p);
+                         ctx.paint.setStrokeWidth(5.0);
                        },
-                       [=](DlCanvas* cv, DlPaint& p) {
+                       [=](const DlSetupContext& ctx) {
                          DlPaint save_p;
                          save_p.setColorFilter(&dl_alpha_rotate_filter);
-                         cv->SaveLayer(&kRenderBounds, &save_p);
-                         p.setStrokeWidth(5.0);
+                         ctx.canvas->SaveLayer(&kRenderBounds, &save_p);
+                         ctx.paint.setStrokeWidth(5.0);
                        })
                        .with_restore(sk_safe_restore, dl_safe_restore, true));
       }
@@ -1170,17 +1355,17 @@ class CanvasCompareTester {
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "saveLayer ImageFilter, no bounds",
-                       [=](SkCanvas* cv, SkPaint& p) {
+                       [=](const SkSetupContext& ctx) {
                          SkPaint save_p;
                          save_p.setImageFilter(sk_cf_image_filter);
-                         cv->saveLayer(nullptr, &save_p);
-                         p.setStrokeWidth(5.0);
+                         ctx.canvas->saveLayer(nullptr, &save_p);
+                         ctx.paint.setStrokeWidth(5.0);
                        },
-                       [=](DlCanvas* cv, DlPaint& p) {
+                       [=](const DlSetupContext& ctx) {
                          DlPaint save_p;
                          save_p.setImageFilter(&dl_cf_image_filter);
-                         cv->SaveLayer(nullptr, &save_p);
-                         p.setStrokeWidth(5.0);
+                         ctx.canvas->SaveLayer(nullptr, &save_p);
+                         ctx.paint.setStrokeWidth(5.0);
                        })
                        .with_restore(sk_safe_restore, dl_safe_restore, true));
       }
@@ -1188,17 +1373,17 @@ class CanvasCompareTester {
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "saveLayer ImageFilter and bounds",
-                       [=](SkCanvas* cv, SkPaint& p) {
+                       [=](const SkSetupContext& ctx) {
                          SkPaint save_p;
                          save_p.setImageFilter(sk_cf_image_filter);
-                         cv->saveLayer(kRenderBounds, &save_p);
-                         p.setStrokeWidth(5.0);
+                         ctx.canvas->saveLayer(kRenderBounds, &save_p);
+                         ctx.paint.setStrokeWidth(5.0);
                        },
-                       [=](DlCanvas* cv, DlPaint& p) {
+                       [=](const DlSetupContext& ctx) {
                          DlPaint save_p;
                          save_p.setImageFilter(&dl_cf_image_filter);
-                         cv->SaveLayer(&kRenderBounds, &save_p);
-                         p.setStrokeWidth(5.0);
+                         ctx.canvas->SaveLayer(&kRenderBounds, &save_p);
+                         ctx.paint.setStrokeWidth(5.0);
                        })
                        .with_restore(sk_safe_restore, dl_safe_restore, true));
       }
@@ -1217,34 +1402,34 @@ class CanvasCompareTester {
       RenderEnvironment aa_env = RenderEnvironment::MakeN32(env.provider());
       // Tweak the bounds tolerance for the displacement of 1/10 of a pixel
       const BoundsTolerance aa_tolerance = tolerance.addBoundsPadding(1, 1);
-      auto sk_aa_setup = [=](SkCanvas* cv, SkPaint& p, bool is_aa) {
-        cv->translate(0.1, 0.1);
-        p.setAntiAlias(is_aa);
-        p.setStrokeWidth(5.0);
+      auto sk_aa_setup = [=](SkSetupContext ctx, bool is_aa) {
+        ctx.canvas->translate(0.1, 0.1);
+        ctx.paint.setAntiAlias(is_aa);
+        ctx.paint.setStrokeWidth(5.0);
       };
-      auto dl_aa_setup = [=](DlCanvas* cv, DlPaint& p, bool is_aa) {
-        cv->Translate(0.1, 0.1);
-        p.setAntiAlias(is_aa);
-        p.setStrokeWidth(5.0);
+      auto dl_aa_setup = [=](DlSetupContext ctx, bool is_aa) {
+        ctx.canvas->Translate(0.1, 0.1);
+        ctx.paint.setAntiAlias(is_aa);
+        ctx.paint.setStrokeWidth(5.0);
       };
       aa_env.init_ref(
-          [=](SkCanvas* cv, SkPaint& p) { sk_aa_setup(cv, p, false); },
+          [=](const SkSetupContext& ctx) { sk_aa_setup(ctx, false); },
           testP.sk_renderer(),
-          [=](DlCanvas* cv, DlPaint& p) { dl_aa_setup(cv, p, false); },
+          [=](const DlSetupContext& ctx) { dl_aa_setup(ctx, false); },
           testP.dl_renderer());
       quickCompareToReference(aa_env, "AntiAlias");
       RenderWith(
           testP, aa_env, aa_tolerance,
           CaseParameters(
               "AntiAlias == True",
-              [=](SkCanvas* cv, SkPaint& p) { sk_aa_setup(cv, p, true); },
-              [=](DlCanvas* cv, DlPaint& p) { dl_aa_setup(cv, p, true); }));
+              [=](const SkSetupContext& ctx) { sk_aa_setup(ctx, true); },
+              [=](const DlSetupContext& ctx) { dl_aa_setup(ctx, true); }));
       RenderWith(
           testP, aa_env, aa_tolerance,
           CaseParameters(
               "AntiAlias == False",
-              [=](SkCanvas* cv, SkPaint& p) { sk_aa_setup(cv, p, false); },
-              [=](DlCanvas* cv, DlPaint& p) { dl_aa_setup(cv, p, false); }));
+              [=](const SkSetupContext& ctx) { sk_aa_setup(ctx, false); },
+              [=](const DlSetupContext& ctx) { dl_aa_setup(ctx, false); }));
     }
 
     {
@@ -1256,23 +1441,19 @@ class CanvasCompareTester {
       RenderEnvironment dither_env = RenderEnvironment::Make565(env.provider());
       if (!dither_env.valid()) {
         // Currently only happens on Metal backend
-        static std::set<std::string> warnings_sent;
-        std::string name = dither_env.backend_name();
-        if (warnings_sent.find(name) == warnings_sent.end()) {
-          warnings_sent.insert(name);
-          FML_LOG(INFO) << "Skipping Dithering tests on " << name;
-        }
+        static OncePerBackendWarning warnings("Skipping Dithering tests");
+        warnings.warn(dither_env.backend_name());
       } else {
         DlColor dither_bg = DlColor::kBlack();
-        SkSetup sk_dither_setup = [=](SkCanvas*, SkPaint& p) {
-          p.setShader(kTestSkImageColorSource);
-          p.setAlpha(0xf0);
-          p.setStrokeWidth(5.0);
+        SkSetup sk_dither_setup = [=](const SkSetupContext& ctx) {
+          ctx.paint.setShader(MakeColorSource(ctx.image));
+          ctx.paint.setAlpha(0xf0);
+          ctx.paint.setStrokeWidth(5.0);
         };
-        DlSetup dl_dither_setup = [=](DlCanvas*, DlPaint& p) {
-          p.setColorSource(&kTestDlImageColorSource);
-          p.setAlpha(0xf0);
-          p.setStrokeWidth(5.0);
+        DlSetup dl_dither_setup = [=](const DlSetupContext& ctx) {
+          ctx.paint.setColorSource(MakeColorSource(ctx.image));
+          ctx.paint.setAlpha(0xf0);
+          ctx.paint.setStrokeWidth(5.0);
         };
         dither_env.init_ref(sk_dither_setup, testP.sk_renderer(),
                             dl_dither_setup, testP.dl_renderer(), dither_bg);
@@ -1280,42 +1461,50 @@ class CanvasCompareTester {
         RenderWith(testP, dither_env, tolerance,
                    CaseParameters(
                        "Dither == True",
-                       [=](SkCanvas* cv, SkPaint& p) {
-                         sk_dither_setup(cv, p);
-                         p.setDither(true);
+                       [=](const SkSetupContext& ctx) {
+                         sk_dither_setup(ctx);
+                         ctx.paint.setDither(true);
                        },
-                       [=](DlCanvas* cv, DlPaint& p) {
-                         dl_dither_setup(cv, p);
-                         p.setDither(true);
+                       [=](const DlSetupContext& ctx) {
+                         dl_dither_setup(ctx);
+                         ctx.paint.setDither(true);
                        })
                        .with_bg(dither_bg));
         RenderWith(testP, dither_env, tolerance,
                    CaseParameters(
                        "Dither = False",
-                       [=](SkCanvas* cv, SkPaint& p) {
-                         sk_dither_setup(cv, p);
-                         p.setDither(false);
+                       [=](const SkSetupContext& ctx) {
+                         sk_dither_setup(ctx);
+                         ctx.paint.setDither(false);
                        },
-                       [=](DlCanvas* cv, DlPaint& p) {
-                         dl_dither_setup(cv, p);
-                         p.setDither(false);
+                       [=](const DlSetupContext& ctx) {
+                         dl_dither_setup(ctx);
+                         ctx.paint.setDither(false);
                        })
                        .with_bg(dither_bg));
       }
     }
 
-    RenderWith(
+    RenderWith(  //
         testP, env, tolerance,
         CaseParameters(
             "Color == Blue",
-            [=](SkCanvas*, SkPaint& p) { p.setColor(SK_ColorBLUE); },
-            [=](DlCanvas*, DlPaint& p) { p.setColor(DlColor::kBlue()); }));
-    RenderWith(
+            [=](const SkSetupContext& ctx) {
+              ctx.paint.setColor(SK_ColorBLUE);
+            },
+            [=](const DlSetupContext& ctx) {
+              ctx.paint.setColor(SK_ColorBLUE);
+            }));
+    RenderWith(  //
         testP, env, tolerance,
         CaseParameters(
             "Color == Green",
-            [=](SkCanvas*, SkPaint& p) { p.setColor(SK_ColorGREEN); },
-            [=](DlCanvas*, DlPaint& p) { p.setColor(DlColor::kGreen()); }));
+            [=](const SkSetupContext& ctx) {
+              ctx.paint.setColor(SK_ColorGREEN);
+            },
+            [=](const DlSetupContext& ctx) {
+              ctx.paint.setColor(SK_ColorGREEN);
+            }));
 
     RenderWithStrokes(testP, env, tolerance);
 
@@ -1327,25 +1516,25 @@ class CanvasCompareTester {
       RenderWith(testP, env, tolerance,
                  CaseParameters(
                      "Blend == SrcIn",
-                     [=](SkCanvas*, SkPaint& p) {
-                       p.setBlendMode(SkBlendMode::kSrcIn);
-                       p.setColor(blendable_color);
+                     [=](const SkSetupContext& ctx) {
+                       ctx.paint.setBlendMode(SkBlendMode::kSrcIn);
+                       ctx.paint.setColor(blendable_color);
                      },
-                     [=](DlCanvas*, DlPaint& p) {
-                       p.setBlendMode(DlBlendMode::kSrcIn);
-                       p.setColor(blendable_color);
+                     [=](const DlSetupContext& ctx) {
+                       ctx.paint.setBlendMode(DlBlendMode::kSrcIn);
+                       ctx.paint.setColor(blendable_color);
                      })
                      .with_bg(bg));
       RenderWith(testP, env, tolerance,
                  CaseParameters(
                      "Blend == DstIn",
-                     [=](SkCanvas*, SkPaint& p) {
-                       p.setBlendMode(SkBlendMode::kDstIn);
-                       p.setColor(blendable_color);
+                     [=](const SkSetupContext& ctx) {
+                       ctx.paint.setBlendMode(SkBlendMode::kDstIn);
+                       ctx.paint.setColor(blendable_color);
                      },
-                     [=](DlCanvas*, DlPaint& p) {
-                       p.setBlendMode(DlBlendMode::kDstIn);
-                       p.setColor(blendable_color);
+                     [=](const DlSetupContext& ctx) {
+                       ctx.paint.setBlendMode(DlBlendMode::kDstIn);
+                       ctx.paint.setColor(blendable_color);
                      })
                      .with_bg(bg));
     }
@@ -1355,13 +1544,13 @@ class CanvasCompareTester {
       // like a non-trivial stroke width and a shader rather than a color
       // (for drawPaint) so we create a new environment for these tests.
       RenderEnvironment blur_env = RenderEnvironment::MakeN32(env.provider());
-      SkSetup sk_blur_setup = [=](SkCanvas*, SkPaint& p) {
-        p.setShader(kTestSkImageColorSource);
-        p.setStrokeWidth(5.0);
+      SkSetup sk_blur_setup = [=](const SkSetupContext& ctx) {
+        ctx.paint.setShader(MakeColorSource(ctx.image));
+        ctx.paint.setStrokeWidth(5.0);
       };
-      DlSetup dl_blur_setup = [=](DlCanvas*, DlPaint& p) {
-        p.setColorSource(&kTestDlImageColorSource);
-        p.setStrokeWidth(5.0);
+      DlSetup dl_blur_setup = [=](const DlSetupContext& ctx) {
+        ctx.paint.setColorSource(MakeColorSource(ctx.image));
+        ctx.paint.setStrokeWidth(5.0);
       };
       blur_env.init_ref(sk_blur_setup, testP.sk_renderer(),  //
                         dl_blur_setup, testP.dl_renderer());
@@ -1374,13 +1563,13 @@ class CanvasCompareTester {
         RenderWith(testP, blur_env, blur_5_tolerance,
                    CaseParameters(
                        "ImageFilter == Decal Blur 5",
-                       [=](SkCanvas* cv, SkPaint& p) {
-                         sk_blur_setup(cv, p);
-                         p.setImageFilter(sk_filter_decal_5);
+                       [=](const SkSetupContext& ctx) {
+                         sk_blur_setup(ctx);
+                         ctx.paint.setImageFilter(sk_filter_decal_5);
                        },
-                       [=](DlCanvas* cv, DlPaint& p) {
-                         dl_blur_setup(cv, p);
-                         p.setImageFilter(&dl_filter_decal_5);
+                       [=](const DlSetupContext& ctx) {
+                         dl_blur_setup(ctx);
+                         ctx.paint.setImageFilter(&dl_filter_decal_5);
                        }));
       }
       DlBlurImageFilter dl_filter_clamp_5(5.0, 5.0, DlTileMode::kClamp);
@@ -1390,13 +1579,13 @@ class CanvasCompareTester {
         RenderWith(testP, blur_env, blur_5_tolerance,
                    CaseParameters(
                        "ImageFilter == Clamp Blur 5",
-                       [=](SkCanvas* cv, SkPaint& p) {
-                         sk_blur_setup(cv, p);
-                         p.setImageFilter(sk_filter_clamp_5);
+                       [=](const SkSetupContext& ctx) {
+                         sk_blur_setup(ctx);
+                         ctx.paint.setImageFilter(sk_filter_clamp_5);
                        },
-                       [=](DlCanvas* cv, DlPaint& p) {
-                         dl_blur_setup(cv, p);
-                         p.setImageFilter(&dl_filter_clamp_5);
+                       [=](const DlSetupContext& ctx) {
+                         dl_blur_setup(ctx);
+                         ctx.paint.setImageFilter(&dl_filter_clamp_5);
                        }));
       }
     }
@@ -1406,13 +1595,13 @@ class CanvasCompareTester {
       // like a non-trivial stroke width and a shader rather than a color
       // (for drawPaint) so we create a new environment for these tests.
       RenderEnvironment dilate_env = RenderEnvironment::MakeN32(env.provider());
-      SkSetup sk_dilate_setup = [=](SkCanvas*, SkPaint& p) {
-        p.setShader(kTestSkImageColorSource);
-        p.setStrokeWidth(5.0);
+      SkSetup sk_dilate_setup = [=](const SkSetupContext& ctx) {
+        ctx.paint.setShader(MakeColorSource(ctx.image));
+        ctx.paint.setStrokeWidth(5.0);
       };
-      DlSetup dl_dilate_setup = [=](DlCanvas*, DlPaint& p) {
-        p.setColorSource(&kTestDlImageColorSource);
-        p.setStrokeWidth(5.0);
+      DlSetup dl_dilate_setup = [=](const DlSetupContext& ctx) {
+        ctx.paint.setColorSource(MakeColorSource(ctx.image));
+        ctx.paint.setStrokeWidth(5.0);
       };
       dilate_env.init_ref(sk_dilate_setup, testP.sk_renderer(),  //
                           dl_dilate_setup, testP.dl_renderer());
@@ -1422,13 +1611,13 @@ class CanvasCompareTester {
       RenderWith(testP, dilate_env, tolerance,
                  CaseParameters(
                      "ImageFilter == Dilate 5",
-                     [=](SkCanvas* cv, SkPaint& p) {
-                       sk_dilate_setup(cv, p);
-                       p.setImageFilter(sk_dilate_filter_5);
+                     [=](const SkSetupContext& ctx) {
+                       sk_dilate_setup(ctx);
+                       ctx.paint.setImageFilter(sk_dilate_filter_5);
                      },
-                     [=](DlCanvas* cv, DlPaint& p) {
-                       dl_dilate_setup(cv, p);
-                       p.setImageFilter(&dl_dilate_filter_5);
+                     [=](const DlSetupContext& ctx) {
+                       dl_dilate_setup(ctx);
+                       ctx.paint.setImageFilter(&dl_dilate_filter_5);
                      }));
     }
 
@@ -1437,13 +1626,13 @@ class CanvasCompareTester {
       // like a non-trivial stroke width and a shader rather than a color
       // (for drawPaint) so we create a new environment for these tests.
       RenderEnvironment erode_env = RenderEnvironment::MakeN32(env.provider());
-      SkSetup sk_erode_setup = [=](SkCanvas*, SkPaint& p) {
-        p.setShader(kTestSkImageColorSource);
-        p.setStrokeWidth(6.0);
+      SkSetup sk_erode_setup = [=](const SkSetupContext& ctx) {
+        ctx.paint.setShader(MakeColorSource(ctx.image));
+        ctx.paint.setStrokeWidth(6.0);
       };
-      DlSetup dl_erode_setup = [=](DlCanvas*, DlPaint& p) {
-        p.setColorSource(&kTestDlImageColorSource);
-        p.setStrokeWidth(6.0);
+      DlSetup dl_erode_setup = [=](const DlSetupContext& ctx) {
+        ctx.paint.setColorSource(MakeColorSource(ctx.image));
+        ctx.paint.setStrokeWidth(6.0);
       };
       erode_env.init_ref(sk_erode_setup, testP.sk_renderer(),  //
                          dl_erode_setup, testP.dl_renderer());
@@ -1455,13 +1644,13 @@ class CanvasCompareTester {
       RenderWith(testP, erode_env, tolerance,
                  CaseParameters(
                      "ImageFilter == Erode 1",
-                     [=](SkCanvas* cv, SkPaint& p) {
-                       sk_erode_setup(cv, p);
-                       p.setImageFilter(sk_erode_filter_1);
+                     [=](const SkSetupContext& ctx) {
+                       sk_erode_setup(ctx);
+                       ctx.paint.setImageFilter(sk_erode_filter_1);
                      },
-                     [=](DlCanvas* cv, DlPaint& p) {
-                       dl_erode_setup(cv, p);
-                       p.setImageFilter(&dl_erode_filter_1);
+                     [=](const DlSetupContext& ctx) {
+                       dl_erode_setup(ctx);
+                       ctx.paint.setImageFilter(&dl_erode_filter_1);
                      }));
     }
 
@@ -1487,31 +1676,31 @@ class CanvasCompareTester {
         RenderWith(testP, env, tolerance,
                    CaseParameters(
                        "ColorFilter == RotateRGB",
-                       [=](SkCanvas*, SkPaint& p) {
-                         p.setColor(DlColor::kYellow());
-                         p.setColorFilter(sk_color_filter);
+                       [=](const SkSetupContext& ctx) {
+                         ctx.paint.setColor(DlColor::kYellow());
+                         ctx.paint.setColorFilter(sk_color_filter);
                        },
-                       [=](DlCanvas*, DlPaint& p) {
-                         p.setColor(DlColor::kYellow());
-                         p.setColorFilter(&dl_color_filter);
+                       [=](const DlSetupContext& ctx) {
+                         ctx.paint.setColor(DlColor::kYellow());
+                         ctx.paint.setColorFilter(&dl_color_filter);
                        })
                        .with_bg(bg));
       }
       {
         DlColor bg = DlColor::kWhite();
-        RenderWith(
-            testP, env, tolerance,
-            CaseParameters(
-                "ColorFilter == Invert",
-                [=](SkCanvas*, SkPaint& p) {
-                  p.setColor(DlColor::kYellow());
-                  p.setColorFilter(SkColorFilters::Matrix(invert_color_matrix));
-                },
-                [=](DlCanvas*, DlPaint& p) {
-                  p.setColor(DlColor::kYellow());
-                  p.setInvertColors(true);
-                })
-                .with_bg(bg));
+        RenderWith(testP, env, tolerance,
+                   CaseParameters(
+                       "ColorFilter == Invert",
+                       [=](const SkSetupContext& ctx) {
+                         ctx.paint.setColor(DlColor::kYellow());
+                         ctx.paint.setColorFilter(
+                             SkColorFilters::Matrix(invert_color_matrix));
+                       },
+                       [=](const DlSetupContext& ctx) {
+                         ctx.paint.setColor(DlColor::kYellow());
+                         ctx.paint.setInvertColors(true);
+                       })
+                       .with_bg(bg));
       }
     }
 
@@ -1524,13 +1713,13 @@ class CanvasCompareTester {
         RenderWith(testP, env, blur_5_tolerance,
                    CaseParameters(
                        "MaskFilter == Blur 5",
-                       [=](SkCanvas*, SkPaint& p) {
-                         p.setStrokeWidth(5.0);
-                         p.setMaskFilter(sk_mask_filter);
+                       [=](const SkSetupContext& ctx) {
+                         ctx.paint.setStrokeWidth(5.0);
+                         ctx.paint.setMaskFilter(sk_mask_filter);
                        },
-                       [=](DlCanvas*, DlPaint& p) {
-                         p.setStrokeWidth(5.0);
-                         p.setMaskFilter(&dl_mask_filter);
+                       [=](const DlSetupContext& ctx) {
+                         ctx.paint.setStrokeWidth(5.0);
+                         ctx.paint.setMaskFilter(&dl_mask_filter);
                        }));
       }
     }
@@ -1561,12 +1750,15 @@ class CanvasCompareTester {
       auto sk_gradient = SkGradientShader::MakeLinear(
           end_points, sk_colors, stops, 3, SkTileMode::kMirror, 0, nullptr);
       {
-        RenderWith(
-            testP, env, tolerance,
-            CaseParameters(
-                "LinearGradient GYB",
-                [=](SkCanvas*, SkPaint& p) { p.setShader(sk_gradient); },
-                [=](DlCanvas*, DlPaint& p) { p.setColorSource(dl_gradient); }));
+        RenderWith(testP, env, tolerance,
+                   CaseParameters(
+                       "LinearGradient GYB",
+                       [=](const SkSetupContext& ctx) {
+                         ctx.paint.setShader(sk_gradient);
+                       },
+                       [=](const DlSetupContext& ctx) {
+                         ctx.paint.setColorSource(dl_gradient);
+                       }));
       }
     }
   }
@@ -1582,11 +1774,11 @@ class CanvasCompareTester {
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "Fill",
-                   [=](SkCanvas*, SkPaint& p) {  //
-                     p.setStyle(SkPaint::kFill_Style);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kFill_Style);
                    },
-                   [=](DlCanvas*, DlPaint& p) {  //
-                     p.setDrawStyle(DlDrawStyle::kFill);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kFill);
                    }));
     // Skia on HW produces a strong miter consistent with width=1.0
     // for any width less than a pixel, but the bounds computations of
@@ -1600,40 +1792,40 @@ class CanvasCompareTester {
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "Stroke + defaults",
-                   [=](SkCanvas*, SkPaint& p) {  //
+                   [=](const SkSetupContext& ctx) {
                      if (no_hairlines) {
-                       p.setStrokeWidth(1.0);
+                       ctx.paint.setStrokeWidth(1.0);
                      }
-                     p.setStyle(SkPaint::kStroke_Style);
+                     ctx.paint.setStyle(SkPaint::kStroke_Style);
                    },
-                   [=](DlCanvas*, DlPaint& p) {  //
+                   [=](const DlSetupContext& ctx) {
                      if (no_hairlines) {
-                       p.setStrokeWidth(1.0);
+                       ctx.paint.setStrokeWidth(1.0);
                      }
-                     p.setDrawStyle(DlDrawStyle::kStroke);
+                     ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
                    }));
 
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "Fill + unnecessary StrokeWidth 10",
-                   [=](SkCanvas*, SkPaint& p) {
-                     p.setStyle(SkPaint::kFill_Style);
-                     p.setStrokeWidth(10.0);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kFill_Style);
+                     ctx.paint.setStrokeWidth(10.0);
                    },
-                   [=](DlCanvas*, DlPaint& p) {
-                     p.setDrawStyle(DlDrawStyle::kFill);
-                     p.setStrokeWidth(10.0);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kFill);
+                     ctx.paint.setStrokeWidth(10.0);
                    }));
 
     RenderEnvironment stroke_base_env =
         RenderEnvironment::MakeN32(env.provider());
-    SkSetup sk_stroke_setup = [=](SkCanvas*, SkPaint& p) {
-      p.setStyle(SkPaint::kStroke_Style);
-      p.setStrokeWidth(5.0);
+    SkSetup sk_stroke_setup = [=](const SkSetupContext& ctx) {
+      ctx.paint.setStyle(SkPaint::kStroke_Style);
+      ctx.paint.setStrokeWidth(5.0);
     };
-    DlSetup dl_stroke_setup = [=](DlCanvas*, DlPaint& p) {
-      p.setDrawStyle(DlDrawStyle::kStroke);
-      p.setStrokeWidth(5.0);
+    DlSetup dl_stroke_setup = [=](const DlSetupContext& ctx) {
+      ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
+      ctx.paint.setStrokeWidth(5.0);
     };
     stroke_base_env.init_ref(sk_stroke_setup, testP.sk_renderer(),
                              dl_stroke_setup, testP.dl_renderer());
@@ -1642,110 +1834,110 @@ class CanvasCompareTester {
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
                    "Stroke Width 10",
-                   [=](SkCanvas*, SkPaint& p) {
-                     p.setStyle(SkPaint::kStroke_Style);
-                     p.setStrokeWidth(10.0);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kStroke_Style);
+                     ctx.paint.setStrokeWidth(10.0);
                    },
-                   [=](DlCanvas*, DlPaint& p) {
-                     p.setDrawStyle(DlDrawStyle::kStroke);
-                     p.setStrokeWidth(10.0);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
+                     ctx.paint.setStrokeWidth(10.0);
                    }));
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
                    "Stroke Width 5",
-                   [=](SkCanvas*, SkPaint& p) {
-                     p.setStyle(SkPaint::kStroke_Style);
-                     p.setStrokeWidth(5.0);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kStroke_Style);
+                     ctx.paint.setStrokeWidth(5.0);
                    },
-                   [=](DlCanvas*, DlPaint& p) {
-                     p.setDrawStyle(DlDrawStyle::kStroke);
-                     p.setStrokeWidth(5.0);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
+                     ctx.paint.setStrokeWidth(5.0);
                    }));
 
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
                    "Stroke Width 5, Square Cap",
-                   [=](SkCanvas*, SkPaint& p) {
-                     p.setStyle(SkPaint::kStroke_Style);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeCap(SkPaint::kSquare_Cap);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kStroke_Style);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeCap(SkPaint::kSquare_Cap);
                    },
-                   [=](DlCanvas*, DlPaint& p) {
-                     p.setDrawStyle(DlDrawStyle::kStroke);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeCap(DlStrokeCap::kSquare);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeCap(DlStrokeCap::kSquare);
                    }));
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
                    "Stroke Width 5, Round Cap",
-                   [=](SkCanvas*, SkPaint& p) {
-                     p.setStyle(SkPaint::kStroke_Style);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeCap(SkPaint::kRound_Cap);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kStroke_Style);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeCap(SkPaint::kRound_Cap);
                    },
-                   [=](DlCanvas*, DlPaint& p) {
-                     p.setDrawStyle(DlDrawStyle::kStroke);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeCap(DlStrokeCap::kRound);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeCap(DlStrokeCap::kRound);
                    }));
 
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
                    "Stroke Width 5, Bevel Join",
-                   [=](SkCanvas*, SkPaint& p) {
-                     p.setStyle(SkPaint::kStroke_Style);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeJoin(SkPaint::kBevel_Join);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kStroke_Style);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeJoin(SkPaint::kBevel_Join);
                    },
-                   [=](DlCanvas*, DlPaint& p) {
-                     p.setDrawStyle(DlDrawStyle::kStroke);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeJoin(DlStrokeJoin::kBevel);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeJoin(DlStrokeJoin::kBevel);
                    }));
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
                    "Stroke Width 5, Round Join",
-                   [=](SkCanvas*, SkPaint& p) {
-                     p.setStyle(SkPaint::kStroke_Style);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeJoin(SkPaint::kRound_Join);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kStroke_Style);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeJoin(SkPaint::kRound_Join);
                    },
-                   [=](DlCanvas*, DlPaint& p) {
-                     p.setDrawStyle(DlDrawStyle::kStroke);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeJoin(DlStrokeJoin::kRound);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeJoin(DlStrokeJoin::kRound);
                    }));
 
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
                    "Stroke Width 5, Miter 10",
-                   [=](SkCanvas*, SkPaint& p) {
-                     p.setStyle(SkPaint::kStroke_Style);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeMiter(10.0);
-                     p.setStrokeJoin(SkPaint::kMiter_Join);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kStroke_Style);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeMiter(10.0);
+                     ctx.paint.setStrokeJoin(SkPaint::kMiter_Join);
                    },
-                   [=](DlCanvas*, DlPaint& p) {
-                     p.setDrawStyle(DlDrawStyle::kStroke);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeMiter(10.0);
-                     p.setStrokeJoin(DlStrokeJoin::kMiter);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeMiter(10.0);
+                     ctx.paint.setStrokeJoin(DlStrokeJoin::kMiter);
                    }));
 
     RenderWith(testP, stroke_base_env, tolerance,
                CaseParameters(
                    "Stroke Width 5, Miter 0",
-                   [=](SkCanvas*, SkPaint& p) {
-                     p.setStyle(SkPaint::kStroke_Style);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeMiter(0.0);
-                     p.setStrokeJoin(SkPaint::kMiter_Join);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.paint.setStyle(SkPaint::kStroke_Style);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeMiter(0.0);
+                     ctx.paint.setStrokeJoin(SkPaint::kMiter_Join);
                    },
-                   [=](DlCanvas*, DlPaint& p) {
-                     p.setDrawStyle(DlDrawStyle::kStroke);
-                     p.setStrokeWidth(5.0);
-                     p.setStrokeMiter(0.0);
-                     p.setStrokeJoin(DlStrokeJoin::kMiter);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
+                     ctx.paint.setStrokeWidth(5.0);
+                     ctx.paint.setStrokeMiter(0.0);
+                     ctx.paint.setStrokeJoin(DlStrokeJoin::kMiter);
                    }));
 
     {
@@ -1757,34 +1949,34 @@ class CanvasCompareTester {
         RenderWith(testP, stroke_base_env, tolerance,
                    CaseParameters(
                        "PathEffect without forced stroking == Dash-29-2",
-                       [=](SkCanvas*, SkPaint& p) {
+                       [=](const SkSetupContext& ctx) {
                          // Provide some non-trivial stroke size to get dashed
-                         p.setStrokeWidth(5.0);
-                         p.setPathEffect(sk_dash_effect);
+                         ctx.paint.setStrokeWidth(5.0);
+                         ctx.paint.setPathEffect(sk_dash_effect);
                        },
-                       [=](DlCanvas*, DlPaint& p) {
+                       [=](const DlSetupContext& ctx) {
                          // Provide some non-trivial stroke size to get dashed
-                         p.setStrokeWidth(5.0);
-                         p.setPathEffect(dl_dash_effect);
+                         ctx.paint.setStrokeWidth(5.0);
+                         ctx.paint.setPathEffect(dl_dash_effect);
                        }));
       }
       {
         RenderWith(testP, stroke_base_env, tolerance,
                    CaseParameters(
                        "PathEffect == Dash-29-2",
-                       [=](SkCanvas*, SkPaint& p) {
+                       [=](const SkSetupContext& ctx) {
                          // Need stroke style to see dashing properly
-                         p.setStyle(SkPaint::kStroke_Style);
+                         ctx.paint.setStyle(SkPaint::kStroke_Style);
                          // Provide some non-trivial stroke size to get dashed
-                         p.setStrokeWidth(5.0);
-                         p.setPathEffect(sk_dash_effect);
+                         ctx.paint.setStrokeWidth(5.0);
+                         ctx.paint.setPathEffect(sk_dash_effect);
                        },
-                       [=](DlCanvas*, DlPaint& p) {
+                       [=](const DlSetupContext& ctx) {
                          // Need stroke style to see dashing properly
-                         p.setDrawStyle(DlDrawStyle::kStroke);
+                         ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
                          // Provide some non-trivial stroke size to get dashed
-                         p.setStrokeWidth(5.0);
-                         p.setPathEffect(dl_dash_effect);
+                         ctx.paint.setStrokeWidth(5.0);
+                         ctx.paint.setPathEffect(dl_dash_effect);
                        }));
       }
       dl_dash_effect = DlDashPathEffect::Make(test_dashes_2, 2, 0.0f);
@@ -1793,19 +1985,19 @@ class CanvasCompareTester {
         RenderWith(testP, stroke_base_env, tolerance,
                    CaseParameters(
                        "PathEffect == Dash-17-1.5",
-                       [=](SkCanvas*, SkPaint& p) {
+                       [=](const SkSetupContext& ctx) {
                          // Need stroke style to see dashing properly
-                         p.setStyle(SkPaint::kStroke_Style);
+                         ctx.paint.setStyle(SkPaint::kStroke_Style);
                          // Provide some non-trivial stroke size to get dashed
-                         p.setStrokeWidth(5.0);
-                         p.setPathEffect(sk_dash_effect);
+                         ctx.paint.setStrokeWidth(5.0);
+                         ctx.paint.setPathEffect(sk_dash_effect);
                        },
-                       [=](DlCanvas*, DlPaint& p) {
+                       [=](const DlSetupContext& ctx) {
                          // Need stroke style to see dashing properly
-                         p.setDrawStyle(DlDrawStyle::kStroke);
+                         ctx.paint.setDrawStyle(DlDrawStyle::kStroke);
                          // Provide some non-trivial stroke size to get dashed
-                         p.setStrokeWidth(5.0);
-                         p.setPathEffect(dl_dash_effect);
+                         ctx.paint.setStrokeWidth(5.0);
+                         ctx.paint.setPathEffect(dl_dash_effect);
                        }));
       }
     }
@@ -1818,26 +2010,30 @@ class CanvasCompareTester {
     // bounds, then the estimate under rotation or skewing will be off
     // so we scale the padding by about 5% to compensate.
     BoundsTolerance skewed_tolerance = tolerance.mulScale(1.05, 1.05);
-    RenderWith(testP, env, tolerance,
-               CaseParameters(
-                   "Translate 5, 10",  //
-                   [=](SkCanvas* c, SkPaint&) { c->translate(5, 10); },
-                   [=](DlCanvas* c, DlPaint&) { c->Translate(5, 10); }));
-    RenderWith(testP, env, tolerance,
-               CaseParameters(
-                   "Scale +5%",  //
-                   [=](SkCanvas* c, SkPaint&) { c->scale(1.05, 1.05); },
-                   [=](DlCanvas* c, DlPaint&) { c->Scale(1.05, 1.05); }));
-    RenderWith(testP, env, skewed_tolerance,
-               CaseParameters(
-                   "Rotate 5 degrees",  //
-                   [=](SkCanvas* c, SkPaint&) { c->rotate(5); },
-                   [=](DlCanvas* c, DlPaint&) { c->Rotate(5); }));
-    RenderWith(testP, env, skewed_tolerance,
-               CaseParameters(
-                   "Skew 5%",  //
-                   [=](SkCanvas* c, SkPaint&) { c->skew(0.05, 0.05); },
-                   [=](DlCanvas* c, DlPaint&) { c->Skew(0.05, 0.05); }));
+    RenderWith(  //
+        testP, env, tolerance,
+        CaseParameters(
+            "Translate 5, 10",  //
+            [=](const SkSetupContext& ctx) { ctx.canvas->translate(5, 10); },
+            [=](const DlSetupContext& ctx) { ctx.canvas->Translate(5, 10); }));
+    RenderWith(  //
+        testP, env, tolerance,
+        CaseParameters(
+            "Scale +5%",  //
+            [=](const SkSetupContext& ctx) { ctx.canvas->scale(1.05, 1.05); },
+            [=](const DlSetupContext& ctx) { ctx.canvas->Scale(1.05, 1.05); }));
+    RenderWith(  //
+        testP, env, skewed_tolerance,
+        CaseParameters(
+            "Rotate 5 degrees",  //
+            [=](const SkSetupContext& ctx) { ctx.canvas->rotate(5); },
+            [=](const DlSetupContext& ctx) { ctx.canvas->Rotate(5); }));
+    RenderWith(  //
+        testP, env, skewed_tolerance,
+        CaseParameters(
+            "Skew 5%",  //
+            [=](const SkSetupContext& ctx) { ctx.canvas->skew(0.05, 0.05); },
+            [=](const DlSetupContext& ctx) { ctx.canvas->Skew(0.05, 0.05); }));
     {
       // This rather odd transform can cause slight differences in
       // computing in-bounds samples depending on which base rendering
@@ -1850,11 +2046,12 @@ class CanvasCompareTester {
       SkMatrix tx = SkMatrix::MakeAll(1.0 + tweak, tweak, 5,   //
                                       tweak, 1.0 + tweak, 10,  //
                                       0, 0, 1);
-      RenderWith(testP, env, skewed_tolerance,
-                 CaseParameters(
-                     "Transform 2D Affine",
-                     [=](SkCanvas* c, SkPaint&) { c->concat(tx); },
-                     [=](DlCanvas* c, DlPaint&) { c->Transform(tx); }));
+      RenderWith(  //
+          testP, env, skewed_tolerance,
+          CaseParameters(
+              "Transform 2D Affine",
+              [=](const SkSetupContext& ctx) { ctx.canvas->concat(tx); },
+              [=](const DlSetupContext& ctx) { ctx.canvas->Transform(tx); }));
     }
     {
       SkM44 m44 = SkM44(1, 0, 0, kRenderCenterX,  //
@@ -1866,11 +2063,12 @@ class CanvasCompareTester {
       m44.preConcat(
           SkM44::Rotate({0, 1, 0}, math::kPi / 45));  // 4 degrees around Y
       m44.preTranslate(-kRenderCenterX, -kRenderCenterY);
-      RenderWith(testP, env, skewed_tolerance,
-                 CaseParameters(
-                     "Transform Full Perspective",
-                     [=](SkCanvas* c, SkPaint&) { c->concat(m44); },
-                     [=](DlCanvas* c, DlPaint&) { c->Transform(m44); }));
+      RenderWith(  //
+          testP, env, skewed_tolerance,
+          CaseParameters(
+              "Transform Full Perspective",
+              [=](const SkSetupContext& ctx) { ctx.canvas->concat(m44); },
+              [=](const DlSetupContext& ctx) { ctx.canvas->Transform(m44); }));
     }
   }
 
@@ -1891,29 +2089,29 @@ class CanvasCompareTester {
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
                    "Hard ClipRect inset by 15.4",
-                   [=](SkCanvas* c, SkPaint&) {
-                     c->clipRect(r_clip, SkClipOp::kIntersect, false);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->clipRect(r_clip, SkClipOp::kIntersect, false);
                    },
-                   [=](DlCanvas* c, DlPaint&) {
-                     c->ClipRect(r_clip, ClipOp::kIntersect, false);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->ClipRect(r_clip, ClipOp::kIntersect, false);
                    }));
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
                    "AntiAlias ClipRect inset by 15.4",
-                   [=](SkCanvas* c, SkPaint&) {
-                     c->clipRect(r_clip, SkClipOp::kIntersect, true);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->clipRect(r_clip, SkClipOp::kIntersect, true);
                    },
-                   [=](DlCanvas* c, DlPaint&) {
-                     c->ClipRect(r_clip, ClipOp::kIntersect, true);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->ClipRect(r_clip, ClipOp::kIntersect, true);
                    }));
     RenderWith(testP, env, diff_tolerance,
                CaseParameters(
                    "Hard ClipRect Diff, inset by 15.4",
-                   [=](SkCanvas* c, SkPaint&) {
-                     c->clipRect(r_clip, SkClipOp::kDifference, false);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->clipRect(r_clip, SkClipOp::kDifference, false);
                    },
-                   [=](DlCanvas* c, DlPaint&) {
-                     c->ClipRect(r_clip, ClipOp::kDifference, false);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->ClipRect(r_clip, ClipOp::kDifference, false);
                    })
                    .with_diff_clip());
     // This test RR clip used to use very small radii, but due to
@@ -1925,29 +2123,31 @@ class CanvasCompareTester {
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
                    "Hard ClipRRect with radius of 15.4",
-                   [=](SkCanvas* c, SkPaint&) {
-                     c->clipRRect(rr_clip, SkClipOp::kIntersect, false);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->clipRRect(rr_clip, SkClipOp::kIntersect,
+                                           false);
                    },
-                   [=](DlCanvas* c, DlPaint&) {
-                     c->ClipRRect(rr_clip, ClipOp::kIntersect, false);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->ClipRRect(rr_clip, ClipOp::kIntersect, false);
                    }));
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
                    "AntiAlias ClipRRect with radius of 15.4",
-                   [=](SkCanvas* c, SkPaint&) {
-                     c->clipRRect(rr_clip, SkClipOp::kIntersect, true);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->clipRRect(rr_clip, SkClipOp::kIntersect, true);
                    },
-                   [=](DlCanvas* c, DlPaint&) {
-                     c->ClipRRect(rr_clip, ClipOp::kIntersect, true);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->ClipRRect(rr_clip, ClipOp::kIntersect, true);
                    }));
     RenderWith(testP, env, diff_tolerance,
                CaseParameters(
                    "Hard ClipRRect Diff, with radius of 15.4",
-                   [=](SkCanvas* c, SkPaint&) {
-                     c->clipRRect(rr_clip, SkClipOp::kDifference, false);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->clipRRect(rr_clip, SkClipOp::kDifference,
+                                           false);
                    },
-                   [=](DlCanvas* c, DlPaint&) {
-                     c->ClipRRect(rr_clip, ClipOp::kDifference, false);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->ClipRRect(rr_clip, ClipOp::kDifference, false);
                    })
                    .with_diff_clip());
     SkPath path_clip = SkPath();
@@ -1957,38 +2157,52 @@ class CanvasCompareTester {
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
                    "Hard ClipPath inset by 15.4",
-                   [=](SkCanvas* c, SkPaint&) {
-                     c->clipPath(path_clip, SkClipOp::kIntersect, false);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->clipPath(path_clip, SkClipOp::kIntersect,
+                                          false);
                    },
-                   [=](DlCanvas* c, DlPaint&) {
-                     c->ClipPath(path_clip, ClipOp::kIntersect, false);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->ClipPath(path_clip, ClipOp::kIntersect, false);
                    }));
     RenderWith(testP, env, intersect_tolerance,
                CaseParameters(
                    "AntiAlias ClipPath inset by 15.4",
-                   [=](SkCanvas* c, SkPaint&) {
-                     c->clipPath(path_clip, SkClipOp::kIntersect, true);
+                   [=](const SkSetupContext& ctx) {
+                     ctx.canvas->clipPath(path_clip, SkClipOp::kIntersect,
+                                          true);
                    },
-                   [=](DlCanvas* c, DlPaint&) {
-                     c->ClipPath(path_clip, ClipOp::kIntersect, true);
+                   [=](const DlSetupContext& ctx) {
+                     ctx.canvas->ClipPath(path_clip, ClipOp::kIntersect, true);
                    }));
-    RenderWith(testP, env, diff_tolerance,
-               CaseParameters(
-                   "Hard ClipPath Diff, inset by 15.4",
-                   [=](SkCanvas* c, SkPaint&) {
-                     c->clipPath(path_clip, SkClipOp::kDifference, false);
-                   },
-                   [=](DlCanvas* c, DlPaint&) {
-                     c->ClipPath(path_clip, ClipOp::kDifference, false);
-                   })
-                   .with_diff_clip());
+    RenderWith(
+        testP, env, diff_tolerance,
+        CaseParameters(
+            "Hard ClipPath Diff, inset by 15.4",
+            [=](const SkSetupContext& ctx) {
+              ctx.canvas->clipPath(path_clip, SkClipOp::kDifference, false);
+            },
+            [=](const DlSetupContext& ctx) {
+              ctx.canvas->ClipPath(path_clip, ClipOp::kDifference, false);
+            })
+            .with_diff_clip());
+  }
+
+  static std::string to_png_filename(const std::string& desc) {
+    std::string ret = "";
+    for (const char& ch : desc) {
+      ret += (ch == ':' || ch == ' ') ? '_' : ch;
+    }
+    return ret + ".png";
   }
 
   static void RenderWith(const TestParameters& testP,
                          const RenderEnvironment& env,
                          const BoundsTolerance& tolerance_in,
                          const CaseParameters& caseP) {
-    const std::string info = env.backend_name() + ": " + caseP.info();
+    std::string test_name =
+        ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    const std::string info =
+        env.backend_name() + ": " + test_name + " (" + caseP.info() + ")";
     const DlColor bg = caseP.bg();
     RenderJobInfo base_info = {
         .bg = bg,
@@ -1999,12 +2213,14 @@ class CanvasCompareTester {
     // SkPaint sk_paint;
     SkJobRenderer sk_job(caseP.sk_setup(),     //
                          testP.sk_renderer(),  //
-                         caseP.sk_restore());
+                         caseP.sk_restore(),   //
+                         env.sk_image());
     auto sk_result = env.getResult(base_info, sk_job);
 
     DlJobRenderer dl_job(caseP.dl_setup(),     //
                          testP.dl_renderer(),  //
-                         caseP.dl_restore());
+                         caseP.dl_restore(),   //
+                         env.dl_image());
     auto dl_result = env.getResult(base_info, dl_job);
 
     EXPECT_EQ(sk_job.setup_matrix(), dl_job.setup_matrix());
@@ -2022,12 +2238,45 @@ class CanvasCompareTester {
     SkRect sk_bounds = sk_picture->cullRect();
     checkPixels(sk_result.get(), sk_bounds, info + " (Skia reference)", bg);
 
-    if (testP.should_match(env, caseP, dl_job.setup_paint(), dl_job)) {
+    bool should_match =
+        testP.should_match(env, caseP, dl_job.setup_paint(), dl_job);
+    if (should_match) {
       quickCompareToReference(env.ref_sk_result(), sk_result.get(), true,
                               info + " (attribute has no effect)");
     } else {
       quickCompareToReference(env.ref_sk_result(), sk_result.get(), false,
                               info + " (attribute affects rendering)");
+    }
+
+    if (env.supports_impeller()) {
+      DlJobRenderer imp_job(caseP.dl_setup(),     //
+                            testP.dl_renderer(),  //
+                            caseP.dl_restore(),   //
+                            env.impeller_image());
+      auto imp_result = env.getImpellerResult(base_info, imp_job);
+      std::string imp_info = info + " (Impeller reference)";
+      if (!checkPixels(imp_result.get(), imp_result->render_bounds(), imp_info,
+                       bg)) {
+        FML_LOG(ERROR) << "Skia bounds: "           //
+                       << sk_bounds.fLeft << ", "   //
+                       << sk_bounds.fTop << " => "  //
+                       << sk_bounds.fRight << ", "  //
+                       << sk_bounds.fBottom;
+        FML_LOG(ERROR) << "impeller dl bounds: "                      //
+                       << imp_result->render_bounds().fLeft << ", "   //
+                       << imp_result->render_bounds().fTop << " => "  //
+                       << imp_result->render_bounds().fRight << ", "  //
+                       << imp_result->render_bounds().fBottom;
+        imp_result->write(to_png_filename(imp_info));
+      }
+      if (should_match) {
+        quickCompareToReference(env.ref_impeller_result(), imp_result.get(),
+                                true, imp_info + " (attribute has no effect)");
+      } else {
+        quickCompareToReference(env.ref_impeller_result(), imp_result.get(),
+                                false,
+                                imp_info + " (attribute affects rendering)");
+      }
     }
 
     quickCompareToReference(sk_result.get(), dl_result.get(), true,
@@ -2211,14 +2460,16 @@ class CanvasCompareTester {
     ASSERT_LE(pixels_different, 1) << info;
   }
 
-  static void checkPixels(const RenderResult* ref_result,
+  static bool checkPixels(const RenderResult* ref_result,
                           const SkRect ref_bounds,
                           const std::string& info,
-                          const DlColor bg) {
+                          const DlColor bg = DlColor::kTransparent()) {
     uint32_t untouched = bg.premultipliedArgb();
     int pixels_touched = 0;
     int pixels_oob = 0;
     SkIRect i_bounds = ref_bounds.roundOut();
+    EXPECT_EQ(ref_result->width(), kTestWidth) << info;
+    EXPECT_EQ(ref_result->height(), kTestWidth) << info;
     for (int y = 0; y < kTestHeight; y++) {
       const uint32_t* ref_row = ref_result->addr32(0, y);
       for (int x = 0; x < kTestWidth; x++) {
@@ -2230,8 +2481,9 @@ class CanvasCompareTester {
         }
       }
     }
-    ASSERT_EQ(pixels_oob, 0) << info;
-    ASSERT_GT(pixels_touched, 0) << info;
+    EXPECT_EQ(pixels_oob, 0) << info;
+    EXPECT_GT(pixels_touched, 0) << info;
+    return pixels_oob == 0 && pixels_touched > 0;
   }
 
   static int countModifiedTransparentPixels(const RenderResult* ref_result,
@@ -2398,31 +2650,6 @@ class CanvasCompareTester {
     }
   }
 
-  static const sk_sp<SkImage> kTestImage;
-  static const sk_sp<SkImage> makeTestImage() {
-    sk_sp<SkSurface> surface = SkSurfaces::Raster(
-        SkImageInfo::MakeN32Premul(kRenderWidth, kRenderHeight));
-    SkCanvas* canvas = surface->getCanvas();
-    SkPaint p0, p1;
-    p0.setStyle(SkPaint::kFill_Style);
-    p0.setColor(SkColorSetARGB(0xff, 0x00, 0xfe, 0x00));  // off-green
-    p1.setStyle(SkPaint::kFill_Style);
-    p1.setColor(SK_ColorBLUE);
-    // Some pixels need some transparency for DstIn testing
-    p1.setAlpha(128);
-    int cbdim = 5;
-    for (int y = 0; y < kRenderHeight; y += cbdim) {
-      for (int x = 0; x < kRenderWidth; x += cbdim) {
-        SkPaint& cellp = ((x + y) & 1) == 0 ? p0 : p1;
-        canvas->drawRect(SkRect::MakeXYWH(x, y, cbdim, cbdim), cellp);
-      }
-    }
-    return surface->makeImageSnapshot();
-  }
-
-  static const DlImageColorSource kTestDlImageColorSource;
-  static const sk_sp<SkShader> kTestSkImageColorSource;
-
   static sk_sp<SkTextBlob> MakeTextBlob(const std::string& string,
                                         SkScalar font_height) {
     SkFont font(SkTypeface::MakeFromName("ahem", SkFontStyle::Normal()),
@@ -2438,24 +2665,14 @@ std::vector<std::unique_ptr<DlSurfaceProvider>>
 BoundsTolerance CanvasCompareTester::DefaultTolerance =
     BoundsTolerance().addAbsolutePadding(1, 1);
 
-const sk_sp<SkImage> CanvasCompareTester::kTestImage = makeTestImage();
-const DlImageColorSource CanvasCompareTester::kTestDlImageColorSource(
-    DlImage::Make(kTestImage),
-    DlTileMode::kRepeat,
-    DlTileMode::kRepeat,
-    DlImageSampling::kLinear);
-const sk_sp<SkShader> CanvasCompareTester::kTestSkImageColorSource =
-    kTestImage->makeShader(SkTileMode::kRepeat,
-                           SkTileMode::kRepeat,
-                           SkImageSampling::kLinear);
-
 // Eventually this bare bones testing::Test fixture will subsume the
 // CanvasCompareTester and the TestParameters could then become just
 // configuration calls made upon the fixture.
 template <typename BaseT>
-class DisplayListCanvasTestBase : public BaseT, protected DisplayListOpFlags {
+class DisplayListRenderingTestBase : public BaseT,
+                                     protected DisplayListOpFlags {
  public:
-  DisplayListCanvasTestBase() = default;
+  DisplayListRenderingTestBase() = default;
 
   static bool StartsWith(std::string str, std::string prefix) {
     if (prefix.length() > str.length()) {
@@ -2525,60 +2742,61 @@ class DisplayListCanvasTestBase : public BaseT, protected DisplayListOpFlags {
   }
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(DisplayListCanvasTestBase);
+  FML_DISALLOW_COPY_AND_ASSIGN(DisplayListRenderingTestBase);
 };
-using DisplayListCanvas = DisplayListCanvasTestBase<::testing::Test>;
+using DisplayListRendering = DisplayListRenderingTestBase<::testing::Test>;
 
-TEST_F(DisplayListCanvas, DrawPaint) {
+TEST_F(DisplayListRendering, DrawPaint) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawPaint(paint);
+          [=](const SkRenderContext& ctx) {  //
+            ctx.canvas->drawPaint(ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawPaint(paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawPaint(ctx.paint);
           },
           kDrawPaintFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawOpaqueColor) {
+TEST_F(DisplayListRendering, DrawOpaqueColor) {
   // We use a non-opaque color to avoid obliterating any backdrop filter output
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {
+          [=](const SkRenderContext& ctx) {
             // DrawColor is not tested against attributes because it is supposed
             // to ignore them. So, if the paint has an alpha, it is because we
             // are doing a saveLayer+backdrop test and we need to not flood over
             // the backdrop output with a solid color. So, we perform an alpha
             // drawColor for that case only.
-            SkColor color = SkColorSetA(SK_ColorMAGENTA, paint.getAlpha());
-            canvas->drawColor(color);
+            SkColor color = SkColorSetA(SK_ColorMAGENTA, ctx.paint.getAlpha());
+            ctx.canvas->drawColor(color);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
+          [=](const DlRenderContext& ctx) {
             // DrawColor is not tested against attributes because it is supposed
             // to ignore them. So, if the paint has an alpha, it is because we
             // are doing a saveLayer+backdrop test and we need to not flood over
             // the backdrop output with a solid color. So, we transfer the alpha
             // from the paint for that case only.
-            canvas->DrawColor(DlColor::kMagenta().withAlpha(paint.getAlpha()));
+            ctx.canvas->DrawColor(
+                DlColor::kMagenta().withAlpha(ctx.paint.getAlpha()));
           },
           kDrawColorFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawAlphaColor) {
+TEST_F(DisplayListRendering, DrawAlphaColor) {
   // We use a non-opaque color to avoid obliterating any backdrop filter output
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawColor(0x7FFF00FF);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawColor(0x7FFF00FF);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawColor(DlColor::kMagenta().withAlpha(0x7f));
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawColor(0x7FFF00FF);
           },
           kDrawColorFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawDiagonalLines) {
+TEST_F(DisplayListRendering, DrawDiagonalLines) {
   SkPoint p1 = SkPoint::Make(kRenderLeft, kRenderTop);
   SkPoint p2 = SkPoint::Make(kRenderRight, kRenderBottom);
   SkPoint p3 = SkPoint::Make(kRenderLeft, kRenderBottom);
@@ -2592,125 +2810,125 @@ TEST_F(DisplayListCanvas, DrawDiagonalLines) {
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
+          [=](const SkRenderContext& ctx) {  //
             // Skia requires kStroke style on horizontal and vertical
             // lines to get the bounds correct.
             // See https://bugs.chromium.org/p/skia/issues/detail?id=12446
-            SkPaint p = paint;
+            SkPaint p = ctx.paint;
             p.setStyle(SkPaint::kStroke_Style);
-            canvas->drawLine(p1, p2, p);
-            canvas->drawLine(p3, p4, p);
-            canvas->drawLine(p5, p6, p);
-            canvas->drawLine(p7, p8, p);
+            ctx.canvas->drawLine(p1, p2, p);
+            ctx.canvas->drawLine(p3, p4, p);
+            ctx.canvas->drawLine(p5, p6, p);
+            ctx.canvas->drawLine(p7, p8, p);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawLine(p1, p2, paint);
-            canvas->DrawLine(p3, p4, paint);
-            canvas->DrawLine(p5, p6, paint);
-            canvas->DrawLine(p7, p8, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawLine(p1, p2, ctx.paint);
+            ctx.canvas->DrawLine(p3, p4, ctx.paint);
+            ctx.canvas->DrawLine(p5, p6, ctx.paint);
+            ctx.canvas->DrawLine(p7, p8, ctx.paint);
           },
           kDrawLineFlags)
           .set_draw_line());
 }
 
-TEST_F(DisplayListCanvas, DrawHorizontalLine) {
+TEST_F(DisplayListRendering, DrawHorizontalLine) {
   SkPoint p1 = SkPoint::Make(kRenderLeft, kRenderCenterY);
   SkPoint p2 = SkPoint::Make(kRenderRight, kRenderCenterY);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
+          [=](const SkRenderContext& ctx) {  //
             // Skia requires kStroke style on horizontal and vertical
             // lines to get the bounds correct.
             // See https://bugs.chromium.org/p/skia/issues/detail?id=12446
-            SkPaint p = paint;
+            SkPaint p = ctx.paint;
             p.setStyle(SkPaint::kStroke_Style);
-            canvas->drawLine(p1, p2, p);
+            ctx.canvas->drawLine(p1, p2, p);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawLine(p1, p2, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawLine(p1, p2, ctx.paint);
           },
           kDrawHVLineFlags)
           .set_draw_line()
           .set_horizontal_line());
 }
 
-TEST_F(DisplayListCanvas, DrawVerticalLine) {
+TEST_F(DisplayListRendering, DrawVerticalLine) {
   SkPoint p1 = SkPoint::Make(kRenderCenterX, kRenderTop);
   SkPoint p2 = SkPoint::Make(kRenderCenterY, kRenderBottom);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
+          [=](const SkRenderContext& ctx) {  //
             // Skia requires kStroke style on horizontal and vertical
             // lines to get the bounds correct.
             // See https://bugs.chromium.org/p/skia/issues/detail?id=12446
-            SkPaint p = paint;
+            SkPaint p = ctx.paint;
             p.setStyle(SkPaint::kStroke_Style);
-            canvas->drawLine(p1, p2, p);
+            ctx.canvas->drawLine(p1, p2, p);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawLine(p1, p2, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawLine(p1, p2, ctx.paint);
           },
           kDrawHVLineFlags)
           .set_draw_line()
           .set_vertical_line());
 }
 
-TEST_F(DisplayListCanvas, DrawRect) {
+TEST_F(DisplayListRendering, DrawRect) {
   // Bounds are offset by 0.5 pixels to induce AA
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawRect(kRenderBounds.makeOffset(0.5, 0.5), paint);
+          [=](const SkRenderContext& ctx) {  //
+            ctx.canvas->drawRect(kRenderBounds.makeOffset(0.5, 0.5), ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawRect(kRenderBounds.makeOffset(0.5, 0.5), paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawRect(kRenderBounds.makeOffset(0.5, 0.5), ctx.paint);
           },
           kDrawRectFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawOval) {
+TEST_F(DisplayListRendering, DrawOval) {
   SkRect rect = kRenderBounds.makeInset(0, 10);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawOval(rect, paint);
+          [=](const SkRenderContext& ctx) {  //
+            ctx.canvas->drawOval(rect, ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawOval(rect, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawOval(rect, ctx.paint);
           },
           kDrawOvalFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawCircle) {
+TEST_F(DisplayListRendering, DrawCircle) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawCircle(kTestCenter, kRenderRadius, paint);
+          [=](const SkRenderContext& ctx) {  //
+            ctx.canvas->drawCircle(kTestCenter, kRenderRadius, ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawCircle(kTestCenter, kRenderRadius, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawCircle(kTestCenter, kRenderRadius, ctx.paint);
           },
           kDrawCircleFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawRRect) {
+TEST_F(DisplayListRendering, DrawRRect) {
   SkRRect rrect = SkRRect::MakeRectXY(kRenderBounds, kRenderCornerRadius,
                                       kRenderCornerRadius);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawRRect(rrect, paint);
+          [=](const SkRenderContext& ctx) {  //
+            ctx.canvas->drawRRect(rrect, ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawRRect(rrect, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawRRect(rrect, ctx.paint);
           },
           kDrawRRectFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawDRRect) {
+TEST_F(DisplayListRendering, DrawDRRect) {
   SkRRect outer = SkRRect::MakeRectXY(kRenderBounds, kRenderCornerRadius,
                                       kRenderCornerRadius);
   SkRect inner_bounds = kRenderBounds.makeInset(30.0, 30.0);
@@ -2718,16 +2936,16 @@ TEST_F(DisplayListCanvas, DrawDRRect) {
                                       kRenderCornerRadius);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawDRRect(outer, inner, paint);
+          [=](const SkRenderContext& ctx) {  //
+            ctx.canvas->drawDRRect(outer, inner, ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawDRRect(outer, inner, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawDRRect(outer, inner, ctx.paint);
           },
           kDrawDRRectFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawPath) {
+TEST_F(DisplayListRendering, DrawPath) {
   SkPath path;
 
   // unclosed lines to show some caps
@@ -2752,29 +2970,29 @@ TEST_F(DisplayListCanvas, DrawPath) {
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawPath(path, paint);
+          [=](const SkRenderContext& ctx) {  //
+            ctx.canvas->drawPath(path, ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawPath(path, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawPath(path, ctx.paint);
           },
           kDrawPathFlags)
           .set_draw_path());
 }
 
-TEST_F(DisplayListCanvas, DrawArc) {
+TEST_F(DisplayListRendering, DrawArc) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawArc(kRenderBounds, 60, 330, false, paint);
+          [=](const SkRenderContext& ctx) {  //
+            ctx.canvas->drawArc(kRenderBounds, 60, 330, false, ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawArc(kRenderBounds, 60, 330, false, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawArc(kRenderBounds, 60, 330, false, ctx.paint);
           },
           kDrawArcNoCenterFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawArcCenter) {
+TEST_F(DisplayListRendering, DrawArcCenter) {
   // Center arcs that inscribe nearly a whole circle except for a small
   // arc extent gap have 2 angles that may appear or disappear at the
   // various miter limits tested (0, 4, and 10).
@@ -2787,17 +3005,17 @@ TEST_F(DisplayListCanvas, DrawArcCenter) {
   // Limit == 10, edge and center corners all miter
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawArc(kRenderBounds, 60, 360 - 12, true, paint);
+          [=](const SkRenderContext& ctx) {  //
+            ctx.canvas->drawArc(kRenderBounds, 60, 360 - 12, true, ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawArc(kRenderBounds, 60, 360 - 12, true, paint);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawArc(kRenderBounds, 60, 360 - 12, true, ctx.paint);
           },
           kDrawArcWithCenterFlags)
           .set_draw_arc_center());
 }
 
-TEST_F(DisplayListCanvas, DrawPointsAsPoints) {
+TEST_F(DisplayListRendering, DrawPointsAsPoints) {
   // The +/- 16 points are designed to fall just inside the clips
   // that are tested against so we avoid lots of undrawn pixels
   // in the accumulated bounds.
@@ -2832,23 +3050,25 @@ TEST_F(DisplayListCanvas, DrawPointsAsPoints) {
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
+          [=](const SkRenderContext& ctx) {
             // Skia requires kStroke style on horizontal and vertical
             // lines to get the bounds correct.
             // See https://bugs.chromium.org/p/skia/issues/detail?id=12446
-            SkPaint p = paint;
+            SkPaint p = ctx.paint;
             p.setStyle(SkPaint::kStroke_Style);
-            canvas->drawPoints(SkCanvas::kPoints_PointMode, count, points, p);
+            auto mode = SkCanvas::kPoints_PointMode;
+            ctx.canvas->drawPoints(mode, count, points, p);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawPoints(PointMode::kPoints, count, points, paint);
+          [=](const DlRenderContext& ctx) {
+            auto mode = PointMode::kPoints;
+            ctx.canvas->DrawPoints(mode, count, points, ctx.paint);
           },
           kDrawPointsAsPointsFlags)
           .set_draw_line()
           .set_ignores_dashes());
 }
 
-TEST_F(DisplayListCanvas, DrawPointsAsLines) {
+TEST_F(DisplayListRendering, DrawPointsAsLines) {
   const SkScalar x0 = kRenderLeft + 1;
   const SkScalar x1 = kRenderLeft + 16;
   const SkScalar x2 = kRenderRight - 16;
@@ -2882,21 +3102,23 @@ TEST_F(DisplayListCanvas, DrawPointsAsLines) {
   ASSERT_TRUE((count & 1) == 0);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
+          [=](const SkRenderContext& ctx) {
             // Skia requires kStroke style on horizontal and vertical
             // lines to get the bounds correct.
             // See https://bugs.chromium.org/p/skia/issues/detail?id=12446
-            SkPaint p = paint;
+            SkPaint p = ctx.paint;
             p.setStyle(SkPaint::kStroke_Style);
-            canvas->drawPoints(SkCanvas::kLines_PointMode, count, points, p);
+            auto mode = SkCanvas::kLines_PointMode;
+            ctx.canvas->drawPoints(mode, count, points, p);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawPoints(PointMode::kLines, count, points, paint);
+          [=](const DlRenderContext& ctx) {
+            auto mode = PointMode::kLines;
+            ctx.canvas->DrawPoints(mode, count, points, ctx.paint);
           },
           kDrawPointsAsLinesFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawPointsAsPolygon) {
+TEST_F(DisplayListRendering, DrawPointsAsPolygon) {
   const SkPoint points1[] = {
       // RenderBounds box with a diamond
       SkPoint::Make(kRenderLeft, kRenderTop),
@@ -2913,22 +3135,23 @@ TEST_F(DisplayListCanvas, DrawPointsAsPolygon) {
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
+          [=](const SkRenderContext& ctx) {
             // Skia requires kStroke style on horizontal and vertical
             // lines to get the bounds correct.
             // See https://bugs.chromium.org/p/skia/issues/detail?id=12446
-            SkPaint p = paint;
+            SkPaint p = ctx.paint;
             p.setStyle(SkPaint::kStroke_Style);
-            canvas->drawPoints(SkCanvas::kPolygon_PointMode, count1, points1,
-                               p);
+            auto mode = SkCanvas::kPolygon_PointMode;
+            ctx.canvas->drawPoints(mode, count1, points1, p);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawPoints(PointMode::kPolygon, count1, points1, paint);
+          [=](const DlRenderContext& ctx) {
+            auto mode = PointMode::kPolygon;
+            ctx.canvas->DrawPoints(mode, count1, points1, ctx.paint);
           },
           kDrawPointsAsPolygonFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawVerticesWithColors) {
+TEST_F(DisplayListRendering, DrawVerticesWithColors) {
   // Cover as many sides of the box with only 6 vertices:
   // +----------+
   // |xxxxxxxxxx|
@@ -2964,16 +3187,18 @@ TEST_F(DisplayListCanvas, DrawVerticesWithColors) {
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawVertices(sk_vertices, SkBlendMode::kSrcOver, paint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawVertices(sk_vertices, SkBlendMode::kSrcOver,
+                                     ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawVertices(dl_vertices, DlBlendMode::kSrcOver, paint);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawVertices(dl_vertices, DlBlendMode::kSrcOver,
+                                     ctx.paint);
           },
           kDrawVerticesFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawVerticesWithImage) {
+TEST_F(DisplayListRendering, DrawVerticesWithImage) {
   // Cover as many sides of the box with only 6 vertices:
   // +----------+
   // |xxxxxxxxxx|
@@ -3008,181 +3233,175 @@ TEST_F(DisplayListCanvas, DrawVerticesWithImage) {
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            SkPaint v_paint = paint;
+          [=](const SkRenderContext& ctx) {  //
+            SkPaint v_paint = ctx.paint;
             if (v_paint.getShader() == nullptr) {
-              v_paint.setShader(CanvasCompareTester::kTestSkImageColorSource);
+              v_paint.setShader(MakeColorSource(ctx.image));
             }
-            canvas->drawVertices(sk_vertices, SkBlendMode::kSrcOver, v_paint);
+            ctx.canvas->drawVertices(sk_vertices, SkBlendMode::kSrcOver,
+                                     v_paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            DlPaint v_paint = paint;
+          [=](const DlRenderContext& ctx) {  //
+            DlPaint v_paint = ctx.paint;
             if (v_paint.getColorSource() == nullptr) {
-              v_paint.setColorSource(
-                  &CanvasCompareTester::kTestDlImageColorSource);
+              v_paint.setColorSource(MakeColorSource(ctx.image));
             }
-            canvas->DrawVertices(dl_vertices, DlBlendMode::kSrcOver, v_paint);
+            ctx.canvas->DrawVertices(dl_vertices, DlBlendMode::kSrcOver,
+                                     v_paint);
           },
           kDrawVerticesFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawImageNearest) {
+TEST_F(DisplayListRendering, DrawImageNearest) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {         //
-            canvas->drawImage(CanvasCompareTester::kTestImage,  //
-                              kRenderLeft, kRenderTop,
-                              SkImageSampling::kNearestNeighbor, &paint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawImage(ctx.image, kRenderLeft, kRenderTop,
+                                  SkImageSampling::kNearestNeighbor,
+                                  &ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawImage(DlImage::Make(CanvasCompareTester::kTestImage),
-                              SkPoint::Make(kRenderLeft, kRenderTop),
-                              DlImageSampling::kNearestNeighbor, &paint);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawImage(ctx.image,  //
+                                  SkPoint::Make(kRenderLeft, kRenderTop),
+                                  DlImageSampling::kNearestNeighbor,
+                                  &ctx.paint);
           },
           kDrawImageWithPaintFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawImageNearestNoPaint) {
+TEST_F(DisplayListRendering, DrawImageNearestNoPaint) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {         //
-            canvas->drawImage(CanvasCompareTester::kTestImage,  //
-                              kRenderLeft, kRenderTop,
-                              SkImageSampling::kNearestNeighbor, nullptr);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawImage(ctx.image, kRenderLeft, kRenderTop,
+                                  SkImageSampling::kNearestNeighbor, nullptr);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawImage(DlImage::Make(CanvasCompareTester::kTestImage),
-                              SkPoint::Make(kRenderLeft, kRenderTop),
-                              DlImageSampling::kNearestNeighbor, nullptr);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawImage(ctx.image,
+                                  SkPoint::Make(kRenderLeft, kRenderTop),
+                                  DlImageSampling::kNearestNeighbor, nullptr);
           },
           kDrawImageFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawImageLinear) {
+TEST_F(DisplayListRendering, DrawImageLinear) {
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {         //
-            canvas->drawImage(CanvasCompareTester::kTestImage,  //
-                              kRenderLeft, kRenderTop, SkImageSampling::kLinear,
-                              &paint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawImage(ctx.image, kRenderLeft, kRenderTop,
+                                  SkImageSampling::kLinear, &ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawImage(DlImage::Make(CanvasCompareTester::kTestImage),
-                              SkPoint::Make(kRenderLeft, kRenderTop),
-                              DlImageSampling::kLinear, &paint);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawImage(ctx.image,
+                                  SkPoint::Make(kRenderLeft, kRenderTop),
+                                  DlImageSampling::kLinear, &ctx.paint);
           },
           kDrawImageWithPaintFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawImageRectNearest) {
+TEST_F(DisplayListRendering, DrawImageRectNearest) {
   SkRect src = SkRect::MakeIWH(kRenderWidth, kRenderHeight).makeInset(5, 5);
   SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawImageRect(CanvasCompareTester::kTestImage, src, dst,
-                                  SkImageSampling::kNearestNeighbor, &paint,
-                                  SkCanvas::kFast_SrcRectConstraint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawImageRect(
+                ctx.image, src, dst, SkImageSampling::kNearestNeighbor,
+                &ctx.paint, SkCanvas::kFast_SrcRectConstraint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawImageRect(
-                DlImage::Make(CanvasCompareTester::kTestImage), src, dst,
-                DlImageSampling::kNearestNeighbor, &paint,
-                DlCanvas::SrcRectConstraint::kFast);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawImageRect(
+                ctx.image, src, dst, DlImageSampling::kNearestNeighbor,
+                &ctx.paint, DlCanvas::SrcRectConstraint::kFast);
           },
           kDrawImageRectWithPaintFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawImageRectNearestNoPaint) {
+TEST_F(DisplayListRendering, DrawImageRectNearestNoPaint) {
   SkRect src = SkRect::MakeIWH(kRenderWidth, kRenderHeight).makeInset(5, 5);
   SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawImageRect(CanvasCompareTester::kTestImage, src, dst,
-                                  SkImageSampling::kNearestNeighbor, nullptr,
-                                  SkCanvas::kFast_SrcRectConstraint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawImageRect(
+                ctx.image, src, dst, SkImageSampling::kNearestNeighbor,  //
+                nullptr, SkCanvas::kFast_SrcRectConstraint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawImageRect(
-                DlImage::Make(CanvasCompareTester::kTestImage), src, dst,
-                DlImageSampling::kNearestNeighbor, nullptr,
-                DlCanvas::SrcRectConstraint::kFast);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawImageRect(
+                ctx.image, src, dst, DlImageSampling::kNearestNeighbor,  //
+                nullptr, DlCanvas::SrcRectConstraint::kFast);
           },
           kDrawImageRectFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawImageRectLinear) {
+TEST_F(DisplayListRendering, DrawImageRectLinear) {
   SkRect src = SkRect::MakeIWH(kRenderWidth, kRenderHeight).makeInset(5, 5);
   SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawImageRect(CanvasCompareTester::kTestImage, src, dst,
-                                  SkImageSampling::kLinear, &paint,
-                                  SkCanvas::kFast_SrcRectConstraint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawImageRect(
+                ctx.image, src, dst, SkImageSampling::kLinear,  //
+                &ctx.paint, SkCanvas::kFast_SrcRectConstraint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawImageRect(
-                DlImage::Make(CanvasCompareTester::kTestImage), src, dst,
-                DlImageSampling::kLinear, &paint,
-                DlCanvas::SrcRectConstraint::kFast);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawImageRect(
+                ctx.image, src, dst, DlImageSampling::kLinear,  //
+                &ctx.paint, DlCanvas::SrcRectConstraint::kFast);
           },
           kDrawImageRectWithPaintFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawImageNineNearest) {
+TEST_F(DisplayListRendering, DrawImageNineNearest) {
   SkIRect src = SkIRect::MakeWH(kRenderWidth, kRenderHeight).makeInset(25, 25);
   SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
-  sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawImageNine(image.get(), src, dst, SkFilterMode::kNearest,
-                                  &paint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawImageNine(ctx.image.get(), src, dst,
+                                      SkFilterMode::kNearest, &ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawImageNine(DlImage::Make(image), src, dst,
-                                  DlFilterMode::kNearest, &paint);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawImageNine(ctx.image, src, dst,
+                                      DlFilterMode::kNearest, &ctx.paint);
           },
           kDrawImageNineWithPaintFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawImageNineNearestNoPaint) {
+TEST_F(DisplayListRendering, DrawImageNineNearestNoPaint) {
   SkIRect src = SkIRect::MakeWH(kRenderWidth, kRenderHeight).makeInset(25, 25);
   SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
-  sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawImageNine(image.get(), src, dst, SkFilterMode::kNearest,
-                                  nullptr);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawImageNine(ctx.image.get(), src, dst,
+                                      SkFilterMode::kNearest, nullptr);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawImageNine(DlImage::Make(image), src, dst,
-                                  DlFilterMode::kNearest, nullptr);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawImageNine(ctx.image, src, dst,
+                                      DlFilterMode::kNearest, nullptr);
           },
           kDrawImageNineFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawImageNineLinear) {
+TEST_F(DisplayListRendering, DrawImageNineLinear) {
   SkIRect src = SkIRect::MakeWH(kRenderWidth, kRenderHeight).makeInset(25, 25);
   SkRect dst = kRenderBounds.makeInset(10.5, 10.5);
-  sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawImageNine(image.get(), src, dst, SkFilterMode::kLinear,
-                                  &paint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawImageNine(ctx.image.get(), src, dst,
+                                      SkFilterMode::kLinear, &ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawImageNine(DlImage::Make(image), src, dst,
-                                  DlFilterMode::kLinear, &paint);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawImageNine(ctx.image, src, dst,
+                                      DlFilterMode::kLinear, &ctx.paint);
           },
           kDrawImageNineWithPaintFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawAtlasNearest) {
+TEST_F(DisplayListRendering, DrawAtlasNearest) {
   const SkRSXform xform[] = {
       // clang-format off
       { 1.2f,  0.0f, kRenderLeft,  kRenderTop},
@@ -3211,25 +3430,24 @@ TEST_F(DisplayListCanvas, DrawAtlasNearest) {
       DlColor::kYellow(),
       DlColor::kMagenta(),
   };
-  const sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   const DlImageSampling dl_sampling = DlImageSampling::kNearestNeighbor;
   const SkSamplingOptions sk_sampling = SkImageSampling::kNearestNeighbor;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawAtlas(image.get(), xform, tex, sk_colors, 4,
-                              SkBlendMode::kSrcOver, sk_sampling, nullptr,
-                              &paint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawAtlas(ctx.image.get(), xform, tex, sk_colors, 4,
+                                  SkBlendMode::kSrcOver, sk_sampling, nullptr,
+                                  &ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawAtlas(DlImage::Make(image), xform, tex, dl_colors, 4,
-                              DlBlendMode::kSrcOver, dl_sampling, nullptr,
-                              &paint);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawAtlas(ctx.image, xform, tex, dl_colors, 4,
+                                  DlBlendMode::kSrcOver, dl_sampling, nullptr,
+                                  &ctx.paint);
           },
           kDrawAtlasWithPaintFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawAtlasNearestNoPaint) {
+TEST_F(DisplayListRendering, DrawAtlasNearestNoPaint) {
   const SkRSXform xform[] = {
       // clang-format off
       { 1.2f,  0.0f, kRenderLeft,  kRenderTop},
@@ -3258,25 +3476,24 @@ TEST_F(DisplayListCanvas, DrawAtlasNearestNoPaint) {
       DlColor::kYellow(),
       DlColor::kMagenta(),
   };
-  const sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   const DlImageSampling dl_sampling = DlImageSampling::kNearestNeighbor;
   const SkSamplingOptions sk_sampling = SkImageSampling::kNearestNeighbor;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawAtlas(image.get(), xform, tex, sk_colors, 4,
-                              SkBlendMode::kSrcOver, sk_sampling,  //
-                              nullptr, nullptr);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawAtlas(ctx.image.get(), xform, tex, sk_colors, 4,
+                                  SkBlendMode::kSrcOver, sk_sampling,  //
+                                  nullptr, nullptr);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawAtlas(DlImage::Make(image), xform, tex, dl_colors, 4,
-                              DlBlendMode::kSrcOver, dl_sampling, nullptr,
-                              nullptr);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawAtlas(ctx.image, xform, tex, dl_colors, 4,
+                                  DlBlendMode::kSrcOver, dl_sampling,  //
+                                  nullptr, nullptr);
           },
           kDrawAtlasFlags));
 }
 
-TEST_F(DisplayListCanvas, DrawAtlasLinear) {
+TEST_F(DisplayListRendering, DrawAtlasLinear) {
   const SkRSXform xform[] = {
       // clang-format off
       { 1.2f,  0.0f, kRenderLeft,  kRenderTop},
@@ -3305,20 +3522,19 @@ TEST_F(DisplayListCanvas, DrawAtlasLinear) {
       DlColor::kYellow(),
       DlColor::kMagenta(),
   };
-  const sk_sp<SkImage> image = CanvasCompareTester::kTestImage;
   const DlImageSampling dl_sampling = DlImageSampling::kLinear;
   const SkSamplingOptions sk_sampling = SkImageSampling::kLinear;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {
-            canvas->drawAtlas(image.get(), xform, tex, sk_colors, 2,  //
-                              SkBlendMode::kSrcOver, sk_sampling, nullptr,
-                              &paint);
+          [=](const SkRenderContext& ctx) {
+            ctx.canvas->drawAtlas(ctx.image.get(), xform, tex, sk_colors, 2,
+                                  SkBlendMode::kSrcOver, sk_sampling,  //
+                                  nullptr, &ctx.paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {
-            canvas->DrawAtlas(DlImage::Make(image), xform, tex, dl_colors, 2,
-                              DlBlendMode::kSrcOver, dl_sampling, nullptr,
-                              &paint);
+          [=](const DlRenderContext& ctx) {
+            ctx.canvas->DrawAtlas(ctx.image, xform, tex, dl_colors, 2,
+                                  DlBlendMode::kSrcOver, dl_sampling,  //
+                                  nullptr, &ctx.paint);
           },
           kDrawAtlasWithPaintFlags));
 }
@@ -3342,21 +3558,21 @@ sk_sp<DisplayList> makeTestDisplayList() {
   return builder.Build();
 }
 
-TEST_F(DisplayListCanvas, DrawDisplayList) {
+TEST_F(DisplayListRendering, DrawDisplayList) {
   sk_sp<DisplayList> display_list = makeTestDisplayList();
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            DlSkCanvasAdapter(canvas).DrawDisplayList(display_list);
+          [=](const SkRenderContext& ctx) {  //
+            DlSkCanvasAdapter(ctx.canvas).DrawDisplayList(display_list);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawDisplayList(display_list);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawDisplayList(display_list);
           },
           kDrawDisplayListFlags)
           .set_draw_display_list());
 }
 
-TEST_F(DisplayListCanvas, DrawTextBlob) {
+TEST_F(DisplayListRendering, DrawTextBlob) {
   // TODO(https://github.com/flutter/flutter/issues/82202): Remove once the
   // performance overlay can use Fuchsia's font manager instead of the empty
   // default.
@@ -3369,15 +3585,17 @@ TEST_F(DisplayListCanvas, DrawTextBlob) {
   SkScalar render_y_2_3 = kRenderTop + kRenderHeight * 0.6;
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            canvas->drawTextBlob(blob, kRenderLeft, render_y_1_3, paint);
-            canvas->drawTextBlob(blob, kRenderLeft, render_y_2_3, paint);
-            canvas->drawTextBlob(blob, kRenderLeft, kRenderBottom, paint);
+          [=](const SkRenderContext& ctx) {
+            auto paint = ctx.paint;
+            ctx.canvas->drawTextBlob(blob, kRenderLeft, render_y_1_3, paint);
+            ctx.canvas->drawTextBlob(blob, kRenderLeft, render_y_2_3, paint);
+            ctx.canvas->drawTextBlob(blob, kRenderLeft, kRenderBottom, paint);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawTextBlob(blob, kRenderLeft, render_y_1_3, paint);
-            canvas->DrawTextBlob(blob, kRenderLeft, render_y_2_3, paint);
-            canvas->DrawTextBlob(blob, kRenderLeft, kRenderBottom, paint);
+          [=](const DlRenderContext& ctx) {
+            auto paint = ctx.paint;
+            ctx.canvas->DrawTextBlob(blob, kRenderLeft, render_y_1_3, paint);
+            ctx.canvas->DrawTextBlob(blob, kRenderLeft, render_y_2_3, paint);
+            ctx.canvas->DrawTextBlob(blob, kRenderLeft, kRenderBottom, paint);
           },
           kDrawTextBlobFlags)
           .set_draw_text_blob(),
@@ -3389,7 +3607,7 @@ TEST_F(DisplayListCanvas, DrawTextBlob) {
   EXPECT_TRUE(blob->unique());
 }
 
-TEST_F(DisplayListCanvas, DrawShadow) {
+TEST_F(DisplayListRendering, DrawShadow) {
   SkPath path;
   path.addRoundRect(
       {
@@ -3404,18 +3622,18 @@ TEST_F(DisplayListCanvas, DrawShadow) {
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            DlSkCanvasDispatcher::DrawShadow(canvas, path, color, elevation,
+          [=](const SkRenderContext& ctx) {  //
+            DlSkCanvasDispatcher::DrawShadow(ctx.canvas, path, color, elevation,
                                              false, 1.0);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawShadow(path, color, elevation, false, 1.0);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawShadow(path, color, elevation, false, 1.0);
           },
           kDrawShadowFlags),
       CanvasCompareTester::DefaultTolerance.addBoundsPadding(3, 3));
 }
 
-TEST_F(DisplayListCanvas, DrawShadowTransparentOccluder) {
+TEST_F(DisplayListRendering, DrawShadowTransparentOccluder) {
   SkPath path;
   path.addRoundRect(
       {
@@ -3430,18 +3648,18 @@ TEST_F(DisplayListCanvas, DrawShadowTransparentOccluder) {
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            DlSkCanvasDispatcher::DrawShadow(canvas, path, color, elevation,
+          [=](const SkRenderContext& ctx) {  //
+            DlSkCanvasDispatcher::DrawShadow(ctx.canvas, path, color, elevation,
                                              true, 1.0);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawShadow(path, color, elevation, true, 1.0);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawShadow(path, color, elevation, true, 1.0);
           },
           kDrawShadowFlags),
       CanvasCompareTester::DefaultTolerance.addBoundsPadding(3, 3));
 }
 
-TEST_F(DisplayListCanvas, DrawShadowDpr) {
+TEST_F(DisplayListRendering, DrawShadowDpr) {
   SkPath path;
   path.addRoundRect(
       {
@@ -3456,18 +3674,18 @@ TEST_F(DisplayListCanvas, DrawShadowDpr) {
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
-          [=](SkCanvas* canvas, const SkPaint& paint) {  //
-            DlSkCanvasDispatcher::DrawShadow(canvas, path, color, elevation,
+          [=](const SkRenderContext& ctx) {  //
+            DlSkCanvasDispatcher::DrawShadow(ctx.canvas, path, color, elevation,
                                              false, 1.5);
           },
-          [=](DlCanvas* canvas, const DlPaint& paint) {  //
-            canvas->DrawShadow(path, color, elevation, false, 1.5);
+          [=](const DlRenderContext& ctx) {  //
+            ctx.canvas->DrawShadow(path, color, elevation, false, 1.5);
           },
           kDrawShadowFlags),
       CanvasCompareTester::DefaultTolerance.addBoundsPadding(3, 3));
 }
 
-TEST_F(DisplayListCanvas, SaveLayerConsolidation) {
+TEST_F(DisplayListRendering, SaveLayerConsolidation) {
   float commutable_color_matrix[]{
       // clang-format off
       0, 1, 0, 0, 0,
@@ -3650,7 +3868,7 @@ TEST_F(DisplayListCanvas, SaveLayerConsolidation) {
   }
 }
 
-TEST_F(DisplayListCanvas, MatrixColorFilterModifyTransparencyCheck) {
+TEST_F(DisplayListRendering, MatrixColorFilterModifyTransparencyCheck) {
   std::vector<std::unique_ptr<RenderEnvironment>> environments;
   for (auto& provider : CanvasCompareTester::kTestProviders) {
     auto env = std::make_unique<RenderEnvironment>(
@@ -3724,7 +3942,7 @@ TEST_F(DisplayListCanvas, MatrixColorFilterModifyTransparencyCheck) {
   }
 }
 
-TEST_F(DisplayListCanvas, MatrixColorFilterOpacityCommuteCheck) {
+TEST_F(DisplayListRendering, MatrixColorFilterOpacityCommuteCheck) {
   std::vector<std::unique_ptr<RenderEnvironment>> environments;
   for (auto& provider : CanvasCompareTester::kTestProviders) {
     auto env = std::make_unique<RenderEnvironment>(
@@ -3841,7 +4059,7 @@ static std::string BlendModeToString(DlBlendMode mode) {
   }
 }
 
-TEST_F(DisplayListCanvas, BlendColorFilterModifyTransparencyCheck) {
+TEST_F(DisplayListRendering, BlendColorFilterModifyTransparencyCheck) {
   std::vector<std::unique_ptr<RenderEnvironment>> environments;
   for (auto& provider : CanvasCompareTester::kTestProviders) {
     auto env = std::make_unique<RenderEnvironment>(
@@ -3903,7 +4121,7 @@ TEST_F(DisplayListCanvas, BlendColorFilterModifyTransparencyCheck) {
 #undef TEST_MODE
 }
 
-TEST_F(DisplayListCanvas, BlendColorFilterOpacityCommuteCheck) {
+TEST_F(DisplayListRendering, BlendColorFilterOpacityCommuteCheck) {
   std::vector<std::unique_ptr<RenderEnvironment>> environments;
   for (auto& provider : CanvasCompareTester::kTestProviders) {
     auto env = std::make_unique<RenderEnvironment>(
@@ -3973,11 +4191,11 @@ TEST_F(DisplayListCanvas, BlendColorFilterOpacityCommuteCheck) {
 #undef TEST_MODE
 }
 
-class DisplayListNopTest : public DisplayListCanvas {
+class DisplayListNopTest : public DisplayListRendering {
   // The following code uses the acronym MTB for "modifies_transparent_black"
 
  protected:
-  DisplayListNopTest() : DisplayListCanvas() {
+  DisplayListNopTest() : DisplayListRendering() {
     test_src_colors = {
         DlColor::kBlack().withAlpha(0),     // transparent black
         DlColor::kBlack().withAlpha(0x7f),  // half transparent black
@@ -4097,7 +4315,7 @@ class DisplayListNopTest : public DisplayListCanvas {
     renderer(canvas);
     canvas->flush();
     surface->flushAndSubmit(true);
-    return std::make_unique<RenderResult>(surface, snapshot);
+    return std::make_unique<SkRenderResult>(surface, snapshot);
   }
 
   int check_color_result(DlColor dst_color,
@@ -4214,8 +4432,8 @@ class DisplayListNopTest : public DisplayListCanvas {
       result_canvas->drawRect(test_bounds, sk_paint);
       result_canvas->flush();
       result_surface->sk_surface()->flushAndSubmit(true);
-      auto result_pixels =
-          std::make_unique<RenderResult>(result_surface->sk_surface());
+      const std::unique_ptr<RenderResult> result_pixels =
+          std::make_unique<SkRenderResult>(result_surface->sk_surface());
 
       int all_flags = check_image_result(test_data, result_pixels, dl, desc);
       report_results(all_flags, dl, desc);
@@ -4272,8 +4490,8 @@ class DisplayListNopTest : public DisplayListCanvas {
                                SkSamplingOptions(), &sk_paint);
       result_canvas->flush();
       result_surface->sk_surface()->flushAndSubmit(true);
-      auto result_pixels =
-          std::make_unique<RenderResult>(result_surface->sk_surface());
+      std::unique_ptr<RenderResult> result_pixels =
+          std::make_unique<SkRenderResult>(result_surface->sk_surface());
 
       int all_flags =
           check_image_result(test_image_dst_data, result_pixels, dl, desc);

--- a/display_list/testing/dl_test_surface_metal.cc
+++ b/display_list/testing/dl_test_surface_metal.cc
@@ -54,14 +54,42 @@ std::shared_ptr<DlSurfaceInstance> DlMetalSurfaceProvider::MakeOffscreenSurface(
   return std::make_shared<DlMetalSurfaceInstance>(std::move(surface));
 }
 
-std::unique_ptr<MetalScreenshot> DlMetalSurfaceProvider::ImpellerSnapshot(
+class DlMetalPixelData : public DlPixelData {
+  using MetalScreenshot = impeller::testing::MetalScreenshot;
+
+ public:
+  explicit DlMetalPixelData(std::unique_ptr<MetalScreenshot> screenshot)
+      : screenshot_(std::move(screenshot)),
+        addr_(reinterpret_cast<const uint32_t*>(screenshot_->GetBytes())),
+        ints_per_row_(screenshot_->GetBytesPerRow() / 4) {
+    FML_DCHECK(screenshot_->GetBytesPerRow() == ints_per_row_ * 4);
+  }
+  ~DlMetalPixelData() override = default;
+
+  const uint32_t* addr32(int x, int y) const override {
+    return addr_ + (y * ints_per_row_) + x;
+  }
+  size_t width() const override { return screenshot_->GetWidth(); }
+  size_t height() const override { return screenshot_->GetHeight(); }
+  void write(const std::string& path) const override {
+    screenshot_->WriteToPNG(path);
+  }
+
+ private:
+  std::unique_ptr<MetalScreenshot> screenshot_;
+  const uint32_t* addr_;
+  const uint32_t ints_per_row_;
+};
+
+sk_sp<DlPixelData> DlMetalSurfaceProvider::ImpellerSnapshot(
     const sk_sp<DisplayList>& list,
     int width,
     int height) const {
   if (!snapshotter_) {
     snapshotter_.reset(new MetalScreenshotter());
   }
-  return snapshotter_->MakeScreenshot(list, {width, height}, false);
+  return sk_make_sp<DlMetalPixelData>(
+      snapshotter_->MakeScreenshot(list, {width, height}, false));
 }
 
 sk_sp<DlImage> DlMetalSurfaceProvider::MakeImpellerImage(

--- a/display_list/testing/dl_test_surface_metal.cc
+++ b/display_list/testing/dl_test_surface_metal.cc
@@ -54,5 +54,25 @@ std::shared_ptr<DlSurfaceInstance> DlMetalSurfaceProvider::MakeOffscreenSurface(
   return std::make_shared<DlMetalSurfaceInstance>(std::move(surface));
 }
 
+std::unique_ptr<MetalScreenshot> DlMetalSurfaceProvider::ImpellerSnapshot(
+    const sk_sp<DisplayList>& list,
+    int width,
+    int height) const {
+  if (!snapshotter_) {
+    snapshotter_.reset(new MetalScreenshotter());
+  }
+  return snapshotter_->MakeScreenshot(list, {width, height}, false);
+}
+
+sk_sp<DlImage> DlMetalSurfaceProvider::MakeImpellerImage(
+    const sk_sp<DisplayList>& list,
+    int width,
+    int height) const {
+  if (!snapshotter_) {
+    snapshotter_.reset(new MetalScreenshotter());
+  }
+  return snapshotter_->MakeImage(list, {width, height});
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/display_list/testing/dl_test_surface_metal.h
+++ b/display_list/testing/dl_test_surface_metal.h
@@ -7,10 +7,13 @@
 
 #include "flutter/display_list/testing/dl_test_surface_provider.h"
 
+#include "flutter/impeller/golden_tests/metal_screenshotter.h"
 #include "flutter/testing/test_metal_surface.h"
 
 namespace flutter {
 namespace testing {
+
+using MetalScreenshotter = impeller::testing::MetalScreenshotter;
 
 class DlMetalSurfaceProvider : public DlSurfaceProvider {
  public:
@@ -30,10 +33,19 @@ class DlMetalSurfaceProvider : public DlSurfaceProvider {
   bool supports(PixelFormat format) const override {
     return format == kN32Premul_PixelFormat;
   }
+  bool supports_impeller() const override { return true; }
+  std::unique_ptr<MetalScreenshot> ImpellerSnapshot(
+      const sk_sp<DisplayList>& list,
+      int width,
+      int height) const override;
+  virtual sk_sp<DlImage> MakeImpellerImage(const sk_sp<DisplayList>& list,
+                                           int width,
+                                           int height) const override;
 
  private:
   std::unique_ptr<TestMetalContext> metal_context_;
   std::shared_ptr<DlSurfaceInstance> metal_surface_;
+  mutable std::unique_ptr<MetalScreenshotter> snapshotter_;
 };
 
 }  // namespace testing

--- a/display_list/testing/dl_test_surface_metal.h
+++ b/display_list/testing/dl_test_surface_metal.h
@@ -34,10 +34,9 @@ class DlMetalSurfaceProvider : public DlSurfaceProvider {
     return format == kN32Premul_PixelFormat;
   }
   bool supports_impeller() const override { return true; }
-  std::unique_ptr<MetalScreenshot> ImpellerSnapshot(
-      const sk_sp<DisplayList>& list,
-      int width,
-      int height) const override;
+  sk_sp<DlPixelData> ImpellerSnapshot(const sk_sp<DisplayList>& list,
+                                      int width,
+                                      int height) const override;
   virtual sk_sp<DlImage> MakeImpellerImage(const sk_sp<DisplayList>& list,
                                            int width,
                                            int height) const override;

--- a/display_list/testing/dl_test_surface_provider.h
+++ b/display_list/testing/dl_test_surface_provider.h
@@ -8,7 +8,6 @@
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/image/dl_image.h"
 #include "flutter/fml/mapping.h"
-#include "flutter/impeller/golden_tests/metal_screenshot.h"
 #include "flutter/testing/testing.h"
 
 #include "third_party/skia/include/core/SkSurface.h"
@@ -16,7 +15,15 @@
 namespace flutter {
 namespace testing {
 
-using MetalScreenshot = impeller::testing::MetalScreenshot;
+class DlPixelData : public SkRefCnt {
+ public:
+  virtual ~DlPixelData() = default;
+
+  virtual const uint32_t* addr32(int x, int y) const = 0;
+  virtual size_t width() const = 0;
+  virtual size_t height() const = 0;
+  virtual void write(const std::string& path) const = 0;
+};
 
 class DlSurfaceInstance {
  public:
@@ -77,10 +84,9 @@ class DlSurfaceProvider {
       PixelFormat format = kN32Premul_PixelFormat) const = 0;
 
   virtual bool Snapshot(std::string& filename) const;
-  virtual std::unique_ptr<MetalScreenshot> ImpellerSnapshot(
-      const sk_sp<DisplayList>& list,
-      int width,
-      int height) const {
+  virtual sk_sp<DlPixelData> ImpellerSnapshot(const sk_sp<DisplayList>& list,
+                                              int width,
+                                              int height) const {
     return nullptr;
   }
   virtual sk_sp<DlImage> MakeImpellerImage(const sk_sp<DisplayList>& list,

--- a/display_list/testing/dl_test_surface_provider.h
+++ b/display_list/testing/dl_test_surface_provider.h
@@ -5,13 +5,18 @@
 #ifndef FLUTTER_DISPLAY_LIST_TESTING_DL_TEST_SURFACE_PROVIDER_H_
 #define FLUTTER_DISPLAY_LIST_TESTING_DL_TEST_SURFACE_PROVIDER_H_
 
+#include "flutter/display_list/display_list.h"
+#include "flutter/display_list/image/dl_image.h"
 #include "flutter/fml/mapping.h"
+#include "flutter/impeller/golden_tests/metal_screenshot.h"
 #include "flutter/testing/testing.h"
 
 #include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
 namespace testing {
+
+using MetalScreenshot = impeller::testing::MetalScreenshot;
 
 class DlSurfaceInstance {
  public:
@@ -60,6 +65,7 @@ class DlSurfaceProvider {
   virtual const std::string backend_name() const = 0;
   virtual BackendType backend_type() const = 0;
   virtual bool supports(PixelFormat format) const = 0;
+  virtual bool supports_impeller() const { return false; }
   virtual bool InitializeSurface(
       size_t width,
       size_t height,
@@ -71,6 +77,17 @@ class DlSurfaceProvider {
       PixelFormat format = kN32Premul_PixelFormat) const = 0;
 
   virtual bool Snapshot(std::string& filename) const;
+  virtual std::unique_ptr<MetalScreenshot> ImpellerSnapshot(
+      const sk_sp<DisplayList>& list,
+      int width,
+      int height) const {
+    return nullptr;
+  }
+  virtual sk_sp<DlImage> MakeImpellerImage(const sk_sp<DisplayList>& list,
+                                           int width,
+                                           int height) const {
+    return nullptr;
+  }
 
  protected:
   DlSurfaceProvider() = default;

--- a/impeller/golden_tests/BUILD.gn
+++ b/impeller/golden_tests/BUILD.gn
@@ -46,12 +46,13 @@ if (is_mac) {
     sources = [
       "metal_screenshot.h",
       "metal_screenshot.mm",
-      "metal_screenshoter.h",
-      "metal_screenshoter.mm",
+      "metal_screenshotter.h",
+      "metal_screenshotter.mm",
     ]
 
     deps = [
       "//flutter/impeller/aiks",
+      "//flutter/impeller/display_list",
       "//flutter/impeller/playground",
       "//flutter/impeller/renderer/backend/metal:metal",
     ]

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -9,7 +9,7 @@
 
 #include "flutter/impeller/aiks/picture.h"
 #include "flutter/impeller/golden_tests/golden_digest.h"
-#include "flutter/impeller/golden_tests/metal_screenshoter.h"
+#include "flutter/impeller/golden_tests/metal_screenshotter.h"
 
 namespace impeller {
 
@@ -79,8 +79,9 @@ bool SaveScreenshot(std::unique_ptr<testing::MetalScreenshot> screenshot) {
 }  // namespace
 
 struct GoldenPlaygroundTest::GoldenPlaygroundTestImpl {
-  GoldenPlaygroundTestImpl() : screenshoter(new testing::MetalScreenshoter()) {}
-  std::unique_ptr<testing::MetalScreenshoter> screenshoter;
+  GoldenPlaygroundTestImpl()
+      : screenshotter(new testing::MetalScreenshotter()) {}
+  std::unique_ptr<testing::MetalScreenshotter> screenshotter;
   ISize window_size = ISize{1024, 768};
 };
 
@@ -125,7 +126,7 @@ PlaygroundBackend GoldenPlaygroundTest::GetBackend() const {
 
 bool GoldenPlaygroundTest::OpenPlaygroundHere(const Picture& picture) {
   auto screenshot =
-      pimpl_->screenshoter->MakeScreenshot(picture, pimpl_->window_size);
+      pimpl_->screenshotter->MakeScreenshot(picture, pimpl_->window_size);
   return SaveScreenshot(std::move(screenshot));
 }
 
@@ -161,11 +162,11 @@ std::shared_ptr<RuntimeStage> GoldenPlaygroundTest::OpenAssetAsRuntimeStage(
 }
 
 std::shared_ptr<Context> GoldenPlaygroundTest::GetContext() const {
-  return pimpl_->screenshoter->GetContext().GetContext();
+  return pimpl_->screenshotter->GetContext().GetContext();
 }
 
 Point GoldenPlaygroundTest::GetContentScale() const {
-  return pimpl_->screenshoter->GetPlayground().GetContentScale();
+  return pimpl_->screenshotter->GetPlayground().GetContentScale();
 }
 
 Scalar GoldenPlaygroundTest::GetSecondsElapsed() const {

--- a/impeller/golden_tests/golden_tests.cc
+++ b/impeller/golden_tests/golden_tests.cc
@@ -11,7 +11,7 @@
 #include "impeller/geometry/path_builder.h"
 #include "impeller/golden_tests/golden_digest.h"
 #include "impeller/golden_tests/metal_screenshot.h"
-#include "impeller/golden_tests/metal_screenshoter.h"
+#include "impeller/golden_tests/metal_screenshotter.h"
 #include "impeller/golden_tests/working_directory.h"
 
 namespace impeller {
@@ -48,18 +48,18 @@ bool SaveScreenshot(std::unique_ptr<MetalScreenshot> screenshot) {
 
 class GoldenTests : public ::testing::Test {
  public:
-  GoldenTests() : screenshoter_(new MetalScreenshoter()) {}
+  GoldenTests() : screenshotter_(new MetalScreenshotter()) {}
 
-  MetalScreenshoter& Screenshoter() { return *screenshoter_; }
+  MetalScreenshotter& Screenshotter() { return *screenshotter_; }
 
   void SetUp() override {
     testing::GoldenDigest::Instance()->AddDimension(
         "gpu_string",
-        Screenshoter().GetContext().GetContext()->DescribeGpuModel());
+        Screenshotter().GetContext().GetContext()->DescribeGpuModel());
   }
 
  private:
-  std::unique_ptr<MetalScreenshoter> screenshoter_;
+  std::unique_ptr<MetalScreenshotter> screenshotter_;
 };
 
 TEST_F(GoldenTests, ConicalGradient) {
@@ -74,7 +74,7 @@ TEST_F(GoldenTests, ConicalGradient) {
   paint.style = Paint::Style::kFill;
   canvas.DrawRect(Rect(10, 10, 250, 250), paint);
   Picture picture = canvas.EndRecordingAsPicture();
-  auto screenshot = Screenshoter().MakeScreenshot(picture);
+  auto screenshot = Screenshotter().MakeScreenshot(picture);
   ASSERT_TRUE(SaveScreenshot(std::move(screenshot)));
 }
 }  // namespace testing

--- a/impeller/golden_tests/metal_screenshot.h
+++ b/impeller/golden_tests/metal_screenshot.h
@@ -13,9 +13,7 @@
 namespace impeller {
 namespace testing {
 
-class MetalScreenshoter;
-
-/// A screenshot that was produced from `MetalScreenshoter`.
+/// A screenshot that was produced from `MetalScreenshotter`.
 class MetalScreenshot {
  public:
   ~MetalScreenshot();
@@ -26,10 +24,12 @@ class MetalScreenshot {
 
   size_t GetWidth() const;
 
+  size_t GetBytesPerRow() const;
+
   bool WriteToPNG(const std::string& path) const;
 
  private:
-  friend class MetalScreenshoter;
+  friend class MetalScreenshotter;
   MetalScreenshot(CGImageRef cgImage);
   FML_DISALLOW_COPY_AND_ASSIGN(MetalScreenshot);
   CGImageRef cgImage_;

--- a/impeller/golden_tests/metal_screenshot.mm
+++ b/impeller/golden_tests/metal_screenshot.mm
@@ -29,6 +29,10 @@ size_t MetalScreenshot::GetWidth() const {
   return CGImageGetWidth(cgImage_);
 }
 
+size_t MetalScreenshot::GetBytesPerRow() const {
+  return CGImageGetBytesPerRow(cgImage_);
+}
+
 bool MetalScreenshot::WriteToPNG(const std::string& path) const {
   bool result = false;
   NSURL* output_url =

--- a/impeller/golden_tests/metal_screenshotter.h
+++ b/impeller/golden_tests/metal_screenshotter.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "flutter/display_list/display_list.h"
+#include "flutter/display_list/image/dl_image.h"
 #include "flutter/fml/macros.h"
 #include "flutter/impeller/aiks/picture.h"
 #include "flutter/impeller/golden_tests/metal_screenshot.h"
@@ -12,14 +14,24 @@
 namespace impeller {
 namespace testing {
 
-/// Converts `Picture`'s to `MetalScreenshot`'s with the playground backend.
-class MetalScreenshoter {
+/// Converts `Picture`'s and `DisplayList`'s to `MetalScreenshot`'s with the
+/// playground backend.
+class MetalScreenshotter {
  public:
-  MetalScreenshoter();
+  MetalScreenshotter();
+
+  sk_sp<flutter::DlImage> MakeImage(const sk_sp<flutter::DisplayList>& list,
+                                    const ISize& size);
+
+  std::unique_ptr<MetalScreenshot> MakeScreenshot(
+      const sk_sp<flutter::DisplayList>& list,
+      const ISize& size,
+      bool scale_content = true);
 
   std::unique_ptr<MetalScreenshot> MakeScreenshot(const Picture& picture,
                                                   const ISize& size = {300,
-                                                                       300});
+                                                                       300},
+                                                  bool scale_content = true);
 
   AiksContext& GetContext() { return *aiks_context_; }
 


### PR DESCRIPTION
By default this PR does nothing because the rendering tests are run only on the Software backend by default.

If the `display_list_rendertests` are run with the `--enable-metal` flag, then during the testing that happens on the metal backend, Impeller results will be checked as well, including only the following verifications:

- Does Impeller draw "something" with the associated attributes and rendering primitives
- Comparing Impeller output with and without an attribute, the output should change if and only if that attribute is supposed to affect the output of the given rendering primitive

Currently there are 2 problems that occur when this extra testing is enabled:

- Frequent `Context leak detected, msgtracer returned -1` error messages coming from somewhere down in Impeller or Metal
- The entire test suite crashes after testing the attribute combinations of several primitives, likely due to memory starvation resulting from the leak mentioned in the previous error

Running on select primitives demonstrates a few missing pieces in the Impeller implementation which I believe are known, but due to the crashes mentioned above a complete assessment is not yet possible. The missing functionality detected so far includes:

- Error messages from Impeller about missing dashing functionality when dashes are  used
- Impeller output is not affected by a DashPathEffect when appropriate (obviously, due to the error messages)
- Impeller output is not affected by AA (known issue)

This PR contains a fix for the typo in the name of the existing `MetalScreenShoter`(sic) class