### PR TITLE
[Impeller] avoid locking fence waiter while querying fence status.

### DIFF
--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -81,7 +81,8 @@ void FenceWaiterVK::Main() {
       break;
     }
 
-    if (!TrimAndCreateWaitSetLocked(device_holder, std::move(temp_wait_set), std::move(callbacks))) {
+    if (!TrimAndCreateWaitSetLocked(device_holder, std::move(temp_wait_set),
+                                    std::move(callbacks))) {
       break;
     }
   }

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -7,7 +7,6 @@
 #include <chrono>
 
 #include "flutter/fml/thread.h"
-#include "flutter/fml/trace_event.h"
 
 namespace impeller {
 
@@ -30,7 +29,6 @@ bool FenceWaiterVK::IsValid() const {
 
 bool FenceWaiterVK::AddFence(vk::UniqueFence fence,
                              const fml::closure& callback) {
-  TRACE_EVENT0("flutter", "FenceWaiterVK::AddFence");
   if (!IsValid() || !fence || !callback) {
     return false;
   }

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.h
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <optional>
 #include <thread>
-#include <unordered_map>
 
 #include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
@@ -38,16 +37,15 @@ class FenceWaiterVK {
   std::unique_ptr<std::thread> waiter_thread_;
   std::mutex wait_set_mutex_;
   std::condition_variable wait_set_cv_;
-  std::unordered_map<SharedHandleVK<vk::Fence>, fml::closure> wait_set_;
+
+  std::vector<vk::UniqueFence> wait_set_;
+  std::vector<fml::closure> wait_set_callbacks_;
   bool terminate_ = false;
   bool is_valid_ = false;
 
   explicit FenceWaiterVK(std::weak_ptr<DeviceHolder> device_holder);
 
   void Main();
-
-  std::optional<std::vector<vk::Fence>> TrimAndCreateWaitSetLocked(
-      const std::shared_ptr<DeviceHolder>& device_holder);
 
   FML_DISALLOW_COPY_AND_ASSIGN(FenceWaiterVK);
 };

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.h
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.h
@@ -33,6 +33,11 @@ class FenceWaiterVK {
  private:
   friend class ContextVK;
 
+  bool TrimAndCreateWaitSetLocked(
+      const std::shared_ptr<DeviceHolder>& device_holder,
+      std::vector<vk::UniqueFence> fences,
+      std::vector<fml::closure> closures);
+
   std::weak_ptr<DeviceHolder> device_holder_;
   std::unique_ptr<std::thread> waiter_thread_;
   std::mutex wait_set_mutex_;


### PR DESCRIPTION
Checking the fence status has been recorded to take up to 70ms on the S10 devices. Change the behavior of fence waiter so that it pulls all fences/cbs into temporaries, then movies any unresolved fences back after the wait.

Fixes https://github.com/flutter/flutter/issues/129371