### PR TITLE
remove include of SkPicture files from non-Fuchsia sources

### DIFF
--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -2083,9 +2083,9 @@ class CanvasCompareTester {
     }
 
     {
-      // This sequence renders the SkCanvas calls to an SkPictureRecorder and
-      // renders the DisplayList calls to a DisplayListBuilder and then
-      // renders both back under a transform (scale(2x)) to see if their
+      // This sequence uses an SkPicture generated previously from the SkCanvas
+      // calls and a DisplayList generated previously from the DlCanvas calls
+      // and renders both back under a transform (scale(2x)) to see if their
       // rendering is affected differently by a change of matrix between
       // recording time and rendering time.
       const int test_width_2 = kTestWidth * 2;

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -14,14 +14,11 @@
 #include "flutter/flow/surface_frame.h"
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/raster_thread_merger.h"
-#include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/skia/include/core/SkPath.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
-#include "third_party/skia/include/core/SkPoint.h"
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkSize.h"
-#include "third_party/skia/include/core/SkSurface.h"
 
 #if IMPELLER_SUPPORTS_RENDERING
 #include "flutter/impeller/aiks/aiks_context.h"  // nogncheck

--- a/flow/frame_timings_recorder_unittests.cc
+++ b/flow/frame_timings_recorder_unittests.cc
@@ -7,7 +7,6 @@
 #include "flutter/flow/testing/layer_test.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/flow/testing/mock_raster_cache.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
 
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -8,15 +8,12 @@
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/frame_timings.h"
 #include "flutter/flow/layer_snapshot_store.h"
-#include "flutter/flow/layers/cacheable_layer.h"
 #include "flutter/flow/layers/layer.h"
 #include "flutter/flow/paint_utils.h"
 #include "flutter/flow/raster_cache.h"
+#include "flutter/flow/raster_cache_item.h"
 #include "flutter/fml/time/time_point.h"
 #include "flutter/fml/trace_event.h"
-#include "include/core/SkMatrix.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
-#include "third_party/skia/include/utils/SkNWayCanvas.h"
 
 namespace flutter {
 

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -17,12 +17,8 @@
 #include "flutter/flow/testing/mock_raster_cache.h"
 #include "flutter/testing/assertions_skia.h"
 #include "gtest/gtest.h"
-#include "include/core/SkMatrix.h"
-#include "include/core/SkPoint.h"
-#include "third_party/skia/include/core/SkCanvas.h"
-#include "third_party/skia/include/core/SkPaint.h"
-#include "third_party/skia/include/core/SkPicture.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
+#include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkPoint.h"
 
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
 // NOLINTBEGIN(bugprone-unchecked-optional-access)

--- a/flow/testing/diff_context_test.h
+++ b/flow/testing/diff_context_test.h
@@ -9,8 +9,6 @@
 #include "flutter/flow/layers/display_list_layer.h"
 #include "flutter/flow/layers/opacity_layer.h"
 #include "flutter/flow/testing/layer_test.h"
-#include "third_party/skia/include/core/SkPicture.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
 
 namespace flutter {
 namespace testing {

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -7,7 +7,6 @@
 
 #include "flutter/flow/embedded_views.h"
 #include "flutter/fml/raster_thread_merger.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
 
 namespace flutter {
 

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -14,7 +14,6 @@
 #include "flutter/shell/platform/android/external_view_embedder/surface_pool.h"
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
 
 namespace flutter {
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -14,7 +14,6 @@
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h"
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
 
 @class FlutterTouchInterceptingView;
 


### PR DESCRIPTION
Addresses most of https://github.com/flutter/flutter/issues/128060

Most of the uses of SkPicture and Recorder are removed from the engine sources. The few that remain are:

- DisplayList <-> Skia consistency testing code
- Legacy code only used from Fuchsia
- Dart CanvasKit uses which aren't actually using the local Skia sources or libraries

These are all comment and include file changes and so the testing is in the building.