### PR TITLE
Remove dead code for recreating a11y node delegates

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -149,18 +149,6 @@ AccessibilityBridge::GetPendingEvents() const {
   return result;
 }
 
-void AccessibilityBridge::RecreateNodeDelegates() {
-  for (const auto& [node_id, old_platform_node_delegate] : id_wrapper_map_) {
-    std::shared_ptr<FlutterPlatformNodeDelegate> platform_node_delegate =
-        CreateFlutterPlatformNodeDelegate();
-    platform_node_delegate->Init(
-        std::static_pointer_cast<FlutterPlatformNodeDelegate::OwnerBridge>(
-            shared_from_this()),
-        old_platform_node_delegate->GetAXNode());
-    id_wrapper_map_[node_id] = platform_node_delegate;
-  }
-}
-
 void AccessibilityBridge::OnNodeWillBeDeleted(ui::AXTree* tree,
                                               ui::AXNode* node) {}
 

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -157,16 +157,6 @@ class AccessibilityBridge
   virtual std::shared_ptr<FlutterPlatformNodeDelegate>
   CreateFlutterPlatformNodeDelegate() = 0;
 
-  //------------------------------------------------------------------------------
-  /// @brief      Recreate all FlutterPlatformNodeDelegates.
-  ///
-  ///             This can be useful for subclasses when updating some
-  ///             properties that are used by node delegates, such as views.
-  ///             Each node is recreated using
-  ///             CreateFlutterPlatformNodeDelegate, then initialized using
-  ///             AXNodes from their corresponding old one.
-  void RecreateNodeDelegates();
-
  private:
   // See FlutterSemanticsNode in embedder.h
   typedef struct {

--- a/shell/platform/common/accessibility_bridge_unittests.cc
+++ b/shell/platform/common/accessibility_bridge_unittests.cc
@@ -205,40 +205,6 @@ TEST(AccessibilityBridgeTest, CanFireChildrenChangedCorrectly) {
               Contains(ui::AXEventGenerator::Event::SUBTREE_CREATED));
 }
 
-TEST(AccessibilityBridgeTest, CanRecreateNodeDelegates) {
-  std::shared_ptr<TestAccessibilityBridge> bridge =
-      std::make_shared<TestAccessibilityBridge>();
-
-  std::vector<int32_t> children{1};
-  FlutterSemanticsNode2 root = CreateSemanticsNode(0, "root", &children);
-  FlutterSemanticsNode2 child1 = CreateSemanticsNode(1, "child 1");
-
-  bridge->AddFlutterSemanticsNodeUpdate(root);
-  bridge->AddFlutterSemanticsNodeUpdate(child1);
-  bridge->CommitUpdates();
-
-  auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0);
-  auto child1_node = bridge->GetFlutterPlatformNodeDelegateFromID(1);
-  EXPECT_FALSE(root_node.expired());
-  EXPECT_FALSE(child1_node.expired());
-
-  bridge->RecreateNodeDelegates();
-
-  // Old tree is destroyed.
-  EXPECT_TRUE(root_node.expired());
-  EXPECT_TRUE(child1_node.expired());
-
-  // New tree still has the data.
-  auto new_root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
-  auto new_child1_node = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
-  EXPECT_EQ(new_root_node->GetChildCount(), 1);
-  EXPECT_EQ(new_root_node->GetData().child_ids[0], 1);
-  EXPECT_EQ(new_root_node->GetName(), "root");
-
-  EXPECT_EQ(new_child1_node->GetChildCount(), 0);
-  EXPECT_EQ(new_child1_node->GetName(), "child 1");
-}
-
 TEST(AccessibilityBridgeTest, CanHandleSelectionChangeCorrectly) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();

--- a/shell/platform/common/test_accessibility_bridge.h
+++ b/shell/platform/common/test_accessibility_bridge.h
@@ -11,8 +11,6 @@ namespace flutter {
 
 class TestAccessibilityBridge : public AccessibilityBridge {
  public:
-  using AccessibilityBridge::RecreateNodeDelegates;
-
   TestAccessibilityBridge() = default;
 
   void DispatchAccessibilityAction(AccessibilityNodeId target,

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.h
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.h
@@ -40,12 +40,6 @@ class AccessibilityBridgeMac : public AccessibilityBridge {
                                    FlutterSemanticsAction action,
                                    fml::MallocMapping data) override;
 
-  // Update the default view controller, and recreate the corresponding
-  // accessibility node delegate.
-  //
-  // This is called by the engine when the default view controller is updated.
-  void UpdateDefaultViewController(__weak FlutterViewController* view_controller);
-
  protected:
   // |AccessibilityBridge|
   void OnAccessibilityEvent(ui::AXEventGenerator::TargetedEvent targeted_event) override;

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.mm
@@ -24,12 +24,6 @@ AccessibilityBridgeMac::AccessibilityBridgeMac(__weak FlutterEngine* flutter_eng
                                                __weak FlutterViewController* view_controller)
     : flutter_engine_(flutter_engine), view_controller_(view_controller) {}
 
-void AccessibilityBridgeMac::UpdateDefaultViewController(
-    __weak FlutterViewController* view_controller) {
-  view_controller_ = view_controller;
-  RecreateNodeDelegates();
-}
-
 void AccessibilityBridgeMac::OnAccessibilityEvent(
     ui::AXEventGenerator::TargetedEvent targeted_event) {
   if (!view_controller_.viewLoaded || !view_controller_.view.window) {


### PR DESCRIPTION
This PR removes some dead code for recreating a11y node delegates. These code was used to refresh a11y information when the macOS embedder live swapped view controllers, but have become obsolete since https://github.com/flutter/engine/pull/39145 removed the support for such live swapping.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
