### PR TITLE
[Impeller] re-enable buffer to texture blit Vulkan.

### DIFF
--- a/impeller/core/device_buffer.cc
+++ b/impeller/core/device_buffer.cc
@@ -39,6 +39,8 @@ std::shared_ptr<Texture> DeviceBuffer::AsTexture(
   return texture;
 }
 
+void DeviceBuffer::Flush() {}
+
 const DeviceBufferDescriptor& DeviceBuffer::GetDeviceBufferDescriptor() const {
   return desc_;
 }

--- a/impeller/core/device_buffer.h
+++ b/impeller/core/device_buffer.h
@@ -32,6 +32,8 @@ class DeviceBuffer : public Buffer,
 
   BufferView AsBufferView() const;
 
+  virtual void Flush();
+
   virtual std::shared_ptr<Texture> AsTexture(
       Allocator& allocator,
       const TextureDescriptor& descriptor,

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -327,7 +327,7 @@ bool CapabilitiesVK::SupportsSSBO() const {
 
 // |Capabilities|
 bool CapabilitiesVK::SupportsBufferToTextureBlits() const {
-  return false;
+  return true;
 }
 
 // |Capabilities|

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.cc
@@ -53,6 +53,10 @@ bool DeviceBufferVK::OnCopyHostBuffer(const uint8_t* source,
   return true;
 }
 
+void DeviceBufferVK::Flush() {
+  ::vmaFlushAllocation(allocator_, allocation_, 0, VK_WHOLE_SIZE);
+}
+
 bool DeviceBufferVK::SetLabel(const std::string& label) {
   auto context = context_.lock();
   if (!context || !buffer_) {

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.h
@@ -28,6 +28,11 @@ class DeviceBufferVK final : public DeviceBuffer,
 
   vk::Buffer GetBuffer() const;
 
+  // If the contents of this buffer have been written to with
+  // `OnGetContents`, then calling flush may be necessary if the memory is
+  // non-coherent.
+  void Flush() override;
+
  private:
   friend class AllocatorVK;
 

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -510,6 +510,9 @@ ImpellerAllocator::ImpellerAllocator(
 
 std::optional<std::shared_ptr<impeller::DeviceBuffer>>
 ImpellerAllocator::GetDeviceBuffer() const {
+  if (buffer_.has_value()) {
+    buffer_.value()->Flush();
+  }
   return buffer_;
 }
 


### PR DESCRIPTION
I was missing the VMA flush.

Because skia is writing directly to the exposed ptr, we don't go through the OnSetContents which makes a flush call. Add a flush API and implement it for Vk DeviceBuffers.

