### PR TITLE
[Windows] Fix `FlutterWindow::GetNativeViewAccessible` crash

### DIFF
--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -279,6 +279,10 @@ bool FlutterWindow::OnBitmapSurfaceUpdated(const void* allocation,
 }
 
 gfx::NativeViewAccessible FlutterWindow::GetNativeViewAccessible() {
+  if (binding_handler_delegate_ == nullptr) {
+    return nullptr;
+  }
+
   return binding_handler_delegate_->GetNativeViewAccessible();
 }
 

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -272,6 +272,15 @@ TEST(FlutterWindowTest, OnThemeChange) {
   win32window.InjectWindowMessage(WM_THEMECHANGED, 0, 0);
 }
 
+// The window should return no root accessibility node if
+// it isn't attached to a view.
+// Regression test for https://github.com/flutter/flutter/issues/129791
+TEST(FlutterWindowTest, AccessibilityNodeWithoutView) {
+  MockFlutterWindow win32window;
+
+  EXPECT_EQ(win32window.GetNativeViewAccessible(), nullptr);
+}
+
 TEST(FlutterWindowTest, InitialAccessibilityFeatures) {
   MockFlutterWindow win32window;
   MockWindowBindingHandlerDelegate delegate;


### PR DESCRIPTION
Flutter shouldn't crash if a view's `HWND` receives a `WM_GETOBJECT` message before it is attached to the view.

Fixes https://github.com/flutter/flutter/issues/129791

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
