### PR TITLE
[Impeller] Unwrap optional procs in EntityPass

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -58,10 +58,9 @@ void Canvas::Save() {
   Save(false);
 }
 
-void Canvas::Save(
-    bool create_subpass,
-    BlendMode blend_mode,
-    std::optional<EntityPass::BackdropFilterProc> backdrop_filter) {
+void Canvas::Save(bool create_subpass,
+                  BlendMode blend_mode,
+                  EntityPass::BackdropFilterProc backdrop_filter) {
   auto entry = CanvasStackEntry{};
   entry.xformation = xformation_stack_.back().xformation;
   entry.cull_rect = xformation_stack_.back().cull_rect;
@@ -482,10 +481,9 @@ size_t Canvas::GetStencilDepth() const {
   return xformation_stack_.back().stencil_depth;
 }
 
-void Canvas::SaveLayer(
-    const Paint& paint,
-    std::optional<Rect> bounds,
-    const std::optional<Paint::ImageFilterProc>& backdrop_filter) {
+void Canvas::SaveLayer(const Paint& paint,
+                       std::optional<Rect> bounds,
+                       const Paint::ImageFilterProc& backdrop_filter) {
   Save(true, paint.blend_mode, backdrop_filter);
 
   auto& new_layer_pass = GetCurrentPass();
@@ -499,7 +497,7 @@ void Canvas::SaveLayer(
         std::make_unique<PaintPassDelegate>(paint, bounds));
   }
 
-  if (bounds.has_value() && !backdrop_filter.has_value()) {
+  if (bounds.has_value() && !backdrop_filter) {
     // Render target switches due to a save layer can be elided. In such cases
     // where passes are collapsed into their parent, the clipping effect to
     // the size of the render target that would have been allocated will be

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -68,8 +68,7 @@ class Canvas {
 
   void SaveLayer(const Paint& paint,
                  std::optional<Rect> bounds = std::nullopt,
-                 const std::optional<Paint::ImageFilterProc>& backdrop_filter =
-                     std::nullopt);
+                 const Paint::ImageFilterProc& backdrop_filter = nullptr);
 
   bool Restore();
 
@@ -182,8 +181,7 @@ class Canvas {
 
   void Save(bool create_subpass,
             BlendMode = BlendMode::kSourceOver,
-            std::optional<EntityPass::BackdropFilterProc> backdrop_filter =
-                std::nullopt);
+            EntityPass::BackdropFilterProc backdrop_filter = nullptr);
 
   void RestoreClip();
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -155,7 +155,7 @@ EntityPass* EntityPass::AddSubpass(std::unique_ptr<EntityPass> pass) {
   FML_DCHECK(pass->superpass_ == nullptr);
   pass->superpass_ = this;
 
-  if (pass->backdrop_filter_proc_.has_value()) {
+  if (pass->backdrop_filter_proc_) {
     backdrop_filter_reads_from_pass_texture_ += 1;
   }
   if (pass->blend_mode_ > Entity::kLastPipelineBlendMode) {
@@ -413,7 +413,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       return EntityPass::EntityResult::Skip();
     }
 
-    if (!subpass->backdrop_filter_proc_.has_value() &&
+    if (!subpass->backdrop_filter_proc_ &&
         subpass->delegate_->CanCollapseIntoParentPass(subpass)) {
       // Directly render into the parent target and move on.
       if (!subpass->OnRender(
@@ -436,10 +436,10 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     }
 
     std::shared_ptr<Contents> backdrop_filter_contents = nullptr;
-    if (subpass->backdrop_filter_proc_.has_value()) {
+    if (subpass->backdrop_filter_proc_) {
       auto texture = pass_context.GetTexture();
       // Render the backdrop texture before any of the pass elements.
-      const auto& proc = subpass->backdrop_filter_proc_.value();
+      const auto& proc = subpass->backdrop_filter_proc_;
       backdrop_filter_contents =
           proc(FilterInput::Make(std::move(texture)), subpass->xformation_,
                /*is_subpass*/ true);
@@ -700,7 +700,7 @@ bool EntityPass::OnRender(
     return true;
   };
 
-  if (backdrop_filter_proc_.has_value()) {
+  if (backdrop_filter_proc_) {
     if (!backdrop_filter_contents) {
       VALIDATION_LOG
           << "EntityPass contains a backdrop filter, but no backdrop filter "
@@ -932,7 +932,7 @@ Color EntityPass::GetClearColor(ISize target_size) const {
   return result;
 }
 
-void EntityPass::SetBackdropFilter(std::optional<BackdropFilterProc> proc) {
+void EntityPass::SetBackdropFilter(BackdropFilterProc proc) {
   if (superpass_) {
     VALIDATION_LOG << "Backdrop filters cannot be set on EntityPasses that "
                       "have already been appended to another pass.";

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -88,7 +88,7 @@ class EntityPass {
 
   Color GetClearColor(ISize size = ISize::Infinite()) const;
 
-  void SetBackdropFilter(std::optional<BackdropFilterProc> proc);
+  void SetBackdropFilter(BackdropFilterProc proc);
 
   void SetEnableOffscreenCheckerboard(bool enabled);
 
@@ -223,7 +223,7 @@ class EntityPass {
 
   uint32_t GetTotalPassReads(ContentContext& renderer) const;
 
-  std::optional<BackdropFilterProc> backdrop_filter_proc_ = std::nullopt;
+  BackdropFilterProc backdrop_filter_proc_ = nullptr;
 
   std::unique_ptr<EntityPassDelegate> delegate_ =
       EntityPassDelegate::MakeDefault();


### PR DESCRIPTION
Whoopsies, I missed a spot... Fix a possible crash where an optional nullptr can be provided as the backdrop filter proc. Related: https://github.com/flutter/engine/pull/43345