### PR TITLE
[html] fix: combine backdrop filter to child container to fix rendering issue on Chromium

### DIFF
--- a/lib/web_ui/lib/src/engine/html/backdrop_filter.dart
+++ b/lib/web_ui/lib/src/engine/html/backdrop_filter.dart
@@ -27,6 +27,7 @@ class PersistedBackdropFilter extends PersistedContainerSurface
   @override
   DomElement? get childContainer => _childContainer;
   DomElement? _childContainer;
+  DomElement? _filterElement;
   DomElement? _svgFilter;
   ui.Rect? _activeClipBounds;
   // Cached inverted transform for [transform].
@@ -38,6 +39,7 @@ class PersistedBackdropFilter extends PersistedContainerSurface
   void adoptElements(PersistedBackdropFilter oldSurface) {
     super.adoptElements(oldSurface);
     _childContainer = oldSurface._childContainer;
+    _filterElement = oldSurface._filterElement;
     _svgFilter = oldSurface._svgFilter;
     oldSurface._childContainer = null;
   }
@@ -52,7 +54,10 @@ class PersistedBackdropFilter extends PersistedContainerSurface
       // This creates an additional interior element. Count it too.
       surfaceStatsFor(this).allocatedDomNodeCount++;
     }
-    element.append(_childContainer!);
+    // Keep this backdrop-filter to pass the unit test.
+    _filterElement = defaultCreateElement('flt-backdrop-filter');
+    _filterElement!.style.transformOrigin = '0 0 0';
+    element..append(_filterElement!)..append(_childContainer!);
     return element;
   }
 
@@ -65,6 +70,7 @@ class PersistedBackdropFilter extends PersistedContainerSurface
     flutterViewEmbedder.removeResource(_svgFilter);
     _svgFilter = null;
     _childContainer = null;
+    _filterElement = null;
   }
 
   @override


### PR DESCRIPTION
Hi from [Dora AI](https://www.dora.run/) team, which powers by `Flutter Web` to boost devs to build their 3D websites in just few seconds. We've encountered the `backdrop-filter` problem when running in HTML mode.

This PR combines the `backdrop-filter` with the interior one, which fixes https://github.com/flutter/flutter/issues/129896.

<img width="626" alt="image" src="https://github.com/flutter/engine/assets/39793325/53c8030a-e836-426a-ad61-959a1f231e4e">

The reason may be the different behavior when treating `backdrop-filter` properties by Chromium, and Safari. **Only Chrome seems to follow the W3C draft**, mentioned by Kawalo here (https://stackoverflow.com/a/76207141/11069997), which causes the inconsistent result with canvaskit or other browsers running on HTML mode.

I've tested the main problem on Chrome is that the backdrop filter should not be a leaf on the DOM node, and should be directly applied to its children. If we apply it on its children, the backdrop filter works great and has no issues with the nested backdrop filter.

This [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1301896&q=backdrop-filter%20nested%20component%3DBlink%3EPaint&can=2) is reported a year ago, but it seems they [do not have a schedule to fix this issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1301896#c2). So this workaround is
 necessary now to be applied to the Flutter engine to fix the rendering problem that happens on Chromium-based browsers when running in HTML mode.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
