### PR TITLE
[Impeller] Report pipeline creation feedback to logs and traces.

### DIFF
--- a/impeller/base/timing.h
+++ b/impeller/base/timing.h
@@ -8,6 +8,7 @@
 
 namespace impeller {
 
+using MillisecondsF = std::chrono::duration<float, std::milli>;
 using SecondsF = std::chrono::duration<float>;
 using Clock = std::chrono::high_resolution_clock;
 using TimePoint = std::chrono::time_point<std::chrono::high_resolution_clock>;

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -18,6 +18,12 @@ namespace impeller {
 
 class ContextVK;
 
+enum class OptionalDeviceExtensionVK : uint32_t {
+  // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_creation_feedback.html
+  kEXTPipelineCreationFeedback,
+  kLast,
+};
+
 //------------------------------------------------------------------------------
 /// @brief      The Vulkan layers and extensions wrangler.
 ///
@@ -32,17 +38,20 @@ class CapabilitiesVK final : public Capabilities,
 
   bool AreValidationsEnabled() const;
 
-  std::optional<std::vector<std::string>> GetRequiredLayers() const;
+  bool HasOptionalDeviceExtension(OptionalDeviceExtensionVK extension) const;
 
-  std::optional<std::vector<std::string>> GetRequiredInstanceExtensions() const;
+  std::optional<std::vector<std::string>> GetEnabledLayers() const;
 
-  std::optional<std::vector<std::string>> GetRequiredDeviceExtensions(
+  std::optional<std::vector<std::string>> GetEnabledInstanceExtensions() const;
+
+  std::optional<std::vector<std::string>> GetEnabledDeviceExtensions(
       const vk::PhysicalDevice& physical_device) const;
 
-  std::optional<vk::PhysicalDeviceFeatures> GetRequiredDeviceFeatures(
+  std::optional<vk::PhysicalDeviceFeatures> GetEnabledDeviceFeatures(
       const vk::PhysicalDevice& physical_device) const;
 
-  [[nodiscard]] bool SetDevice(const vk::PhysicalDevice& physical_device);
+  [[nodiscard]] bool SetPhysicalDevice(
+      const vk::PhysicalDevice& physical_device);
 
   const vk::PhysicalDeviceProperties& GetPhysicalDeviceProperties() const;
 
@@ -90,6 +99,7 @@ class CapabilitiesVK final : public Capabilities,
  private:
   const bool enable_validations_;
   std::map<std::string, std::set<std::string>> exts_;
+  std::set<OptionalDeviceExtensionVK> optional_device_extensions_;
   mutable PixelFormat color_format_ = PixelFormat::kUnknown;
   PixelFormat depth_stencil_format_ = PixelFormat::kUnknown;
   vk::PhysicalDeviceProperties device_properties_;

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -42,7 +42,7 @@ static std::optional<vk::PhysicalDevice> PickPhysicalDevice(
     const CapabilitiesVK& caps,
     const vk::Instance& instance) {
   for (const auto& device : instance.enumeratePhysicalDevices().value) {
-    if (caps.GetRequiredDeviceFeatures(device).has_value()) {
+    if (caps.GetEnabledDeviceFeatures(device).has_value()) {
       return device;
     }
   }
@@ -140,8 +140,8 @@ void ContextVK::Setup(Settings settings) {
 
   gHasValidationLayers = caps->AreValidationsEnabled();
 
-  auto enabled_layers = caps->GetRequiredLayers();
-  auto enabled_extensions = caps->GetRequiredInstanceExtensions();
+  auto enabled_layers = caps->GetEnabledLayers();
+  auto enabled_extensions = caps->GetEnabledInstanceExtensions();
 
   if (!enabled_layers.has_value() || !enabled_extensions.has_value()) {
     VALIDATION_LOG << "Device has insufficient capabilities.";
@@ -268,7 +268,7 @@ void ContextVK::Setup(Settings settings) {
   /// Create the logical device.
   ///
   auto enabled_device_extensions =
-      caps->GetRequiredDeviceExtensions(device_holder->physical_device);
+      caps->GetEnabledDeviceExtensions(device_holder->physical_device);
   if (!enabled_device_extensions.has_value()) {
     // This shouldn't happen since we already did device selection. But doesn't
     // hurt to check again.
@@ -283,9 +283,9 @@ void ContextVK::Setup(Settings settings) {
   const auto queue_create_infos = GetQueueCreateInfos(
       {graphics_queue.value(), compute_queue.value(), transfer_queue.value()});
 
-  const auto required_features =
-      caps->GetRequiredDeviceFeatures(device_holder->physical_device);
-  if (!required_features.has_value()) {
+  const auto enabled_features =
+      caps->GetEnabledDeviceFeatures(device_holder->physical_device);
+  if (!enabled_features.has_value()) {
     // This shouldn't happen since the device can't be picked if this was not
     // true. But doesn't hurt to check.
     return;
@@ -295,7 +295,7 @@ void ContextVK::Setup(Settings settings) {
 
   device_info.setQueueCreateInfos(queue_create_infos);
   device_info.setPEnabledExtensionNames(enabled_device_extensions_c);
-  device_info.setPEnabledFeatures(&required_features.value());
+  device_info.setPEnabledFeatures(&enabled_features.value());
   // Device layers are deprecated and ignored.
 
   {
@@ -308,7 +308,7 @@ void ContextVK::Setup(Settings settings) {
     device_holder->device = std::move(device_result.value);
   }
 
-  if (!caps->SetDevice(device_holder->physical_device)) {
+  if (!caps->SetPhysicalDevice(device_holder->physical_device)) {
     VALIDATION_LOG << "Capabilities could not be updated.";
     return;
   }

--- a/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
@@ -186,4 +186,8 @@ void PipelineCacheVK::PersistCacheToDisk() const {
   }
 }
 
+const CapabilitiesVK* PipelineCacheVK::GetCapabilities() const {
+  return CapabilitiesVK::Cast(caps_.get());
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
+++ b/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
@@ -31,6 +31,8 @@ class PipelineCacheVK {
 
   vk::UniquePipeline CreatePipeline(const vk::ComputePipelineCreateInfo& info);
 
+  const CapabilitiesVK* GetCapabilities() const;
+
   void PersistCacheToDisk() const;
 
  private:


### PR DESCRIPTION
Piping the feedback to logs is disabled by default but can be enabled by patching the source for now. If reading from logs gets to be useful, we can move it behind a flag. In traces, enabled by default, pipeline cache hits and misses will be shown via counters. The time taken to create a pipeline variant is already covered by existing traces.

This patch also sets up infrastructure in the impeller::CapabilitiesVK to quickly enable optional device extensions.

Pipeline feedback will only be reported if the device supports `VK_EXT_pipeline_creation_feedback`.

Example of logs:

```
E/flutter ( 2011): >>>>>>
E/flutter ( 2011): Pipeline 'GaussianBlurAlphaDecal Pipeline' Time: 48.60ms Cache Hit: 0 Base Accel: 0 Thread: 481449901232
E/flutter ( 2011):  Stage 1: Time: 12.91ms Cache Hit: 0 Base Accel: 0 Thread: 481449901232
E/flutter ( 2011):  Stage 2: Time: 15.10ms Cache Hit: 0 Base Accel: 0 Thread: 481449901232
E/flutter ( 2011): <<<<<<
```
