### PR TITLE
[Impeller] remove redundant highp modifiers in vertex shaders.

### DIFF
--- a/impeller/entity/shaders/blending/advanced_blend.vert
+++ b/impeller/entity/shaders/blending/advanced_blend.vert
@@ -12,12 +12,12 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 vertices;
-in highp vec2 dst_texture_coords;
-in highp vec2 src_texture_coords;
+in vec2 vertices;
+in vec2 dst_texture_coords;
+in vec2 src_texture_coords;
 
-out highp vec2 v_dst_texture_coords;
-out highp vec2 v_src_texture_coords;
+out vec2 v_dst_texture_coords;
+out vec2 v_src_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);

--- a/impeller/entity/shaders/blending/blend.vert
+++ b/impeller/entity/shaders/blending/blend.vert
@@ -11,10 +11,10 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 vertices;
-in highp vec2 texture_coords;
+in vec2 vertices;
+in vec2 texture_coords;
 
-out highp vec2 v_texture_coords;
+out vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);

--- a/impeller/entity/shaders/border_mask_blur.vert
+++ b/impeller/entity/shaders/border_mask_blur.vert
@@ -11,10 +11,10 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
-in highp vec2 texture_coords;
+in vec2 position;
+in vec2 texture_coords;
 
-out highp vec2 v_texture_coords;
+out vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/color_matrix_color_filter.vert
+++ b/impeller/entity/shaders/color_matrix_color_filter.vert
@@ -11,9 +11,9 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 
-out highp vec2 v_texture_coords;
+out vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur.vert
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur.vert
@@ -12,12 +12,12 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 vertices;
-in highp vec2 texture_coords;
-in highp vec2 src_texture_coords;
+in vec2 vertices;
+in vec2 texture_coords;
+in vec2 src_texture_coords;
 
-out highp vec2 v_texture_coords;
-out highp vec2 v_src_texture_coords;
+out vec2 v_texture_coords;
+out vec2 v_src_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);

--- a/impeller/entity/shaders/glyph_atlas.vert
+++ b/impeller/entity/shaders/glyph_atlas.vert
@@ -4,26 +4,24 @@
 
 #include <impeller/transform.glsl>
 
-precision highp float;
-
 uniform FrameInfo {
-  highp mat4 mvp;
-  highp mat4 entity_transform;
-  highp vec2 atlas_size;
-  highp vec2 offset;
+  mat4 mvp;
+  mat4 entity_transform;
+  vec2 atlas_size;
+  vec2 offset;
   float is_translation_scale;
 }
 frame_info;
 
 // XYWH.
-in highp vec4 atlas_glyph_bounds;
+in vec4 atlas_glyph_bounds;
 // XYWH
-in highp vec4 glyph_bounds;
+in vec4 glyph_bounds;
 
-in highp vec2 unit_position;
-in highp vec2 glyph_position;
+in vec2 unit_position;
+in vec2 glyph_position;
 
-out highp vec2 v_uv;
+out vec2 v_uv;
 
 mat4 basis(mat4 m) {
   return mat4(m[0][0], m[0][1], m[0][2], 0.0,  //

--- a/impeller/entity/shaders/gradient_fill.vert
+++ b/impeller/entity/shaders/gradient_fill.vert
@@ -11,9 +11,9 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 
-out highp vec2 v_position;
+out vec2 v_position;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/linear_to_srgb_filter.vert
+++ b/impeller/entity/shaders/linear_to_srgb_filter.vert
@@ -11,9 +11,9 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 
-out highp vec2 v_texture_coords;
+out vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/morphology_filter.vert
+++ b/impeller/entity/shaders/morphology_filter.vert
@@ -11,10 +11,10 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
-in highp vec2 texture_coords;
+in vec2 position;
+in vec2 texture_coords;
 
-out highp vec2 v_texture_coords;
+out vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/position_color.vert
+++ b/impeller/entity/shaders/position_color.vert
@@ -10,7 +10,7 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 in vec4 color;
 
 out vec4 v_color;

--- a/impeller/entity/shaders/rrect_blur.vert
+++ b/impeller/entity/shaders/rrect_blur.vert
@@ -9,9 +9,9 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 
-out highp vec2 v_position;
+out vec2 v_position;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/runtime_effect.vert
+++ b/impeller/entity/shaders/runtime_effect.vert
@@ -9,11 +9,11 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 // Note: The GLES backend uses name matching for attribute locations. This name
 // must match the name of the attribute input in:
 // impeller/compiler/shader_lib/flutter/runtime_effect.glsl
-out highp vec2 _fragCoord;
+out vec2 _fragCoord;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/solid_fill.vert
+++ b/impeller/entity/shaders/solid_fill.vert
@@ -9,7 +9,7 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/srgb_to_linear_filter.vert
+++ b/impeller/entity/shaders/srgb_to_linear_filter.vert
@@ -11,9 +11,9 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 
-out highp vec2 v_texture_coords;
+out vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/texture_fill.vert
+++ b/impeller/entity/shaders/texture_fill.vert
@@ -11,10 +11,10 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 in vec2 texture_coords;
 
-out highp vec2 v_texture_coords;
+out vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);

--- a/impeller/entity/shaders/yuv_to_rgb_filter.vert
+++ b/impeller/entity/shaders/yuv_to_rgb_filter.vert
@@ -11,9 +11,9 @@ uniform FrameInfo {
 }
 frame_info;
 
-in highp vec2 position;
+in vec2 position;
 
-out highp vec2 v_texture_coords;
+out vec2 v_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);


### PR DESCRIPTION
Since we've let all vertex shaders opt into highp by default I believe these are redundant (though lets wait for malioc diff to confirm).
