### PR TITLE
Revert "[Impeller] dont use concurrent runner to decode images on Android."

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -456,11 +456,7 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
     });
   };
 
-#ifdef FML_OS_ANDROID
-  runners_.GetIOTaskRunner()->PostTask(
-#else
   concurrent_task_runner_->PostTask(
-#endif
       [raw_descriptor,                                            //
        context = context_.get(),                                  //
        target_size = SkISize::Make(target_width, target_height),  //
@@ -499,16 +495,12 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
             result(image, decode_error);
           }
         };
-// TODO(jonahwilliams):
-// https://github.com/flutter/flutter/issues/123058 Technically we
-// don't need to post tasks to the io runner, but without this
-// forced serialization we can end up overloading the GPU and/or
-// competing with raster workloads.
-#ifdef FML_OS_ANDROID
-        upload_texture_and_invoke_result();
-#else
+        // TODO(jonahwilliams):
+        // https://github.com/flutter/flutter/issues/123058 Technically we
+        // don't need to post tasks to the io runner, but without this
+        // forced serialization we can end up overloading the GPU and/or
+        // competing with raster workloads.
         io_runner->PostTask(upload_texture_and_invoke_result);
-#endif
       });
 }
 


### PR DESCRIPTION
Reverts flutter/engine#42944

This didn't improve any of the benchmarks, which I think at least disproves my theory on overloading. Lets go back to the prior strategy and look for improvements elsewhere.