### PR TITLE
Reduce redundant Linux clang-tidy work and run on more cores

### DIFF
--- a/ci/builders/linux_clang_tidy.json
+++ b/ci/builders/linux_clang_tidy.json
@@ -159,7 +159,8 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Linux"
+                "os=Linux",
+                "cores=32"
             ],
             "dependencies": [
                 "host_debug",
@@ -173,7 +174,7 @@
                         "android_debug_arm64",
                         "--lint-all",
                         "--shard-id=0",
-                        "--shard-variants=host_debug"
+                        "--shard-variants=host_debug,host_debug,host_debug,host_debug"
                     ],
 		    "max_attempts": 1,
                     "script": "flutter/ci/lint.sh"


### PR DESCRIPTION
This PR runs the android_debug_arm64 clang-tidy job on a machine with more cores, and reduces the number of files linted that are redundant with the `host_debug` clang-tidy jobs.