### PR TITLE
Add a note in ImeSyncDeferringInsetsCallback explaining the reason behind capturing the latest final inset state

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
+++ b/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
@@ -67,7 +67,13 @@ class ImeSyncDeferringInsetsCallback {
   private boolean animating = false;
   // When an animation begins, android sends a WindowInset with the final
   // state of the animation. When needsSave is true, we know to capture this
-  // initial WindowInset.
+  // initial WindowInset. 
+  //
+  // Certain actions, like dismissing the keyboard, can trigger multiple 
+  // animations that are slightly offset in start time. To capture the 
+  // correct final insets in these situations we update needsSave to true
+  // in each onPrepare callback, so that we save the latest final state
+  // to apply in onEnd.
   private boolean needsSave = false;
 
   ImeSyncDeferringInsetsCallback(@NonNull View view) {

--- a/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
+++ b/shell/platform/android/io/flutter/plugin/editing/ImeSyncDeferringInsetsCallback.java
@@ -67,10 +67,10 @@ class ImeSyncDeferringInsetsCallback {
   private boolean animating = false;
   // When an animation begins, android sends a WindowInset with the final
   // state of the animation. When needsSave is true, we know to capture this
-  // initial WindowInset. 
+  // initial WindowInset.
   //
-  // Certain actions, like dismissing the keyboard, can trigger multiple 
-  // animations that are slightly offset in start time. To capture the 
+  // Certain actions, like dismissing the keyboard, can trigger multiple
+  // animations that are slightly offset in start time. To capture the
   // correct final insets in these situations we update needsSave to true
   // in each onPrepare callback, so that we save the latest final state
   // to apply in onEnd.


### PR DESCRIPTION
Solely documentation change to explain the reasoning behind the change in https://github.com/flutter/engine/pull/42700.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
