### PR TITLE
[fuchsia][cml] Mark Tracing as Optional

### DIFF
--- a/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
+++ b/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
@@ -32,9 +32,15 @@
                 "fuchsia.logger.LogSink",  // For syslog
                 "fuchsia.net.name.Lookup",  // For fdio sockets
                 "fuchsia.posix.socket.Provider",  // For fdio sockets
+            ],
+            from: "parent",
+        },
+        {
+            protocol: [
                 "fuchsia.tracing.provider.Registry",  // For trace-provider
             ],
             from: "parent",
+            availability: "optional",
         },
     ],
     expose: [

--- a/shell/platform/fuchsia/flutter/meta/common.shard.cml
+++ b/shell/platform/fuchsia/flutter/meta/common.shard.cml
@@ -42,7 +42,6 @@
                 "fuchsia.net.name.Lookup",
                 "fuchsia.posix.socket.Provider",
                 "fuchsia.sysmem.Allocator",
-                "fuchsia.tracing.provider.Registry", // Copied from vulkan/client.shard.cml.
                 "fuchsia.ui.composition.Allocator",
                 "fuchsia.ui.composition.Flatland",
                 "fuchsia.ui.input.ImeService",
@@ -51,6 +50,12 @@
                 "fuchsia.ui.scenic.Scenic",
                 "fuchsia.vulkan.loader.Loader", // Copied from vulkan/client.shard.cml.
             ],
+        },
+        {
+            protocol: [
+                "fuchsia.tracing.provider.Registry", // Copied from vulkan/client.shard.cml.
+            ],
+            availability: "optional",
         },
     ],
     expose: [


### PR DESCRIPTION
Tracing is an optional component that is only included in eng builds, so the usage should be marked optional.

Bug: fxbug.dev/112433