### PR TITLE
[Impeller] Check for lazy memory support.

### DIFF
--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -76,6 +76,7 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
             .SetSupportsReadFromResolve(false)
             .SetSupportsReadFromOnscreenTexture(false)
             .SetSupportsDecalTileMode(false)
+            .SetSupportsMemorylessTextures(false)
             .Build();
   }
 

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -64,6 +64,7 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetSupportsComputeSubgroups(DeviceSupportsComputeSubgroups(device))
       .SetSupportsReadFromResolve(true)
       .SetSupportsReadFromOnscreenTexture(true)
+      .SetSupportsMemorylessTextures(true)
       .Build();
 }
 

--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -112,9 +112,11 @@ ISize AllocatorVK::GetMaxTextureSizeSupported() const {
   return max_texture_size_;
 }
 
-static constexpr vk::ImageUsageFlags ToVKImageUsageFlags(PixelFormat format,
-                                                         TextureUsageMask usage,
-                                                         StorageMode mode) {
+static constexpr vk::ImageUsageFlags ToVKImageUsageFlags(
+    PixelFormat format,
+    TextureUsageMask usage,
+    StorageMode mode,
+    bool supports_memoryless_textures) {
   vk::ImageUsageFlags vk_usage;
 
   switch (mode) {
@@ -122,7 +124,9 @@ static constexpr vk::ImageUsageFlags ToVKImageUsageFlags(PixelFormat format,
     case StorageMode::kDevicePrivate:
       break;
     case StorageMode::kDeviceTransient:
-      vk_usage |= vk::ImageUsageFlagBits::eTransientAttachment;
+      if (supports_memoryless_textures) {
+        vk_usage |= vk::ImageUsageFlagBits::eTransientAttachment;
+      }
       break;
   }
 
@@ -245,7 +249,8 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
     image_info.tiling = vk::ImageTiling::eOptimal;
     image_info.initialLayout = vk::ImageLayout::eUndefined;
     image_info.usage =
-        ToVKImageUsageFlags(desc.format, desc.usage, desc.storage_mode);
+        ToVKImageUsageFlags(desc.format, desc.usage, desc.storage_mode,
+                            supports_memoryless_textures);
     image_info.sharingMode = vk::SharingMode::eExclusive;
 
     VmaAllocationCreateInfo alloc_nfo = {};

--- a/impeller/renderer/backend/vulkan/allocator_vk.h
+++ b/impeller/renderer/backend/vulkan/allocator_vk.h
@@ -31,6 +31,7 @@ class AllocatorVK final : public Allocator {
   std::weak_ptr<DeviceHolder> device_holder_;
   ISize max_texture_size_;
   bool is_valid_ = false;
+  bool supports_lazy_memory_ = false;
 
   AllocatorVK(std::weak_ptr<Context> context,
               uint32_t vulkan_api_version,
@@ -53,6 +54,8 @@ class AllocatorVK final : public Allocator {
 
   // |Allocator|
   ISize GetMaxTextureSizeSupported() const override;
+
+  void CheckForMemoryTypeSupport();
 
   FML_DISALLOW_COPY_AND_ASSIGN(AllocatorVK);
 };

--- a/impeller/renderer/backend/vulkan/allocator_vk.h
+++ b/impeller/renderer/backend/vulkan/allocator_vk.h
@@ -31,7 +31,7 @@ class AllocatorVK final : public Allocator {
   std::weak_ptr<DeviceHolder> device_holder_;
   ISize max_texture_size_;
   bool is_valid_ = false;
-  bool supports_lazy_memory_ = false;
+  bool supports_memoryless_textures_ = false;
 
   AllocatorVK(std::weak_ptr<Context> context,
               uint32_t vulkan_api_version,
@@ -39,7 +39,8 @@ class AllocatorVK final : public Allocator {
               const std::shared_ptr<DeviceHolder>& device_holder,
               const vk::Instance& instance,
               PFN_vkGetInstanceProcAddr get_instance_proc_address,
-              PFN_vkGetDeviceProcAddr get_device_proc_address);
+              PFN_vkGetDeviceProcAddr get_device_proc_address,
+              const CapabilitiesVK& capabilities);
 
   // |Allocator|
   bool IsValid() const;
@@ -54,8 +55,6 @@ class AllocatorVK final : public Allocator {
 
   // |Allocator|
   ISize GetMaxTextureSizeSupported() const override;
-
-  void CheckForMemoryTypeSupport();
 
   FML_DISALLOW_COPY_AND_ASSIGN(AllocatorVK);
 };

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -348,6 +348,21 @@ bool CapabilitiesVK::SetPhysicalDevice(const vk::PhysicalDevice& device) {
              .supportedOperations &
          vk::SubgroupFeatureFlagBits::eArithmetic);
 
+  {
+    // Query texture support.
+    // TODO(jonahwilliams):
+    // https://github.com/flutter/flutter/issues/129784
+    vk::PhysicalDeviceMemoryProperties memory_properties;
+    device.getMemoryProperties(&memory_properties);
+
+    for (auto i = 0u; i < memory_properties.memoryTypeCount; i++) {
+      if (memory_properties.memoryTypes[i].propertyFlags &
+          vk::MemoryPropertyFlagBits::eLazilyAllocated) {
+        supports_memoryless_textures_ = true;
+      }
+    }
+  }
+
   // Determine the optional device extensions this physical device supports.
   {
     optional_device_extensions_.clear();
@@ -420,6 +435,11 @@ bool CapabilitiesVK::SupportsReadFromOnscreenTexture() const {
 
 bool CapabilitiesVK::SupportsDecalTileMode() const {
   return true;
+}
+
+// |Capabilities|
+bool CapabilitiesVK::SupportsMemorylessTextures() const {
+  return supports_memoryless_textures_;
 }
 
 // |Capabilities|

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -91,6 +91,9 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsDecalTileMode() const override;
 
   // |Capabilities|
+  bool SupportsMemorylessTextures() const override;
+
+  // |Capabilities|
   PixelFormat GetDefaultColorFormat() const override;
 
   // |Capabilities|
@@ -104,6 +107,7 @@ class CapabilitiesVK final : public Capabilities,
   PixelFormat depth_stencil_format_ = PixelFormat::kUnknown;
   vk::PhysicalDeviceProperties device_properties_;
   bool supports_compute_subgroups_ = false;
+  bool supports_memoryless_textures_ = false;
   bool is_valid_ = false;
 
   bool HasExtension(const std::string& ext) const;

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -332,7 +332,8 @@ void ContextVK::Setup(Settings settings) {
       device_holder,                     //
       device_holder->instance.get(),     //
       dispatcher.vkGetInstanceProcAddr,  //
-      dispatcher.vkGetDeviceProcAddr     //
+      dispatcher.vkGetDeviceProcAddr,    //
+      *caps                              //
       ));
 
   if (!allocator->IsValid()) {

--- a/impeller/renderer/capabilities.cc
+++ b/impeller/renderer/capabilities.cc
@@ -76,6 +76,10 @@ class StandardCapabilities final : public Capabilities {
     return default_stencil_format_;
   }
 
+  bool SupportsMemorylessTextures() const override {
+    return supports_memoryless_textures_;
+  }
+
  private:
   StandardCapabilities(bool has_threading_restrictions,
                        bool supports_offscreen_msaa,
@@ -88,6 +92,7 @@ class StandardCapabilities final : public Capabilities {
                        bool supports_read_from_onscreen_texture,
                        bool supports_read_from_resolve,
                        bool supports_decal_tile_mode,
+                       bool supports_memoryless_textures,
                        PixelFormat default_color_format,
                        PixelFormat default_stencil_format)
       : has_threading_restrictions_(has_threading_restrictions),
@@ -102,6 +107,7 @@ class StandardCapabilities final : public Capabilities {
             supports_read_from_onscreen_texture),
         supports_read_from_resolve_(supports_read_from_resolve),
         supports_decal_tile_mode_(supports_decal_tile_mode),
+        supports_memoryless_textures_(supports_memoryless_textures),
         default_color_format_(default_color_format),
         default_stencil_format_(default_stencil_format) {}
 
@@ -118,6 +124,7 @@ class StandardCapabilities final : public Capabilities {
   bool supports_read_from_onscreen_texture_ = false;
   bool supports_read_from_resolve_ = false;
   bool supports_decal_tile_mode_ = false;
+  bool supports_memoryless_textures_ = false;
   PixelFormat default_color_format_ = PixelFormat::kUnknown;
   PixelFormat default_stencil_format_ = PixelFormat::kUnknown;
 
@@ -202,6 +209,12 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsDecalTileMode(bool value) {
   return *this;
 }
 
+CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsMemorylessTextures(
+    bool value) {
+  supports_memoryless_textures_ = value;
+  return *this;
+}
+
 std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
   return std::unique_ptr<StandardCapabilities>(new StandardCapabilities(  //
       has_threading_restrictions_,                                        //
@@ -215,6 +228,7 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       supports_read_from_onscreen_texture_,                               //
       supports_read_from_resolve_,                                        //
       supports_decal_tile_mode_,                                          //
+      supports_memoryless_textures_,                                      //
       default_color_format_.value_or(PixelFormat::kUnknown),              //
       default_stencil_format_.value_or(PixelFormat::kUnknown)             //
       ));

--- a/impeller/renderer/capabilities.h
+++ b/impeller/renderer/capabilities.h
@@ -37,6 +37,8 @@ class Capabilities {
 
   virtual bool SupportsDecalTileMode() const = 0;
 
+  virtual bool SupportsMemorylessTextures() const = 0;
+
   virtual PixelFormat GetDefaultColorFormat() const = 0;
 
   virtual PixelFormat GetDefaultStencilFormat() const = 0;
@@ -79,6 +81,8 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetSupportsDecalTileMode(bool value);
 
+  CapabilitiesBuilder& SetSupportsMemorylessTextures(bool value);
+
   std::unique_ptr<Capabilities> Build();
 
  private:
@@ -93,6 +97,7 @@ class CapabilitiesBuilder {
   bool supports_read_from_onscreen_texture_ = false;
   bool supports_read_from_resolve_ = false;
   bool supports_decal_tile_mode_ = false;
+  bool supports_memoryless_textures_ = false;
   std::optional<PixelFormat> default_color_format_ = std::nullopt;
   std::optional<PixelFormat> default_stencil_format_ = std::nullopt;
 

--- a/impeller/renderer/capabilities_unittests.cc
+++ b/impeller/renderer/capabilities_unittests.cc
@@ -30,7 +30,6 @@ CAPABILITY_TEST(SupportsReadFromOnscreenTexture, false);
 CAPABILITY_TEST(SupportsReadFromResolve, false);
 CAPABILITY_TEST(SupportsDecalTileMode, false);
 CAPABILITY_TEST(SupportsMemorylessTextures, false);
-CAPABILITY_TEST(SupportsHostVisibleTextures, false);
 
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/renderer/capabilities_unittests.cc
+++ b/impeller/renderer/capabilities_unittests.cc
@@ -29,6 +29,8 @@ CAPABILITY_TEST(SupportsComputeSubgroups, false);
 CAPABILITY_TEST(SupportsReadFromOnscreenTexture, false);
 CAPABILITY_TEST(SupportsReadFromResolve, false);
 CAPABILITY_TEST(SupportsDecalTileMode, false);
+CAPABILITY_TEST(SupportsMemorylessTextures, false);
+CAPABILITY_TEST(SupportsHostVisibleTextures, false);
 
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/scene/scene_context.cc
+++ b/impeller/scene/scene_context.cc
@@ -39,33 +39,33 @@ SceneContext::SceneContext(std::shared_ptr<Context> context)
     return;
   }
 
-  pipelines_[{PipelineKey{GeometryType::kUnskinned, MaterialType::kUnlit}}] =
-      MakePipelineVariants<UnskinnedVertexShader, UnlitFragmentShader>(
-          *context_);
-  pipelines_[{PipelineKey{GeometryType::kSkinned, MaterialType::kUnlit}}] =
-      MakePipelineVariants<SkinnedVertexShader, UnlitFragmentShader>(*context_);
+  // pipelines_[{PipelineKey{GeometryType::kUnskinned, MaterialType::kUnlit}}] =
+  //     MakePipelineVariants<UnskinnedVertexShader, UnlitFragmentShader>(
+  //         *context_);
+  // pipelines_[{PipelineKey{GeometryType::kSkinned, MaterialType::kUnlit}}] =
+  //     MakePipelineVariants<SkinnedVertexShader, UnlitFragmentShader>(*context_);
 
-  {
-    impeller::TextureDescriptor texture_descriptor;
-    texture_descriptor.storage_mode = impeller::StorageMode::kHostVisible;
-    texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
-    texture_descriptor.size = {1, 1};
-    texture_descriptor.mip_count = 1u;
+  // {
+  //   impeller::TextureDescriptor texture_descriptor;
+  //   texture_descriptor.storage_mode = impeller::StorageMode::kHostVisible;
+  //   texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
+  //   texture_descriptor.size = {1, 1};
+  //   texture_descriptor.mip_count = 1u;
 
-    placeholder_texture_ =
-        context_->GetResourceAllocator()->CreateTexture(texture_descriptor);
-    placeholder_texture_->SetLabel("Placeholder Texture");
-    if (!placeholder_texture_) {
-      FML_LOG(ERROR) << "Could not create placeholder texture.";
-      return;
-    }
+  //   placeholder_texture_ =
+  //       context_->GetResourceAllocator()->CreateTexture(texture_descriptor);
+  //   placeholder_texture_->SetLabel("Placeholder Texture");
+  //   if (!placeholder_texture_) {
+  //     FML_LOG(ERROR) << "Could not create placeholder texture.";
+  //     return;
+  //   }
 
-    uint8_t pixel[] = {0xFF, 0xFF, 0xFF, 0xFF};
-    if (!placeholder_texture_->SetContents(pixel, 4)) {
-      FML_LOG(ERROR) << "Could not set contents of placeholder texture.";
-      return;
-    }
-  }
+  //   uint8_t pixel[] = {0xFF, 0xFF, 0xFF, 0xFF};
+  //   if (!placeholder_texture_->SetContents(pixel, 4)) {
+  //     FML_LOG(ERROR) << "Could not set contents of placeholder texture.";
+  //     return;
+  //   }
+  // }
 
   is_valid_ = true;
 }

--- a/impeller/scene/scene_context.cc
+++ b/impeller/scene/scene_context.cc
@@ -39,33 +39,33 @@ SceneContext::SceneContext(std::shared_ptr<Context> context)
     return;
   }
 
-  // pipelines_[{PipelineKey{GeometryType::kUnskinned, MaterialType::kUnlit}}] =
-  //     MakePipelineVariants<UnskinnedVertexShader, UnlitFragmentShader>(
-  //         *context_);
-  // pipelines_[{PipelineKey{GeometryType::kSkinned, MaterialType::kUnlit}}] =
-  //     MakePipelineVariants<SkinnedVertexShader, UnlitFragmentShader>(*context_);
+  pipelines_[{PipelineKey{GeometryType::kUnskinned, MaterialType::kUnlit}}] =
+      MakePipelineVariants<UnskinnedVertexShader, UnlitFragmentShader>(
+          *context_);
+  pipelines_[{PipelineKey{GeometryType::kSkinned, MaterialType::kUnlit}}] =
+      MakePipelineVariants<SkinnedVertexShader, UnlitFragmentShader>(*context_);
 
-  // {
-  //   impeller::TextureDescriptor texture_descriptor;
-  //   texture_descriptor.storage_mode = impeller::StorageMode::kHostVisible;
-  //   texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
-  //   texture_descriptor.size = {1, 1};
-  //   texture_descriptor.mip_count = 1u;
+  {
+    impeller::TextureDescriptor texture_descriptor;
+    texture_descriptor.storage_mode = impeller::StorageMode::kHostVisible;
+    texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
+    texture_descriptor.size = {1, 1};
+    texture_descriptor.mip_count = 1u;
 
-  //   placeholder_texture_ =
-  //       context_->GetResourceAllocator()->CreateTexture(texture_descriptor);
-  //   placeholder_texture_->SetLabel("Placeholder Texture");
-  //   if (!placeholder_texture_) {
-  //     FML_LOG(ERROR) << "Could not create placeholder texture.";
-  //     return;
-  //   }
+    placeholder_texture_ =
+        context_->GetResourceAllocator()->CreateTexture(texture_descriptor);
+    placeholder_texture_->SetLabel("Placeholder Texture");
+    if (!placeholder_texture_) {
+      FML_LOG(ERROR) << "Could not create placeholder texture.";
+      return;
+    }
 
-  //   uint8_t pixel[] = {0xFF, 0xFF, 0xFF, 0xFF};
-  //   if (!placeholder_texture_->SetContents(pixel, 4)) {
-  //     FML_LOG(ERROR) << "Could not set contents of placeholder texture.";
-  //     return;
-  //   }
-  // }
+    uint8_t pixel[] = {0xFF, 0xFF, 0xFF, 0xFF};
+    if (!placeholder_texture_->SetContents(pixel, 4)) {
+      FML_LOG(ERROR) << "Could not set contents of placeholder texture.";
+      return;
+    }
+  }
 
   is_valid_ = true;
 }


### PR DESCRIPTION
Some Android devices do not support the memory type eLazilyAllocated, which we use for MSAA and stencil textures. These textures were falling back to device local in dedicated allocations, which are expensive to both allocate and free. The dedicated allocation is implied by asking for eLazilyAllocated

Instead, perform a check for support for this memory type. Never request dedicated allocations (at least not until we have a compelling use case)


This should fix https://github.com/flutter/flutter/issues/129737

https://github.com/flutter/flutter/issues/129784
