### PR TITLE
[Impeller] use default precision specifiers.

### DIFF
--- a/impeller/compiler/shader_lib/impeller/types.glsl
+++ b/impeller/compiler/shader_lib/impeller/types.glsl
@@ -12,7 +12,6 @@
 #ifndef IMPELLER_TARGET_METAL_IOS
 
 precision mediump sampler2D;
-precision mediump float;
 
 #define float16_t float
 #define f16vec2 vec2

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>

--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-precision mediump float;
-
 #include <impeller/blending.glsl>
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>

--- a/impeller/entity/shaders/blending/advanced_blend_color.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_color.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colorburn.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_colordodge.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_darken.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_darken.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_difference.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_difference.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_exclusion.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_exclusion.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_hardlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_hardlight.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_hue.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_hue.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_lighten.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_lighten.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_luminosity.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_luminosity.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_multiply.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_multiply.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_overlay.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_overlay.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_saturation.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_saturation.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_screen.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_screen.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/advanced_blend_softlight.frag
+++ b/impeller/entity/shaders/blending/advanced_blend_softlight.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/blend.frag
+++ b/impeller/entity/shaders/blending/blend.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend.glsl
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend.glsl
@@ -4,8 +4,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-precision mediump float;
-
 #include <impeller/blending.glsl>
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend.glsl
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend.glsl
@@ -4,6 +4,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_color.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_color.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_colorburn.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_colorburn.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_colordodge.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_colordodge.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_darken.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_darken.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_difference.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_difference.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_exclusion.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_exclusion.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_hardlight.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_hardlight.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_hue.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_hue.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_lighten.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_lighten.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_luminosity.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_luminosity.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_multiply.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_multiply.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_overlay.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_overlay.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_saturation.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_saturation.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_screen.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_screen.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend_softlight.frag
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend_softlight.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/blending/porter_duff_blend.frag
+++ b/impeller/entity/shaders/blending/porter_duff_blend.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/blending.glsl>
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>

--- a/impeller/entity/shaders/border_mask_blur.frag
+++ b/impeller/entity/shaders/border_mask_blur.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/gaussian.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/entity/shaders/color_matrix_color_filter.frag
+++ b/impeller/entity/shaders/color_matrix_color_filter.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/entity/shaders/conical_gradient_fill.frag
+++ b/impeller/entity/shaders/conical_gradient_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/entity/shaders/conical_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/conical_gradient_ssbo_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/entity/shaders/debug/checkerboard.frag
+++ b/impeller/entity/shaders/debug/checkerboard.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 uniform FragInfo {
   vec4 color;
   float square_size;

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur.glsl
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur.glsl
@@ -13,8 +13,6 @@
 //     reduced in the first pass by sampling the source textures with a mip
 //     level of log2(min_radius).
 
-precision mediump float;
-
 #include <impeller/constants.glsl>
 #include <impeller/gaussian.glsl>
 #include <impeller/texture.glsl>

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur.glsl
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur.glsl
@@ -13,6 +13,8 @@
 //     reduced in the first pass by sampling the source textures with a mip
 //     level of log2(min_radius).
 
+precision mediump float;
+
 #include <impeller/constants.glsl>
 #include <impeller/gaussian.glsl>
 #include <impeller/texture.glsl>

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur_alpha_decal.frag
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur_alpha_decal.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #define ENABLE_ALPHA_MASK 1
 #define ENABLE_DECAL_SPECIALIZATION 1
 

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur_alpha_nodecal.frag
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur_alpha_nodecal.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #define ENABLE_ALPHA_MASK 1
 #define ENABLE_DECAL_SPECIALIZATION 0
 

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur_noalpha_decal.frag
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur_noalpha_decal.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #define ENABLE_ALPHA_MASK 0
 #define ENABLE_DECAL_SPECIALIZATION 1
 

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur_noalpha_nodecal.frag
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur_noalpha_nodecal.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #define ENABLE_ALPHA_MASK 0
 #define ENABLE_DECAL_SPECIALIZATION 0
 

--- a/impeller/entity/shaders/glyph_atlas.frag
+++ b/impeller/entity/shaders/glyph_atlas.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/types.glsl>
 
 uniform f16sampler2D glyph_atlas_sampler;

--- a/impeller/entity/shaders/glyph_atlas_color.frag
+++ b/impeller/entity/shaders/glyph_atlas_color.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/types.glsl>
 
 uniform f16sampler2D glyph_atlas_sampler;

--- a/impeller/entity/shaders/linear_gradient_fill.frag
+++ b/impeller/entity/shaders/linear_gradient_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/linear_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/linear_gradient_ssbo_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/linear_to_srgb_filter.frag
+++ b/impeller/entity/shaders/linear_to_srgb_filter.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/color.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/morphology_filter.frag
+++ b/impeller/entity/shaders/morphology_filter.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/constants.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/entity/shaders/radial_gradient_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/radial_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_ssbo_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision highp float;
+
 #include <impeller/gaussian.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/solid_fill.frag
+++ b/impeller/entity/shaders/solid_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/types.glsl>
 
 uniform FragInfo {

--- a/impeller/entity/shaders/srgb_to_linear_filter.frag
+++ b/impeller/entity/shaders/srgb_to_linear_filter.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/color.glsl>
 
 // Creates a color filter that applies the inverse of the sRGB gamma curve

--- a/impeller/entity/shaders/sweep_gradient_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/constants.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/entity/shaders/texture_fill.frag
+++ b/impeller/entity/shaders/texture_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/constants.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/tiled_texture_fill.frag
+++ b/impeller/entity/shaders/tiled_texture_fill.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 

--- a/impeller/entity/shaders/vertices.frag
+++ b/impeller/entity/shaders/vertices.frag
@@ -2,16 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/types.glsl>
 
 uniform FragInfo {
-  float alpha;
+  float16_t alpha;
 }
 frag_info;
 
-in vec4 v_color;
+in f16vec4 v_color;
 
-out vec4 frag_color;
+out f16vec4 frag_color;
 
 void main() {
   frag_color = v_color * frag_info.alpha;

--- a/impeller/entity/shaders/yuv_to_rgb_filter.frag
+++ b/impeller/entity/shaders/yuv_to_rgb_filter.frag
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+precision mediump float;
+
 #include <impeller/color.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -1599,16 +1599,16 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 0,
+          "fp16_arithmetic": 80,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "load_store"
             ],
             "longest_path_cycles": [
-              0.171875,
-              0.171875,
-              0.140625,
+              0.125,
+              0.125,
+              0.125,
               0.0625,
               1.0,
               0.0,
@@ -1627,9 +1627,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.171875,
-              0.171875,
-              0.140625,
+              0.125,
+              0.125,
+              0.125,
               0.0625,
               1.0,
               0.0,
@@ -1639,9 +1639,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.171875,
-              0.171875,
-              0.140625,
+              0.125,
+              0.125,
+              0.125,
               0.0625,
               1.0,
               0.0,
@@ -1650,7 +1650,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 8,
+          "uniform_registers_used": 6,
           "work_registers_used": 7
         }
       }
@@ -2058,16 +2058,16 @@
       "type": "Vertex",
       "variants": {
         "Position": {
-          "fp16_arithmetic": 100,
+          "fp16_arithmetic": 0,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "load_store"
             ],
             "longest_path_cycles": [
-              0.0625,
-              0.0625,
-              0.0625,
+              0.125,
+              0.125,
+              0.0,
               0.0,
               2.0,
               0.0
@@ -2084,9 +2084,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.0625,
-              0.0625,
-              0.0625,
+              0.125,
+              0.125,
+              0.0,
               0.0,
               2.0,
               0.0
@@ -2095,9 +2095,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.0625,
-              0.0625,
-              0.0625,
+              0.125,
+              0.125,
+              0.0,
               0.0,
               2.0,
               0.0
@@ -2105,20 +2105,20 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 30,
           "work_registers_used": 32
         },
         "Varying": {
-          "fp16_arithmetic": 100,
+          "fp16_arithmetic": 0,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "load_store"
             ],
             "longest_path_cycles": [
-              0.03125,
               0.015625,
-              0.03125,
+              0.015625,
+              0.015625,
               0.0,
               3.0,
               0.0
@@ -2135,9 +2135,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.03125,
               0.015625,
-              0.03125,
+              0.015625,
+              0.015625,
               0.0,
               3.0,
               0.0
@@ -2146,9 +2146,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.03125,
               0.015625,
-              0.03125,
+              0.015625,
+              0.015625,
               0.0,
               3.0,
               0.0
@@ -2156,8 +2156,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 16,
-          "work_registers_used": 7
+          "uniform_registers_used": 22,
+          "work_registers_used": 8
         }
       }
     }
@@ -3713,7 +3713,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -3782,7 +3782,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              3.630000114440918,
+              3.299999952316284,
               7.0,
               0.0
             ],
@@ -3795,7 +3795,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              3.630000114440918,
+              3.299999952316284,
               7.0,
               0.0
             ],
@@ -3803,13 +3803,13 @@
               "load_store"
             ],
             "total_cycles": [
-              3.6666667461395264,
+              3.3333332538604736,
               7.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
+          "uniform_registers_used": 6,
           "work_registers_used": 3
         }
       }
@@ -5801,7 +5801,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -5897,8 +5897,8 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
-          "work_registers_used": 3
+          "uniform_registers_used": 6,
+          "work_registers_used": 2
         }
       }
     }
@@ -6076,7 +6076,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -6172,8 +6172,8 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
-          "work_registers_used": 3
+          "uniform_registers_used": 6,
+          "work_registers_used": 2
         }
       }
     }
@@ -6191,15 +6191,15 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 0,
+          "fp16_arithmetic": 27,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "load_store"
             ],
             "longest_path_cycles": [
-              0.265625,
-              0.265625,
+              0.234375,
+              0.234375,
               0.171875,
               0.0625,
               1.0,
@@ -6219,8 +6219,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.265625,
-              0.265625,
+              0.234375,
+              0.234375,
               0.140625,
               0.0625,
               1.0,
@@ -6231,8 +6231,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.265625,
-              0.265625,
+              0.234375,
+              0.234375,
               0.171875,
               0.0625,
               1.0,
@@ -6242,8 +6242,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 14,
-          "work_registers_used": 20
+          "uniform_registers_used": 12,
+          "work_registers_used": 21
         }
       }
     },
@@ -6578,7 +6578,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -6674,8 +6674,8 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
-          "work_registers_used": 3
+          "uniform_registers_used": 6,
+          "work_registers_used": 2
         }
       }
     }
@@ -6852,7 +6852,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -6921,7 +6921,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              3.630000114440918,
+              3.299999952316284,
               7.0,
               0.0
             ],
@@ -6934,7 +6934,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              3.630000114440918,
+              3.299999952316284,
               7.0,
               0.0
             ],
@@ -6942,13 +6942,13 @@
               "load_store"
             ],
             "total_cycles": [
-              3.6666667461395264,
+              3.3333332538604736,
               7.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
+          "uniform_registers_used": 6,
           "work_registers_used": 3
         }
       }
@@ -7884,7 +7884,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 28,
+          "uniform_registers_used": 30,
           "work_registers_used": 32
         },
         "Varying": {
@@ -7936,7 +7936,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 18,
-          "work_registers_used": 9
+          "work_registers_used": 11
         }
       }
     },
@@ -7980,7 +7980,7 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 5,
+          "uniform_registers_used": 8,
           "work_registers_used": 2
         }
       }
@@ -8278,7 +8278,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -8374,8 +8374,8 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
-          "work_registers_used": 3
+          "uniform_registers_used": 6,
+          "work_registers_used": 2
         }
       }
     }
@@ -8553,7 +8553,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -8649,8 +8649,8 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
-          "work_registers_used": 3
+          "uniform_registers_used": 6,
+          "work_registers_used": 2
         }
       }
     }
@@ -8828,7 +8828,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 18,
+          "uniform_registers_used": 20,
           "work_registers_used": 32
         },
         "Varying": {
@@ -8880,7 +8880,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 7
+          "work_registers_used": 9
         }
       }
     },
@@ -8924,7 +8924,7 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
+          "uniform_registers_used": 5,
           "work_registers_used": 2
         }
       }
@@ -9060,20 +9060,20 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 68,
+          "fp16_arithmetic": 0,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "longest_path_cycles": [
-              1.5,
-              1.3875000476837158,
-              0.737500011920929,
+              1.53125,
+              1.53125,
+              0.484375,
               1.5,
               0.0,
-              0.125,
+              0.25,
               0.0
             ],
             "pipelines": [
@@ -9086,35 +9086,34 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_fma"
+              "varying"
             ],
             "shortest_path_cycles": [
-              0.203125,
-              0.203125,
-              0.046875,
+              0.234375,
+              0.234375,
+              0.078125,
               0.0625,
               0.0,
-              0.125,
+              0.25,
               0.0
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "total_cycles": [
-              1.5625,
-              1.5125000476837158,
-              0.762499988079071,
+              1.6749999523162842,
+              1.6749999523162842,
+              0.546875,
               1.5625,
               0.0,
-              0.125,
+              0.25,
               0.0
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 16,
+          "uniform_registers_used": 24,
           "work_registers_used": 32
         }
       }
@@ -9132,7 +9131,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              22.110000610351562,
+              23.43000030517578,
               1.0,
               0.0
             ],
@@ -9153,14 +9152,14 @@
               "arithmetic"
             ],
             "total_cycles": [
-              10.0,
+              10.333333015441895,
               1.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 2,
-          "work_registers_used": 3
+          "uniform_registers_used": 3,
+          "work_registers_used": 4
         }
       }
     }
@@ -9220,7 +9219,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 18,
+          "uniform_registers_used": 20,
           "work_registers_used": 32
         },
         "Varying": {
@@ -9316,7 +9315,7 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
+          "uniform_registers_used": 5,
           "work_registers_used": 2
         }
       }
@@ -9377,7 +9376,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 18,
+          "uniform_registers_used": 20,
           "work_registers_used": 32
         },
         "Varying": {
@@ -9473,7 +9472,7 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
+          "uniform_registers_used": 5,
           "work_registers_used": 2
         }
       }
@@ -9652,7 +9651,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 18,
+          "uniform_registers_used": 20,
           "work_registers_used": 32
         }
       }
@@ -9697,7 +9696,7 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
+          "uniform_registers_used": 5,
           "work_registers_used": 2
         }
       }
@@ -9876,7 +9875,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -9972,8 +9971,8 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
-          "work_registers_used": 3
+          "uniform_registers_used": 6,
+          "work_registers_used": 2
         }
       }
     }
@@ -10274,7 +10273,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -10370,7 +10369,7 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
+          "uniform_registers_used": 6,
           "work_registers_used": 2
         }
       }
@@ -10781,7 +10780,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -10877,8 +10876,8 @@
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 4,
-          "work_registers_used": 3
+          "uniform_registers_used": 6,
+          "work_registers_used": 2
         }
       }
     }
@@ -11772,7 +11771,7 @@
       "type": "Compute",
       "variants": {
         "Main": {
-          "fp16_arithmetic": 35,
+          "fp16_arithmetic": 0,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -11810,9 +11809,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.453125,
-              0.21875,
-              0.453125,
+              0.296875,
+              0.296875,
+              0.28125,
               0.1875,
               5.0,
               0.0
@@ -11821,8 +11820,8 @@
           "shared_storage_used": 0,
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 16,
-          "work_registers_used": 17
+          "uniform_registers_used": 20,
+          "work_registers_used": 16
         }
       }
     }
@@ -12007,7 +12006,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 20,
-          "work_registers_used": 7
+          "work_registers_used": 9
         }
       }
     }
@@ -12167,20 +12166,20 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 65,
+          "fp16_arithmetic": 0,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "longest_path_cycles": [
-              1.5,
-              1.4249999523162842,
-              0.699999988079071,
+              1.59375,
+              1.59375,
+              0.453125,
               1.5,
               0.0,
-              0.125,
+              0.25,
               0.0
             ],
             "pipelines": [
@@ -12193,36 +12192,35 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_fma"
+              "varying"
             ],
             "shortest_path_cycles": [
-              0.171875,
-              0.171875,
-              0.0625,
+              0.234375,
+              0.234375,
+              0.078125,
               0.0625,
               0.0,
-              0.125,
+              0.25,
               0.0
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_sfu"
+              "arith_fma"
             ],
             "total_cycles": [
-              1.5625,
-              1.5499999523162842,
-              0.75,
+              1.7374999523162842,
+              1.7374999523162842,
+              0.515625,
               1.5625,
               0.0,
-              0.125,
+              0.25,
               0.0
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 18,
-          "work_registers_used": 31
+          "uniform_registers_used": 24,
+          "work_registers_used": 32
         }
       }
     }
@@ -12856,7 +12854,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 31,
+          "fp16_arithmetic": 0,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -12882,13 +12880,13 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_fma"
+              "arith_sfu"
             ],
             "shortest_path_cycles": [
+              0.3125,
               0.28125,
-              0.28125,
-              0.171875,
-              0.25,
+              0.21875,
+              0.3125,
               0.0,
               0.25,
               0.0
@@ -12897,10 +12895,10 @@
               "load_store"
             ],
             "total_cycles": [
+              0.699999988079071,
               0.65625,
-              0.546875,
-              0.65625,
-              0.3125,
+              0.699999988079071,
+              0.375,
               4.0,
               0.25,
               0.0
@@ -12909,7 +12907,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 16,
-          "work_registers_used": 18
+          "work_registers_used": 19
         }
       }
     }
@@ -13183,7 +13181,7 @@
       "type": "Compute",
       "variants": {
         "Main": {
-          "fp16_arithmetic": 100,
+          "fp16_arithmetic": 0,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -13192,7 +13190,7 @@
             "longest_path_cycles": [
               0.1875,
               0.1875,
-              0.1875,
+              0.125,
               0.0625,
               2.0,
               0.0
@@ -13223,7 +13221,7 @@
             "total_cycles": [
               0.1875,
               0.1875,
-              0.1875,
+              0.125,
               0.0625,
               2.0,
               0.0
@@ -13232,7 +13230,7 @@
           "shared_storage_used": 0,
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 14,
+          "uniform_registers_used": 24,
           "work_registers_used": 10
         }
       }


### PR DESCRIPTION
Instead of adding precision mediump float to all shaders that import types.glsl, let vertex shaders be highp by default. Opt rrect blur into highp and all other fragment shaders into mediump. For reasons I don't understand, the default for fragment shaders is being treated as highp without any specifiers.

Fixes https://github.com/flutter/flutter/issues/128284