### PR TITLE
[Impeller] Remove all double empties

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1944,7 +1944,7 @@ TEST_P(AiksTest, PaintWithFilters) {
 
   ASSERT_TRUE(paint.HasColorFilter());
 
-  paint.color_filter = std::nullopt;
+  paint.color_filter = nullptr;
 
   ASSERT_FALSE(paint.HasColorFilter());
 }
@@ -1963,7 +1963,7 @@ TEST_P(AiksTest, OpacityPeepHoleApplicationTest) {
   auto delegate = std::make_shared<OpacityPeepholePassDelegate>(paint, rect);
   ASSERT_FALSE(delegate->CanCollapseIntoParentPass(entity_pass.get()));
 
-  paint.color_filter = std::nullopt;
+  paint.color_filter = nullptr;
   paint.image_filter = [](const FilterInput::Ref& input,
                           const Matrix& effect_transform, bool is_subpass) {
     return FilterContents::MakeGaussianBlur(
@@ -1975,7 +1975,7 @@ TEST_P(AiksTest, OpacityPeepHoleApplicationTest) {
   delegate = std::make_shared<OpacityPeepholePassDelegate>(paint, rect);
   ASSERT_FALSE(delegate->CanCollapseIntoParentPass(entity_pass.get()));
 
-  paint.image_filter = std::nullopt;
+  paint.image_filter = nullptr;
   paint.color = Color::Red();
 
   // Paint has no alpha, can't elide;

--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -74,9 +74,9 @@ std::shared_ptr<Contents> Paint::WithImageFilter(
     std::shared_ptr<Contents> input,
     const Matrix& effect_transform,
     bool is_subpass) const {
-  if (image_filter.has_value()) {
-    const ImageFilterProc& filter = image_filter.value();
-    input = filter(FilterInput::Make(input), effect_transform, is_subpass);
+  if (image_filter) {
+    input =
+        image_filter(FilterInput::Make(input), effect_transform, is_subpass);
   }
   return input;
 }
@@ -89,9 +89,8 @@ std::shared_ptr<Contents> Paint::WithColorFilter(
   if (color_source.GetType() == ColorSource::Type::kImage) {
     return input;
   }
-  if (color_filter.has_value()) {
-    const ColorFilterProc& filter = color_filter.value();
-    auto color_filter_contents = filter(FilterInput::Make(input));
+  if (color_filter) {
+    auto color_filter_contents = color_filter(FilterInput::Make(input));
     if (color_filter_contents) {
       color_filter_contents->SetAbsorbOpacity(absorb_opacity);
     }
@@ -166,7 +165,7 @@ std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
 }
 
 bool Paint::HasColorFilter() const {
-  return color_filter.has_value();
+  return !!color_filter;
 }
 
 }  // namespace impeller

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -61,8 +61,8 @@ struct Paint {
   BlendMode blend_mode = BlendMode::kSourceOver;
   bool invert_colors = false;
 
-  std::optional<ImageFilterProc> image_filter;
-  std::optional<ColorFilterProc> color_filter;
+  ImageFilterProc image_filter = nullptr;
+  ColorFilterProc color_filter = nullptr;
   std::optional<MaskBlurDescriptor> mask_blur_descriptor;
 
   /// @brief      Wrap this paint's configured filters to the given contents.

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -80,7 +80,7 @@ bool OpacityPeepholePassDelegate::CanCollapseIntoParentPass(
   // OpacityPeepholePassDelegate will only get used if the pass's blend mode is
   // SourceOver, so no need to check here.
   if (paint_.color.alpha <= 0.0 || paint_.color.alpha >= 1.0 ||
-      paint_.image_filter.has_value() || paint_.color_filter.has_value()) {
+      paint_.image_filter || paint_.color_filter) {
     return false;
   }
 

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -389,11 +389,10 @@ bool AtlasColorContents::Render(const ContentContext& renderer,
   std::vector<Rect> texture_coords;
   std::vector<Matrix> transforms;
   std::vector<Color> colors;
-  if (subatlas_.has_value()) {
-    auto subatlas = subatlas_.value();
-    texture_coords = subatlas->sub_texture_coords;
-    colors = subatlas->sub_colors;
-    transforms = subatlas->sub_transforms;
+  if (subatlas_) {
+    texture_coords = subatlas_->sub_texture_coords;
+    colors = subatlas_->sub_colors;
+    transforms = subatlas_->sub_transforms;
   } else {
     texture_coords = parent_.GetTextureCoordinates();
     transforms = parent_.GetTransforms();

--- a/impeller/entity/contents/atlas_contents.h
+++ b/impeller/entity/contents/atlas_contents.h
@@ -149,7 +149,7 @@ class AtlasColorContents final : public Contents {
   const AtlasContents& parent_;
   Scalar alpha_ = 1.0;
   Rect coverage_;
-  std::optional<std::shared_ptr<SubAtlasResult>> subatlas_ = std::nullopt;
+  std::shared_ptr<SubAtlasResult> subatlas_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AtlasColorContents);
 };

--- a/impeller/entity/contents/tiled_texture_contents.h
+++ b/impeller/entity/contents/tiled_texture_contents.h
@@ -51,7 +51,7 @@ class TiledTextureContents final : public ColorSourceContents {
   ///
   /// This may not be a performance improvement if the image is tiled into a
   /// much smaller size that its original texture size.
-  void SetColorFilter(std::optional<ColorFilterProc> color_filter);
+  void SetColorFilter(ColorFilterProc color_filter);
 
   // |Contents|
   std::optional<Snapshot> RenderToSnapshot(
@@ -63,7 +63,7 @@ class TiledTextureContents final : public ColorSourceContents {
       const std::string& label = "Tiled Texture Snapshot") const override;
 
  private:
-  std::optional<std::shared_ptr<Texture>> CreateFilterTexture(
+  std::shared_ptr<Texture> CreateFilterTexture(
       const ContentContext& renderer) const;
 
   SamplerDescriptor CreateDescriptor(const Capabilities& capabilities) const;
@@ -74,7 +74,7 @@ class TiledTextureContents final : public ColorSourceContents {
   SamplerDescriptor sampler_descriptor_ = {};
   Entity::TileMode x_tile_mode_ = Entity::TileMode::kClamp;
   Entity::TileMode y_tile_mode_ = Entity::TileMode::kClamp;
-  std::optional<ColorFilterProc> color_filter_;
+  ColorFilterProc color_filter_ = nullptr;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TiledTextureContents);
 };

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -208,10 +208,10 @@ DecompressResult ImageDecoderImpeller::DecompressTexture(
 
   if (bitmap->dimensions() == target_size) {
     auto buffer = bitmap_allocator->GetDeviceBuffer();
-    if (!buffer.has_value()) {
+    if (!buffer) {
       return DecompressResult{.decode_error = "Unable to get device buffer"};
     }
-    return DecompressResult{.device_buffer = buffer.value(),
+    return DecompressResult{.device_buffer = buffer,
                             .sk_bitmap = bitmap,
                             .image_info = bitmap->info()};
   }
@@ -240,10 +240,10 @@ DecompressResult ImageDecoderImpeller::DecompressTexture(
   scaled_bitmap->setImmutable();
 
   auto buffer = scaled_allocator->GetDeviceBuffer();
-  if (!buffer.has_value()) {
+  if (!buffer) {
     return DecompressResult{.decode_error = "Unable to get device buffer"};
   }
-  return DecompressResult{.device_buffer = buffer.value(),
+  return DecompressResult{.device_buffer = buffer,
                           .sk_bitmap = scaled_bitmap,
                           .image_info = scaled_bitmap->info()};
 }
@@ -508,10 +508,10 @@ ImpellerAllocator::ImpellerAllocator(
     std::shared_ptr<impeller::Allocator> allocator)
     : allocator_(std::move(allocator)) {}
 
-std::optional<std::shared_ptr<impeller::DeviceBuffer>>
-ImpellerAllocator::GetDeviceBuffer() const {
-  if (buffer_.has_value()) {
-    buffer_.value()->Flush();
+std::shared_ptr<impeller::DeviceBuffer> ImpellerAllocator::GetDeviceBuffer()
+    const {
+  if (buffer_) {
+    buffer_->Flush();
   }
   return buffer_;
 }

--- a/lib/ui/painting/image_decoder_impeller.h
+++ b/lib/ui/painting/image_decoder_impeller.h
@@ -29,12 +29,11 @@ class ImpellerAllocator : public SkBitmap::Allocator {
   // |Allocator|
   bool allocPixelRef(SkBitmap* bitmap) override;
 
-  std::optional<std::shared_ptr<impeller::DeviceBuffer>> GetDeviceBuffer()
-      const;
+  std::shared_ptr<impeller::DeviceBuffer> GetDeviceBuffer() const;
 
  private:
   std::shared_ptr<impeller::Allocator> allocator_;
-  std::optional<std::shared_ptr<impeller::DeviceBuffer>> buffer_;
+  std::shared_ptr<impeller::DeviceBuffer> buffer_;
 };
 
 struct DecompressResult {


### PR DESCRIPTION
Unwrap optionals that already have an empty state that must be checked, like `std::optional<std::shared_ptr<T>>` and `std::optional<std::function<T>>`.