### PR TITLE
[web] Remove image codecs from CanvasKit Chromium (again)

### DIFF
--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -5,6 +5,7 @@
 import 'package:meta/meta.dart';
 
 import 'dom.dart';
+import 'safe_browser_api.dart';
 
 // iOS 15 launched WebGL 2.0, but there's something broken about it, which
 // leads to apps failing to load. For now, we're forcing WebGL 1 on iOS.
@@ -269,4 +270,4 @@ int _detectWebGLVersion() {
 
 /// Whether the current browser supports the Chromium variant of CanvasKit.
 bool get browserSupportsCanvaskitChromium =>
-    domIntl.v8BreakIterator != null && domIntl.Segmenter != null;
+    domIntl.v8BreakIterator != null && domIntl.Segmenter != null && browserSupportsImageDecoder;

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -82,8 +82,8 @@ extension CanvasKitExtension on CanvasKit {
   SkAnimatedImage? MakeAnimatedImageFromEncoded(Uint8List imageData) {
     assert(
       !isChromiumVariant,
-      'This constructor should only be used with a non-Chromium build of '
-      'CanvasKit.',
+      'CanvasKit.MakeAnimatedImageFromEncoded cannot be used with the Chromium '
+      'build of CanvasKit.',
     );
     return  _MakeAnimatedImageFromEncoded(imageData.toJS);
   }

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -27,6 +27,9 @@ import 'renderer.dart';
 /// Entrypoint into the CanvasKit API.
 late CanvasKit canvasKit;
 
+/// Whether the [canvasKit] being used is a Chromium variant.
+final bool isChromiumVariant = canvasKit.ParagraphBuilder.RequiresClientICU();
+
 bool get _enableCanvasKitChromiumInAutoMode => browserSupportsCanvaskitChromium;
 
 /// Sets the [CanvasKit] object on `window` so we can use `@JS()` to bind to
@@ -76,8 +79,14 @@ extension CanvasKitExtension on CanvasKit {
   @JS('MakeAnimatedImageFromEncoded')
   external SkAnimatedImage? _MakeAnimatedImageFromEncoded(
       JSUint8Array imageData);
-  SkAnimatedImage? MakeAnimatedImageFromEncoded(Uint8List imageData) =>
-      _MakeAnimatedImageFromEncoded(imageData.toJS);
+  SkAnimatedImage? MakeAnimatedImageFromEncoded(Uint8List imageData) {
+    assert(
+      !isChromiumVariant,
+      'This constructor should only be used with a non-Chromium build of '
+      'CanvasKit.',
+    );
+    return  _MakeAnimatedImageFromEncoded(imageData.toJS);
+  }
 
   external SkShaderNamespace get Shader;
   external SkMaskFilterNamespace get MaskFilter;

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1162,10 +1162,10 @@ extension SkImageExtension on SkImage {
                           matrix?.toJS);
 
   @JS('readPixels')
-  external JSUint8Array _readPixels(
+  external JSUint8Array? _readPixels(
       JSNumber srcX, JSNumber srcY, SkImageInfo imageInfo);
-  Uint8List readPixels(double srcX, double srcY, SkImageInfo imageInfo) =>
-      _readPixels(srcX.toJS, srcY.toJS, imageInfo).toDart;
+  Uint8List? readPixels(double srcX, double srcY, SkImageInfo imageInfo) =>
+      _readPixels(srcX.toJS, srcY.toJS, imageInfo)?.toDart;
 
   @JS('encodeToBytes')
   external JSUint8Array? _encodeToBytes();

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -13,7 +13,7 @@ import 'package:ui/ui.dart' as ui;
 FutureOr<ui.Codec> skiaInstantiateImageCodec(Uint8List list,
     [int? targetWidth, int? targetHeight]) {
   // If we have either a target width or target height, use canvaskit to decode.
-  if (browserSupportsImageDecoder && (targetWidth == null && targetHeight == null)) {
+  if (browserSupportsImageDecoder) {
     return CkBrowserImageDecoder.create(
       data: list,
       debugSource: 'encoded image bytes',

--- a/lib/web_ui/lib/src/engine/canvaskit/image_wasm_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_wasm_codecs.dart
@@ -27,8 +27,8 @@ class CkAnimatedImage implements ui.Codec {
     this.targetHeight,
   }) : assert(
           !isChromiumVariant,
-          'This constructor should only be used with a non-Chromium build of '
-          'CanvasKit.',
+          'CkAnimatedImage.decodeFromBytes cannot be used with the Chromium '
+          'build of CanvasKit.',
         ) {
     final SkAnimatedImage skAnimatedImage = createSkAnimatedImage();
     _ref = UniqueRef<SkAnimatedImage>(this, skAnimatedImage, 'Codec');

--- a/lib/web_ui/lib/src/engine/canvaskit/image_wasm_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_wasm_codecs.dart
@@ -20,7 +20,16 @@ import 'package:ui/ui.dart' as ui;
 /// Wraps `SkAnimatedImage`.
 class CkAnimatedImage implements ui.Codec {
   /// Decodes an image from a list of encoded bytes.
-  CkAnimatedImage.decodeFromBytes(this._bytes, this.src, {this.targetWidth, this.targetHeight}) {
+  CkAnimatedImage.decodeFromBytes(
+    this._bytes,
+    this.src, {
+    this.targetWidth,
+    this.targetHeight,
+  }) : assert(
+          !isChromiumVariant,
+          'This constructor should only be used with a non-Chromium build of '
+          'CanvasKit.',
+        ) {
     final SkAnimatedImage skAnimatedImage = createSkAnimatedImage();
     _ref = UniqueRef<SkAnimatedImage>(this, skAnimatedImage, 'Codec');
   }

--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -109,7 +109,10 @@ class CkPicture implements ui.Picture {
       width: width.toDouble(),
       height: height.toDouble(),
     );
-    final Uint8List pixels = skImage.readPixels(0, 0, imageInfo);
+    final Uint8List? pixels = skImage.readPixels(0, 0, imageInfo);
+    if (pixels == null) {
+      throw StateError('Unable to read pixels from SkImage.');
+    }
     final SkImage? rasterImage = canvasKit.MakeImage(imageInfo, pixels, (4 * width).toDouble());
     if (rasterImage == null) {
       throw StateError('Unable to convert image pixels into SkImage.');

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -9,8 +9,6 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-final bool _ckRequiresClientICU = canvasKit.ParagraphBuilder.RequiresClientICU();
-
 final List<String> _testFonts = <String>['FlutterTest', 'Ahem'];
 String? _effectiveFontFamily(String? fontFamily) {
   return ui_web.debugEmulateFlutterTesterEnvironment && !_testFonts.contains(fontFamily)
@@ -882,7 +880,7 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
 
   /// Builds the CkParagraph with the builder and deletes the builder.
   SkParagraph _buildSkParagraph() {
-    if (_ckRequiresClientICU) {
+    if (isChromiumVariant) {
       injectClientICU(_paragraphBuilder);
     }
     final SkParagraph result = _paragraphBuilder.build();

--- a/lib/web_ui/lib/src/engine/canvaskit/text_fragmenter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text_fragmenter.dart
@@ -84,7 +84,7 @@ extension SegmentationCacheExtensions on SegmentationCache {
 /// without ICU data.
 void injectClientICU(SkParagraphBuilder builder) {
   assert(
-    canvasKit.ParagraphBuilder.RequiresClientICU(),
+    isChromiumVariant,
     'This method should only be used with the CanvasKit Chromium variant.',
   );
 

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -296,7 +296,7 @@ void _imageTests() {
       ),
       isNotNull,
     );
-  });
+  }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
 
   test('MakeAnimatedImageFromEncoded makes an animated image', () {
     final SkAnimatedImage animated =
@@ -311,7 +311,7 @@ void _imageTests() {
       expect(frame.height(), 1);
       expect(animated.decodeNextFrame(), 100);
     }
-  });
+  }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
 }
 
 void _shaderTests() {
@@ -1153,7 +1153,7 @@ void _canvasTests() {
       canvasKit.BlendMode.SrcOver,
       Uint32List.fromList(<int>[0xff000000, 0xffffffff]),
     );
-  });
+  }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
 
   test('drawCircle', () {
     canvas.drawCircle(1, 2, 3, SkPaint());
@@ -1171,69 +1171,71 @@ void _canvasTests() {
     );
   });
 
-  test('drawImageOptions', () {
-    final SkAnimatedImage image =
-        canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
-    canvas.drawImageOptions(
-      image.makeImageAtCurrentFrame(),
-      10,
-      20,
-      canvasKit.FilterMode.Linear,
-      canvasKit.MipmapMode.None,
-      SkPaint(),
-    );
-  });
+  group('[image codecs]', () {
+    test('drawImageOptions', () {
+      final SkAnimatedImage image =
+          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
+      canvas.drawImageOptions(
+        image.makeImageAtCurrentFrame(),
+        10,
+        20,
+        canvasKit.FilterMode.Linear,
+        canvasKit.MipmapMode.None,
+        SkPaint(),
+      );
+    });
 
-  test('drawImageCubic', () {
-    final SkAnimatedImage image =
-        canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
-    canvas.drawImageCubic(
-      image.makeImageAtCurrentFrame(),
-      10,
-      20,
-      0.3,
-      0.3,
-      SkPaint(),
-    );
-  });
+    test('drawImageCubic', () {
+      final SkAnimatedImage image =
+          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
+      canvas.drawImageCubic(
+        image.makeImageAtCurrentFrame(),
+        10,
+        20,
+        0.3,
+        0.3,
+        SkPaint(),
+      );
+    });
 
-  test('drawImageRectOptions', () {
-    final SkAnimatedImage image =
-        canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
-    canvas.drawImageRectOptions(
-      image.makeImageAtCurrentFrame(),
-      Float32List.fromList(<double>[0, 0, 1, 1]),
-      Float32List.fromList(<double>[0, 0, 1, 1]),
-      canvasKit.FilterMode.Linear,
-      canvasKit.MipmapMode.None,
-      SkPaint(),
-    );
-  });
+    test('drawImageRectOptions', () {
+      final SkAnimatedImage image =
+          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
+      canvas.drawImageRectOptions(
+        image.makeImageAtCurrentFrame(),
+        Float32List.fromList(<double>[0, 0, 1, 1]),
+        Float32List.fromList(<double>[0, 0, 1, 1]),
+        canvasKit.FilterMode.Linear,
+        canvasKit.MipmapMode.None,
+        SkPaint(),
+      );
+    });
 
-  test('drawImageRectCubic', () {
-    final SkAnimatedImage image =
-        canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
-    canvas.drawImageRectCubic(
-      image.makeImageAtCurrentFrame(),
-      Float32List.fromList(<double>[0, 0, 1, 1]),
-      Float32List.fromList(<double>[0, 0, 1, 1]),
-      0.3,
-      0.3,
-      SkPaint(),
-    );
-  });
+    test('drawImageRectCubic', () {
+      final SkAnimatedImage image =
+          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
+      canvas.drawImageRectCubic(
+        image.makeImageAtCurrentFrame(),
+        Float32List.fromList(<double>[0, 0, 1, 1]),
+        Float32List.fromList(<double>[0, 0, 1, 1]),
+        0.3,
+        0.3,
+        SkPaint(),
+      );
+    });
 
-  test('drawImageNine', () {
-    final SkAnimatedImage image =
-        canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
-    canvas.drawImageNine(
-      image.makeImageAtCurrentFrame(),
-      Float32List.fromList(<double>[0, 0, 1, 1]),
-      Float32List.fromList(<double>[0, 0, 1, 1]),
-      canvasKit.FilterMode.Linear,
-      SkPaint(),
-    );
-  });
+    test('drawImageNine', () {
+      final SkAnimatedImage image =
+          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;
+      canvas.drawImageNine(
+        image.makeImageAtCurrentFrame(),
+        Float32List.fromList(<double>[0, 0, 1, 1]),
+        Float32List.fromList(<double>[0, 0, 1, 1]),
+        canvasKit.FilterMode.Linear,
+        SkPaint(),
+      );
+    });
+  }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
 
   test('drawLine', () {
     canvas.drawLine(0, 1, 2, 3, SkPaint());

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1873,11 +1873,9 @@ void _paragraphTests() {
 
       v8BreakIterator = Object();
       browserSupportsImageDecoder = false;
-      // TODO(mdebbar): we don't check image codecs for now.
-      // https://github.com/flutter/flutter/issues/122331
       expect(getCanvasKitJsFileNames(CanvasKitVariant.full), <String>['canvaskit.js']);
       expect(getCanvasKitJsFileNames(CanvasKitVariant.chromium), <String>['chromium/canvaskit.js']);
-      expect(getCanvasKitJsFileNames(CanvasKitVariant.auto), <String>['chromium/canvaskit.js', 'canvaskit.js']);
+      expect(getCanvasKitJsFileNames(CanvasKitVariant.auto), <String>['canvaskit.js']);
 
       v8BreakIterator = null;
       browserSupportsImageDecoder = false;

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -312,6 +312,13 @@ void _imageTests() {
       expect(animated.decodeNextFrame(), 100);
     }
   }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
+
+  test('MakeAnimatedImageFromEncoded throws with Chromium variant', () {
+    expect(
+      () => canvasKit.MakeAnimatedImageFromEncoded(kAnimatedGif),
+      throwsA(isA<AssertionError>()),
+    );
+  }, skip: configuration.canvasKitVariant != CanvasKitVariant.chromium);
 }
 
 void _shaderTests() {

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1178,7 +1178,7 @@ void _canvasTests() {
     );
   });
 
-  group('[image codecs]', () {
+  group('[wasm codecs]', () {
     test('drawImageOptions', () {
       final SkAnimatedImage image =
           canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!;

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -296,7 +296,7 @@ void _imageTests() {
       ),
       isNotNull,
     );
-  }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
+  }, skip: !canvasKitContainsCodecs);
 
   test('MakeAnimatedImageFromEncoded makes an animated image', () {
     final SkAnimatedImage animated =
@@ -311,14 +311,14 @@ void _imageTests() {
       expect(frame.height(), 1);
       expect(animated.decodeNextFrame(), 100);
     }
-  }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
+  }, skip: !canvasKitContainsCodecs);
 
   test('MakeAnimatedImageFromEncoded throws with Chromium variant', () {
     expect(
       () => canvasKit.MakeAnimatedImageFromEncoded(kAnimatedGif),
-      throwsA(isA<AssertionError>()),
+      canvasKitContainsCodecs ? returnsNormally : throwsAssertionError,
     );
-  }, skip: configuration.canvasKitVariant != CanvasKitVariant.chromium);
+  });
 }
 
 void _shaderTests() {
@@ -1160,7 +1160,7 @@ void _canvasTests() {
       canvasKit.BlendMode.SrcOver,
       Uint32List.fromList(<int>[0xff000000, 0xffffffff]),
     );
-  }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
+  }, skip: !canvasKitContainsCodecs);
 
   test('drawCircle', () {
     canvas.drawCircle(1, 2, 3, SkPaint());
@@ -1242,7 +1242,7 @@ void _canvasTests() {
         SkPaint(),
       );
     });
-  }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
+  }, skip: !canvasKitContainsCodecs);
 
   test('drawLine', () {
     canvas.drawLine(0, 1, 2, 3, SkPaint());

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1615,7 +1615,7 @@ void _paragraphTests() {
     builder.pushStyle(
         canvasKit.TextStyle(SkTextStyleProperties()..halfLeading = true));
     builder.pop();
-    if (canvasKit.ParagraphBuilder.RequiresClientICU()) {
+    if (isChromiumVariant) {
       injectClientICU(builder);
     }
     final SkParagraph paragraph = builder.build();
@@ -1733,7 +1733,7 @@ void _paragraphTests() {
     );
     builder.addText('hello');
 
-    if (canvasKit.ParagraphBuilder.RequiresClientICU()) {
+    if (isChromiumVariant) {
       injectClientICU(builder);
     }
 

--- a/lib/web_ui/test/canvaskit/common.dart
+++ b/lib/web_ui/test/canvaskit/common.dart
@@ -15,6 +15,9 @@ import '../common/test_initialization.dart';
 
 const MethodCodec codec = StandardMethodCodec();
 
+bool get canvasKitContainsCodecs =>
+    configuration.canvasKitVariant == CanvasKitVariant.full;
+
 /// Common test setup for all CanvasKit unit-tests.
 void setUpCanvasKitTest() {
   setUpUnitTests(

--- a/lib/web_ui/test/canvaskit/image_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/image_golden_test.dart
@@ -111,68 +111,70 @@ void _testForImageCodecs({required bool useBrowserImageDecoder}) {
       await expectFrameData(frame3, <int>[0, 0, 255, 255]);
     });
 
-    test('CkImage toString', () {
-      final SkImage skImage =
-          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!
-              .makeImageAtCurrentFrame();
-      final CkImage image = CkImage(skImage);
-      expect(image.toString(), '[1×1]');
-      image.dispose();
-    });
+    group('[image codecs]', () {
+      test('CkImage toString', () {
+        final SkImage skImage =
+            canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!
+                .makeImageAtCurrentFrame();
+        final CkImage image = CkImage(skImage);
+        expect(image.toString(), '[1×1]');
+        image.dispose();
+      });
 
-    test('CkImage can be explicitly disposed of', () {
-      final SkImage skImage =
-          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!
-              .makeImageAtCurrentFrame();
-      final CkImage image = CkImage(skImage);
-      expect(image.debugDisposed, isFalse);
-      expect(image.box.isDisposed, isFalse);
-      image.dispose();
-      expect(image.debugDisposed, isTrue);
-      expect(image.box.isDisposed, isTrue);
+      test('CkImage can be explicitly disposed of', () {
+        final SkImage skImage =
+            canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!
+                .makeImageAtCurrentFrame();
+        final CkImage image = CkImage(skImage);
+        expect(image.debugDisposed, isFalse);
+        expect(image.box.isDisposed, isFalse);
+        image.dispose();
+        expect(image.debugDisposed, isTrue);
+        expect(image.box.isDisposed, isTrue);
 
-      // Disallow double-dispose.
-      expect(() => image.dispose(), throwsAssertionError);
-    });
+        // Disallow double-dispose.
+        expect(() => image.dispose(), throwsAssertionError);
+      });
 
-    test('CkImage can be explicitly disposed of when cloned', () async {
-      final SkImage skImage =
-          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!
-              .makeImageAtCurrentFrame();
-      final CkImage image = CkImage(skImage);
-      final CountedRef<CkImage, SkImage> box = image.box;
-      expect(box.refCount, 1);
-      expect(box.debugGetStackTraces().length, 1);
+      test('CkImage can be explicitly disposed of when cloned', () async {
+        final SkImage skImage =
+            canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!
+                .makeImageAtCurrentFrame();
+        final CkImage image = CkImage(skImage);
+        final CountedRef<CkImage, SkImage> box = image.box;
+        expect(box.refCount, 1);
+        expect(box.debugGetStackTraces().length, 1);
 
-      final CkImage clone = image.clone();
-      expect(box.refCount, 2);
-      expect(box.debugGetStackTraces().length, 2);
+        final CkImage clone = image.clone();
+        expect(box.refCount, 2);
+        expect(box.debugGetStackTraces().length, 2);
 
-      expect(image.isCloneOf(clone), isTrue);
-      expect(box.isDisposed, isFalse);
+        expect(image.isCloneOf(clone), isTrue);
+        expect(box.isDisposed, isFalse);
 
-      expect(skImage.isDeleted(), isFalse);
-      image.dispose();
-      expect(box.refCount, 1);
-      expect(box.isDisposed, isFalse);
+        expect(skImage.isDeleted(), isFalse);
+        image.dispose();
+        expect(box.refCount, 1);
+        expect(box.isDisposed, isFalse);
 
-      expect(skImage.isDeleted(), isFalse);
-      clone.dispose();
-      expect(box.refCount, 0);
-      expect(box.isDisposed, isTrue);
+        expect(skImage.isDeleted(), isFalse);
+        clone.dispose();
+        expect(box.refCount, 0);
+        expect(box.isDisposed, isTrue);
 
-      expect(skImage.isDeleted(), isTrue);
-      expect(box.debugGetStackTraces().length, 0);
-    });
+        expect(skImage.isDeleted(), isTrue);
+        expect(box.debugGetStackTraces().length, 0);
+      });
 
-    test('CkImage toByteData', () async {
-      final SkImage skImage =
-          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!
-              .makeImageAtCurrentFrame();
-      final CkImage image = CkImage(skImage);
-      expect((await image.toByteData()).lengthInBytes, greaterThan(0));
-      expect((await image.toByteData(format: ui.ImageByteFormat.png)).lengthInBytes, greaterThan(0));
-    });
+      test('CkImage toByteData', () async {
+        final SkImage skImage =
+            canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!
+                .makeImageAtCurrentFrame();
+        final CkImage image = CkImage(skImage);
+        expect((await image.toByteData()).lengthInBytes, greaterThan(0));
+        expect((await image.toByteData(format: ui.ImageByteFormat.png)).lengthInBytes, greaterThan(0));
+      });
+    }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
 
     test('toByteData with decodeImageFromPixels on videoFrame formats', () async {
       // This test ensures that toByteData() returns pixels that can be used by decodeImageFromPixels

--- a/lib/web_ui/test/canvaskit/shader_test.dart
+++ b/lib/web_ui/test/canvaskit/shader_test.dart
@@ -128,7 +128,7 @@ void testMain() {
         expect(imageShader.ref, isNull);
         expect(image.debugDisposed, true);
       });
-    }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
+    }, skip: !canvasKitContainsCodecs);
   });
 }
 

--- a/lib/web_ui/test/canvaskit/shader_test.dart
+++ b/lib/web_ui/test/canvaskit/shader_test.dart
@@ -60,7 +60,7 @@ void testMain() {
       expect(gradient.getSkShader(ui.FilterQuality.none), isNotNull);
     });
 
-    group('[image codecs]', () {
+    group('[wasm codecs]', () {
       test('Image shader initialize/dispose cycle', () {
         final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!.makeImageAtCurrentFrame();
         final CkImage image = CkImage(skImage);

--- a/lib/web_ui/test/canvaskit/shader_test.dart
+++ b/lib/web_ui/test/canvaskit/shader_test.dart
@@ -60,73 +60,75 @@ void testMain() {
       expect(gradient.getSkShader(ui.FilterQuality.none), isNotNull);
     });
 
-    test('Image shader initialize/dispose cycle', () {
-      final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!.makeImageAtCurrentFrame();
-      final CkImage image = CkImage(skImage);
-      final CkImageShader imageShader = ui.ImageShader(
-        image,
-        ui.TileMode.clamp,
-        ui.TileMode.repeated,
-        Float64List.fromList(Matrix4.diagonal3Values(1, 2, 3).storage),
-      ) as CkImageShader;
-      expect(imageShader, isA<CkImageShader>());
+    group('[image codecs]', () {
+      test('Image shader initialize/dispose cycle', () {
+        final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!.makeImageAtCurrentFrame();
+        final CkImage image = CkImage(skImage);
+        final CkImageShader imageShader = ui.ImageShader(
+          image,
+          ui.TileMode.clamp,
+          ui.TileMode.repeated,
+          Float64List.fromList(Matrix4.diagonal3Values(1, 2, 3).storage),
+        ) as CkImageShader;
+        expect(imageShader, isA<CkImageShader>());
 
-      final UniqueRef<SkShader> ref = imageShader.ref!;
-      expect(imageShader.debugDisposed, false);
-      expect(imageShader.getSkShader(ui.FilterQuality.none), same(ref.nativeObject));
-      expect(ref.isDisposed, false);
-      expect(image.debugDisposed, false);
-      imageShader.dispose();
-      expect(imageShader.debugDisposed, true);
-      expect(ref.isDisposed, true);
-      expect(imageShader.ref, isNull);
-      expect(image.debugDisposed, true);
-    });
+        final UniqueRef<SkShader> ref = imageShader.ref!;
+        expect(imageShader.debugDisposed, false);
+        expect(imageShader.getSkShader(ui.FilterQuality.none), same(ref.nativeObject));
+        expect(ref.isDisposed, false);
+        expect(image.debugDisposed, false);
+        imageShader.dispose();
+        expect(imageShader.debugDisposed, true);
+        expect(ref.isDisposed, true);
+        expect(imageShader.ref, isNull);
+        expect(image.debugDisposed, true);
+      });
 
-    test('Image shader withQuality', () {
-      final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!.makeImageAtCurrentFrame();
-      final CkImage image = CkImage(skImage);
-      final CkImageShader imageShader = ui.ImageShader(
-        image,
-        ui.TileMode.clamp,
-        ui.TileMode.repeated,
-        Float64List.fromList(Matrix4.diagonal3Values(1, 2, 3).storage),
-      ) as CkImageShader;
-      expect(imageShader, isA<CkImageShader>());
+      test('Image shader withQuality', () {
+        final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)!.makeImageAtCurrentFrame();
+        final CkImage image = CkImage(skImage);
+        final CkImageShader imageShader = ui.ImageShader(
+          image,
+          ui.TileMode.clamp,
+          ui.TileMode.repeated,
+          Float64List.fromList(Matrix4.diagonal3Values(1, 2, 3).storage),
+        ) as CkImageShader;
+        expect(imageShader, isA<CkImageShader>());
 
-      final UniqueRef<SkShader> ref1 = imageShader.ref!;
-      expect(imageShader.getSkShader(ui.FilterQuality.none), same(ref1.nativeObject));
+        final UniqueRef<SkShader> ref1 = imageShader.ref!;
+        expect(imageShader.getSkShader(ui.FilterQuality.none), same(ref1.nativeObject));
 
-      // Request the same quality as the default quality (none).
-      expect(imageShader.getSkShader(ui.FilterQuality.none), isNotNull);
-      final UniqueRef<SkShader> ref2 = imageShader.ref!;
-      expect(ref1, same(ref2));
-      expect(ref1.isDisposed, false);
-      expect(image.debugDisposed, false);
+        // Request the same quality as the default quality (none).
+        expect(imageShader.getSkShader(ui.FilterQuality.none), isNotNull);
+        final UniqueRef<SkShader> ref2 = imageShader.ref!;
+        expect(ref1, same(ref2));
+        expect(ref1.isDisposed, false);
+        expect(image.debugDisposed, false);
 
-      // Change quality to medium.
-      expect(imageShader.getSkShader(ui.FilterQuality.medium), isNotNull);
-      final UniqueRef<SkShader> ref3 = imageShader.ref!;
-      expect(ref1, isNot(same(ref3)));
-      expect(ref1.isDisposed, true, reason: 'The previous reference must be released to avoid a memory leak');
-      expect(image.debugDisposed, false);
-      expect(imageShader.ref!.nativeObject, same(ref3.nativeObject));
+        // Change quality to medium.
+        expect(imageShader.getSkShader(ui.FilterQuality.medium), isNotNull);
+        final UniqueRef<SkShader> ref3 = imageShader.ref!;
+        expect(ref1, isNot(same(ref3)));
+        expect(ref1.isDisposed, true, reason: 'The previous reference must be released to avoid a memory leak');
+        expect(image.debugDisposed, false);
+        expect(imageShader.ref!.nativeObject, same(ref3.nativeObject));
 
-      // Ask for medium again.
-      expect(imageShader.getSkShader(ui.FilterQuality.medium), isNotNull);
-      final UniqueRef<SkShader> ref4 = imageShader.ref!;
-      expect(ref4, same(ref3));
-      expect(ref3.isDisposed, false);
-      expect(image.debugDisposed, false);
-      expect(imageShader.ref!.nativeObject, same(ref4.nativeObject));
+        // Ask for medium again.
+        expect(imageShader.getSkShader(ui.FilterQuality.medium), isNotNull);
+        final UniqueRef<SkShader> ref4 = imageShader.ref!;
+        expect(ref4, same(ref3));
+        expect(ref3.isDisposed, false);
+        expect(image.debugDisposed, false);
+        expect(imageShader.ref!.nativeObject, same(ref4.nativeObject));
 
-      // Done with the shader.
-      imageShader.dispose();
-      expect(imageShader.debugDisposed, true);
-      expect(ref4.isDisposed, true);
-      expect(imageShader.ref, isNull);
-      expect(image.debugDisposed, true);
-    });
+        // Done with the shader.
+        imageShader.dispose();
+        expect(imageShader.debugDisposed, true);
+        expect(ref4.isDisposed, true);
+        expect(imageShader.ref, isNull);
+        expect(image.debugDisposed, true);
+      });
+    }, skip: configuration.canvasKitVariant != CanvasKitVariant.full);
   });
 }
 

--- a/lib/web_ui/test/engine/browser_detect_test.dart
+++ b/lib/web_ui/test/engine/browser_detect_test.dart
@@ -183,9 +183,7 @@ void testMain() {
       intlSegmenter = Object(); // Any non-null value.
       browserSupportsImageDecoder = false;
 
-      // TODO(mdebbar): we don't check image codecs for now.
-      // https://github.com/flutter/flutter/issues/122331
-      expect(browserSupportsCanvaskitChromium, isTrue);
+      expect(browserSupportsCanvaskitChromium, isFalse);
     });
 
     test('Detect browsers that do not support v8BreakIterator', () {

--- a/third_party/canvaskit/BUILD.gn
+++ b/third_party/canvaskit/BUILD.gn
@@ -41,14 +41,10 @@ wasm_toolchain("canvaskit_chromium") {
     skia_use_client_icu = true
     skia_icu_bidi_third_party_dir = "//flutter/third_party/canvaskit/icu_bidi"
 
-    # TODO(mdebbar): Set these to false once all image decoding can be done
-    # using the browser's built-in codecs.
-    # https://github.com/flutter/flutter/issues/122331
-
     # In Chromium browsers, we can use the browser's built-in codecs.
-    skia_use_libjpeg_turbo_decode = true
-    skia_use_libpng_decode = true
-    skia_use_libwebp_decode = true
+    skia_use_libjpeg_turbo_decode = false
+    skia_use_libpng_decode = false
+    skia_use_libwebp_decode = false
 
     # Disable LTO.
     enable_lto = false


### PR DESCRIPTION
First attempt was made at https://github.com/flutter/engine/pull/40309

- Handle `targetWidth` and `targetHeight` using our `ResizingCodec`.
- Add some asserts to prevent calling the wrong decoding methods.
- Fix an issue with `FlutterConfiguration` being reset to the wrong value in tests.
- In Chromium mode, skip tests that exercise CanvasKit image codecs directly.

Fixes https://github.com/flutter/flutter/issues/122331