### PR TITLE
[fuchsia] flutter-embedder-test and touch-input-test use Flatland Test UI Stack

### DIFF
--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
@@ -66,7 +66,8 @@ constexpr char kChildViewUrl[] =
 constexpr char kParentViewUrl[] =
     "fuchsia-pkg://fuchsia.com/parent-view#meta/parent-view.cm";
 static constexpr auto kTestUiStackUrl =
-    "fuchsia-pkg://fuchsia.com/test-ui-stack#meta/test-ui-stack.cm";
+    "fuchsia-pkg://fuchsia.com/flatland-scene-manager-test-ui-stack#meta/"
+    "test-ui-stack.cm";
 
 constexpr auto kFlutterRunnerEnvironment = "flutter_runner_env";
 constexpr auto kFlutterJitRunner = "flutter_jit_runner";
@@ -84,33 +85,19 @@ constexpr auto kParentViewRef = ChildRef{kParentView};
 constexpr auto kTestUiStack = "ui";
 constexpr auto kTestUiStackRef = ChildRef{kTestUiStack};
 
-constexpr fuchsia_test_utils::Color kParentBackgroundColor = {0x00, 0x00, 0xFF,
+// Background and foreground color values.
+constexpr fuchsia_test_utils::Color kParentBackgroundColor = {0xFF, 0x00, 0x00,
                                                               0xFF};  // Blue
 constexpr fuchsia_test_utils::Color kChildBackgroundColor = {0xFF, 0x00, 0xFF,
                                                              0xFF};  // Pink
-
-// TODO(fxb/64201): Remove forced opacity colors when Flatland is enabled.
-constexpr fuchsia_test_utils::Color kOverlayBackgroundColor1 = {
-    0x00, 0xFF, 0x0E, 0xFF};  // Green, blended with blue (FEMU local)
-constexpr fuchsia_test_utils::Color kOverlayBackgroundColor2 = {
-    0x0E, 0xFF, 0x0E, 0xFF};  // Green, blended with pink (FEMU local)
-constexpr fuchsia_test_utils::Color kOverlayBackgroundColor3 = {
-    0x00, 0xFF, 0x0D, 0xFF};  // Green, blended with blue (AEMU infra)
-constexpr fuchsia_test_utils::Color kOverlayBackgroundColor4 = {
-    0x0D, 0xFF, 0x0D, 0xFF};  // Green, blended with pink (AEMU infra)
-constexpr fuchsia_test_utils::Color kOverlayBackgroundColor5 = {
-    0x00, 0xFE, 0x0D, 0xFF};  // Green, blended with blue (NUC)
-constexpr fuchsia_test_utils::Color kOverlayBackgroundColor6 = {
-    0x0D, 0xFF, 0x00, 0xFF};  // Green, blended with pink (NUC)
+constexpr fuchsia_test_utils::Color kChildTappedColor = {0x00, 0xFF, 0xFF,
+                                                         0xFF};  // Yellow
+constexpr fuchsia_test_utils::Color kFlatlandOverlayColor = {0x00, 0xFF, 0x00,
+                                                             0xFF};  // Green
 
 static size_t OverlayPixelCount(
     std::map<fuchsia_test_utils::Color, size_t>& histogram) {
-  return histogram[kOverlayBackgroundColor1] +
-         histogram[kOverlayBackgroundColor2] +
-         histogram[kOverlayBackgroundColor3] +
-         histogram[kOverlayBackgroundColor4] +
-         histogram[kOverlayBackgroundColor5] +
-         histogram[kOverlayBackgroundColor6];
+  return histogram[kFlatlandOverlayColor];
 }
 
 // Timeout for Scenic's |TakeScreenshot| FIDL call.

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/lib/parent_view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/lib/parent_view.dart
@@ -20,17 +20,15 @@ void main(List<String> args) async {
   final parser = ArgParser()
     ..addFlag('showOverlay', defaultsTo: false)
     ..addFlag('hitTestable', defaultsTo: true)
-    ..addFlag('focusable', defaultsTo: true)
-    ..addFlag('useFlatland', defaultsTo: false);
+    ..addFlag('focusable', defaultsTo: true);
   final arguments = parser.parse(args);
   for (final option in arguments.options) {
     print('parent-view: $option: ${arguments[option]}');
   }
 
   TestApp app;
-  final useFlatland = arguments['useFlatland'];
   app = TestApp(
-    ChildView(await _launchChildView(useFlatland)),
+    ChildView(await _launchChildView()),
     showOverlay: arguments['showOverlay'],
     hitTestable: arguments['hitTestable'],
     focusable: arguments['focusable'],
@@ -184,8 +182,8 @@ class ChildView {
   }
 }
 
-Future<int> _launchChildView(bool useFlatland) async {
-  final message = Int8List.fromList([useFlatland ? 0x31 : 0x30]);
+Future<int> _launchChildView() async {
+  final message = Int8List.fromList([0x31]);
   final completer = new Completer<ByteData>();
   PlatformDispatcher.instance.sendPlatformMessage(
       'fuchsia/child_view', ByteData.sublistView(message), (ByteData reply) {

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/BUILD.gn
@@ -33,6 +33,7 @@ executable("touch-input-test-bin") {
     "$fuchsia_sdk_root/fidl:fuchsia.net.interfaces",
     "$fuchsia_sdk_root/fidl:fuchsia.tracing.provider",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
+    "$fuchsia_sdk_root/fidl:fuchsia.ui.display.singleton",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.input",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.pointerinjector",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.policy",

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/lib/embedding-flutter-view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/lib/embedding-flutter-view.dart
@@ -28,9 +28,8 @@ void main(List<String> args) async {
     print('embedding-flutter-view args: $option: ${arguments[option]}');
   }
 
-  // TODO(fxbug.dev/125514): Support Flatland Child View.
   TestApp app = TestApp(
-    ChildView(await _launchChildView(false)),
+    ChildView(await _launchChildView()),
     showOverlay: arguments['showOverlay'],
     hitTestable: arguments['hitTestable'],
     focusable: arguments['focusable'],
@@ -220,8 +219,8 @@ class ChildView {
   }
 }
 
-Future<int> _launchChildView(bool useFlatland) async {
-  final message = Int8List.fromList([useFlatland ? 0x31 : 0x30]);
+Future<int> _launchChildView() async {
+  final message = Int8List.fromList([0x31]);
   final completer = new Completer<ByteData>();
   PlatformDispatcher.instance.sendPlatformMessage(
       'fuchsia/child_view', ByteData.sublistView(message), (ByteData reply) {

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
@@ -55,7 +55,6 @@
         "fuchsia.test": {
             "deprecated-allowed-packages": [
                 "embedding-flutter-view",
-                "gfx-scene-manager-test-ui-stack",
                 "flatland-scene-manager-test-ui-stack",
                 "oot_flutter_aot_runner",
                 "oot_flutter_jit_runner",

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-test.cc
@@ -14,9 +14,9 @@
 #include <fuchsia/sysmem/cpp/fidl.h>
 #include <fuchsia/tracing/provider/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>
+#include <fuchsia/ui/display/singleton/cpp/fidl.h>
 #include <fuchsia/ui/input/cpp/fidl.h>
 #include <fuchsia/ui/policy/cpp/fidl.h>
-#include <fuchsia/ui/scenic/cpp/fidl.h>
 #include <fuchsia/ui/test/input/cpp/fidl.h>
 #include <fuchsia/ui/test/scene/cpp/fidl.h>
 #include <fuchsia/web/cpp/fidl.h>
@@ -26,9 +26,6 @@
 #include <lib/sys/component/cpp/testing/realm_builder.h>
 #include <lib/sys/component/cpp/testing/realm_builder_types.h>
 #include <lib/sys/cpp/component_context.h>
-#include <lib/ui/scenic/cpp/resources.h>
-#include <lib/ui/scenic/cpp/session.h>
-#include <lib/ui/scenic/cpp/view_token_pair.h>
 #include <lib/zx/clock.h>
 #include <lib/zx/time.h>
 #include <zircon/status.h>
@@ -127,9 +124,6 @@ using RealmBuilder = component_testing::RealmBuilder;
 // Set this as low as you can that still works across all test platforms.
 constexpr zx::duration kTimeout = zx::min(1);
 
-constexpr auto kGfxTestUIStackUrl =
-    "fuchsia-pkg://fuchsia.com/gfx-scene-manager-test-ui-stack#meta/"
-    "test-ui-stack.cm";
 constexpr auto kTestUIStackUrl =
     "fuchsia-pkg://fuchsia.com/flatland-scene-manager-test-ui-stack#meta/"
     "test-ui-stack.cm";
@@ -206,8 +200,7 @@ class TouchInputListenerServer
 };
 
 class FlutterTapTestBase : public PortableUITest,
-                           public ::testing::Test,
-                           public ::testing::WithParamInterface<std::string> {
+                           public ::testing::Test {
  protected:
   ~FlutterTapTestBase() override {
     FML_CHECK(touch_injection_request_count() > 0)
@@ -226,18 +219,20 @@ class FlutterTapTestBase : public PortableUITest,
         },
         kTimeout);
 
-    // Get the display dimensions.
+    // Get the display information using the |fuchsia.ui.display.singleton.Info|.
     FML_LOG(INFO) << "Waiting for scenic display info";
-    scenic_ = realm_root()->component().Connect<fuchsia::ui::scenic::Scenic>();
-    scenic_->GetDisplayInfo([this](fuchsia::ui::gfx::DisplayInfo display_info) {
-      display_width_ = display_info.width_in_px;
-      display_height_ = display_info.height_in_px;
-      FML_LOG(INFO) << "Got display_width = " << display_width_
-                    << " and display_height = " << display_height_;
+    std::optional<bool> display_metrics_obtained;
+    fuchsia::ui::display::singleton::InfoPtr display_info =
+        realm_->component().Connect<fuchsia::ui::display::singleton::Info>();
+    display_info->GetMetrics([this, &display_metrics_obtained](auto info) {
+      display_width_ = info.extent_in_px().width;
+      display_height_ = info.extent_in_px().height;
+      display_metrics_obtained = true;
     });
-    RunLoopUntil(
-        [this] { return display_width_ != 0 && display_height_ != 0; });
-
+    RunLoopUntil([&display_metrics_obtained] {
+      return display_metrics_obtained.has_value();
+    });
+    
     // Register input injection device.
     FML_LOG(INFO) << "Registering input injection device";
     RegisterTouchScreen();
@@ -287,7 +282,7 @@ class FlutterTapTestBase : public PortableUITest,
   uint32_t display_width() const { return display_width_; }
   uint32_t display_height() const { return display_height_; }
 
-  ParamType GetTestUIStackUrl() override { return GetParam(); };
+  ParamType GetTestUIStackUrl() override { return kTestUIStackUrl; };
 
   TouchInputListenerServer* touch_input_listener_server_;
 };
@@ -345,17 +340,19 @@ class FlutterEmbedTapTest : public FlutterTapTestBase {
   void LaunchClientWithEmbeddedView() {
     BuildRealm();
 
-    // Get the display dimensions.
+    // Get the display information using the |fuchsia.ui.display.singleton.Info|.
     FML_LOG(INFO) << "Waiting for scenic display info";
-    scenic_ = realm_root()->component().Connect<fuchsia::ui::scenic::Scenic>();
-    scenic_->GetDisplayInfo([this](fuchsia::ui::gfx::DisplayInfo display_info) {
-      display_width_ = display_info.width_in_px;
-      display_height_ = display_info.height_in_px;
-      FML_LOG(INFO) << "Got display_width = " << display_width_
-                    << " and display_height = " << display_height_;
+    std::optional<bool> display_metrics_obtained;
+    fuchsia::ui::display::singleton::InfoPtr display_info =
+        realm_->component().Connect<fuchsia::ui::display::singleton::Info>();
+    display_info->GetMetrics([this, &display_metrics_obtained](auto info) {
+      display_width_ = info.extent_in_px().width;
+      display_height_ = info.extent_in_px().height;
+      display_metrics_obtained = true;
     });
-    RunLoopUntil(
-        [this] { return display_width_ != 0 && display_height_ != 0; });
+    RunLoopUntil([&display_metrics_obtained] {
+      return display_metrics_obtained.has_value();
+    });
 
     // Register input injection device.
     FML_LOG(INFO) << "Registering input injection device";
@@ -424,16 +421,7 @@ class FlutterEmbedTapTest : public FlutterTapTestBase {
   }
 };
 
-// Makes use of gtest's parameterized testing, allowing us
-// to test different combinations of test-ui-stack + runners. Currently, there
-// are both GFX and Flatland variants. Documentation:
-// http://go/gunitadvanced#value-parameterized-tests
-INSTANTIATE_TEST_SUITE_P(FlutterTapTestParameterized,
-                         FlutterTapTest,
-                         ::testing::Values(kGfxTestUIStackUrl,
-                                           kTestUIStackUrl));
-
-TEST_P(FlutterTapTest, FlutterTap) {
+TEST_F(FlutterTapTest, FlutterTap) {
   // Launch client view, and wait until it's rendering to proceed with the test.
   FML_LOG(INFO) << "Initializing scene";
   LaunchClient();
@@ -457,13 +445,7 @@ TEST_P(FlutterTapTest, FlutterTap) {
   ASSERT_EQ(touch_injection_request_count(), 1);
 }
 
-// TODO(fxbug.dev/125514): Embedded Child View needs to support Flatland.
-// Only test GFX Test UI stack for embedded test cases for now.
-INSTANTIATE_TEST_SUITE_P(FlutterEmbedTapTestParameterized,
-                         FlutterEmbedTapTest,
-                         ::testing::Values(kGfxTestUIStackUrl));
-
-TEST_P(FlutterEmbedTapTest, FlutterEmbedTap) {
+TEST_F(FlutterEmbedTapTest, FlutterEmbedTap) {
   // Launch view
   FML_LOG(INFO) << "Initializing scene";
   LaunchClientWithEmbeddedView();
@@ -497,7 +479,7 @@ TEST_P(FlutterEmbedTapTest, FlutterEmbedTap) {
   ASSERT_EQ(touch_injection_request_count(), 2);
 }
 
-TEST_P(FlutterEmbedTapTest, FlutterEmbedHittestDisabled) {
+TEST_F(FlutterEmbedTapTest, FlutterEmbedHittestDisabled) {
   FML_LOG(INFO) << "Initializing scene";
   AddComponentArgument("--no-hitTestable");
   LaunchClientWithEmbeddedView();
@@ -519,7 +501,7 @@ TEST_P(FlutterEmbedTapTest, FlutterEmbedHittestDisabled) {
   ASSERT_EQ(touch_injection_request_count(), 1);
 }
 
-TEST_P(FlutterEmbedTapTest, FlutterEmbedOverlayEnabled) {
+TEST_F(FlutterEmbedTapTest, FlutterEmbedOverlayEnabled) {
   FML_LOG(INFO) << "Initializing scene";
   AddComponentArgument("--showOverlay");
   LaunchClientWithEmbeddedView();

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/BUILD.gn
@@ -51,6 +51,7 @@ source_set("portable_ui_test") {
   deps = [
     ":check_view",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
+    "$fuchsia_sdk_root/fidl:fuchsia.ui.display.singleton",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.input",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.observation.geometry",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.policy",

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -93,6 +93,7 @@ void PortableUITest::SetUpRealmBase() {
                        Protocol{fuchsia::ui::scenic::Scenic::Name_},
                        Protocol{fuchsia::ui::test::input::Registry::Name_},
                        Protocol{fuchsia::ui::test::scene::Controller::Name_},
+                       Protocol{fuchsia::ui::display::singleton::Info::Name_},
                        Protocol{kPointerInjectorRegistryName}},
       .source = kTestUIStackRef,
       .targets = {ParentRef(), kFlutterJitRunnerRef}});

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.h
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.h
@@ -7,6 +7,7 @@
 
 #include <fuchsia/sysmem/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>
+#include <fuchsia/ui/display/singleton/cpp/fidl.h>
 #include <fuchsia/ui/input/cpp/fidl.h>
 #include <fuchsia/ui/policy/cpp/fidl.h>
 #include <fuchsia/ui/scenic/cpp/fidl.h>


### PR DESCRIPTION
This change also:
- removes reliance on fuchsia.ui.scenic.Scenic protocols
- migrates touch-input-test from fuchsia.ui.gfx.DisplayInfo to fuchsia.ui.display.singleton.Info
- adds support for fuchsia.ui.display.singleton.Info in portable_ui_test

Bug: fxbug.dev/125514