### PR TITLE
[Impeller] Merge lazy glyph atlases in DrawPicture

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2851,5 +2851,35 @@ TEST_P(AiksTest, CanCanvasDrawPicture) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, DrawPictureWithText) {
+  Canvas subcanvas;
+  ASSERT_TRUE(RenderTextInCanvas(
+      GetContext(), subcanvas,
+      "the quick brown fox jumped over the lazy dog!.?", "Roboto-Regular.ttf"));
+  subcanvas.Translate({0, 10});
+  subcanvas.Scale(Vector2(3, 3));
+  ASSERT_TRUE(RenderTextInCanvas(
+      GetContext(), subcanvas,
+      "the quick brown fox jumped over the very big lazy dog!.?",
+      "Roboto-Regular.ttf"));
+  auto picture = subcanvas.EndRecordingAsPicture();
+
+  Canvas canvas;
+  canvas.Scale(Vector2(.2, .2));
+  canvas.Save();
+  canvas.Translate({200, 200});
+  canvas.Scale(Vector2(3.5, 3.5));  // The text must not be blurry after this.
+  canvas.DrawPicture(picture);
+  canvas.Restore();
+
+  canvas.Scale(Vector2(1.5, 1.5));
+  ASSERT_TRUE(RenderTextInCanvas(
+      GetContext(), canvas,
+      "the quick brown fox jumped over the smaller lazy dog!.?",
+      "Roboto-Regular.ttf"));
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -411,10 +411,14 @@ void Canvas::DrawPicture(const Picture& picture) {
 
   // Clone the base pass and account for the CTM updates.
   auto pass = picture.pass->Clone();
+  auto scale = GetCurrentTransformation().GetMaxBasisLengthXY();
   pass->IterateAllEntities([&](auto& entity) -> bool {
     entity.IncrementStencilDepth(GetStencilDepth());
     entity.SetTransformation(GetCurrentTransformation() *
                              entity.GetTransformation());
+    if (auto contents = entity.GetContents()) {
+      contents->AdoptLazyGlyphAtlas(lazy_glyph_atlas_, scale);
+    }
     return true;
   });
   GetCurrentPass().AddSubpassInline(std::move(pass));

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -155,4 +155,8 @@ void Contents::SetColorSourceSize(Size size) {
   color_source_size_ = size;
 }
 
+void Contents::AdoptLazyGlyphAtlas(
+    std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas,
+    Scalar scale) {}
+
 }  // namespace impeller

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -14,6 +14,7 @@
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/renderer/snapshot.h"
+#include "impeller/typographer/lazy_glyph_atlas.h"
 
 namespace impeller {
 
@@ -125,6 +126,15 @@ class Contents {
   ///        subpass clear colors.
   virtual std::optional<Color> AsBackgroundColor(const Entity& entity,
                                                  ISize target_size) const;
+
+  /// @brief If this contents uses the LazyGlyphAtlas, notifies it that the
+  ///        atlas has changed and potentially that the scale has changed.
+  ///
+  ///        For example, a TextContents implements this by updating the scale
+  ///        of its text frame and merging its atlas into the incoming one.
+  virtual void AdoptLazyGlyphAtlas(
+      std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas,
+      Scalar scale);
 
  private:
   std::optional<Rect> coverage_hint_;

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -224,4 +224,17 @@ bool TextContents::Render(const ContentContext& renderer,
                       cmd);
 }
 
+// |Contents|
+void TextContents::AdoptLazyGlyphAtlas(
+    std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas,
+    Scalar scale) {
+  FML_DCHECK(lazy_atlas_);
+  if (!lazy_atlas_) {
+    VALIDATION_LOG << "TextContents asked to adopt a lazy glyph atlas, but "
+                      "does not have one to begin with.";
+    return;
+  }
+  lazy_atlas_->Absorb(lazy_glyph_atlas, scale);
+}
+
 }  // namespace impeller

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -50,6 +50,10 @@ class TextContents final : public Contents {
               const Entity& entity,
               RenderPass& pass) const override;
 
+  // |Contents|
+  void AdoptLazyGlyphAtlas(std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas,
+                           Scalar scale) override;
+
  private:
   TextFrame frame_;
   Color color_;

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -31,7 +31,6 @@ class EntityPass {
   /// When the element is a child `EntityPass`, it may be rendered to an
   /// offscreen texture and converted into an `Entity` that draws the texture
   /// into the current pass, or its children may be collapsed into the current
-  ///
   /// `EntityPass`. Elements are converted to Entities in
   /// `GetEntityForElement()`.
   using Element = std::variant<Entity, std::unique_ptr<EntityPass>>;

--- a/impeller/typographer/font.cc
+++ b/impeller/typographer/font.cc
@@ -38,4 +38,19 @@ const Font::Metrics& Font::GetMetrics() const {
   return metrics_;
 }
 
+Font::Metrics Font::Metrics::Scaled(Scalar new_scale) const {
+  Font::Metrics metrics;
+  metrics.scale = scale * new_scale;
+  metrics.point_size = point_size;
+  metrics.embolden = embolden;
+  metrics.skewX = skewX;
+  metrics.scaleX = scaleX;  // This is an actual font property, not a canvas
+                            // transform property.
+  return metrics;
+}
+
+Font Font::Scaled(Scalar scale) const {
+  return Font(typeface_, metrics_.Scaled(scale));
+}
+
 }  // namespace impeller

--- a/impeller/typographer/font.h
+++ b/impeller/typographer/font.h
@@ -42,6 +42,8 @@ class Font : public Comparable<Font> {
     Scalar skewX = 0.0f;
     Scalar scaleX = 1.0f;
 
+    Metrics Scaled(Scalar new_scale) const;
+
     constexpr bool operator==(const Metrics& o) const {
       return scale == o.scale && point_size == o.point_size &&
              embolden == o.embolden && skewX == o.skewX && scaleX == o.scaleX;
@@ -63,6 +65,8 @@ class Font : public Comparable<Font> {
 
   const Metrics& GetMetrics() const;
 
+  Font Scaled(Scalar scale) const;
+
   // |Comparable<Font>|
   std::size_t GetHash() const override;
 
@@ -80,6 +84,7 @@ class Font : public Comparable<Font> {
 template <>
 struct std::hash<impeller::Font::Metrics> {
   constexpr std::size_t operator()(const impeller::Font::Metrics& m) const {
-    return fml::HashCombine(m.scale, m.point_size);
+    return fml::HashCombine(m.scale, m.point_size, m.embolden, m.skewX,
+                            m.scaleX);
   }
 };

--- a/impeller/typographer/lazy_glyph_atlas.cc
+++ b/impeller/typographer/lazy_glyph_atlas.cc
@@ -6,6 +6,7 @@
 
 #include "impeller/base/validation.h"
 #include "impeller/typographer/text_render_context.h"
+#include "lazy_glyph_atlas.h"
 
 #include <utility>
 
@@ -58,6 +59,28 @@ std::shared_ptr<GlyphAtlas> LazyGlyphAtlas::CreateOrGetGlyphAtlas(
   }
   atlas_map_[type] = atlas;
   return atlas;
+}
+
+void LazyGlyphAtlas::Absorb(std::shared_ptr<LazyGlyphAtlas> atlas,
+                            Scalar scale) {
+  if (!atlas) {
+    return;
+  }
+  FML_DCHECK(atlas->atlas_map_.empty());
+  FML_DCHECK(atlas_map_.empty());
+
+  if (!atlas->atlas_map_.empty() || !atlas_map_.empty()) {
+    VALIDATION_LOG << "LazyGlyphAtlas::Absorb must only be called before "
+                      "CreateOrGetGlyphAtlas.";
+    return;
+  }
+
+  for (const auto& frame : atlas->alpha_frames_) {
+    alpha_frames_.push_back(frame.Scaled(scale));
+  }
+  for (const auto& frame : atlas->color_frames_) {
+    color_frames_.push_back(frame.Scaled(scale));
+  }
 }
 
 }  // namespace impeller

--- a/impeller/typographer/lazy_glyph_atlas.h
+++ b/impeller/typographer/lazy_glyph_atlas.h
@@ -26,6 +26,8 @@ class LazyGlyphAtlas {
       std::shared_ptr<GlyphAtlasContext> atlas_context,
       std::shared_ptr<Context> context) const;
 
+  void Absorb(std::shared_ptr<LazyGlyphAtlas> atlas, Scalar scale);
+
  private:
   std::vector<TextFrame> alpha_frames_;
   std::vector<TextFrame> color_frames_;

--- a/impeller/typographer/text_frame.cc
+++ b/impeller/typographer/text_frame.cc
@@ -79,4 +79,14 @@ bool TextFrame::MaybeHasOverlapping() const {
   return false;
 }
 
+TextFrame TextFrame::Scaled(Scalar scale) const {
+  TextFrame frame;
+  frame.runs_.reserve(runs_.size());
+  for (const auto run : runs_) {
+    frame.runs_.push_back(run.Scaled(scale));
+  }
+  frame.has_color_ = has_color_;
+  return frame;
+}
+
 }  // namespace impeller

--- a/impeller/typographer/text_frame.h
+++ b/impeller/typographer/text_frame.h
@@ -23,6 +23,12 @@ class TextFrame {
   ~TextFrame();
 
   //----------------------------------------------------------------------------
+  /// @brief      Creates a new TextFrame containing runs scaled by the scale
+  ///             value.
+  ///
+  TextFrame Scaled(Scalar scale) const;
+
+  //----------------------------------------------------------------------------
   /// @brief      The conservative bounding box for this text frame.
   ///
   /// @return     The bounds rectangle. If there are no glyphs in this text

--- a/impeller/typographer/text_run.cc
+++ b/impeller/typographer/text_run.cc
@@ -41,4 +41,12 @@ bool TextRun::HasColor() const {
   return has_color_;
 }
 
+TextRun TextRun::Scaled(Scalar scale) const {
+  TextRun run(font_.Scaled(scale));
+  run.glyphs_ = std::vector<GlyphPosition>(glyphs_);
+  run.is_valid_ = is_valid_;
+  run.has_color_ = has_color_;
+  return run;
+}
+
 }  // namespace impeller

--- a/impeller/typographer/text_run.h
+++ b/impeller/typographer/text_run.h
@@ -72,6 +72,12 @@ class TextRun {
   /// @brief      Whether any glyph in this run has color.
   bool HasColor() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Creates a new TextRun containing a font scaled by the scale
+  ///             value.
+  ///
+  TextRun Scaled(Scalar scale) const;
+
  private:
   Font font_;
   std::vector<GlyphPosition> glyphs_;


### PR DESCRIPTION
This is a re-do of https://github.com/flutter/engine/pull/43468

The test has been slightly altered and now the glyph atlas has all the right text sizes in it.

Fixes https://github.com/flutter/flutter/issues/130142