### PR TITLE
[Impeller] Fix Vulkan validation error when there is a blit directed at a swapchain image.

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -164,8 +164,8 @@ static constexpr vk::ImageUsageFlags ToVKImageUsageFlags(
   }
 
   if (mode != StorageMode::kDeviceTransient) {
-    // TODO (https://github.com/flutter/flutter/issues/121634):
-    // Add transfer usage flags to support blit passes
+    // Add transfer usage flags to support blit passes only if image isn't
+    // device transient.
     vk_usage |= vk::ImageUsageFlagBits::eTransferSrc |
                 vk::ImageUsageFlagBits::eTransferDst;
   }

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -198,7 +198,10 @@ SwapchainImplVK::SwapchainImplVK(const std::shared_ptr<Context>& context,
                                : caps.maxImageCount  // max zero means no limit
   );
   swapchain_info.imageArrayLayers = 1u;
-  swapchain_info.imageUsage = vk::ImageUsageFlagBits::eColorAttachment;
+  // Swapchain images are primarily used as color attachments (via resolve) or
+  // blit targets.
+  swapchain_info.imageUsage = vk::ImageUsageFlagBits::eColorAttachment |
+                              vk::ImageUsageFlagBits::eTransferDst;
   swapchain_info.preTransform = vk::SurfaceTransformFlagBitsKHR::eIdentity;
   swapchain_info.compositeAlpha = composite.value();
   // If we set the clipped value to true, Vulkan expects we will never read back


### PR DESCRIPTION
This shows up in the the aiks test harness in the color wheel with advanced blends.

Fixes https://github.com/flutter/flutter/issues/129853