### PR TITLE
[Impeller] Correct advanced blending behavior.

### DIFF
--- a/impeller/entity/shaders/blending/advanced_blend.glsl
+++ b/impeller/entity/shaders/blending/advanced_blend.glsl
@@ -38,16 +38,14 @@ void main() {
                               ) *
                        blend_info.dst_input_alpha;
 
-  f16vec4 dst = IPHalfUnpremultiply(dst_sample);
+  f16vec4 dst = dst_sample;
   f16vec4 src = blend_info.color_factor > 0.0hf
                     ? blend_info.color
-                    : IPHalfUnpremultiply(
-                          Sample(texture_sampler_src,  // sampler
-                                 v_src_texture_coords  // texture coordinates
-                                 ) *
-                          blend_info.src_input_alpha);
+                    : Sample(texture_sampler_src,  // sampler
+                             v_src_texture_coords  // texture coordinates
+                             ) *
+                          blend_info.src_input_alpha;
 
-  f16vec4 blended = f16vec4(Blend(dst.rgb, src.rgb), 1.0hf) * dst.a;
-
+  f16vec4 blended = mix(src, f16vec4(Blend(dst.rgb, src.rgb), dst.a), dst.a);
   frag_color = mix(dst_sample, blended, src.a);
 }

--- a/impeller/entity/shaders/blending/ios/framebuffer_blend.glsl
+++ b/impeller/entity/shaders/blending/ios/framebuffer_blend.glsl
@@ -37,14 +37,12 @@ out vec4 frag_color;
 
 void main() {
   f16vec4 dst_sample = f16vec4(ReadDestination());
-  f16vec4 dst = IPHalfUnpremultiply(dst_sample);
-  f16vec4 src = IPHalfUnpremultiply(
-      f16vec4(texture(texture_sampler_src,  // sampler
-                      v_src_texture_coords  // texture coordinates
-                      )) *
-      frag_info.src_input_alpha);
+  f16vec4 dst = dst_sample;
+  f16vec4 src = f16vec4(texture(texture_sampler_src,  // sampler
+                                v_src_texture_coords  // texture coordinates
+                                )) *
+                frag_info.src_input_alpha;
 
-  f16vec4 blended = f16vec4(Blend(dst.rgb, src.rgb), 1.0hf) * dst.a;
-
-  frag_color = vec4(mix(dst_sample, blended, src.a));
+  f16vec4 blended = mix(src, f16vec4(Blend(dst.rgb, src.rgb), dst.a), dst.a);
+  frag_color = vec4(mix(dst, blended, src.a));
 }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -124,7 +124,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 88,
+          "fp16_arithmetic": 87,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -132,10 +132,10 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.625,
-              0.625,
-              0.28125,
-              0.25,
+              0.609375,
+              0.609375,
+              0.15625,
+              0.125,
               0.0,
               0.5,
               0.5
@@ -154,10 +154,10 @@
               "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.328125,
-              0.328125,
-              0.265625,
-              0.0625,
+              0.34375,
+              0.34375,
+              0.203125,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -167,10 +167,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.625,
-              0.625,
-              0.328125,
-              0.25,
+              0.609375,
+              0.609375,
+              0.203125,
+              0.125,
               0.0,
               0.5,
               0.5
@@ -179,7 +179,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 12,
-          "work_registers_used": 13
+          "work_registers_used": 12
         }
       }
     }
@@ -205,10 +205,10 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.421875,
               0.296875,
-              0.421875,
-              0.3125,
+              0.28125,
+              0.296875,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -227,10 +227,10 @@
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.40625,
-              0.234375,
-              0.40625,
+              0.34375,
               0.25,
+              0.34375,
+              0.1875,
               0.0,
               0.25,
               0.25
@@ -240,10 +240,10 @@
               "texture"
             ],
             "total_cycles": [
-              0.46875,
-              0.296875,
-              0.46875,
-              0.3125,
+              0.34375,
+              0.28125,
+              0.34375,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -252,7 +252,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 12,
-          "work_registers_used": 16
+          "work_registers_used": 14
         }
       }
     }
@@ -278,10 +278,10 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.421875,
-              0.265625,
-              0.421875,
-              0.3125,
+              0.296875,
+              0.25,
+              0.296875,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -300,10 +300,10 @@
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.40625,
-              0.203125,
-              0.40625,
-              0.25,
+              0.34375,
+              0.21875,
+              0.34375,
+              0.1875,
               0.0,
               0.25,
               0.25
@@ -313,10 +313,10 @@
               "texture"
             ],
             "total_cycles": [
-              0.46875,
-              0.265625,
-              0.46875,
-              0.3125,
+              0.34375,
+              0.25,
+              0.34375,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -325,7 +325,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 12,
-          "work_registers_used": 14
+          "work_registers_used": 12
         }
       }
     }
@@ -351,10 +351,10 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.203125,
-              0.203125,
               0.1875,
-              0.125,
+              0.1875,
+              0.0625,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -373,10 +373,10 @@
               "texture"
             ],
             "shortest_path_cycles": [
-              0.171875,
-              0.140625,
-              0.171875,
-              0.0625,
+              0.15625,
+              0.15625,
+              0.109375,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -386,10 +386,10 @@
               "texture"
             ],
             "total_cycles": [
-              0.234375,
-              0.203125,
-              0.234375,
-              0.125,
+              0.1875,
+              0.1875,
+              0.109375,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -398,7 +398,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 12
+          "work_registers_used": 11
         }
       }
     }
@@ -426,8 +426,8 @@
             "longest_path_cycles": [
               0.234375,
               0.234375,
-              0.15625,
-              0.125,
+              0.03125,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -446,10 +446,10 @@
               "texture"
             ],
             "shortest_path_cycles": [
-              0.171875,
-              0.171875,
-              0.140625,
-              0.0625,
+              0.203125,
+              0.203125,
+              0.078125,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -461,8 +461,8 @@
             "total_cycles": [
               0.234375,
               0.234375,
-              0.203125,
-              0.125,
+              0.078125,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -471,7 +471,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 12
+          "work_registers_used": 11
         }
       }
     }
@@ -497,10 +497,10 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.3125,
-              0.3125,
-              0.15625,
-              0.125,
+              0.296875,
+              0.296875,
+              0.03125,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -516,15 +516,13 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_fma",
-              "varying",
-              "texture"
+              "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.25,
-              0.25,
-              0.140625,
-              0.0625,
+              0.265625,
+              0.265625,
+              0.078125,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -534,10 +532,10 @@
               "texture"
             ],
             "total_cycles": [
-              0.3125,
-              0.3125,
-              0.203125,
-              0.125,
+              0.296875,
+              0.296875,
+              0.078125,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -546,7 +544,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 13
+          "work_registers_used": 11
         }
       }
     }
@@ -568,16 +566,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_fma",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.5,
-              0.21875,
-              0.125,
+              0.46875,
+              0.46875,
+              0.09375,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -598,23 +594,21 @@
             "shortest_path_cycles": [
               0.4375,
               0.4375,
-              0.203125,
-              0.0625,
+              0.140625,
+              0.0,
               0.0,
               0.25,
               0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_fma",
               "varying",
               "texture"
             ],
             "total_cycles": [
-              0.5,
-              0.5,
-              0.265625,
-              0.125,
+              0.46875,
+              0.46875,
+              0.140625,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -623,7 +617,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 16
+          "work_registers_used": 13
         }
       }
     }
@@ -641,7 +635,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 91,
+          "fp16_arithmetic": 90,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -649,10 +643,10 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.737500011920929,
-              0.737500011920929,
-              0.453125,
-              0.3125,
+              0.71875,
+              0.71875,
+              0.328125,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -668,13 +662,14 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
+              "arith_fma",
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.390625,
-              0.328125,
-              0.390625,
-              0.0625,
+              0.34375,
+              0.34375,
+              0.34375,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -684,10 +679,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.737500011920929,
-              0.737500011920929,
-              0.53125,
-              0.3125,
+              0.71875,
+              0.71875,
+              0.40625,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -696,7 +691,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 12,
-          "work_registers_used": 13
+          "work_registers_used": 12
         }
       }
     }
@@ -722,10 +717,10 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.203125,
-              0.203125,
               0.1875,
-              0.125,
+              0.1875,
+              0.0625,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -744,10 +739,10 @@
               "texture"
             ],
             "shortest_path_cycles": [
-              0.171875,
-              0.140625,
-              0.171875,
-              0.0625,
+              0.15625,
+              0.15625,
+              0.109375,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -757,10 +752,10 @@
               "texture"
             ],
             "total_cycles": [
-              0.234375,
-              0.203125,
-              0.234375,
-              0.125,
+              0.1875,
+              0.1875,
+              0.109375,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -769,7 +764,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 12
+          "work_registers_used": 11
         }
       }
     }
@@ -787,7 +782,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 88,
+          "fp16_arithmetic": 87,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -795,10 +790,10 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.625,
-              0.625,
-              0.28125,
-              0.25,
+              0.609375,
+              0.609375,
+              0.15625,
+              0.125,
               0.0,
               0.5,
               0.5
@@ -817,10 +812,10 @@
               "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.328125,
-              0.328125,
-              0.265625,
-              0.0625,
+              0.34375,
+              0.34375,
+              0.203125,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -830,10 +825,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.625,
-              0.625,
-              0.328125,
-              0.25,
+              0.609375,
+              0.609375,
+              0.203125,
+              0.125,
               0.0,
               0.5,
               0.5
@@ -842,7 +837,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 12,
-          "work_registers_used": 13
+          "work_registers_used": 12
         }
       }
     }
@@ -868,10 +863,10 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.234375,
-              0.234375,
-              0.15625,
-              0.125,
+              0.203125,
+              0.203125,
+              0.03125,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -892,8 +887,8 @@
             "shortest_path_cycles": [
               0.171875,
               0.171875,
-              0.140625,
-              0.0625,
+              0.078125,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -903,10 +898,10 @@
               "texture"
             ],
             "total_cycles": [
-              0.234375,
-              0.234375,
               0.203125,
-              0.125,
+              0.203125,
+              0.078125,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -915,7 +910,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 12
+          "work_registers_used": 11
         }
       }
     }
@@ -937,16 +932,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_fma",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.5,
-              0.21875,
-              0.125,
+              0.46875,
+              0.46875,
+              0.09375,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -967,23 +960,21 @@
             "shortest_path_cycles": [
               0.4375,
               0.4375,
-              0.203125,
-              0.0625,
+              0.140625,
+              0.0,
               0.0,
               0.25,
               0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_fma",
               "varying",
               "texture"
             ],
             "total_cycles": [
-              0.5,
-              0.5,
-              0.265625,
-              0.125,
+              0.46875,
+              0.46875,
+              0.140625,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -992,7 +983,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 16
+          "work_registers_used": 13
         }
       }
     }
@@ -1010,7 +1001,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 91,
+          "fp16_arithmetic": 90,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -1018,10 +1009,10 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.737500011920929,
-              0.737500011920929,
-              0.453125,
-              0.3125,
+              0.71875,
+              0.71875,
+              0.328125,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -1037,13 +1028,14 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
+              "arith_fma",
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.390625,
-              0.328125,
-              0.390625,
-              0.0625,
+              0.34375,
+              0.34375,
+              0.34375,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -1053,10 +1045,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.737500011920929,
-              0.737500011920929,
-              0.53125,
-              0.3125,
+              0.71875,
+              0.71875,
+              0.40625,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -1065,7 +1057,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 12,
-          "work_registers_used": 13
+          "work_registers_used": 12
         }
       }
     }
@@ -1091,10 +1083,10 @@
               "texture"
             ],
             "longest_path_cycles": [
-              0.28125,
-              0.28125,
-              0.15625,
-              0.125,
+              0.265625,
+              0.265625,
+              0.03125,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -1113,10 +1105,10 @@
               "texture"
             ],
             "shortest_path_cycles": [
-              0.21875,
-              0.21875,
-              0.140625,
-              0.0625,
+              0.234375,
+              0.234375,
+              0.078125,
+              0.0,
               0.0,
               0.25,
               0.25
@@ -1126,10 +1118,10 @@
               "texture"
             ],
             "total_cycles": [
-              0.28125,
-              0.28125,
-              0.203125,
-              0.125,
+              0.265625,
+              0.265625,
+              0.078125,
+              0.0,
               0.0,
               0.5,
               0.5
@@ -1138,7 +1130,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 12
+          "work_registers_used": 10
         }
       }
     }
@@ -1164,10 +1156,10 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.8125,
-              0.8125,
-              0.359375,
-              0.3125,
+              0.800000011920929,
+              0.800000011920929,
+              0.234375,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -1186,10 +1178,10 @@
               "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.75,
-              0.75,
-              0.34375,
-              0.25,
+              0.762499988079071,
+              0.762499988079071,
+              0.28125,
+              0.1875,
               0.0,
               0.25,
               0.25
@@ -1199,10 +1191,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.8125,
-              0.8125,
-              0.40625,
-              0.3125,
+              0.800000011920929,
+              0.800000011920929,
+              0.28125,
+              0.1875,
               0.0,
               0.5,
               0.5
@@ -1211,7 +1203,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 14,
-          "work_registers_used": 21
+          "work_registers_used": 22
         }
       }
     }
@@ -2167,7 +2159,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_color.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2175,21 +2167,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2201,36 +2193,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2240,7 +2232,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_colorburn.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2248,21 +2240,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2274,36 +2266,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2313,7 +2305,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_colordodge.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2321,21 +2313,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2347,36 +2339,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2386,7 +2378,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_darken.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2394,21 +2386,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2420,36 +2412,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2459,7 +2451,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_difference.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2467,21 +2459,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2493,36 +2485,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2532,7 +2524,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_exclusion.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2540,21 +2532,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2566,36 +2558,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2605,7 +2597,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_hardlight.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2613,21 +2605,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2639,36 +2631,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2678,7 +2670,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_hue.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2686,21 +2678,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2712,36 +2704,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2751,7 +2743,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_lighten.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2759,21 +2751,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2785,36 +2777,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2824,7 +2816,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_luminosity.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2832,21 +2824,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2858,36 +2850,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2897,7 +2889,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_multiply.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2905,21 +2897,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -2931,36 +2923,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -2970,7 +2962,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_overlay.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -2978,21 +2970,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -3004,36 +2996,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -3043,7 +3035,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_saturation.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -3051,21 +3043,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -3077,36 +3069,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -3116,7 +3108,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_screen.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -3124,21 +3116,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -3150,36 +3142,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -3189,7 +3181,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/framebuffer_blend_softlight.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -3197,21 +3189,21 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": null,
+          "fp16_arithmetic": 100,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "pipelines": [
               "arith_total",
@@ -3223,36 +3215,36 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.03125,
-              0.0,
-              0.03125,
-              0.0,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
-              0.0
+              0.0,
+              0.25,
+              0.25
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
-          "work_registers_used": 3
+          "uniform_registers_used": 4,
+          "work_registers_used": 6
         }
       }
     }
@@ -3833,14 +3825,13 @@
           "performance": {
             "longest_path_bound_pipelines": [
               "arith_total",
-              "arith_fma",
-              "arith_sfu"
+              "arith_fma"
             ],
             "longest_path_cycles": [
-              0.625,
-              0.625,
-              0.5625,
-              0.625,
+              0.609375,
+              0.609375,
+              0.4375,
+              0.5,
               0.0,
               0.5,
               0.5
@@ -3856,27 +3847,26 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_cvt"
+              "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.375,
-              0.328125,
-              0.375,
-              0.25,
+              0.34375,
+              0.34375,
+              0.3125,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_fma",
-              "arith_sfu"
+              "arith_fma"
             ],
             "total_cycles": [
-              0.625,
-              0.625,
               0.609375,
-              0.625,
+              0.609375,
+              0.484375,
+              0.5,
               0.0,
               0.5,
               0.5
@@ -3902,7 +3892,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              9.899999618530273,
+              8.90999984741211,
               2.0,
               2.0
             ],
@@ -3915,7 +3905,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              5.940000057220459,
+              5.28000020980835,
               1.0,
               0.0
             ],
@@ -3923,7 +3913,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              11.0,
+              9.666666984558105,
               2.0,
               2.0
             ]
@@ -3956,10 +3946,10 @@
               "arith_cvt"
             ],
             "longest_path_cycles": [
-              0.699999988079071,
-              0.296875,
-              0.699999988079071,
-              0.6875,
+              0.578125,
+              0.28125,
+              0.578125,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -3978,10 +3968,10 @@
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.515625,
-              0.234375,
-              0.515625,
-              0.4375,
+              0.453125,
+              0.25,
+              0.453125,
+              0.375,
               0.0,
               0.25,
               0.0
@@ -3991,10 +3981,10 @@
               "arith_cvt"
             ],
             "total_cycles": [
-              0.75,
-              0.296875,
-              0.75,
-              0.6875,
+              0.625,
+              0.28125,
+              0.625,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -4020,7 +4010,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              10.5600004196167,
+              9.569999694824219,
               2.0,
               2.0
             ],
@@ -4033,7 +4023,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              8.25,
+              7.920000076293945,
               1.0,
               0.0
             ],
@@ -4041,14 +4031,14 @@
               "arithmetic"
             ],
             "total_cycles": [
-              11.333333015441895,
+              10.333333015441895,
               2.0,
               2.0
             ]
           },
           "thread_occupancy": 100,
           "uniform_registers_used": 1,
-          "work_registers_used": 3
+          "work_registers_used": 2
         }
       }
     }
@@ -4071,13 +4061,14 @@
           "performance": {
             "longest_path_bound_pipelines": [
               "arith_total",
-              "arith_cvt"
+              "arith_cvt",
+              "arith_sfu"
             ],
             "longest_path_cycles": [
-              0.699999988079071,
-              0.265625,
-              0.699999988079071,
-              0.6875,
+              0.5625,
+              0.25,
+              0.5625,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -4096,10 +4087,10 @@
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.515625,
-              0.203125,
-              0.515625,
               0.4375,
+              0.21875,
+              0.4375,
+              0.375,
               0.0,
               0.25,
               0.0
@@ -4109,10 +4100,10 @@
               "arith_cvt"
             ],
             "total_cycles": [
-              0.75,
-              0.265625,
-              0.75,
-              0.6875,
+              0.609375,
+              0.25,
+              0.609375,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -4121,7 +4112,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 12,
-          "work_registers_used": 26
+          "work_registers_used": 24
         }
       }
     },
@@ -4138,7 +4129,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              10.229999542236328,
+              9.569999694824219,
               2.0,
               2.0
             ],
@@ -4159,14 +4150,14 @@
               "arithmetic"
             ],
             "total_cycles": [
-              11.0,
+              10.333333015441895,
               2.0,
               2.0
             ]
           },
           "thread_occupancy": 100,
           "uniform_registers_used": 1,
-          "work_registers_used": 3
+          "work_registers_used": 2
         }
       }
     }
@@ -4188,16 +4179,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.203125,
-              0.46875,
-              0.5,
+              0.375,
+              0.1875,
+              0.34375,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4212,27 +4201,26 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying"
             ],
             "shortest_path_cycles": [
-              0.28125,
-              0.140625,
-              0.28125,
-              0.25,
+              0.21875,
+              0.15625,
+              0.21875,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.515625,
-              0.203125,
-              0.515625,
-              0.5,
+              0.390625,
+              0.1875,
+              0.390625,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4258,7 +4246,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              5.940000057220459,
+              4.619999885559082,
               2.0,
               2.0
             ],
@@ -4271,7 +4259,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              3.299999952316284,
+              2.640000104904175,
               1.0,
               0.0
             ],
@@ -4279,7 +4267,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              6.333333492279053,
+              5.0,
               2.0,
               2.0
             ]
@@ -4308,16 +4296,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
+              0.375,
               0.234375,
-              0.4375,
-              0.5,
+              0.3125,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4332,31 +4318,26 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt",
-              "arith_sfu",
               "varying"
             ],
             "shortest_path_cycles": [
-              0.25,
-              0.171875,
-              0.25,
-              0.25,
+              0.203125,
+              0.203125,
+              0.1875,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "total_cycles": [
-              0.5,
+              0.375,
               0.234375,
-              0.484375,
-              0.5,
+              0.359375,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4382,7 +4363,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              5.940000057220459,
+              4.949999809265137,
               2.0,
               2.0
             ],
@@ -4395,7 +4376,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              3.299999952316284,
+              2.9700000286102295,
               1.0,
               0.0
             ],
@@ -4403,7 +4384,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              6.333333492279053,
+              5.333333492279053,
               2.0,
               2.0
             ]
@@ -4432,16 +4413,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.296875,
-              0.4375,
-              0.5,
+              0.375,
+              0.28125,
+              0.3125,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4457,30 +4436,27 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_cvt",
-              "arith_sfu",
+              "arith_fma",
               "varying"
             ],
             "shortest_path_cycles": [
               0.25,
-              0.234375,
               0.25,
-              0.25,
+              0.1875,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "total_cycles": [
-              0.5,
-              0.296875,
-              0.484375,
-              0.5,
+              0.375,
+              0.28125,
+              0.359375,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4489,7 +4465,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 21
+          "work_registers_used": 20
         }
       }
     },
@@ -4506,7 +4482,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              6.599999904632568,
+              4.949999809265137,
               2.0,
               2.0
             ],
@@ -4519,7 +4495,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              3.9600000381469727,
+              2.9700000286102295,
               1.0,
               0.0
             ],
@@ -4527,14 +4503,14 @@
               "arithmetic"
             ],
             "total_cycles": [
-              7.0,
+              5.333333492279053,
               2.0,
               2.0
             ]
           },
           "thread_occupancy": 100,
           "uniform_registers_used": 1,
-          "work_registers_used": 3
+          "work_registers_used": 2
         }
       }
     }
@@ -4556,17 +4532,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.484375,
-              0.5,
-              0.5,
+              0.453125,
+              0.453125,
+              0.359375,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4587,21 +4560,21 @@
             "shortest_path_cycles": [
               0.421875,
               0.421875,
-              0.3125,
-              0.25,
+              0.234375,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.546875,
-              0.484375,
-              0.546875,
-              0.5,
+              0.453125,
+              0.453125,
+              0.40625,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4610,7 +4583,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 25
+          "work_registers_used": 24
         }
       }
     },
@@ -4627,7 +4600,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              7.590000152587891,
+              5.940000057220459,
               2.0,
               2.0
             ],
@@ -4640,7 +4613,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              4.949999809265137,
+              4.289999961853027,
               1.0,
               0.0
             ],
@@ -4648,7 +4621,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              8.0,
+              6.666666507720947,
               2.0,
               2.0
             ]
@@ -4681,10 +4654,10 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.737500011920929,
-              0.737500011920929,
               0.71875,
-              0.6875,
+              0.71875,
+              0.59375,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -4703,23 +4676,23 @@
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.515625,
-              0.328125,
-              0.515625,
-              0.25,
+              0.453125,
+              0.34375,
+              0.453125,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_cvt"
+              "arith_fma"
             ],
             "total_cycles": [
-              0.8125,
-              0.737500011920929,
-              0.8125,
+              0.71875,
+              0.71875,
               0.6875,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -4728,7 +4701,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 12,
-          "work_registers_used": 21
+          "work_registers_used": 20
         }
       }
     },
@@ -4745,7 +4718,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              11.880000114440918,
+              10.5600004196167,
               2.0,
               2.0
             ],
@@ -4758,7 +4731,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              6.269999980926514,
+              5.940000057220459,
               1.0,
               0.0
             ],
@@ -4766,7 +4739,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              12.666666984558105,
+              11.666666984558105,
               2.0,
               2.0
             ]
@@ -4795,16 +4768,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.203125,
-              0.46875,
-              0.5,
+              0.375,
+              0.1875,
+              0.34375,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4819,27 +4790,26 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying"
             ],
             "shortest_path_cycles": [
-              0.28125,
-              0.140625,
-              0.28125,
-              0.25,
+              0.21875,
+              0.15625,
+              0.21875,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.515625,
-              0.203125,
-              0.515625,
-              0.5,
+              0.390625,
+              0.1875,
+              0.390625,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -4865,7 +4835,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              5.940000057220459,
+              4.619999885559082,
               2.0,
               2.0
             ],
@@ -4878,7 +4848,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              3.299999952316284,
+              2.640000104904175,
               1.0,
               0.0
             ],
@@ -4886,7 +4856,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              6.333333492279053,
+              5.0,
               2.0,
               2.0
             ]
@@ -4916,14 +4886,13 @@
           "performance": {
             "longest_path_bound_pipelines": [
               "arith_total",
-              "arith_fma",
-              "arith_sfu"
+              "arith_fma"
             ],
             "longest_path_cycles": [
-              0.625,
-              0.625,
-              0.5625,
-              0.625,
+              0.609375,
+              0.609375,
+              0.4375,
+              0.5,
               0.0,
               0.5,
               0.5
@@ -4939,27 +4908,26 @@
             ],
             "shortest_path_bound_pipelines": [
               "arith_total",
-              "arith_cvt"
+              "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.375,
-              0.328125,
-              0.375,
-              0.25,
+              0.34375,
+              0.34375,
+              0.3125,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_fma",
-              "arith_sfu"
+              "arith_fma"
             ],
             "total_cycles": [
-              0.625,
-              0.625,
               0.609375,
-              0.625,
+              0.609375,
+              0.484375,
+              0.5,
               0.0,
               0.5,
               0.5
@@ -4985,7 +4953,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              9.899999618530273,
+              8.90999984741211,
               2.0,
               2.0
             ],
@@ -4998,7 +4966,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              5.940000057220459,
+              5.28000020980835,
               1.0,
               0.0
             ],
@@ -5006,7 +4974,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              11.0,
+              9.666666984558105,
               2.0,
               2.0
             ]
@@ -5035,16 +5003,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.234375,
-              0.4375,
-              0.5,
+              0.375,
+              0.203125,
+              0.3125,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -5059,31 +5025,26 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt",
-              "arith_sfu",
               "varying"
             ],
             "shortest_path_cycles": [
-              0.25,
+              0.1875,
               0.171875,
-              0.25,
-              0.25,
+              0.1875,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "total_cycles": [
-              0.5,
-              0.234375,
-              0.484375,
-              0.5,
+              0.375,
+              0.203125,
+              0.359375,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -5109,7 +5070,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              6.269999980926514,
+              4.949999809265137,
               2.0,
               2.0
             ],
@@ -5122,7 +5083,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              3.630000114440918,
+              2.9700000286102295,
               1.0,
               0.0
             ],
@@ -5130,7 +5091,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              6.666666507720947,
+              5.333333492279053,
               2.0,
               2.0
             ]
@@ -5159,17 +5120,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.484375,
-              0.5,
-              0.5,
+              0.453125,
+              0.453125,
+              0.375,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -5190,21 +5148,21 @@
             "shortest_path_cycles": [
               0.421875,
               0.421875,
-              0.3125,
               0.25,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_cvt"
+              "varying",
+              "texture"
             ],
             "total_cycles": [
-              0.546875,
-              0.484375,
-              0.546875,
-              0.5,
+              0.453125,
+              0.453125,
+              0.421875,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -5213,7 +5171,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 25
+          "work_registers_used": 24
         }
       }
     },
@@ -5230,7 +5188,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              7.260000228881836,
+              6.269999980926514,
               2.0,
               2.0
             ],
@@ -5243,7 +5201,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              4.949999809265137,
+              4.289999961853027,
               1.0,
               0.0
             ],
@@ -5251,7 +5209,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              8.0,
+              6.666666507720947,
               2.0,
               2.0
             ]
@@ -5284,10 +5242,10 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.737500011920929,
-              0.737500011920929,
               0.71875,
-              0.6875,
+              0.71875,
+              0.59375,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -5306,23 +5264,23 @@
               "arith_cvt"
             ],
             "shortest_path_cycles": [
-              0.515625,
-              0.328125,
-              0.515625,
-              0.25,
+              0.453125,
+              0.34375,
+              0.453125,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
               "arith_total",
-              "arith_cvt"
+              "arith_fma"
             ],
             "total_cycles": [
-              0.8125,
-              0.737500011920929,
-              0.8125,
+              0.71875,
+              0.71875,
               0.6875,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -5331,7 +5289,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 12,
-          "work_registers_used": 21
+          "work_registers_used": 20
         }
       }
     },
@@ -5348,7 +5306,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              12.210000038146973,
+              10.890000343322754,
               2.0,
               2.0
             ],
@@ -5361,7 +5319,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              6.599999904632568,
+              5.940000057220459,
               1.0,
               0.0
             ],
@@ -5369,7 +5327,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              13.0,
+              11.666666984558105,
               2.0,
               2.0
             ]
@@ -5398,16 +5356,14 @@
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.265625,
-              0.4375,
-              0.5,
+              0.375,
+              0.25,
+              0.3125,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -5422,31 +5378,26 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "arith_total",
-              "arith_cvt",
-              "arith_sfu",
               "varying"
             ],
             "shortest_path_cycles": [
-              0.25,
-              0.203125,
-              0.25,
-              0.25,
+              0.21875,
+              0.21875,
+              0.1875,
+              0.1875,
               0.0,
               0.25,
               0.0
             ],
             "total_bound_pipelines": [
-              "arith_total",
-              "arith_sfu",
               "varying",
               "texture"
             ],
             "total_cycles": [
-              0.5,
-              0.265625,
-              0.484375,
-              0.5,
+              0.375,
+              0.25,
+              0.359375,
+              0.375,
               0.0,
               0.5,
               0.5
@@ -5455,7 +5406,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 8,
-          "work_registers_used": 21
+          "work_registers_used": 20
         }
       }
     },
@@ -5472,7 +5423,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              6.269999980926514,
+              4.949999809265137,
               2.0,
               2.0
             ],
@@ -5485,7 +5436,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              3.630000114440918,
+              2.9700000286102295,
               1.0,
               0.0
             ],
@@ -5493,7 +5444,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              6.666666507720947,
+              5.333333492279053,
               2.0,
               2.0
             ]
@@ -5528,8 +5479,8 @@
             "longest_path_cycles": [
               0.75,
               0.75,
-              0.637499988079071,
-              0.6875,
+              0.515625,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -5548,10 +5499,10 @@
               "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.6875,
-              0.6875,
-              0.453125,
-              0.4375,
+              0.71875,
+              0.71875,
+              0.390625,
+              0.375,
               0.0,
               0.25,
               0.0
@@ -5563,8 +5514,8 @@
             "total_cycles": [
               0.75,
               0.75,
-              0.6875,
-              0.6875,
+              0.5625,
+              0.5625,
               0.0,
               0.5,
               0.5
@@ -5573,7 +5524,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 14,
-          "work_registers_used": 32
+          "work_registers_used": 30
         }
       }
     },
@@ -5590,7 +5541,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              10.5600004196167,
+              8.90999984741211,
               2.0,
               2.0
             ],
@@ -5603,7 +5554,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              8.25,
+              6.929999828338623,
               1.0,
               0.0
             ],
@@ -5611,7 +5562,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              11.333333015441895,
+              9.333333015441895,
               2.0,
               2.0
             ]


### PR DESCRIPTION
Investigated as part of https://github.com/flutter/flutter/issues/127232.

This took some time to work out, but:
* The amount of blending applied to the source color needs to be weighted by the destination alpha, which is pretty sensible behavior. This is in addition to applying source-over behavior with the resulting blended color.
* All of the blend functions assume that the color is already premultiplied, so remove the unpremultiply/premultiply surrounding the blend call.

All of the blend modes now visually match up with the [Flutter docs](https://api.flutter.dev/flutter/dart-ui/BlendMode.html), except for ColorBurn and Saturation, which appear to have a slight miscalculation going on with the red channel. Going to investigate and fix in a follow-up.