### PR TITLE
[web] TextField a11y focus should call didGain/didLose a11y focus action

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -301,7 +301,16 @@ class TextField extends PrimaryRoleManager {
           }
 
           EnginePlatformDispatcher.instance.invokeOnSemanticsAction(
-              semanticsObject.id, ui.SemanticsAction.tap, null);
+              semanticsObject.id, ui.SemanticsAction.didGainAccessibilityFocus, null);
+        }));
+    activeEditableElement.addEventListener('blur',
+        createDomEventListener((DomEvent event) {
+          if (semanticsObject.owner.gestureMode != GestureMode.browserGestures) {
+            return;
+          }
+
+          EnginePlatformDispatcher.instance.invokeOnSemanticsAction(
+              semanticsObject.id, ui.SemanticsAction.didLoseAccessibilityFocus, null);
         }));
   }
 

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -1517,7 +1517,7 @@ void _testTextField() {
 
   // TODO(yjbanov): this test will need to be adjusted for Safari when we add
   //                Safari testing.
-  test('sends a tap action when text field is activated', () async {
+  test('sends a focus action when text field is activated', () async {
     final SemanticsActionLogger logger = SemanticsActionLogger();
     semantics()
       ..debugOverrideTimestampFunction(() => _testTime)
@@ -1526,7 +1526,7 @@ void _testTextField() {
     final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
     updateNode(
       builder,
-      actions: 0 | ui.SemanticsAction.tap.index,
+      actions: 0 | ui.SemanticsAction.didGainAccessibilityFocus.index,
       flags: 0 | ui.SemanticsFlag.isTextField.index,
       value: 'hello',
       transform: Matrix4.identity().toFloat64(),
@@ -1544,7 +1544,7 @@ void _testTextField() {
 
     expect(appHostNode.ownerDocument?.activeElement, textField);
     expect(await logger.idLog.first, 0);
-    expect(await logger.actionLog.first, ui.SemanticsAction.tap);
+    expect(await logger.actionLog.first, ui.SemanticsAction.didGainAccessibilityFocus);
 
     semantics().semanticsEnabled = false;
   }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -92,25 +92,45 @@ void testMain() {
 </sem>''');
   });
 
-  // TODO(yjbanov): this test will need to be adjusted for Safari when we add
-  //                Safari testing.
-  test('sends a tap action when browser requests focus', () async {
-    final SemanticsActionLogger logger = SemanticsActionLogger();
-    createTextFieldSemantics(value: 'hello');
+    // TODO(yjbanov): this test will need to be adjusted for Safari when we add
+    //                Safari testing.
+    test('sends a didGainAccessibilityFocus action when browser requests focus', () async {
+      final SemanticsActionLogger logger = SemanticsActionLogger();
+      createTextFieldSemantics(value: 'hello');
 
-    final DomElement textField = appHostNode
-        .querySelector('input[data-semantics-role="text-field"]')!;
+      final DomElement textField = appHostNode
+          .querySelector('input[data-semantics-role="text-field"]')!;
 
-    expect(appHostNode.ownerDocument?.activeElement, isNot(textField));
+      expect(appHostNode.ownerDocument?.activeElement, isNot(textField));
 
-    textField.focus();
+      textField.focus();
 
-    expect(appHostNode.ownerDocument?.activeElement, textField);
-    expect(await logger.idLog.first, 0);
-    expect(await logger.actionLog.first, ui.SemanticsAction.tap);
+      expect(appHostNode.ownerDocument?.activeElement, textField);
+      expect(await logger.idLog.first, 0);
+      expect(await logger.actionLog.first, ui.SemanticsAction.didGainAccessibilityFocus);
     }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/50590
-      skip: browserEngine != BrowserEngine.blink);
+       // TODO(yjbanov): https://github.com/flutter/flutter/issues/50590
+    skip: browserEngine != BrowserEngine.blink);
+
+    // TODO(yjbanov): this test will need to be adjusted for Safari when we add
+    //                Safari testing.
+    test('sends a didLoseAccessibilityFocus action when browser requests focus', () async {
+      final SemanticsActionLogger logger = SemanticsActionLogger();
+      createTextFieldSemantics(value: 'hello');
+
+      final DomElement textField = appHostNode
+          .querySelector('input[data-semantics-role="text-field"]')!;
+
+      expect(appHostNode.ownerDocument?.activeElement, isNot(textField));
+
+      textField.blur();
+
+      expect(appHostNode.ownerDocument?.activeElement, textField);
+      expect(await logger.idLog.first, 0);
+      expect(await logger.actionLog.first, ui.SemanticsAction.didLoseAccessibilityFocus);
+    }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
+       // TODO(yjbanov): https://github.com/flutter/flutter/issues/50590
+    skip: browserEngine != BrowserEngine.blink);
 
     test('Syncs semantic state from framework', () {
       expect(appHostNode.ownerDocument?.activeElement, domDocument.body);

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -125,7 +125,6 @@ void testMain() {
 
       textField.blur();
 
-      expect(appHostNode.ownerDocument?.activeElement, textField);
       expect(await logger.idLog.first, 0);
       expect(await logger.actionLog.first, ui.SemanticsAction.didLoseAccessibilityFocus);
     }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -94,7 +94,7 @@ void testMain() {
 
     // TODO(yjbanov): this test will need to be adjusted for Safari when we add
     //                Safari testing.
-    test('sends a didGainAccessibilityFocus action when browser requests focus', () async {
+    test('sends a didGainAccessibilityFocus/didLoseAccessibilityFocus action when browser requests focus/blur', () async {
       final SemanticsActionLogger logger = SemanticsActionLogger();
       createTextFieldSemantics(value: 'hello');
 
@@ -108,23 +108,10 @@ void testMain() {
       expect(appHostNode.ownerDocument?.activeElement, textField);
       expect(await logger.idLog.first, 0);
       expect(await logger.actionLog.first, ui.SemanticsAction.didGainAccessibilityFocus);
-    }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
-       // TODO(yjbanov): https://github.com/flutter/flutter/issues/50590
-    skip: browserEngine != BrowserEngine.blink);
-
-    // TODO(yjbanov): this test will need to be adjusted for Safari when we add
-    //                Safari testing.
-    test('sends a didLoseAccessibilityFocus action when browser requests focus', () async {
-      final SemanticsActionLogger logger = SemanticsActionLogger();
-      createTextFieldSemantics(value: 'hello');
-
-      final DomElement textField = appHostNode
-          .querySelector('input[data-semantics-role="text-field"]')!;
-
-      expect(appHostNode.ownerDocument?.activeElement, isNot(textField));
 
       textField.blur();
 
+      expect(appHostNode.ownerDocument?.activeElement, isNot(textField));
       expect(await logger.idLog.first, 0);
       expect(await logger.actionLog.first, ui.SemanticsAction.didLoseAccessibilityFocus);
     }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/128709

requires https://github.com/flutter/flutter/pull/129652

The issue is that when textfield focus in framework and web engine a11y are out of sync, the framework keep sending update with textfield focus = true and causes web engine to keep refocusing the textfield.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
