### PR TITLE
fix: use 4x4 matrix on TransformLayer from natives

### DIFF
--- a/flow/diff_context.cc
+++ b/flow/diff_context.cc
@@ -53,6 +53,10 @@ DiffContext::State::State()
       has_filter_bounds_adjustment(false),
       has_texture(false) {}
 
+void DiffContext::PushTransform(const SkM44& transform) {
+  clip_tracker_.transform(transform);
+}
+
 void DiffContext::PushTransform(const SkMatrix& transform) {
   clip_tracker_.transform(transform);
 }

--- a/flow/diff_context.h
+++ b/flow/diff_context.h
@@ -68,8 +68,11 @@ class DiffContext {
     DiffContext* context_;
   };
 
-  // Pushes additional transform for current subtree
+  // Pushes additional 3x3 transform for current subtree.
   void PushTransform(const SkMatrix& transform);
+
+  // Pushes additional 4x4 transform for current subtree.
+  void PushTransform(const SkM44& transform);
 
   // Pushes cull rect for current subtree
   bool PushCullRect(const SkRect& clip);

--- a/flow/layers/backdrop_filter_layer_unittests.cc
+++ b/flow/layers/backdrop_filter_layer_unittests.cc
@@ -455,7 +455,7 @@ TEST_F(BackdropLayerDiffTest, BackdropLayer) {
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 90, 90));
 
   MockLayerTree l3;
-  auto scale = std::make_shared<TransformLayer>(SkMatrix::Scale(2.0, 2.0));
+  auto scale = std::make_shared<TransformLayer>(SkM44::Scale(2.0, 2.0));
   scale->Add(clip);
   l3.root()->Add(scale);
 
@@ -499,7 +499,7 @@ TEST_F(BackdropLayerDiffTest, BackdropLayerInvalidTransform) {
   transform.setPerspX(0.1);
   transform.setPerspY(0.1);
 
-  auto transform_layer = std::make_shared<TransformLayer>(transform);
+  auto transform_layer = std::make_shared<TransformLayer>(SkM44(transform));
   l1.root()->Add(transform_layer);
   transform_layer->Add(std::make_shared<BackdropFilterLayer>(
       filter.shared(), DlBlendMode::kSrcOver));

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -644,7 +644,7 @@ TEST_F(ImageFilterLayerDiffTest, ImageFilterLayer) {
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(70, 70, 140, 140));
 
   MockLayerTree l2;
-  auto scale = std::make_shared<TransformLayer>(SkMatrix::Scale(2.0, 2.0));
+  auto scale = std::make_shared<TransformLayer>(SkM44::Scale(2.0, 2.0));
   scale->Add(filter_layer);
   l2.root()->Add(scale);
 

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -534,7 +534,7 @@ TEST_F(OpacityLayerTest, OpacityInheritanceThroughContainer) {
 TEST_F(OpacityLayerTest, OpacityInheritanceThroughTransform) {
   auto opacity_layer =
       std::make_shared<OpacityLayer>(128, SkPoint::Make(20, 20));
-  auto transformLayer = std::make_shared<TransformLayer>(SkMatrix::Scale(2, 2));
+  auto transformLayer = std::make_shared<TransformLayer>(SkM44::Scale(2, 2));
   auto mock_layer = MockLayer::MakeOpacityCompatible(SkPath());
   transformLayer->Add(mock_layer);
   opacity_layer->Add(transformLayer);

--- a/flow/layers/platform_view_layer_unittests.cc
+++ b/flow/layers/platform_view_layer_unittests.cc
@@ -113,8 +113,8 @@ TEST_F(PlatformViewLayerTest, StateTransfer) {
   //   |- platform_layer
   //   |- transform_layer2
   //        |- child2
-  auto transform_layer1 = std::make_shared<TransformLayer>(transform1);
-  auto transform_layer2 = std::make_shared<TransformLayer>(transform2);
+  auto transform_layer1 = std::make_shared<TransformLayer>(SkM44(transform1));
+  auto transform_layer2 = std::make_shared<TransformLayer>(SkM44(transform2));
   auto platform_layer =
       std::make_shared<PlatformViewLayer>(layer_offset, layer_size, view_id);
   auto child1 = std::make_shared<MockLayer>(path1);

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -8,9 +8,8 @@
 
 namespace flutter {
 
-TransformLayer::TransformLayer(const SkMatrix& transform)
-    : transform_(transform) {
-  // Checks (in some degree) that SkMatrix transform_ is valid and initialized.
+TransformLayer::TransformLayer(const SkM44& transform) : transform_(transform) {
+  // Checks (in some degree) that SkM44 transform_ is valid and initialized.
   //
   // If transform_ is uninitialized, this assert may look flaky as it doesn't
   // fail all the time, and some rerun may make it pass. But don't ignore it and
@@ -47,7 +46,7 @@ void TransformLayer::Preroll(PrerollContext* context) {
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, &child_paint_bounds);
 
-  transform_.mapRect(&child_paint_bounds);
+  transform_.asM33().mapRect(&child_paint_bounds);
   set_paint_bounds(child_paint_bounds);
 }
 

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -41,7 +41,7 @@ void TransformLayer::Diff(DiffContext* context, const Layer* old_layer) {
 
 void TransformLayer::Preroll(PrerollContext* context) {
   auto mutator = context->state_stack.save();
-  mutator.transform(transform_);
+  mutator.transform(transform_.asM33());
 
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, &child_paint_bounds);

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/transform_layer.h"
+#include "third_party/skia/src/core/SkMatrixPriv.h"
 
 #include <optional>
 
@@ -41,12 +42,11 @@ void TransformLayer::Diff(DiffContext* context, const Layer* old_layer) {
 
 void TransformLayer::Preroll(PrerollContext* context) {
   auto mutator = context->state_stack.save();
-  mutator.transform(transform_.asM33());
+  mutator.transform(transform_);
 
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, &child_paint_bounds);
-
-  transform_.asM33().mapRect(&child_paint_bounds);
+  SkMatrixPriv::MapRect(transform_, child_paint_bounds);
   set_paint_bounds(child_paint_bounds);
 }
 

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -13,7 +13,7 @@ namespace flutter {
 // at all. Hence |set_transform| must be called with an initialized SkMatrix.
 class TransformLayer : public ContainerLayer {
  public:
-  explicit TransformLayer(const SkMatrix& transform);
+  explicit TransformLayer(const SkM44& transform);
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
 
@@ -22,7 +22,7 @@ class TransformLayer : public ContainerLayer {
   void Paint(PaintContext& context) const override;
 
  private:
-  SkMatrix transform_;
+  SkM44 transform_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TransformLayer);
 };

--- a/flow/layers/transform_layer_unittests.cc
+++ b/flow/layers/transform_layer_unittests.cc
@@ -16,7 +16,8 @@ using TransformLayerTest = LayerTest;
 
 #ifndef NDEBUG
 TEST_F(TransformLayerTest, PaintingEmptyLayerDies) {
-  auto layer = std::make_shared<TransformLayer>(SkMatrix());  // identity
+  auto layer =
+      std::make_shared<TransformLayer>(SkM44().setIdentity());  // identity
 
   layer->Preroll(preroll_context());
   EXPECT_EQ(layer->paint_bounds(), SkRect::MakeEmpty());
@@ -31,7 +32,8 @@ TEST_F(TransformLayerTest, PaintBeforePrerollDies) {
   SkPath child_path;
   child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
   auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
-  auto layer = std::make_shared<TransformLayer>(SkMatrix());  // identity
+  auto layer =
+      std::make_shared<TransformLayer>(SkM44().setIdentity());  // identity
   layer->Add(mock_layer);
 
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
@@ -44,7 +46,8 @@ TEST_F(TransformLayerTest, Identity) {
   child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
   SkRect cull_rect = SkRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
   auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
-  auto layer = std::make_shared<TransformLayer>(SkMatrix());  // identity
+  auto layer =
+      std::make_shared<TransformLayer>(SkM44().setIdentity());  // identity
   layer->Add(mock_layer);
 
   preroll_context()->state_stack.set_preroll_delegate(cull_rect);
@@ -84,7 +87,7 @@ TEST_F(TransformLayerTest, Simple) {
   EXPECT_TRUE(layer_transform.invert(&inverse_layer_transform));
 
   auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
-  auto layer = std::make_shared<TransformLayer>(layer_transform);
+  auto layer = std::make_shared<TransformLayer>(SkM44(layer_transform));
   layer->Add(mock_layer);
 
   preroll_context()->state_stack.set_preroll_delegate(device_cull_rect,
@@ -131,8 +134,8 @@ TEST_F(TransformLayerTest, Nested) {
   EXPECT_TRUE(layer2_transform.invert(&inverse_layer2_transform));
 
   auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
-  auto layer1 = std::make_shared<TransformLayer>(layer1_transform);
-  auto layer2 = std::make_shared<TransformLayer>(layer2_transform);
+  auto layer1 = std::make_shared<TransformLayer>(SkM44(layer1_transform));
+  auto layer2 = std::make_shared<TransformLayer>(SkM44(layer2_transform));
   layer1->Add(layer2);
   layer2->Add(mock_layer);
 
@@ -198,8 +201,8 @@ TEST_F(TransformLayerTest, NestedSeparated) {
 
   auto mock_layer1 = std::make_shared<MockLayer>(child_path, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path, child_paint2);
-  auto layer1 = std::make_shared<TransformLayer>(layer1_transform);
-  auto layer2 = std::make_shared<TransformLayer>(layer2_transform);
+  auto layer1 = std::make_shared<TransformLayer>(SkM44(layer1_transform));
+  auto layer2 = std::make_shared<TransformLayer>(SkM44(layer2_transform));
   layer1->Add(mock_layer1);
   layer1->Add(layer2);
   layer2->Add(mock_layer2);
@@ -268,7 +271,7 @@ TEST_F(TransformLayerTest, NestedSeparated) {
 TEST_F(TransformLayerTest, OpacityInheritance) {
   auto path1 = SkPath().addRect({10, 10, 30, 30});
   auto mock1 = MockLayer::MakeOpacityCompatible(path1);
-  auto transform1 = std::make_shared<TransformLayer>(SkMatrix::Scale(2, 2));
+  auto transform1 = std::make_shared<TransformLayer>(SkM44::Scale(2, 2));
   transform1->Add(mock1);
 
   // TransformLayer will pass through compatibility from a compatible child
@@ -296,7 +299,7 @@ TEST_F(TransformLayerTest, OpacityInheritance) {
   transform1->Preroll(context);
   EXPECT_EQ(context->renderable_state_flags, 0);
 
-  auto transform2 = std::make_shared<TransformLayer>(SkMatrix::Scale(2, 2));
+  auto transform2 = std::make_shared<TransformLayer>(SkM44::Scale(2, 2));
   transform2->Add(mock1);
   transform2->Add(mock2);
 
@@ -321,7 +324,7 @@ TEST_F(TransformLayerTest, OpacityInheritancePainting) {
   auto path2 = SkPath().addRect({40, 40, 50, 50});
   auto mock2 = MockLayer::MakeOpacityCompatible(path2);
   auto transform = SkMatrix::Scale(2, 2);
-  auto transform_layer = std::make_shared<TransformLayer>(transform);
+  auto transform_layer = std::make_shared<TransformLayer>(SkM44(transform));
   transform_layer->Add(mock1);
   transform_layer->Add(mock2);
 
@@ -369,8 +372,7 @@ TEST_F(TransformLayerLayerDiffTest, Transform) {
   auto path1 = SkPath().addRect(SkRect::MakeLTRB(0, 0, 50, 50));
   auto m1 = std::make_shared<MockLayer>(path1);
 
-  auto transform1 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(10, 10));
+  auto transform1 = std::make_shared<TransformLayer>(SkM44::Translate(10, 10));
   transform1->Add(m1);
 
   MockLayerTree t1;
@@ -379,8 +381,7 @@ TEST_F(TransformLayerLayerDiffTest, Transform) {
   auto damage = DiffLayerTree(t1, MockLayerTree());
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 60, 60));
 
-  auto transform2 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(20, 20));
+  auto transform2 = std::make_shared<TransformLayer>(SkM44::Translate(20, 20));
   transform2->Add(m1);
   transform2->AssignOldLayer(transform1.get());
 
@@ -390,8 +391,7 @@ TEST_F(TransformLayerLayerDiffTest, Transform) {
   damage = DiffLayerTree(t2, t1);
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 70, 70));
 
-  auto transform3 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(20, 20));
+  auto transform3 = std::make_shared<TransformLayer>(SkM44::Translate(20, 20));
   transform3->Add(m1);
   transform3->AssignOldLayer(transform2.get());
 
@@ -408,20 +408,20 @@ TEST_F(TransformLayerLayerDiffTest, TransformNested) {
   auto m2 = CreateContainerLayer(std::make_shared<MockLayer>(path1));
   auto m3 = CreateContainerLayer(std::make_shared<MockLayer>(path1));
 
-  auto transform1 = std::make_shared<TransformLayer>(SkMatrix::Scale(2.0, 2.0));
+  auto transform1 = std::make_shared<TransformLayer>(SkM44::Scale(2.0, 2.0));
 
   auto transform1_1 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(10, 10));
+      std::make_shared<TransformLayer>(SkM44::Translate(10, 10));
   transform1_1->Add(m1);
   transform1->Add(transform1_1);
 
   auto transform1_2 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(100, 100));
+      std::make_shared<TransformLayer>(SkM44::Translate(100, 100));
   transform1_2->Add(m2);
   transform1->Add(transform1_2);
 
   auto transform1_3 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(200, 200));
+      std::make_shared<TransformLayer>(SkM44::Translate(200, 200));
   transform1_3->Add(m3);
   transform1->Add(transform1_3);
 
@@ -431,23 +431,23 @@ TEST_F(TransformLayerLayerDiffTest, TransformNested) {
   auto damage = DiffLayerTree(l1, MockLayerTree());
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(20, 20, 500, 500));
 
-  auto transform2 = std::make_shared<TransformLayer>(SkMatrix::Scale(2.0, 2.0));
+  auto transform2 = std::make_shared<TransformLayer>(SkM44::Scale(2.0, 2.0));
 
   auto transform2_1 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(10, 10));
+      std::make_shared<TransformLayer>(SkM44::Translate(10, 10));
   transform2_1->Add(m1);
   transform2_1->AssignOldLayer(transform1_1.get());
   transform2->Add(transform2_1);
 
   // Offset 1px from transform1_2 so that they're not the same
   auto transform2_2 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(100, 101));
+      std::make_shared<TransformLayer>(SkM44::Translate(100, 101));
   transform2_2->Add(m2);
   transform2_2->AssignOldLayer(transform1_2.get());
   transform2->Add(transform2_2);
 
   auto transform2_3 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(200, 200));
+      std::make_shared<TransformLayer>(SkM44::Translate(200, 200));
   transform2_3->Add(m3);
   transform2_3->AssignOldLayer(transform1_3.get());
   transform2->Add(transform2_3);

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -673,7 +673,7 @@ TEST(RasterCache, PrepareLayerTransform) {
       std::make_shared<DlBlurImageFilter>(5, 5, DlTileMode::kClamp);
   auto blur_layer = std::make_shared<ImageFilterLayer>(blur_filter);
   SkMatrix matrix = SkMatrix::Scale(2, 2);
-  auto transform_layer = std::make_shared<TransformLayer>(matrix);
+  auto transform_layer = std::make_shared<TransformLayer>(SkM44(matrix));
   SkMatrix cache_matrix = SkMatrix::Translate(-20, -20);
   cache_matrix.preConcat(matrix);
   child_layer->set_expected_paint_matrix(cache_matrix);

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -24,6 +24,7 @@
 #include "flutter/lib/ui/floating_point.h"
 #include "flutter/lib/ui/painting/matrix.h"
 #include "flutter/lib/ui/painting/shader.h"
+#include "third_party/skia/include/core/SkM44.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"
 #include "third_party/tonic/dart_binding_macros.h"
@@ -44,7 +45,7 @@ SceneBuilder::~SceneBuilder() = default;
 void SceneBuilder::pushTransform(Dart_Handle layer_handle,
                                  tonic::Float64List& matrix4,
                                  const fml::RefPtr<EngineLayer>& oldLayer) {
-  SkMatrix sk_matrix = ToSkMatrix(matrix4);
+  SkM44 sk_matrix = ToSkM44(matrix4);
   auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix);
   PushLayer(layer);
   // matrix4 has to be released before we can return another Dart object
@@ -60,8 +61,8 @@ void SceneBuilder::pushOffset(Dart_Handle layer_handle,
                               double dx,
                               double dy,
                               const fml::RefPtr<EngineLayer>& oldLayer) {
-  SkMatrix sk_matrix = SkMatrix::Translate(SafeNarrow(dx), SafeNarrow(dy));
-  auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix);
+  SkM44 sk_m44 = SkM44::Translate(SafeNarrow(dx), SafeNarrow(dy));
+  auto layer = std::make_shared<flutter::TransformLayer>(sk_m44);
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
 

--- a/lib/ui/painting/matrix.cc
+++ b/lib/ui/painting/matrix.cc
@@ -32,6 +32,23 @@ SkMatrix ToSkMatrix(const tonic::Float64List& matrix4) {
   return sk_matrix;
 }
 
+SkM44 ToSkM44(const tonic::Float64List& matrix4) {
+  FML_DCHECK(matrix4.data());
+  SkM44 sk_m44;
+  for (int i = 0; i < 16; ++i) {
+    sk_m44.setRC(i % 4, i / 4, SafeNarrow(matrix4[i]));
+  }
+  return sk_m44;
+}
+
+tonic::Float64List ToMatrix4FromSkM44(const SkM44& m44) {
+  tonic::Float64List matrix4(Dart_NewTypedData(Dart_TypedData_kFloat64, 16));
+  for (int i = 0; i < 16; ++i) {
+    matrix4[i] = m44.row(i % 4)[i / 4];
+  }
+  return matrix4;
+}
+
 tonic::Float64List ToMatrix4(const SkMatrix& sk_matrix) {
   tonic::Float64List matrix4(Dart_NewTypedData(Dart_TypedData_kFloat64, 16));
   for (int i = 0; i < 9; ++i) {

--- a/lib/ui/painting/matrix.cc
+++ b/lib/ui/painting/matrix.cc
@@ -33,20 +33,14 @@ SkMatrix ToSkMatrix(const tonic::Float64List& matrix4) {
 }
 
 SkM44 ToSkM44(const tonic::Float64List& matrix4) {
-  FML_DCHECK(matrix4.data());
-  SkM44 sk_m44;
-  for (int i = 0; i < 16; ++i) {
-    sk_m44.setRC(i % 4, i / 4, SafeNarrow(matrix4[i]));
-  }
-  return sk_m44;
-}
-
-tonic::Float64List ToMatrix4FromSkM44(const SkM44& m44) {
-  tonic::Float64List matrix4(Dart_NewTypedData(Dart_TypedData_kFloat64, 16));
-  for (int i = 0; i < 16; ++i) {
-    matrix4[i] = m44.row(i % 4)[i / 4];
-  }
-  return matrix4;
+  FML_DCHECK(matrix4.data() && matrix4.num_elements() >= 16);
+  return SkM44(
+      SafeNarrow(matrix4[0]), SafeNarrow(matrix4[4]), SafeNarrow(matrix4[8]),
+      SafeNarrow(matrix4[12]), SafeNarrow(matrix4[1]), SafeNarrow(matrix4[5]),
+      SafeNarrow(matrix4[9]), SafeNarrow(matrix4[13]), SafeNarrow(matrix4[2]),
+      SafeNarrow(matrix4[6]), SafeNarrow(matrix4[10]), SafeNarrow(matrix4[14]),
+      SafeNarrow(matrix4[3]), SafeNarrow(matrix4[7]), SafeNarrow(matrix4[11]),
+      SafeNarrow(matrix4[15]));
 }
 
 tonic::Float64List ToMatrix4(const SkMatrix& sk_matrix) {

--- a/lib/ui/painting/matrix.h
+++ b/lib/ui/painting/matrix.h
@@ -14,8 +14,6 @@ namespace flutter {
 SkMatrix ToSkMatrix(const tonic::Float64List& matrix4);
 tonic::Float64List ToMatrix4(const SkMatrix& sk_matrix);
 SkM44 ToSkM44(const tonic::Float64List& matrix4);
-tonic::Float64List ToMatrix4FromSkM44(const SkM44& m44);
-
 }  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_MATRIX_H_

--- a/lib/ui/painting/matrix.h
+++ b/lib/ui/painting/matrix.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_MATRIX_H_
 #define FLUTTER_LIB_UI_PAINTING_MATRIX_H_
 
+#include "third_party/skia/include/core/SkM44.h"
 #include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/tonic/typed_data/typed_list.h"
 
@@ -12,6 +13,8 @@ namespace flutter {
 
 SkMatrix ToSkMatrix(const tonic::Float64List& matrix4);
 tonic::Float64List ToMatrix4(const SkMatrix& sk_matrix);
+SkM44 ToSkM44(const tonic::Float64List& matrix4);
+tonic::Float64List ToMatrix4FromSkM44(const SkM44& m44);
 
 }  // namespace flutter
 

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -203,7 +203,7 @@ void ShellTest::PumpOneFrame(Shell* shell,
   fml::WeakPtr<RuntimeDelegate> runtime_delegate = shell->weak_engine_;
   shell->GetTaskRunners().GetUITaskRunner()->PostTask(
       [&latch, runtime_delegate, &builder, viewport_metrics]() {
-        SkMatrix identity;
+        SkM44 identity;
         identity.setIdentity();
         auto root_layer = std::make_shared<TransformLayer>(identity);
         auto layer_tree = std::make_unique<LayerTree>(

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -890,7 +890,7 @@ TEST_F(ShellTest, PushBackdropFilterToVisitedPlatformViews) {
         SkPoint::Make(10, 10), SkSize::Make(10, 10), 50);
     root->Add(platform_view_layer);
     auto transform_layer =
-        std::make_shared<TransformLayer>(SkMatrix::Translate(1, 1));
+        std::make_shared<TransformLayer>(SkM44::Translate(1, 1));
     root->Add(transform_layer);
     auto clip_rect_layer = std::make_shared<ClipRectLayer>(
         SkRect::MakeLTRB(0, 0, 30, 30), Clip::hardEdge);


### PR DESCRIPTION
Hi from [Dora](https://www.dora.run/) team, which is powered by Flutter Web to boost devs to build their 3D websites in just a few seconds. We've encountered the 3d transform problem when running in HTML mode and we found the same issue on the Native engine.

This pr fixes part of https://github.com/flutter/flutter/issues/128480, which fixes the transform running on natives but not Flutter web(html renderer), Because the html renderer needs more context to be told to have 3d transform like `preverse-3d`, etc.

![image](https://github.com/flutter/engine/assets/39793325/963df4aa-cdb2-4778-84f3-e7591819341d)

I've found that the transform layer doesn't accept a 4x4 transform, which contains Z-axis. Without the information on Z-axis, the 3d nested transform cannot be applied correctly and it will remain 2d transform when combining 2 or more transform layers.

Note that the Flutter web(canvaskit, HTML) is already 4x4 transform but the transform layer from native is 3x3, which has confused the developers and it exactly performs incorrectly. As for more, the reason why flutter web which is rendered by HTML renderer cannot perform well is lacking `preserve-3d` properties on some DOM nodes, which requires further investigating, because after filling the `preserve-3d` on the transform nodes and parents, many golden test cannot be passed due to this property.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
