### PR TITLE
Workaround a release blocker after libc++ change

### DIFF
--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -215,6 +215,11 @@ class EncodableValue : public internal::EncodableValueVariant {
     }
     return std::get<int64_t>(*this);
   }
+
+  // Avoid operator<=> problems with std::variant in C++20 mode.
+  friend bool operator<(const EncodableValue& lhs, const EncodableValue& rhs) {
+    return static_cast<const super&>(lhs) < static_cast<const super&>(rhs);
+  }
 };
 
 }  // namespace flutter

--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -217,7 +217,8 @@ class EncodableValue : public internal::EncodableValueVariant {
   }
 
   // Explicitly provide operator<, delegating to std::variant's operator<.
-  // This avoids operator<=> problems with std::variant in C++20 mode.
+  // There are issues with with the way the standard library-provided
+  // < and <=> comparisons interact with classes derived from variant.
   friend bool operator<(const EncodableValue& lhs, const EncodableValue& rhs) {
     return static_cast<const super&>(lhs) < static_cast<const super&>(rhs);
   }

--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -216,7 +216,8 @@ class EncodableValue : public internal::EncodableValueVariant {
     return std::get<int64_t>(*this);
   }
 
-  // Avoid operator<=> problems with std::variant in C++20 mode.
+  // Explicitly provide operator<, delegating to std::variant's operator<.
+  // This avoids operator<=> problems with std::variant in C++20 mode.
   friend bool operator<(const EncodableValue& lhs, const EncodableValue& rhs) {
     return static_cast<const super&>(lhs) < static_cast<const super&>(rhs);
   }


### PR DESCRIPTION
The code breaks in C++20 mode after libc++ removes comparisons for `std::vector` and replaces them with 'operator <=>'.

See cl/542541552 for context.