### PR TITLE
Move Dart licenses into a separate golden file

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -1480,6 +1480,7 @@
 ../../../third_party/colorama/src/requirements.txt
 ../../../third_party/colorama/src/screenshots
 ../../../third_party/colorama/src/setup.py
+../../../third_party/dart
 ../../../third_party/dart/.clang-format
 ../../../third_party/dart/.dart_tool
 ../../../third_party/dart/.git

--- a/ci/licenses_golden/licenses_dart
+++ b/ci/licenses_golden/licenses_dart
@@ -1,0 +1,4828 @@
+Signature: d47bee3faca906ba1fa0dfe3801b7d57
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/common/builtin_clock.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/clock_snapshot.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/interned_data/interned_data.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/profiling/profile_common.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/profiling/profile_packet.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/trace.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/trace_packet.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/debug_annotation.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/process_descriptor.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/thread_descriptor.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/track_descriptor.proto
+ORIGIN: http://www.apache.org/licenses/LICENSE-2.0 referenced by ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/track_event.proto
+TYPE: LicenseType.apache
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/common/builtin_clock.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/clock_snapshot.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/interned_data/interned_data.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/profiling/profile_common.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/profiling/profile_packet.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/trace.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/trace_packet.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/debug_annotation.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/process_descriptor.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/thread_descriptor.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/track_descriptor.proto
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/track_event.proto
+----------------------------------------------------------------------------------------------------
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/bigint_patch.dart
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/bigint_patch.dart
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/bigint_patch.dart
+TYPE: LicenseType.mit
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/bigint_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/bigint_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/bigint_patch.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2003-2005  Tom Wu
+Copyright (c) 2012 Adam Singer (adam@solvr.io)
+All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND,
+EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY
+WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+IN NO EVENT SHALL TOM WU BE LIABLE FOR ANY SPECIAL, INCIDENTAL,
+INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND, OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER OR NOT ADVISED OF
+THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF LIABILITY, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+In addition, the following condition applies:
+
+All redistributions must retain an intact copy of this copyright notice
+and disclaimer.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/platform/splay-tree-inl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/splay-tree.h + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/platform/splay-tree-inl.h
+FILE: ../../../third_party/dart/runtime/platform/splay-tree.h
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2010, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/snapshot_empty.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/snapshot_in.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/dart_tools_api.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/double.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/math.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/mirrors.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/object.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/string.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bitfield.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dart.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dart_api_impl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dart_entry.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dart_entry.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/debugger_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/debugger_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/debugger_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/double_conversion.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/double_conversion.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/exceptions.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/exceptions.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/handle_visitor.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/handles.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/freelist.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/marker.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/marker.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/pages.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/scavenger.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/sweeper.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/sweeper.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/verifier.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/longjump.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/memory_region.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/message.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/message.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/message_handler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/message_handler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_entry.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_entry.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_function.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/port.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/resolver.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/resolver.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/runtime_entry.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/runtime_entry.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/runtime_entry_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/runtime_entry_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/runtime_entry_list.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/runtime_entry_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stack_frame.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stub_code.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/timer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/timer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/token.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/unicode_data.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/visitor.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/queue.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/comparable.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/date_time.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/duration.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/function.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/iterable.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/pattern.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/set.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/stopwatch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/string_buffer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/html_common/device.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/html_common/filtered_element_list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/html_common/lists.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/iterable.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/sort.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/snapshot_empty.cc
+FILE: ../../../third_party/dart/runtime/bin/snapshot_in.cc
+FILE: ../../../third_party/dart/runtime/include/dart_tools_api.h
+FILE: ../../../third_party/dart/runtime/lib/double.cc
+FILE: ../../../third_party/dart/runtime/lib/math.cc
+FILE: ../../../third_party/dart/runtime/lib/mirrors.h
+FILE: ../../../third_party/dart/runtime/lib/object.cc
+FILE: ../../../third_party/dart/runtime/lib/string.cc
+FILE: ../../../third_party/dart/runtime/vm/bitfield.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler.h
+FILE: ../../../third_party/dart/runtime/vm/cpu_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/dart.h
+FILE: ../../../third_party/dart/runtime/vm/dart_api_impl.h
+FILE: ../../../third_party/dart/runtime/vm/dart_entry.cc
+FILE: ../../../third_party/dart/runtime/vm/dart_entry.h
+FILE: ../../../third_party/dart/runtime/vm/debugger_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/debugger_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/debugger_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/double_conversion.cc
+FILE: ../../../third_party/dart/runtime/vm/double_conversion.h
+FILE: ../../../third_party/dart/runtime/vm/exceptions.cc
+FILE: ../../../third_party/dart/runtime/vm/exceptions.h
+FILE: ../../../third_party/dart/runtime/vm/handle_visitor.h
+FILE: ../../../third_party/dart/runtime/vm/handles.h
+FILE: ../../../third_party/dart/runtime/vm/heap/freelist.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/marker.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/marker.h
+FILE: ../../../third_party/dart/runtime/vm/heap/pages.h
+FILE: ../../../third_party/dart/runtime/vm/heap/scavenger.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/sweeper.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/sweeper.h
+FILE: ../../../third_party/dart/runtime/vm/heap/verifier.h
+FILE: ../../../third_party/dart/runtime/vm/longjump.cc
+FILE: ../../../third_party/dart/runtime/vm/memory_region.cc
+FILE: ../../../third_party/dart/runtime/vm/message.cc
+FILE: ../../../third_party/dart/runtime/vm/message.h
+FILE: ../../../third_party/dart/runtime/vm/message_handler.cc
+FILE: ../../../third_party/dart/runtime/vm/message_handler.h
+FILE: ../../../third_party/dart/runtime/vm/native_entry.cc
+FILE: ../../../third_party/dart/runtime/vm/native_entry.h
+FILE: ../../../third_party/dart/runtime/vm/native_function.h
+FILE: ../../../third_party/dart/runtime/vm/os.h
+FILE: ../../../third_party/dart/runtime/vm/port.h
+FILE: ../../../third_party/dart/runtime/vm/resolver.cc
+FILE: ../../../third_party/dart/runtime/vm/resolver.h
+FILE: ../../../third_party/dart/runtime/vm/runtime_entry.cc
+FILE: ../../../third_party/dart/runtime/vm/runtime_entry.h
+FILE: ../../../third_party/dart/runtime/vm/runtime_entry_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/runtime_entry_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/runtime_entry_list.h
+FILE: ../../../third_party/dart/runtime/vm/runtime_entry_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/stack_frame.h
+FILE: ../../../third_party/dart/runtime/vm/stub_code.h
+FILE: ../../../third_party/dart/runtime/vm/timer.cc
+FILE: ../../../third_party/dart/runtime/vm/timer.h
+FILE: ../../../third_party/dart/runtime/vm/token.cc
+FILE: ../../../third_party/dart/runtime/vm/unicode_data.cc
+FILE: ../../../third_party/dart/runtime/vm/visitor.h
+FILE: ../../../third_party/dart/sdk/lib/collection/queue.dart
+FILE: ../../../third_party/dart/sdk/lib/core/comparable.dart
+FILE: ../../../third_party/dart/sdk/lib/core/date_time.dart
+FILE: ../../../third_party/dart/sdk/lib/core/duration.dart
+FILE: ../../../third_party/dart/sdk/lib/core/function.dart
+FILE: ../../../third_party/dart/sdk/lib/core/iterable.dart
+FILE: ../../../third_party/dart/sdk/lib/core/map.dart
+FILE: ../../../third_party/dart/sdk/lib/core/pattern.dart
+FILE: ../../../third_party/dart/sdk/lib/core/set.dart
+FILE: ../../../third_party/dart/sdk/lib/core/stopwatch.dart
+FILE: ../../../third_party/dart/sdk/lib/core/string_buffer.dart
+FILE: ../../../third_party/dart/sdk/lib/html/html_common/device.dart
+FILE: ../../../third_party/dart/sdk/lib/html/html_common/filtered_element_list.dart
+FILE: ../../../third_party/dart/sdk/lib/html/html_common/lists.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/iterable.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/sort.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2011, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/builtin.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/builtin.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/builtin_gen_snapshot.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/builtin_in.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/builtin_natives.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/crashpad.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/crypto.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/crypto.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/crypto_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/crypto_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/crypto_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/crypto_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/dartutils.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/dartutils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/directory.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/directory.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/directory_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/directory_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/directory_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/directory_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_android.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_linux.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_macos.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_win.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/fdutils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/fdutils_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/fdutils_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/fdutils_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/fdutils_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/io_buffer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/io_buffer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/io_natives.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/isolate_data.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/lockers.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/main.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/main_impl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/process.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/process_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/process_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/process_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/process_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/run_vm_tests.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/secure_socket_unsupported.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_android.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_linux.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_macos.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_win.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_android.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_linux.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_macos.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_win.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/utils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/utils_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/utils_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/utils_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/utils_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/utils_win.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/dart_api.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/array.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/bool.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/date.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/errors.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/function.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/growable_array.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/identical.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/integers.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/isolate.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/mirrors.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/regexp.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/stopwatch.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/assert.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/assert.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/floating_point.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/floating_point_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/floating_point_win.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/globals.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/hashmap.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/hashmap.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/syslog.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/syslog_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/syslog_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/syslog_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/syslog_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/text_buffer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/text_buffer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/unicode.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/unicode.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_android.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_linux.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_macos.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_win.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/allocation.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/base_isolate.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bit_set.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bit_vector.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bit_vector.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bitmap.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bitmap.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/boolfield.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bootstrap.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bootstrap.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bootstrap_natives.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bootstrap_natives.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/class_finalizer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/class_table.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/class_table.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_descriptors.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_descriptors.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_observers.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_observers.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_patcher.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_patcher.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_patcher_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_patcher_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/aot/aot_call_specializer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_base.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_x86.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/object_pool_builder.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/constant_propagator.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_printer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_printer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/inliner.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/cha.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/cha.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/flow_graph_builder.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/flow_graph_builder.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/intrinsifier.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/intrinsifier.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/jit/compiler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/jit/compiler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpuinfo_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpuinfo_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dart_api_message.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dart_api_state.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/datastream.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/debugger.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/debugger.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/double_internals.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/flag_list.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/flags.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/flags.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/globals.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/growable_array.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/handles.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/handles_impl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/hash_map.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/freelist.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/heap.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/heap.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/pages.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/pointer_block.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/pointer_block.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/scavenger.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/verifier.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_ia32.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_x64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/lockers.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/megamorphic_cache_table.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/megamorphic_cache_table.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/memory_region.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_arguments.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_message_handler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_message_handler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_set.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_store.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_android.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_linux.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_macos.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_win.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/parser.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/parser.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/port.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/proccpuinfo.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/proccpuinfo.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/raw_object.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/raw_object.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/scopes.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/scopes.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/snapshot.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/snapshot.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stack_frame.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stub_code.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/symbols.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/symbols.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_pool.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_pool.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/token.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/unicode.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/version.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/version_in.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/virtual_memory.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/virtual_memory.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/virtual_memory_posix.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/virtual_memory_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/zone.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/zone.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/crypto.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/http_date.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/bigint_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/core_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/isolate_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/math_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/foreign_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/interceptors.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/isolate_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_array.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_number.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_string.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/native_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/regexp_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/string_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/async_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/bigint_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/constant_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/core_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/foreign_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/interceptors.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/isolate_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_array.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_number.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_string.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/math_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/native_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/regexp_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/string_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/sdk_library_metadata/lib/libraries.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/builtin.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/common_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/directory_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/eventhandler_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/file_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/platform_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/secure_socket_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/array.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/double.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/double_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/empty_source.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/errors_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/expando_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/function_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/growable_array.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/identical_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/immutable_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/integers.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/invocation_mirror_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/isolate_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/math_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/mirrors_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/mirrors_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/object_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/print_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/regexp_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/stopwatch_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/string_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/timer_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/type_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/weak_property.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/array_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/bool_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/date_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/integers_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/map_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/string_buffer_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/async.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/async_error.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/broadcast_stream_controller.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/future.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/future_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/stream_controller.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/stream_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/stream_pipe.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/timer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/collection.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/iterable.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/iterator.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/maps.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/splay_tree.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/bool.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/core.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/double.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/errors.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/exceptions.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/identical.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/int.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/invocation.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/iterator.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/num.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/print.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/regexp.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/string.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/type.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/uri.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/weak.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/dart2js/html_dart2js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/dartium/nativewrappers.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/html_common/conversions.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/html_common/css_class_set.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/html_common/html_common_dart2js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/html_common/metadata.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/indexed_db/dart2js/indexed_db_dart2js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/async_cast.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/cast.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/internal.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/common.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/directory.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/directory_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/eventhandler.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/io.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/platform.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/platform_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/secure_server_socket.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/isolate/isolate.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/math/math.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/math/random.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/web_sql/dart2js/web_sql_dart2js.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/builtin.cc
+FILE: ../../../third_party/dart/runtime/bin/builtin.h
+FILE: ../../../third_party/dart/runtime/bin/builtin_gen_snapshot.cc
+FILE: ../../../third_party/dart/runtime/bin/builtin_in.cc
+FILE: ../../../third_party/dart/runtime/bin/builtin_natives.cc
+FILE: ../../../third_party/dart/runtime/bin/crashpad.cc
+FILE: ../../../third_party/dart/runtime/bin/crypto.cc
+FILE: ../../../third_party/dart/runtime/bin/crypto.h
+FILE: ../../../third_party/dart/runtime/bin/crypto_android.cc
+FILE: ../../../third_party/dart/runtime/bin/crypto_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/crypto_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/crypto_win.cc
+FILE: ../../../third_party/dart/runtime/bin/dartutils.cc
+FILE: ../../../third_party/dart/runtime/bin/dartutils.h
+FILE: ../../../third_party/dart/runtime/bin/directory.cc
+FILE: ../../../third_party/dart/runtime/bin/directory.h
+FILE: ../../../third_party/dart/runtime/bin/directory_android.cc
+FILE: ../../../third_party/dart/runtime/bin/directory_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/directory_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/directory_win.cc
+FILE: ../../../third_party/dart/runtime/bin/eventhandler.cc
+FILE: ../../../third_party/dart/runtime/bin/eventhandler.h
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_android.cc
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_android.h
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_linux.h
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_macos.h
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_win.h
+FILE: ../../../third_party/dart/runtime/bin/fdutils.h
+FILE: ../../../third_party/dart/runtime/bin/fdutils_android.cc
+FILE: ../../../third_party/dart/runtime/bin/fdutils_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/fdutils_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/fdutils_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/file_android.cc
+FILE: ../../../third_party/dart/runtime/bin/file_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/file_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/file_win.cc
+FILE: ../../../third_party/dart/runtime/bin/io_buffer.cc
+FILE: ../../../third_party/dart/runtime/bin/io_buffer.h
+FILE: ../../../third_party/dart/runtime/bin/io_natives.h
+FILE: ../../../third_party/dart/runtime/bin/isolate_data.h
+FILE: ../../../third_party/dart/runtime/bin/lockers.h
+FILE: ../../../third_party/dart/runtime/bin/main.cc
+FILE: ../../../third_party/dart/runtime/bin/main_impl.cc
+FILE: ../../../third_party/dart/runtime/bin/platform.cc
+FILE: ../../../third_party/dart/runtime/bin/platform.h
+FILE: ../../../third_party/dart/runtime/bin/platform_android.cc
+FILE: ../../../third_party/dart/runtime/bin/platform_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/platform_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/platform_win.cc
+FILE: ../../../third_party/dart/runtime/bin/process.h
+FILE: ../../../third_party/dart/runtime/bin/process_android.cc
+FILE: ../../../third_party/dart/runtime/bin/process_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/process_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/process_win.cc
+FILE: ../../../third_party/dart/runtime/bin/run_vm_tests.cc
+FILE: ../../../third_party/dart/runtime/bin/secure_socket_unsupported.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_android.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base_android.h
+FILE: ../../../third_party/dart/runtime/bin/socket_base_linux.h
+FILE: ../../../third_party/dart/runtime/bin/socket_base_macos.h
+FILE: ../../../third_party/dart/runtime/bin/socket_base_win.h
+FILE: ../../../third_party/dart/runtime/bin/thread.h
+FILE: ../../../third_party/dart/runtime/bin/thread_android.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_android.h
+FILE: ../../../third_party/dart/runtime/bin/thread_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_linux.h
+FILE: ../../../third_party/dart/runtime/bin/thread_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_macos.h
+FILE: ../../../third_party/dart/runtime/bin/thread_win.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_win.h
+FILE: ../../../third_party/dart/runtime/bin/utils.h
+FILE: ../../../third_party/dart/runtime/bin/utils_android.cc
+FILE: ../../../third_party/dart/runtime/bin/utils_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/utils_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/utils_win.cc
+FILE: ../../../third_party/dart/runtime/bin/utils_win.h
+FILE: ../../../third_party/dart/runtime/include/dart_api.h
+FILE: ../../../third_party/dart/runtime/lib/array.cc
+FILE: ../../../third_party/dart/runtime/lib/bool.cc
+FILE: ../../../third_party/dart/runtime/lib/date.cc
+FILE: ../../../third_party/dart/runtime/lib/errors.cc
+FILE: ../../../third_party/dart/runtime/lib/function.cc
+FILE: ../../../third_party/dart/runtime/lib/growable_array.cc
+FILE: ../../../third_party/dart/runtime/lib/identical.cc
+FILE: ../../../third_party/dart/runtime/lib/integers.cc
+FILE: ../../../third_party/dart/runtime/lib/isolate.cc
+FILE: ../../../third_party/dart/runtime/lib/mirrors.cc
+FILE: ../../../third_party/dart/runtime/lib/regexp.cc
+FILE: ../../../third_party/dart/runtime/lib/stopwatch.cc
+FILE: ../../../third_party/dart/runtime/platform/assert.cc
+FILE: ../../../third_party/dart/runtime/platform/assert.h
+FILE: ../../../third_party/dart/runtime/platform/floating_point.h
+FILE: ../../../third_party/dart/runtime/platform/floating_point_win.cc
+FILE: ../../../third_party/dart/runtime/platform/floating_point_win.h
+FILE: ../../../third_party/dart/runtime/platform/globals.h
+FILE: ../../../third_party/dart/runtime/platform/hashmap.cc
+FILE: ../../../third_party/dart/runtime/platform/hashmap.h
+FILE: ../../../third_party/dart/runtime/platform/syslog.h
+FILE: ../../../third_party/dart/runtime/platform/syslog_android.cc
+FILE: ../../../third_party/dart/runtime/platform/syslog_linux.cc
+FILE: ../../../third_party/dart/runtime/platform/syslog_macos.cc
+FILE: ../../../third_party/dart/runtime/platform/syslog_win.cc
+FILE: ../../../third_party/dart/runtime/platform/text_buffer.cc
+FILE: ../../../third_party/dart/runtime/platform/text_buffer.h
+FILE: ../../../third_party/dart/runtime/platform/unicode.cc
+FILE: ../../../third_party/dart/runtime/platform/unicode.h
+FILE: ../../../third_party/dart/runtime/platform/utils.cc
+FILE: ../../../third_party/dart/runtime/platform/utils.h
+FILE: ../../../third_party/dart/runtime/platform/utils_android.cc
+FILE: ../../../third_party/dart/runtime/platform/utils_android.h
+FILE: ../../../third_party/dart/runtime/platform/utils_linux.cc
+FILE: ../../../third_party/dart/runtime/platform/utils_linux.h
+FILE: ../../../third_party/dart/runtime/platform/utils_macos.cc
+FILE: ../../../third_party/dart/runtime/platform/utils_macos.h
+FILE: ../../../third_party/dart/runtime/platform/utils_win.cc
+FILE: ../../../third_party/dart/runtime/platform/utils_win.h
+FILE: ../../../third_party/dart/runtime/vm/allocation.cc
+FILE: ../../../third_party/dart/runtime/vm/base_isolate.h
+FILE: ../../../third_party/dart/runtime/vm/bit_set.h
+FILE: ../../../third_party/dart/runtime/vm/bit_vector.cc
+FILE: ../../../third_party/dart/runtime/vm/bit_vector.h
+FILE: ../../../third_party/dart/runtime/vm/bitmap.cc
+FILE: ../../../third_party/dart/runtime/vm/bitmap.h
+FILE: ../../../third_party/dart/runtime/vm/boolfield.h
+FILE: ../../../third_party/dart/runtime/vm/bootstrap.cc
+FILE: ../../../third_party/dart/runtime/vm/bootstrap.h
+FILE: ../../../third_party/dart/runtime/vm/bootstrap_natives.cc
+FILE: ../../../third_party/dart/runtime/vm/bootstrap_natives.h
+FILE: ../../../third_party/dart/runtime/vm/class_finalizer.h
+FILE: ../../../third_party/dart/runtime/vm/class_table.cc
+FILE: ../../../third_party/dart/runtime/vm/class_table.h
+FILE: ../../../third_party/dart/runtime/vm/code_descriptors.cc
+FILE: ../../../third_party/dart/runtime/vm/code_descriptors.h
+FILE: ../../../third_party/dart/runtime/vm/code_observers.cc
+FILE: ../../../third_party/dart/runtime/vm/code_observers.h
+FILE: ../../../third_party/dart/runtime/vm/code_patcher.cc
+FILE: ../../../third_party/dart/runtime/vm/code_patcher.h
+FILE: ../../../third_party/dart/runtime/vm/code_patcher_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/code_patcher_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/aot_call_specializer.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_base.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_x86.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/object_pool_builder.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/constant_propagator.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_printer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_printer.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/inliner.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/cha.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/cha.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/flow_graph_builder.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/flow_graph_builder.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/intrinsifier.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/intrinsifier.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/jit/compiler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/jit/compiler.h
+FILE: ../../../third_party/dart/runtime/vm/cpu.h
+FILE: ../../../third_party/dart/runtime/vm/cpu_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/cpu_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/cpuinfo_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/cpuinfo_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/dart_api_message.h
+FILE: ../../../third_party/dart/runtime/vm/dart_api_state.h
+FILE: ../../../third_party/dart/runtime/vm/datastream.h
+FILE: ../../../third_party/dart/runtime/vm/debugger.cc
+FILE: ../../../third_party/dart/runtime/vm/debugger.h
+FILE: ../../../third_party/dart/runtime/vm/double_internals.h
+FILE: ../../../third_party/dart/runtime/vm/flag_list.h
+FILE: ../../../third_party/dart/runtime/vm/flags.cc
+FILE: ../../../third_party/dart/runtime/vm/flags.h
+FILE: ../../../third_party/dart/runtime/vm/globals.h
+FILE: ../../../third_party/dart/runtime/vm/growable_array.h
+FILE: ../../../third_party/dart/runtime/vm/handles.cc
+FILE: ../../../third_party/dart/runtime/vm/handles_impl.h
+FILE: ../../../third_party/dart/runtime/vm/hash_map.h
+FILE: ../../../third_party/dart/runtime/vm/heap/freelist.h
+FILE: ../../../third_party/dart/runtime/vm/heap/heap.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/heap.h
+FILE: ../../../third_party/dart/runtime/vm/heap/pages.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/pointer_block.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/pointer_block.h
+FILE: ../../../third_party/dart/runtime/vm/heap/scavenger.h
+FILE: ../../../third_party/dart/runtime/vm/heap/verifier.cc
+FILE: ../../../third_party/dart/runtime/vm/instructions_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/instructions_ia32.h
+FILE: ../../../third_party/dart/runtime/vm/instructions_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/instructions_x64.h
+FILE: ../../../third_party/dart/runtime/vm/lockers.h
+FILE: ../../../third_party/dart/runtime/vm/megamorphic_cache_table.cc
+FILE: ../../../third_party/dart/runtime/vm/megamorphic_cache_table.h
+FILE: ../../../third_party/dart/runtime/vm/memory_region.h
+FILE: ../../../third_party/dart/runtime/vm/native_arguments.h
+FILE: ../../../third_party/dart/runtime/vm/native_message_handler.cc
+FILE: ../../../third_party/dart/runtime/vm/native_message_handler.h
+FILE: ../../../third_party/dart/runtime/vm/object.cc
+FILE: ../../../third_party/dart/runtime/vm/object.h
+FILE: ../../../third_party/dart/runtime/vm/object_set.h
+FILE: ../../../third_party/dart/runtime/vm/object_store.h
+FILE: ../../../third_party/dart/runtime/vm/os_android.cc
+FILE: ../../../third_party/dart/runtime/vm/os_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/os_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread.h
+FILE: ../../../third_party/dart/runtime/vm/os_thread_android.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_android.h
+FILE: ../../../third_party/dart/runtime/vm/os_thread_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_linux.h
+FILE: ../../../third_party/dart/runtime/vm/os_thread_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_macos.h
+FILE: ../../../third_party/dart/runtime/vm/os_thread_win.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_win.h
+FILE: ../../../third_party/dart/runtime/vm/os_win.cc
+FILE: ../../../third_party/dart/runtime/vm/parser.cc
+FILE: ../../../third_party/dart/runtime/vm/parser.h
+FILE: ../../../third_party/dart/runtime/vm/port.cc
+FILE: ../../../third_party/dart/runtime/vm/proccpuinfo.cc
+FILE: ../../../third_party/dart/runtime/vm/proccpuinfo.h
+FILE: ../../../third_party/dart/runtime/vm/raw_object.cc
+FILE: ../../../third_party/dart/runtime/vm/raw_object.h
+FILE: ../../../third_party/dart/runtime/vm/scopes.cc
+FILE: ../../../third_party/dart/runtime/vm/scopes.h
+FILE: ../../../third_party/dart/runtime/vm/snapshot.cc
+FILE: ../../../third_party/dart/runtime/vm/snapshot.h
+FILE: ../../../third_party/dart/runtime/vm/stack_frame.cc
+FILE: ../../../third_party/dart/runtime/vm/stub_code.cc
+FILE: ../../../third_party/dart/runtime/vm/symbols.cc
+FILE: ../../../third_party/dart/runtime/vm/symbols.h
+FILE: ../../../third_party/dart/runtime/vm/thread_pool.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_pool.h
+FILE: ../../../third_party/dart/runtime/vm/token.h
+FILE: ../../../third_party/dart/runtime/vm/unicode.cc
+FILE: ../../../third_party/dart/runtime/vm/version.h
+FILE: ../../../third_party/dart/runtime/vm/version_in.cc
+FILE: ../../../third_party/dart/runtime/vm/virtual_memory.cc
+FILE: ../../../third_party/dart/runtime/vm/virtual_memory.h
+FILE: ../../../third_party/dart/runtime/vm/virtual_memory_posix.cc
+FILE: ../../../third_party/dart/runtime/vm/virtual_memory_win.cc
+FILE: ../../../third_party/dart/runtime/vm/zone.cc
+FILE: ../../../third_party/dart/runtime/vm/zone.h
+FILE: ../../../third_party/dart/sdk/lib/_http/crypto.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http_date.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/bigint_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/core_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/isolate_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/math_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/foreign_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/interceptors.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/isolate_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_array.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_number.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_string.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/native_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/regexp_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/string_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/async_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/bigint_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/constant_map.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/core_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/foreign_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/interceptors.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/isolate_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_array.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_number.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_string.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/math_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/native_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/regexp_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/string_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/sdk_library_metadata/lib/libraries.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/builtin.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/common_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/directory_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/eventhandler_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/file_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/platform_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/secure_socket_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/array.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/double.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/double_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/empty_source.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/errors_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/expando_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/function_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/growable_array.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/identical_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/immutable_map.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/integers.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/invocation_mirror_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/isolate_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/math_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/mirrors_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/mirrors_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/object_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/print_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/regexp_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/stopwatch_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/string_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/timer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/type_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/weak_property.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/array_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/bool_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/date_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/integers_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/map_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/string_buffer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/async/async.dart
+FILE: ../../../third_party/dart/sdk/lib/async/async_error.dart
+FILE: ../../../third_party/dart/sdk/lib/async/broadcast_stream_controller.dart
+FILE: ../../../third_party/dart/sdk/lib/async/future.dart
+FILE: ../../../third_party/dart/sdk/lib/async/future_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/async/stream_controller.dart
+FILE: ../../../third_party/dart/sdk/lib/async/stream_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/async/stream_pipe.dart
+FILE: ../../../third_party/dart/sdk/lib/async/timer.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/collection.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/iterable.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/iterator.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/maps.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/splay_tree.dart
+FILE: ../../../third_party/dart/sdk/lib/core/bool.dart
+FILE: ../../../third_party/dart/sdk/lib/core/core.dart
+FILE: ../../../third_party/dart/sdk/lib/core/double.dart
+FILE: ../../../third_party/dart/sdk/lib/core/errors.dart
+FILE: ../../../third_party/dart/sdk/lib/core/exceptions.dart
+FILE: ../../../third_party/dart/sdk/lib/core/identical.dart
+FILE: ../../../third_party/dart/sdk/lib/core/int.dart
+FILE: ../../../third_party/dart/sdk/lib/core/invocation.dart
+FILE: ../../../third_party/dart/sdk/lib/core/iterator.dart
+FILE: ../../../third_party/dart/sdk/lib/core/list.dart
+FILE: ../../../third_party/dart/sdk/lib/core/num.dart
+FILE: ../../../third_party/dart/sdk/lib/core/object.dart
+FILE: ../../../third_party/dart/sdk/lib/core/print.dart
+FILE: ../../../third_party/dart/sdk/lib/core/regexp.dart
+FILE: ../../../third_party/dart/sdk/lib/core/string.dart
+FILE: ../../../third_party/dart/sdk/lib/core/type.dart
+FILE: ../../../third_party/dart/sdk/lib/core/uri.dart
+FILE: ../../../third_party/dart/sdk/lib/core/weak.dart
+FILE: ../../../third_party/dart/sdk/lib/html/dart2js/html_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/html/dartium/nativewrappers.dart
+FILE: ../../../third_party/dart/sdk/lib/html/html_common/conversions.dart
+FILE: ../../../third_party/dart/sdk/lib/html/html_common/css_class_set.dart
+FILE: ../../../third_party/dart/sdk/lib/html/html_common/html_common_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/html/html_common/metadata.dart
+FILE: ../../../third_party/dart/sdk/lib/indexed_db/dart2js/indexed_db_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/async_cast.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/cast.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/internal.dart
+FILE: ../../../third_party/dart/sdk/lib/io/common.dart
+FILE: ../../../third_party/dart/sdk/lib/io/directory.dart
+FILE: ../../../third_party/dart/sdk/lib/io/directory_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/io/eventhandler.dart
+FILE: ../../../third_party/dart/sdk/lib/io/io.dart
+FILE: ../../../third_party/dart/sdk/lib/io/platform.dart
+FILE: ../../../third_party/dart/sdk/lib/io/platform_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/io/secure_server_socket.dart
+FILE: ../../../third_party/dart/sdk/lib/isolate/isolate.dart
+FILE: ../../../third_party/dart/sdk/lib/math/math.dart
+FILE: ../../../third_party/dart/sdk/lib/math/random.dart
+FILE: ../../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/web_sql/dart2js/web_sql_dart2js.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_system_watcher.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_system_watcher.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_system_watcher_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_system_watcher_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_system_watcher_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_system_watcher_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/filter.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/filter.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/gen_snapshot.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/io_natives.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/io_service.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/io_service.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/io_service_no_ssl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/io_service_no_ssl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/process.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/stdio.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/stdio.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/stdio_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/stdio_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/stdio_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/stdio_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/vmservice_impl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/vmservice_impl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/dart_native_api.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/invocation_mirror.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/libgen_in.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/simd128.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/stacktrace.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/typed_data.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/uri.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/app/application.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/app/location_manager.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_instances.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/code_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/code_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/context_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/context_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile/virtual_tree.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile_table.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/curly_block.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/error_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/eval_box.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/field_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/field_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/flag_list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/function_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/function_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/any_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/icdata_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/icdata_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/instance_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/instance_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/json_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/library_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/library_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/local_var_descriptors_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/megamorphiccache_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/native_memory_profiler.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/object_common.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/object_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectpool_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectstore_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/observatory_application.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/pc_descriptors_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/sample_buffer_control.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_inset.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/sentinel_value.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/sentinel_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/source_inset.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/stack_trace_tree_config.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/type_arguments_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/unknown_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/tracer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/app/application.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/app/location_manager.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_instances.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/code_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/code_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/context_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/context_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/cpu_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/cpu_profile/virtual_tree.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/cpu_profile_table.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/curly_block.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/error_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/eval_box.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/field_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/field_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/flag_list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/function_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/function_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/any_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/icdata_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/icdata_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/instance_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/instance_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/json_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/library_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/library_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/local_var_descriptors_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/megamorphiccache_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/native_memory_profiler.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/object_common.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/object_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/objectpool_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/objectstore_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/observatory_application.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/pc_descriptors_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/sample_buffer_control.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/script_inset.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/script_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/script_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/sentinel_value.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/sentinel_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/source_inset.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/stack_trace_tree_config.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/type_arguments_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/unknown_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/vm_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/tracer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/atomic.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/signal_blocker.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/allocation.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/class_finalizer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_patcher_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/aot/aot_call_specializer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_ia32.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_x64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/block_scheduler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/block_scheduler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/constant_propagator.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/inliner.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/linearscan.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/linearscan.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/locations.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/locations.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/jit/jit_call_specializer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_arm.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_ia32.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_x64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dart.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dart_api_impl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/deferred_objects.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/deferred_objects.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/deopt_instructions.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/deopt_instructions.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/weak_table.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/weak_table.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_arm.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/isolate.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/isolate.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/json_stream.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/json_stream.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_api_impl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_symbol.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_symbol_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_symbol_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_symbol_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_symbol_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_id_ring.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_id_ring.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_store.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/profiler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/profiler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/random.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/random.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/reusable_handles.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/service.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/service.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/service_isolate.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/signal_handler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/signal_handler_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/signal_handler_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/signal_handler_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/signal_handler_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/simulator.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/simulator_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/simulator_arm.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stack_frame_arm.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stack_frame_ia32.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stack_frame_x64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/tags.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_interrupter.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_interrupter.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_interrupter_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_interrupter_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_interrupter_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_interrupter_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/http.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/http_headers.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/http_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/http_parser.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/http_session.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/websocket.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/websocket_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/collection_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/convert_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/internal_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/io_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/typed_data_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/annotations.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_primitives.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_rti.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/mirror_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/native_typed_data.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/annotations.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/collection_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/convert_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/internal_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/io_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_names.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_primitives.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/native_typed_data.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/typed_data_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/file_system_entity_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/filter_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/io_service_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/process_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/socket_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/stdio_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/vmservice_io.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/vmservice_server.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/core_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/function.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/internal_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/mirror_reference.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/schedule_microtask_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/stacktrace.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/symbol_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/timer_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/typed_data_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/uri_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/collection_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/null_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/io_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/deferred_load.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/schedule_microtask.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/stream.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/stream_transformers.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/zone.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/collections.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/hash_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/hash_set.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/linked_hash_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/linked_hash_set.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/linked_list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/ascii.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/byte_conversion.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/chunked_conversion.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/codec.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/convert.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/converter.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/encoding.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/html_escape.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/json.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/latin1.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/line_splitter.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/string_conversion.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/utf.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/annotations.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/null.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/stacktrace.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/string_sink.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/symbol.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/html/dart2js/html_dart2js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/indexed_db/dart2js/indexed_db_dart2js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/bytes_builder.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/print.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/symbol.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/data_transformer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/file.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/file_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/file_system_entity.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/io_service.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/io_sink.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/link.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/secure_socket.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/socket.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/stdio.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/string_transformer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js/js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/math/point.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/math/rectangle.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/mirrors/mirrors.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/typed_data/typed_data.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/client.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/constants.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/message.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/message_router.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/running_isolate.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/running_isolates.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/utils/compiler/create_snapshot_entry.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_win.cc
+FILE: ../../../third_party/dart/runtime/bin/file.cc
+FILE: ../../../third_party/dart/runtime/bin/file.h
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher.h
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_android.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_win.cc
+FILE: ../../../third_party/dart/runtime/bin/filter.cc
+FILE: ../../../third_party/dart/runtime/bin/filter.h
+FILE: ../../../third_party/dart/runtime/bin/gen_snapshot.cc
+FILE: ../../../third_party/dart/runtime/bin/io_natives.cc
+FILE: ../../../third_party/dart/runtime/bin/io_service.cc
+FILE: ../../../third_party/dart/runtime/bin/io_service.h
+FILE: ../../../third_party/dart/runtime/bin/io_service_no_ssl.cc
+FILE: ../../../third_party/dart/runtime/bin/io_service_no_ssl.h
+FILE: ../../../third_party/dart/runtime/bin/process.cc
+FILE: ../../../third_party/dart/runtime/bin/socket.cc
+FILE: ../../../third_party/dart/runtime/bin/socket.h
+FILE: ../../../third_party/dart/runtime/bin/socket_base_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base_win.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_win.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio.h
+FILE: ../../../third_party/dart/runtime/bin/stdio_android.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio_win.cc
+FILE: ../../../third_party/dart/runtime/bin/vmservice_impl.cc
+FILE: ../../../third_party/dart/runtime/bin/vmservice_impl.h
+FILE: ../../../third_party/dart/runtime/include/dart_native_api.h
+FILE: ../../../third_party/dart/runtime/lib/invocation_mirror.h
+FILE: ../../../third_party/dart/runtime/lib/libgen_in.cc
+FILE: ../../../third_party/dart/runtime/lib/simd128.cc
+FILE: ../../../third_party/dart/runtime/lib/stacktrace.cc
+FILE: ../../../third_party/dart/runtime/lib/typed_data.cc
+FILE: ../../../third_party/dart/runtime/lib/uri.cc
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/application.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/location_manager.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/code_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/code_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/context_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/context_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile/virtual_tree.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile_table.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/curly_block.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/error_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/eval_box.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/field_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/field_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/flag_list.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/function_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/function_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/any_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/icdata_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/icdata_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/instance_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/instance_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/json_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/library_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/library_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/local_var_descriptors_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/megamorphiccache_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/native_memory_profiler.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/object_common.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/object_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectpool_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectstore_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/observatory_application.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/pc_descriptors_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/sample_buffer_control.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_inset.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/sentinel_value.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/sentinel_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/source_inset.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/stack_trace_tree_config.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/type_arguments_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/unknown_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/tracer.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/app/application.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/app/location_manager.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/code_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/code_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/context_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/context_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/cpu_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/cpu_profile/virtual_tree.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/cpu_profile_table.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/curly_block.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/error_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/eval_box.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/field_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/field_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/flag_list.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/function_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/function_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/any_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/icdata_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/icdata_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/instance_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/instance_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/json_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/library_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/library_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/local_var_descriptors_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/megamorphiccache_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/native_memory_profiler.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/object_common.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/object_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/objectpool_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/objectstore_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/observatory_application.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/pc_descriptors_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/sample_buffer_control.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/script_inset.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/script_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/script_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/sentinel_value.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/sentinel_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/source_inset.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/stack_trace_tree_config.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/type_arguments_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/unknown_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/vm_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/tracer.dart
+FILE: ../../../third_party/dart/runtime/platform/atomic.h
+FILE: ../../../third_party/dart/runtime/platform/signal_blocker.h
+FILE: ../../../third_party/dart/runtime/vm/allocation.h
+FILE: ../../../third_party/dart/runtime/vm/class_finalizer.cc
+FILE: ../../../third_party/dart/runtime/vm/code_patcher_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/aot_call_specializer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_ia32.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_x64.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/block_scheduler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/block_scheduler.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/constant_propagator.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/inliner.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/linearscan.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/linearscan.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/locations.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/locations.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/jit/jit_call_specializer.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_arm.h
+FILE: ../../../third_party/dart/runtime/vm/constants_ia32.h
+FILE: ../../../third_party/dart/runtime/vm/constants_x64.h
+FILE: ../../../third_party/dart/runtime/vm/dart.cc
+FILE: ../../../third_party/dart/runtime/vm/dart_api_impl.cc
+FILE: ../../../third_party/dart/runtime/vm/deferred_objects.cc
+FILE: ../../../third_party/dart/runtime/vm/deferred_objects.h
+FILE: ../../../third_party/dart/runtime/vm/deopt_instructions.cc
+FILE: ../../../third_party/dart/runtime/vm/deopt_instructions.h
+FILE: ../../../third_party/dart/runtime/vm/heap/weak_table.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/weak_table.h
+FILE: ../../../third_party/dart/runtime/vm/instructions.h
+FILE: ../../../third_party/dart/runtime/vm/instructions_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/instructions_arm.h
+FILE: ../../../third_party/dart/runtime/vm/isolate.cc
+FILE: ../../../third_party/dart/runtime/vm/isolate.h
+FILE: ../../../third_party/dart/runtime/vm/json_stream.cc
+FILE: ../../../third_party/dart/runtime/vm/json_stream.h
+FILE: ../../../third_party/dart/runtime/vm/native_api_impl.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol.h
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_android.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_win.cc
+FILE: ../../../third_party/dart/runtime/vm/object_id_ring.cc
+FILE: ../../../third_party/dart/runtime/vm/object_id_ring.h
+FILE: ../../../third_party/dart/runtime/vm/object_store.cc
+FILE: ../../../third_party/dart/runtime/vm/profiler.cc
+FILE: ../../../third_party/dart/runtime/vm/profiler.h
+FILE: ../../../third_party/dart/runtime/vm/random.cc
+FILE: ../../../third_party/dart/runtime/vm/random.h
+FILE: ../../../third_party/dart/runtime/vm/reusable_handles.h
+FILE: ../../../third_party/dart/runtime/vm/service.cc
+FILE: ../../../third_party/dart/runtime/vm/service.h
+FILE: ../../../third_party/dart/runtime/vm/service_isolate.h
+FILE: ../../../third_party/dart/runtime/vm/signal_handler.h
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_android.cc
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_win.cc
+FILE: ../../../third_party/dart/runtime/vm/simulator.h
+FILE: ../../../third_party/dart/runtime/vm/simulator_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/simulator_arm.h
+FILE: ../../../third_party/dart/runtime/vm/stack_frame_arm.h
+FILE: ../../../third_party/dart/runtime/vm/stack_frame_ia32.h
+FILE: ../../../third_party/dart/runtime/vm/stack_frame_x64.h
+FILE: ../../../third_party/dart/runtime/vm/tags.h
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter.h
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_android.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_win.cc
+FILE: ../../../third_party/dart/sdk/lib/_http/http.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http_headers.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http_parser.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http_session.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/websocket.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/websocket_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/collection_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/convert_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/internal_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/io_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/typed_data_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/annotations.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_primitives.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_rti.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/mirror_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/native_typed_data.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/annotations.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/collection_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/convert_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/internal_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/io_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_names.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_primitives.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/native_typed_data.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/typed_data_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/file_system_entity_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/filter_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/io_service_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/process_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/socket_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/stdio_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/vmservice_io.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/vmservice_server.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/core_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/function.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/internal_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/mirror_reference.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/schedule_microtask_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/stacktrace.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/symbol_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/timer_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/typed_data_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/uri_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/collection_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/null_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/io_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/async/deferred_load.dart
+FILE: ../../../third_party/dart/sdk/lib/async/schedule_microtask.dart
+FILE: ../../../third_party/dart/sdk/lib/async/stream.dart
+FILE: ../../../third_party/dart/sdk/lib/async/stream_transformers.dart
+FILE: ../../../third_party/dart/sdk/lib/async/zone.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/collections.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/hash_map.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/hash_set.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/linked_hash_map.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/linked_hash_set.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/linked_list.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/list.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/ascii.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/byte_conversion.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/chunked_conversion.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/codec.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/convert.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/converter.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/encoding.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/html_escape.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/json.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/latin1.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/line_splitter.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/string_conversion.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/utf.dart
+FILE: ../../../third_party/dart/sdk/lib/core/annotations.dart
+FILE: ../../../third_party/dart/sdk/lib/core/null.dart
+FILE: ../../../third_party/dart/sdk/lib/core/stacktrace.dart
+FILE: ../../../third_party/dart/sdk/lib/core/string_sink.dart
+FILE: ../../../third_party/dart/sdk/lib/core/symbol.dart
+FILE: ../../../third_party/dart/sdk/lib/html/dart2js/html_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/indexed_db/dart2js/indexed_db_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/bytes_builder.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/list.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/print.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/symbol.dart
+FILE: ../../../third_party/dart/sdk/lib/io/data_transformer.dart
+FILE: ../../../third_party/dart/sdk/lib/io/file.dart
+FILE: ../../../third_party/dart/sdk/lib/io/file_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/io/file_system_entity.dart
+FILE: ../../../third_party/dart/sdk/lib/io/io_service.dart
+FILE: ../../../third_party/dart/sdk/lib/io/io_sink.dart
+FILE: ../../../third_party/dart/sdk/lib/io/link.dart
+FILE: ../../../third_party/dart/sdk/lib/io/secure_socket.dart
+FILE: ../../../third_party/dart/sdk/lib/io/socket.dart
+FILE: ../../../third_party/dart/sdk/lib/io/stdio.dart
+FILE: ../../../third_party/dart/sdk/lib/io/string_transformer.dart
+FILE: ../../../third_party/dart/sdk/lib/js/js.dart
+FILE: ../../../third_party/dart/sdk/lib/math/point.dart
+FILE: ../../../third_party/dart/sdk/lib/math/rectangle.dart
+FILE: ../../../third_party/dart/sdk/lib/mirrors/mirrors.dart
+FILE: ../../../third_party/dart/sdk/lib/typed_data/typed_data.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/client.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/constants.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/message.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/message_router.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/running_isolate.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/running_isolates.dart
+FILE: ../../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart
+FILE: ../../../third_party/dart/utils/compiler/create_snapshot_entry.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/observatory/web/third_party/webcomponents.min.js + http://polymer.github.io/LICENSE.txt referenced by ../../../third_party/dart/runtime/observatory/web/third_party/webcomponents.min.js
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/web/third_party/webcomponents.min.js + http://polymer.github.io/LICENSE.txt referenced by ../../../third_party/dart/runtime/observatory_2/web/third_party/webcomponents.min.js
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/observatory/web/third_party/webcomponents.min.js
+FILE: ../../../third_party/dart/runtime/observatory_2/web/third_party/webcomponents.min.js
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/lib/profiler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/bin/shell.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/app.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/object_graph.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/service.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/service_common.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/service_html.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/service_io.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/app/page.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/app/settings.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/app/view_model.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_tree.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/debugger.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_reconnect.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/metrics.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_connect.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/service/object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/utils.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/web/main.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/bin/shell.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/app.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/object_graph.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/service.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/service_common.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/service_html.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/service_io.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/app/page.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/app/settings.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/app/view_model.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_tree.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/debugger.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/heap_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate_reconnect.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metrics.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/vm_connect.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/service/object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/utils.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/web/main.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/address_sanitizer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/memory_sanitizer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/safe_stack.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/verbose_gc_to_bmu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_patcher_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/range_analysis.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/range_analysis.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/method_recognizer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/method_recognizer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_arm64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_arm.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_arm64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_ia32.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_x64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpuid.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpuid.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpuinfo.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpuinfo_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpuinfo_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/debugger_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/hash_table.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/spaces.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/weak_code.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/weak_code.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_arm64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/metrics.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/metrics.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_graph.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_graph.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_assembler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_assembler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_assembler_ir.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_assembler_ir.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_ast.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_ast.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_parser.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_parser.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/report.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/report.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/ring_buffer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/runtime_entry_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/simulator_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/simulator_arm64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stack_frame_arm64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/tags.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/unibrow-inl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/unibrow.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/unibrow.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/preambles/d8.js + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/preambles/jsshell.js + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/linked_hash_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/synced/embedded_names.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/lib_prefix.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/profiler.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/convert_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/collection/set.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/sink.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/developer/profiler.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/process.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/service_object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/isolate/capability.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/lib/profiler.cc
+FILE: ../../../third_party/dart/runtime/observatory/bin/shell.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/app.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/object_graph.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/service.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/service_common.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/service_html.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/service_io.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/page.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/settings.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/view_model.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_tree.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/debugger.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_map.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_reconnect.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/metrics.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_connect.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/service/object.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/utils.dart
+FILE: ../../../third_party/dart/runtime/observatory/web/main.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/bin/shell.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/app.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/object_graph.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/service.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/service_common.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/service_html.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/service_io.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/app/page.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/app/settings.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/app/view_model.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_tree.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/debugger.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/heap_map.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate_reconnect.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metrics.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/vm_connect.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/service/object.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/utils.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/web/main.dart
+FILE: ../../../third_party/dart/runtime/platform/address_sanitizer.h
+FILE: ../../../third_party/dart/runtime/platform/memory_sanitizer.h
+FILE: ../../../third_party/dart/runtime/platform/safe_stack.h
+FILE: ../../../third_party/dart/runtime/tools/verbose_gc_to_bmu.dart
+FILE: ../../../third_party/dart/runtime/vm/code_patcher_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm64.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/range_analysis.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/range_analysis.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/method_recognizer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/method_recognizer.h
+FILE: ../../../third_party/dart/runtime/vm/constants_arm64.h
+FILE: ../../../third_party/dart/runtime/vm/cpu_arm.h
+FILE: ../../../third_party/dart/runtime/vm/cpu_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/cpu_arm64.h
+FILE: ../../../third_party/dart/runtime/vm/cpu_ia32.h
+FILE: ../../../third_party/dart/runtime/vm/cpu_x64.h
+FILE: ../../../third_party/dart/runtime/vm/cpuid.cc
+FILE: ../../../third_party/dart/runtime/vm/cpuid.h
+FILE: ../../../third_party/dart/runtime/vm/cpuinfo.h
+FILE: ../../../third_party/dart/runtime/vm/cpuinfo_android.cc
+FILE: ../../../third_party/dart/runtime/vm/cpuinfo_win.cc
+FILE: ../../../third_party/dart/runtime/vm/debugger_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/hash_table.h
+FILE: ../../../third_party/dart/runtime/vm/heap/spaces.h
+FILE: ../../../third_party/dart/runtime/vm/heap/weak_code.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/weak_code.h
+FILE: ../../../third_party/dart/runtime/vm/instructions_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/instructions_arm64.h
+FILE: ../../../third_party/dart/runtime/vm/metrics.cc
+FILE: ../../../third_party/dart/runtime/vm/metrics.h
+FILE: ../../../third_party/dart/runtime/vm/object_graph.cc
+FILE: ../../../third_party/dart/runtime/vm/object_graph.h
+FILE: ../../../third_party/dart/runtime/vm/regexp.cc
+FILE: ../../../third_party/dart/runtime/vm/regexp.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler.cc
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_ir.cc
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_ir.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_ast.cc
+FILE: ../../../third_party/dart/runtime/vm/regexp_ast.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_parser.cc
+FILE: ../../../third_party/dart/runtime/vm/regexp_parser.h
+FILE: ../../../third_party/dart/runtime/vm/report.cc
+FILE: ../../../third_party/dart/runtime/vm/report.h
+FILE: ../../../third_party/dart/runtime/vm/ring_buffer.h
+FILE: ../../../third_party/dart/runtime/vm/runtime_entry_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/simulator_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/simulator_arm64.h
+FILE: ../../../third_party/dart/runtime/vm/stack_frame_arm64.h
+FILE: ../../../third_party/dart/runtime/vm/tags.cc
+FILE: ../../../third_party/dart/runtime/vm/unibrow-inl.h
+FILE: ../../../third_party/dart/runtime/vm/unibrow.cc
+FILE: ../../../third_party/dart/runtime/vm/unibrow.h
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/preambles/d8.js
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/preambles/jsshell.js
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/linked_hash_map.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/synced/embedded_names.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/lib_prefix.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/profiler.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/convert_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/set.dart
+FILE: ../../../third_party/dart/sdk/lib/core/sink.dart
+FILE: ../../../third_party/dart/sdk/lib/developer/profiler.dart
+FILE: ../../../third_party/dart/sdk/lib/io/process.dart
+FILE: ../../../third_party/dart/sdk/lib/io/service_object.dart
+FILE: ../../../third_party/dart/sdk/lib/isolate/capability.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/address_sanitizer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/dart_io_api_impl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/observatory_assets_empty.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/bin/dart_io_api.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/developer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/timeline.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/vmservice.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/cli.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/debugger.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/allocation_profile/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/cli/command.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/debugger/debugger.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/debugger/debugger_location.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/logging.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/logging_list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/megamorphiccache_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectpool_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/persistent_handles.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/ports.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/timeline_page.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/sample_profile/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/web/timeline.js + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/cli.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/debugger.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/allocation_profile/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/cli/command.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/debugger/debugger.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/debugger/debugger_location.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/logging.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/logging_list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/megamorphiccache_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/objectpool_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/persistent_handles.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/ports.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/timeline_page.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/sample_profile/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/web/timeline.js + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/log.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/log.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/profiler_service.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/profiler_service.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/program_visitor.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/program_visitor.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode_inl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_bytecodes.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_interpreter.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/regexp_interpreter.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/scope_timer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/service_event.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/service_event.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/service_isolate.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/source_report.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/source_report.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_barrier.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_registry.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_registry.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/timeline.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/timeline.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/developer_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/classes.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/rtti.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/runtime.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/types.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/utils.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/debugger.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/developer_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/preambles/d8.js + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/preambles/jsshell.js + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/synced/async_status_codes.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/async_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/developer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/timeline.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/compact_hash.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/convert/base64.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/developer/developer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/developer/extension.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/developer/timeline.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/io_resource_info.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/security_context.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js/_js_annotations.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/asset.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/vmservice.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/address_sanitizer.cc
+FILE: ../../../third_party/dart/runtime/bin/dart_io_api_impl.cc
+FILE: ../../../third_party/dart/runtime/bin/observatory_assets_empty.cc
+FILE: ../../../third_party/dart/runtime/include/bin/dart_io_api.h
+FILE: ../../../third_party/dart/runtime/lib/developer.cc
+FILE: ../../../third_party/dart/runtime/lib/timeline.cc
+FILE: ../../../third_party/dart/runtime/lib/vmservice.cc
+FILE: ../../../third_party/dart/runtime/observatory/lib/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/cli.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/debugger.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/allocation_profile/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/cli/command.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/debugger/debugger.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/debugger/debugger_location.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/logging.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/logging_list.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/megamorphiccache_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectpool_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/timeline_page.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/sample_profile/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/web/timeline.js
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/cli.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/debugger.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/allocation_profile/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/cli/command.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/debugger/debugger.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/debugger/debugger_location.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/logging.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/logging_list.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/megamorphiccache_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/objectpool_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/timeline_page.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/sample_profile/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/web/timeline.js
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler.h
+FILE: ../../../third_party/dart/runtime/vm/log.cc
+FILE: ../../../third_party/dart/runtime/vm/log.h
+FILE: ../../../third_party/dart/runtime/vm/os_thread.cc
+FILE: ../../../third_party/dart/runtime/vm/profiler_service.cc
+FILE: ../../../third_party/dart/runtime/vm/profiler_service.h
+FILE: ../../../third_party/dart/runtime/vm/program_visitor.cc
+FILE: ../../../third_party/dart/runtime/vm/program_visitor.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode.cc
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode_inl.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_bytecodes.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_interpreter.cc
+FILE: ../../../third_party/dart/runtime/vm/regexp_interpreter.h
+FILE: ../../../third_party/dart/runtime/vm/scope_timer.h
+FILE: ../../../third_party/dart/runtime/vm/service_event.cc
+FILE: ../../../third_party/dart/runtime/vm/service_event.h
+FILE: ../../../third_party/dart/runtime/vm/service_isolate.cc
+FILE: ../../../third_party/dart/runtime/vm/source_report.cc
+FILE: ../../../third_party/dart/runtime/vm/source_report.h
+FILE: ../../../third_party/dart/runtime/vm/thread.cc
+FILE: ../../../third_party/dart/runtime/vm/thread.h
+FILE: ../../../third_party/dart/runtime/vm/thread_barrier.h
+FILE: ../../../third_party/dart/runtime/vm/thread_registry.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_registry.h
+FILE: ../../../third_party/dart/runtime/vm/timeline.cc
+FILE: ../../../third_party/dart/runtime/vm/timeline.h
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/developer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/classes.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/rtti.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/runtime.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/types.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/utils.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/debugger.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/developer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/preambles/d8.js
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/preambles/jsshell.js
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/synced/async_status_codes.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/async_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/developer.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/timeline.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/compact_hash.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/base64.dart
+FILE: ../../../third_party/dart/sdk/lib/developer/developer.dart
+FILE: ../../../third_party/dart/sdk/lib/developer/extension.dart
+FILE: ../../../third_party/dart/sdk/lib/developer/timeline.dart
+FILE: ../../../third_party/dart/sdk/lib/io/io_resource_info.dart
+FILE: ../../../third_party/dart/sdk/lib/io/security_context.dart
+FILE: ../../../third_party/dart/sdk/lib/js/_js_annotations.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/asset.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/vmservice.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/crypto_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/directory_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/eventhandler_fuchsia.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_support.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_system_watcher_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/loader.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/loader.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/process_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/reference_counting.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/root_certificates_unsupported.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_fuchsia.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/stdio_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_fuchsia.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/utils_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/stacktrace.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/models.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/repositories.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/app/notification.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/virtual_collection.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/virtual_tree.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/error_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/general_error.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/custom_element.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/nav_bar.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/nav_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/rendering_queue.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/rendering_scheduler.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/uris.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/inbound_references.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/counter_chart.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/location.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/run_state.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/shared_summary.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/summary.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/metric/details.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/metric/graph.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/class_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/isolate_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/library_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/menu_item.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify_event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify_exception.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/refresh.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/top_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/vm_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/retaining_path.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/source_link.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/strongly_reachable_instances.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_connect_target.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/exceptions.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/breakpoint.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/class.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/code.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/context.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/error.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/extension_data.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/field.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/flag.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/frame.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/function.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/guarded.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/heap_space.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/icdata.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/inbound_references.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/instance.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/isolate.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/library.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/local_var_descriptors.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/map_association.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/megamorphiccache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/metric.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/notification.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/objectpool.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/objectstore.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/pc_descriptors.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/persistent_handles.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/ports.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/retaining_path.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/script.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/sentinel.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/source_location.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/target.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/timeline_event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/type_arguments.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/unknown.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/vm.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/breakpoint.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/class.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/context.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/editor.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/eval.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/field.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/flag.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/function.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/icdata.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/inbound_references.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/instance.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/isolate.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/library.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/megamorphiccache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/metric.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/notification.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/objectpool.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/objectstore.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/persistent_handles.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/ports.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/reachable_size.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/retained_size.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/retaining_path.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/script.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/strongly_reachable_instances.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/target.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/type_arguments.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/breakpoint.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/class.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/context.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/editor.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/eval.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/field.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/flag.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/function.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/icdata.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/inbound_references.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/instance.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/isolate.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/library.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/megamorphiccache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/metric.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/notification.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/objectpool.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/objectstore.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/persistent_handles.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/ports.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/reachable_size.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/retained_size.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/retaining_path.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/script.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/settings.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/strongly_reachable_instances.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/target.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/type_arguments.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/web/timeline_message_handler.js + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/models.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/repositories.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/app/notification.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/virtual_collection.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/virtual_tree.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/error_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/general_error.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/custom_element.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/nav_bar.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/nav_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/rendering_queue.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/rendering_scheduler.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/tag.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/uris.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/inbound_references.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/counter_chart.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/location.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/run_state.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/shared_summary.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/summary.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metric/details.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metric/graph.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/class_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/isolate_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/library_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/menu_item.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify_event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify_exception.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/refresh.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/top_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/vm_menu.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/retaining_path.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/source_link.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/strongly_reachable_instances.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/vm_connect_target.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/exceptions.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/breakpoint.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/class.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/code.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/context.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/error.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/extension_data.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/field.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/flag.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/frame.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/function.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/guarded.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/heap_space.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/icdata.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/inbound_references.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/instance.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/isolate.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/library.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/local_var_descriptors.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/map_association.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/megamorphiccache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/metric.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/notification.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/objectpool.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/objectstore.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/pc_descriptors.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/persistent_handles.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/ports.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/retaining_path.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/script.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/sentinel.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/source_location.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/target.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/timeline_event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/type_arguments.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/unknown.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/vm.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/breakpoint.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/class.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/context.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/editor.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/eval.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/field.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/flag.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/function.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/icdata.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/inbound_references.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/instance.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/isolate.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/library.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/megamorphiccache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/metric.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/notification.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/objectpool.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/objectstore.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/persistent_handles.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/ports.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/reachable_size.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/retained_size.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/retaining_path.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/script.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/strongly_reachable_instances.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/target.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/type_arguments.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/allocation_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/breakpoint.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/class.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/context.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/editor.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/eval.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/event.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/field.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/flag.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/function.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/icdata.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/inbound_references.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/instance.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/isolate.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/library.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/megamorphiccache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/metric.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/notification.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/object.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/objectpool.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/objectstore.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/persistent_handles.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/ports.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/reachable_size.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/retained_size.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/retaining_path.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/sample_profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/script.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/settings.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/strongly_reachable_instances.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/target.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/type_arguments.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/web/timeline_message_handler.js + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/syslog_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/utils_fuchsia.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/app_snapshot.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/app_snapshot.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/canonical_tables.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/branch_optimizer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/branch_optimizer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/redundancy_elimination.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/redundancy_elimination.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_binary_flowgraph.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_to_il.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_to_il.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpuinfo_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dart_api_state.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/become.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/become.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/safepoint.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/safepoint.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/isolate_reload.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/isolate_reload.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/kernel.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/kernel.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/kernel_binary.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/kernel_isolate.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/kernel_isolate.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/kernel_loader.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/kernel_loader.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/lockers.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/native_symbol_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_reload.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_service.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_fuchsia.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/signal_handler_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_interrupter_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/token_position.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/token_position.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/uri.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/uri.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/virtual_memory_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/developer/service.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js_util/js_util.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/devfs.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/crypto_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/directory_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_fuchsia.h
+FILE: ../../../third_party/dart/runtime/bin/file_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/file_support.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/loader.cc
+FILE: ../../../third_party/dart/runtime/bin/loader.h
+FILE: ../../../third_party/dart/runtime/bin/platform_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/process_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/reference_counting.h
+FILE: ../../../third_party/dart/runtime/bin/root_certificates_unsupported.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base_fuchsia.h
+FILE: ../../../third_party/dart/runtime/bin/socket_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_fuchsia.h
+FILE: ../../../third_party/dart/runtime/bin/utils_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/lib/stacktrace.h
+FILE: ../../../third_party/dart/runtime/observatory/lib/event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/models.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/repositories.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/virtual_collection.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/virtual_tree.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/error_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/general_error.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/custom_element.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/nav_bar.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/nav_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/rendering_queue.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/rendering_scheduler.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/uris.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/counter_chart.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/location.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/run_state.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/shared_summary.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate/summary.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/metric/details.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/metric/graph.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/class_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/isolate_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/library_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/menu_item.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify_event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/notify_exception.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/refresh.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/top_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/vm_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/source_link.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_connect_target.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/exceptions.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/class.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/code.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/context.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/error.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/extension_data.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/field.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/frame.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/function.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/guarded.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/heap_space.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/library.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/local_var_descriptors.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/map_association.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/object.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/pc_descriptors.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/script.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/sentinel.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/source_location.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/target.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/timeline_event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/unknown.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/vm.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/class.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/context.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/editor.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/eval.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/field.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/function.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/library.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/object.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/reachable_size.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/retained_size.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/script.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/target.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/class.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/context.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/editor.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/eval.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/event.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/field.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/function.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/library.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/object.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/reachable_size.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/retained_size.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/script.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/settings.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/target.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory/web/timeline_message_handler.js
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/models.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/repositories.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/app/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/class_allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/virtual_collection.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/virtual_tree.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/error_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/general_error.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/custom_element.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/nav_bar.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/nav_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/rendering_queue.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/rendering_scheduler.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/tag.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/helpers/uris.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/counter_chart.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/location.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/run_state.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/shared_summary.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/isolate/summary.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metric/details.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/metric/graph.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/class_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/isolate_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/library_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/menu_item.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify_event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/notify_exception.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/refresh.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/top_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/vm_menu.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/source_link.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/vm_connect_target.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/exceptions.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/class.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/code.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/context.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/error.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/extension_data.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/field.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/frame.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/function.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/guarded.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/heap_space.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/library.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/local_var_descriptors.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/map_association.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/object.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/pc_descriptors.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/script.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/sentinel.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/source_location.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/target.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/timeline_event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/unknown.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/vm.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/class.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/context.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/editor.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/eval.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/field.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/function.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/library.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/object.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/reachable_size.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/retained_size.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/script.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/target.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/breakpoint.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/class.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/context.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/editor.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/eval.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/event.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/field.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/flag.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/function.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/icdata.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/inbound_references.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/instance.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/isolate.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/library.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/megamorphiccache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/metric.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/notification.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/object.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/objectpool.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/objectstore.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/reachable_size.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/retained_size.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/retaining_path.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/script.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/settings.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/strongly_reachable_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/target.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/type_arguments.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/web/timeline_message_handler.js
+FILE: ../../../third_party/dart/runtime/platform/syslog_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/platform/utils_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/platform/utils_fuchsia.h
+FILE: ../../../third_party/dart/runtime/vm/app_snapshot.cc
+FILE: ../../../third_party/dart/runtime/vm/app_snapshot.h
+FILE: ../../../third_party/dart/runtime/vm/canonical_tables.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/branch_optimizer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/branch_optimizer.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/redundancy_elimination.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/redundancy_elimination.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_binary_flowgraph.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_to_il.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_to_il.h
+FILE: ../../../third_party/dart/runtime/vm/cpuinfo_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/dart_api_state.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/become.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/become.h
+FILE: ../../../third_party/dart/runtime/vm/heap/safepoint.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/safepoint.h
+FILE: ../../../third_party/dart/runtime/vm/isolate_reload.cc
+FILE: ../../../third_party/dart/runtime/vm/isolate_reload.h
+FILE: ../../../third_party/dart/runtime/vm/kernel.cc
+FILE: ../../../third_party/dart/runtime/vm/kernel.h
+FILE: ../../../third_party/dart/runtime/vm/kernel_binary.cc
+FILE: ../../../third_party/dart/runtime/vm/kernel_isolate.cc
+FILE: ../../../third_party/dart/runtime/vm/kernel_isolate.h
+FILE: ../../../third_party/dart/runtime/vm/kernel_loader.cc
+FILE: ../../../third_party/dart/runtime/vm/kernel_loader.h
+FILE: ../../../third_party/dart/runtime/vm/lockers.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/object_reload.cc
+FILE: ../../../third_party/dart/runtime/vm/object_service.cc
+FILE: ../../../third_party/dart/runtime/vm/os_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_fuchsia.h
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/token_position.cc
+FILE: ../../../third_party/dart/runtime/vm/token_position.h
+FILE: ../../../third_party/dart/runtime/vm/uri.cc
+FILE: ../../../third_party/dart/runtime/vm/uri.h
+FILE: ../../../third_party/dart/runtime/vm/virtual_memory_fuchsia.cc
+FILE: ../../../third_party/dart/sdk/lib/developer/service.dart
+FILE: ../../../third_party/dart/sdk/lib/js_util/js_util.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/devfs.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/cli.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/dfe.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/dfe.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/error_exit.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/error_exit.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/gzip.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/gzip.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/isolate_data.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/main_options.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/main_options.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/namespace.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/namespace.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/namespace_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/namespace_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/namespace_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/namespace_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/namespace_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/options.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/options.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/secure_socket_filter.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/secure_socket_filter.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/secure_socket_utils.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/secure_socket_utils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/security_context.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/security_context.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/security_context_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/security_context_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/security_context_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/security_context_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/security_context_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/snapshot_utils.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/snapshot_utils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/sync_socket.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/sync_socket.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/sync_socket_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/sync_socket_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/sync_socket_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/sync_socket_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/sync_socket_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/async.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/search_bar.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/reload.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/singletargetcache_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/singletargetcache_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/subtypetestcache_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/subtypetestcache_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/unlinkedcall_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/unlinkedcall_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/service.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/single_target_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/subtype_test_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/timeline.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/unlinked_call.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/single_target_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/subtype_test_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/timeline.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/unlinked_call.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/vm.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/single_target_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/subtype_test_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/timeline.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/unlinked_call.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/vm.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/search_bar.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/reload.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/singletargetcache_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/singletargetcache_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/subtypetestcache_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/subtypetestcache_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/timeline/dashboard.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/unlinkedcall_ref.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/unlinkedcall_view.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/service.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/single_target_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/subtype_test_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/timeline.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/unlinked_call.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/single_target_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/subtype_test_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/timeline.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/unlinked_call.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/vm.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/single_target_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/subtype_test_cache.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/timeline.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/unlinked_call.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/vm.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/allocation.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/growable_array.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_riscv.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/locations_helpers.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/locations_helpers_arm.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/call_specializer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/call_specializer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_binary_flowgraph.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/prologue_builder.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/prologue_builder.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/jit/jit_call_specializer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_riscv.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_x86.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dwarf.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dwarf.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/fixed_cache.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/gdb_helpers.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/compactor.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/compactor.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/image_snapshot.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/image_snapshot.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/json_writer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/json_writer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/kernel_binary.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/simulator_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/simulator_riscv.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stack_trace.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stack_trace.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/timeline_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/timeline_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/timeline_linux.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/zone_text_buffer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/zone_text_buffer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/overrides.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/custom_hash_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/identity_hash_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/linked_hash_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/profile.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/cli_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/namespace_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/bin/sync_socket_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/class_id_fasta.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/bigint_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/cli/cli.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/cli/wait_for.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/bigint.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/linked_list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/embedder_config.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/namespace_impl.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/overrides.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/io/sync_socket.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/vmservice/named_lookup.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/utils/bazel/kernel_worker.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/cli.cc
+FILE: ../../../third_party/dart/runtime/bin/dfe.cc
+FILE: ../../../third_party/dart/runtime/bin/dfe.h
+FILE: ../../../third_party/dart/runtime/bin/error_exit.cc
+FILE: ../../../third_party/dart/runtime/bin/error_exit.h
+FILE: ../../../third_party/dart/runtime/bin/gzip.cc
+FILE: ../../../third_party/dart/runtime/bin/gzip.h
+FILE: ../../../third_party/dart/runtime/bin/isolate_data.cc
+FILE: ../../../third_party/dart/runtime/bin/main_options.cc
+FILE: ../../../third_party/dart/runtime/bin/main_options.h
+FILE: ../../../third_party/dart/runtime/bin/namespace.cc
+FILE: ../../../third_party/dart/runtime/bin/namespace.h
+FILE: ../../../third_party/dart/runtime/bin/namespace_android.cc
+FILE: ../../../third_party/dart/runtime/bin/namespace_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/namespace_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/namespace_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/namespace_win.cc
+FILE: ../../../third_party/dart/runtime/bin/options.cc
+FILE: ../../../third_party/dart/runtime/bin/options.h
+FILE: ../../../third_party/dart/runtime/bin/secure_socket_filter.cc
+FILE: ../../../third_party/dart/runtime/bin/secure_socket_filter.h
+FILE: ../../../third_party/dart/runtime/bin/secure_socket_utils.cc
+FILE: ../../../third_party/dart/runtime/bin/secure_socket_utils.h
+FILE: ../../../third_party/dart/runtime/bin/security_context.cc
+FILE: ../../../third_party/dart/runtime/bin/security_context.h
+FILE: ../../../third_party/dart/runtime/bin/security_context_android.cc
+FILE: ../../../third_party/dart/runtime/bin/security_context_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/security_context_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/security_context_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/security_context_win.cc
+FILE: ../../../third_party/dart/runtime/bin/snapshot_utils.cc
+FILE: ../../../third_party/dart/runtime/bin/snapshot_utils.h
+FILE: ../../../third_party/dart/runtime/bin/socket_base.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base.h
+FILE: ../../../third_party/dart/runtime/bin/sync_socket.cc
+FILE: ../../../third_party/dart/runtime/bin/sync_socket.h
+FILE: ../../../third_party/dart/runtime/bin/sync_socket_android.cc
+FILE: ../../../third_party/dart/runtime/bin/sync_socket_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/sync_socket_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/sync_socket_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/sync_socket_win.cc
+FILE: ../../../third_party/dart/runtime/lib/async.cc
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/search_bar.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/nav/reload.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/singletargetcache_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/singletargetcache_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/subtypetestcache_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/subtypetestcache_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/unlinkedcall_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/unlinkedcall_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/service.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/single_target_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/subtype_test_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/timeline.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/unlinked_call.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/single_target_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/subtype_test_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/timeline.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/unlinked_call.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/vm.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/single_target_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/subtype_test_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/timeline.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/unlinked_call.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/vm.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/containers/search_bar.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/nav/reload.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/singletargetcache_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/singletargetcache_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/subtypetestcache_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/subtypetestcache_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/timeline/dashboard.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/unlinkedcall_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/unlinkedcall_view.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/service.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/single_target_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/subtype_test_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/timeline.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/unlinked_call.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/single_target_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/subtype_test_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/timeline.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/unlinked_call.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/vm.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/single_target_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/subtype_test_cache.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/timeline.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/unlinked_call.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/vm.dart
+FILE: ../../../third_party/dart/runtime/platform/allocation.h
+FILE: ../../../third_party/dart/runtime/platform/growable_array.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_riscv.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/locations_helpers.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/locations_helpers_arm.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/call_specializer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/call_specializer.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_binary_flowgraph.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/prologue_builder.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/prologue_builder.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/jit/jit_call_specializer.h
+FILE: ../../../third_party/dart/runtime/vm/constants_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_riscv.h
+FILE: ../../../third_party/dart/runtime/vm/constants_x86.h
+FILE: ../../../third_party/dart/runtime/vm/dwarf.cc
+FILE: ../../../third_party/dart/runtime/vm/dwarf.h
+FILE: ../../../third_party/dart/runtime/vm/fixed_cache.h
+FILE: ../../../third_party/dart/runtime/vm/gdb_helpers.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/compactor.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/compactor.h
+FILE: ../../../third_party/dart/runtime/vm/image_snapshot.cc
+FILE: ../../../third_party/dart/runtime/vm/image_snapshot.h
+FILE: ../../../third_party/dart/runtime/vm/json_writer.cc
+FILE: ../../../third_party/dart/runtime/vm/json_writer.h
+FILE: ../../../third_party/dart/runtime/vm/kernel_binary.h
+FILE: ../../../third_party/dart/runtime/vm/simulator_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/simulator_riscv.h
+FILE: ../../../third_party/dart/runtime/vm/stack_trace.cc
+FILE: ../../../third_party/dart/runtime/vm/stack_trace.h
+FILE: ../../../third_party/dart/runtime/vm/timeline_android.cc
+FILE: ../../../third_party/dart/runtime/vm/timeline_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/vm/timeline_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/zone_text_buffer.cc
+FILE: ../../../third_party/dart/runtime/vm/zone_text_buffer.h
+FILE: ../../../third_party/dart/sdk/lib/_http/overrides.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/custom_hash_map.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/identity_hash_map.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/linked_hash_map.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/profile.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/cli_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/namespace_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/bin/sync_socket_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/class_id_fasta.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm_shared/lib/bigint_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/cli/cli.dart
+FILE: ../../../third_party/dart/sdk/lib/cli/wait_for.dart
+FILE: ../../../third_party/dart/sdk/lib/core/bigint.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/linked_list.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/patch.dart
+FILE: ../../../third_party/dart/sdk/lib/io/embedder_config.dart
+FILE: ../../../third_party/dart/sdk/lib/io/namespace_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/io/overrides.dart
+FILE: ../../../third_party/dart/sdk/lib/io/sync_socket.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/named_lookup.dart
+FILE: ../../../third_party/dart/utils/bazel/kernel_worker.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/crashpad.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/dart_embedder_api_impl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/typed_data_utils.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/typed_data_utils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/dart_embedder_api.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/base64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/base64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/compile_type.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/loops.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/loops.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/slot.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/slot.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/compiler_state.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/compiler_state.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/constant_reader.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/constant_reader.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_fingerprints.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_fingerprints.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_translation_helper.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_translation_helper.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/scope_builder.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/frontend/scope_builder.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/relocation.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/datastream.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/finalizable_data.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/hash.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/raw_object_fields.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/raw_object_fields.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/reverse_pc_lookup_cache.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/reverse_pc_lookup_cache.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/type_testing_stubs.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/type_testing_stubs.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/v8_snapshot_writer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/v8_snapshot_writer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/instantiation.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js/_js.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js/_js_client.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js/_js_server.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/typed_data/unmodifiable_typed_data.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/crashpad.h
+FILE: ../../../third_party/dart/runtime/bin/dart_embedder_api_impl.cc
+FILE: ../../../third_party/dart/runtime/bin/typed_data_utils.cc
+FILE: ../../../third_party/dart/runtime/bin/typed_data_utils.h
+FILE: ../../../third_party/dart/runtime/include/dart_embedder_api.h
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz.dart
+FILE: ../../../third_party/dart/runtime/vm/base64.cc
+FILE: ../../../third_party/dart/runtime/vm/base64.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/compile_type.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/loops.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/loops.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/slot.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/slot.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_state.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_state.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/constant_reader.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/constant_reader.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_fingerprints.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_fingerprints.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_translation_helper.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_translation_helper.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/scope_builder.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/scope_builder.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/relocation.h
+FILE: ../../../third_party/dart/runtime/vm/constants.h
+FILE: ../../../third_party/dart/runtime/vm/datastream.cc
+FILE: ../../../third_party/dart/runtime/vm/finalizable_data.h
+FILE: ../../../third_party/dart/runtime/vm/hash.h
+FILE: ../../../third_party/dart/runtime/vm/raw_object_fields.cc
+FILE: ../../../third_party/dart/runtime/vm/raw_object_fields.h
+FILE: ../../../third_party/dart/runtime/vm/reverse_pc_lookup_cache.cc
+FILE: ../../../third_party/dart/runtime/vm/reverse_pc_lookup_cache.h
+FILE: ../../../third_party/dart/runtime/vm/type_testing_stubs.cc
+FILE: ../../../third_party/dart/runtime/vm/type_testing_stubs.h
+FILE: ../../../third_party/dart/runtime/vm/v8_snapshot_writer.cc
+FILE: ../../../third_party/dart/runtime/vm/v8_snapshot_writer.h
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/instantiation.dart
+FILE: ../../../third_party/dart/sdk/lib/js/_js.dart
+FILE: ../../../third_party/dart/sdk/lib/js/_js_client.dart
+FILE: ../../../third_party/dart/sdk/lib/js/_js_server.dart
+FILE: ../../../third_party/dart/sdk/lib/typed_data/unmodifiable_typed_data.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/console.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/console_posix.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/console_win.cc + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/console.h
+FILE: ../../../third_party/dart/runtime/bin/console_posix.cc
+FILE: ../../../third_party/dart/runtime/bin/console_win.cc
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/elf_loader.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/elf_loader.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/ifaddrs-android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/ifaddrs-android.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/namespace_fuchsia.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_android.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/ffi.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/ffi_dynamic_library.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/tree_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/isolate_group.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/isolate_group.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/isolate_group.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/repositories/timeline_base.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/tree_map.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/isolate_group.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/isolate_group.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/isolate_group.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/timeline_base.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/elf.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/thread_sanitizer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_api_table.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_ffi_api.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_type_table.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/dartfuzz/gen_api_table.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/dartfuzz/gen_type_table.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/dartfuzz/gen_util.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/ffi/sdk_lib_ffi_generator.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/graphexplorer/graphexplorer.html + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/graphexplorer/graphexplorer.js + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/run_clang_tidy.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bss_relocs.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/bss_relocs.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/class_id.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_comments.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_comments.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_entry_kind.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/block_builder.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/evaluator.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/evaluator.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_checker.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_checker.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_test_helper.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_test_helper.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/graph_intrinsifier.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/graph_intrinsifier.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/offsets_extractor.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/recognized_methods_list.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/relocation.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/runtime_api.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/runtime_api.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/runtime_offsets_extracted.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/runtime_offsets_list.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_arm.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_arm64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_ia32.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/elf.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/elf.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/frame_layout.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/intrusive_dlist.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/libfuzzer/dart_libfuzzer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/longjump.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/pointer_tagging.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/splay-tree.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/static_type_exactness_state.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stub_code_list.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_stack_resource.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_stack_resource.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_state.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_state.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/rti.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/synced/recipe_syntax.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/annotations.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/dynamic_library.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/ffi.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/native_type.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/struct.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/errors.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/elf_loader.cc
+FILE: ../../../third_party/dart/runtime/bin/elf_loader.h
+FILE: ../../../third_party/dart/runtime/bin/ifaddrs-android.cc
+FILE: ../../../third_party/dart/runtime/bin/ifaddrs-android.h
+FILE: ../../../third_party/dart/runtime/bin/namespace_fuchsia.h
+FILE: ../../../third_party/dart/runtime/bin/socket_base_android.cc
+FILE: ../../../third_party/dart/runtime/lib/ffi.cc
+FILE: ../../../third_party/dart/runtime/lib/ffi_dynamic_library.cc
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/tree_map.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/objects/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/models/repositories/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/repositories/timeline_base.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/tree_map.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/objects/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/models/repositories/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/isolate_group.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/repositories/timeline_base.dart
+FILE: ../../../third_party/dart/runtime/platform/elf.h
+FILE: ../../../third_party/dart/runtime/platform/thread_sanitizer.h
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_api_table.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_ffi_api.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_type_table.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/gen_api_table.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/gen_type_table.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/gen_util.dart
+FILE: ../../../third_party/dart/runtime/tools/ffi/sdk_lib_ffi_generator.dart
+FILE: ../../../third_party/dart/runtime/tools/graphexplorer/graphexplorer.html
+FILE: ../../../third_party/dart/runtime/tools/graphexplorer/graphexplorer.js
+FILE: ../../../third_party/dart/runtime/tools/run_clang_tidy.dart
+FILE: ../../../third_party/dart/runtime/vm/bss_relocs.cc
+FILE: ../../../third_party/dart/runtime/vm/bss_relocs.h
+FILE: ../../../third_party/dart/runtime/vm/class_id.h
+FILE: ../../../third_party/dart/runtime/vm/code_comments.cc
+FILE: ../../../third_party/dart/runtime/vm/code_comments.h
+FILE: ../../../third_party/dart/runtime/vm/code_entry_kind.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/block_builder.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/evaluator.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/evaluator.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_checker.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_checker.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_test_helper.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_test_helper.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/graph_intrinsifier.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/graph_intrinsifier.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/offsets_extractor.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/recognized_methods_list.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/relocation.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_api.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_api.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_offsets_extracted.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/runtime_offsets_list.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_arm64.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/elf.cc
+FILE: ../../../third_party/dart/runtime/vm/elf.h
+FILE: ../../../third_party/dart/runtime/vm/frame_layout.h
+FILE: ../../../third_party/dart/runtime/vm/intrusive_dlist.h
+FILE: ../../../third_party/dart/runtime/vm/libfuzzer/dart_libfuzzer.cc
+FILE: ../../../third_party/dart/runtime/vm/longjump.h
+FILE: ../../../third_party/dart/runtime/vm/pointer_tagging.h
+FILE: ../../../third_party/dart/runtime/vm/splay-tree.h
+FILE: ../../../third_party/dart/runtime/vm/static_type_exactness_state.h
+FILE: ../../../third_party/dart/runtime/vm/stub_code_list.h
+FILE: ../../../third_party/dart/runtime/vm/thread_stack_resource.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_stack_resource.h
+FILE: ../../../third_party/dart/runtime/vm/thread_state.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_state.h
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/rti.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/synced/recipe_syntax.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/annotations.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/dynamic_library.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/ffi.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/native_type.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/struct.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/errors.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/sdk/lib/io/network_profiling.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/sdk/lib/io/network_profiling.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/dartdev_isolate.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/dartdev_isolate.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/exe_utils.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/exe_utils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/ffi_unit_test/run_ffi_unit_tests.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/file_win.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform_macos.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/dart_api_dl.c + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/dart_api_dl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/dart_version.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/internal/dart_api_dl_impl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/bin/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory/lib/src/elements/process_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/bin/heap_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/process_snapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/allocation.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/leak_sanitizer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/priority_queue.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/unaligned.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/undefined_behavior_sanitizer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/canonical_tables.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/closure_functions_cache.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/closure_functions_cache.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/aot/dispatch_table_generator.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/aot/dispatch_table_generator.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler_tracer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler_tracer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/api/deopt_id.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/api/print_filter.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/api/print_filter.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/api/type_check_mode.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_base.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/abi.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/abi.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/call.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/call.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/callback.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/callback.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/frame_rebase.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/frame_rebase.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/marshaller.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/marshaller.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/recognized_method.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/recognized_method.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test_custom_zone.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test_custom_zone.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/constants_base.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dispatch_table.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/dispatch_table.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/experimental_features.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/experimental_features.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/field_table.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/field_table.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/port_set.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/tagged_pointer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/timeline_macos.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/visitor.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/embedder_config.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/js_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/internal/lowering.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/dartdev_isolate.cc
+FILE: ../../../third_party/dart/runtime/bin/dartdev_isolate.h
+FILE: ../../../third_party/dart/runtime/bin/exe_utils.cc
+FILE: ../../../third_party/dart/runtime/bin/exe_utils.h
+FILE: ../../../third_party/dart/runtime/bin/ffi_unit_test/run_ffi_unit_tests.cc
+FILE: ../../../third_party/dart/runtime/bin/file_win.h
+FILE: ../../../third_party/dart/runtime/bin/platform_macos.h
+FILE: ../../../third_party/dart/runtime/include/dart_api_dl.c
+FILE: ../../../third_party/dart/runtime/include/dart_api_dl.h
+FILE: ../../../third_party/dart/runtime/include/dart_version.h
+FILE: ../../../third_party/dart/runtime/include/internal/dart_api_dl_impl.h
+FILE: ../../../third_party/dart/runtime/observatory/bin/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/process_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/bin/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/process_snapshot.dart
+FILE: ../../../third_party/dart/runtime/platform/allocation.cc
+FILE: ../../../third_party/dart/runtime/platform/leak_sanitizer.h
+FILE: ../../../third_party/dart/runtime/platform/priority_queue.h
+FILE: ../../../third_party/dart/runtime/platform/unaligned.h
+FILE: ../../../third_party/dart/runtime/platform/undefined_behavior_sanitizer.h
+FILE: ../../../third_party/dart/runtime/vm/canonical_tables.cc
+FILE: ../../../third_party/dart/runtime/vm/closure_functions_cache.cc
+FILE: ../../../third_party/dart/runtime/vm/closure_functions_cache.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/dispatch_table_generator.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/dispatch_table_generator.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler_tracer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler_tracer.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/api/deopt_id.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/api/print_filter.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/api/print_filter.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/api/type_check_mode.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_base.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/abi.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/abi.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/call.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/call.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/callback.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/callback.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/frame_rebase.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/frame_rebase.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/marshaller.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/marshaller.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_calling_convention.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_location.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/native_type.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/recognized_method.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/recognized_method.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test_custom_zone.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/unit_test_custom_zone.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/write_barrier_elimination.h
+FILE: ../../../third_party/dart/runtime/vm/constants_base.h
+FILE: ../../../third_party/dart/runtime/vm/dispatch_table.cc
+FILE: ../../../third_party/dart/runtime/vm/dispatch_table.h
+FILE: ../../../third_party/dart/runtime/vm/experimental_features.cc
+FILE: ../../../third_party/dart/runtime/vm/experimental_features.h
+FILE: ../../../third_party/dart/runtime/vm/field_table.cc
+FILE: ../../../third_party/dart/runtime/vm/field_table.h
+FILE: ../../../third_party/dart/runtime/vm/port_set.h
+FILE: ../../../third_party/dart/runtime/vm/tagged_pointer.h
+FILE: ../../../third_party/dart/runtime/vm/timeline_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/visitor.cc
+FILE: ../../../third_party/dart/sdk/lib/_http/embedder_config.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/js_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/lowering.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/analyze_snapshot.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform_macos_cocoa.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/platform_macos_cocoa.mm + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/socket_base_posix.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/utils.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/virtual_memory.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/virtual_memory_fuchsia.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/virtual_memory_posix.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/virtual_memory_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/include/analyze_snapshot_api.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/analyze_snapshot_api_impl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/code_patcher_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/compiler_timings.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/compiler_timings.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/ffi/range.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/cpu_riscv.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/debugger_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions_riscv.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/message_snapshot.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/message_snapshot.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_graph_copy.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/object_graph_copy.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/pending_deopts.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/pending_deopts.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/runtime_entry_riscv.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/stack_frame_riscv.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/thread_interrupter_android_arm.S + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/virtual_memory_compressed.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/virtual_memory_compressed.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/dart2js_runtime_metrics.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/late_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/enum.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/abi.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/abi_specific.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/allocation.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/union.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/analyze_snapshot.cc
+FILE: ../../../third_party/dart/runtime/bin/platform_macos_cocoa.h
+FILE: ../../../third_party/dart/runtime/bin/platform_macos_cocoa.mm
+FILE: ../../../third_party/dart/runtime/bin/socket_base_posix.cc
+FILE: ../../../third_party/dart/runtime/bin/utils.cc
+FILE: ../../../third_party/dart/runtime/bin/virtual_memory.h
+FILE: ../../../third_party/dart/runtime/bin/virtual_memory_fuchsia.cc
+FILE: ../../../third_party/dart/runtime/bin/virtual_memory_posix.cc
+FILE: ../../../third_party/dart/runtime/bin/virtual_memory_win.cc
+FILE: ../../../third_party/dart/runtime/include/analyze_snapshot_api.h
+FILE: ../../../third_party/dart/runtime/vm/analyze_snapshot_api_impl.cc
+FILE: ../../../third_party/dart/runtime/vm/code_patcher_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/asm_intrinsifier_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_timings.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_timings.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/ffi/range.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/stub_code_compiler_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/cpu_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/cpu_riscv.h
+FILE: ../../../third_party/dart/runtime/vm/debugger_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/instructions_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/instructions_riscv.h
+FILE: ../../../third_party/dart/runtime/vm/message_snapshot.cc
+FILE: ../../../third_party/dart/runtime/vm/message_snapshot.h
+FILE: ../../../third_party/dart/runtime/vm/object_graph_copy.cc
+FILE: ../../../third_party/dart/runtime/vm/object_graph_copy.h
+FILE: ../../../third_party/dart/runtime/vm/pending_deopts.cc
+FILE: ../../../third_party/dart/runtime/vm/pending_deopts.h
+FILE: ../../../third_party/dart/runtime/vm/runtime_entry_riscv.cc
+FILE: ../../../third_party/dart/runtime/vm/stack_frame_riscv.h
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_android_arm.S
+FILE: ../../../third_party/dart/runtime/vm/virtual_memory_compressed.cc
+FILE: ../../../third_party/dart/runtime/vm/virtual_memory_compressed.h
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/dart2js_runtime_metrics.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/late_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/core/enum.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/abi.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/abi_specific.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/allocation.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/union.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/test_utils.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/test_utils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_absl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/bin/thread_absl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/lib/integers.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/mach_o.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/pe.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/bin/download.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/bin/explore.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/heapsnapshot.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/analysis.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/cli.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/completion.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/console.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/expression.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/format.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/intset.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/load.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_serializer.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/il_serializer.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/gc_shared.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/gc_shared.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/page.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/page.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/sampler.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/heap/sampler.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/instructions.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_absl.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/os_thread_absl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/simulator_x64.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/simulator_x64.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_http/http_testing.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_names.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/runtime_metrics.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/synced/load_library_priority.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_util_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/synced/embedded_names.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_finalizer_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/finalizer_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/hash_factories.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/vm/lib/record_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/bool.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/class_id.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/convert_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/core_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/deferred.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/developer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/double.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/errors_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/growable_list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/hash_factories.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/identical_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/int.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/internal_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/isolate_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_util_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/list.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/math_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/named_parameters.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/object_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/print_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/regexp_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/regexp_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/simd_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/stack_trace_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/stopwatch_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/symbol_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/timer_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/type.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/typed_data_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/uri_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_wasm/wasm_types.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/core/record.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/c_type.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/ffi/native_finalizer.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js/js_wasm.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js_util/js_util_wasm.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/test_utils.cc
+FILE: ../../../third_party/dart/runtime/bin/test_utils.h
+FILE: ../../../third_party/dart/runtime/bin/thread_absl.cc
+FILE: ../../../third_party/dart/runtime/bin/thread_absl.h
+FILE: ../../../third_party/dart/runtime/lib/integers.h
+FILE: ../../../third_party/dart/runtime/platform/mach_o.h
+FILE: ../../../third_party/dart/runtime/platform/pe.h
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/bin/download.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/bin/explore.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/heapsnapshot.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/analysis.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/cli.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/completion.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/console.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/expression.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/format.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/intset.dart
+FILE: ../../../third_party/dart/runtime/tools/heapsnapshot/lib/src/load.dart
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_serializer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_serializer.h
+FILE: ../../../third_party/dart/runtime/vm/heap/gc_shared.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/gc_shared.h
+FILE: ../../../third_party/dart/runtime/vm/heap/page.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/page.h
+FILE: ../../../third_party/dart/runtime/vm/heap/sampler.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/sampler.h
+FILE: ../../../third_party/dart/runtime/vm/instructions.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_absl.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread_absl.h
+FILE: ../../../third_party/dart/runtime/vm/simulator_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/simulator_x64.h
+FILE: ../../../third_party/dart/sdk/lib/_http/http_testing.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/js_names.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/runtime_metrics.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/synced/load_library_priority.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_util_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/synced/embedded_names.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_finalizer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/finalizer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/hash_factories.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/record_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/bool.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/class_id.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/convert_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/core_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/deferred.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/developer.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/double.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/errors_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/growable_list.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/hash_factories.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/identical_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/int.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/internal_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/isolate_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_util_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/list.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/math_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/named_parameters.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/object_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/print_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/regexp_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/regexp_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/simd_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/stack_trace_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/stopwatch_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/symbol_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/timer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/type.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/typed_data_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/uri_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_wasm/wasm_types.dart
+FILE: ../../../third_party/dart/sdk/lib/core/record.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/c_type.dart
+FILE: ../../../third_party/dart/sdk/lib/ffi/native_finalizer.dart
+FILE: ../../../third_party/dart/sdk/lib/js/js_wasm.dart
+FILE: ../../../third_party/dart/sdk/lib/js_util/js_util_wasm.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/main_impl.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/unwinding_records.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/unwinding_records.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/platform/unwinding_records_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/parallel_move_resolver.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/parallel_move_resolver.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/ffi/native_assets.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/ffi/native_assets.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/ffi_callback_metadata.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/ffi_callback_metadata.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/unwinding_records.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/unwinding_records.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/unwinding_records_win.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/js_allow_interop_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/records.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_allow_interop_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/records.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_interop_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_interop_unsafe_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_types.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/closure.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/date_patch_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_array.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_interop_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_interop_unsafe_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_string.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_typed_array.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_types.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/record_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_buffer_create.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_helper.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_stringref_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/sync_star_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/weak_patch.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/async/future_extensions.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js_interop/js_interop.dart + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/sdk/lib/js_interop_unsafe/js_interop_unsafe.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/main_impl.h
+FILE: ../../../third_party/dart/runtime/platform/unwinding_records.cc
+FILE: ../../../third_party/dart/runtime/platform/unwinding_records.h
+FILE: ../../../third_party/dart/runtime/platform/unwinding_records_win.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/parallel_move_resolver.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/parallel_move_resolver.h
+FILE: ../../../third_party/dart/runtime/vm/ffi/native_assets.cc
+FILE: ../../../third_party/dart/runtime/vm/ffi/native_assets.h
+FILE: ../../../third_party/dart/runtime/vm/ffi_callback_metadata.cc
+FILE: ../../../third_party/dart/runtime/vm/ffi_callback_metadata.h
+FILE: ../../../third_party/dart/runtime/vm/unwinding_records.cc
+FILE: ../../../third_party/dart/runtime/vm/unwinding_records.h
+FILE: ../../../third_party/dart/runtime/vm/unwinding_records_win.cc
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/patch/js_allow_interop_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/records.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_allow_interop_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/records.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_interop_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_interop_unsafe_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_types.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/closure.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/date_patch_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_array.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_interop_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_interop_unsafe_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_string.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_typed_array.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/js_types.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/record_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_buffer_create.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/string_stringref_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/sync_star_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/weak_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/async/future_extensions.dart
+FILE: ../../../third_party/dart/sdk/lib/js_interop/js_interop.dart
+FILE: ../../../third_party/dart/sdk/lib/js_interop_unsafe/js_interop_unsafe.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/vm/perfetto_utils.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/common/builtin_clock.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/clock_snapshot.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/interned_data/interned_data.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/profiling/profile_common.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/profiling/profile_packet.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/trace.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/trace_packet.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/debug_annotation.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/process_descriptor.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/thread_descriptor.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/track_descriptor.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/track_event.pbzero.h + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/protos/tools/compile_perfetto_protos.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/vm/perfetto_utils.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/common/builtin_clock.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/clock_snapshot.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/interned_data/interned_data.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/profiling/profile_common.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/profiling/profile_packet.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/trace.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/trace_packet.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/debug_annotation.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/process_descriptor.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/thread_descriptor.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/track_descriptor.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/perfetto/trace/track_event/track_event.pbzero.h
+FILE: ../../../third_party/dart/runtime/vm/protos/tools/compile_perfetto_protos.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: double-conversion
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/cached-powers.cc
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/cached-powers.cc
+----------------------------------------------------------------------------------------------------
+Copyright 2006-2008 the V8 project authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: double-conversion
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/bignum-dtoa.cc
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/bignum-dtoa.h
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/bignum.cc
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/bignum.h
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/cached-powers.h
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/diy-fp.cc
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/diy-fp.h
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/double-conversion.cc
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/fast-dtoa.h
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/fixed-dtoa.cc
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/fixed-dtoa.h
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/strtod.cc
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/strtod.h
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/utils.h
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/bignum-dtoa.cc
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/bignum-dtoa.h
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/bignum.cc
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/bignum.h
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/cached-powers.h
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/diy-fp.cc
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/diy-fp.h
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/double-conversion.cc
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/fast-dtoa.h
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/fixed-dtoa.cc
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/fixed-dtoa.h
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/strtod.cc
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/strtod.h
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/utils.h
+----------------------------------------------------------------------------------------------------
+Copyright 2010 the V8 project authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: double-conversion
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/double-conversion.h
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/fast-dtoa.cc
+ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/src/ieee.h
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/double-conversion.h
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/fast-dtoa.cc
+FILE: ../../../third_party/dart/runtime/third_party/double-conversion/src/ieee.h
+----------------------------------------------------------------------------------------------------
+Copyright 2012 the V8 project authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/observatory/lib/elements.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/img/chromium_icon.png
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/img/dart_icon.png
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/img/isolate_icon.png
+FILE: ../../../third_party/dart/runtime/observatory/web/favicon.ico
+FILE: ../../../third_party/dart/runtime/observatory/web/index.html
+FILE: ../../../third_party/dart/runtime/observatory/web/third_party/trace_viewer_full.html
+FILE: ../../../third_party/dart/runtime/observatory/web/timeline.html
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/elements.dart
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/img/chromium_icon.png
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/img/dart_icon.png
+FILE: ../../../third_party/dart/runtime/observatory_2/lib/src/elements/img/isolate_icon.png
+FILE: ../../../third_party/dart/runtime/observatory_2/web/favicon.ico
+FILE: ../../../third_party/dart/runtime/observatory_2/web/index.html
+FILE: ../../../third_party/dart/runtime/observatory_2/web/third_party/trace_viewer_full.html
+FILE: ../../../third_party/dart/runtime/observatory_2/web/timeline.html
+FILE: ../../../third_party/dart/runtime/tools/wiki/styles/style.scss
+FILE: ../../../third_party/dart/runtime/tools/wiki/templates/includes/auto-refresh.html
+FILE: ../../../third_party/dart/runtime/tools/wiki/templates/page.html
+FILE: ../../../third_party/dart/sdk.code-workspace
+FILE: ../../../third_party/dart/sdk/lib/_internal/wasm/lib/async_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/html/html_common/conversions_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/html/html_common/html_common.dart
+----------------------------------------------------------------------------------------------------
+Copyright 2012, the Dart project authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+Total license count: 24

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 70f28de8b1b5d020e6870e2da16913ee
+Signature: 146d867e969af92134525e494a501d48
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1451,7 +1451,11 @@ class _EngineSrcDirectory extends _RepositoryDirectory {
     // is therefore represented as a separate top-level component.
     final fs.Directory thirdPartyNode = findChildDirectory(ioDirectory, 'third_party')!;
     final fs.Directory skiaNode = findChildDirectory(thirdPartyNode, 'skia')!;
-    return <_RepositoryDirectory>[_RepositorySkiaDirectory(this, skiaNode)];
+    final fs.Directory dartNode = findChildDirectory(thirdPartyNode, 'dart')!;
+    return <_RepositoryDirectory>[
+      _RepositorySkiaDirectory(this, skiaNode),
+      _RepositorySkiaDirectory(this, dartNode),
+    ];
   }
 }
 
@@ -1468,6 +1472,7 @@ class _RepositoryRootThirdPartyDirectory extends _RepositoryGenericThirdPartyDir
   @override
   bool shouldRecurse(fs.IoNode entry) {
     return entry.name != 'skia' // handled as a virtual directory of the root
+        && entry.name != 'dart' // handled as a virtual directory of the root
         && super.shouldRecurse(entry);
   }
 


### PR DESCRIPTION
This will avoid conflicts between Dart rolls and rolls of other third party components such as ANGLE.
