### PR TITLE
[Impeller] Fix up coverage hints for blending/vertices, fix TiledTextureContents::RenderToSnapshot

### DIFF
--- a/impeller/core/allocator.cc
+++ b/impeller/core/allocator.cc
@@ -49,9 +49,8 @@ std::shared_ptr<Texture> Allocator::CreateTexture(
     const TextureDescriptor& desc) {
   const auto max_size = GetMaxTextureSizeSupported();
   if (desc.size.width > max_size.width || desc.size.height > max_size.height) {
-    VALIDATION_LOG
-        << "Requested texture size exceeds maximum supported size of "
-        << desc.size;
+    VALIDATION_LOG << "Requested texture size " << desc.size
+                   << " exceeds maximum supported size of " << max_size;
     return nullptr;
   }
 

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -68,8 +68,10 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
     return std::nullopt;
   }
 
-  if (GetCoverageHint().has_value()) {
-    coverage = coverage->Intersection(*GetCoverageHint());
+  auto coverage_hint = GetCoverageHint();
+  if (coverage_hint.has_value()) {
+    coverage = coverage->Intersection(coverage_hint.value())
+                   .value_or(coverage.value());
   }
 
   // Pad Contents snapshots with 1 pixel borders to ensure correct sampling

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -92,9 +92,9 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
         Entity sub_entity;
         auto color_size = contents.GetColorSourceSize();
         if (color_size.has_value()) {
-          auto sx = coverage->size.width / color_size->width;
-          auto sy = coverage->size.height / color_size->height;
-          sub_entity.SetTransformation(Matrix::MakeScale(Vector2{sx, sy}));
+          auto scale_size = coverage->size / color_size.value();
+          sub_entity.SetTransformation(
+              Matrix::MakeScale(Vector2{scale_size.width, scale_size.height}));
         } else {
           sub_entity.SetTransformation(
               Matrix::MakeTranslation(Vector3(-coverage->origin)) *

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -68,12 +68,6 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
     return std::nullopt;
   }
 
-  auto coverage_hint = GetCoverageHint();
-  if (coverage_hint.has_value()) {
-    coverage = coverage->Intersection(coverage_hint.value())
-                   .value_or(coverage.value());
-  }
-
   // Pad Contents snapshots with 1 pixel borders to ensure correct sampling
   // behavior. Not doing so results in a coverage leak for filters that support
   // customizing the input sampling mode. Snapshots of contents should be
@@ -92,17 +86,10 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
       [&contents = *this, &entity, &coverage](const ContentContext& renderer,
                                               RenderPass& pass) -> bool {
         Entity sub_entity;
-        auto color_size = contents.GetColorSourceSize();
-        if (color_size.has_value()) {
-          auto scale_size = coverage->size / color_size.value();
-          sub_entity.SetTransformation(
-              Matrix::MakeScale(Vector2{scale_size.width, scale_size.height}));
-        } else {
-          sub_entity.SetTransformation(
-              Matrix::MakeTranslation(Vector3(-coverage->origin)) *
-              entity.GetTransformation());
-        }
         sub_entity.SetBlendMode(BlendMode::kSourceOver);
+        sub_entity.SetTransformation(
+            Matrix::MakeTranslation(Vector3(-coverage->origin)) *
+            entity.GetTransformation());
         return contents.Render(renderer, sub_entity, pass);
       },
       msaa_enabled);

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -168,8 +168,13 @@ static std::optional<Entity> AdvancedBlend(
     return true;
   };
 
-  auto out_texture = renderer.MakeSubpass("Advanced Blend Filter",
-                                          ISize(coverage.size), callback);
+  auto subpass_size = ISize(coverage.size);
+  auto coverage_hint = entity.GetContents()->GetCoverageHint();
+  if (coverage_hint.has_value()) {
+    subpass_size = subpass_size.Min(ISize(coverage_hint->size));
+  }
+  auto out_texture =
+      renderer.MakeSubpass("Advanced Blend Filter", subpass_size, callback);
   if (!out_texture) {
     return std::nullopt;
   }
@@ -531,7 +536,8 @@ static std::optional<Entity> PipelineBlend(
 
       VS::FrameInfo frame_info;
       frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                       Matrix::MakeTranslation(-coverage.origin) *
+                       Matrix::MakeTranslation(
+                           -input->GetCoverage().value_or(coverage).origin) *
                        input->transform;
       frame_info.texture_sampler_y_coord_scale =
           input->texture->GetYCoordScale();
@@ -587,8 +593,14 @@ static std::optional<Entity> PipelineBlend(
     return true;
   };
 
-  auto out_texture = renderer.MakeSubpass("Pipeline Blend Filter",
-                                          ISize(coverage.size), callback);
+  auto subpass_size = ISize(coverage.size);
+  auto coverage_hint = entity.GetContents()->GetCoverageHint();
+  if (coverage_hint.has_value()) {
+    subpass_size = subpass_size.Min(ISize(coverage_hint->size));
+  }
+  auto out_texture =
+      renderer.MakeSubpass("Pipeline Blend Filter", subpass_size, callback);
+
   if (!out_texture) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -169,9 +169,11 @@ static std::optional<Entity> AdvancedBlend(
   };
 
   auto subpass_size = ISize(coverage.size);
-  auto coverage_hint = entity.GetContents()->GetCoverageHint();
-  if (coverage_hint.has_value()) {
-    subpass_size = subpass_size.Min(ISize(coverage_hint->size));
+  if (entity.GetContents()) {
+    auto coverage_hint = entity.GetContents()->GetCoverageHint();
+    if (coverage_hint.has_value()) {
+      subpass_size = subpass_size.Min(ISize(coverage_hint->size));
+    }
   }
   auto out_texture =
       renderer.MakeSubpass("Advanced Blend Filter", subpass_size, callback);
@@ -594,9 +596,11 @@ static std::optional<Entity> PipelineBlend(
   };
 
   auto subpass_size = ISize(coverage.size);
-  auto coverage_hint = entity.GetContents()->GetCoverageHint();
-  if (coverage_hint.has_value()) {
-    subpass_size = subpass_size.Min(ISize(coverage_hint->size));
+  if (entity.GetContents()) {
+    auto coverage_hint = entity.GetContents()->GetCoverageHint();
+    if (coverage_hint.has_value()) {
+      subpass_size = subpass_size.Min(ISize(coverage_hint->size));
+    }
   }
   auto out_texture =
       renderer.MakeSubpass("Pipeline Blend Filter", subpass_size, callback);

--- a/impeller/entity/contents/filters/inputs/contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/contents_filter_input.cc
@@ -26,6 +26,9 @@ std::optional<Snapshot> ContentsFilterInput::GetSnapshot(
     const ContentContext& renderer,
     const Entity& entity,
     std::optional<Rect> coverage_limit) const {
+  if (!coverage_limit.has_value()) {
+    coverage_limit = entity.GetContents()->GetCoverageHint();
+  }
   if (!snapshot_.has_value()) {
     snapshot_ = contents_->RenderToSnapshot(
         renderer,        // renderer

--- a/impeller/entity/contents/filters/inputs/contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/contents_filter_input.cc
@@ -26,7 +26,7 @@ std::optional<Snapshot> ContentsFilterInput::GetSnapshot(
     const ContentContext& renderer,
     const Entity& entity,
     std::optional<Rect> coverage_limit) const {
-  if (!coverage_limit.has_value()) {
+  if (!coverage_limit.has_value() && entity.GetContents()) {
     coverage_limit = entity.GetContents()->GetCoverageHint();
   }
   if (!snapshot_.has_value()) {

--- a/impeller/entity/contents/filters/inputs/filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_input.h
@@ -10,12 +10,12 @@
 #include <vector>
 
 #include "impeller/entity/contents/contents.h"
+#include "impeller/entity/entity.h"
 #include "impeller/geometry/rect.h"
 
 namespace impeller {
 
 class ContentContext;
-class Entity;
 class FilterContents;
 
 /// `FilterInput` is a lazy/single eval `Snapshot` which may be shared across

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -198,4 +198,29 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
   return true;
 }
 
+std::optional<Snapshot> TiledTextureContents::RenderToSnapshot(
+    const ContentContext& renderer,
+    const Entity& entity,
+    std::optional<Rect> coverage_limit,
+    const std::optional<SamplerDescriptor>& sampler_descriptor,
+    bool msaa_enabled,
+    const std::string& label) const {
+  if (GetInverseMatrix().IsIdentity()) {
+    return Snapshot{
+        .texture = texture_,
+        .transform = entity.GetTransformation(),
+        .sampler_descriptor = sampler_descriptor.value_or(sampler_descriptor_),
+        .opacity = GetOpacity(),
+    };
+  }
+
+  return Contents::RenderToSnapshot(
+      renderer,                                          // renderer
+      entity,                                            // entity
+      std::nullopt,                                      // coverage_limit
+      sampler_descriptor.value_or(sampler_descriptor_),  // sampler_descriptor
+      true,                                              // msaa_enabled
+      label);                                            // label
+}
+
 }  // namespace impeller

--- a/impeller/entity/contents/tiled_texture_contents.h
+++ b/impeller/entity/contents/tiled_texture_contents.h
@@ -53,6 +53,15 @@ class TiledTextureContents final : public ColorSourceContents {
   /// much smaller size that its original texture size.
   void SetColorFilter(std::optional<ColorFilterProc> color_filter);
 
+  // |Contents|
+  std::optional<Snapshot> RenderToSnapshot(
+      const ContentContext& renderer,
+      const Entity& entity,
+      std::optional<Rect> coverage_limit = std::nullopt,
+      const std::optional<SamplerDescriptor>& sampler_descriptor = std::nullopt,
+      bool msaa_enabled = true,
+      const std::string& label = "Tiled Texture Snapshot") const override;
+
  private:
   std::optional<std::shared_ptr<Texture>> CreateFilterTexture(
       const ContentContext& renderer) const;

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -57,8 +57,10 @@ bool VerticesContents::Render(const ContentContext& renderer,
     return true;
   }
   std::shared_ptr<Contents> src_contents = src_contents_;
+  src_contents->SetCoverageHint(GetCoverageHint());
   if (geometry_->HasTextureCoordinates()) {
     auto contents = std::make_shared<VerticesUVContents>(*this);
+    contents->SetCoverageHint(GetCoverageHint());
     if (!geometry_->HasVertexColors()) {
       contents->SetAlpha(alpha_);
       return contents->Render(renderer, entity, pass);
@@ -67,6 +69,7 @@ bool VerticesContents::Render(const ContentContext& renderer,
   }
 
   auto dst_contents = std::make_shared<VerticesColorContents>(*this);
+  dst_contents->SetCoverageHint(GetCoverageHint());
 
   std::shared_ptr<Contents> contents;
   if (blend_mode_ == BlendMode::kDestination) {
@@ -76,9 +79,11 @@ bool VerticesContents::Render(const ContentContext& renderer,
         blend_mode_, {FilterInput::Make(dst_contents, false),
                       FilterInput::Make(src_contents, false)});
     color_filter_contents->SetAlpha(alpha_);
+    color_filter_contents->SetCoverageHint(GetCoverageHint());
     contents = color_filter_contents;
   }
 
+  FML_DCHECK(contents->GetCoverageHint() == GetCoverageHint());
   return contents->Render(renderer, entity, pass);
 }
 
@@ -108,11 +113,11 @@ bool VerticesUVContents::Render(const ContentContext& renderer,
   auto src_contents = parent_.GetSourceContents();
 
   auto snapshot =
-      src_contents->RenderToSnapshot(renderer,      // renderer
-                                     entity,        // entity
-                                     std::nullopt,  // coverage_limit
-                                     std::nullopt,  // sampler_descriptor
-                                     true,          // msaa_enabled
+      src_contents->RenderToSnapshot(renderer,           // renderer
+                                     entity,             // entity
+                                     GetCoverageHint(),  // coverage_limit
+                                     std::nullopt,       // sampler_descriptor
+                                     true,               // msaa_enabled
                                      "VerticesUVContents Snapshot");  // label
   if (!snapshot.has_value()) {
     return false;

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -154,6 +154,11 @@ bool Entity::Render(const ContentContext& renderer,
     return true;
   }
 
+  if (!contents_->GetCoverageHint().has_value()) {
+    contents_->SetCoverageHint(
+        Rect::MakeSize(parent_pass.GetRenderTargetSize()));
+  }
+
   return contents_->Render(renderer, *this, parent_pass);
 }
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2415,6 +2415,26 @@ TEST_P(EntityTest, PointFieldGeometryDivisions) {
   ASSERT_EQ(PointFieldGeometry::ComputeCircleDivisions(20000.0, true), 140u);
 }
 
+TEST_P(EntityTest, ColorFilterContentsWithLargeGeometry) {
+  Entity entity;
+  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  auto src_contents = std::make_shared<SolidColorContents>();
+  src_contents->SetGeometry(
+      Geometry::MakeRect(Rect::MakeLTRB(-300, -500, 30000, 50000)));
+  src_contents->SetColor(Color::Red());
+
+  auto dst_contents = std::make_shared<SolidColorContents>();
+  dst_contents->SetGeometry(
+      Geometry::MakeRect(Rect::MakeLTRB(300, 500, 20000, 30000)));
+  dst_contents->SetColor(Color::Blue());
+
+  auto contents = ColorFilterContents::MakeBlend(
+      BlendMode::kSourceOver, {FilterInput::Make(dst_contents, false),
+                               FilterInput::Make(src_contents, false)});
+  entity.SetContents(std::move(contents));
+  ASSERT_TRUE(OpenPlaygroundHere(entity));
+}
+
 }  // namespace testing
 }  // namespace impeller
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/128329
Fixes https://github.com/flutter/flutter/issues/128807


The panorama example app is still not quite visually on par with skia - the scaling or filtering or something isn't quite as nice as in the skia backend - but it does render now and no longer tries to create gigantical textures.