### PR TITLE
Initialize skwasm codecs before handing them back to the user.

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -369,11 +369,12 @@ class SkwasmRenderer implements Renderer {
     if (contentType == null) {
       throw Exception('Could not determine content type of image from data');
     }
-    final ui.Codec baseDecoder = SkwasmImageDecoder(
+    final SkwasmImageDecoder baseDecoder = SkwasmImageDecoder(
       contentType: contentType,
       dataSource: list.toJS,
       debugSource: 'encoded image bytes',
     );
+    await baseDecoder.initialize();
     if (targetWidth == null && targetHeight == null) {
       return baseDecoder;
     }
@@ -395,11 +396,13 @@ class SkwasmRenderer implements Renderer {
     if (contentType == null) {
       throw Exception('Could not determine content type of image at url $uri');
     }
-    return SkwasmImageDecoder(
+    final SkwasmImageDecoder decoder = SkwasmImageDecoder(
       contentType: contentType,
       dataSource: response.body as JSAny,
       debugSource: uri.toString(),
     );
+    await decoder.initialize();
+    return decoder;
   }
 
   @override

--- a/lib/web_ui/test/ui/filters_test.dart
+++ b/lib/web_ui/test/ui/filters_test.dart
@@ -29,6 +29,8 @@ Future<void> testMain() async {
     final ui.Codec codec = await renderer.instantiateImageCodecFromUrl(
       Uri(path: '/test_images/mandrill_128.png')
     );
+    expect(codec.frameCount, 1);
+    expect(codec.repetitionCount, 0);
 
     final ui.FrameInfo info = await codec.getNextFrame();
     final ui.Image image = info.image;

--- a/lib/web_ui/test/ui/filters_test.dart
+++ b/lib/web_ui/test/ui/filters_test.dart
@@ -30,7 +30,6 @@ Future<void> testMain() async {
       Uri(path: '/test_images/mandrill_128.png')
     );
     expect(codec.frameCount, 1);
-    expect(codec.repetitionCount, 0);
 
     final ui.FrameInfo info = await codec.getNextFrame();
     final ui.Image image = info.image;

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -289,7 +289,6 @@ Future<void> testMain() async {
       Uri(path: '/test_images/mandrill_128.png')
     );
     expect(codec.frameCount, 1);
-    expect(codec.repetitionCount, 0);
 
     final ui.FrameInfo info = await codec.getNextFrame();
     return info.image;
@@ -303,7 +302,6 @@ Future<void> testMain() async {
       targetHeight: 150,
     );
     expect(codec.frameCount, 1);
-    expect(codec.repetitionCount, 0);
 
     final ui.FrameInfo info = await codec.getNextFrame();
     return info.image;

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -288,6 +288,8 @@ Future<void> testMain() async {
     final ui.Codec codec = await renderer.instantiateImageCodecFromUrl(
       Uri(path: '/test_images/mandrill_128.png')
     );
+    expect(codec.frameCount, 1);
+    expect(codec.repetitionCount, 0);
 
     final ui.FrameInfo info = await codec.getNextFrame();
     return info.image;
@@ -300,6 +302,8 @@ Future<void> testMain() async {
       targetWidth: 150,
       targetHeight: 150,
     );
+    expect(codec.frameCount, 1);
+    expect(codec.repetitionCount, 0);
 
     final ui.FrameInfo info = await codec.getNextFrame();
     return info.image;


### PR DESCRIPTION
Benchmarks were failing because the code was reading the `frameCount` and `repetitionCount` before reading any frames out of the codec. The codec gets implicitly initialized when you read a frame, but we should return it to the user initialized so that `frameCount` and `repetitionCount` work even if you haven't read a frame yet. This is consistent with how CanvasKit's codec works.

Also, modified our unit tests so that they exercise the codecs in this way.