### PR TITLE
[Impeller] Don't decompress into device buffer on Vulkan.

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -34,6 +34,7 @@ namespace flutter {
 
 namespace {
 
+#ifdef FML_OS_ANDROID
 class MallocDeviceBuffer : public impeller::DeviceBuffer {
  public:
   MallocDeviceBuffer(impeller::DeviceBufferDescriptor desc, uint8_t* data)
@@ -73,6 +74,7 @@ std::shared_ptr<MallocDeviceBuffer> CreateMallocDeviceBuffer(
   return std::make_shared<MallocDeviceBuffer>(
       desc, static_cast<uint8_t*>(malloc(desc.size)));
 }
+#endif  // FML_OS_ANDROID
 
 /**
  *  Loads the gamut as a set of three points (triangle).


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/129392

It seems that both allocation of the device buffers and the device private textures can compete with raster tasks. I've tried a few different approaches that haven't panned out.