### PR TITLE
Revert "Add a flag to `ParagraphBuilder` for rounding hack migration"

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -78,7 +78,7 @@ typedef CanvasPath Path;
   V(Gradient::Create, 1)                                              \
   V(ImageFilter::Create, 1)                                           \
   V(ImageShader::Create, 1)                                           \
-  V(ParagraphBuilder::Create, 10)                                     \
+  V(ParagraphBuilder::Create, 9)                                      \
   V(PathMeasure::Create, 3)                                           \
   V(Path::Create, 1)                                                  \
   V(PictureRecorder::Create, 1)                                       \

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2798,7 +2798,7 @@ abstract class Paragraph {
   /// This only returns a valid value if asserts are enabled, and must not be
   /// used otherwise.
   bool get debugDisposed;
-}
+ }
 
 @pragma('vm:entry-point')
 base class _NativeParagraph extends NativeFieldWrapperClass1 implements Paragraph {
@@ -3015,28 +3015,6 @@ abstract class ParagraphBuilder {
   /// [Paragraph].
   factory ParagraphBuilder(ParagraphStyle style) = _NativeParagraphBuilder;
 
-  /// Whether the rounding hack enabled by default in SkParagraph and TextPainter
-  /// is disabled.
-  ///
-  /// Do not rely on this getter as it exists for migration purposes only and
-  /// will soon be removed.
-  static bool get shouldDisableRoundingHack {
-    return const bool.hasEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK')
-        || _roundingHackDisabledInDebugMode;
-  }
-  static bool _roundingHackDisabledInDebugMode = true;
-
-  /// Only works in debug mode. Do not call this method as it is for migration
-  /// purposes only and will soon be removed.
-  static void setDisableRoundingHack(bool disableRoundingHack) {
-    // bool.hasEnvironment does not work in internal tests so an additional flag
-    // is needed for tests.
-    assert(() {
-      _roundingHackDisabledInDebugMode = disableRoundingHack;
-      return true;
-    }());
-  }
-
   /// The number of placeholders currently in the paragraph.
   int get placeholderCount;
 
@@ -3154,12 +3132,11 @@ base class _NativeParagraphBuilder extends NativeFieldWrapperClass1 implements P
         style._fontSize ?? 0,
         style._height ?? 0,
         style._ellipsis ?? '',
-        _encodeLocale(style._locale),
-        !ParagraphBuilder.shouldDisableRoundingHack,
+        _encodeLocale(style._locale)
       );
   }
 
-  @Native<Void Function(Handle, Handle, Handle, Handle, Handle, Double, Double, Handle, Handle, Bool)>(symbol: 'ParagraphBuilder::Create')
+  @Native<Void Function(Handle, Handle, Handle, Handle, Handle, Double, Double, Handle, Handle)>(symbol: 'ParagraphBuilder::Create')
   external void _constructor(
       Int32List encoded,
       ByteData? strutData,
@@ -3168,8 +3145,7 @@ base class _NativeParagraphBuilder extends NativeFieldWrapperClass1 implements P
       double fontSize,
       double height,
       String ellipsis,
-      String locale,
-      bool applyRoundingHack);
+      String locale);
 
   @override
   int get placeholderCount => _placeholderCount;

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -151,12 +151,11 @@ void ParagraphBuilder::Create(Dart_Handle wrapper,
                               double fontSize,
                               double height,
                               const std::u16string& ellipsis,
-                              const std::string& locale,
-                              bool applyRoundingHack) {
+                              const std::string& locale) {
   UIDartState::ThrowIfUIOperationsProhibited();
   auto res = fml::MakeRefCounted<ParagraphBuilder>(
       encoded_handle, strutData, fontFamily, strutFontFamilies, fontSize,
-      height, ellipsis, locale, applyRoundingHack);
+      height, ellipsis, locale);
   res->AssociateWithDartWrapper(wrapper);
 }
 
@@ -231,8 +230,7 @@ ParagraphBuilder::ParagraphBuilder(
     double fontSize,
     double height,
     const std::u16string& ellipsis,
-    const std::string& locale,
-    bool applyRoundingHack) {
+    const std::string& locale) {
   int32_t mask = 0;
   txt::ParagraphStyle style;
   {
@@ -293,7 +291,6 @@ ParagraphBuilder::ParagraphBuilder(
   if (mask & kPSLocaleMask) {
     style.locale = locale;
   }
-  style.apply_rounding_hack = applyRoundingHack;
 
   FontCollection& font_collection = UIDartState::Current()
                                         ->platform_configuration()

--- a/lib/ui/text/paragraph_builder.h
+++ b/lib/ui/text/paragraph_builder.h
@@ -30,8 +30,7 @@ class ParagraphBuilder : public RefCountedDartWrappable<ParagraphBuilder> {
                      double fontSize,
                      double height,
                      const std::u16string& ellipsis,
-                     const std::string& locale,
-                     bool applyRoundingHack);
+                     const std::string& locale);
 
   ~ParagraphBuilder() override;
 
@@ -77,8 +76,7 @@ class ParagraphBuilder : public RefCountedDartWrappable<ParagraphBuilder> {
                             double fontSize,
                             double height,
                             const std::u16string& ellipsis,
-                            const std::string& locale,
-                            bool applyRoundingHack);
+                            const std::string& locale);
 
   std::unique_ptr<txt::ParagraphBuilder> m_paragraphBuilder;
 };

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -2722,8 +2722,6 @@ extension SkParagraphStylePropertiesExtension on SkParagraphStyleProperties {
   @JS('replaceTabCharacters')
   external set _replaceTabCharacters(JSBoolean? bool);
   set replaceTabCharacters(bool? bool) => _replaceTabCharacters = bool?.toJS;
-
-  external set applyRoundingHack(bool applyRoundingHack);
 }
 
 @JS()

--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -328,7 +328,6 @@ class CanvasKitRenderer implements Renderer {
     strutStyle: strutStyle,
     ellipsis: ellipsis,
     locale: locale,
-    applyRoundingHack: !ui.ParagraphBuilder.shouldDisableRoundingHack,
   );
 
   @override

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -33,7 +33,6 @@ class CkParagraphStyle implements ui.ParagraphStyle {
     ui.StrutStyle? strutStyle,
     String? ellipsis,
     ui.Locale? locale,
-    bool applyRoundingHack = true,
   })  : skParagraphStyle = toSkParagraphStyle(
           textAlign,
           textDirection,
@@ -47,7 +46,6 @@ class CkParagraphStyle implements ui.ParagraphStyle {
           strutStyle,
           ellipsis,
           locale,
-          applyRoundingHack,
         ),
         _fontFamily = _effectiveFontFamily(fontFamily),
         _fontSize = fontSize,
@@ -147,7 +145,6 @@ class CkParagraphStyle implements ui.ParagraphStyle {
     ui.StrutStyle? strutStyle,
     String? ellipsis,
     ui.Locale? locale,
-    bool applyRoundingHack,
   ) {
     final SkParagraphStyleProperties properties = SkParagraphStyleProperties();
 
@@ -184,7 +181,6 @@ class CkParagraphStyle implements ui.ParagraphStyle {
     properties.replaceTabCharacters = true;
     properties.textStyle = toSkTextStyleProperties(
         fontFamily, fontSize, height, fontWeight, fontStyle);
-    properties.applyRoundingHack = applyRoundingHack;
 
     return canvasKit.ParagraphStyle(properties);
   }

--- a/lib/web_ui/lib/text.dart
+++ b/lib/web_ui/lib/text.dart
@@ -685,19 +685,6 @@ abstract class Paragraph {
 abstract class ParagraphBuilder {
   factory ParagraphBuilder(ParagraphStyle style) =>
     engine.renderer.createParagraphBuilder(style);
-
-  static bool get shouldDisableRoundingHack {
-    return const bool.hasEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK')
-        || _roundingHackDisabledInDebugMode;
-  }
-  static bool _roundingHackDisabledInDebugMode = true;
-  static void setDisableRoundingHack(bool disableRoundingHack) {
-    assert(() {
-      _roundingHackDisabledInDebugMode = disableRoundingHack;
-      return true;
-    }());
-  }
-
   void pushStyle(TextStyle style);
   void pop();
   void addText(String text);

--- a/lib/web_ui/test/canvaskit/text_test.dart
+++ b/lib/web_ui/test/canvaskit/text_test.dart
@@ -123,29 +123,7 @@ void testMain() {
         }
       });
     });
-
-    test('applyRoundingHack works', () {
-      const double fontSize = 1.25;
-      const String text = '12345';
-      assert((fontSize * text.length).truncate() != fontSize * text.length);
-      final bool roundingHackWasDisabled = ui.ParagraphBuilder.shouldDisableRoundingHack;
-      ui.ParagraphBuilder.setDisableRoundingHack(true);
-      final ui.ParagraphBuilder builder = ui.ParagraphBuilder(
-        ui.ParagraphStyle(fontSize: fontSize, fontFamily: 'FlutterTest'),
-      );
-      builder.addText(text);
-      final ui.Paragraph paragraph = builder.build()
-        ..layout(const ui.ParagraphConstraints(width: text.length * fontSize));
-
-      expect(paragraph.maxIntrinsicWidth, text.length * fontSize);
-      switch (paragraph.computeLineMetrics()) {
-        case [ui.LineMetrics(width: final double width)]:
-          expect(width, text.length * fontSize);
-        case final List<ui.LineMetrics> metrics:
-          expect(metrics, hasLength(1));
-      }
-      ui.ParagraphBuilder.setDisableRoundingHack(roundingHackWasDisabled);
-    });
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520
   }, skip: isSafari || isFirefox);
+
 }

--- a/testing/dart/paragraph_test.dart
+++ b/testing/dart/paragraph_test.dart
@@ -233,25 +233,4 @@ void main() {
       expect(callback, throwsStateError);
     }
   });
-
-  test('disableRoundingHack works', () {
-    const double fontSize = 1.25;
-    const String text = '12345';
-    assert((fontSize * text.length).truncate() != fontSize * text.length);
-    final bool roundingHackWasDisabled = ParagraphBuilder.shouldDisableRoundingHack;
-    ParagraphBuilder.setDisableRoundingHack(true);
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(fontSize: fontSize));
-    builder.addText(text);
-    final Paragraph paragraph = builder.build()
-      ..layout(const ParagraphConstraints(width: text.length * fontSize));
-
-    expect(paragraph.maxIntrinsicWidth, text.length * fontSize);
-    switch (paragraph.computeLineMetrics()) {
-      case [LineMetrics(width: final double width)]:
-        expect(width, text.length * fontSize);
-      case final List<LineMetrics> metrics:
-        expect(metrics, hasLength(1));
-    }
-    ParagraphBuilder.setDisableRoundingHack(roundingHackWasDisabled);
-  });
 }

--- a/third_party/txt/src/skia/paragraph_builder_skia.cc
+++ b/third_party/txt/src/skia/paragraph_builder_skia.cc
@@ -138,7 +138,6 @@ skt::ParagraphStyle ParagraphBuilderSkia::TxtToSkia(const ParagraphStyle& txt) {
 
   skia.turnHintingOff();
   skia.setReplaceTabCharacters(true);
-  skia.setApplyRoundingHack(txt.apply_rounding_hack);
 
   return skia;
 }

--- a/third_party/txt/src/txt/paragraph_style.h
+++ b/third_party/txt/src/txt/paragraph_style.h
@@ -95,14 +95,6 @@ class ParagraphStyle {
   std::u16string ellipsis;
   std::string locale;
 
-  // Temporary flag that indicates whether the Paragraph should report its
-  // metrics with rounding hacks applied.
-  //
-  // This flag currently defaults to true and will be flipped to false once the
-  // migration is complete.
-  // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/31707
-  bool apply_rounding_hack = true;
-
   TextStyle GetTextStyle() const;
 
   bool unlimited_lines() const;


### PR DESCRIPTION
Reverts flutter/engine#43118

The incorrect default value (`true` instead of  `false`) was used in the PR and that caused internal test failures. I'll add a test before trying to reland.