### PR TITLE
[Impeller] Disable blending for Source blend mode

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -42,6 +42,7 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
       color0.src_color_blend_factor = BlendFactor::kZero;
       break;
     case BlendMode::kSource:
+      color0.blending_enabled = false;
       color0.dst_alpha_blend_factor = BlendFactor::kZero;
       color0.dst_color_blend_factor = BlendFactor::kZero;
       color0.src_alpha_blend_factor = BlendFactor::kOne;


### PR DESCRIPTION
All of the backends already respect this property for the first color attachment in the pipeline. ~~Our Vulkan backend disables blending for a whole pipeline if the first color attachment has blending turned off.~~ This has been under our nose but I haven't checked it until now.

HSR might not be working on some Vulkan & OpenGLES drivers because of this.