### PR TITLE
[CP] Use the arm64 dsymutil on Mac M1 machines (#42533)

### DIFF
--- a/sky/tools/create_embedder_framework.py
+++ b/sky/tools/create_embedder_framework.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 import argparse
+import platform
 import subprocess
 import shutil
 import sys
@@ -14,8 +15,9 @@ buildroot_dir = os.path.abspath(
     os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
 )
 
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
-    os.path.dirname(__file__), '..', '..', '..', 'buildtools', 'mac-x64',
+    os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'
 )
 

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -9,14 +9,16 @@
 
 import argparse
 import os
+import platform
 import shutil
 import subprocess
 import sys
 
 from create_xcframework import create_xcframework  # pylint: disable=import-error
 
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
-    os.path.dirname(__file__), '..', '..', '..', 'buildtools', 'mac-x64',
+    os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'
 )
 

--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 import argparse
+import platform
 import subprocess
 import shutil
 import sys
@@ -12,8 +13,9 @@ import os
 
 from create_xcframework import create_xcframework  # pylint: disable=import-error
 
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
-    os.path.dirname(__file__), '..', '..', '..', 'buildtools', 'mac-x64',
+    os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'
 )
 

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 import argparse
+import platform
 import subprocess
 import shutil
 import sys
@@ -14,8 +15,9 @@ buildroot_dir = os.path.abspath(
     os.path.join(os.path.realpath(__file__), '..', '..', '..', '..')
 )
 
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
 DSYMUTIL = os.path.join(
-    os.path.dirname(__file__), '..', '..', '..', 'buildtools', 'mac-x64',
+    os.path.dirname(__file__), '..', '..', '..', 'buildtools', ARCH_SUBPATH,
     'clang', 'bin', 'dsymutil'
 )
 


### PR DESCRIPTION
Cherry pick into beta branch
[example build failures on beta](https://luci-milo.appspot.com/ui/p/dart-internal/builders/flutter/Mac%20engine_release_builder/232/overview)

Use the right binary architectures on scripts running dsymutil.

This is to fix the problem of bad architecture binary for builds running on dart internal: https://github.com/flutter/flutter/issues/128098

