### PR TITLE
Fix inverted boolean in Windows document selection changed a11y event

### DIFF
--- a/shell/platform/windows/accessibility_bridge_windows.cc
+++ b/shell/platform/windows/accessibility_bridge_windows.cc
@@ -45,10 +45,8 @@ void AccessibilityBridgeWindows::OnAccessibilityEvent(
       // only for the focused node whose selection has changed. If a valid
       // caret and selection exist in the app tree, they must both be within
       // the focus node.
-      ui::AXNode::AXID focus_id = GetAXTreeData().sel_focus_object_id;
-      auto focus_delegate =
-          GetFlutterPlatformNodeDelegateFromID(focus_id).lock();
-      if (!focus_delegate) {
+      auto focus_delegate = GetFocusedNode().lock();
+      if (focus_delegate) {
         win_delegate =
             std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(
                 focus_delegate);
@@ -202,6 +200,12 @@ AccessibilityBridgeWindows::GetParentOfAXFragmentRoot() {
 
 bool AccessibilityBridgeWindows::IsAXFragmentRootAControlElement() {
   return true;
+}
+
+std::weak_ptr<FlutterPlatformNodeDelegate>
+AccessibilityBridgeWindows::GetFocusedNode() {
+  ui::AXNode::AXID focus_id = GetAXTreeData().sel_focus_object_id;
+  return GetFlutterPlatformNodeDelegateFromID(focus_id);
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/accessibility_bridge_windows.h
+++ b/shell/platform/windows/accessibility_bridge_windows.h
@@ -68,6 +68,9 @@ class AccessibilityBridgeWindows : public AccessibilityBridge,
   std::shared_ptr<FlutterPlatformNodeDelegate>
   CreateFlutterPlatformNodeDelegate() override;
 
+  // Retrieve the focused node for accessibility events.
+  virtual std::weak_ptr<FlutterPlatformNodeDelegate> GetFocusedNode();
+
  private:
   FlutterWindowsView* view_;
 

--- a/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -50,7 +50,7 @@ class AccessibilityBridgeWindowsSpy : public AccessibilityBridgeWindows {
 
   void SetFocus(std::shared_ptr<FlutterPlatformNodeDelegateWindows>
                     node_delegate) override {
-    focused_nodes_.push_back(node_delegate);
+    focused_nodes_.push_back(std::move(node_delegate));
   }
 
   void ResetRecords() {

--- a/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -50,7 +50,7 @@ class AccessibilityBridgeWindowsSpy : public AccessibilityBridgeWindows {
 
   void SetFocus(std::shared_ptr<FlutterPlatformNodeDelegateWindows>
                     node_delegate) override {
-    focused_nodes_.push_back(node_delegate->GetAXNode()->id());
+    focused_nodes_.push_back(node_delegate);
   }
 
   void ResetRecords() {
@@ -62,11 +62,24 @@ class AccessibilityBridgeWindowsSpy : public AccessibilityBridgeWindows {
     return dispatched_events_;
   }
 
-  const std::vector<int32_t> focused_nodes() const { return focused_nodes_; }
+  const std::vector<int32_t> focused_nodes() const {
+    std::vector<int32_t> ids;
+    std::transform(focused_nodes_.begin(), focused_nodes_.end(),
+                   std::back_inserter(ids),
+                   [](std::shared_ptr<FlutterPlatformNodeDelegate> node) {
+                     return node->GetAXNode()->id();
+                   });
+    return ids;
+  }
+
+ protected:
+  std::weak_ptr<FlutterPlatformNodeDelegate> GetFocusedNode() override {
+    return focused_nodes_.back();
+  }
 
  private:
   std::vector<MsaaEvent> dispatched_events_;
-  std::vector<int32_t> focused_nodes_;
+  std::vector<std::shared_ptr<FlutterPlatformNodeDelegate>> focused_nodes_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridgeWindowsSpy);
 };
@@ -187,6 +200,32 @@ void ExpectWinEventFromAXEvent(int32_t node_id,
                                 {ax_event, ax::mojom::EventFrom::kNone, {}}});
   ASSERT_EQ(bridge->dispatched_events().size(), 1);
   EXPECT_EQ(bridge->dispatched_events()[0].event_type, expected_event);
+}
+
+void ExpectWinEventFromAXEventOnFocusNode(int32_t node_id,
+                                          ui::AXEventGenerator::Event ax_event,
+                                          ax::mojom::Event expected_event,
+                                          int32_t focus_id) {
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  FlutterWindowsViewSpy view(std::move(window_binding_handler));
+  view.SetEngine(GetTestEngine());
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = GetAccessibilityBridgeSpy(view.GetEngine());
+  PopulateAXTree(bridge);
+
+  bridge->ResetRecords();
+  auto focus_delegate =
+      bridge->GetFlutterPlatformNodeDelegateFromID(focus_id).lock();
+  bridge->SetFocus(std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(
+      focus_delegate));
+  bridge->OnAccessibilityEvent({AXNodeFromID(bridge, node_id),
+                                {ax_event, ax::mojom::EventFrom::kNone, {}}});
+  ASSERT_EQ(bridge->dispatched_events().size(), 1);
+  EXPECT_EQ(bridge->dispatched_events()[0].event_type, expected_event);
+  EXPECT_EQ(bridge->dispatched_events()[0].node_delegate->GetAXNode()->id(),
+            focus_id);
 }
 
 }  // namespace
@@ -342,9 +381,9 @@ TEST(AccessibilityBridgeWindows, OnAccessibilityStateChanged) {
 }
 
 TEST(AccessibilityBridgeWindows, OnDocumentSelectionChanged) {
-  ExpectWinEventFromAXEvent(
+  ExpectWinEventFromAXEventOnFocusNode(
       1, ui::AXEventGenerator::Event::DOCUMENT_SELECTION_CHANGED,
-      ax::mojom::Event::kDocumentSelectionChanged);
+      ax::mojom::Event::kDocumentSelectionChanged, 2);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Fix a typo that inverted an intended condition, and amend a unit test to check for this. This a11y event should target the focused node, but a fallback for when the focus returns null was inverted.

https://github.com/flutter/flutter/issues/127789

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
