### PR TITLE
Revert "Refactor JSNumber.toDart and Object.toJS"

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -130,19 +130,19 @@ extension CanvasKitExtension on CanvasKit {
   // Text decoration enum is embedded in the CanvasKit object itself.
   @JS('NoDecoration')
   external JSNumber get _NoDecoration;
-  double get NoDecoration => _NoDecoration.toDartDouble;
+  double get NoDecoration => _NoDecoration.toDart;
 
   @JS('UnderlineDecoration')
   external JSNumber get _UnderlineDecoration;
-  double get UnderlineDecoration => _UnderlineDecoration.toDartDouble;
+  double get UnderlineDecoration => _UnderlineDecoration.toDart;
 
   @JS('OverlineDecoration')
   external JSNumber get _OverlineDecoration;
-  double get OverlineDecoration => _OverlineDecoration.toDartDouble;
+  double get OverlineDecoration => _OverlineDecoration.toDart;
 
   @JS('LineThroughDecoration')
   external JSNumber get _LineThroughDecoration;
-  double get LineThroughDecoration => _LineThroughDecoration.toDartDouble;
+  double get LineThroughDecoration => _LineThroughDecoration.toDart;
   // End of text decoration enum.
 
   external SkTextDecorationStyleEnum get DecorationStyle;
@@ -159,7 +159,7 @@ extension CanvasKitExtension on CanvasKit {
       DomCanvasElement canvas, SkWebGLContextOptions options);
   double GetWebGLContext(
       DomCanvasElement canvas, SkWebGLContextOptions options) =>
-        _GetWebGLContext(canvas, options).toDartDouble;
+        _GetWebGLContext(canvas, options).toDart;
 
   @JS('MakeGrContext')
   external SkGrContext _MakeGrContext(JSNumber glContext);
@@ -286,11 +286,11 @@ extension SkSurfaceExtension on SkSurface {
 
   @JS('width')
   external JSNumber _width();
-  double width() => _width().toDartDouble;
+  double width() => _width().toDart;
 
   @JS('height')
   external JSNumber _height();
-  double height() => _height().toDartDouble;
+  double height() => _height().toDart;
 
   external JSVoid dispose();
   external SkImage makeImageSnapshot();
@@ -327,7 +327,7 @@ class SkFontSlant {}
 extension SkFontSlantExtension on SkFontSlant {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkFontSlant> _skFontSlants = <SkFontSlant>[
@@ -363,7 +363,7 @@ class SkFontWeight {}
 extension SkFontWeightExtension on SkFontWeight {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkFontWeight> _skFontWeights = <SkFontWeight>[
@@ -398,7 +398,7 @@ class SkAffinity {}
 extension SkAffinityExtension on SkAffinity {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkAffinity> _skAffinitys = <SkAffinity>[
@@ -426,7 +426,7 @@ class SkTextDirection {}
 extension SkTextDirectionExtension on SkTextDirection {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 // Flutter enumerates text directions as RTL, LTR, while CanvasKit
@@ -460,7 +460,7 @@ class SkTextAlign {}
 extension SkTextAlignExtension on SkTextAlign {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkTextAlign> _skTextAligns = <SkTextAlign>[
@@ -494,7 +494,7 @@ class SkTextHeightBehavior {}
 extension SkTextHeightBehaviorExtension on SkTextHeightBehavior {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkTextHeightBehavior> _skTextHeightBehaviors =
@@ -531,7 +531,7 @@ class SkRectHeightStyle {}
 extension SkRectHeightStyleExtension on SkRectHeightStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkRectHeightStyle> _skRectHeightStyles = <SkRectHeightStyle>[
@@ -563,7 +563,7 @@ class SkRectWidthStyle {}
 extension SkRectWidthStyleExtension on SkRectWidthStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkRectWidthStyle> _skRectWidthStyles = <SkRectWidthStyle>[
@@ -593,7 +593,7 @@ class SkVertexMode {}
 extension SkVertexModeExtension on SkVertexMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkVertexMode> _skVertexModes = <SkVertexMode>[
@@ -623,7 +623,7 @@ class SkPointMode {}
 extension SkPointModeExtension on SkPointMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkPointMode> _skPointModes = <SkPointMode>[
@@ -652,7 +652,7 @@ class SkClipOp {}
 extension SkClipOpExtension on SkClipOp {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkClipOp> _skClipOps = <SkClipOp>[
@@ -680,7 +680,7 @@ class SkFillType {}
 extension SkFillTypeExtension on SkFillType {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkFillType> _skFillTypes = <SkFillType>[
@@ -711,7 +711,7 @@ class SkPathOp {}
 extension SkPathOpExtension on SkPathOp {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkPathOp> _skPathOps = <SkPathOp>[
@@ -744,7 +744,7 @@ class SkBlurStyle {}
 extension SkBlurStyleExtension on SkBlurStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkBlurStyle> _skBlurStyles = <SkBlurStyle>[
@@ -775,7 +775,7 @@ class SkStrokeCap {}
 extension SkStrokeCapExtension on SkStrokeCap {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkStrokeCap> _skStrokeCaps = <SkStrokeCap>[
@@ -804,7 +804,7 @@ class SkPaintStyle {}
 extension SkPaintStyleExtension on SkPaintStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkPaintStyle> _skPaintStyles = <SkPaintStyle>[
@@ -859,7 +859,7 @@ class SkBlendMode {}
 extension SkBlendModeExtension on SkBlendMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkBlendMode> _skBlendModes = <SkBlendMode>[
@@ -915,7 +915,7 @@ class SkStrokeJoin {}
 extension SkStrokeJoinExtension on SkStrokeJoin {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkStrokeJoin> _skStrokeJoins = <SkStrokeJoin>[
@@ -946,7 +946,7 @@ class SkTileMode {}
 extension SkTileModeExtension on SkTileMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkTileMode> _skTileModes = <SkTileMode>[
@@ -976,7 +976,7 @@ class SkFilterMode {}
 extension SkFilterModeExtension on SkFilterMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 SkFilterMode toSkFilterMode(ui.FilterQuality filterQuality) {
@@ -1002,7 +1002,7 @@ class SkMipmapMode {}
 extension SkMipmapModeExtension on SkMipmapMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 SkMipmapMode toSkMipmapMode(ui.FilterQuality filterQuality) {
@@ -1028,7 +1028,7 @@ class SkAlphaType {}
 extension SkAlphaTypeExtension on SkAlphaType {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 @JS()
@@ -1056,7 +1056,7 @@ class SkColorType {}
 extension SkColorTypeExtension on SkColorType {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 @JS()
@@ -1067,31 +1067,31 @@ class SkAnimatedImage {}
 extension SkAnimatedImageExtension on SkAnimatedImage {
   @JS('getFrameCount')
   external JSNumber _getFrameCount();
-  double getFrameCount() => _getFrameCount().toDartDouble;
+  double getFrameCount() => _getFrameCount().toDart;
 
   @JS('getRepetitionCount')
   external JSNumber _getRepetitionCount();
-  double getRepetitionCount() => _getRepetitionCount().toDartDouble;
+  double getRepetitionCount() => _getRepetitionCount().toDart;
 
   /// Returns duration in milliseconds.
   @JS('currentFrameDuration')
   external JSNumber _currentFrameDuration();
-  double currentFrameDuration() => _currentFrameDuration().toDartDouble;
+  double currentFrameDuration() => _currentFrameDuration().toDart;
 
   /// Advances to the next frame and returns its duration in milliseconds.
   @JS('decodeNextFrame')
   external JSNumber _decodeNextFrame();
-  double decodeNextFrame() => _decodeNextFrame().toDartDouble;
+  double decodeNextFrame() => _decodeNextFrame().toDart;
 
   external SkImage makeImageAtCurrentFrame();
 
   @JS('width')
   external JSNumber _width();
-  double width() => _width().toDartDouble;
+  double width() => _width().toDart;
 
   @JS('height')
   external JSNumber _height();
-  double height() => _height().toDartDouble;
+  double height() => _height().toDart;
 
   /// Deletes the C++ object.
   ///
@@ -1113,11 +1113,11 @@ extension SkImageExtension on SkImage {
 
   @JS('width')
   external JSNumber _width();
-  double width() => _width().toDartDouble;
+  double width() => _width().toDart;
 
   @JS('height')
   external JSNumber _height();
-  double height() => _height().toDartDouble;
+  double height() => _height().toDart;
 
   @JS('makeShaderCubic')
   external SkShader _makeShaderCubic(
@@ -1624,7 +1624,7 @@ extension SkFloat32ListExtension on SkFloat32List {
   /// The number of objects this pointer refers to.
   @JS('length')
   external JSNumber get _length;
-  double get length => _length.toDartDouble;
+  double get length => _length.toDart;
 
   @JS('length')
   external set _length(JSNumber length);
@@ -1655,7 +1655,7 @@ extension SkUint32ListExtension on SkUint32List {
   /// The number of objects this pointer refers to.
   @JS('length')
   external JSNumber get _length;
-  double get length => _length.toDartDouble;
+  double get length => _length.toDart;
 
   @JS('length')
   external set _length(JSNumber length);
@@ -2084,7 +2084,7 @@ extension SkContourMeasureExtension on SkContourMeasure {
 
   @JS('length')
   external JSNumber _length();
-  double length() => _length().toDartDouble;
+  double length() => _length().toDart;
 
   external JSVoid delete();
 }
@@ -2513,11 +2513,11 @@ extension SkCanvasExtension on SkCanvas {
 
   @JS('save')
   external JSNumber _save();
-  double save() => _save().toDartDouble;
+  double save() => _save().toDart;
 
   @JS('getSaveCount')
   external JSNumber _getSaveCount();
-  double getSaveCount() => _getSaveCount().toDartDouble;
+  double getSaveCount() => _getSaveCount().toDart;
 
   @JS('saveLayer')
   external JSVoid _saveLayer(
@@ -2747,7 +2747,7 @@ class SkTextDecorationStyle {}
 extension SkTextDecorationStyleExtension on SkTextDecorationStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkTextDecorationStyle> _skTextDecorationStyles =
@@ -2779,7 +2779,7 @@ class SkTextBaseline {}
 extension SkTextBaselineExtension on SkTextBaseline {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkTextBaseline> _skTextBaselines = <SkTextBaseline>[
@@ -2811,7 +2811,7 @@ class SkPlaceholderAlignment {}
 extension SkPlaceholderAlignmentExtension on SkPlaceholderAlignment {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDartDouble;
+  double get value => _value.toDart;
 }
 
 final List<SkPlaceholderAlignment> _skPlaceholderAlignments =
@@ -3101,19 +3101,19 @@ class SkLineMetrics {}
 extension SkLineMetricsExtension on SkLineMetrics {
   @JS('startIndex')
   external JSNumber get _startIndex;
-  double get startIndex => _startIndex.toDartDouble;
+  double get startIndex => _startIndex.toDart;
 
   @JS('endIndex')
   external JSNumber get _endIndex;
-  double get endIndex => _endIndex.toDartDouble;
+  double get endIndex => _endIndex.toDart;
 
   @JS('endExcludingWhitespaces')
   external JSNumber get _endExcludingWhitespaces;
-  double get endExcludingWhitespaces => _endExcludingWhitespaces.toDartDouble;
+  double get endExcludingWhitespaces => _endExcludingWhitespaces.toDart;
 
   @JS('endIncludingNewline')
   external JSNumber get _endIncludingNewline;
-  double get endIncludingNewline => _endIncludingNewline.toDartDouble;
+  double get endIncludingNewline => _endIncludingNewline.toDart;
 
   @JS('isHardBreak')
   external JSBoolean get _isHardBreak;
@@ -3121,31 +3121,31 @@ extension SkLineMetricsExtension on SkLineMetrics {
 
   @JS('ascent')
   external JSNumber get _ascent;
-  double get ascent => _ascent.toDartDouble;
+  double get ascent => _ascent.toDart;
 
   @JS('descent')
   external JSNumber get _descent;
-  double get descent => _descent.toDartDouble;
+  double get descent => _descent.toDart;
 
   @JS('height')
   external JSNumber get _height;
-  double get height => _height.toDartDouble;
+  double get height => _height.toDart;
 
   @JS('width')
   external JSNumber get _width;
-  double get width => _width.toDartDouble;
+  double get width => _width.toDart;
 
   @JS('left')
   external JSNumber get _left;
-  double get left => _left.toDartDouble;
+  double get left => _left.toDart;
 
   @JS('baseline')
   external JSNumber get _baseline;
-  double get baseline => _baseline.toDartDouble;
+  double get baseline => _baseline.toDart;
 
   @JS('lineNumber')
   external JSNumber get _lineNumber;
-  double get lineNumber => _lineNumber.toDartDouble;
+  double get lineNumber => _lineNumber.toDart;
 }
 
 @JS()
@@ -3173,7 +3173,7 @@ class SkParagraph {}
 extension SkParagraphExtension on SkParagraph {
   @JS('getAlphabeticBaseline')
   external JSNumber _getAlphabeticBaseline();
-  double getAlphabeticBaseline() => _getAlphabeticBaseline().toDartDouble;
+  double getAlphabeticBaseline() => _getAlphabeticBaseline().toDart;
 
   @JS('didExceedMaxLines')
   external JSBoolean _didExceedMaxLines();
@@ -3181,11 +3181,11 @@ extension SkParagraphExtension on SkParagraph {
 
   @JS('getHeight')
   external JSNumber _getHeight();
-  double getHeight() => _getHeight().toDartDouble;
+  double getHeight() => _getHeight().toDart;
 
   @JS('getIdeographicBaseline')
   external JSNumber _getIdeographicBaseline();
-  double getIdeographicBaseline() => _getIdeographicBaseline().toDartDouble;
+  double getIdeographicBaseline() => _getIdeographicBaseline().toDart;
 
   @JS('getLineMetrics')
   external JSArray _getLineMetrics();
@@ -3194,19 +3194,19 @@ extension SkParagraphExtension on SkParagraph {
 
   @JS('getLongestLine')
   external JSNumber _getLongestLine();
-  double getLongestLine() => _getLongestLine().toDartDouble;
+  double getLongestLine() => _getLongestLine().toDart;
 
   @JS('getMaxIntrinsicWidth')
   external JSNumber _getMaxIntrinsicWidth();
-  double getMaxIntrinsicWidth() => _getMaxIntrinsicWidth().toDartDouble;
+  double getMaxIntrinsicWidth() => _getMaxIntrinsicWidth().toDart;
 
   @JS('getMinIntrinsicWidth')
   external JSNumber _getMinIntrinsicWidth();
-  double getMinIntrinsicWidth() => _getMinIntrinsicWidth().toDartDouble;
+  double getMinIntrinsicWidth() => _getMinIntrinsicWidth().toDart;
 
   @JS('getMaxWidth')
   external JSNumber _getMaxWidth();
-  double getMaxWidth() => _getMaxWidth().toDartDouble;
+  double getMaxWidth() => _getMaxWidth().toDart;
 
   @JS('getRectsForRange')
   external JSArray _getRectsForRange(
@@ -3259,7 +3259,7 @@ extension SkTextPositionExtnsion on SkTextPosition {
 
   @JS('pos')
   external JSNumber get _pos;
-  double get pos => _pos.toDartDouble;
+  double get pos => _pos.toDart;
 }
 
 @JS()
@@ -3269,11 +3269,11 @@ class SkTextRange {}
 extension SkTextRangeExtension on SkTextRange {
   @JS('start')
   external JSNumber get _start;
-  double get start => _start.toDartDouble;
+  double get start => _start.toDart;
 
   @JS('end')
   external JSNumber get _end;
-  double get end => _end.toDartDouble;
+  double get end => _end.toDart;
 }
 
 @JS()
@@ -3391,7 +3391,7 @@ class SkData {}
 extension SkDataExtension on SkData {
   @JS('size')
   external JSNumber _size();
-  double size() => _size().toDartDouble;
+  double size() => _size().toDart;
 
   @JS('isEmpty')
   external JSBoolean _isEmpty();
@@ -3435,7 +3435,7 @@ extension SkImageInfoExtension on SkImageInfo {
 
   @JS('height')
   external JSNumber get _height;
-  double get height => _height.toDartDouble;
+  double get height => _height.toDart;
 
   @JS('isEmpty')
   external JSBoolean get _isEmpty;
@@ -3451,7 +3451,7 @@ extension SkImageInfoExtension on SkImageInfo {
 
   @JS('width')
   external JSNumber get _width;
-  double get width => _width.toDartDouble;
+  double get width => _width.toDart;
 
   external SkImageInfo makeAlphaType(SkAlphaType alphaType);
   external SkImageInfo makeColorSpace(ColorSpace colorSpace);
@@ -3494,11 +3494,11 @@ extension SkPartialImageInfoExtension on SkPartialImageInfo {
 
   @JS('height')
   external JSNumber get _height;
-  double get height => _height.toDartDouble;
+  double get height => _height.toDart;
 
   @JS('width')
   external JSNumber get _width;
-  double get width => _width.toDartDouble;
+  double get width => _width.toDart;
 }
 
 @JS('window.flutterCanvasKit.RuntimeEffect')

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -205,10 +205,10 @@ Future<Uint8List> readChunked(HttpFetchPayload payload, int contentLength, WebOn
   int position = 0;
   int cumulativeBytesLoaded = 0;
   await payload.read<JSUint8Array1>((JSUint8Array1 chunk) {
-    cumulativeBytesLoaded += chunk.length.toDartInt;
+    cumulativeBytesLoaded += chunk.length.toDart.toInt();
     chunkCallback(cumulativeBytesLoaded, contentLength);
     result.set(chunk, position.toJS);
-    position += chunk.length.toDartInt;
+    position += chunk.length.toDart.toInt();
   });
   return result.toDart;
 }

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -312,7 +312,7 @@ extension JsFlutterConfigurationExtension on JsFlutterConfiguration {
 
   @JS('canvasKitMaximumSurfaces')
   external JSNumber? get _canvasKitMaximumSurfaces;
-  double? get canvasKitMaximumSurfaces => _canvasKitMaximumSurfaces?.toDartDouble;
+  double? get canvasKitMaximumSurfaces => _canvasKitMaximumSurfaces?.toDart;
 
   @JS('debugShowSemanticsNodes')
   external JSBoolean? get _debugShowSemanticsNodes;

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -41,6 +41,9 @@ extension ObjectToJSAnyExtension on Object {
     if (isWasm) {
       return toJSAnyDeep;
     } else {
+      // TODO(joshualitt): remove this cast when we reify JS types on JS
+      // backends.
+      // ignore: unnecessary_cast
       return this as JSAny;
     }
   }
@@ -73,18 +76,18 @@ extension DomWindowExtension on DomWindow {
 
   @JS('devicePixelRatio')
   external JSNumber get _devicePixelRatio;
-  double get devicePixelRatio => _devicePixelRatio.toDartDouble;
+  double get devicePixelRatio => _devicePixelRatio.toDart;
 
   external DomDocument get document;
   external DomHistory get history;
 
   @JS('innerHeight')
   external JSNumber? get _innerHeight;
-  double? get innerHeight => _innerHeight?.toDartDouble;
+  double? get innerHeight => _innerHeight?.toDart;
 
   @JS('innerWidth')
   external JSNumber? get _innerWidth;
-  double? get innerWidth => _innerWidth?.toDartDouble;
+  double? get innerWidth => _innerWidth?.toDart;
 
   external DomLocation get location;
   external DomNavigator get navigator;
@@ -136,7 +139,7 @@ extension DomWindowExtension on DomWindow {
   @JS('requestAnimationFrame')
   external JSNumber _requestAnimationFrame(JSFunction callback);
   double requestAnimationFrame(DomRequestAnimationFrameCallback callback) =>
-      _requestAnimationFrame(callback.toJS).toDartDouble;
+      _requestAnimationFrame(callback.toJS).toDart;
 
   @JS('postMessage')
   external JSVoid _postMessage1(JSAny message, JSString targetOrigin);
@@ -200,7 +203,7 @@ extension DomNavigatorExtension on DomNavigator {
 
   @JS('maxTouchPoints')
   external JSNumber? get _maxTouchPoints;
-  double? get maxTouchPoints => _maxTouchPoints?.toDartDouble;
+  double? get maxTouchPoints => _maxTouchPoints?.toDart;
 
   @JS('vendor')
   external JSString get _vendor;
@@ -382,7 +385,7 @@ extension DomEventExtension on DomEvent {
 
   @JS('timeStamp')
   external JSNumber? get _timeStamp;
-  double? get timeStamp => _timeStamp?.toDartDouble;
+  double? get timeStamp => _timeStamp?.toDart;
 
   @JS('type')
   external JSString get _type;
@@ -429,11 +432,11 @@ class DomProgressEvent extends DomEvent {
 extension DomProgressEventExtension on DomProgressEvent {
   @JS('loaded')
   external JSNumber? get _loaded;
-  double? get loaded => _loaded?.toDartDouble;
+  double? get loaded => _loaded?.toDart;
 
   @JS('total')
   external JSNumber? get _total;
-  double? get total => _total?.toDartDouble;
+  double? get total => _total?.toDart;
 }
 
 @JS()
@@ -525,11 +528,11 @@ extension DomElementExtension on DomElement {
 
   @JS('clientHeight')
   external JSNumber get _clientHeight;
-  double get clientHeight => _clientHeight.toDartDouble;
+  double get clientHeight => _clientHeight.toDart;
 
   @JS('clientWidth')
   external JSNumber get _clientWidth;
-  double get clientWidth => _clientWidth.toDartDouble;
+  double get clientWidth => _clientWidth.toDart;
 
   @JS('id')
   external JSString get _id;
@@ -594,13 +597,13 @@ extension DomElementExtension on DomElement {
 
   @JS('tabIndex')
   external JSNumber? get _tabIndex;
-  double? get tabIndex => _tabIndex?.toDartDouble;
+  double? get tabIndex => _tabIndex?.toDart;
 
   external JSVoid focus();
 
   @JS('scrollTop')
   external JSNumber get _scrollTop;
-  double get scrollTop => _scrollTop.toDartDouble;
+  double get scrollTop => _scrollTop.toDart;
 
   @JS('scrollTop')
   external set _scrollTop(JSNumber value);
@@ -608,7 +611,7 @@ extension DomElementExtension on DomElement {
 
   @JS('scrollLeft')
   external JSNumber get _scrollLeft;
-  double get scrollLeft => _scrollLeft.toDartDouble;
+  double get scrollLeft => _scrollLeft.toDart;
 
   @JS('scrollLeft')
   external set _scrollLeft(JSNumber value);
@@ -825,15 +828,15 @@ class DomHTMLElement extends DomElement {}
 extension DomHTMLElementExtension on DomHTMLElement {
   @JS('offsetWidth')
   external JSNumber get _offsetWidth;
-  double get offsetWidth => _offsetWidth.toDartDouble;
+  double get offsetWidth => _offsetWidth.toDart;
 
   @JS('offsetLeft')
   external JSNumber get _offsetLeft;
-  double get offsetLeft => _offsetLeft.toDartDouble;
+  double get offsetLeft => _offsetLeft.toDart;
 
   @JS('offsetTop')
   external JSNumber get _offsetTop;
-  double get offsetTop => _offsetTop.toDartDouble;
+  double get offsetTop => _offsetTop.toDart;
 
   external DomHTMLElement? get offsetParent;
 }
@@ -898,11 +901,11 @@ extension DomHTMLImageElementExtension on DomHTMLImageElement {
 
   @JS('naturalWidth')
   external JSNumber get _naturalWidth;
-  double get naturalWidth => _naturalWidth.toDartDouble;
+  double get naturalWidth => _naturalWidth.toDart;
 
   @JS('naturalHeight')
   external JSNumber get _naturalHeight;
-  double get naturalHeight => _naturalHeight.toDartDouble;
+  double get naturalHeight => _naturalHeight.toDart;
 
   @JS('width')
   external set _width(JSNumber? value);
@@ -992,7 +995,7 @@ extension DomPerformanceExtension on DomPerformance {
 
   @JS('now')
   external JSNumber _now();
-  double now() => _now().toDartDouble;
+  double now() => _now().toDart;
 }
 
 @JS()
@@ -1031,7 +1034,7 @@ DomCanvasElement createDomCanvasElement({int? width, int? height}) {
 extension DomCanvasElementExtension on DomCanvasElement {
   @JS('width')
   external JSNumber? get _width;
-  double? get width => _width?.toDartDouble;
+  double? get width => _width?.toDart;
 
   @JS('width')
   external set _width(JSNumber? value);
@@ -1039,7 +1042,7 @@ extension DomCanvasElementExtension on DomCanvasElement {
 
   @JS('height')
   external JSNumber? get _height;
-  double? get height => _height?.toDartDouble;
+  double? get height => _height?.toDart;
 
   @JS('height')
   external set _height(JSNumber? value);
@@ -1083,15 +1086,15 @@ class WebGLContext {}
 extension WebGLContextExtension on WebGLContext {
   @JS('getParameter')
   external JSNumber _getParameter(JSNumber value);
-  int getParameter(int value) => _getParameter(value.toJS).toDartDouble.toInt();
+  int getParameter(int value) => _getParameter(value.toJS).toDart.toInt();
 
   @JS('SAMPLES')
   external JSNumber get _samples;
-  int get samples => _samples.toDartDouble.toInt();
+  int get samples => _samples.toDart.toInt();
 
   @JS('STENCIL_BITS')
   external JSNumber get _stencilBits;
-  int get stencilBits => _stencilBits.toDartDouble.toInt();
+  int get stencilBits => _stencilBits.toDart.toInt();
 }
 
 @JS()
@@ -1751,7 +1754,7 @@ class DomResponse {}
 extension DomResponseExtension on DomResponse {
   @JS('status')
   external JSNumber get _status;
-  int get status => _status.toDartInt;
+  int get status => _status.toDart.toInt();
 
   external DomHeaders get headers;
 
@@ -1829,7 +1832,7 @@ class DomTextMetrics {}
 extension DomTextMetricsExtension on DomTextMetrics {
   @JS('width')
   external JSNumber? get _width;
-  double? get width => _width?.toDartDouble;
+  double? get width => _width?.toDart;
 }
 
 @JS()
@@ -1851,35 +1854,35 @@ class DomRectReadOnly {}
 extension DomRectReadOnlyExtension on DomRectReadOnly {
   @JS('x')
   external JSNumber get _x;
-  double get x => _x.toDartDouble;
+  double get x => _x.toDart;
 
   @JS('y')
   external JSNumber get _y;
-  double get y => _y.toDartDouble;
+  double get y => _y.toDart;
 
   @JS('width')
   external JSNumber get _width;
-  double get width => _width.toDartDouble;
+  double get width => _width.toDart;
 
   @JS('height')
   external JSNumber get _height;
-  double get height => _height.toDartDouble;
+  double get height => _height.toDart;
 
   @JS('top')
   external JSNumber get _top;
-  double get top => _top.toDartDouble;
+  double get top => _top.toDart;
 
   @JS('right')
   external JSNumber get _right;
-  double get right => _right.toDartDouble;
+  double get right => _right.toDart;
 
   @JS('bottom')
   external JSNumber get _bottom;
-  double get bottom => _bottom.toDartDouble;
+  double get bottom => _bottom.toDart;
 
   @JS('left')
   external JSNumber get _left;
-  double get left => _left.toDartDouble;
+  double get left => _left.toDart;
 }
 
 DomRect createDomRectFromPoints(DomPoint a, DomPoint b) {
@@ -1957,11 +1960,11 @@ class DomVisualViewport extends DomEventTarget {}
 extension DomVisualViewportExtension on DomVisualViewport {
   @JS('height')
   external JSNumber? get _height;
-  double? get height => _height?.toDartDouble;
+  double? get height => _height?.toDart;
 
   @JS('width')
   external JSNumber? get _width;
-  double? get width => _width?.toDartDouble;
+  double? get width => _width?.toDart;
 }
 
 @JS()
@@ -1988,11 +1991,11 @@ extension DomHTMLTextAreaElementExtension on DomHTMLTextAreaElement {
 
   @JS('selectionStart')
   external JSNumber? get _selectionStart;
-  double? get selectionStart => _selectionStart?.toDartDouble;
+  double? get selectionStart => _selectionStart?.toDart;
 
   @JS('selectionEnd')
   external JSNumber? get _selectionEnd;
-  double? get selectionEnd => _selectionEnd?.toDartDouble;
+  double? get selectionEnd => _selectionEnd?.toDart;
 
   @JS('selectionStart')
   external set _selectionStart(JSNumber? value);
@@ -2073,11 +2076,11 @@ extension DomKeyboardEventExtension on DomKeyboardEvent {
 
   @JS('keyCode')
   external JSNumber get _keyCode;
-  double get keyCode => _keyCode.toDartDouble;
+  double get keyCode => _keyCode.toDart;
 
   @JS('location')
   external JSNumber get _location;
-  double get location => _location.toDartDouble;
+  double get location => _location.toDart;
 
   @JS('metaKey')
   external JSBoolean get _metaKey;
@@ -2327,38 +2330,38 @@ class DomMouseEvent extends DomUIEvent {
 extension DomMouseEventExtension on DomMouseEvent {
   @JS('clientX')
   external JSNumber get _clientX;
-  double get clientX => _clientX.toDartDouble;
+  double get clientX => _clientX.toDart;
 
   @JS('clientY')
   external JSNumber get _clientY;
-  double get clientY => _clientY.toDartDouble;
+  double get clientY => _clientY.toDart;
 
   @JS('offsetX')
   external JSNumber get _offsetX;
-  double get offsetX => _offsetX.toDartDouble;
+  double get offsetX => _offsetX.toDart;
 
   @JS('offsetY')
   external JSNumber get _offsetY;
-  double get offsetY => _offsetY.toDartDouble;
+  double get offsetY => _offsetY.toDart;
 
   @JS('pageX')
   external JSNumber get _pageX;
-  double get pageX => _pageX.toDartDouble;
+  double get pageX => _pageX.toDart;
 
   @JS('pageY')
   external JSNumber get _pageY;
-  double get pageY => _pageY.toDartDouble;
+  double get pageY => _pageY.toDart;
 
   DomPoint get client => DomPoint(clientX, clientY);
   DomPoint get offset => DomPoint(offsetX, offsetY);
 
   @JS('button')
   external JSNumber get _button;
-  double get button => _button.toDartDouble;
+  double get button => _button.toDart;
 
   @JS('buttons')
   external JSNumber? get _buttons;
-  double? get buttons => _buttons?.toDartDouble;
+  double? get buttons => _buttons?.toDart;
 
   @JS('ctrlKey')
   external JSBoolean get _ctrlKey;
@@ -2387,7 +2390,7 @@ class DomPointerEvent extends DomMouseEvent {
 extension DomPointerEventExtension on DomPointerEvent {
   @JS('pointerId')
   external JSNumber? get _pointerId;
-  double? get pointerId => _pointerId?.toDartDouble;
+  double? get pointerId => _pointerId?.toDart;
 
   @JS('pointerType')
   external JSString? get _pointerType;
@@ -2395,15 +2398,15 @@ extension DomPointerEventExtension on DomPointerEvent {
 
   @JS('pressure')
   external JSNumber? get _pressure;
-  double? get pressure => _pressure?.toDartDouble;
+  double? get pressure => _pressure?.toDart;
 
   @JS('tiltX')
   external JSNumber? get _tiltX;
-  double? get tiltX => _tiltX?.toDartDouble;
+  double? get tiltX => _tiltX?.toDart;
 
   @JS('tiltY')
   external JSNumber? get _tiltY;
-  double? get tiltY => _tiltY?.toDartDouble;
+  double? get tiltY => _tiltY?.toDart;
 
   @JS('getCoalescedEvents')
   external JSArray _getCoalescedEvents();
@@ -2430,23 +2433,23 @@ class DomWheelEvent extends DomMouseEvent {
 extension DomWheelEventExtension on DomWheelEvent {
   @JS('deltaX')
   external JSNumber get _deltaX;
-  double get deltaX => _deltaX.toDartDouble;
+  double get deltaX => _deltaX.toDart;
 
   @JS('deltaY')
   external JSNumber get _deltaY;
-  double get deltaY => _deltaY.toDartDouble;
+  double get deltaY => _deltaY.toDart;
 
   @JS('wheelDeltaX')
   external JSNumber? get _wheelDeltaX;
-  double? get wheelDeltaX => _wheelDeltaX?.toDartDouble;
+  double? get wheelDeltaX => _wheelDeltaX?.toDart;
 
   @JS('wheelDeltaY')
   external JSNumber? get _wheelDeltaY;
-  double? get wheelDeltaY => _wheelDeltaY?.toDartDouble;
+  double? get wheelDeltaY => _wheelDeltaY?.toDart;
 
   @JS('deltaMode')
   external JSNumber get _deltaMode;
-  double get deltaMode => _deltaMode.toDartDouble;
+  double get deltaMode => _deltaMode.toDart;
 }
 
 DomWheelEvent createDomWheelEvent(String type, [Map<dynamic, dynamic>? init]) {
@@ -2497,15 +2500,15 @@ class DomTouch {
 extension DomTouchExtension on DomTouch {
   @JS('identifier')
   external JSNumber? get _identifier;
-  double? get identifier => _identifier?.toDartDouble;
+  double? get identifier => _identifier?.toDart;
 
   @JS('clientX')
   external JSNumber get _clientX;
-  double get clientX => _clientX.toDartDouble;
+  double get clientX => _clientX.toDart;
 
   @JS('clientY')
   external JSNumber get _clientY;
-  double get clientY => _clientY.toDartDouble;
+  double get clientY => _clientY.toDart;
 
   DomPoint get client => DomPoint(clientX, clientY);
 }
@@ -2595,11 +2598,11 @@ extension DomHTMLInputElementExtension on DomHTMLInputElement {
 
   @JS('selectionStart')
   external JSNumber? get _selectionStart;
-  double? get selectionStart => _selectionStart?.toDartDouble;
+  double? get selectionStart => _selectionStart?.toDart;
 
   @JS('selectionEnd')
   external JSNumber? get _selectionEnd;
-  double? get selectionEnd => _selectionEnd?.toDartDouble;
+  double? get selectionEnd => _selectionEnd?.toDart;
 
   @JS('selectionStart')
   external set _selectionStart(JSNumber? value);
@@ -2697,11 +2700,11 @@ class DomOffscreenCanvas extends DomEventTarget {
 extension DomOffscreenCanvasExtension on DomOffscreenCanvas {
   @JS('height')
   external JSNumber? get _height;
-  double? get height => _height?.toDartDouble;
+  double? get height => _height?.toDart;
 
   @JS('width')
   external JSNumber? get _width;
-  double? get width => _width?.toDartDouble;
+  double? get width => _width?.toDart;
 
   @JS('height')
   external set _height(JSNumber? value);
@@ -2810,9 +2813,9 @@ extension DomCSSStyleSheetExtension on DomCSSStyleSheet {
   external JSNumber _insertRule2(JSString rule, JSNumber index);
   double insertRule(String rule, [int? index]) {
     if (index == null) {
-      return _insertRule1(rule.toJS).toDartDouble;
+      return _insertRule1(rule.toJS).toDart;
     } else {
-      return _insertRule2(rule.toJS, index.toJS).toDartDouble;
+      return _insertRule2(rule.toJS, index.toJS).toDart;
     }
   }
 }
@@ -3164,7 +3167,7 @@ class _DomList {}
 extension DomListExtension on _DomList {
   @JS('length')
   external JSNumber get _length;
-  double get length => _length.toDartDouble;
+  double get length => _length.toDart;
 
   @JS('item')
   external DomNode _item(JSNumber index);
@@ -3216,7 +3219,7 @@ class _DomTouchList {}
 extension DomTouchListExtension on _DomTouchList {
   @JS('length')
   external JSNumber get _length;
-  double get length => _length.toDartDouble;
+  double get length => _length.toDart;
 
   @JS('item')
   external DomNode _item(JSNumber index);
@@ -3359,7 +3362,7 @@ class DomSegment {}
 extension DomSegmentExtension on DomSegment {
   @JS('index')
   external JSNumber get _index;
-  int get index => _index.toDartDouble.toInt();
+  int get index => _index.toDart.toInt();
 
   @JS('isWordLike')
   external JSBoolean get _isWordLike;
@@ -3397,15 +3400,15 @@ extension DomV8BreakIteratorExtension on DomV8BreakIterator {
 
   @JS('first')
   external JSNumber _first();
-  double first() => _first().toDartDouble;
+  double first() => _first().toDart;
 
   @JS('next')
   external JSNumber _next();
-  double next() => _next().toDartDouble;
+  double next() => _next().toDart;
 
   @JS('current')
   external JSNumber _current();
-  double current() => _current().toDartDouble;
+  double current() => _current().toDart;
 
   @JS('breakType')
   external JSString _breakType();

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -169,8 +169,7 @@ Future<void> initializeEngineServices({
         // milliseconds as a double value, with sub-millisecond information
         // hidden in the fraction. So we first multiply it by 1000 to uncover
         // microsecond precision, and only then convert to `int`.
-        final int highResTimeMicroseconds =
-            (1000 * highResTime.toDartDouble).toInt();
+        final int highResTimeMicroseconds = (1000 * highResTime.toDart).toInt();
 
         // In Flutter terminology "building a frame" consists of "beginning
         // frame" and "drawing frame".

--- a/lib/web_ui/lib/src/engine/profiler.dart
+++ b/lib/web_ui/lib/src/engine/profiler.dart
@@ -12,7 +12,8 @@ import 'platform_dispatcher.dart';
 import 'safe_browser_api.dart';
 
 @JS('window._flutter_internal_on_benchmark')
-external JSBoxedDartObject? get onBenchmark;
+external JSAny? get _onBenchmark;
+Object? get onBenchmark => _onBenchmark?.toObjectShallow;
 
 /// A function that computes a value of type [R].
 ///
@@ -105,7 +106,7 @@ class Profiler {
   void benchmark(String name, double value) {
     _checkBenchmarkMode();
 
-    final OnBenchmark? callback = onBenchmark?.toDart as OnBenchmark?;
+    final OnBenchmark? callback = onBenchmark as OnBenchmark?;
     if (callback != null) {
       callback(name, value);
     }

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -302,7 +302,7 @@ class VideoFrame implements DomCanvasImageSource {}
 extension VideoFrameExtension on VideoFrame {
   @JS('allocationSize')
   external JSNumber _allocationSize();
-  double allocationSize() => _allocationSize().toDartDouble;
+  double allocationSize() => _allocationSize().toDart;
 
   @JS('copyTo')
   external JsPromise _copyTo(JSAny destination);
@@ -314,23 +314,23 @@ extension VideoFrameExtension on VideoFrame {
 
   @JS('codedWidth')
   external JSNumber get _codedWidth;
-  double get codedWidth => _codedWidth.toDartDouble;
+  double get codedWidth => _codedWidth.toDart;
 
   @JS('codedHeight')
   external JSNumber get _codedHeight;
-  double get codedHeight => _codedHeight.toDartDouble;
+  double get codedHeight => _codedHeight.toDart;
 
   @JS('displayWidth')
   external JSNumber get _displayWidth;
-  double get displayWidth => _displayWidth.toDartDouble;
+  double get displayWidth => _displayWidth.toDart;
 
   @JS('displayHeight')
   external JSNumber get _displayHeight;
-  double get displayHeight => _displayHeight.toDartDouble;
+  double get displayHeight => _displayHeight.toDart;
 
   @JS('duration')
   external JSNumber? get _duration;
-  double? get duration => _duration?.toDartDouble;
+  double? get duration => _duration?.toDart;
 
   external VideoFrame clone();
   external JSVoid close();
@@ -364,11 +364,11 @@ class ImageTrack {}
 extension ImageTrackExtension on ImageTrack {
   @JS('repetitionCount')
   external JSNumber get _repetitionCount;
-  double get repetitionCount => _repetitionCount.toDartDouble;
+  double get repetitionCount => _repetitionCount.toDart;
 
   @JS('frameCount')
   external JSNumber get _frameCount;
-  double get frameCount => _frameCount.toDartDouble;
+  double get frameCount => _frameCount.toDart;
 }
 
 void scaleCanvas2D(Object context2d, num x, num y) {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -29,7 +29,7 @@ typedef DisposeFunction<T extends NativeType> = void Function(Pointer<T>);
 class SkwasmFinalizationRegistry<T extends NativeType> {
   SkwasmFinalizationRegistry(this.dispose)
     : registry = createDomFinalizationRegistry(((JSNumber address) =>
-      dispose(Pointer<T>.fromAddress(address.toDartDouble.toInt()))
+      dispose(Pointer<T>.fromAddress(address.toDart.toInt()))
     ).toJS);
 
   final DomFinalizationRegistry registry;

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
@@ -75,9 +75,9 @@ class SkwasmSurface {
   }
 
   void _callbackHandler(JSNumber jsCallbackId, JSNumber jsPointer) {
-    final int callbackId = jsCallbackId.toDartDouble.toInt();
+    final int callbackId = jsCallbackId.toDart.toInt();
     final Completer<int> completer = _pendingCallbacks.remove(callbackId)!;
-    completer.complete(jsPointer.toDartDouble.toInt());
+    completer.complete(jsPointer.toDart.toInt());
   }
 
   void dispose() {


### PR DESCRIPTION
Reverts flutter/engine#43149

Reason for reverting: Broke the roll into the framework.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.