### PR TITLE
[Impeller] Fix validation error in position color shader.

### DIFF
--- a/impeller/entity/shaders/position_color.vert
+++ b/impeller/entity/shaders/position_color.vert
@@ -13,9 +13,9 @@ frame_info;
 in vec2 position;
 in vec4 color;
 
-out vec4 v_color;
+out f16vec4 v_color;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
-  v_color = color;
+  v_color = f16vec4(color);
 }


### PR DESCRIPTION
The input was a float16 vec4, so the corresponding output must match or else we get a validation error. Not related to platform view issue.
