### PR TITLE
Revert "[Impeller] Correctly compute UVs in texture fill"

### DIFF
--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -4,8 +4,6 @@
 
 #include "impeller/aiks/paint_pass_delegate.h"
 
-#include "impeller/core/formats.h"
-#include "impeller/core/sampler_descriptor.h"
 #include "impeller/entity/contents/contents.h"
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/entity_pass.h"
@@ -48,13 +46,6 @@ std::shared_ptr<Contents> PaintPassDelegate::CreateContentsForSubpassTarget(
   contents->SetSourceRect(Rect::MakeSize(target->GetSize()));
   contents->SetOpacity(paint_.color.alpha);
   contents->SetDeferApplyingOpacity(true);
-
-  SamplerDescriptor sampler_desc;
-  sampler_desc.label = "Subpass";
-  sampler_desc.width_address_mode = SamplerAddressMode::kDecal;
-  sampler_desc.height_address_mode = SamplerAddressMode::kDecal;
-  contents->SetSamplerDescriptor(sampler_desc);
-
   return paint_.WithFiltersForSubpassTarget(std::move(contents),
                                             effect_transform);
 }
@@ -149,13 +140,6 @@ OpacityPeepholePassDelegate::CreateContentsForSubpassTarget(
   contents->SetSourceRect(Rect::MakeSize(target->GetSize()));
   contents->SetOpacity(paint_.color.alpha);
   contents->SetDeferApplyingOpacity(true);
-
-  SamplerDescriptor sampler_desc;
-  sampler_desc.label = "Subpass";
-  sampler_desc.width_address_mode = SamplerAddressMode::kDecal;
-  sampler_desc.height_address_mode = SamplerAddressMode::kDecal;
-  contents->SetSamplerDescriptor(sampler_desc);
-
   return paint_.WithFiltersForSubpassTarget(std::move(contents),
                                             effect_transform);
 }

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -30,7 +30,7 @@ class TextureContents final : public Contents {
 
   void SetLabel(std::string label);
 
-  void SetDestinationRect(Rect rect);
+  void SetRect(Rect rect);
 
   void SetTexture(std::shared_ptr<Texture> texture);
 
@@ -78,7 +78,7 @@ class TextureContents final : public Contents {
  private:
   std::string label_;
 
-  Rect destination_rect_;
+  Rect rect_;
   bool stencil_enabled_ = true;
 
   std::shared_ptr<Texture> texture_;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1069,7 +1069,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     if (selected_input_type == 0) {
       auto texture = std::make_shared<TextureContents>();
       texture->SetSourceRect(Rect::MakeSize(boston->GetSize()));
-      texture->SetDestinationRect(input_rect);
+      texture->SetRect(input_rect);
       texture->SetTexture(boston);
       texture->SetOpacity(input_color.alpha);
 
@@ -1192,7 +1192,7 @@ TEST_P(EntityTest, MorphologyFilter) {
         Rect::MakeXYWH(path_rect[0], path_rect[1], path_rect[2], path_rect[3]);
     auto texture = std::make_shared<TextureContents>();
     texture->SetSourceRect(Rect::MakeSize(boston->GetSize()));
-    texture->SetDestinationRect(input_rect);
+    texture->SetRect(input_rect);
     texture->SetTexture(boston);
     texture->SetOpacity(input_color.alpha);
 

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "gtest/gtest.h"
 #include "impeller/geometry/geometry_asserts.h"
 
 #include <limits>
@@ -2141,20 +2140,6 @@ TEST(GeometryTest, RectScale) {
     auto expected = Rect::MakeLTRB(100, 200, -100, -200);
     ASSERT_RECT_NEAR(expected, actual);
   }
-}
-
-TEST(GeometryTest, RectDirections) {
-  auto r = Rect::MakeLTRB(1, 2, 3, 4);
-
-  ASSERT_EQ(r.GetLeft(), 1);
-  ASSERT_EQ(r.GetTop(), 2);
-  ASSERT_EQ(r.GetRight(), 3);
-  ASSERT_EQ(r.GetBottom(), 4);
-
-  ASSERT_POINT_NEAR(r.GetLeftTop(), Point(1, 2));
-  ASSERT_POINT_NEAR(r.GetRightTop(), Point(3, 2));
-  ASSERT_POINT_NEAR(r.GetLeftBottom(), Point(1, 4));
-  ASSERT_POINT_NEAR(r.GetRightBottom(), Point(3, 4));
 }
 
 TEST(GeometryTest, RectProject) {

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -162,16 +162,6 @@ struct TRect {
     return std::max(origin.y, origin.y + size.height);
   }
 
-  constexpr TPoint<T> GetLeftTop() const { return {GetLeft(), GetTop()}; }
-
-  constexpr TPoint<T> GetRightTop() const { return {GetRight(), GetTop()}; }
-
-  constexpr TPoint<T> GetLeftBottom() const { return {GetLeft(), GetBottom()}; }
-
-  constexpr TPoint<T> GetRightBottom() const {
-    return {GetRight(), GetBottom()};
-  }
-
   constexpr std::array<T, 4> GetLTRB() const {
     return {GetLeft(), GetTop(), GetRight(), GetBottom()};
   }


### PR DESCRIPTION
Reverts flutter/engine#43028

An engine roll containing only this commit turned the framework tree red with a crasher on Android. I'm a bit concerned because it looked like one of the benchmarks that crashed should not have been using Impeller see https://github.com/flutter/flutter/pull/129353 and https://ci.chromium.org/ui/p/flutter/builders/prod/Linux_android%20animated_blur_backdrop_filter_perf__timeline_summary/1120/overview