### PR TITLE
Handle null images in Metal Screenshot mechanism

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1390,6 +1390,7 @@ ORIGIN: ../../../flutter/impeller/golden_tests/golden_playground_test_mac.cc + .
 ORIGIN: ../../../flutter/impeller/golden_tests/golden_playground_test_stub.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests/golden_tests.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests/main.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshot_tests.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshot.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshot.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/golden_tests/metal_screenshoter.h + ../../../flutter/LICENSE
@@ -4069,6 +4070,7 @@ FILE: ../../../flutter/impeller/golden_tests/golden_playground_test_mac.cc
 FILE: ../../../flutter/impeller/golden_tests/golden_playground_test_stub.cc
 FILE: ../../../flutter/impeller/golden_tests/golden_tests.cc
 FILE: ../../../flutter/impeller/golden_tests/main.cc
+FILE: ../../../flutter/impeller/golden_tests/metal_screenshot_tests.cc
 FILE: ../../../flutter/impeller/golden_tests/metal_screenshot.h
 FILE: ../../../flutter/impeller/golden_tests/metal_screenshot.mm
 FILE: ../../../flutter/impeller/golden_tests/metal_screenshoter.h

--- a/impeller/golden_tests/BUILD.gn
+++ b/impeller/golden_tests/BUILD.gn
@@ -65,6 +65,7 @@ if (is_mac) {
     sources = [
       "golden_tests.cc",
       "main.cc",
+      "metal_screenshot_tests.cc",
     ]
 
     deps = [

--- a/impeller/golden_tests/metal_screenshot.h
+++ b/impeller/golden_tests/metal_screenshot.h
@@ -30,6 +30,8 @@ class MetalScreenshot {
 
  private:
   friend class MetalScreenshoter;
+  friend std::unique_ptr<MetalScreenshot> MetalScreenshotTestConstructor(
+      CGImageRef image);
   MetalScreenshot(CGImageRef cgImage);
   FML_DISALLOW_COPY_AND_ASSIGN(MetalScreenshot);
   CGImageRef cgImage_;

--- a/impeller/golden_tests/metal_screenshot.mm
+++ b/impeller/golden_tests/metal_screenshot.mm
@@ -13,37 +13,48 @@ MetalScreenshot::MetalScreenshot(CGImageRef cgImage) : cgImage_(cgImage) {
 }
 
 MetalScreenshot::~MetalScreenshot() {
-  CFRelease(pixel_data_);
+  if (pixel_data_) {
+    // CFRelease is documented to not accept a null pointer
+    CFRelease(pixel_data_);
+  }
+  // CGImageRelease is documented to accept a null pointer
   CGImageRelease(cgImage_);
 }
 
 const UInt8* MetalScreenshot::GetBytes() const {
-  return CFDataGetBytePtr(pixel_data_);
+  // CFDataGetBytePtr will crash on a null pointer
+  return pixel_data_ ? CFDataGetBytePtr(pixel_data_) : nullptr;
 }
 
 size_t MetalScreenshot::GetHeight() const {
-  return CGImageGetHeight(cgImage_);
+  // CGImageGetHeight actually returns 0 for a null image,
+  // but that is not documented
+  return cgImage_ ? CGImageGetHeight(cgImage_) : 0;
 }
 
 size_t MetalScreenshot::GetWidth() const {
-  return CGImageGetWidth(cgImage_);
+  // CGImageGetWidth actually returns 0 for a null image,
+  // but that is not documented
+  return cgImage_ ? CGImageGetWidth(cgImage_) : 0;
 }
 
 bool MetalScreenshot::WriteToPNG(const std::string& path) const {
   bool result = false;
-  NSURL* output_url =
-      [NSURL fileURLWithPath:[NSString stringWithUTF8String:path.c_str()]];
-  CGImageDestinationRef destination = CGImageDestinationCreateWithURL(
-      (__bridge CFURLRef)output_url, kUTTypePNG, 1, nullptr);
-  if (destination != nullptr) {
-    CGImageDestinationAddImage(destination, cgImage_,
-                               (__bridge CFDictionaryRef) @{});
+  if (cgImage_) {
+    NSURL* output_url =
+        [NSURL fileURLWithPath:[NSString stringWithUTF8String:path.c_str()]];
+    CGImageDestinationRef destination = CGImageDestinationCreateWithURL(
+        (__bridge CFURLRef)output_url, kUTTypePNG, 1, nullptr);
+    if (destination != nullptr) {
+      CGImageDestinationAddImage(destination, cgImage_,
+                                 (__bridge CFDictionaryRef) @{});
 
-    if (CGImageDestinationFinalize(destination)) {
-      result = true;
+      if (CGImageDestinationFinalize(destination)) {
+        result = true;
+      }
+
+      CFRelease(destination);
     }
-
-    CFRelease(destination);
   }
   return result;
 }

--- a/impeller/golden_tests/metal_screenshot_tests.cc
+++ b/impeller/golden_tests/metal_screenshot_tests.cc
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include "impeller/golden_tests/metal_screenshot.h"
+
+namespace impeller {
+namespace testing {
+
+std::unique_ptr<MetalScreenshot> MetalScreenshotTestConstructor(
+    CGImageRef image) {
+  return std::unique_ptr<MetalScreenshot>(new MetalScreenshot(image));
+};
+
+TEST(MetalScreenshotTests, NullScreenshot) {
+  auto shot = MetalScreenshotTestConstructor(nullptr);
+  ASSERT_EQ(shot->GetBytes(), nullptr);
+  ASSERT_EQ(shot->GetWidth(), 0u);
+  ASSERT_EQ(shot->GetHeight(), 0u);
+  ASSERT_EQ(shot->WriteToPNG("foo"), false);
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/golden_tests/metal_screenshoter.mm
+++ b/impeller/golden_tests/metal_screenshoter.mm
@@ -51,6 +51,9 @@ std::unique_ptr<MetalScreenshot> MetalScreenshoter::MakeScreenshot(
 
   CGImageRef cgImage = [cicontext createCGImage:flipped
                                        fromRect:[ciImage extent]];
+  if (!cgImage) {
+    return {};
+  }
 
   return std::unique_ptr<MetalScreenshot>(new MetalScreenshot(cgImage));
 }


### PR DESCRIPTION
Recent resource leaks discovered in the way Metal generates its screenshots resulted in null pointers being returned from various methods and then objects would try to either release those null pointers or dereference them. While this PR doesn't address any test code that might get a null screenshot from the mechanism (which shouldn't happen in practice unless a test fails), at least it fixes internal cases where we might have null pointers and try to access or release them within the mechanism itself.