### PR TITLE
[Impeller] Add validation forbidding SamplerAddressMode::kDecal on the OpenGLES backend

### DIFF
--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -75,6 +75,7 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
             .SetSupportsComputeSubgroups(false)
             .SetSupportsReadFromResolve(false)
             .SetSupportsReadFromOnscreenTexture(false)
+            .SetSupportsDecalTileMode(false)
             .Build();
   }
 

--- a/impeller/renderer/backend/gles/sampler_library_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_library_gles.cc
@@ -19,6 +19,9 @@ SamplerLibraryGLES::~SamplerLibraryGLES() = default;
 // |SamplerLibrary|
 std::shared_ptr<const Sampler> SamplerLibraryGLES::GetSampler(
     SamplerDescriptor descriptor) {
+  // TODO(bdero): Change this validation once optional support for kDecal is
+  //              added to the OpenGLES backend:
+  //              https://github.com/flutter/flutter/issues/129358
   if (descriptor.width_address_mode == SamplerAddressMode::kDecal ||
       descriptor.height_address_mode == SamplerAddressMode::kDecal ||
       descriptor.depth_address_mode == SamplerAddressMode::kDecal) {

--- a/impeller/renderer/backend/gles/sampler_library_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_library_gles.cc
@@ -5,6 +5,8 @@
 #include "impeller/renderer/backend/gles/sampler_library_gles.h"
 
 #include "impeller/base/config.h"
+#include "impeller/base/validation.h"
+#include "impeller/core/formats.h"
 #include "impeller/renderer/backend/gles/sampler_gles.h"
 
 namespace impeller {
@@ -17,6 +19,14 @@ SamplerLibraryGLES::~SamplerLibraryGLES() = default;
 // |SamplerLibrary|
 std::shared_ptr<const Sampler> SamplerLibraryGLES::GetSampler(
     SamplerDescriptor descriptor) {
+  if (descriptor.width_address_mode == SamplerAddressMode::kDecal ||
+      descriptor.height_address_mode == SamplerAddressMode::kDecal ||
+      descriptor.depth_address_mode == SamplerAddressMode::kDecal) {
+    VALIDATION_LOG << "SamplerAddressMode::kDecal is not supported by the "
+                      "OpenGLES backend.";
+    return nullptr;
+  }
+
   auto found = samplers_.find(descriptor);
   if (found != samplers_.end()) {
     return found->second;


### PR DESCRIPTION
Fixes uncontrolled crash when kDecal is used (as seen on https://github.com/flutter/engine/pull/43087).