### PR TITLE
[iOS] Add darwin_extension_safe flag and use UIScene api when building for extensions

### DIFF
--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -224,6 +224,77 @@
                 }
 
             ]
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ios_debug_sim_arm64_extension_safe/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                    ],
+                    "name": "ios_debug_sim_arm64_extension_safe"
+                }
+            ],
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "runtime_versions": [
+                        "ios-16-4_14e300c",
+                        "ios-16-2_14c18"
+                    ],
+                    "sdk_version": "14e300c"
+                }
+            },
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--ios",
+                "--runtime-mode",
+                "debug",
+                "--simulator",
+                "--no-lto",
+                "--force-mac-arm64",
+                "--simulator-cpu",
+                "arm64",
+                "--darwin-extension-safe"
+            ],
+            "name": "ios_debug_sim_arm64_extension_safe",
+            "ninja": {
+                "config": "ios_debug_sim_arm64_extension_safe",
+                "targets": [
+                    "flutter/testing/scenario_app",
+                    "flutter/shell/platform/darwin/ios:ios_test_flutter"
+                ]
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Tests for ios_debug_sim_arm64_extension_safe",
+                    "parameters": [
+                        "--variant",
+                        "ios_debug_sim_arm64_extension_safe",
+                        "--type",
+                        "objc",
+                        "--engine-capture-core-dump",
+                        "--ios-variant",
+                        "ios_debug_sim_arm64_extension_safe"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                },
+                {
+                    "name": "Scenario App Integration Tests",
+                    "parameters": [
+                        "ios_debug_sim_arm64_extension_safe"
+                    ],
+                    "script": "flutter/testing/scenario_app/run_ios_tests.sh"
+                }
+
+            ]
         }
     ]
 }

--- a/common/config.gni
+++ b/common/config.gni
@@ -22,6 +22,12 @@ declare_args() {
 
   # Whether to include backtrace support.
   enable_backtrace = true
+
+  # Whether to include --fapplication-extension when build iOS framework.
+  # This is currently a test flag and does not work properly.
+  #TODO(cyanglaz): Remove above comment about test flag when the entire iOS embedder supports app extension
+  #https://github.com/flutter/flutter/issues/124289
+  darwin_extension_safe = false
 }
 
 # feature_defines_list ---------------------------------------------------------

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -44,6 +44,9 @@ source_set("flutter_framework_source_arc") {
   cflags_objcc = flutter_cflags_objcc_arc
 
   defines = [ "FLUTTER_FRAMEWORK=1" ]
+  if (darwin_extension_safe) {
+    defines += [ "APPLICATION_EXTENSION_API_ONLY=1" ]
+  }
   allow_circular_includes_from = [ ":flutter_framework_source" ]
   deps = [
     ":flutter_framework_source",
@@ -153,6 +156,9 @@ source_set("flutter_framework_source") {
   sources += _flutter_framework_headers
 
   defines = [ "FLUTTER_FRAMEWORK=1" ]
+  if (darwin_extension_safe) {
+    defines += [ "APPLICATION_EXTENSION_API_ONLY=1" ]
+  }
 
   if (shell_enable_metal) {
     sources += [
@@ -249,6 +255,10 @@ source_set("ios_test_flutter_mrc") {
   if (shell_enable_vulkan) {
     deps += [ "//flutter/vulkan" ]
   }
+
+  if (darwin_extension_safe) {
+    defines = [ "APPLICATION_EXTENSION_API_ONLY=1" ]
+  }
 }
 
 shared_library("ios_test_flutter") {
@@ -312,6 +322,10 @@ shared_library("ios_test_flutter") {
     ":ios_gpu_configuration_config",
     "//flutter:config",
   ]
+
+  if (darwin_extension_safe) {
+    defines = [ "APPLICATION_EXTENSION_API_ONLY=1" ]
+  }
 }
 
 shared_library("create_flutter_framework_dylib") {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
@@ -35,4 +35,9 @@ class ThreadHost;
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
                performAction:(FlutterTextInputAction)action
                   withClient:(int)client;
+- (void)sceneWillEnterForeground:(NSNotification*)notification API_AVAILABLE(ios(13.0));
+- (void)sceneDidEnterBackground:(NSNotification*)notification API_AVAILABLE(ios(13.0));
+- (void)applicationWillEnterForeground:(NSNotification*)notification;
+- (void)applicationDidEnterBackground:(NSNotification*)notification;
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -269,13 +269,23 @@ using namespace flutter;
   // It's also possible in an Add2App scenario that the FlutterViewController was presented
   // outside the context of a UINavigationController, and still wants to be popped.
 
-  UIViewController* engineViewController = [_engine.get() viewController];
+  FlutterViewController* engineViewController = [_engine.get() viewController];
   UINavigationController* navigationController = [engineViewController navigationController];
   if (navigationController) {
     [navigationController popViewControllerAnimated:isAnimated];
   } else {
-    UIViewController* rootViewController =
-        [UIApplication sharedApplication].keyWindow.rootViewController;
+    UIViewController* rootViewController = nil;
+#if APPLICATION_EXTENSION_API_ONLY
+    if (@available(iOS 15.0, *)) {
+      rootViewController =
+          [engineViewController windowSceneIfViewLoaded].keyWindow.rootViewController;
+    } else {
+      FML_LOG(WARNING)
+          << "rootViewController is not available in application extension prior to iOS 15.0.";
+    }
+#else
+    rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+#endif
     if (engineViewController != rootViewController) {
       [engineViewController dismissViewControllerAnimated:isAnimated completion:nil];
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -37,9 +37,8 @@
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Look Up view controller presented"];
 
-  FlutterViewController* engineViewController = [[FlutterViewController alloc] initWithEngine:engine
-                                                                                      nibName:nil
-                                                                                       bundle:nil];
+  FlutterViewController* engineViewController =
+      [[[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil] autorelease];
   FlutterViewController* mockEngineViewController = OCMPartialMock(engineViewController);
 
   FlutterPlatformPlugin* plugin =

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -147,6 +147,16 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (flutter::PointerData)generatePointerDataForFake;
 - (void)sharedSetupWithProject:(nullable FlutterDartProject*)project
                   initialRoute:(nullable NSString*)initialRoute;
+- (void)applicationBecameActive:(NSNotification*)notification;
+- (void)applicationWillResignActive:(NSNotification*)notification;
+- (void)applicationWillTerminate:(NSNotification*)notification;
+- (void)applicationDidEnterBackground:(NSNotification*)notification;
+- (void)applicationWillEnterForeground:(NSNotification*)notification;
+- (void)sceneBecameActive:(NSNotification*)notification API_AVAILABLE(ios(13.0));
+- (void)sceneWillResignActive:(NSNotification*)notification API_AVAILABLE(ios(13.0));
+- (void)sceneWillDisconnect:(NSNotification*)notification API_AVAILABLE(ios(13.0));
+- (void)sceneDidEnterBackground:(NSNotification*)notification API_AVAILABLE(ios(13.0));
+- (void)sceneWillEnterForeground:(NSNotification*)notification API_AVAILABLE(ios(13.0));
 @end
 
 @interface FlutterViewControllerTest : XCTestCase
@@ -1492,13 +1502,17 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   id mockApplication = OCMClassMock([UIApplication class]);
   id mockWindowScene;
   id deviceMock;
+  id mockVC;
   __block __weak id weakPreferences;
   @autoreleasepool {
     FlutterViewController* realVC = [[FlutterViewController alloc] initWithEngine:self.mockEngine
                                                                           nibName:nil
                                                                            bundle:nil];
+
     if (@available(iOS 16.0, *)) {
       mockWindowScene = OCMClassMock([UIWindowScene class]);
+      mockVC = OCMPartialMock(realVC);
+      OCMStub([mockVC windowSceneIfViewLoaded]).andReturn(mockWindowScene);
       if (realVC.supportedInterfaceOrientations == mask) {
         OCMReject([mockWindowScene requestGeometryUpdateWithPreferences:[OCMArg any]
                                                            errorHandler:[OCMArg any]]);
@@ -1524,7 +1538,9 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
         OCMExpect([deviceMock setValue:@(resultingOrientation) forKey:@"orientation"]);
       }
       if (@available(iOS 13.0, *)) {
-        mockWindowScene = OCMPartialMock(realVC.view.window.windowScene);
+        mockWindowScene = OCMClassMock([UIWindowScene class]);
+        mockVC = OCMPartialMock(realVC);
+        OCMStub([mockVC windowSceneIfViewLoaded]).andReturn(mockWindowScene);
         OCMStub(((UIWindowScene*)mockWindowScene).interfaceOrientation)
             .andReturn(currentOrientation);
       } else {
@@ -1813,6 +1829,149 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   FlutterViewController* flutterViewController =
       [[FlutterViewController alloc] initWithProject:nil nibName:nil bundle:nil];
   [flutterViewController setSplashScreenView:nil];
+}
+
+- (void)testLifeCycleNotificationBecameActive {
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* flutterViewController =
+      [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  UIWindow* window = [[UIWindow alloc] init];
+  [window addSubview:flutterViewController.view];
+  flutterViewController.view.bounds = CGRectMake(0, 0, 100, 100);
+  [flutterViewController viewDidLayoutSubviews];
+  NSNotification* sceneNotification =
+      [NSNotification notificationWithName:UISceneDidActivateNotification object:nil userInfo:nil];
+  NSNotification* applicationNotification =
+      [NSNotification notificationWithName:UIApplicationDidBecomeActiveNotification
+                                    object:nil
+                                  userInfo:nil];
+  id mockVC = OCMPartialMock(flutterViewController);
+  [[NSNotificationCenter defaultCenter] postNotification:sceneNotification];
+  [[NSNotificationCenter defaultCenter] postNotification:applicationNotification];
+#if APPLICATION_EXTENSION_API_ONLY
+  OCMVerify([mockVC sceneBecameActive:[OCMArg any]]);
+  OCMReject([mockVC applicationBecameActive:[OCMArg any]]);
+#else
+  OCMReject([mockVC sceneBecameActive:[OCMArg any]]);
+  OCMVerify([mockVC applicationBecameActive:[OCMArg any]]);
+#endif
+  XCTAssertFalse(flutterViewController.isKeyboardInOrTransitioningFromBackground);
+  OCMVerify([mockVC surfaceUpdated:YES]);
+  OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.resumed"]);
+  [flutterViewController deregisterNotifications];
+}
+
+- (void)testLifeCycleNotificationWillResignActive {
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* flutterViewController =
+      [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  NSNotification* sceneNotification =
+      [NSNotification notificationWithName:UISceneWillDeactivateNotification
+                                    object:nil
+                                  userInfo:nil];
+  NSNotification* applicationNotification =
+      [NSNotification notificationWithName:UIApplicationWillResignActiveNotification
+                                    object:nil
+                                  userInfo:nil];
+  id mockVC = OCMPartialMock(flutterViewController);
+  [[NSNotificationCenter defaultCenter] postNotification:sceneNotification];
+  [[NSNotificationCenter defaultCenter] postNotification:applicationNotification];
+#if APPLICATION_EXTENSION_API_ONLY
+  OCMVerify([mockVC sceneWillResignActive:[OCMArg any]]);
+  OCMReject([mockVC applicationWillResignActive:[OCMArg any]]);
+#else
+  OCMReject([mockVC sceneWillResignActive:[OCMArg any]]);
+  OCMVerify([mockVC applicationWillResignActive:[OCMArg any]]);
+#endif
+  OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.inactive"]);
+  [flutterViewController deregisterNotifications];
+}
+
+- (void)testLifeCycleNotificationWillTerminate {
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* flutterViewController =
+      [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  NSNotification* sceneNotification =
+      [NSNotification notificationWithName:UISceneDidDisconnectNotification
+                                    object:nil
+                                  userInfo:nil];
+  NSNotification* applicationNotification =
+      [NSNotification notificationWithName:UIApplicationWillTerminateNotification
+                                    object:nil
+                                  userInfo:nil];
+  id mockVC = OCMPartialMock(flutterViewController);
+  [[NSNotificationCenter defaultCenter] postNotification:sceneNotification];
+  [[NSNotificationCenter defaultCenter] postNotification:applicationNotification];
+  id mockEngine = OCMPartialMock(engine);
+#if APPLICATION_EXTENSION_API_ONLY
+  OCMVerify([mockVC sceneWillDisconnect:[OCMArg any]]);
+  OCMReject([mockVC applicationWillTerminate:[OCMArg any]]);
+#else
+  OCMReject([mockVC sceneWillDisconnect:[OCMArg any]]);
+  OCMVerify([mockVC applicationWillTerminate:[OCMArg any]]);
+#endif
+  OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.detached"]);
+  OCMVerify([mockEngine destroyContext]);
+  [flutterViewController deregisterNotifications];
+}
+
+- (void)testLifeCycleNotificationDidEnterBackground {
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* flutterViewController =
+      [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  NSNotification* sceneNotification =
+      [NSNotification notificationWithName:UISceneDidEnterBackgroundNotification
+                                    object:nil
+                                  userInfo:nil];
+  NSNotification* applicationNotification =
+      [NSNotification notificationWithName:UIApplicationDidEnterBackgroundNotification
+                                    object:nil
+                                  userInfo:nil];
+  id mockVC = OCMPartialMock(flutterViewController);
+  [[NSNotificationCenter defaultCenter] postNotification:sceneNotification];
+  [[NSNotificationCenter defaultCenter] postNotification:applicationNotification];
+#if APPLICATION_EXTENSION_API_ONLY
+  OCMVerify([mockVC sceneDidEnterBackground:[OCMArg any]]);
+  OCMReject([mockVC applicationDidEnterBackground:[OCMArg any]]);
+#else
+  OCMReject([mockVC sceneDidEnterBackground:[OCMArg any]]);
+  OCMVerify([mockVC applicationDidEnterBackground:[OCMArg any]]);
+#endif
+  XCTAssertFalse(flutterViewController.isKeyboardInOrTransitioningFromBackground);
+  OCMVerify([mockVC surfaceUpdated:YES]);
+  OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.paused"]);
+  [flutterViewController deregisterNotifications];
+}
+
+- (void)testLifeCycleNotificationWillEnterForeground {
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* flutterViewController =
+      [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  NSNotification* sceneNotification =
+      [NSNotification notificationWithName:UISceneWillEnterForegroundNotification
+                                    object:nil
+                                  userInfo:nil];
+  NSNotification* applicationNotification =
+      [NSNotification notificationWithName:UIApplicationWillEnterForegroundNotification
+                                    object:nil
+                                  userInfo:nil];
+  id mockVC = OCMPartialMock(flutterViewController);
+  [[NSNotificationCenter defaultCenter] postNotification:sceneNotification];
+  [[NSNotificationCenter defaultCenter] postNotification:applicationNotification];
+#if APPLICATION_EXTENSION_API_ONLY
+  OCMVerify([mockVC sceneWillEnterForeground:[OCMArg any]]);
+  OCMReject([mockVC applicationWillEnterForeground:[OCMArg any]]);
+#else
+  OCMReject([mockVC sceneWillEnterForeground:[OCMArg any]]);
+  OCMVerify([mockVC applicationWillEnterForeground:[OCMArg any]]);
+#endif
+  OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.inactive"]);
+  [flutterViewController deregisterNotifications];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -1903,9 +1903,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                     object:nil
                                   userInfo:nil];
   id mockVC = OCMPartialMock(flutterViewController);
+  id mockEngine = OCMPartialMock(engine);
+  OCMStub([mockVC engine]).andReturn(mockEngine);
   [[NSNotificationCenter defaultCenter] postNotification:sceneNotification];
   [[NSNotificationCenter defaultCenter] postNotification:applicationNotification];
-  id mockEngine = OCMPartialMock(engine);
 #if APPLICATION_EXTENSION_API_ONLY
   OCMVerify([mockVC sceneWillDisconnect:[OCMArg any]]);
   OCMReject([mockVC applicationWillTerminate:[OCMArg any]]);
@@ -1941,8 +1942,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   OCMReject([mockVC sceneDidEnterBackground:[OCMArg any]]);
   OCMVerify([mockVC applicationDidEnterBackground:[OCMArg any]]);
 #endif
-  XCTAssertFalse(flutterViewController.isKeyboardInOrTransitioningFromBackground);
-  OCMVerify([mockVC surfaceUpdated:YES]);
+  XCTAssertTrue(flutterViewController.isKeyboardInOrTransitioningFromBackground);
+  OCMVerify([mockVC surfaceUpdated:NO]);
   OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.paused"]);
   [flutterViewController deregisterNotifications];
 }

--- a/tools/gn
+++ b/tools/gn
@@ -67,6 +67,9 @@ def get_out_dir(args):
   if args.target_dir != '':
     target_dir = [args.target_dir]
 
+  if args.darwin_extension_safe:
+    target_dir.append('extension_safe')
+
   return os.path.join(args.out_dir, 'out', '_'.join(target_dir))
 
 
@@ -652,6 +655,9 @@ def to_gn_args(args):
     gn_args['angle_vulkan_tools_dir'
            ] = '//third_party/vulkan-deps/vulkan-tools/src'
 
+  if args.darwin_extension_safe:
+    gn_args['darwin_extension_safe'] = True
+
   return gn_args
 
 
@@ -1140,6 +1146,13 @@ def parse_args(args):
       action='store_true',
       help='Write a GN trace log (gn_trace.json) in the Chromium tracing '
       'format in the build directory.'
+  )
+
+  parser.add_argument(
+      '--darwin-extension-safe',
+      default=False,
+      action='store_true',
+      help='Whether the produced Flutter.framework is app extension safe. Only for iOS.'
   )
 
   # Verbose output.


### PR DESCRIPTION
iOS extensions forbids the usage of UIApplication.sharedApplication. This PR refactors the engine to use UISceneAPI when darwin_extension_safe flag is on. Using UISceneAPI can help avoid the usage of `UIApplication.sharedApplication` as much as possible.
This PR also added a new `_extension_safe` variant for the engine build so all the logic with the `darwin_extension_safe` flag is on can be tested separately.

This PR doesn't enable the engine to build for the extension even when darwin_extension_safe is true.

part of https://github.com/flutter/flutter/issues/124289

There are several issues related to UIApplication life cycle and I manually tested they still work with the scene API:
- [x] https://github.com/flutter/flutter/issues/50732
- [x] https://github.com/flutter/flutter/issues/33236
- [x] https://github.com/flutter/flutter/issues/71051 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
