### PR TITLE
[Impeller] Fix float issue rrect blur.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1098,6 +1098,7 @@ ORIGIN: ../../../flutter/impeller/compiler/shader_lib/impeller/color.glsl + ../.
 ORIGIN: ../../../flutter/impeller/compiler/shader_lib/impeller/constants.glsl + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/compiler/shader_lib/impeller/conversions.glsl + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/compiler/shader_lib/impeller/gaussian.glsl + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/compiler/shader_lib/impeller/gaussian_highp.glsl + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/compiler/shader_lib/impeller/gradient.glsl + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/compiler/shader_lib/impeller/path.glsl + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/compiler/shader_lib/impeller/prefix_sum.glsl + ../../../flutter/LICENSE
@@ -3777,6 +3778,7 @@ FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/color.glsl
 FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/constants.glsl
 FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/conversions.glsl
 FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/gaussian.glsl
+FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/gaussian_highp.glsl
 FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/gradient.glsl
 FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/path.glsl
 FILE: ../../../flutter/impeller/compiler/shader_lib/impeller/prefix_sum.glsl

--- a/impeller/compiler/shader_lib/impeller/BUILD.gn
+++ b/impeller/compiler/shader_lib/impeller/BUILD.gn
@@ -10,6 +10,7 @@ copy("impeller") {
     "constants.glsl",
     "conversions.glsl",
     "gaussian.glsl",
+    "gaussian_highp.glsl",
     "gradient.glsl",
     "path.glsl",
     "texture.glsl",

--- a/impeller/compiler/shader_lib/impeller/gaussian.glsl
+++ b/impeller/compiler/shader_lib/impeller/gaussian.glsl
@@ -7,12 +7,7 @@
 
 #include <impeller/constants.glsl>
 #include <impeller/types.glsl>
-
-/// Gaussian distribution function.
-float IPGaussian(float x, float sigma) {
-  float variance = sigma * sigma;
-  return exp(-0.5f * x * x / variance) / (kSqrtTwoPi * sigma);
-}
+#include <impeller/gaussian_highp.glsl>
 
 /// Gaussian distribution function.
 float16_t IPHalfGaussian(float16_t x, float16_t sigma) {
@@ -49,11 +44,6 @@ float16_t IPGaussianIntegral(float16_t x, float16_t sigma) {
 f16vec2 IPVec2GaussianIntegral(f16vec2 x, float16_t sigma) {
   // ( 1 + erf( x * (sqrt(2) / (2 * sigma) ) ) / 2
   return (1.0hf + IPVec2Erf(x * (float16_t(kHalfSqrtTwo) / sigma))) * 0.5hf;
-}
-
-/// Simpler (but less accurate) approximation of the Gaussian integral.
-vec2 IPVec2FastGaussianIntegral(vec2 x, float sigma) {
-  return 1.0 / (1.0 + exp(-kSqrtThree / sigma * x));
 }
 
 /// Simpler (but less accurate) approximation of the Gaussian integral.

--- a/impeller/compiler/shader_lib/impeller/gaussian.glsl
+++ b/impeller/compiler/shader_lib/impeller/gaussian.glsl
@@ -6,8 +6,8 @@
 #define GAUSSIAN_GLSL_
 
 #include <impeller/constants.glsl>
-#include <impeller/types.glsl>
 #include <impeller/gaussian_highp.glsl>
+#include <impeller/types.glsl>
 
 /// Gaussian distribution function.
 float16_t IPHalfGaussian(float16_t x, float16_t sigma) {

--- a/impeller/compiler/shader_lib/impeller/gaussian_highp.glsl
+++ b/impeller/compiler/shader_lib/impeller/gaussian_highp.glsl
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef GAUSSIAN_HIGHP_GLSL_
+#define GAUSSIAN_HIGHP_GLSL_
+
+/// Gaussian distribution function.
+float IPGaussian(float x, float sigma) {
+  // sqrt(2 * pi)
+  const float kSqrtTwoPi = 2.50662827463;
+  float variance = sigma * sigma;
+  return exp(-0.5f * x * x / variance) / (kSqrtTwoPi * sigma);
+}
+
+/// Simpler (but less accurate) approximation of the Gaussian integral.
+vec2 IPVec2FastGaussianIntegral(vec2 x, float sigma) {
+  // sqrt(3)
+  const float kSqrtThree = 1.73205080757;
+  return 1.0 / (1.0 + exp(-kSqrtThree / sigma * x));
+}
+
+#endif

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -23,7 +23,7 @@ const int kSampleCount = 4;
 float RRectDistance(vec2 sample_position, vec2 half_size) {
   vec2 space = abs(sample_position) - half_size + frag_info.corner_radius;
   return float(length(max(space, 0.0)) + min(max(space.x, space.y), 0.0) -
-                   frag_info.corner_radius);
+               frag_info.corner_radius);
 }
 
 /// Closed form unidirectional rounded rect blur mask solution using the

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -2,26 +2,27 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <impeller/gaussian.glsl>
-#include <impeller/types.glsl>
+precision highp float;
+
+#include <impeller/gaussian_highp.glsl>
 
 uniform FragInfo {
-  f16vec4 color;
+  vec4 color;
   vec2 rect_size;
   float blur_sigma;
   float corner_radius;
 }
 frag_info;
 
-in vec2 v_position;
+in highp vec2 v_position;
 
-out f16vec4 frag_color;
+out vec4 frag_color;
 
 const int kSampleCount = 4;
 
-float16_t RRectDistance(vec2 sample_position, vec2 half_size) {
+float RRectDistance(vec2 sample_position, vec2 half_size) {
   vec2 space = abs(sample_position) - half_size + frag_info.corner_radius;
-  return float16_t(length(max(space, 0.0)) + min(max(space.x, space.y), 0.0) -
+  return float(length(max(space, 0.0)) + min(max(space.x, space.y), 0.0) -
                    frag_info.corner_radius);
 }
 
@@ -72,8 +73,8 @@ void main() {
   vec2 sample_position = v_position - half_size;
 
   if (frag_info.blur_sigma > 0.0) {
-    frag_color *= float16_t(RRectBlur(sample_position, half_size));
+    frag_color *= float(RRectBlur(sample_position, half_size));
   } else {
-    frag_color *= float16_t(-RRectDistance(sample_position, half_size));
+    frag_color *= float(-RRectDistance(sample_position, half_size));
   }
 }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -9060,20 +9060,20 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 68,
+          "fp16_arithmetic": 0,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "longest_path_cycles": [
-              1.5,
-              1.3875000476837158,
-              0.737500011920929,
+              1.53125,
+              1.53125,
+              0.484375,
               1.5,
               0.0,
-              0.125,
+              0.25,
               0.0
             ],
             "pipelines": [
@@ -9086,35 +9086,34 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_fma"
+              "varying"
             ],
             "shortest_path_cycles": [
-              0.203125,
-              0.203125,
-              0.046875,
+              0.234375,
+              0.234375,
+              0.078125,
               0.0625,
               0.0,
-              0.125,
+              0.25,
               0.0
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "total_cycles": [
-              1.5625,
-              1.5125000476837158,
-              0.762499988079071,
+              1.6749999523162842,
+              1.6749999523162842,
+              0.546875,
               1.5625,
               0.0,
-              0.125,
+              0.25,
               0.0
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 16,
+          "uniform_registers_used": 24,
           "work_registers_used": 32
         }
       }
@@ -9132,7 +9131,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              22.110000610351562,
+              23.43000030517578,
               1.0,
               0.0
             ],
@@ -9153,14 +9152,14 @@
               "arithmetic"
             ],
             "total_cycles": [
-              10.0,
+              10.333333015441895,
               1.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 2,
-          "work_registers_used": 3
+          "uniform_registers_used": 3,
+          "work_registers_used": 4
         }
       }
     }
@@ -12167,20 +12166,20 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 65,
+          "fp16_arithmetic": 0,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "longest_path_cycles": [
-              1.5,
-              1.4249999523162842,
-              0.699999988079071,
+              1.59375,
+              1.59375,
+              0.453125,
               1.5,
               0.0,
-              0.125,
+              0.25,
               0.0
             ],
             "pipelines": [
@@ -12193,36 +12192,35 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_fma"
+              "varying"
             ],
             "shortest_path_cycles": [
-              0.171875,
-              0.171875,
-              0.0625,
+              0.234375,
+              0.234375,
+              0.078125,
               0.0625,
               0.0,
-              0.125,
+              0.25,
               0.0
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "total_cycles": [
-              1.5625,
-              1.5499999523162842,
-              0.75,
+              1.7374999523162842,
+              1.7374999523162842,
+              0.515625,
               1.5625,
               0.0,
-              0.125,
+              0.25,
               0.0
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 18,
-          "work_registers_used": 31
+          "uniform_registers_used": 24,
+          "work_registers_used": 32
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/128284

Rearrange the gaussian imports so that we can get away with a single `precision highp float` in the rrect blur shader.
