### PR TITLE
Further shard clang-tidy runs

### DIFF
--- a/ci/builders/linux_clang_tidy.json
+++ b/ci/builders/linux_clang_tidy.json
@@ -37,7 +37,65 @@
     ],
     "tests": [
         {
-            "name": "test: lint host_debug",
+            "name": "test: lint host_debug 0",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cores=32"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--lint-all",
+                        "--shard-id=0",
+                        "--shard-variants=host_debug,host_debug,host_debug"
+                    ],
+		    "max_attempts": 1,
+                    "script": "flutter/ci/lint.sh"
+                }
+            ]
+        },
+        {
+            "name": "test: lint host_debug 1",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cores=32"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--lint-all",
+                        "--shard-id=1",
+                        "--shard-variants=host_debug,host_debug,host_debug"
+                    ],
+            "max_attempts": 1,
+                    "script": "flutter/ci/lint.sh"
+                }
+            ]
+        },
+        {
+            "name": "test: lint host_debug 2",
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
@@ -58,10 +116,40 @@
                         "--variant",
                         "host_debug",
                         "--lint-all",
-                        "--shard-id=1",
-                        "--shard-variants=android_debug_arm64"
+                        "--shard-id=2",
+                        "--shard-variants=host_debug,host_debug,host_debug"
                     ],
-		    "max_attempts": 1,
+            "max_attempts": 1,
+                    "script": "flutter/ci/lint.sh"
+                }
+            ]
+        },
+        {
+            "name": "test: lint host_debug 3",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cores=32"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug",
+                "android_debug_arm64"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--lint-all",
+                        "--shard-id=3",
+                        "--shard-variants=host_debug,host_debug,host_debug"
+                    ],
+            "max_attempts": 1,
                     "script": "flutter/ci/lint.sh"
                 }
             ]

--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -46,7 +46,7 @@
     ],
     "tests": [
         {
-            "name": "test: lint host_debug",
+            "name": "test: lint host_debug 0",
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
@@ -57,8 +57,39 @@
                 "download_android_deps": false
             },
             "dependencies": [
-                "host_debug",
-                "ios_debug_sim"
+                "host_debug"
+            ],
+            "contexts": [
+                "osx_sdk"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--lint-all",
+                        "--shard-id=0",
+                        "--shard-variants=host_debug,host_debug,host_debug"
+                    ],
+		    "max_attempts": 1,
+                    "script": "flutter/ci/lint.sh"
+                }
+            ]
+        },
+        {
+            "name": "test: lint host_debug 1",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug"
             ],
             "contexts": [
                 "osx_sdk"
@@ -71,9 +102,73 @@
                         "host_debug",
                         "--lint-all",
                         "--shard-id=1",
-                        "--shard-variants=ios_debug_sim"
+                        "--shard-variants=host_debug,host_debug,host_debug"
                     ],
-		    "max_attempts": 1,
+            "max_attempts": 1,
+                    "script": "flutter/ci/lint.sh"
+                }
+            ]
+        },
+        {
+            "name": "test: lint host_debug 2",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug"
+            ],
+            "contexts": [
+                "osx_sdk"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--lint-all",
+                        "--shard-id=2",
+                        "--shard-variants=host_debug,host_debug,host_debug"
+                    ],
+            "max_attempts": 1,
+                    "script": "flutter/ci/lint.sh"
+                }
+            ]
+        },
+        {
+            "name": "test: lint host_debug 3",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug"
+            ],
+            "contexts": [
+                "osx_sdk"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--lint-all",
+                        "--shard-id=3",
+                        "--shard-variants=host_debug,host_debug,host_debug"
+                    ],
+            "max_attempts": 1,
                     "script": "flutter/ci/lint.sh"
                 }
             ]


### PR DESCRIPTION
The clang-tidy shards have crept up to 60 minutes on some runs. This PR will bring them back down to around 30 minutes.

It does this by sharding the work for Mac/Linux `host_debug` across 4 shards. The clang-tidy work for ios/Android remains constrained to one shard. Unfortunately, the clang-tidy script sharding isn't smart enough to allow the ios/Android shards to participate in the `host_debug` sharding. This PR leaves that shard as-is, but we could further improve the runtime there if needed.