### PR TITLE
Release the mutex in the CanCreateConcurrentMessageLoop test before waking the latch

### DIFF
--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -331,8 +331,10 @@ TEST(MessageLoop, CanCreateConcurrentMessageLoop) {
     task_runner->PostTask([&]() {
       std::this_thread::sleep_for(std::chrono::seconds(1));
       std::cout << "Ran on thread: " << std::this_thread::get_id() << std::endl;
-      std::scoped_lock lock(thread_ids_mutex);
-      thread_ids.insert(std::this_thread::get_id());
+      {
+        std::scoped_lock lock(thread_ids_mutex);
+        thread_ids.insert(std::this_thread::get_id());
+      }
       latch.CountDown();
     });
   }


### PR DESCRIPTION
If the wake happens while thread_ids_mutex is still held, then the test function may exit and destroy thread_ids_mutex before the pool thread task releases it.

Fixes https://github.com/flutter/flutter/issues/130344
