### PR TITLE
[Impeller] Switch back to using explicit flush for device buffers.

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -251,8 +251,7 @@ ToVKTextureMemoryPropertyFlags(StorageMode mode,
   switch (mode) {
     case StorageMode::kHostVisible:
       return vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eDeviceLocal |
-             vk::MemoryPropertyFlagBits::eHostCoherent;
+             vk::MemoryPropertyFlagBits::eDeviceLocal;
     case StorageMode::kDevicePrivate:
       return vk::MemoryPropertyFlagBits::eDeviceLocal;
     case StorageMode::kDeviceTransient:
@@ -266,25 +265,16 @@ ToVKTextureMemoryPropertyFlags(StorageMode mode,
 }
 
 static VmaAllocationCreateFlags ToVmaAllocationCreateFlags(StorageMode mode,
-                                                           bool is_texture,
                                                            size_t size) {
   VmaAllocationCreateFlags flags = 0;
   switch (mode) {
     case StorageMode::kHostVisible:
-      if (is_texture) {
-        if (size >= kImageSizeThresholdForDedicatedMemoryAllocation) {
-          flags |= VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
-        } else {
-          flags |= {};
-        }
-      } else {
-        flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
-        flags |= VMA_ALLOCATION_CREATE_MAPPED_BIT;
+      if (size >= kImageSizeThresholdForDedicatedMemoryAllocation) {
+        flags |= VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
       }
       return flags;
     case StorageMode::kDevicePrivate:
-      if (is_texture &&
-          size >= kImageSizeThresholdForDedicatedMemoryAllocation) {
+      if (size >= kImageSizeThresholdForDedicatedMemoryAllocation) {
         flags |= VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
       }
       return flags;
@@ -328,9 +318,8 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
     alloc_nfo.preferredFlags =
         static_cast<VkMemoryPropertyFlags>(ToVKTextureMemoryPropertyFlags(
             desc.storage_mode, supports_memoryless_textures));
-    alloc_nfo.flags =
-        ToVmaAllocationCreateFlags(desc.storage_mode, /*is_texture=*/true,
-                                   desc.GetByteSizeOfBaseMipLevel());
+    alloc_nfo.flags = ToVmaAllocationCreateFlags(
+        desc.storage_mode, desc.GetByteSizeOfBaseMipLevel());
 
     auto create_info_native =
         static_cast<vk::ImageCreateInfo::NativeType>(image_info);

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.cc
@@ -40,6 +40,9 @@ bool DeviceBufferVK::OnCopyHostBuffer(const uint8_t* source,
   if (source) {
     ::memmove(dest + offset, source + source_range.offset, source_range.length);
   }
+  ::vmaFlushAllocation(resource_->buffer.get().allocator,
+                       resource_->buffer.get().allocation, offset,
+                       source_range.length);
 
   return true;
 }


### PR DESCRIPTION
Not all devices support the host_coherent + host_visible + device_local combo (though most do). I believe this change was associated with a slight regression in performance, so back it out and go back to flush to see if that improves things.

https://flutter-flutter-perf.skia.org/e/?begin=1687535096&end=1689267073&queries=device_type%3DSM-G973U1%26test%3Dnew_gallery_impeller__transition_perf&requestType=0&selected=commit%3D35596%26name%3D%252Carch%253Dintel%252Cbranch%253Dmaster%252Cconfig%253Ddefault%252Cdevice_type%253DSM-G973U1%252Cdevice_version%253Dnone%252Chost_type%253Dlinux%252Csub_result%253D99th_percentile_frame_rasterizer_time_millis%252Ctest%253Dnew_gallery_impeller__transition_perf%252C

Specifically:

![image](https://github.com/flutter/engine/assets/8975114/fedabc18-9091-45c0-b7b3-ee9945c2239c)
