### PR TITLE
Explicitly cast enum class to int before passing it with a format string

### DIFF
--- a/impeller/renderer/blit_pass.cc
+++ b/impeller/renderer/blit_pass.cc
@@ -48,8 +48,8 @@ bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
     VALIDATION_LOG << SPrintF(
         "The source sample count (%d) must match the destination sample count "
         "(%d) for blits.",
-        source->GetTextureDescriptor().sample_count,
-        destination->GetTextureDescriptor().sample_count);
+        static_cast<int>(source->GetTextureDescriptor().sample_count),
+        static_cast<int>(destination->GetTextureDescriptor().sample_count));
     return false;
   }
 


### PR DESCRIPTION
Next version of the crosstool will start warning about this (see: https://github.com/llvm/llvm-project/issues/38717)

For context, see cl/542803761

Reviewers, please leave comment in the internal change, thanks.