### PR TITLE
[Impeller] Refactor barriers and add documentation.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1494,6 +1494,8 @@ ORIGIN: ../../../flutter/impeller/renderer/backend/metal/vertex_descriptor_mtl.h
 ORIGIN: ../../../flutter/impeller/renderer/backend/metal/vertex_descriptor_mtl.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/allocator_vk.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/allocator_vk.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/barrier_vk.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/barrier_vk.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/blit_command_vk.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/blit_command_vk.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc + ../../../flutter/LICENSE
@@ -4177,6 +4179,8 @@ FILE: ../../../flutter/impeller/renderer/backend/metal/vertex_descriptor_mtl.h
 FILE: ../../../flutter/impeller/renderer/backend/metal/vertex_descriptor_mtl.mm
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/allocator_vk.cc
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/allocator_vk.h
+FILE: ../../../flutter/impeller/renderer/backend/vulkan/barrier_vk.cc
+FILE: ../../../flutter/impeller/renderer/backend/vulkan/barrier_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/blit_command_vk.cc
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/blit_command_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/blit_pass_vk.cc

--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -24,6 +24,8 @@ impeller_component("vulkan") {
   sources = [
     "allocator_vk.cc",
     "allocator_vk.h",
+    "barrier_vk.cc",
+    "barrier_vk.h",
     "blit_command_vk.cc",
     "blit_command_vk.h",
     "blit_pass_vk.cc",

--- a/impeller/renderer/backend/vulkan/barrier_vk.cc
+++ b/impeller/renderer/backend/vulkan/barrier_vk.cc
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/barrier_vk.h"
+
+namespace impeller {}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/barrier_vk.h
+++ b/impeller/renderer/backend/vulkan/barrier_vk.h
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "flutter/fml/macros.h"
+#include "impeller/renderer/backend/vulkan/vk.h"
+
+namespace impeller {
+
+//------------------------------------------------------------------------------
+/// @brief      Defines an operations and memory access barrier on a resource.
+///
+///             For further reading, see
+///             https://www.khronos.org/events/vulkan-how-to-use-synchronisation-validation-across-multiple-queues-and-command-buffers
+///             and the Vulkan spec. The docs for the various member of this
+///             class are based on verbiage in the spec.
+///
+struct BarrierVK {
+  vk::CommandBuffer cmd_buffer = {};
+  vk::ImageLayout new_layout = vk::ImageLayout::eUndefined;
+
+  // The first synchronization scope defines what operations the barrier waits
+  // for to be done. In the Vulkan spec, this is usually referred to as the src
+  // scope.
+  vk::PipelineStageFlags src_stage = vk::PipelineStageFlagBits::eNone;
+
+  // The first access scope defines what memory operations are guaranteed to
+  // happen before the barrier. In the Vulkan spec, this is usually referred to
+  // as the src scope.
+  vk::AccessFlags src_access = vk::AccessFlagBits::eNone;
+
+  // The second synchronization scope defines what operations wait for the
+  // barrier to be done. In the Vulkan spec, this is usually referred to as the
+  // dst scope.
+  vk::PipelineStageFlags dst_stage = vk::PipelineStageFlagBits::eNone;
+
+  // The second access scope defines what memory operations are prevented from
+  // running till after the barrier. In the Vulkan spec, this is usually
+  // referred to as the dst scope.
+  vk::AccessFlags dst_access = vk::AccessFlagBits::eNone;
+};
+
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/compute_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/compute_pass_vk.cc
@@ -32,17 +32,17 @@ void ComputePassVK::OnSetLabel(const std::string& label) {
 
 static bool UpdateBindingLayouts(const Bindings& bindings,
                                  const vk::CommandBuffer& buffer) {
-  LayoutTransition transition;
-  transition.cmd_buffer = buffer;
-  transition.src_access = vk::AccessFlagBits::eTransferWrite;
-  transition.src_stage = vk::PipelineStageFlagBits::eTransfer;
-  transition.dst_access = vk::AccessFlagBits::eShaderRead;
-  transition.dst_stage = vk::PipelineStageFlagBits::eComputeShader;
+  BarrierVK barrier;
+  barrier.cmd_buffer = buffer;
+  barrier.src_access = vk::AccessFlagBits::eTransferWrite;
+  barrier.src_stage = vk::PipelineStageFlagBits::eTransfer;
+  barrier.dst_access = vk::AccessFlagBits::eShaderRead;
+  barrier.dst_stage = vk::PipelineStageFlagBits::eComputeShader;
 
-  transition.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
+  barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
 
   for (const auto& [_, texture] : bindings.textures) {
-    if (!TextureVK::Cast(*texture.resource).SetLayout(transition)) {
+    if (!TextureVK::Cast(*texture.resource).SetLayout(barrier)) {
       return false;
     }
   }

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -645,13 +645,4 @@ constexpr vk::ImageAspectFlags ToImageAspectFlags(PixelFormat format) {
   FML_UNREACHABLE();
 }
 
-struct LayoutTransition {
-  vk::CommandBuffer cmd_buffer = {};
-  vk::ImageLayout new_layout = vk::ImageLayout::eUndefined;
-  vk::PipelineStageFlags src_stage = vk::PipelineStageFlagBits::eNone;
-  vk::AccessFlags src_access = vk::AccessFlagBits::eNone;
-  vk::PipelineStageFlags dst_stage = vk::PipelineStageFlagBits::eNone;
-  vk::AccessFlags dst_access = vk::AccessFlagBits::eNone;
-};
-
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -407,15 +407,15 @@ bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
                                  .GetEncoder()
                                  ->GetCommandBuffer();
   {
-    LayoutTransition transition;
-    transition.new_layout = vk::ImageLayout::ePresentSrcKHR;
-    transition.cmd_buffer = vk_final_cmd_buffer;
-    transition.src_access = vk::AccessFlagBits::eColorAttachmentWrite;
-    transition.src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-    transition.dst_access = {};
-    transition.dst_stage = vk::PipelineStageFlagBits::eBottomOfPipe;
+    BarrierVK barrier;
+    barrier.new_layout = vk::ImageLayout::ePresentSrcKHR;
+    barrier.cmd_buffer = vk_final_cmd_buffer;
+    barrier.src_access = vk::AccessFlagBits::eColorAttachmentWrite;
+    barrier.src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+    barrier.dst_access = {};
+    barrier.dst_stage = vk::PipelineStageFlagBits::eBottomOfPipe;
 
-    if (!image->SetLayout(transition)) {
+    if (!image->SetLayout(barrier)) {
       return false;
     }
 

--- a/impeller/renderer/backend/vulkan/texture_source_vk.cc
+++ b/impeller/renderer/backend/vulkan/texture_source_vk.cc
@@ -27,17 +27,17 @@ vk::ImageLayout TextureSourceVK::SetLayoutWithoutEncoding(
   return old_layout;
 }
 
-bool TextureSourceVK::SetLayout(const LayoutTransition& transition) const {
-  const auto old_layout = SetLayoutWithoutEncoding(transition.new_layout);
-  if (transition.new_layout == old_layout) {
+bool TextureSourceVK::SetLayout(const BarrierVK& barrier) const {
+  const auto old_layout = SetLayoutWithoutEncoding(barrier.new_layout);
+  if (barrier.new_layout == old_layout) {
     return true;
   }
 
   vk::ImageMemoryBarrier image_barrier;
-  image_barrier.srcAccessMask = transition.src_access;
-  image_barrier.dstAccessMask = transition.dst_access;
+  image_barrier.srcAccessMask = barrier.src_access;
+  image_barrier.dstAccessMask = barrier.dst_access;
   image_barrier.oldLayout = old_layout;
-  image_barrier.newLayout = transition.new_layout;
+  image_barrier.newLayout = barrier.new_layout;
   image_barrier.image = GetImage();
   image_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
   image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -47,12 +47,12 @@ bool TextureSourceVK::SetLayout(const LayoutTransition& transition) const {
   image_barrier.subresourceRange.baseArrayLayer = 0u;
   image_barrier.subresourceRange.layerCount = ToArrayLayerCount(desc_.type);
 
-  transition.cmd_buffer.pipelineBarrier(transition.src_stage,  // src stage
-                                        transition.dst_stage,  // dst stage
-                                        {},            // dependency flags
-                                        nullptr,       // memory barriers
-                                        nullptr,       // buffer barriers
-                                        image_barrier  // image barriers
+  barrier.cmd_buffer.pipelineBarrier(barrier.src_stage,  // src stage
+                                     barrier.dst_stage,  // dst stage
+                                     {},                 // dependency flags
+                                     nullptr,            // memory barriers
+                                     nullptr,            // buffer barriers
+                                     image_barrier       // image barriers
   );
 
   return true;

--- a/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -7,6 +7,7 @@
 #include "flutter/fml/macros.h"
 #include "impeller/base/thread.h"
 #include "impeller/core/texture_descriptor.h"
+#include "impeller/renderer/backend/vulkan/barrier_vk.h"
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 
@@ -22,7 +23,7 @@ class TextureSourceVK {
 
   virtual vk::ImageView GetImageView() const = 0;
 
-  bool SetLayout(const LayoutTransition& transition) const;
+  bool SetLayout(const BarrierVK& barrier) const;
 
   vk::ImageLayout SetLayoutWithoutEncoding(vk::ImageLayout layout) const;
 

--- a/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -71,15 +71,15 @@ bool TextureVK::OnSetContents(const uint8_t* contents,
 
   const auto& vk_cmd_buffer = encoder->GetCommandBuffer();
 
-  LayoutTransition transition;
-  transition.cmd_buffer = vk_cmd_buffer;
-  transition.new_layout = vk::ImageLayout::eTransferDstOptimal;
-  transition.src_access = {};
-  transition.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
-  transition.dst_access = vk::AccessFlagBits::eTransferWrite;
-  transition.dst_stage = vk::PipelineStageFlagBits::eTransfer;
+  BarrierVK barrier;
+  barrier.cmd_buffer = vk_cmd_buffer;
+  barrier.new_layout = vk::ImageLayout::eTransferDstOptimal;
+  barrier.src_access = {};
+  barrier.src_stage = vk::PipelineStageFlagBits::eTopOfPipe;
+  barrier.dst_access = vk::AccessFlagBits::eTransferWrite;
+  barrier.dst_stage = vk::PipelineStageFlagBits::eTransfer;
 
-  if (!SetLayout(transition)) {
+  if (!SetLayout(barrier)) {
     return false;
   }
 
@@ -101,7 +101,7 @@ bool TextureVK::OnSetContents(const uint8_t* contents,
   vk_cmd_buffer.copyBufferToImage(
       DeviceBufferVK::Cast(*staging_buffer).GetBuffer(),  // src buffer
       GetImage(),                                         // dst image
-      transition.new_layout,                              // dst image layout
+      barrier.new_layout,                                 // dst image layout
       1u,                                                 // region count
       &copy                                               // regions
   );
@@ -136,8 +136,8 @@ std::shared_ptr<const TextureSourceVK> TextureVK::GetTextureSource() const {
   return source_;
 }
 
-bool TextureVK::SetLayout(const LayoutTransition& transition) const {
-  return source_ ? source_->SetLayout(transition) : false;
+bool TextureVK::SetLayout(const BarrierVK& barrier) const {
+  return source_ ? source_->SetLayout(barrier) : false;
 }
 
 vk::ImageLayout TextureVK::SetLayoutWithoutEncoding(

--- a/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/impeller/renderer/backend/vulkan/texture_vk.h
@@ -29,7 +29,7 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
 
   vk::ImageView GetImageView() const;
 
-  bool SetLayout(const LayoutTransition& transition) const;
+  bool SetLayout(const BarrierVK& barrier) const;
 
   vk::ImageLayout SetLayoutWithoutEncoding(vk::ImageLayout layout) const;
 


### PR DESCRIPTION
Calling a pipeline barrier a transition seemed odd. Also, the members of the layout transition weren't documented and I always had a tough time remembering how barriers worked. It's hopefully clearer now.