### PR TITLE
[Impeller] Set up the clear color for non-MSAA render targets

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -210,6 +210,7 @@ static EntityPassTarget CreateRenderTarget(ContentContext& renderer,
             .storage_mode = StorageMode::kDevicePrivate,
             .load_action = LoadAction::kDontCare,
             .store_action = StoreAction::kDontCare,
+            .clear_color = clear_color,
         },                                 // color_attachment_config
         GetDefaultStencilConfig(readable)  // stencil_attachment_config
     );

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -232,7 +232,7 @@ RenderTarget RenderTarget::CreateOffscreen(
                      static_cast<uint64_t>(TextureUsage::kShaderRead);
 
   ColorAttachment color0;
-  color0.clear_color = Color::BlackTransparent();
+  color0.clear_color = color_attachment_config.clear_color;
   color0.load_action = color_attachment_config.load_action;
   color0.store_action = color_attachment_config.store_action;
   color0.texture = context.GetResourceAllocator()->CreateTexture(color_tex0);


### PR DESCRIPTION
This is needed when using the "collapse DrawRects into clear colors" optimization on GLES.
