### PR TITLE
[Impeller] FenceWaiterVK: Move potentially slow calls out of wait set mutex critical section.

### DIFF
--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.h
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.h
@@ -6,9 +6,8 @@
 
 #include <condition_variable>
 #include <memory>
-#include <optional>
 #include <thread>
-#include <unordered_map>
+#include <vector>
 
 #include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
@@ -20,6 +19,9 @@
 namespace impeller {
 
 class ContextVK;
+class WaitSetEntry;
+
+using WaitSet = std::vector<std::shared_ptr<WaitSetEntry>>;
 
 class FenceWaiterVK {
  public:
@@ -38,16 +40,13 @@ class FenceWaiterVK {
   std::unique_ptr<std::thread> waiter_thread_;
   std::mutex wait_set_mutex_;
   std::condition_variable wait_set_cv_;
-  std::unordered_map<SharedHandleVK<vk::Fence>, fml::closure> wait_set_;
+  WaitSet wait_set_;
   bool terminate_ = false;
   bool is_valid_ = false;
 
   explicit FenceWaiterVK(std::weak_ptr<DeviceHolder> device_holder);
 
   void Main();
-
-  std::optional<std::vector<vk::Fence>> TrimAndCreateWaitSetLocked(
-      const std::shared_ptr<DeviceHolder>& device_holder);
 
   FML_DISALLOW_COPY_AND_ASSIGN(FenceWaiterVK);
 };


### PR DESCRIPTION
Moves signaled checks and callbacks out of the wait set mutex critical section.

The signaled checked can apparently be super slow on Qualcomm devices and the callback may hit allocators that could be slow as well.