### PR TITLE
Run linux_unopt on a machine with more cores

### DIFF
--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -3,7 +3,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Linux"
+                "os=Linux",
+                "cores=32"
             ],
             "gn": [
                 "--runtime-mode",

--- a/testing/run_all_unittests.cc
+++ b/testing/run_all_unittests.cc
@@ -23,8 +23,8 @@ std::optional<fml::TimeDelta> GetTestTimeout() {
 
   std::string timeout_seconds;
   if (!command_line.GetOptionValue("timeout", &timeout_seconds)) {
-    // No timeout specified. Default to 120s.
-    return fml::TimeDelta::FromSeconds(120u);
+    // No timeout specified. Default to 300s.
+    return fml::TimeDelta::FromSeconds(300u);
   }
 
   const auto seconds = std::stoi(timeout_seconds);


### PR DESCRIPTION
The unit tests can run in parallel so running on a bigger machine gives a good speedup. This shaves ~10 minutes off of linux_unopt time. Some of the DisplayList unit tests go over the 120s limit, so this PR also bumps the default limit to 300s.