### PR TITLE
[Impeller] hack solution to texture deallocation blocking raster thread.

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -340,7 +340,7 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
   ~AllocatedTextureSourceVK() {
     image_view_.reset();
     auto context = context_.lock();
-    if (context && ContextVK::Cast(*context).IsOnRasterThread()) {
+    if (context && ContextVK::Cast(*context).IsOnRasterThread() && image_) {
       ContextVK::Cast(*context).GetConcurrentWorkerTaskRunner()->PostTask(
           [image = std::move(image_), allocation = std::move(allocation_),
            allocator = allocator_] {

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -136,6 +136,14 @@ class ContextVK final : public Context,
 
   std::shared_ptr<FenceWaiterVK> GetFenceWaiter() const;
 
+  void MarkRasterThread() const {
+    raster_thread_id_ = std::this_thread::get_id();
+  }
+
+  bool IsOnRasterThread() const {
+    return raster_thread_id_ == std::this_thread::get_id();
+  }
+
  private:
   struct DeviceHolderImpl : public DeviceHolder {
     // |DeviceHolder|
@@ -162,6 +170,7 @@ class ContextVK final : public Context,
   std::shared_ptr<FenceWaiterVK> fence_waiter_;
   std::string device_name_;
   std::shared_ptr<fml::ConcurrentMessageLoop> raster_message_loop_;
+  mutable std::thread::id raster_thread_id_;
   const uint64_t hash_;
 
   bool is_valid_ = false;

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -326,6 +326,7 @@ SwapchainImplVK::AcquireResult SwapchainImplVK::AcquireNextDrawable() {
   }
 
   const auto& context = ContextVK::Cast(*context_strong);
+  context.MarkRasterThread();
 
   current_frame_ = (current_frame_ + 1u) % synchronizers_.size();
 


### PR DESCRIPTION
On CI the remaining blips seem to be texture deallocation happening on the raster thread. This happens if the fence waiter finishes before the raster thread is done, leaving the final reference to the allocated texture on the raster thread. Thus the expensive destructed is called during the frame workload.

We can approximately detect this by checking the current thread in the destructor, though this solution feels hacky.

The way that dawn handles this is a bit inverted from what we do. Rather than tracking textures by giving a reference to a fence waiter, they give the fence to the texture. When the texture is destructed on the encoding thread, it gets automatically moved to a background thread with the fence. We could adapt this approach too but it would require some substantial refactoring in the fence waiter.

https://user-images.githubusercontent.com/8975114/251817713-44bebfbd-bc91-411d-a786-32a1f8194b7c.png

Fixes https://github.com/flutter/flutter/issues/130157