### PR TITLE
[Impeller] Add fence waiter trace event.

### DIFF
--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -30,7 +30,7 @@ bool FenceWaiterVK::IsValid() const {
 
 bool FenceWaiterVK::AddFence(vk::UniqueFence fence,
                              const fml::closure& callback) {
-  TRACE_EVENT_0("flutter", "FenceWaiterVK::AddFence");
+  TRACE_EVENT0("flutter", "FenceWaiterVK::AddFence");
   if (!IsValid() || !fence || !callback) {
     return false;
   }

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -30,6 +30,7 @@ bool FenceWaiterVK::IsValid() const {
 
 bool FenceWaiterVK::AddFence(vk::UniqueFence fence,
                              const fml::closure& callback) {
+  TRACE_EVENT_0("flutter", "FenceWaiterVK::AddFence");
   if (!IsValid() || !fence || !callback) {
     return false;
   }


### PR DESCRIPTION
I suspect that some of the worst frame times are caused by submission blocking on adding a fence. Add a trace event that would make that obvious.

![unnamed](https://github.com/flutter/engine/assets/8975114/93650ac8-4451-49d7-b8fa-00fc9f7f4277)
