### PR TITLE
Detaches the previous |FlutterView| from the shared |FlutterEngine| before attaching a new one

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1145,7 +1145,15 @@ public class FlutterView extends FrameLayout
       detachFromFlutterEngine();
     }
 
+    // Detach the previous FlutterView from this FlutterEngine before attaching a new one
+    if (flutterEngine.getAttachedFlutterView() != null) {
+      flutterEngine.getAttachedFlutterView().detachFromFlutterEngine();
+    }
+
     this.flutterEngine = flutterEngine;
+
+    // Set a new FlutterView for this FlutterEngine
+    this.flutterEngine.setAttachedFlutterView(this);
 
     // Instruct our FlutterRenderer that we are now its designated RenderSurface.
     FlutterRenderer flutterRenderer = this.flutterEngine.getRenderer();
@@ -1294,6 +1302,9 @@ public class FlutterView extends FrameLayout
     releaseImageView();
 
     previousRenderSurface = null;
+
+    // No FlutterView is currently attached
+    flutterEngine.setAttachedFlutterView(null);
     flutterEngine = null;
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
+import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.dart.DartExecutor.DartEntrypoint;
 import io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager;
@@ -105,6 +106,9 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
 
   // Engine Lifecycle.
   @NonNull private final Set<EngineLifecycleListener> engineLifecycleListeners = new HashSet<>();
+
+  // Attached FlutterView.
+  @Nullable private FlutterView attachedFlutterView;
 
   @NonNull
   private final EngineLifecycleListener engineLifecycleListener =
@@ -652,5 +656,19 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
   @Override
   public void updateDisplayMetrics(float width, float height, float density) {
     flutterJNI.updateDisplayMetrics(0 /* display ID */, width, height, density);
+  }
+
+  /**
+   * Returns the {@code FlutterView} that is attached to this {@code FlutterEngine}, or null if no
+   * {@code FlutterView} is currently attached.
+   */
+  @Nullable
+  public FlutterView getAttachedFlutterView() {
+    return attachedFlutterView;
+  }
+
+  /** Set the {@code FlutterView} for this {@code FlutterEngine}. */
+  public void setAttachedFlutterView(@Nullable FlutterView flutterView) {
+    attachedFlutterView = flutterView;
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -93,6 +93,25 @@ public class FlutterViewTest {
   }
 
   @Test
+  public void attachToFlutterEngine_twoFlutterViewsAttachToTheSameEngineConsecutively() {
+    FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
+
+    FlutterView flutterView1 = spy(new FlutterView(ctx));
+    when(flutterView1.getContext()).thenReturn(ctx);
+    flutterView1.attachToFlutterEngine(flutterEngine);
+    assertTrue(flutterView1.isAttachedToFlutterEngine());
+    assertTrue(flutterEngine.getAttachedFlutterView() == flutterView1);
+
+    FlutterView flutterView2 = spy(new FlutterView(ctx));
+    when(flutterView2.getContext()).thenReturn(ctx);
+    flutterView2.attachToFlutterEngine(flutterEngine);
+
+    assertFalse(flutterView1.isAttachedToFlutterEngine());
+    assertTrue(flutterView2.isAttachedToFlutterEngine());
+    assertTrue(flutterEngine.getAttachedFlutterView() == flutterView2);
+  }
+
+  @Test
   public void flutterView_importantForAutofillDoesNotExcludeDescendants() {
     FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
 


### PR DESCRIPTION
This PR is aimed at addressing the issue of inconsistent state caused by attaching a new FlutterView to a FlutterEngine without detaching the previous one in the scenario where multiple FlutterViews are sharing the same engine through attach/detach.

Partial fix: https://github.com/flutter/flutter/issues/130235

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
