### PR TITLE
Handle nested display list clips in Impeller dispatcher

### DIFF
--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -1052,6 +1052,10 @@ void DlDispatcher::drawDisplayList(
   Matrix saved_initial_matrix = initial_matrix_;
   int restore_count = canvas_.GetSaveCount();
 
+  // The display list may alter the clip, which must be restored to the current
+  // clip at the end of playback.
+  canvas_.Save();
+
   // Establish a new baseline for interpreting the new DL.
   // Matrix and clip are left untouched, the current
   // transform is saved as the new base matrix, and paint
@@ -1101,6 +1105,7 @@ void DlDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                 SkScalar x,
                                 SkScalar y) {
   Scalar scale = canvas_.GetCurrentTransformation().GetMaxBasisLengthXY();
+  FML_LOG(ERROR) << "drawTextBlob with scale " << scale;
   canvas_.DrawTextFrame(TextFrameFromTextBlob(blob, scale),  //
                         impeller::Point{x, y},               //
                         paint_                               //

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -1105,7 +1105,6 @@ void DlDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                 SkScalar x,
                                 SkScalar y) {
   Scalar scale = canvas_.GetCurrentTransformation().GetMaxBasisLengthXY();
-  FML_LOG(ERROR) << "drawTextBlob with scale " << scale;
   canvas_.DrawTextFrame(TextFrameFromTextBlob(blob, scale),  //
                         impeller::Point{x, y},               //
                         paint_                               //

--- a/impeller/display_list/dl_unittests.cc
+++ b/impeller/display_list/dl_unittests.cc
@@ -45,6 +45,19 @@ flutter::DlColor toColor(const float* components) {
 using DisplayListTest = DlPlayground;
 INSTANTIATE_PLAYGROUND_SUITE(DisplayListTest);
 
+TEST_P(DisplayListTest, DrawPictureWithAClip) {
+  flutter::DisplayListBuilder sub_builder;
+  sub_builder.ClipRect(SkRect::MakeXYWH(0, 0, 24, 24));
+  sub_builder.DrawPaint(flutter::DlPaint(flutter::DlColor::kBlue()));
+
+  auto display_list = sub_builder.Build();
+  flutter::DisplayListBuilder builder;
+  builder.DrawDisplayList(display_list);
+  builder.DrawRect(SkRect::MakeXYWH(30, 30, 24, 24),
+                   flutter::DlPaint(flutter::DlColor::kRed()));
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 TEST_P(DisplayListTest, CanDrawRect) {
   flutter::DisplayListBuilder builder;
   builder.DrawRect(SkRect::MakeXYWH(10, 10, 100, 100),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/130084

If a display list is drawn into another display list and the child display list establishes a small clip, subsequent drawing operations are discarded when really they should not be.

The test is expected to render both a blue and a red square; before the fix it renders only the blue square since the red square is incorrectly clipped out.

See also https://github.com/dnfield/flutter_svg/issues/938