### PR TITLE
[impeller] Explicitly cast enum class to int before passing it to a formatted string

### DIFF
--- a/impeller/renderer/blit_pass.cc
+++ b/impeller/renderer/blit_pass.cc
@@ -48,8 +48,8 @@ bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
     VALIDATION_LOG << SPrintF(
         "The source sample count (%d) must match the destination sample count "
         "(%d) for blits.",
-        source->GetTextureDescriptor().sample_count,
-        destination->GetTextureDescriptor().sample_count);
+        static_cast<int>(source->GetTextureDescriptor().sample_count),
+        static_cast<int>(destination->GetTextureDescriptor().sample_count));
     return false;
   }
 


### PR DESCRIPTION
Next version of the crosstool will start warning about this (see: https://github.com/llvm/llvm-project/issues/38717)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
