### PR TITLE
[Impeller] Fixes for GLES color mask setup

### DIFF
--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -38,27 +38,27 @@ void RenderPassGLES::OnSetLabel(std::string label) {
 
 void ConfigureBlending(const ProcTableGLES& gl,
                        const ColorAttachmentDescriptor* color) {
-  if (!color->blending_enabled) {
+  if (color->blending_enabled) {
+    gl.Enable(GL_BLEND);
+    gl.BlendFuncSeparate(
+        ToBlendFactor(color->src_color_blend_factor),  // src color
+        ToBlendFactor(color->dst_color_blend_factor),  // dst color
+        ToBlendFactor(color->src_alpha_blend_factor),  // src alpha
+        ToBlendFactor(color->dst_alpha_blend_factor)   // dst alpha
+    );
+    gl.BlendEquationSeparate(
+        ToBlendOperation(color->color_blend_op),  // mode color
+        ToBlendOperation(color->alpha_blend_op)   // mode alpha
+    );
+  } else {
     gl.Disable(GL_BLEND);
-    return;
   }
 
-  gl.Enable(GL_BLEND);
-  gl.BlendFuncSeparate(
-      ToBlendFactor(color->src_color_blend_factor),  // src color
-      ToBlendFactor(color->dst_color_blend_factor),  // dst color
-      ToBlendFactor(color->src_alpha_blend_factor),  // src alpha
-      ToBlendFactor(color->dst_alpha_blend_factor)   // dst alpha
-  );
-  gl.BlendEquationSeparate(
-      ToBlendOperation(color->color_blend_op),  // mode color
-      ToBlendOperation(color->alpha_blend_op)   // mode alpha
-  );
   {
     const auto is_set = [](std::underlying_type_t<ColorWriteMask> mask,
                            ColorWriteMask check) -> GLboolean {
       using RawType = decltype(mask);
-      return (static_cast<RawType>(mask) & static_cast<RawType>(mask))
+      return (static_cast<RawType>(mask) & static_cast<RawType>(check))
                  ? GL_TRUE
                  : GL_FALSE;
     };


### PR DESCRIPTION
* Always set the color mask even if blending is disabled
* Fix a typo in the check of the mask against each color bit
