### PR TITLE
Handle nested display list clips in Impeller dispatcher (#43442)

### DIFF
--- a/impeller/display_list/display_list_dispatcher.cc
+++ b/impeller/display_list/display_list_dispatcher.cc
@@ -1252,6 +1252,10 @@ void DisplayListDispatcher::drawDisplayList(
   Matrix saved_initial_matrix = initial_matrix_;
   int restore_count = canvas_.GetSaveCount();
 
+  // The display list may alter the clip, which must be restored to the current
+  // clip at the end of playback.
+  canvas_.Save();
+
   // Establish a new baseline for interpreting the new DL.
   // Matrix and clip are left untouched, the current
   // transform is saved as the new base matrix, and paint

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -47,7 +47,8 @@ INSTANTIATE_PLAYGROUND_SUITE(DisplayListTest);
 
 TEST_P(DisplayListTest, DrawPictureWithAClip) {
   flutter::DisplayListBuilder sub_builder;
-  sub_builder.ClipRect(SkRect::MakeXYWH(0, 0, 24, 24), ClipOp::kIntersect,
+  sub_builder.ClipRect(SkRect::MakeXYWH(0, 0, 24, 24),
+                       flutter::ClipOp::kIntersect,
                        /*is_aa=*/false);
   sub_builder.DrawPaint(flutter::DlPaint(flutter::DlColor::kBlue()));
 

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -45,6 +45,19 @@ flutter::DlColor toColor(const float* components) {
 using DisplayListTest = DisplayListPlayground;
 INSTANTIATE_PLAYGROUND_SUITE(DisplayListTest);
 
+TEST_P(DisplayListTest, DrawPictureWithAClip) {
+  flutter::DisplayListBuilder sub_builder;
+  sub_builder.ClipRect(SkRect::MakeXYWH(0, 0, 24, 24));
+  sub_builder.DrawPaint(flutter::DlPaint(flutter::DlColor::kBlue()));
+
+  auto display_list = sub_builder.Build();
+  flutter::DisplayListBuilder builder;
+  builder.DrawDisplayList(display_list);
+  builder.DrawRect(SkRect::MakeXYWH(30, 30, 24, 24),
+                   flutter::DlPaint(flutter::DlColor::kRed()));
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 TEST_P(DisplayListTest, CanDrawRect) {
   flutter::DisplayListBuilder builder;
   builder.DrawRect(SkRect::MakeXYWH(10, 10, 100, 100),

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -47,7 +47,8 @@ INSTANTIATE_PLAYGROUND_SUITE(DisplayListTest);
 
 TEST_P(DisplayListTest, DrawPictureWithAClip) {
   flutter::DisplayListBuilder sub_builder;
-  sub_builder.ClipRect(SkRect::MakeXYWH(0, 0, 24, 24));
+  sub_builder.ClipRect(SkRect::MakeXYWH(0, 0, 24, 24), ClipOp::kIntersect,
+                       /*is_aa=*/false);
   sub_builder.DrawPaint(flutter::DlPaint(flutter::DlColor::kBlue()));
 
   auto display_list = sub_builder.Build();

--- a/impeller/display_list/display_list_unittests.cc
+++ b/impeller/display_list/display_list_unittests.cc
@@ -48,7 +48,7 @@ INSTANTIATE_PLAYGROUND_SUITE(DisplayListTest);
 TEST_P(DisplayListTest, DrawPictureWithAClip) {
   flutter::DisplayListBuilder sub_builder;
   sub_builder.ClipRect(SkRect::MakeXYWH(0, 0, 24, 24),
-                       flutter::ClipOp::kIntersect,
+                       flutter::DlCanvas::ClipOp::kIntersect,
                        /*is_aa=*/false);
   sub_builder.DrawPaint(flutter::DlPaint(flutter::DlColor::kBlue()));
 


### PR DESCRIPTION
CP issue: https://github.com/flutter/flutter/issues/130149

Fixes https://github.com/flutter/flutter/issues/130084

If a display list is drawn into another display list and the child display list establishes a small clip, subsequent drawing operations are discarded when really they should not be.

The test is expected to render both a blue and a red square; before the fix it renders only the blue square since the red square is incorrectly clipped out.

See also https://github.com/dnfield/flutter_svg/issues/938