### PR TITLE
[Impeller] default sample count back to 1 (but configure to 4 in defaults).

### DIFF
--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -62,7 +62,7 @@ std::shared_ptr<Texture> Picture::RenderToTexture(
         "Picture Snapshot MSAA",  // label
         RenderTarget::
             kDefaultColorAttachmentConfigMSAA  // color_attachment_config
-#ifndef FML_OS_ANDROID
+#ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.
         ,
         std::nullopt  // stencil_attachment_config
 #endif                // FML_OS_ANDROID
@@ -73,7 +73,7 @@ std::shared_ptr<Texture> Picture::RenderToTexture(
         size,                                        // size
         "Picture Snapshot",                          // label
         RenderTarget::kDefaultColorAttachmentConfig  // color_attachment_config
-#ifndef FML_OS_ANDROID
+#ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.
         ,
         std::nullopt  // stencil_attachment_config
 #endif                // FML_OS_ANDROID

--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -61,16 +61,22 @@ std::shared_ptr<Texture> Picture::RenderToTexture(
         size,                     // size
         "Picture Snapshot MSAA",  // label
         RenderTarget::
-            kDefaultColorAttachmentConfigMSAA,  // color_attachment_config
-        std::nullopt                            // stencil_attachment_config
+            kDefaultColorAttachmentConfigMSAA  // color_attachment_config
+#ifndef FML_OS_ANDROID
+        ,
+        std::nullopt  // stencil_attachment_config
+#endif                // FML_OS_ANDROID
     );
   } else {
     target = RenderTarget::CreateOffscreen(
-        *impeller_context,                            // context
-        size,                                         // size
-        "Picture Snapshot",                           // label
-        RenderTarget::kDefaultColorAttachmentConfig,  // color_attachment_config
+        *impeller_context,                           // context
+        size,                                        // size
+        "Picture Snapshot",                          // label
+        RenderTarget::kDefaultColorAttachmentConfig  // color_attachment_config
+#ifndef FML_OS_ANDROID
+        ,
         std::nullopt  // stencil_attachment_config
+#endif                // FML_OS_ANDROID
     );
   }
   if (!target.IsValid()) {

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -355,7 +355,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
     subpass_target = RenderTarget::CreateOffscreenMSAA(
         *context, texture_size, SPrintF("%s Offscreen", label.c_str()),
         RenderTarget::kDefaultColorAttachmentConfigMSAA  //
-#ifndef FML_OS_ANDROID
+#ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.
         ,
         std::nullopt  // stencil_attachment_config
 #endif                // FML_OS_ANDROID
@@ -364,7 +364,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
     subpass_target = RenderTarget::CreateOffscreen(
         *context, texture_size, SPrintF("%s Offscreen", label.c_str()),
         RenderTarget::kDefaultColorAttachmentConfig  //
-#ifndef FML_OS_ANDROID
+#ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.
         ,
         std::nullopt  // stencil_attachment_config
 #endif                // FML_OS_ANDROID

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -151,7 +151,8 @@ static std::unique_ptr<PipelineT> CreateDefaultPipeline(
   // Apply default ContentContextOptions to the descriptor.
   const auto default_color_fmt =
       context.GetCapabilities()->GetDefaultColorFormat();
-  ContentContextOptions{.color_attachment_pixel_format = default_color_fmt}
+  ContentContextOptions{.sample_count = SampleCount::kCount4,
+                        .color_attachment_pixel_format = default_color_fmt}
       .ApplyToPipelineDescriptor(*desc);
   return std::make_unique<PipelineT>(context, desc);
 }
@@ -166,6 +167,7 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
     return;
   }
   default_options_ = ContentContextOptions{
+      .sample_count = SampleCount::kCount4,
       .color_attachment_pixel_format =
           context_->GetCapabilities()->GetDefaultColorFormat()};
 
@@ -352,11 +354,21 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
   if (context->GetCapabilities()->SupportsOffscreenMSAA() && msaa_enabled) {
     subpass_target = RenderTarget::CreateOffscreenMSAA(
         *context, texture_size, SPrintF("%s Offscreen", label.c_str()),
-        RenderTarget::kDefaultColorAttachmentConfigMSAA, std::nullopt);
+        RenderTarget::kDefaultColorAttachmentConfigMSAA  //
+#ifndef FML_OS_ANDROID
+        ,
+        std::nullopt  // stencil_attachment_config
+#endif                // FML_OS_ANDROID
+    );
   } else {
     subpass_target = RenderTarget::CreateOffscreen(
         *context, texture_size, SPrintF("%s Offscreen", label.c_str()),
-        RenderTarget::kDefaultColorAttachmentConfig, std::nullopt);
+        RenderTarget::kDefaultColorAttachmentConfig  //
+#ifndef FML_OS_ANDROID
+        ,
+        std::nullopt  // stencil_attachment_config
+#endif                // FML_OS_ANDROID
+    );
   }
   auto subpass_texture = subpass_target.GetRenderTargetTexture();
   if (!subpass_texture) {

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -291,7 +291,7 @@ using UvComputeShaderPipeline = ComputePipelineBuilder<UvComputeShader>;
 /// Flutter application may easily require building hundreds of PSOs in total,
 /// but they shouldn't require e.g. 10s of thousands.
 struct ContentContextOptions {
-  SampleCount sample_count = SampleCount::kCount4;
+  SampleCount sample_count = SampleCount::kCount1;
   BlendMode blend_mode = BlendMode::kSourceOver;
   CompareFunction stencil_compare = CompareFunction::kEqual;
   StencilOperation stencil_operation = StencilOperation::kKeep;

--- a/impeller/renderer/pipeline_descriptor.h
+++ b/impeller/renderer/pipeline_descriptor.h
@@ -133,7 +133,7 @@ class PipelineDescriptor final : public Comparable<PipelineDescriptor> {
 
  private:
   std::string label_;
-  SampleCount sample_count_ = SampleCount::kCount4;
+  SampleCount sample_count_ = SampleCount::kCount1;
   WindingOrder winding_order_ = WindingOrder::kClockwise;
   CullMode cull_mode_ = CullMode::kNone;
   std::map<ShaderStage, std::shared_ptr<const ShaderFunction>> entrypoints_;

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -217,6 +217,11 @@ RenderTarget RenderTarget::CreateOffscreen(
     return {};
   }
 
+// Dont force additional PSO variants on Vulkan.
+#ifdef FML_OS_ANDROID
+  FML_DCHECK(stencil_attachment_config.has_value());
+#endif  // FML_OS_ANDROID
+
   RenderTarget target;
   PixelFormat pixel_format = context.GetCapabilities()->GetDefaultColorFormat();
   TextureDescriptor color_tex0;
@@ -257,6 +262,11 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   if (size.IsEmpty()) {
     return {};
   }
+
+// Dont force additional PSO variants on Vulkan.
+#ifdef FML_OS_ANDROID
+  FML_DCHECK(stencil_attachment_config.has_value());
+#endif  // FML_OS_ANDROID
 
   RenderTarget target;
   PixelFormat pixel_format = context.GetCapabilities()->GetDefaultColorFormat();


### PR DESCRIPTION
Also forces the creation of a stencil attachment always on Android to reduce the number of PSO variants.

https://github.com/flutter/flutter/issues/129050