### PR TITLE
[Impeller] Supply surface cull rect for Vulkan & GLES dispatchers

### DIFF
--- a/shell/gpu/gpu_surface_gl_impeller.cc
+++ b/shell/gpu/gpu_surface_gl_impeller.cc
@@ -103,10 +103,13 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
           return false;
         }
 
+        auto cull_rect =
+            surface->GetTargetRenderPassDescriptor().GetRenderTargetSize();
+
         impeller::DlDispatcher impeller_dispatcher;
         display_list->Dispatch(
             impeller_dispatcher,
-            surface->GetTargetRenderPassDescriptor().GetRenderTargetSize());
+            SkIRect::MakeWH(cull_rect.width, cull_rect.height));
         auto picture = impeller_dispatcher.EndRecordingAsPicture();
 
         return renderer->Render(

--- a/shell/gpu/gpu_surface_gl_impeller.cc
+++ b/shell/gpu/gpu_surface_gl_impeller.cc
@@ -104,7 +104,9 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
         }
 
         impeller::DlDispatcher impeller_dispatcher;
-        display_list->Dispatch(impeller_dispatcher);
+        display_list->Dispatch(
+            impeller_dispatcher,
+            surface->GetTargetRenderPassDescriptor().GetRenderTargetSize());
         auto picture = impeller_dispatcher.EndRecordingAsPicture();
 
         return renderer->Render(

--- a/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -73,7 +73,9 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
         }
 
         impeller::DlDispatcher impeller_dispatcher;
-        display_list->Dispatch(impeller_dispatcher);
+        display_list->Dispatch(
+            impeller_dispatcher,
+            surface->GetTargetRenderPassDescriptor().GetRenderTargetSize());
         auto picture = impeller_dispatcher.EndRecordingAsPicture();
 
         return renderer->Render(

--- a/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -72,10 +72,13 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
           return false;
         }
 
+        auto cull_rect =
+            surface->GetTargetRenderPassDescriptor().GetRenderTargetSize();
+
         impeller::DlDispatcher impeller_dispatcher;
         display_list->Dispatch(
             impeller_dispatcher,
-            surface->GetTargetRenderPassDescriptor().GetRenderTargetSize());
+            SkIRect::MakeWH(cull_rect.width, cull_rect.height));
         auto picture = impeller_dispatcher.EndRecordingAsPicture();
 
         return renderer->Render(


### PR DESCRIPTION
Similar to Metal, have the DL cull entities early that lie entirely outside the surface texture.