### PR TITLE
Reland "Refactor JSNumber.toDart and Object.toJS"

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -130,19 +130,19 @@ extension CanvasKitExtension on CanvasKit {
   // Text decoration enum is embedded in the CanvasKit object itself.
   @JS('NoDecoration')
   external JSNumber get _NoDecoration;
-  double get NoDecoration => _NoDecoration.toDart;
+  double get NoDecoration => _NoDecoration.toDartDouble;
 
   @JS('UnderlineDecoration')
   external JSNumber get _UnderlineDecoration;
-  double get UnderlineDecoration => _UnderlineDecoration.toDart;
+  double get UnderlineDecoration => _UnderlineDecoration.toDartDouble;
 
   @JS('OverlineDecoration')
   external JSNumber get _OverlineDecoration;
-  double get OverlineDecoration => _OverlineDecoration.toDart;
+  double get OverlineDecoration => _OverlineDecoration.toDartDouble;
 
   @JS('LineThroughDecoration')
   external JSNumber get _LineThroughDecoration;
-  double get LineThroughDecoration => _LineThroughDecoration.toDart;
+  double get LineThroughDecoration => _LineThroughDecoration.toDartDouble;
   // End of text decoration enum.
 
   external SkTextDecorationStyleEnum get DecorationStyle;
@@ -159,7 +159,7 @@ extension CanvasKitExtension on CanvasKit {
       DomCanvasElement canvas, SkWebGLContextOptions options);
   double GetWebGLContext(
       DomCanvasElement canvas, SkWebGLContextOptions options) =>
-        _GetWebGLContext(canvas, options).toDart;
+        _GetWebGLContext(canvas, options).toDartDouble;
 
   @JS('MakeGrContext')
   external SkGrContext _MakeGrContext(JSNumber glContext);
@@ -286,11 +286,11 @@ extension SkSurfaceExtension on SkSurface {
 
   @JS('width')
   external JSNumber _width();
-  double width() => _width().toDart;
+  double width() => _width().toDartDouble;
 
   @JS('height')
   external JSNumber _height();
-  double height() => _height().toDart;
+  double height() => _height().toDartDouble;
 
   external JSVoid dispose();
   external SkImage makeImageSnapshot();
@@ -327,7 +327,7 @@ class SkFontSlant {}
 extension SkFontSlantExtension on SkFontSlant {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkFontSlant> _skFontSlants = <SkFontSlant>[
@@ -363,7 +363,7 @@ class SkFontWeight {}
 extension SkFontWeightExtension on SkFontWeight {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkFontWeight> _skFontWeights = <SkFontWeight>[
@@ -398,7 +398,7 @@ class SkAffinity {}
 extension SkAffinityExtension on SkAffinity {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkAffinity> _skAffinitys = <SkAffinity>[
@@ -426,7 +426,7 @@ class SkTextDirection {}
 extension SkTextDirectionExtension on SkTextDirection {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 // Flutter enumerates text directions as RTL, LTR, while CanvasKit
@@ -460,7 +460,7 @@ class SkTextAlign {}
 extension SkTextAlignExtension on SkTextAlign {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkTextAlign> _skTextAligns = <SkTextAlign>[
@@ -494,7 +494,7 @@ class SkTextHeightBehavior {}
 extension SkTextHeightBehaviorExtension on SkTextHeightBehavior {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkTextHeightBehavior> _skTextHeightBehaviors =
@@ -531,7 +531,7 @@ class SkRectHeightStyle {}
 extension SkRectHeightStyleExtension on SkRectHeightStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkRectHeightStyle> _skRectHeightStyles = <SkRectHeightStyle>[
@@ -563,7 +563,7 @@ class SkRectWidthStyle {}
 extension SkRectWidthStyleExtension on SkRectWidthStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkRectWidthStyle> _skRectWidthStyles = <SkRectWidthStyle>[
@@ -593,7 +593,7 @@ class SkVertexMode {}
 extension SkVertexModeExtension on SkVertexMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkVertexMode> _skVertexModes = <SkVertexMode>[
@@ -623,7 +623,7 @@ class SkPointMode {}
 extension SkPointModeExtension on SkPointMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkPointMode> _skPointModes = <SkPointMode>[
@@ -652,7 +652,7 @@ class SkClipOp {}
 extension SkClipOpExtension on SkClipOp {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkClipOp> _skClipOps = <SkClipOp>[
@@ -680,7 +680,7 @@ class SkFillType {}
 extension SkFillTypeExtension on SkFillType {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkFillType> _skFillTypes = <SkFillType>[
@@ -711,7 +711,7 @@ class SkPathOp {}
 extension SkPathOpExtension on SkPathOp {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkPathOp> _skPathOps = <SkPathOp>[
@@ -744,7 +744,7 @@ class SkBlurStyle {}
 extension SkBlurStyleExtension on SkBlurStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkBlurStyle> _skBlurStyles = <SkBlurStyle>[
@@ -775,7 +775,7 @@ class SkStrokeCap {}
 extension SkStrokeCapExtension on SkStrokeCap {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkStrokeCap> _skStrokeCaps = <SkStrokeCap>[
@@ -804,7 +804,7 @@ class SkPaintStyle {}
 extension SkPaintStyleExtension on SkPaintStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkPaintStyle> _skPaintStyles = <SkPaintStyle>[
@@ -859,7 +859,7 @@ class SkBlendMode {}
 extension SkBlendModeExtension on SkBlendMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkBlendMode> _skBlendModes = <SkBlendMode>[
@@ -915,7 +915,7 @@ class SkStrokeJoin {}
 extension SkStrokeJoinExtension on SkStrokeJoin {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkStrokeJoin> _skStrokeJoins = <SkStrokeJoin>[
@@ -946,7 +946,7 @@ class SkTileMode {}
 extension SkTileModeExtension on SkTileMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkTileMode> _skTileModes = <SkTileMode>[
@@ -976,7 +976,7 @@ class SkFilterMode {}
 extension SkFilterModeExtension on SkFilterMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 SkFilterMode toSkFilterMode(ui.FilterQuality filterQuality) {
@@ -1002,7 +1002,7 @@ class SkMipmapMode {}
 extension SkMipmapModeExtension on SkMipmapMode {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 SkMipmapMode toSkMipmapMode(ui.FilterQuality filterQuality) {
@@ -1028,7 +1028,7 @@ class SkAlphaType {}
 extension SkAlphaTypeExtension on SkAlphaType {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 @JS()
@@ -1056,7 +1056,7 @@ class SkColorType {}
 extension SkColorTypeExtension on SkColorType {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 @JS()
@@ -1067,31 +1067,31 @@ class SkAnimatedImage {}
 extension SkAnimatedImageExtension on SkAnimatedImage {
   @JS('getFrameCount')
   external JSNumber _getFrameCount();
-  double getFrameCount() => _getFrameCount().toDart;
+  double getFrameCount() => _getFrameCount().toDartDouble;
 
   @JS('getRepetitionCount')
   external JSNumber _getRepetitionCount();
-  double getRepetitionCount() => _getRepetitionCount().toDart;
+  double getRepetitionCount() => _getRepetitionCount().toDartDouble;
 
   /// Returns duration in milliseconds.
   @JS('currentFrameDuration')
   external JSNumber _currentFrameDuration();
-  double currentFrameDuration() => _currentFrameDuration().toDart;
+  double currentFrameDuration() => _currentFrameDuration().toDartDouble;
 
   /// Advances to the next frame and returns its duration in milliseconds.
   @JS('decodeNextFrame')
   external JSNumber _decodeNextFrame();
-  double decodeNextFrame() => _decodeNextFrame().toDart;
+  double decodeNextFrame() => _decodeNextFrame().toDartDouble;
 
   external SkImage makeImageAtCurrentFrame();
 
   @JS('width')
   external JSNumber _width();
-  double width() => _width().toDart;
+  double width() => _width().toDartDouble;
 
   @JS('height')
   external JSNumber _height();
-  double height() => _height().toDart;
+  double height() => _height().toDartDouble;
 
   /// Deletes the C++ object.
   ///
@@ -1113,11 +1113,11 @@ extension SkImageExtension on SkImage {
 
   @JS('width')
   external JSNumber _width();
-  double width() => _width().toDart;
+  double width() => _width().toDartDouble;
 
   @JS('height')
   external JSNumber _height();
-  double height() => _height().toDart;
+  double height() => _height().toDartDouble;
 
   @JS('makeShaderCubic')
   external SkShader _makeShaderCubic(
@@ -1624,7 +1624,7 @@ extension SkFloat32ListExtension on SkFloat32List {
   /// The number of objects this pointer refers to.
   @JS('length')
   external JSNumber get _length;
-  double get length => _length.toDart;
+  double get length => _length.toDartDouble;
 
   @JS('length')
   external set _length(JSNumber length);
@@ -1655,7 +1655,7 @@ extension SkUint32ListExtension on SkUint32List {
   /// The number of objects this pointer refers to.
   @JS('length')
   external JSNumber get _length;
-  double get length => _length.toDart;
+  double get length => _length.toDartDouble;
 
   @JS('length')
   external set _length(JSNumber length);
@@ -2084,7 +2084,7 @@ extension SkContourMeasureExtension on SkContourMeasure {
 
   @JS('length')
   external JSNumber _length();
-  double length() => _length().toDart;
+  double length() => _length().toDartDouble;
 
   external JSVoid delete();
 }
@@ -2513,11 +2513,11 @@ extension SkCanvasExtension on SkCanvas {
 
   @JS('save')
   external JSNumber _save();
-  double save() => _save().toDart;
+  double save() => _save().toDartDouble;
 
   @JS('getSaveCount')
   external JSNumber _getSaveCount();
-  double getSaveCount() => _getSaveCount().toDart;
+  double getSaveCount() => _getSaveCount().toDartDouble;
 
   @JS('saveLayer')
   external JSVoid _saveLayer(
@@ -2747,7 +2747,7 @@ class SkTextDecorationStyle {}
 extension SkTextDecorationStyleExtension on SkTextDecorationStyle {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkTextDecorationStyle> _skTextDecorationStyles =
@@ -2779,7 +2779,7 @@ class SkTextBaseline {}
 extension SkTextBaselineExtension on SkTextBaseline {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkTextBaseline> _skTextBaselines = <SkTextBaseline>[
@@ -2811,7 +2811,7 @@ class SkPlaceholderAlignment {}
 extension SkPlaceholderAlignmentExtension on SkPlaceholderAlignment {
   @JS('value')
   external JSNumber get _value;
-  double get value => _value.toDart;
+  double get value => _value.toDartDouble;
 }
 
 final List<SkPlaceholderAlignment> _skPlaceholderAlignments =
@@ -3101,19 +3101,19 @@ class SkLineMetrics {}
 extension SkLineMetricsExtension on SkLineMetrics {
   @JS('startIndex')
   external JSNumber get _startIndex;
-  double get startIndex => _startIndex.toDart;
+  double get startIndex => _startIndex.toDartDouble;
 
   @JS('endIndex')
   external JSNumber get _endIndex;
-  double get endIndex => _endIndex.toDart;
+  double get endIndex => _endIndex.toDartDouble;
 
   @JS('endExcludingWhitespaces')
   external JSNumber get _endExcludingWhitespaces;
-  double get endExcludingWhitespaces => _endExcludingWhitespaces.toDart;
+  double get endExcludingWhitespaces => _endExcludingWhitespaces.toDartDouble;
 
   @JS('endIncludingNewline')
   external JSNumber get _endIncludingNewline;
-  double get endIncludingNewline => _endIncludingNewline.toDart;
+  double get endIncludingNewline => _endIncludingNewline.toDartDouble;
 
   @JS('isHardBreak')
   external JSBoolean get _isHardBreak;
@@ -3121,31 +3121,31 @@ extension SkLineMetricsExtension on SkLineMetrics {
 
   @JS('ascent')
   external JSNumber get _ascent;
-  double get ascent => _ascent.toDart;
+  double get ascent => _ascent.toDartDouble;
 
   @JS('descent')
   external JSNumber get _descent;
-  double get descent => _descent.toDart;
+  double get descent => _descent.toDartDouble;
 
   @JS('height')
   external JSNumber get _height;
-  double get height => _height.toDart;
+  double get height => _height.toDartDouble;
 
   @JS('width')
   external JSNumber get _width;
-  double get width => _width.toDart;
+  double get width => _width.toDartDouble;
 
   @JS('left')
   external JSNumber get _left;
-  double get left => _left.toDart;
+  double get left => _left.toDartDouble;
 
   @JS('baseline')
   external JSNumber get _baseline;
-  double get baseline => _baseline.toDart;
+  double get baseline => _baseline.toDartDouble;
 
   @JS('lineNumber')
   external JSNumber get _lineNumber;
-  double get lineNumber => _lineNumber.toDart;
+  double get lineNumber => _lineNumber.toDartDouble;
 }
 
 @JS()
@@ -3173,7 +3173,7 @@ class SkParagraph {}
 extension SkParagraphExtension on SkParagraph {
   @JS('getAlphabeticBaseline')
   external JSNumber _getAlphabeticBaseline();
-  double getAlphabeticBaseline() => _getAlphabeticBaseline().toDart;
+  double getAlphabeticBaseline() => _getAlphabeticBaseline().toDartDouble;
 
   @JS('didExceedMaxLines')
   external JSBoolean _didExceedMaxLines();
@@ -3181,11 +3181,11 @@ extension SkParagraphExtension on SkParagraph {
 
   @JS('getHeight')
   external JSNumber _getHeight();
-  double getHeight() => _getHeight().toDart;
+  double getHeight() => _getHeight().toDartDouble;
 
   @JS('getIdeographicBaseline')
   external JSNumber _getIdeographicBaseline();
-  double getIdeographicBaseline() => _getIdeographicBaseline().toDart;
+  double getIdeographicBaseline() => _getIdeographicBaseline().toDartDouble;
 
   @JS('getLineMetrics')
   external JSArray _getLineMetrics();
@@ -3194,19 +3194,19 @@ extension SkParagraphExtension on SkParagraph {
 
   @JS('getLongestLine')
   external JSNumber _getLongestLine();
-  double getLongestLine() => _getLongestLine().toDart;
+  double getLongestLine() => _getLongestLine().toDartDouble;
 
   @JS('getMaxIntrinsicWidth')
   external JSNumber _getMaxIntrinsicWidth();
-  double getMaxIntrinsicWidth() => _getMaxIntrinsicWidth().toDart;
+  double getMaxIntrinsicWidth() => _getMaxIntrinsicWidth().toDartDouble;
 
   @JS('getMinIntrinsicWidth')
   external JSNumber _getMinIntrinsicWidth();
-  double getMinIntrinsicWidth() => _getMinIntrinsicWidth().toDart;
+  double getMinIntrinsicWidth() => _getMinIntrinsicWidth().toDartDouble;
 
   @JS('getMaxWidth')
   external JSNumber _getMaxWidth();
-  double getMaxWidth() => _getMaxWidth().toDart;
+  double getMaxWidth() => _getMaxWidth().toDartDouble;
 
   @JS('getRectsForRange')
   external JSArray _getRectsForRange(
@@ -3259,7 +3259,7 @@ extension SkTextPositionExtnsion on SkTextPosition {
 
   @JS('pos')
   external JSNumber get _pos;
-  double get pos => _pos.toDart;
+  double get pos => _pos.toDartDouble;
 }
 
 @JS()
@@ -3269,11 +3269,11 @@ class SkTextRange {}
 extension SkTextRangeExtension on SkTextRange {
   @JS('start')
   external JSNumber get _start;
-  double get start => _start.toDart;
+  double get start => _start.toDartDouble;
 
   @JS('end')
   external JSNumber get _end;
-  double get end => _end.toDart;
+  double get end => _end.toDartDouble;
 }
 
 @JS()
@@ -3391,7 +3391,7 @@ class SkData {}
 extension SkDataExtension on SkData {
   @JS('size')
   external JSNumber _size();
-  double size() => _size().toDart;
+  double size() => _size().toDartDouble;
 
   @JS('isEmpty')
   external JSBoolean _isEmpty();
@@ -3435,7 +3435,7 @@ extension SkImageInfoExtension on SkImageInfo {
 
   @JS('height')
   external JSNumber get _height;
-  double get height => _height.toDart;
+  double get height => _height.toDartDouble;
 
   @JS('isEmpty')
   external JSBoolean get _isEmpty;
@@ -3451,7 +3451,7 @@ extension SkImageInfoExtension on SkImageInfo {
 
   @JS('width')
   external JSNumber get _width;
-  double get width => _width.toDart;
+  double get width => _width.toDartDouble;
 
   external SkImageInfo makeAlphaType(SkAlphaType alphaType);
   external SkImageInfo makeColorSpace(ColorSpace colorSpace);
@@ -3494,11 +3494,11 @@ extension SkPartialImageInfoExtension on SkPartialImageInfo {
 
   @JS('height')
   external JSNumber get _height;
-  double get height => _height.toDart;
+  double get height => _height.toDartDouble;
 
   @JS('width')
   external JSNumber get _width;
-  double get width => _width.toDart;
+  double get width => _width.toDartDouble;
 }
 
 @JS('window.flutterCanvasKit.RuntimeEffect')

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -205,10 +205,10 @@ Future<Uint8List> readChunked(HttpFetchPayload payload, int contentLength, WebOn
   int position = 0;
   int cumulativeBytesLoaded = 0;
   await payload.read<JSUint8Array1>((JSUint8Array1 chunk) {
-    cumulativeBytesLoaded += chunk.length.toDart.toInt();
+    cumulativeBytesLoaded += chunk.length.toDartInt;
     chunkCallback(cumulativeBytesLoaded, contentLength);
     result.set(chunk, position.toJS);
-    position += chunk.length.toDart.toInt();
+    position += chunk.length.toDartInt;
   });
   return result.toDart;
 }

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -317,7 +317,7 @@ extension JsFlutterConfigurationExtension on JsFlutterConfiguration {
 
   @JS('canvasKitMaximumSurfaces')
   external JSNumber? get _canvasKitMaximumSurfaces;
-  double? get canvasKitMaximumSurfaces => _canvasKitMaximumSurfaces?.toDart;
+  double? get canvasKitMaximumSurfaces => _canvasKitMaximumSurfaces?.toDartDouble;
 
   @JS('debugShowSemanticsNodes')
   external JSBoolean? get _debugShowSemanticsNodes;

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -41,9 +41,6 @@ extension ObjectToJSAnyExtension on Object {
     if (isWasm) {
       return toJSAnyDeep;
     } else {
-      // TODO(joshualitt): remove this cast when we reify JS types on JS
-      // backends.
-      // ignore: unnecessary_cast
       return this as JSAny;
     }
   }
@@ -76,18 +73,18 @@ extension DomWindowExtension on DomWindow {
 
   @JS('devicePixelRatio')
   external JSNumber get _devicePixelRatio;
-  double get devicePixelRatio => _devicePixelRatio.toDart;
+  double get devicePixelRatio => _devicePixelRatio.toDartDouble;
 
   external DomDocument get document;
   external DomHistory get history;
 
   @JS('innerHeight')
   external JSNumber? get _innerHeight;
-  double? get innerHeight => _innerHeight?.toDart;
+  double? get innerHeight => _innerHeight?.toDartDouble;
 
   @JS('innerWidth')
   external JSNumber? get _innerWidth;
-  double? get innerWidth => _innerWidth?.toDart;
+  double? get innerWidth => _innerWidth?.toDartDouble;
 
   external DomLocation get location;
   external DomNavigator get navigator;
@@ -139,7 +136,7 @@ extension DomWindowExtension on DomWindow {
   @JS('requestAnimationFrame')
   external JSNumber _requestAnimationFrame(JSFunction callback);
   double requestAnimationFrame(DomRequestAnimationFrameCallback callback) =>
-      _requestAnimationFrame(callback.toJS).toDart;
+      _requestAnimationFrame(callback.toJS).toDartDouble;
 
   @JS('postMessage')
   external JSVoid _postMessage1(JSAny message, JSString targetOrigin);
@@ -203,7 +200,7 @@ extension DomNavigatorExtension on DomNavigator {
 
   @JS('maxTouchPoints')
   external JSNumber? get _maxTouchPoints;
-  double? get maxTouchPoints => _maxTouchPoints?.toDart;
+  double? get maxTouchPoints => _maxTouchPoints?.toDartDouble;
 
   @JS('vendor')
   external JSString get _vendor;
@@ -385,7 +382,7 @@ extension DomEventExtension on DomEvent {
 
   @JS('timeStamp')
   external JSNumber? get _timeStamp;
-  double? get timeStamp => _timeStamp?.toDart;
+  double? get timeStamp => _timeStamp?.toDartDouble;
 
   @JS('type')
   external JSString get _type;
@@ -432,11 +429,11 @@ class DomProgressEvent extends DomEvent {
 extension DomProgressEventExtension on DomProgressEvent {
   @JS('loaded')
   external JSNumber? get _loaded;
-  double? get loaded => _loaded?.toDart;
+  double? get loaded => _loaded?.toDartDouble;
 
   @JS('total')
   external JSNumber? get _total;
-  double? get total => _total?.toDart;
+  double? get total => _total?.toDartDouble;
 }
 
 @JS()
@@ -528,11 +525,11 @@ extension DomElementExtension on DomElement {
 
   @JS('clientHeight')
   external JSNumber get _clientHeight;
-  double get clientHeight => _clientHeight.toDart;
+  double get clientHeight => _clientHeight.toDartDouble;
 
   @JS('clientWidth')
   external JSNumber get _clientWidth;
-  double get clientWidth => _clientWidth.toDart;
+  double get clientWidth => _clientWidth.toDartDouble;
 
   @JS('id')
   external JSString get _id;
@@ -597,13 +594,13 @@ extension DomElementExtension on DomElement {
 
   @JS('tabIndex')
   external JSNumber? get _tabIndex;
-  double? get tabIndex => _tabIndex?.toDart;
+  double? get tabIndex => _tabIndex?.toDartDouble;
 
   external JSVoid focus();
 
   @JS('scrollTop')
   external JSNumber get _scrollTop;
-  double get scrollTop => _scrollTop.toDart;
+  double get scrollTop => _scrollTop.toDartDouble;
 
   @JS('scrollTop')
   external set _scrollTop(JSNumber value);
@@ -611,7 +608,7 @@ extension DomElementExtension on DomElement {
 
   @JS('scrollLeft')
   external JSNumber get _scrollLeft;
-  double get scrollLeft => _scrollLeft.toDart;
+  double get scrollLeft => _scrollLeft.toDartDouble;
 
   @JS('scrollLeft')
   external set _scrollLeft(JSNumber value);
@@ -828,15 +825,15 @@ class DomHTMLElement extends DomElement {}
 extension DomHTMLElementExtension on DomHTMLElement {
   @JS('offsetWidth')
   external JSNumber get _offsetWidth;
-  double get offsetWidth => _offsetWidth.toDart;
+  double get offsetWidth => _offsetWidth.toDartDouble;
 
   @JS('offsetLeft')
   external JSNumber get _offsetLeft;
-  double get offsetLeft => _offsetLeft.toDart;
+  double get offsetLeft => _offsetLeft.toDartDouble;
 
   @JS('offsetTop')
   external JSNumber get _offsetTop;
-  double get offsetTop => _offsetTop.toDart;
+  double get offsetTop => _offsetTop.toDartDouble;
 
   external DomHTMLElement? get offsetParent;
 }
@@ -901,11 +898,11 @@ extension DomHTMLImageElementExtension on DomHTMLImageElement {
 
   @JS('naturalWidth')
   external JSNumber get _naturalWidth;
-  double get naturalWidth => _naturalWidth.toDart;
+  double get naturalWidth => _naturalWidth.toDartDouble;
 
   @JS('naturalHeight')
   external JSNumber get _naturalHeight;
-  double get naturalHeight => _naturalHeight.toDart;
+  double get naturalHeight => _naturalHeight.toDartDouble;
 
   @JS('width')
   external set _width(JSNumber? value);
@@ -1019,7 +1016,7 @@ extension DomPerformanceExtension on DomPerformance {
 
   @JS('now')
   external JSNumber _now();
-  double now() => _now().toDart;
+  double now() => _now().toDartDouble;
 }
 
 @JS()
@@ -1058,7 +1055,7 @@ DomCanvasElement createDomCanvasElement({int? width, int? height}) {
 extension DomCanvasElementExtension on DomCanvasElement {
   @JS('width')
   external JSNumber? get _width;
-  double? get width => _width?.toDart;
+  double? get width => _width?.toDartDouble;
 
   @JS('width')
   external set _width(JSNumber? value);
@@ -1066,7 +1063,7 @@ extension DomCanvasElementExtension on DomCanvasElement {
 
   @JS('height')
   external JSNumber? get _height;
-  double? get height => _height?.toDart;
+  double? get height => _height?.toDartDouble;
 
   @JS('height')
   external set _height(JSNumber? value);
@@ -1110,15 +1107,15 @@ class WebGLContext {}
 extension WebGLContextExtension on WebGLContext {
   @JS('getParameter')
   external JSNumber _getParameter(JSNumber value);
-  int getParameter(int value) => _getParameter(value.toJS).toDart.toInt();
+  int getParameter(int value) => _getParameter(value.toJS).toDartDouble.toInt();
 
   @JS('SAMPLES')
   external JSNumber get _samples;
-  int get samples => _samples.toDart.toInt();
+  int get samples => _samples.toDartDouble.toInt();
 
   @JS('STENCIL_BITS')
   external JSNumber get _stencilBits;
-  int get stencilBits => _stencilBits.toDart.toInt();
+  int get stencilBits => _stencilBits.toDartDouble.toInt();
 }
 
 @JS()
@@ -1778,7 +1775,7 @@ class DomResponse {}
 extension DomResponseExtension on DomResponse {
   @JS('status')
   external JSNumber get _status;
-  int get status => _status.toDart.toInt();
+  int get status => _status.toDartInt;
 
   external DomHeaders get headers;
 
@@ -1856,7 +1853,7 @@ class DomTextMetrics {}
 extension DomTextMetricsExtension on DomTextMetrics {
   @JS('width')
   external JSNumber? get _width;
-  double? get width => _width?.toDart;
+  double? get width => _width?.toDartDouble;
 }
 
 @JS()
@@ -1878,35 +1875,35 @@ class DomRectReadOnly {}
 extension DomRectReadOnlyExtension on DomRectReadOnly {
   @JS('x')
   external JSNumber get _x;
-  double get x => _x.toDart;
+  double get x => _x.toDartDouble;
 
   @JS('y')
   external JSNumber get _y;
-  double get y => _y.toDart;
+  double get y => _y.toDartDouble;
 
   @JS('width')
   external JSNumber get _width;
-  double get width => _width.toDart;
+  double get width => _width.toDartDouble;
 
   @JS('height')
   external JSNumber get _height;
-  double get height => _height.toDart;
+  double get height => _height.toDartDouble;
 
   @JS('top')
   external JSNumber get _top;
-  double get top => _top.toDart;
+  double get top => _top.toDartDouble;
 
   @JS('right')
   external JSNumber get _right;
-  double get right => _right.toDart;
+  double get right => _right.toDartDouble;
 
   @JS('bottom')
   external JSNumber get _bottom;
-  double get bottom => _bottom.toDart;
+  double get bottom => _bottom.toDartDouble;
 
   @JS('left')
   external JSNumber get _left;
-  double get left => _left.toDart;
+  double get left => _left.toDartDouble;
 }
 
 DomRect createDomRectFromPoints(DomPoint a, DomPoint b) {
@@ -1984,11 +1981,11 @@ class DomVisualViewport extends DomEventTarget {}
 extension DomVisualViewportExtension on DomVisualViewport {
   @JS('height')
   external JSNumber? get _height;
-  double? get height => _height?.toDart;
+  double? get height => _height?.toDartDouble;
 
   @JS('width')
   external JSNumber? get _width;
-  double? get width => _width?.toDart;
+  double? get width => _width?.toDartDouble;
 }
 
 @JS()
@@ -2015,11 +2012,11 @@ extension DomHTMLTextAreaElementExtension on DomHTMLTextAreaElement {
 
   @JS('selectionStart')
   external JSNumber? get _selectionStart;
-  double? get selectionStart => _selectionStart?.toDart;
+  double? get selectionStart => _selectionStart?.toDartDouble;
 
   @JS('selectionEnd')
   external JSNumber? get _selectionEnd;
-  double? get selectionEnd => _selectionEnd?.toDart;
+  double? get selectionEnd => _selectionEnd?.toDartDouble;
 
   @JS('selectionStart')
   external set _selectionStart(JSNumber? value);
@@ -2100,11 +2097,11 @@ extension DomKeyboardEventExtension on DomKeyboardEvent {
 
   @JS('keyCode')
   external JSNumber get _keyCode;
-  double get keyCode => _keyCode.toDart;
+  double get keyCode => _keyCode.toDartDouble;
 
   @JS('location')
   external JSNumber get _location;
-  double get location => _location.toDart;
+  double get location => _location.toDartDouble;
 
   @JS('metaKey')
   external JSBoolean get _metaKey;
@@ -2354,38 +2351,38 @@ class DomMouseEvent extends DomUIEvent {
 extension DomMouseEventExtension on DomMouseEvent {
   @JS('clientX')
   external JSNumber get _clientX;
-  double get clientX => _clientX.toDart;
+  double get clientX => _clientX.toDartDouble;
 
   @JS('clientY')
   external JSNumber get _clientY;
-  double get clientY => _clientY.toDart;
+  double get clientY => _clientY.toDartDouble;
 
   @JS('offsetX')
   external JSNumber get _offsetX;
-  double get offsetX => _offsetX.toDart;
+  double get offsetX => _offsetX.toDartDouble;
 
   @JS('offsetY')
   external JSNumber get _offsetY;
-  double get offsetY => _offsetY.toDart;
+  double get offsetY => _offsetY.toDartDouble;
 
   @JS('pageX')
   external JSNumber get _pageX;
-  double get pageX => _pageX.toDart;
+  double get pageX => _pageX.toDartDouble;
 
   @JS('pageY')
   external JSNumber get _pageY;
-  double get pageY => _pageY.toDart;
+  double get pageY => _pageY.toDartDouble;
 
   DomPoint get client => DomPoint(clientX, clientY);
   DomPoint get offset => DomPoint(offsetX, offsetY);
 
   @JS('button')
   external JSNumber get _button;
-  double get button => _button.toDart;
+  double get button => _button.toDartDouble;
 
   @JS('buttons')
   external JSNumber? get _buttons;
-  double? get buttons => _buttons?.toDart;
+  double? get buttons => _buttons?.toDartDouble;
 
   @JS('ctrlKey')
   external JSBoolean get _ctrlKey;
@@ -2414,7 +2411,7 @@ class DomPointerEvent extends DomMouseEvent {
 extension DomPointerEventExtension on DomPointerEvent {
   @JS('pointerId')
   external JSNumber? get _pointerId;
-  double? get pointerId => _pointerId?.toDart;
+  double? get pointerId => _pointerId?.toDartDouble;
 
   @JS('pointerType')
   external JSString? get _pointerType;
@@ -2422,15 +2419,15 @@ extension DomPointerEventExtension on DomPointerEvent {
 
   @JS('pressure')
   external JSNumber? get _pressure;
-  double? get pressure => _pressure?.toDart;
+  double? get pressure => _pressure?.toDartDouble;
 
   @JS('tiltX')
   external JSNumber? get _tiltX;
-  double? get tiltX => _tiltX?.toDart;
+  double? get tiltX => _tiltX?.toDartDouble;
 
   @JS('tiltY')
   external JSNumber? get _tiltY;
-  double? get tiltY => _tiltY?.toDart;
+  double? get tiltY => _tiltY?.toDartDouble;
 
   @JS('getCoalescedEvents')
   external JSArray _getCoalescedEvents();
@@ -2457,23 +2454,23 @@ class DomWheelEvent extends DomMouseEvent {
 extension DomWheelEventExtension on DomWheelEvent {
   @JS('deltaX')
   external JSNumber get _deltaX;
-  double get deltaX => _deltaX.toDart;
+  double get deltaX => _deltaX.toDartDouble;
 
   @JS('deltaY')
   external JSNumber get _deltaY;
-  double get deltaY => _deltaY.toDart;
+  double get deltaY => _deltaY.toDartDouble;
 
   @JS('wheelDeltaX')
   external JSNumber? get _wheelDeltaX;
-  double? get wheelDeltaX => _wheelDeltaX?.toDart;
+  double? get wheelDeltaX => _wheelDeltaX?.toDartDouble;
 
   @JS('wheelDeltaY')
   external JSNumber? get _wheelDeltaY;
-  double? get wheelDeltaY => _wheelDeltaY?.toDart;
+  double? get wheelDeltaY => _wheelDeltaY?.toDartDouble;
 
   @JS('deltaMode')
   external JSNumber get _deltaMode;
-  double get deltaMode => _deltaMode.toDart;
+  double get deltaMode => _deltaMode.toDartDouble;
 }
 
 DomWheelEvent createDomWheelEvent(String type, [Map<dynamic, dynamic>? init]) {
@@ -2524,15 +2521,15 @@ class DomTouch {
 extension DomTouchExtension on DomTouch {
   @JS('identifier')
   external JSNumber? get _identifier;
-  double? get identifier => _identifier?.toDart;
+  double? get identifier => _identifier?.toDartDouble;
 
   @JS('clientX')
   external JSNumber get _clientX;
-  double get clientX => _clientX.toDart;
+  double get clientX => _clientX.toDartDouble;
 
   @JS('clientY')
   external JSNumber get _clientY;
-  double get clientY => _clientY.toDart;
+  double get clientY => _clientY.toDartDouble;
 
   DomPoint get client => DomPoint(clientX, clientY);
 }
@@ -2622,11 +2619,11 @@ extension DomHTMLInputElementExtension on DomHTMLInputElement {
 
   @JS('selectionStart')
   external JSNumber? get _selectionStart;
-  double? get selectionStart => _selectionStart?.toDart;
+  double? get selectionStart => _selectionStart?.toDartDouble;
 
   @JS('selectionEnd')
   external JSNumber? get _selectionEnd;
-  double? get selectionEnd => _selectionEnd?.toDart;
+  double? get selectionEnd => _selectionEnd?.toDartDouble;
 
   @JS('selectionStart')
   external set _selectionStart(JSNumber? value);
@@ -2724,11 +2721,11 @@ class DomOffscreenCanvas extends DomEventTarget {
 extension DomOffscreenCanvasExtension on DomOffscreenCanvas {
   @JS('height')
   external JSNumber? get _height;
-  double? get height => _height?.toDart;
+  double? get height => _height?.toDartDouble;
 
   @JS('width')
   external JSNumber? get _width;
-  double? get width => _width?.toDart;
+  double? get width => _width?.toDartDouble;
 
   @JS('height')
   external set _height(JSNumber? value);
@@ -2837,9 +2834,9 @@ extension DomCSSStyleSheetExtension on DomCSSStyleSheet {
   external JSNumber _insertRule2(JSString rule, JSNumber index);
   double insertRule(String rule, [int? index]) {
     if (index == null) {
-      return _insertRule1(rule.toJS).toDart;
+      return _insertRule1(rule.toJS).toDartDouble;
     } else {
-      return _insertRule2(rule.toJS, index.toJS).toDart;
+      return _insertRule2(rule.toJS, index.toJS).toDartDouble;
     }
   }
 }
@@ -3191,7 +3188,7 @@ class _DomList {}
 extension DomListExtension on _DomList {
   @JS('length')
   external JSNumber get _length;
-  double get length => _length.toDart;
+  double get length => _length.toDartDouble;
 
   @JS('item')
   external DomNode _item(JSNumber index);
@@ -3243,7 +3240,7 @@ class _DomTouchList {}
 extension DomTouchListExtension on _DomTouchList {
   @JS('length')
   external JSNumber get _length;
-  double get length => _length.toDart;
+  double get length => _length.toDartDouble;
 
   @JS('item')
   external DomNode _item(JSNumber index);
@@ -3386,7 +3383,7 @@ class DomSegment {}
 extension DomSegmentExtension on DomSegment {
   @JS('index')
   external JSNumber get _index;
-  int get index => _index.toDart.toInt();
+  int get index => _index.toDartDouble.toInt();
 
   @JS('isWordLike')
   external JSBoolean get _isWordLike;
@@ -3424,15 +3421,15 @@ extension DomV8BreakIteratorExtension on DomV8BreakIterator {
 
   @JS('first')
   external JSNumber _first();
-  double first() => _first().toDart;
+  double first() => _first().toDartDouble;
 
   @JS('next')
   external JSNumber _next();
-  double next() => _next().toDart;
+  double next() => _next().toDartDouble;
 
   @JS('current')
   external JSNumber _current();
-  double current() => _current().toDart;
+  double current() => _current().toDartDouble;
 
   @JS('breakType')
   external JSString _breakType();

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -169,7 +169,8 @@ Future<void> initializeEngineServices({
         // milliseconds as a double value, with sub-millisecond information
         // hidden in the fraction. So we first multiply it by 1000 to uncover
         // microsecond precision, and only then convert to `int`.
-        final int highResTimeMicroseconds = (1000 * highResTime.toDart).toInt();
+        final int highResTimeMicroseconds =
+            (1000 * highResTime.toDartDouble).toInt();
 
         // In Flutter terminology "building a frame" consists of "beginning
         // frame" and "drawing frame".

--- a/lib/web_ui/lib/src/engine/profiler.dart
+++ b/lib/web_ui/lib/src/engine/profiler.dart
@@ -12,8 +12,7 @@ import 'platform_dispatcher.dart';
 import 'safe_browser_api.dart';
 
 @JS('window._flutter_internal_on_benchmark')
-external JSAny? get _onBenchmark;
-Object? get onBenchmark => _onBenchmark?.toObjectShallow;
+external JSExportedDartFunction? get onBenchmark;
 
 /// A function that computes a value of type [R].
 ///
@@ -106,7 +105,7 @@ class Profiler {
   void benchmark(String name, double value) {
     _checkBenchmarkMode();
 
-    final OnBenchmark? callback = onBenchmark as OnBenchmark?;
+    final OnBenchmark? callback = onBenchmark?.toDart as OnBenchmark?;
     if (callback != null) {
       callback(name, value);
     }

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -302,7 +302,7 @@ class VideoFrame implements DomCanvasImageSource {}
 extension VideoFrameExtension on VideoFrame {
   @JS('allocationSize')
   external JSNumber _allocationSize();
-  double allocationSize() => _allocationSize().toDart;
+  double allocationSize() => _allocationSize().toDartDouble;
 
   @JS('copyTo')
   external JsPromise _copyTo(JSAny destination);
@@ -314,23 +314,23 @@ extension VideoFrameExtension on VideoFrame {
 
   @JS('codedWidth')
   external JSNumber get _codedWidth;
-  double get codedWidth => _codedWidth.toDart;
+  double get codedWidth => _codedWidth.toDartDouble;
 
   @JS('codedHeight')
   external JSNumber get _codedHeight;
-  double get codedHeight => _codedHeight.toDart;
+  double get codedHeight => _codedHeight.toDartDouble;
 
   @JS('displayWidth')
   external JSNumber get _displayWidth;
-  double get displayWidth => _displayWidth.toDart;
+  double get displayWidth => _displayWidth.toDartDouble;
 
   @JS('displayHeight')
   external JSNumber get _displayHeight;
-  double get displayHeight => _displayHeight.toDart;
+  double get displayHeight => _displayHeight.toDartDouble;
 
   @JS('duration')
   external JSNumber? get _duration;
-  double? get duration => _duration?.toDart;
+  double? get duration => _duration?.toDartDouble;
 
   external VideoFrame clone();
   external JSVoid close();
@@ -364,11 +364,11 @@ class ImageTrack {}
 extension ImageTrackExtension on ImageTrack {
   @JS('repetitionCount')
   external JSNumber get _repetitionCount;
-  double get repetitionCount => _repetitionCount.toDart;
+  double get repetitionCount => _repetitionCount.toDartDouble;
 
   @JS('frameCount')
   external JSNumber get _frameCount;
-  double get frameCount => _frameCount.toDart;
+  double get frameCount => _frameCount.toDartDouble;
 }
 
 void scaleCanvas2D(Object context2d, num x, num y) {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/font_collection.dart
@@ -110,7 +110,7 @@ class SkwasmFontCollection implements FlutterFontCollection {
     int length = 0;
     final List<JSUint8Array> chunks = <JSUint8Array>[];
     await response.read((JSUint8Array chunk) {
-      length += chunk.length.toDart.toInt();
+      length += chunk.length.toDartInt;
       chunks.add(chunk);
     });
     final SkDataHandle fontData = skDataCreate(length);
@@ -118,7 +118,7 @@ class SkwasmFontCollection implements FlutterFontCollection {
     final JSUint8Array wasmMemory = createUint8ArrayFromBuffer(skwasmInstance.wasmMemory.buffer);
     for (final JSUint8Array chunk in chunks) {
       wasmMemory.set(chunk, dataAddress.toJS);
-      dataAddress += chunk.length.toDart.toInt();
+      dataAddress += chunk.length.toDartInt;
     }
     final SkwasmTypeface typeface = SkwasmTypeface(fontData);
     skDataDispose(fontData);
@@ -138,7 +138,7 @@ class SkwasmFontCollection implements FlutterFontCollection {
     int length = 0;
     final List<JSUint8Array> chunks = <JSUint8Array>[];
     await response.read((JSUint8Array chunk) {
-      length += chunk.length.toDart.toInt();
+      length += chunk.length.toDartInt;
       chunks.add(chunk);
     });
     final SkDataHandle fontData = skDataCreate(length);
@@ -146,7 +146,7 @@ class SkwasmFontCollection implements FlutterFontCollection {
     final JSUint8Array wasmMemory = createUint8ArrayFromBuffer(skwasmInstance.wasmMemory.buffer);
     for (final JSUint8Array chunk in chunks) {
       wasmMemory.set(chunk, dataAddress.toJS);
-      dataAddress += chunk.length.toDart.toInt();
+      dataAddress += chunk.length.toDartInt;
     }
 
     final SkwasmTypeface typeface = SkwasmTypeface(fontData);

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -29,7 +29,7 @@ typedef DisposeFunction<T extends NativeType> = void Function(Pointer<T>);
 class SkwasmFinalizationRegistry<T extends NativeType> {
   SkwasmFinalizationRegistry(this.dispose)
     : registry = createDomFinalizationRegistry(((JSNumber address) =>
-      dispose(Pointer<T>.fromAddress(address.toDart.toInt()))
+      dispose(Pointer<T>.fromAddress(address.toDartDouble.toInt()))
     ).toJS);
 
   final DomFinalizationRegistry registry;

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
@@ -37,7 +37,7 @@ class SkwasmSurface {
         skwasmInstance.addFunction(
           _callbackHandler.toJS,
           'vii'.toJS
-        ).toDart.toInt()
+        ).toDartDouble.toInt()
       );
     surfaceSetCallbackHandler(handle, _callbackHandle);
   }
@@ -75,9 +75,9 @@ class SkwasmSurface {
   }
 
   void _callbackHandler(JSNumber jsCallbackId, JSNumber jsPointer) {
-    final int callbackId = jsCallbackId.toDart.toInt();
+    final int callbackId = jsCallbackId.toDartDouble.toInt();
     final Completer<int> completer = _pendingCallbacks.remove(callbackId)!;
-    completer.complete(jsPointer.toDart.toInt());
+    completer.complete(jsPointer.toDartDouble.toInt());
   }
 
   void dispose() {

--- a/lib/web_ui/test/engine/profiler_test.dart
+++ b/lib/web_ui/test/engine/profiler_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:js_interop';
 
-import 'package:js/js_util.dart' as js_util;
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -12,8 +11,7 @@ import 'package:ui/src/engine.dart';
 import '../common/spy.dart';
 
 @JS('window._flutter_internal_on_benchmark')
-external set _onBenchmark (JSAny? object);
-set onBenchmark (Object? object) => _onBenchmark = object?.toJSAnyShallow;
+external set onBenchmark(JSAny? object);
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
@@ -46,9 +44,9 @@ void _profilerTests() {
 
   test('can listen to benchmarks', () {
     final List<BenchmarkDatapoint> data = <BenchmarkDatapoint>[];
-    onBenchmark = js_util.allowInterop((String name, num value) {
+    onBenchmark = (String name, num value) {
       data.add(BenchmarkDatapoint(name, value));
-    });
+    }.toJS;
 
     Profiler.instance.benchmark('foo', 123);
     expect(data, <BenchmarkDatapoint>[BenchmarkDatapoint('foo', 123)]);
@@ -69,9 +67,9 @@ void _profilerTests() {
     final List<BenchmarkDatapoint> data = <BenchmarkDatapoint>[];
 
     // Wrong callback signature.
-    onBenchmark = js_util.allowInterop((num value) {
+    onBenchmark = (num value) {
       data.add(BenchmarkDatapoint('bad', value));
-    });
+    }.toJS;
     expect(
       () => Profiler.instance.benchmark('foo', 123),
 
@@ -82,10 +80,12 @@ void _profilerTests() {
     expect(data, isEmpty);
 
     // Not even a callback.
-    onBenchmark = 'string';
+    onBenchmark = 'string'.toJS;
     expect(
       () => Profiler.instance.benchmark('foo', 123),
-      throwsA(isA<TypeError>()),
+      // dart2js throws a TypeError, while dart2wasm throws an explicit
+      // exception.
+      throwsA(anything),
     );
   });
 }


### PR DESCRIPTION
This reverts commit dce75ab4cf647eec6699f8a30ba2289a3738b307.

This also makes some small changes to make onBenchmark a JSExportedDartFunction instead of a JSBoxedDartObject. This is for changes in https://github.com/flutter/flutter/pull/129436 and to account for the fact that flutter/packages provides an `allowInterop`'d function. Benchmarks tests pass with this CL.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.
