### PR TITLE
[Impeller] Treat SubOptimalKHR as rotated.

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -346,8 +346,12 @@ SwapchainImplVK::AcquireResult SwapchainImplVK::AcquireNextDrawable() {
       nullptr                                // fence
   );
 
-  if (acq_result == vk::Result::eSuboptimalKHR ||
-      acq_result == vk::Result::eErrorOutOfDateKHR) {
+  if (acq_result == vk::Result::eSuboptimalKHR) {
+    is_rotated_ = true;
+    return AcquireResult{true /* out of date */};
+  }
+
+  if (acq_result == vk::Result::eErrorOutOfDateKHR) {
     return AcquireResult{true /* out of date */};
   }
 

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
@@ -31,6 +31,7 @@ class SwapchainImplVK final
   static std::shared_ptr<SwapchainImplVK> Create(
       const std::shared_ptr<Context>& context,
       vk::UniqueSurfaceKHR surface,
+      bool was_rotated,
       vk::SwapchainKHR old_swapchain = VK_NULL_HANDLE);
 
   ~SwapchainImplVK();
@@ -46,6 +47,8 @@ class SwapchainImplVK final
     AcquireResult(std::unique_ptr<Surface> p_surface)
         : surface(std::move(p_surface)) {}
   };
+
+  bool GetIsRotated() const { return is_rotated_; }
 
   AcquireResult AcquireNextDrawable();
 
@@ -66,8 +69,12 @@ class SwapchainImplVK final
   size_t current_frame_ = 0u;
   bool is_valid_ = false;
 
+  bool was_rotated_ = false;
+  bool is_rotated_ = false;
+
   SwapchainImplVK(const std::shared_ptr<Context>& context,
                   vk::UniqueSurfaceKHR surface,
+                  bool was_rotated,
                   vk::SwapchainKHR old_swapchain);
 
   bool Present(const std::shared_ptr<SwapchainImageVK>& image, uint32_t index);

--- a/impeller/renderer/backend/vulkan/swapchain_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_vk.cc
@@ -12,7 +12,8 @@ namespace impeller {
 std::shared_ptr<SwapchainVK> SwapchainVK::Create(
     const std::shared_ptr<Context>& context,
     vk::UniqueSurfaceKHR surface) {
-  auto impl = SwapchainImplVK::Create(context, std::move(surface));
+  auto impl = SwapchainImplVK::Create(context, std::move(surface),
+                                      /*was_rotated=*/false);
   if (!impl || !impl->IsValid()) {
     return nullptr;
   }
@@ -45,10 +46,12 @@ std::unique_ptr<Surface> SwapchainVK::AcquireNextDrawable() {
   // This swapchain implementation indicates that it is out of date. Tear it
   // down and make a new one.
   auto context = impl_->GetContext();
+  auto was_rotated = impl_->GetIsRotated();
   auto [surface, old_swapchain] = impl_->DestroySwapchain();
 
   auto new_impl = SwapchainImplVK::Create(context,             //
                                           std::move(surface),  //
+                                          was_rotated,         //
                                           *old_swapchain       //
   );
   if (!new_impl || !new_impl->IsValid()) {


### PR DESCRIPTION
If we don't follow the guidelines at https://developer.android.com/games/optimize/vulkan-prerotation , then any presentations while the screen is rotated will result in suboptimalKHR. Use a change in state across presentations from sucess -> suboptimal or suboptimal -> sucess to detect whether the swapchain needs to be recreated.

Fixes https://github.com/flutter/flutter/issues/129459 (mostly)
