### PR TITLE
Generate treemap.

### DIFF
--- a/ci/builders/linux_android_aot_engine.json
+++ b/ci/builders/linux_android_aot_engine.json
@@ -110,7 +110,22 @@
                     "flutter/shell/platform/android:abi_jars",
                     "flutter/shell/platform/android:analyze_snapshot"
                 ]
-            }
+            },
+            "tests": [
+                {
+                    "name": "Generate treemap for android_release_arm64",
+                    "language": "python3",
+                    "script": "third_party/dart/runtime/third_party/binary_size/src/run_binary_size_analysis.py",
+                    "parameters": [
+                        "--library",
+                        "src/out/android_release_arm64/libflutter.so",
+                        "--destdir",
+                        "${FLUTTER_LOGS_DIRECTORY}",
+                        "--addr2line-binary",
+                        "src/third_party/android_tools/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-addr2line"
+                    ]
+                }
+            ]
         },
         {
             "archives": [

--- a/ci/builders/linux_android_aot_engine.json
+++ b/ci/builders/linux_android_aot_engine.json
@@ -120,7 +120,7 @@
                         "--library",
                         "../../src/out/android_release_arm64/libflutter.so",
                         "--destdir",
-                        "${FLUTTER_LOGS_DIRECTORY}",
+                        "${FLUTTER_LOGS_DIR}",
                         "--addr2line-binary",
                         "../../src/third_party/android_tools/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-addr2line"
                     ]

--- a/ci/builders/linux_android_aot_engine.json
+++ b/ci/builders/linux_android_aot_engine.json
@@ -118,11 +118,11 @@
                     "script": "third_party/dart/runtime/third_party/binary_size/src/run_binary_size_analysis.py",
                     "parameters": [
                         "--library",
-                        "src/out/android_release_arm64/libflutter.so",
+                        "../../src/out/android_release_arm64/libflutter.so",
                         "--destdir",
                         "${FLUTTER_LOGS_DIRECTORY}",
                         "--addr2line-binary",
-                        "src/third_party/android_tools/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-addr2line"
+                        "../../src/third_party/android_tools/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-addr2line"
                     ]
                 }
             ]


### PR DESCRIPTION
Engine V2 was not generating the size treemap. This change will start uploading the size treemap to the test logs.

Bug: https://github.com/flutter/flutter/issues/128482

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
