### PR TITLE
[Impeller] Add RAII wrappers for VMA objects.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -4250,6 +4250,8 @@ FILE: ../../../flutter/impeller/renderer/backend/vulkan/texture_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/vertex_descriptor_vk.cc
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/vertex_descriptor_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/vk.h
+FILE: ../../../flutter/impeller/renderer/backend/vulkan/vma.cc
+FILE: ../../../flutter/impeller/renderer/backend/vulkan/vma.h
 FILE: ../../../flutter/impeller/renderer/blit_command.cc
 FILE: ../../../flutter/impeller/renderer/blit_command.h
 FILE: ../../../flutter/impeller/renderer/blit_pass.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1562,6 +1562,8 @@ ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/texture_vk.h + ../../.
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/vertex_descriptor_vk.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/vertex_descriptor_vk.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/vk.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/vma.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/vma.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/blit_command.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/blit_command.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/blit_pass.cc + ../../../flutter/LICENSE

--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -94,6 +94,8 @@ impeller_component("vulkan") {
     "vertex_descriptor_vk.cc",
     "vertex_descriptor_vk.h",
     "vk.h",
+    "vma.cc",
+    "vma.h",
   ]
 
   public_deps = [

--- a/impeller/renderer/backend/vulkan/allocator_vk.h
+++ b/impeller/renderer/backend/vulkan/allocator_vk.h
@@ -13,6 +13,7 @@
 #include "impeller/renderer/backend/vulkan/device_holder.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 
+#include <array>
 #include <memory>
 
 namespace impeller {
@@ -28,8 +29,8 @@ class AllocatorVK final : public Allocator {
   static constexpr size_t kPoolCount = 3;
 
   fml::RefPtr<vulkan::VulkanProcTable> vk_;
-  VmaAllocator allocator_ = {};
-  VmaPool staging_buffer_pools_[kPoolCount] = {};
+  UniqueAllocatorVMA allocator_;
+  std::array<UniquePoolVMA, kPoolCount> staging_buffer_pools_;
   std::weak_ptr<Context> context_;
   std::weak_ptr<DeviceHolder> device_holder_;
   ISize max_texture_size_;
@@ -65,8 +66,6 @@ class AllocatorVK final : public Allocator {
 
   // |Allocator|
   ISize GetMaxTextureSizeSupported() const override;
-
-  static bool CreateBufferPool(VmaAllocator allocator, VmaPool* pool);
 
   FML_DISALLOW_COPY_AND_ASSIGN(AllocatorVK);
 };

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -8,7 +8,6 @@
 #include "impeller/core/formats.h"
 #include "impeller/core/shader_types.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
-#include "vulkan/vulkan_enums.hpp"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/pipeline_library_vk.h
+++ b/impeller/renderer/backend/vulkan/pipeline_library_vk.h
@@ -17,7 +17,6 @@
 #include "impeller/renderer/backend/vulkan/pipeline_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 #include "impeller/renderer/pipeline_library.h"
-#include "vulkan/vulkan_handles.hpp"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -23,8 +23,6 @@
 #include "impeller/renderer/backend/vulkan/sampler_vk.h"
 #include "impeller/renderer/backend/vulkan/shared_object_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
-#include "vulkan/vulkan_enums.hpp"
-#include "vulkan/vulkan_structs.hpp"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/sampler_vk.h
+++ b/impeller/renderer/backend/vulkan/sampler_vk.h
@@ -9,7 +9,6 @@
 #include "impeller/core/sampler.h"
 #include "impeller/renderer/backend/vulkan/shared_object_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
-#include "vulkan/vulkan_handles.hpp"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/vk.h
+++ b/impeller/renderer/backend/vulkan/vk.h
@@ -67,5 +67,3 @@
 #include "vulkan/vulkan.hpp"
 
 static_assert(VK_HEADER_VERSION >= 215, "Vulkan headers must not be too old.");
-
-#include "flutter/flutter_vma/flutter_vma.h"

--- a/impeller/renderer/backend/vulkan/vma.cc
+++ b/impeller/renderer/backend/vulkan/vma.cc
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/vma.h"
+
+namespace impeller {
+
+//
+
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/vma.h
+++ b/impeller/renderer/backend/vulkan/vma.h
@@ -89,7 +89,8 @@ struct BufferVMATraits {
 
   static void Free(const BufferVMA& buffer) {
     TRACE_EVENT0("impeller", "DestroyBuffer");
-    ::vmaDestroyBuffer(buffer.allocator, buffer.buffer, buffer.allocation);
+    ::vmaDestroyBuffer(buffer.allocator, static_cast<VkBuffer>(buffer.buffer),
+                       buffer.allocation);
   }
 };
 
@@ -123,7 +124,8 @@ struct ImageVMATraits {
 
   static void Free(const ImageVMA& image) {
     TRACE_EVENT0("impeller", "DestroyImage");
-    ::vmaDestroyImage(image.allocator, image.image, image.allocation);
+    ::vmaDestroyImage(image.allocator, static_cast<VkImage>(image.image),
+                      image.allocation);
   }
 };
 

--- a/impeller/renderer/backend/vulkan/vma.h
+++ b/impeller/renderer/backend/vulkan/vma.h
@@ -1,0 +1,132 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "flutter/flutter_vma/flutter_vma.h"
+#include "flutter/fml/trace_event.h"
+#include "flutter/fml/unique_object.h"
+#include "impeller/renderer/backend/vulkan/vk.h"
+
+namespace impeller {
+
+// -----------------------------------------------------------------------------
+// Unique handles to VMA allocators.
+// -----------------------------------------------------------------------------
+struct AllocatorVMATraits {
+  static VmaAllocator InvalidValue() { return {}; }
+
+  static bool IsValid(const VmaAllocator& value) {
+    return value != InvalidValue();
+  }
+
+  static void Free(VmaAllocator allocator) {
+    TRACE_EVENT0("impeller", "DestroyAllocator");
+    ::vmaDestroyAllocator(allocator);
+  }
+};
+
+using UniqueAllocatorVMA = fml::UniqueObject<VmaAllocator, AllocatorVMATraits>;
+
+// -----------------------------------------------------------------------------
+// Unique handles to VMA pools.
+// -----------------------------------------------------------------------------
+
+struct PoolVMA {
+  VmaAllocator allocator = {};
+  VmaPool pool = {};
+
+  constexpr bool operator==(const PoolVMA& other) const {
+    return allocator == other.allocator && pool == other.pool;
+  }
+
+  constexpr bool operator!=(const PoolVMA& other) const {
+    return !(*this == other);
+  }
+};
+
+struct PoolVMATraits {
+  static PoolVMA InvalidValue() { return {}; }
+
+  static bool IsValid(const PoolVMA& value) {
+    return value.allocator != VmaAllocator{};
+  }
+
+  static void Free(const PoolVMA& pool) {
+    TRACE_EVENT0("impeller", "DestroyPool");
+    ::vmaDestroyPool(pool.allocator, pool.pool);
+  }
+};
+
+using UniquePoolVMA = fml::UniqueObject<PoolVMA, PoolVMATraits>;
+
+// -----------------------------------------------------------------------------
+// Unique handles to VMA buffers.
+// -----------------------------------------------------------------------------
+
+struct BufferVMA {
+  VmaAllocator allocator = {};
+  VmaAllocation allocation = {};
+  vk::Buffer buffer = {};
+
+  constexpr bool operator==(const BufferVMA& other) const {
+    return allocator == other.allocator && allocation == other.allocation &&
+           buffer == other.buffer;
+  }
+
+  constexpr bool operator!=(const BufferVMA& other) const {
+    return !(*this == other);
+  }
+};
+
+struct BufferVMATraits {
+  static BufferVMA InvalidValue() { return {}; }
+
+  static bool IsValid(const BufferVMA& value) {
+    return value.allocator != VmaAllocator{};
+  }
+
+  static void Free(const BufferVMA& buffer) {
+    TRACE_EVENT0("impeller", "DestroyBuffer");
+    ::vmaDestroyBuffer(buffer.allocator, buffer.buffer, buffer.allocation);
+  }
+};
+
+using UniqueBufferVMA = fml::UniqueObject<BufferVMA, BufferVMATraits>;
+
+// -----------------------------------------------------------------------------
+// Unique handles to VMA images.
+// -----------------------------------------------------------------------------
+
+struct ImageVMA {
+  VmaAllocator allocator = {};
+  VmaAllocation allocation = {};
+  vk::Image image = {};
+
+  constexpr bool operator==(const ImageVMA& other) const {
+    return allocator == other.allocator && allocation == other.allocation &&
+           image == other.image;
+  }
+
+  constexpr bool operator!=(const ImageVMA& other) const {
+    return !(*this == other);
+  }
+};
+
+struct ImageVMATraits {
+  static ImageVMA InvalidValue() { return {}; }
+
+  static bool IsValid(const ImageVMA& value) {
+    return value.allocator != VmaAllocator{};
+  }
+
+  static void Free(const ImageVMA& image) {
+    TRACE_EVENT0("impeller", "DestroyImage");
+    ::vmaDestroyImage(image.allocator, image.image, image.allocation);
+  }
+};
+
+using UniqueImageVMA = fml::UniqueObject<ImageVMA, ImageVMATraits>;
+
+}  // namespace impeller


### PR DESCRIPTION
Uses `fml::UniqueObject<T>`.