### PR TITLE
Add osx_sdk context to mac_clang_tidy

### DIFF
--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -60,6 +60,9 @@
                 "host_debug",
                 "ios_debug_sim"
             ],
+            "contexts": [
+                "osx_sdk"
+            ],
             "tasks": [
                 {
                     "name": "test: lint host_debug",
@@ -89,6 +92,9 @@
             "dependencies": [
                 "host_debug",
                 "ios_debug_sim"
+            ],
+            "contexts": [
+                "osx_sdk"
             ],
             "tasks": [
                 {


### PR DESCRIPTION
With context, recipes logic should be simplified without checking corresponding platform/property conditions.

With the `osx_sdk` context, it will install xcode accordingly.