### PR TITLE
[Impeller] Correctly compute UVs in texture fill

### DIFF
--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/aiks/paint_pass_delegate.h"
 
+#include "impeller/core/formats.h"
+#include "impeller/core/sampler_descriptor.h"
 #include "impeller/entity/contents/contents.h"
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/entity_pass.h"
@@ -46,6 +48,13 @@ std::shared_ptr<Contents> PaintPassDelegate::CreateContentsForSubpassTarget(
   contents->SetSourceRect(Rect::MakeSize(target->GetSize()));
   contents->SetOpacity(paint_.color.alpha);
   contents->SetDeferApplyingOpacity(true);
+
+  SamplerDescriptor sampler_desc;
+  sampler_desc.label = "Subpass";
+  sampler_desc.width_address_mode = SamplerAddressMode::kDecal;
+  sampler_desc.height_address_mode = SamplerAddressMode::kDecal;
+  contents->SetSamplerDescriptor(sampler_desc);
+
   return paint_.WithFiltersForSubpassTarget(std::move(contents),
                                             effect_transform);
 }
@@ -140,6 +149,13 @@ OpacityPeepholePassDelegate::CreateContentsForSubpassTarget(
   contents->SetSourceRect(Rect::MakeSize(target->GetSize()));
   contents->SetOpacity(paint_.color.alpha);
   contents->SetDeferApplyingOpacity(true);
+
+  SamplerDescriptor sampler_desc;
+  sampler_desc.label = "Subpass";
+  sampler_desc.width_address_mode = SamplerAddressMode::kDecal;
+  sampler_desc.height_address_mode = SamplerAddressMode::kDecal;
+  contents->SetSamplerDescriptor(sampler_desc);
+
   return paint_.WithFiltersForSubpassTarget(std::move(contents),
                                             effect_transform);
 }

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -115,12 +115,14 @@ bool TextureContents::Render(const ContentContext& renderer,
     return true;  // Nothing to render.
   }
 
-  auto half_texel_size =
-      Size(0.5 / texture_->GetSize().width, 0.5 / texture_->GetSize().height);
   auto texture_coords =
       Rect::MakeSize(texture_->GetSize()).Project(source_rect_);
+
+  // Expand the texture coordinates
+  auto half_texel_size =
+      Size(0.5 / texture_->GetSize().width, 0.5 / texture_->GetSize().height);
   texture_coords =
-      texture_coords.Expand(-half_texel_size.width, -half_texel_size.height,
+      texture_coords.Expand(half_texel_size.width, half_texel_size.height,
                             half_texel_size.width, half_texel_size.height);
 
   // Expand the destination rect by one pixel towards the bottom right. Map the

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -115,28 +115,18 @@ bool TextureContents::Render(const ContentContext& renderer,
     return true;  // Nothing to render.
   }
 
+  // Expand the source rect by half a texel, which aligns sampled texels to the
+  // pixel grid if the source rect is the same size as the destination rect.
   auto texture_coords =
-      Rect::MakeSize(texture_->GetSize()).Project(source_rect_);
-
-  // Expand the texture coordinates
-  auto half_texel_size =
-      Size(0.5 / texture_->GetSize().width, 0.5 / texture_->GetSize().height);
-  texture_coords =
-      texture_coords.Expand(half_texel_size.width, half_texel_size.height,
-                            half_texel_size.width, half_texel_size.height);
-
-  // Expand the destination rect by one pixel towards the bottom right. Map the
-  // texture coordinates such that texels are evenly spaced across the pixel
-  // grid.
-  auto destination_rect = destination_rect_.Expand(0, 0, 1, 1);
+      Rect::MakeSize(texture_->GetSize()).Project(source_rect_.Expand(0.5));
 
   VertexBufferBuilder<VS::PerVertexData> vertex_builder;
 
   vertex_builder.AddVertices({
-      {destination_rect.GetLeftTop(), texture_coords.GetLeftTop()},
-      {destination_rect.GetRightTop(), texture_coords.GetRightTop()},
-      {destination_rect.GetLeftBottom(), texture_coords.GetLeftBottom()},
-      {destination_rect.GetRightBottom(), texture_coords.GetRightBottom()},
+      {destination_rect_.GetLeftTop(), texture_coords.GetLeftTop()},
+      {destination_rect_.GetRightTop(), texture_coords.GetRightTop()},
+      {destination_rect_.GetLeftBottom(), texture_coords.GetLeftBottom()},
+      {destination_rect_.GetRightBottom(), texture_coords.GetRightBottom()},
   });
 
   auto& host_buffer = pass.GetTransientsBuffer();

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -112,20 +112,21 @@ bool TextureContents::Render(const ContentContext& renderer,
 
   if (destination_rect_.size.IsEmpty() || source_rect_.IsEmpty() ||
       texture_ == nullptr || texture_->GetSize().IsEmpty()) {
-    return true;
+    return true;  // Nothing to render.
   }
+
+  auto half_texel_size =
+      Size(0.5 / texture_->GetSize().width, 0.5 / texture_->GetSize().height);
+  auto texture_coords =
+      Rect::MakeSize(texture_->GetSize()).Project(source_rect_);
+  texture_coords =
+      texture_coords.Expand(-half_texel_size.width, -half_texel_size.height,
+                            half_texel_size.width, half_texel_size.height);
 
   // Expand the destination rect by one pixel towards the bottom right. Map the
   // texture coordinates such that texels are evenly spaced across the pixel
   // grid.
   auto destination_rect = destination_rect_.Expand(0, 0, 1, 1);
-  auto half_texel_size =
-      Size(0.5 / texture_->GetSize().width, 0.5 / texture_->GetSize().height);
-  auto texture_coords =
-      destination_rect_.Project(source_rect_.Shift(destination_rect_.origin));
-  texture_coords =
-      texture_coords.Expand(-half_texel_size.width, -half_texel_size.height,
-                            half_texel_size.width, half_texel_size.height);
 
   VertexBufferBuilder<VS::PerVertexData> vertex_builder;
 

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -30,7 +30,7 @@ class TextureContents final : public Contents {
 
   void SetLabel(std::string label);
 
-  void SetRect(Rect rect);
+  void SetDestinationRect(Rect rect);
 
   void SetTexture(std::shared_ptr<Texture> texture);
 
@@ -78,7 +78,7 @@ class TextureContents final : public Contents {
  private:
   std::string label_;
 
-  Rect rect_;
+  Rect destination_rect_;
   bool stencil_enabled_ = true;
 
   std::shared_ptr<Texture> texture_;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1069,7 +1069,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     if (selected_input_type == 0) {
       auto texture = std::make_shared<TextureContents>();
       texture->SetSourceRect(Rect::MakeSize(boston->GetSize()));
-      texture->SetRect(input_rect);
+      texture->SetDestinationRect(input_rect);
       texture->SetTexture(boston);
       texture->SetOpacity(input_color.alpha);
 
@@ -1192,7 +1192,7 @@ TEST_P(EntityTest, MorphologyFilter) {
         Rect::MakeXYWH(path_rect[0], path_rect[1], path_rect[2], path_rect[3]);
     auto texture = std::make_shared<TextureContents>();
     texture->SetSourceRect(Rect::MakeSize(boston->GetSize()));
-    texture->SetRect(input_rect);
+    texture->SetDestinationRect(input_rect);
     texture->SetTexture(boston);
     texture->SetOpacity(input_color.alpha);
 

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "gtest/gtest.h"
 #include "impeller/geometry/geometry_asserts.h"
 
 #include <limits>
@@ -2140,6 +2141,20 @@ TEST(GeometryTest, RectScale) {
     auto expected = Rect::MakeLTRB(100, 200, -100, -200);
     ASSERT_RECT_NEAR(expected, actual);
   }
+}
+
+TEST(GeometryTest, RectDirections) {
+  auto r = Rect::MakeLTRB(1, 2, 3, 4);
+
+  ASSERT_EQ(r.GetLeft(), 1);
+  ASSERT_EQ(r.GetTop(), 2);
+  ASSERT_EQ(r.GetRight(), 3);
+  ASSERT_EQ(r.GetBottom(), 4);
+
+  ASSERT_POINT_NEAR(r.GetLeftTop(), Point(1, 2));
+  ASSERT_POINT_NEAR(r.GetRightTop(), Point(3, 2));
+  ASSERT_POINT_NEAR(r.GetLeftBottom(), Point(1, 4));
+  ASSERT_POINT_NEAR(r.GetRightBottom(), Point(3, 4));
 }
 
 TEST(GeometryTest, RectProject) {

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -162,6 +162,16 @@ struct TRect {
     return std::max(origin.y, origin.y + size.height);
   }
 
+  constexpr TPoint<T> GetLeftTop() const { return {GetLeft(), GetTop()}; }
+
+  constexpr TPoint<T> GetRightTop() const { return {GetRight(), GetTop()}; }
+
+  constexpr TPoint<T> GetLeftBottom() const { return {GetLeft(), GetBottom()}; }
+
+  constexpr TPoint<T> GetRightBottom() const {
+    return {GetRight(), GetBottom()};
+  }
+
   constexpr std::array<T, 4> GetLTRB() const {
     return {GetLeft(), GetTop(), GetRight(), GetBottom()};
   }


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/128353.

Depends on https://github.com/flutter/engine/pull/43026.

* Maps the texel coordinate space correctly relative to the geometry pixel coordinates.
* Use decal sampling for subpass textures.
* Simplify the computation by using new rect utilities such as `Rect::Project`.

Texture in subpass (the issue was that when copying to the parent pass, this image gets screwed up):
<img width="549" alt="image" src="https://github.com/flutter/engine/assets/919017/018b1ee2-7708-4c99-ae0d-a96c7f721e0b">

Before Impeller:
<img width="461" alt="image" src="https://github.com/flutter/engine/assets/919017/0899f0ab-22fb-4aa4-a129-ae300258cb8f">

After Impeller:
<img width="478" alt="image" src="https://github.com/flutter/engine/assets/919017/95ad1772-48e5-4bb6-bf23-11e9de225cc9">
