### PR TITLE
Prepare for utf8.encode() to return more precise Uint8List type

### DIFF
--- a/lib/web_ui/test/canvaskit/fragment_program_test.dart
+++ b/lib/web_ui/test/canvaskit/fragment_program_test.dart
@@ -186,7 +186,7 @@ void testMain() {
   });
 
   test('FragmentProgram can be created from JSON IPLR bundle', () {
-    final Uint8List data = utf8.encode(kJsonIPLR) as Uint8List;
+    final Uint8List data = const Utf8Encoder().convert(kJsonIPLR);
     final CkFragmentProgram program = CkFragmentProgram.fromBytes('test', data);
 
     expect(program.effect, isNotNull);

--- a/lib/web_ui/test/engine/channel_buffers_test.dart
+++ b/lib/web_ui/test/engine/channel_buffers_test.dart
@@ -23,7 +23,7 @@ void main() {
 }
 
 ByteData _makeByteData(String str) {
-  final Uint8List list = utf8.encode(str) as Uint8List;
+  final Uint8List list = const Utf8Encoder().convert(str);
   final ByteBuffer buffer = list.buffer;
   return ByteData.view(buffer);
 }

--- a/testing/dart/channel_buffers_test.dart
+++ b/testing/dart/channel_buffers_test.dart
@@ -12,7 +12,7 @@ import 'dart:ui' as ui;
 import 'package:litetest/litetest.dart';
 
 ByteData _makeByteData(String str) {
-  final Uint8List list = utf8.encode(str) as Uint8List;
+  final Uint8List list = const Utf8Encoder().convert(str);
   final ByteBuffer buffer = list.buffer;
   return ByteData.view(buffer);
 }


### PR DESCRIPTION
To avoid analyzer warnings when utf8.encode() will return the more precise Uint8List type, we use const Utf8Encoder().convert() which already returns Uint8List

See https://github.com/dart-lang/sdk/issues/52801