### PR TITLE
Release log capture at end of test

### DIFF
--- a/fml/logging.cc
+++ b/fml/logging.cc
@@ -75,9 +75,21 @@ LogMessage::LogMessage(LogSeverity severity,
 // static
 thread_local std::ostringstream* LogMessage::capture_next_log_stream_ = nullptr;
 
-void CaptureNextLog(std::ostringstream* stream) {
-  LogMessage::CaptureNextLog(stream);
+namespace testing {
+
+LogCapture::LogCapture() {
+  fml::LogMessage::CaptureNextLog(&stream_);
 }
+
+LogCapture::~LogCapture() {
+  fml::LogMessage::CaptureNextLog(nullptr);
+}
+
+std::string LogCapture::str() const {
+  return stream_.str();
+}
+
+}  // namespace testing
 
 // static
 void LogMessage::CaptureNextLog(std::ostringstream* stream) {

--- a/fml/logging.h
+++ b/fml/logging.h
@@ -12,7 +12,17 @@
 
 namespace fml {
 
-void CaptureNextLog(std::ostringstream* stream);
+namespace testing {
+struct LogCapture {
+  LogCapture();
+  ~LogCapture();
+
+  std::string str() const;
+
+ private:
+  std::ostringstream stream_;
+};
+}  // namespace testing
 
 class LogMessageVoidify {
  public:

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -4271,6 +4271,12 @@ TEST_F(ShellTest, PrintsErrorWhenPlatformMessageSentFromWrongThread) {
                                        "com.test.plugin", nullptr));
 
   EXPECT_EQ(stream->str(), "");
+
+  // Reset the log stream capturing after verifying no log was printed.
+  fml::CaptureNextLog(nullptr);
+
+  DestroyShell(std::move(shell), task_runners);
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
 }  // namespace testing

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -4243,37 +4243,37 @@ TEST_F(ShellTest, PrintsErrorWhenPlatformMessageSentFromWrongThread) {
                            task_runner);
   auto shell = CreateShell(settings, task_runners);
 
-  auto stream = std::make_shared<std::ostringstream>();
-  fml::CaptureNextLog(stream.get());
+  {
+    fml::testing::LogCapture log_capture;
 
-  // The next call will result in a thread checker violation.
-  fml::ThreadChecker::DisableNextThreadCheckFailure();
-  SendPlatformMessage(shell.get(), std::make_unique<PlatformMessage>(
-                                       "com.test.plugin", nullptr));
+    // The next call will result in a thread checker violation.
+    fml::ThreadChecker::DisableNextThreadCheckFailure();
+    SendPlatformMessage(shell.get(), std::make_unique<PlatformMessage>(
+                                         "com.test.plugin", nullptr));
 
-  EXPECT_THAT(stream->str(),
-              ::testing::EndsWith(
-                  "The 'com.test.plugin' channel sent a message from native to "
-                  "Flutter on a non-platform thread. Platform channel messages "
-                  "must be sent on the platform thread. Failure to do so may "
-                  "result in data loss or crashes, and must be fixed in the "
-                  "plugin or application code creating that channel.\nSee "
-                  "https://docs.flutter.dev/platform-integration/"
-                  "platform-channels#channels-and-platform-threading for more "
-                  "information.\n"));
+    EXPECT_THAT(
+        log_capture.str(),
+        ::testing::EndsWith(
+            "The 'com.test.plugin' channel sent a message from native to "
+            "Flutter on a non-platform thread. Platform channel messages "
+            "must be sent on the platform thread. Failure to do so may "
+            "result in data loss or crashes, and must be fixed in the "
+            "plugin or application code creating that channel.\nSee "
+            "https://docs.flutter.dev/platform-integration/"
+            "platform-channels#channels-and-platform-threading for more "
+            "information.\n"));
+  }
 
-  stream = std::make_shared<std::ostringstream>();
-  fml::CaptureNextLog(stream.get());
+  {
+    fml::testing::LogCapture log_capture;
 
-  // The next call will result in a thread checker violation.
-  fml::ThreadChecker::DisableNextThreadCheckFailure();
-  SendPlatformMessage(shell.get(), std::make_unique<PlatformMessage>(
-                                       "com.test.plugin", nullptr));
+    // The next call will result in a thread checker violation.
+    fml::ThreadChecker::DisableNextThreadCheckFailure();
+    SendPlatformMessage(shell.get(), std::make_unique<PlatformMessage>(
+                                         "com.test.plugin", nullptr));
 
-  EXPECT_EQ(stream->str(), "");
-
-  // Reset the log stream capturing after verifying no log was printed.
-  fml::CaptureNextLog(nullptr);
+    EXPECT_EQ(log_capture.str(), "");
+  }
 
   DestroyShell(std::move(shell), task_runners);
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/130036

Also fixes a potential issue where the shell wasn't getting destroyed at the end of the test.

Since no log is actually printed ont he second go, the destructor of `LogMessage` never clears the static pointer, and the next test that tries to print a log tries to print to that pointer which is now garbage.

