### PR TITLE
[web] fix clicks on merged semantic nodes

### DIFF
--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -349,7 +349,10 @@ class ClickDebouncer {
     // It's only interesting to debounce clicks when both `pointerdown` and
     // `pointerup` land on the same element.
     if (event.type == 'pointerup') {
-      final bool targetChanged = event.target != state.target;
+      // TODO(yjbanov): this is a bit mouthful, but see https://github.com/dart-lang/sdk/issues/53070
+      final DomEventTarget? eventTarget = event.target;
+      final DomElement stateTarget = state.target;
+      final bool targetChanged = eventTarget != stateTarget;
       if (targetChanged) {
         _flush();
       }

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -279,7 +279,7 @@ class ClickDebouncer {
     }
 
     if (isListening) {
-      // There's a pending queue of pointer events. Prefer sendind the tap action
+      // There's a pending queue of pointer events. Prefer sending the tap action
       // instead of pointer events, because the pointer events may not land on the
       // combined semantic node and miss the click/tap.
       final DebounceState state = _state!;
@@ -415,15 +415,9 @@ class ClickDebouncer {
   ///
   /// This object can be used as if it was just initialized.
   void reset() {
-    final DebounceState? state = _state;
+    _state?.timer.cancel();
     _state = null;
     _lastFlushedPointerUpTimeStamp = null;
-
-    if (state == null) {
-      return;
-    }
-
-    state.timer.cancel();
   }
 }
 

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -1980,8 +1980,9 @@ class EngineSemanticsOwner {
   }
 
   /// Receives DOM events from the pointer event system to correlate with the
-  /// semantics events; returns true if the event should be forwarded to the
-  /// framework.
+  /// semantics events.
+  ///
+  /// Returns true if the event should be forwarded to the framework.
   ///
   /// The browser sends us both raw pointer events and gestures from
   /// [SemanticsObject.element]s. There could be three possibilities:

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -54,6 +54,10 @@ class Tappable extends RoleManager {
   }
 
   void _updateAttribute() {
+    // The `flt-tappable` attribute marks the element for the ClickDebouncer to
+    // to know that it should debounce click events on this element. The
+    // contract is that the element that has this attribute is also the element
+    // that receives pointer and "click" events.
     if (_isListening) {
       semanticsObject.element.setAttribute('flt-tappable', '');
     } else {

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -32,14 +32,11 @@ class Button extends PrimaryRoleManager {
 class Tappable extends RoleManager {
   Tappable(SemanticsObject semanticsObject) : super(Role.tappable, semanticsObject) {
     _clickListener = createDomEventListener((DomEvent click) {
-      final bool shouldDeduplicateClickEvent = PointerBinding.instance!.clickDebouncer.onClick(click);
-
-      if (!_isListening || shouldDeduplicateClickEvent) {
-        return;
-      }
-
-      EnginePlatformDispatcher.instance.invokeOnSemanticsAction(
-          semanticsObject.id, ui.SemanticsAction.tap, null);
+      PointerBinding.instance!.clickDebouncer.onClick(
+        click,
+        semanticsObject.id,
+        _isListening,
+      );
     });
     semanticsObject.element.addEventListener('click', _clickListener);
   }

--- a/lib/web_ui/test/common/matchers.dart
+++ b/lib/web_ui/test/common/matchers.dart
@@ -293,17 +293,23 @@ String canonicalizeHtml(
         html_package.Element.tag(replacementTag);
 
     if (mode != HtmlComparisonMode.noAttributes) {
-      original.attributes.forEach((dynamic name, String value) {
-        if (name is! String) {
-          throw ArgumentError('"$name" should be String but was ${name.runtimeType}.');
-        }
+      // Sort the attributes so tests are not sensitive to their order, which
+      // does not matter in terms of functionality.
+      final List<String> attributeNames = original.attributes.keys.cast<String>().toList();
+      attributeNames.sort();
+      for (final String name in attributeNames) {
+        final String value = original.attributes[name]!;
         if (name == 'style') {
-          return;
+          // The style attribute is handled separately because it contains substructure.
+          continue;
         }
-        if (name.startsWith('aria-')) {
+
+        // These are the only attributes we're interested in testing. This list
+        // can change over time.
+        if (name.startsWith('aria-') || name.startsWith('flt-') || name == 'role') {
           replacement.attributes[name] = value;
         }
-      });
+      }
 
       if (original.attributes.containsKey('style')) {
         final String styleValue = original.attributes['style']!;

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -3088,7 +3088,7 @@ void testMain() {
     },
   );
 
-  group('$ClickDebouncer', () {
+  group('ClickDebouncer', () {
     _testClickDebouncer();
   });
 }
@@ -3159,7 +3159,7 @@ void _testClickDebouncer() {
     expect(binding.clickDebouncer.isDebouncing, false);
 
     // This test DOM element is missing the `flt-tappable` attribute on purpose
-    // so that the debouncer does not debounce events and simply let's
+    // so that the debouncer does not debounce events and simply lets
     // everything through.
     final DomElement testElement = createDomElement('flt-semantics');
     flutterViewEmbedder.semanticsHostElement!.appendChild(testElement);

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -3087,6 +3087,385 @@ void testMain() {
       packets.clear();
     },
   );
+
+  group('$ClickDebouncer', () {
+    _testClickDebouncer();
+  });
+}
+
+typedef CapturedSemanticsEvent = ({
+  ui.SemanticsAction type,
+  int nodeId,
+});
+
+void _testClickDebouncer() {
+  final DateTime testTime = DateTime(2018, 12, 17);
+  late List<ui.PointerChange> pointerPackets;
+  late List<CapturedSemanticsEvent> semanticsActions;
+  late _PointerEventContext context;
+  late PointerBinding binding;
+
+  void testWithSemantics(
+    String description,
+    Future<void> Function() body,
+  ) {
+    test(
+      description,
+      () async {
+        EngineSemanticsOwner.instance
+          ..debugOverrideTimestampFunction(() => testTime)
+          ..semanticsEnabled = true;
+        await body();
+        EngineSemanticsOwner.instance.semanticsEnabled = false;
+      },
+    );
+  }
+
+  setUp(() {
+    context = _PointerEventContext();
+    pointerPackets = <ui.PointerChange>[];
+    semanticsActions = <CapturedSemanticsEvent>[];
+    ui.window.onPointerDataPacket = (ui.PointerDataPacket packet) {
+      for (final ui.PointerData data in packet.data) {
+        pointerPackets.add(data.change);
+      }
+    };
+    EnginePlatformDispatcher.instance.onSemanticsActionEvent = (ui.SemanticsActionEvent event) {
+      semanticsActions.add((type: event.type, nodeId: event.nodeId));
+    };
+    binding = PointerBinding.instance!;
+    binding.debugOverrideDetector(context);
+    binding.clickDebouncer.reset();
+  });
+
+  tearDown(() {
+    binding.clickDebouncer.reset();
+  });
+
+  test('Forwards to framework when semantics is off', () {
+    expect(EnginePlatformDispatcher.instance.semanticsEnabled, false);
+    expect(binding.clickDebouncer.isDebouncing, false);
+    flutterViewEmbedder.flutterViewElement.dispatchEvent(context.primaryDown());
+    expect(pointerPackets, <ui.PointerChange>[
+      ui.PointerChange.add,
+      ui.PointerChange.down,
+    ]);
+    expect(binding.clickDebouncer.isDebouncing, false);
+    expect(semanticsActions, isEmpty);
+  });
+
+  testWithSemantics('Forwards to framework when not debouncing', () async {
+    expect(EnginePlatformDispatcher.instance.semanticsEnabled, true);
+    expect(binding.clickDebouncer.isDebouncing, false);
+
+    // This test DOM element is missing the `flt-tappable` attribute on purpose
+    // so that the debouncer does not debounce events and simply let's
+    // everything through.
+    final DomElement testElement = createDomElement('flt-semantics');
+    flutterViewEmbedder.semanticsHostElement!.appendChild(testElement);
+
+    testElement.dispatchEvent(context.primaryDown());
+    testElement.dispatchEvent(context.primaryUp());
+    expect(binding.clickDebouncer.isDebouncing, false);
+
+    expect(pointerPackets, <ui.PointerChange>[
+      ui.PointerChange.add,
+      ui.PointerChange.down,
+      ui.PointerChange.up,
+    ]);
+    expect(semanticsActions, isEmpty);
+  });
+
+  testWithSemantics('Accumulates pointer events starting from pointerdown', () async {
+    expect(EnginePlatformDispatcher.instance.semanticsEnabled, true);
+    expect(binding.clickDebouncer.isDebouncing, false);
+
+    final DomElement testElement = createDomElement('flt-semantics');
+    testElement.setAttribute('flt-tappable', '');
+    flutterViewEmbedder.semanticsHostElement!.appendChild(testElement);
+
+    testElement.dispatchEvent(context.primaryDown());
+    expect(
+      reason: 'Should start debouncing at first pointerdown',
+      binding.clickDebouncer.isDebouncing,
+      true,
+    );
+
+    testElement.dispatchEvent(context.primaryUp());
+    expect(
+      reason: 'Should still be debouncing after pointerup',
+      binding.clickDebouncer.isDebouncing,
+      true,
+    );
+
+    expect(
+      reason: 'Events are withheld from the framework while debouncing',
+      pointerPackets,
+      <ui.PointerChange>[],
+    );
+    expect(
+      binding.clickDebouncer.debugState!.target,
+      testElement,
+    );
+    expect(
+      binding.clickDebouncer.debugState!.timer.isActive,
+      isTrue,
+    );
+    expect(
+      binding.clickDebouncer.debugState!.queue.map<String>((QueuedEvent e) => e.event.type),
+      <String>['pointerdown', 'pointerup'],
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+    expect(
+      reason: 'Should stop debouncing after timer expires.',
+      binding.clickDebouncer.isDebouncing,
+      false,
+    );
+    expect(
+      reason: 'Queued up events should be flushed to the framework.',
+      pointerPackets,
+      <ui.PointerChange>[
+        ui.PointerChange.add,
+        ui.PointerChange.down,
+        ui.PointerChange.up,
+      ],
+    );
+    expect(semanticsActions, isEmpty);
+  });
+
+  testWithSemantics('Flushes events to framework when target changes', () async {
+    expect(EnginePlatformDispatcher.instance.semanticsEnabled, true);
+    expect(binding.clickDebouncer.isDebouncing, false);
+
+    final DomElement testElement = createDomElement('flt-semantics');
+    testElement.setAttribute('flt-tappable', '');
+    flutterViewEmbedder.semanticsHostElement!.appendChild(testElement);
+
+    testElement.dispatchEvent(context.primaryDown());
+    expect(
+      reason: 'Should start debouncing at first pointerdown',
+      binding.clickDebouncer.isDebouncing,
+      true,
+    );
+
+    final DomElement newTarget = createDomElement('flt-semantics');
+    newTarget.setAttribute('flt-tappable', '');
+    flutterViewEmbedder.semanticsHostElement!.appendChild(newTarget);
+    newTarget.dispatchEvent(context.primaryUp());
+
+    expect(
+      reason: 'Should stop debouncing when target changes.',
+      binding.clickDebouncer.isDebouncing,
+      false,
+    );
+    expect(
+      reason: 'The state should be cleaned up after stopping debouncing.',
+      binding.clickDebouncer.debugState,
+      isNull,
+    );
+    expect(
+      reason: 'Queued up events should be flushed to the framework.',
+      pointerPackets,
+      <ui.PointerChange>[
+        ui.PointerChange.add,
+        ui.PointerChange.down,
+        ui.PointerChange.up,
+      ],
+    );
+    expect(semanticsActions, isEmpty);
+  });
+
+  testWithSemantics('Forwards click to framework when not debouncing but listening', () async {
+    expect(binding.clickDebouncer.isDebouncing, false);
+
+    final DomElement testElement = createDomElement('flt-semantics');
+    testElement.setAttribute('flt-tappable', '');
+    flutterViewEmbedder.semanticsHostElement!.appendChild(testElement);
+
+    final DomEvent click = createDomMouseEvent(
+      'click',
+      <Object?, Object?>{
+        'clientX': testElement.getBoundingClientRect().x,
+        'clientY': testElement.getBoundingClientRect().y,
+      }
+    );
+
+    binding.clickDebouncer.onClick(click, 42, true);
+    expect(binding.clickDebouncer.isDebouncing, false);
+    expect(pointerPackets, isEmpty);
+    expect(semanticsActions, <CapturedSemanticsEvent>[
+      (type: ui.SemanticsAction.tap, nodeId: 42)
+    ]);
+  });
+
+  testWithSemantics('Forwards click to framework when debouncing and listening', () async {
+    expect(binding.clickDebouncer.isDebouncing, false);
+
+    final DomElement testElement = createDomElement('flt-semantics');
+    testElement.setAttribute('flt-tappable', '');
+    flutterViewEmbedder.semanticsHostElement!.appendChild(testElement);
+    testElement.dispatchEvent(context.primaryDown());
+    expect(binding.clickDebouncer.isDebouncing, true);
+
+    final DomEvent click = createDomMouseEvent(
+      'click',
+      <Object?, Object?>{
+        'clientX': testElement.getBoundingClientRect().x,
+        'clientY': testElement.getBoundingClientRect().y,
+      }
+    );
+
+    binding.clickDebouncer.onClick(click, 42, true);
+    expect(pointerPackets, isEmpty);
+    expect(semanticsActions, <CapturedSemanticsEvent>[
+      (type: ui.SemanticsAction.tap, nodeId: 42)
+    ]);
+  });
+
+  testWithSemantics('Dedupes click if debouncing but not listening', () async {
+    expect(binding.clickDebouncer.isDebouncing, false);
+
+    final DomElement testElement = createDomElement('flt-semantics');
+    testElement.setAttribute('flt-tappable', '');
+    flutterViewEmbedder.semanticsHostElement!.appendChild(testElement);
+    testElement.dispatchEvent(context.primaryDown());
+    expect(binding.clickDebouncer.isDebouncing, true);
+
+    final DomEvent click = createDomMouseEvent(
+      'click',
+      <Object?, Object?>{
+        'clientX': testElement.getBoundingClientRect().x,
+        'clientY': testElement.getBoundingClientRect().y,
+      }
+    );
+
+    binding.clickDebouncer.onClick(click, 42, false);
+    expect(
+      reason: 'When tappable declares that it is not listening to click events '
+              'the debouncer flushes the pointer events to the framework and '
+              'lets it sort it out.',
+      pointerPackets,
+      <ui.PointerChange>[
+        ui.PointerChange.add,
+        ui.PointerChange.down,
+      ],
+    );
+    expect(semanticsActions, isEmpty);
+  });
+
+  testWithSemantics('Dedupes click if pointer down/up flushed recently', () async {
+    expect(EnginePlatformDispatcher.instance.semanticsEnabled, true);
+    expect(binding.clickDebouncer.isDebouncing, false);
+
+    final DomElement testElement = createDomElement('flt-semantics');
+    testElement.setAttribute('flt-tappable', '');
+    flutterViewEmbedder.semanticsHostElement!.appendChild(testElement);
+
+    testElement.dispatchEvent(context.primaryDown());
+
+    // Simulate the user holding the pointer down for some time before releasing,
+    // such that the pointerup event happens close to timer expiration. This
+    // will create the situation that the click event arrives just after the
+    // pointerup is flushed. Forwarding the click to the framework would look
+    // like a double-click, so the click event is deduped.
+    await Future<void>.delayed(const Duration(milliseconds: 190));
+
+    testElement.dispatchEvent(context.primaryUp());
+    expect(binding.clickDebouncer.isDebouncing, true);
+    expect(
+      reason: 'Timer has not expired yet',
+      pointerPackets, isEmpty,
+    );
+
+    // Wait for the timer to expire to make sure pointer events are flushed.
+    await Future<void>.delayed(const Duration(milliseconds: 11));
+
+    expect(
+      reason: 'Queued up events should be flushed to the framework because the '
+              'time expired before the click event arrived.',
+      pointerPackets,
+      <ui.PointerChange>[
+        ui.PointerChange.add,
+        ui.PointerChange.down,
+        ui.PointerChange.up,
+      ],
+    );
+
+    final DomEvent click = createDomMouseEvent(
+      'click',
+      <Object?, Object?>{
+        'clientX': testElement.getBoundingClientRect().x,
+        'clientY': testElement.getBoundingClientRect().y,
+      }
+    );
+    binding.clickDebouncer.onClick(click, 42, true);
+
+    expect(
+      reason: 'Because the DOM click event was deduped.',
+      semanticsActions,
+      isEmpty,
+    );
+  });
+
+
+  testWithSemantics('Forwards click if enough time passed after the last flushed pointerup', () async {
+    expect(EnginePlatformDispatcher.instance.semanticsEnabled, true);
+    expect(binding.clickDebouncer.isDebouncing, false);
+
+    final DomElement testElement = createDomElement('flt-semantics');
+    testElement.setAttribute('flt-tappable', '');
+    flutterViewEmbedder.semanticsHostElement!.appendChild(testElement);
+
+    testElement.dispatchEvent(context.primaryDown());
+
+    // Simulate the user holding the pointer down for some time before releasing,
+    // such that the pointerup event happens close to timer expiration. This
+    // makes it possible for the click to arrive early. However, this test in
+    // particular will delay the click to check that the delay is checked
+    // correctly. The inverse situation was already tested in the previous test.
+    await Future<void>.delayed(const Duration(milliseconds: 190));
+
+    testElement.dispatchEvent(context.primaryUp());
+    expect(binding.clickDebouncer.isDebouncing, true);
+    expect(
+      reason: 'Timer has not expired yet',
+      pointerPackets, isEmpty,
+    );
+
+    // Wait for the timer to expire to make sure pointer events are flushed.
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    expect(
+      reason: 'Queued up events should be flushed to the framework because the '
+              'time expired before the click event arrived.',
+      pointerPackets,
+      <ui.PointerChange>[
+        ui.PointerChange.add,
+        ui.PointerChange.down,
+        ui.PointerChange.up,
+      ],
+    );
+
+    final DomEvent click = createDomMouseEvent(
+      'click',
+      <Object?, Object?>{
+        'clientX': testElement.getBoundingClientRect().x,
+        'clientY': testElement.getBoundingClientRect().y,
+      }
+    );
+    binding.clickDebouncer.onClick(click, 42, true);
+
+    expect(
+      reason: 'The DOM click should still be sent to the framework because it '
+              'happened far enough from the last pointerup that it is unlikely '
+              'to be a duplicate.',
+      semanticsActions,
+      <CapturedSemanticsEvent>[
+        (type: ui.SemanticsAction.tap, nodeId: 42)
+      ],
+    );
+  });
 }
 
 class MockSafariPointerEventWorkaround implements SafariPointerEventWorkaround {

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -377,7 +377,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
-    <sem aria-label="Hello"></sem>
+    <sem role="text" aria-label="Hello"></sem>
   </sem-c>
 </sem>''');
 
@@ -387,7 +387,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
-    <sem aria-label="World"></sem>
+    <sem role="text" aria-label="World"></sem>
   </sem-c>
 </sem>''');
 
@@ -397,7 +397,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
-    <sem></sem>
+    <sem role="text"></sem>
   </sem-c>
 </sem>''');
 
@@ -430,7 +430,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
-    <sem aria-label="tooltip\nHello"></sem>
+    <sem role="text" aria-label="tooltip\nHello"></sem>
   </sem-c>
 </sem>''');
 
@@ -440,7 +440,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
   <sem-c>
-    <sem></sem>
+    <sem role="text"></sem>
   </sem-c>
 </sem>''');
 
@@ -1388,7 +1388,7 @@ void _testIncrementables() {
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
-  <input aria-valuenow="1" aria-valuetext="d" aria-valuemax="1" aria-valuemin="1">
+  <input role="slider" aria-valuenow="1" aria-valuetext="d" aria-valuemax="1" aria-valuemin="1">
 </sem>''');
 
     final SemanticsObject node = semantics().debugSemanticsTree![0]!;
@@ -1421,7 +1421,7 @@ void _testIncrementables() {
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
-  <input aria-valuenow="1" aria-valuetext="d" aria-valuemax="2" aria-valuemin="1">
+  <input role="slider" aria-valuenow="1" aria-valuetext="d" aria-valuemax="2" aria-valuemin="1">
 </sem>''');
 
     final DomHTMLInputElement input =
@@ -1454,7 +1454,7 @@ void _testIncrementables() {
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
-  <input aria-valuenow="1" aria-valuetext="d" aria-valuemax="1" aria-valuemin="0">
+  <input role="slider" aria-valuenow="1" aria-valuetext="d" aria-valuemax="1" aria-valuemin="0">
 </sem>''');
 
     final DomHTMLInputElement input =
@@ -1489,7 +1489,7 @@ void _testIncrementables() {
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
 <sem style="$rootSemanticStyle">
-  <input aria-valuenow="1" aria-valuetext="d" aria-valuemax="2" aria-valuemin="0">
+  <input role="slider" aria-valuenow="1" aria-valuetext="d" aria-valuemax="2" aria-valuemin="0">
 </sem>''');
 
     semantics().semanticsEnabled = false;
@@ -1632,7 +1632,7 @@ void _testCheckables() {
 
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
-<sem aria-label="test label" role="switch" aria-checked="true" style="$rootSemanticStyle"></sem>
+<sem aria-label="test label" flt-tappable role="switch" aria-checked="true" style="$rootSemanticStyle"></sem>
 ''');
 
     final SemanticsObject node = semantics().debugSemanticsTree![0]!;
@@ -1690,7 +1690,7 @@ void _testCheckables() {
 
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
-<sem role="switch" aria-checked="false" style="$rootSemanticStyle"></sem>
+<sem role="switch" flt-tappable aria-checked="false" style="$rootSemanticStyle"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1716,7 +1716,7 @@ void _testCheckables() {
 
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
-<sem role="checkbox" aria-checked="true" style="$rootSemanticStyle"></sem>
+<sem role="checkbox" flt-tappable aria-checked="true" style="$rootSemanticStyle"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1766,7 +1766,7 @@ void _testCheckables() {
 
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
-<sem role="checkbox" aria-checked="false" style="$rootSemanticStyle"></sem>
+<sem role="checkbox" flt-tappable aria-checked="false" style="$rootSemanticStyle"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1793,7 +1793,7 @@ void _testCheckables() {
 
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
-<sem role="radio" aria-checked="true" style="$rootSemanticStyle"></sem>
+<sem role="radio" flt-tappable aria-checked="true" style="$rootSemanticStyle"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1845,7 +1845,7 @@ void _testCheckables() {
 
     semantics().updateSemantics(builder.build());
     expectSemanticsTree('''
-<sem role="radio" aria-checked="false" style="$rootSemanticStyle"></sem>
+<sem role="radio" flt-tappable aria-checked="false" style="$rootSemanticStyle"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1918,7 +1918,7 @@ void _testTappable() {
     tester.apply();
 
     expectSemanticsTree('''
-<sem role="button" style="$rootSemanticStyle"></sem>
+<sem role="button" flt-tappable style="$rootSemanticStyle"></sem>
 ''');
 
     final SemanticsObject node = semantics().debugSemanticsTree![0]!;
@@ -1979,14 +1979,14 @@ void _testTappable() {
         '<sem role="button" aria-disabled="true" style="$rootSemanticStyle"></sem>');
 
     updateTappable(enabled: true);
-    expectSemanticsTree('<sem role="button" style="$rootSemanticStyle"></sem>');
+    expectSemanticsTree('<sem role="button" flt-tappable style="$rootSemanticStyle"></sem>');
 
     updateTappable(enabled: false);
     expectSemanticsTree(
         '<sem role="button" aria-disabled="true" style="$rootSemanticStyle"></sem>');
 
     updateTappable(enabled: true);
-    expectSemanticsTree('<sem role="button" style="$rootSemanticStyle"></sem>');
+    expectSemanticsTree('<sem role="button" flt-tappable style="$rootSemanticStyle"></sem>');
 
     semantics().semanticsEnabled = false;
   });
@@ -2623,11 +2623,11 @@ void _testDialog() {
       tester.apply();
 
       expectSemanticsTree('''
-        <sem aria-describedby="flt-semantic-node-2" style="$rootSemanticStyle">
+        <sem role="dialog" aria-describedby="flt-semantic-node-2" style="$rootSemanticStyle">
           <sem-c>
             <sem>
               <sem-c>
-                <sem aria-label="$label"></sem>
+                <sem role="text" aria-label="$label"></sem>
               </sem-c>
             </sem>
           </sem-c>
@@ -2716,7 +2716,7 @@ void _testDialog() {
         <sem-c>
           <sem>
             <sem-c>
-              <sem aria-label="Hello"></sem>
+              <sem role="text" aria-label="Hello"></sem>
             </sem-c>
           </sem>
         </sem-c>
@@ -2853,9 +2853,9 @@ void _testFocusable() {
     }
 
     expectSemanticsTree('''
-<sem role="group" style="$rootSemanticStyle">
+<sem style="$rootSemanticStyle">
   <sem-c>
-    <sem aria-label="focusable text"></sem>
+    <sem role="text" aria-label="focusable text"></sem>
   </sem-c>
 </sem>
 ''');

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -353,6 +353,27 @@ class SemanticsTester {
 /// Verifies the HTML structure of the current semantics tree.
 void expectSemanticsTree(String semanticsHtml) {
   const List<String> ignoredAttributes = <String>['pointer-events'];
+//   print('\n============================================================================');
+//   print('''
+// semanticsHtml:
+//   $semanticsHtml
+// '''.trim());
+//   print('----------------------------------------------------------------------------');
+//   print('''
+// canonicalizeHtml(semanticsHtml):
+//   ${canonicalizeHtml(semanticsHtml)}
+// '''.trim());
+//   print('----------------------------------------------------------------------------');
+//   print('''
+// canonicalizeHtml(appHostNode.querySelector('flt-semantics')!.outerHTML!, ignoredAttributes: ignoredAttributes):
+//   ${canonicalizeHtml(appHostNode.querySelector('flt-semantics')!.outerHTML!, ignoredAttributes: ignoredAttributes)}
+// '''.trim());
+//   print('''
+// appHostNode.querySelector('flt-semantics')!.outerHTML!:
+//   ${appHostNode.querySelector('flt-semantics')!.outerHTML!}
+// '''.trim());
+//   print('============================================================================\n');
+
   expect(
     canonicalizeHtml(appHostNode.querySelector('flt-semantics')!.outerHTML!, ignoredAttributes: ignoredAttributes),
     canonicalizeHtml(semanticsHtml),


### PR DESCRIPTION
This should significantly improve the situation described in https://github.com/flutter/flutter/issues/130162.

When the framework merges semantics trees of multiple widgets into a single node, it can expand the tap area of one of the descendants to the size of the combined node as follows:

<img width="865" alt="Screenshot 2023-07-07 at 4 11 30 PM" src="https://github.com/flutter/flutter/assets/211513/50e4f9f2-d36b-4820-93d2-c53714f33b08">

When a screen reader taps on the combined node, the pointer events and the click all land in the center. This produces a stalemate resulting in the user action never producing a tap/click gesture in the framework:

* The web engine, seeing `pointerdown`/`pointerup`, switches to the gesture mode ignores the `click`, believing that the framework will interpret the pointer events as one.
* The framework, seeing pointer events landing outside the checkbox, never reacts to the pointer events.

This PR mostly solves the issue by delaying event sequences starting with pointerdown for up to 200ms. If within those 200ms a click is observed, `SemanticsAction.tap` is sent to the framework. Otherwise, the pointer events are sent to the framework and the DOM `click` event is dropped. The tradeoff is that even when the drag gesture detector is the only one present, there's a 200ms delay before dragging can start. However, it seems to be a better trade-off than missing clicks entirely.