### PR TITLE
[Impeller] Label present waiter command buffer in SurfaceMTL

### DIFF
--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -84,7 +84,7 @@ class ContextMTL final : public Context,
   // |Context|
   bool UpdateOffscreenLayerPixelFormat(PixelFormat format) override;
 
-  id<MTLCommandBuffer> CreateMTLCommandBuffer() const;
+  id<MTLCommandBuffer> CreateMTLCommandBuffer(const std::string& label) const;
 
   const std::shared_ptr<fml::ConcurrentTaskRunner>& GetWorkerTaskRunner() const;
 

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -343,8 +343,13 @@ bool ContextMTL::UpdateOffscreenLayerPixelFormat(PixelFormat format) {
   return true;
 }
 
-id<MTLCommandBuffer> ContextMTL::CreateMTLCommandBuffer() const {
-  return [command_queue_ commandBuffer];
+id<MTLCommandBuffer> ContextMTL::CreateMTLCommandBuffer(
+    const std::string& label) const {
+  auto buffer = [command_queue_ commandBuffer];
+  if (!label.empty()) {
+    [buffer setLabel:@(label.data())];
+  }
+  return buffer;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -262,9 +262,13 @@ bool SurfaceMTL::Present() const {
   }
 
   if (drawable_) {
+    // In certain situations, we need to wait until the command queue has been
+    // flushed before presenting to the onscreen texture. See the comments in
+    // `ShouldWaitForCommandBuffer` for more details.
     if (ShouldWaitForCommandBuffer()) {
       id<MTLCommandBuffer> command_buffer =
-          ContextMTL::Cast(context.get())->CreateMTLCommandBuffer();
+          ContextMTL::Cast(context.get())
+              ->CreateMTLCommandBuffer("Present Waiter Command Buffer");
       [command_buffer commit];
       [command_buffer waitUntilScheduled];
     }


### PR DESCRIPTION
Just to curb confusion and make it searchable. I double-take this lingering command buffer in frame captures quite a bit.