### PR TITLE
[Impeller] remove Vulkan pipeline cache mutex.

### DIFF
--- a/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
@@ -68,13 +68,6 @@ PipelineCacheVK::PipelineCacheVK(std::shared_ptr<const Capabilities> caps,
       OpenCacheFile(cache_directory_, kPipelineCacheFileName, vk_caps);
 
   vk::PipelineCacheCreateInfo cache_info;
-
-  // TODO(csg): VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT is behind
-  // an extension. Check it and set it. If not, the implementation is doing
-  // unnecessary synchronization.
-  // cache_info.flags =
-  // vk::PipelineCacheCreateFlagBits::eExternallySynchronized;
-
   if (existing_cache_data) {
     cache_info.initialDataSize = existing_cache_data->GetSize();
     cache_info.pInitialData = existing_cache_data->GetMapping();
@@ -126,7 +119,6 @@ vk::UniquePipeline PipelineCacheVK::CreatePipeline(
     return {};
   }
 
-  Lock lock(cache_mutex_);
   auto [result, pipeline] =
       strong_device->GetDevice().createGraphicsPipelineUnique(*cache_, info);
   if (result != vk::Result::eSuccess) {
@@ -143,7 +135,6 @@ vk::UniquePipeline PipelineCacheVK::CreatePipeline(
     return {};
   }
 
-  Lock lock(cache_mutex_);
   auto [result, pipeline] =
       strong_device->GetDevice().createComputePipelineUnique(*cache_, info);
   if (result != vk::Result::eSuccess) {
@@ -162,7 +153,6 @@ std::shared_ptr<fml::Mapping> PipelineCacheVK::CopyPipelineCacheData() const {
   if (!IsValid()) {
     return nullptr;
   }
-  Lock lock(cache_mutex_);
   auto [result, data] =
       strong_device->GetDevice().getPipelineCacheData(*cache_);
   if (result != vk::Result::eSuccess) {

--- a/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
+++ b/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
@@ -37,8 +37,7 @@ class PipelineCacheVK {
   const std::shared_ptr<const Capabilities> caps_;
   std::weak_ptr<DeviceHolder> device_holder_;
   const fml::UniqueFD cache_directory_;
-  mutable Mutex cache_mutex_;
-  vk::UniquePipelineCache cache_ IPLR_GUARDED_BY(cache_mutex_);
+  vk::UniquePipelineCache cache_;
   bool is_valid_ = false;
 
   std::shared_ptr<fml::Mapping> CopyPipelineCacheData() const;


### PR DESCRIPTION
At least from what I've found online, this API is already safe to call from multiple threads. From testing, at startup the presence of the mutex is adding ~100ms to shader creation time, as all compilations across N threads are fighting for the same lock.

https://github.com/flutter/flutter/issues/129050

