### PR TITLE
[Impeller] Fix advanced CPU blend modes

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2098,7 +2098,7 @@ static Picture BlendModeTest(BlendMode blend_mode,
   ///
 
   canvas.Save();
-  for (auto& color : source_colors) {
+  for (const auto& color : source_colors) {
     canvas.Save();
     {
       canvas.ClipRect(Rect::MakeXYWH(50, 50, 100, 100));
@@ -2134,7 +2134,7 @@ static Picture BlendModeTest(BlendMode blend_mode,
   // fully transparent black. SourceOver blend the result onto the parent pass.
   canvas.SaveLayer({});
   // canvas.DrawPaint({.color = destination_color});
-  for (auto& color : source_colors) {
+  for (const auto& color : source_colors) {
     // Simply write the CPU blended color to the pass.
     canvas.DrawRect({50, 50, 100, 100},
                     {.color = destination_color.Blend(color, blend_mode),

--- a/impeller/geometry/color.h
+++ b/impeller/geometry/color.h
@@ -222,7 +222,7 @@ struct Color {
 
   /**
    * @brief Return a color that is linearly interpolated between colors a
-   * and b, according to the value of t.
+   *        and b, according to the value of t.
    *
    * @param a The lower color.
    * @param b The upper color.
@@ -230,9 +230,7 @@ struct Color {
    * @return constexpr Color
    */
   constexpr static Color Lerp(Color a, Color b, Scalar t) {
-    Scalar tt = 1.0f - t;
-    return {a.red * tt + b.red * t, a.green * tt + b.green * t,
-            a.blue * tt + b.blue * t, a.alpha * tt + b.alpha * t};
+    return a + (b - a) * t;
   }
 
   constexpr Color Clamp01() const {
@@ -853,7 +851,7 @@ struct Color {
   ///
   ///        If either the source or destination are premultiplied, the result
   ///        will be incorrect.
-  Color Blend(const Color& source, BlendMode blend_mode) const;
+  Color Blend(Color source, BlendMode blend_mode) const;
 
   /// @brief A color filter that transforms colors through a 4x5 color matrix.
   ///

--- a/impeller/geometry/vector.h
+++ b/impeller/geometry/vector.h
@@ -52,6 +52,10 @@ struct Vector3 {
     return ((x * other.x) + (y * other.y) + (z * other.z));
   }
 
+  constexpr Vector3 Abs() const {
+    return {std::fabs(x), std::fabs(y), std::fabs(z)};
+  }
+
   constexpr Vector3 Cross(const Vector3& other) const {
     return {
         (y * other.z) - (z * other.y),  //


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/128606.

All CPU blends now match the behavior of Impeller's GPU blends, which (after https://github.com/flutter/engine/pull/43283) closely matches Skia's blends! Now we can finally use these.

https://github.com/flutter/engine/assets/919017/f9dc7323-fd14-4cdc-ba8b-930622be4206