### PR TITLE
[Impeller] Fix and reland drawPaint collapsing optimization.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1992,6 +1992,18 @@ TEST_P(AiksTest, OpacityPeepHoleApplicationTest) {
   ASSERT_TRUE(delegate->CanCollapseIntoParentPass(entity_pass.get()));
 }
 
+TEST_P(AiksTest, DrawPaintAbsorbsClears) {
+  Canvas canvas;
+  canvas.DrawPaint({.color = Color::Red(), .blend_mode = BlendMode::kSource});
+  canvas.DrawPaint(
+      {.color = Color::CornflowerBlue(), .blend_mode = BlendMode::kSource});
+
+  Picture picture = canvas.EndRecordingAsPicture();
+
+  ASSERT_EQ(picture.pass->GetElementCount(), 0u);
+  ASSERT_EQ(picture.pass->GetClearColor(), Color::CornflowerBlue());
+}
+
 TEST_P(AiksTest, ForegroundBlendSubpassCollapseOptimization) {
   Canvas canvas;
 

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -174,7 +174,9 @@ void Canvas::DrawPath(const Path& path, const Paint& paint) {
 void Canvas::DrawPaint(const Paint& paint) {
   if (xformation_stack_.size() == 1 &&  // If we're recording the root pass,
       GetCurrentPass().GetElementCount() == 0 &&  // and this is the first item,
-      paint.blend_mode == BlendMode::kSourceOver && paint.color.alpha >= 1.0f) {
+      (paint.blend_mode == BlendMode::kSourceOver ||
+       paint.blend_mode == BlendMode::kSource) &&
+      paint.color.alpha >= 1.0f) {
     // Then we can absorb this drawPaint as the clear color of the pass.
     GetCurrentPass().SetClearColor(paint.color);
     return;

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -172,6 +172,14 @@ void Canvas::DrawPath(const Path& path, const Paint& paint) {
 }
 
 void Canvas::DrawPaint(const Paint& paint) {
+  if (xformation_stack_.size() == 1 &&  // If we're recording the root pass,
+      GetCurrentPass().GetElementCount() == 0 &&  // and this is the first item,
+      paint.blend_mode == BlendMode::kSourceOver && paint.color.alpha >= 1.0f) {
+    // Then we can absorb this drawPaint as the clear color of the pass.
+    GetCurrentPass().SetClearColor(paint.color);
+    return;
+  }
+
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -477,7 +477,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
         renderer,                                  // renderer
         subpass_size,                              // size
         subpass->GetTotalPassReads(renderer) > 0,  // readable
-        clear_color_.Premultiply());               // clear_color
+        Color::BlackTransparent());                // clear_color
 
     if (!subpass_target.IsValid()) {
       VALIDATION_LOG << "Subpass render target is invalid.";

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -303,7 +303,7 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   // Color attachment.
 
   ColorAttachment color0;
-  color0.clear_color = Color::BlackTransparent();
+  color0.clear_color = color_attachment_config.clear_color;
   color0.load_action = color_attachment_config.load_action;
   color0.store_action = color_attachment_config.store_action;
   color0.texture = color0_msaa_tex;


### PR DESCRIPTION
Collapses DrawPaint calls into clear colors when possible.

issue https://github.com/flutter/flutter/issues/129292
relands https://github.com/flutter/engine/pull/41711

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
