### PR TITLE
[Impeller] Check for a null command buffer in InlinePassContext::EndPass

### DIFF
--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -54,10 +54,13 @@ bool InlinePassContext::EndPass() {
     return true;
   }
 
-  if (!command_buffer_->SubmitCommandsAsync(std::move(pass_))) {
-    VALIDATION_LOG << "Failed to encode and submit command buffer while ending "
-                      "render pass.";
-    return false;
+  if (command_buffer_) {
+    if (!command_buffer_->SubmitCommandsAsync(std::move(pass_))) {
+      VALIDATION_LOG
+          << "Failed to encode and submit command buffer while ending "
+             "render pass.";
+      return false;
+    }
   }
 
   pass_ = nullptr;


### PR DESCRIPTION
This could happen if the pass is immediately ended due to clear color optimization.

Fixes https://github.com/flutter/flutter/issues/130167
