### PR TITLE
Account for updated Impeller label.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@
 embedder:
   - shell/platform/embedder
 
-"e: impeller":
+'e: impeller':
   - impeller/**/*
 
 platform-android:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@
 embedder:
   - shell/platform/embedder
 
-impeller:
+"e: impeller":
   - impeller/**/*
 
 platform-android:


### PR DESCRIPTION
The label was updated per flutter.dev/go/triage-2023-rfc