### PR TITLE
header file cleanup focusing on removing unnecessary SkPicture includes

### DIFF
--- a/display_list/effects/dl_path_effect.h
+++ b/display_list/effects/dl_path_effect.h
@@ -9,7 +9,7 @@
 
 #include "flutter/display_list/dl_attributes.h"
 #include "flutter/fml/logging.h"
-#include "include/core/SkRect.h"
+#include "third_party/skia/include/core/SkRect.h"
 
 namespace flutter {
 

--- a/display_list/effects/dl_path_effect_unittests.cc
+++ b/display_list/effects/dl_path_effect_unittests.cc
@@ -6,7 +6,7 @@
 #include "flutter/display_list/testing/dl_test_equality.h"
 #include "flutter/display_list/utils/dl_comparable.h"
 #include "gtest/gtest.h"
-#include "include/core/SkScalar.h"
+#include "third_party/skia/include/core/SkScalar.h"
 
 namespace flutter {
 namespace testing {

--- a/display_list/image/dl_image.h
+++ b/display_list/image/dl_image.h
@@ -10,8 +10,8 @@
 #include <string>
 
 #include "flutter/fml/macros.h"
-#include "include/core/SkRefCnt.h"
 #include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/core/SkRefCnt.h"
 
 namespace impeller {
 class Texture;

--- a/display_list/skia/dl_sk_conversions_unittests.cc
+++ b/display_list/skia/dl_sk_conversions_unittests.cc
@@ -10,7 +10,7 @@
 #include "flutter/display_list/dl_tile_mode.h"
 #include "flutter/display_list/dl_vertices.h"
 #include "gtest/gtest.h"
-#include "include/core/SkSamplingOptions.h"
+#include "third_party/skia/include/core/SkSamplingOptions.h"
 
 namespace flutter {
 namespace testing {

--- a/display_list/testing/dl_test_snippets.h
+++ b/display_list/testing/dl_test_snippets.h
@@ -244,18 +244,6 @@ struct DisplayListInvocation {
   DlInvoker invoker;
   bool supports_group_opacity_ = false;
 
-  bool sk_version_matches() {
-    return (static_cast<int>(op_count_) == sk_op_count_ &&
-            byte_count_ == sk_byte_count_);
-  }
-
-  // A negative sk_op_count means "do not test this op".
-  // Used mainly for these cases:
-  // - we cannot encode a DrawShadowRec (Skia private header)
-  // - SkCanvas cannot receive a DisplayList
-  // - SkCanvas may or may not inline an SkPicture
-  bool sk_testing_invalid() { return sk_op_count_ < 0; }
-
   bool is_empty() { return byte_count_ == 0; }
 
   bool supports_group_opacity() { return supports_group_opacity_; }
@@ -266,11 +254,6 @@ struct DisplayListInvocation {
   // byte count for the ops with DisplayList overhead, comparable
   // to |DisplayList.byte_count().
   size_t byte_count() { return sizeof(DisplayList) + byte_count_; }
-
-  int sk_op_count() { return sk_op_count_; }
-  // byte count for the ops with DisplayList overhead as translated
-  // through an SkCanvas interface, comparable to |DisplayList.byte_count().
-  size_t sk_byte_count() { return sizeof(DisplayList) + sk_byte_count_; }
 
   void Invoke(DlOpReceiver& builder) { invoker(builder); }
 

--- a/flow/layers/display_list_raster_cache_item.h
+++ b/flow/layers/display_list_raster_cache_item.h
@@ -11,12 +11,8 @@
 #include "flutter/display_list/display_list.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/raster_cache_item.h"
-#include "include/core/SkCanvas.h"
-#include "include/core/SkColorSpace.h"
-#include "include/core/SkMatrix.h"
-#include "include/core/SkPicture.h"
-#include "include/core/SkPoint.h"
-#include "include/core/SkRect.h"
+#include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkPoint.h"
 
 namespace flutter {
 

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -14,8 +14,6 @@
 #include "flutter/flow/raster_cache.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_delta.h"
-#include "third_party/skia/include/core/SkPicture.h"
-#include "third_party/skia/include/core/SkSize.h"
 
 class GrDirectContext;
 

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -18,7 +18,6 @@
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkImage.h"
-#include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -14,10 +14,8 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/trace_event.h"
-#include "include/core/SkMatrix.h"
-#include "include/core/SkRect.h"
-#include "third_party/skia/include/core/SkImage.h"
-#include "third_party/skia/include/core/SkSize.h"
+#include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkRect.h"
 
 class GrDirectContext;
 class SkColorSpace;
@@ -182,16 +180,14 @@ class RasterCache {
   size_t GetLayerCachedEntriesCount() const;
 
   /**
-   * Return the number of map entries in the picture caches (SkPicture and
-   * DisplayList) regardless of whether the entries have been populated with
-   * an image.
+   * Return the number of map entries in the picture (DisplayList) cache
+   * regardless of whether the entries have been populated with an image.
    */
   size_t GetPictureCachedEntriesCount() const;
 
   /**
    * @brief Estimate how much memory is used by picture raster cache entries in
-   * bytes, including cache entries in the SkPicture cache and the DisplayList
-   * cache.
+   * bytes.
    *
    * Only SkImage's memory usage is counted as other objects are often much
    * smaller compared to SkImage. SkImageInfo::computeMinByteSize is used to

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -182,39 +182,6 @@ TEST(RasterCache, SetCheckboardCacheImages) {
   ASSERT_TRUE(did_draw_checkerboard);
 }
 
-TEST(RasterCache, AccessThresholdOfZeroDisablesCachingForSkPicture) {
-  size_t threshold = 0;
-  flutter::RasterCache cache(threshold);
-
-  SkMatrix matrix = SkMatrix::I();
-
-  auto display_list = GetSampleDisplayList();
-
-  MockCanvas dummy_canvas(1000, 1000);
-  DlPaint paint;
-
-  LayerStateStack preroll_state_stack;
-  preroll_state_stack.set_preroll_delegate(kGiantRect, matrix);
-  LayerStateStack paint_state_stack;
-  preroll_state_stack.set_delegate(&dummy_canvas);
-
-  FixedRefreshRateStopwatch raster_time;
-  FixedRefreshRateStopwatch ui_time;
-  PrerollContextHolder preroll_context_holder = GetSamplePrerollContextHolder(
-      preroll_state_stack, &cache, &raster_time, &ui_time);
-  PaintContextHolder paint_context_holder = GetSamplePaintContextHolder(
-      paint_state_stack, &cache, &raster_time, &ui_time);
-  auto& preroll_context = preroll_context_holder.preroll_context;
-  auto& paint_context = paint_context_holder.paint_context;
-
-  cache.BeginFrame();
-  DisplayListRasterCacheItem display_list_item(display_list, SkPoint(), true,
-                                               false);
-  ASSERT_FALSE(RasterCacheItemPrerollAndTryToRasterCache(
-      display_list_item, preroll_context, paint_context, matrix));
-  ASSERT_FALSE(display_list_item.Draw(paint_context, &dummy_canvas, &paint));
-}
-
 TEST(RasterCache, AccessThresholdOfZeroDisablesCachingForDisplayList) {
   size_t threshold = 0;
   flutter::RasterCache cache(threshold);
@@ -244,46 +211,6 @@ TEST(RasterCache, AccessThresholdOfZeroDisablesCachingForDisplayList) {
 
   DisplayListRasterCacheItem display_list_item(display_list, SkPoint(), true,
                                                false);
-  ASSERT_FALSE(RasterCacheItemPrerollAndTryToRasterCache(
-      display_list_item, preroll_context, paint_context, matrix));
-  ASSERT_FALSE(display_list_item.Draw(paint_context, &dummy_canvas, &paint));
-}
-
-TEST(RasterCache, PictureCacheLimitPerFrameIsRespectedWhenZeroForSkPicture) {
-  size_t picture_cache_limit_per_frame = 0;
-  flutter::RasterCache cache(3, picture_cache_limit_per_frame);
-
-  SkMatrix matrix = SkMatrix::I();
-
-  auto display_list = GetSampleDisplayList();
-
-  MockCanvas dummy_canvas(1000, 1000);
-  DlPaint paint;
-
-  LayerStateStack preroll_state_stack;
-  preroll_state_stack.set_preroll_delegate(kGiantRect, matrix);
-  LayerStateStack paint_state_stack;
-  preroll_state_stack.set_delegate(&dummy_canvas);
-
-  FixedRefreshRateStopwatch raster_time;
-  FixedRefreshRateStopwatch ui_time;
-  PrerollContextHolder preroll_context_holder = GetSamplePrerollContextHolder(
-      preroll_state_stack, &cache, &raster_time, &ui_time);
-  PaintContextHolder paint_context_holder = GetSamplePaintContextHolder(
-      paint_state_stack, &cache, &raster_time, &ui_time);
-  auto& preroll_context = preroll_context_holder.preroll_context;
-  auto& paint_context = paint_context_holder.paint_context;
-
-  cache.BeginFrame();
-
-  DisplayListRasterCacheItem display_list_item(display_list, SkPoint(), true,
-                                               false);
-  ASSERT_FALSE(RasterCacheItemPrerollAndTryToRasterCache(
-      display_list_item, preroll_context, paint_context, matrix));
-  ASSERT_FALSE(display_list_item.Draw(paint_context, &dummy_canvas, &paint));
-  ASSERT_FALSE(RasterCacheItemPrerollAndTryToRasterCache(
-      display_list_item, preroll_context, paint_context, matrix));
-  ASSERT_FALSE(display_list_item.Draw(paint_context, &dummy_canvas, &paint));
   ASSERT_FALSE(RasterCacheItemPrerollAndTryToRasterCache(
       display_list_item, preroll_context, paint_context, matrix));
   ASSERT_FALSE(display_list_item.Draw(paint_context, &dummy_canvas, &paint));

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -20,7 +20,7 @@ namespace testing {
 
 /**
  * @brief A RasterCacheResult implementation that represents a cached Layer or
- * SkPicture without the overhead of storage.
+ * DisplayList without the overhead of storage.
  *
  * This implementation is used by MockRasterCache only for testing proper usage
  * of the RasterCache in layer unit tests.
@@ -50,7 +50,7 @@ static std::vector<RasterCacheItem*> raster_cache_items_;
 
 /**
  * @brief A RasterCache implementation that simulates the act of rendering a
- * Layer or SkPicture without the overhead of rasterization or pixel storage.
+ * Layer or DisplayList without the overhead of rasterization or pixel storage.
  * This implementation is used only for testing proper usage of the RasterCache
  * in layer unit tests.
  */

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -10,7 +10,6 @@
 
 #include "flutter/flow/layers/layer_tree.h"
 #include "flutter/lib/ui/dart_wrapper.h"
-#include "third_party/skia/include/core/SkPicture.h"
 
 namespace flutter {
 

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -10,7 +10,6 @@
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/painting/image.h"
 #include "flutter/lib/ui/ui_dart_state.h"
-#include "third_party/skia/include/core/SkPicture.h"
 
 namespace flutter {
 class Canvas;

--- a/lib/ui/snapshot_delegate.h
+++ b/lib/ui/snapshot_delegate.h
@@ -10,7 +10,6 @@
 #include "flutter/common/graphics/texture.h"
 #include "flutter/display_list/display_list.h"
 #include "third_party/skia/include/core/SkImage.h"
-#include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrContextThreadSafeProxy.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -32,7 +32,6 @@
 #include "flutter/shell/common/rasterizer.h"
 #include "flutter/shell/common/run_configuration.h"
 #include "flutter/shell/common/shell_io_manager.h"
-#include "third_party/skia/include/core/SkPicture.h"
 
 namespace flutter {
 
@@ -345,7 +344,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   ///                                snapshot a specified scene. The engine
   ///                                cannot snapshot a scene on the UI thread
   ///                                directly because the scene (described via
-  ///                                an `SkPicture`) may reference resources on
+  ///                                a `DisplayList`) may reference resources on
   ///                                the GPU and there is no GPU context current
   ///                                on the UI thread. The delegate is a
   ///                                component that has access to all the

--- a/shell/common/persistent_cache_unittests.cc
+++ b/shell/common/persistent_cache_unittests.cc
@@ -17,7 +17,6 @@
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/version/version.h"
 #include "flutter/testing/testing.h"
-#include "include/core/SkPicture.h"
 
 namespace flutter {
 namespace testing {

--- a/shell/common/serialization_callbacks.cc
+++ b/shell/common/serialization_callbacks.cc
@@ -3,13 +3,11 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/logging.h"
-#include "include/core/SkColorSpace.h"
-#include "include/core/SkImage.h"
-#include "include/core/SkImageInfo.h"
-#include "include/core/SkPicture.h"
-#include "include/core/SkSerialProcs.h"
-#include "include/core/SkStream.h"
-#include "include/core/SkTypeface.h"
+#include "third_party/skia/include/core/SkColorSpace.h"
+#include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/core/SkImageInfo.h"
+#include "third_party/skia/include/core/SkStream.h"
+#include "third_party/skia/include/core/SkTypeface.h"
 
 namespace flutter {
 

--- a/shell/common/serialization_callbacks.h
+++ b/shell/common/serialization_callbacks.h
@@ -6,9 +6,8 @@
 #define FLUTTER_SHELL_COMMON_SERIALIZATION_CALLBACKS_H_
 
 #include "flutter/fml/logging.h"
-#include "include/core/SkImage.h"
-#include "include/core/SkPicture.h"
-#include "include/core/SkTypeface.h"
+#include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/core/SkTypeface.h"
 
 namespace flutter {
 

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -7,7 +7,6 @@
 #include "flutter/fml/logging.h"
 #include "flutter/testing/display_list_testing.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
-#include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSerialProcs.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkTextBlob.h"


### PR DESCRIPTION
Most of the #include directives for SkPicture are removed except where they are still functional. Many comments rewritten to no longer be SkPicture-centric.

- DL unit tests still use it for consistency testing
- rasterizer/engine still use it for screen shot support
- Fuchsia still uses it extensively