### PR TITLE
[web] always add secondary role managers

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -67,6 +67,10 @@ class RouteName extends RoleManager {
 
   @override
   void update() {
+    if (!semanticsObject.namesRoute) {
+      return;
+    }
+
     // NOTE(yjbanov): this does not handle the case when the node structure
     // changes such that this RouteName is no longer attached to the same
     // dialog. While this is technically expressible using the semantics API,

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -67,10 +67,6 @@ class RouteName extends RoleManager {
 
   @override
   void update() {
-    if (!semanticsObject.namesRoute) {
-      return;
-    }
-
     // NOTE(yjbanov): this does not handle the case when the node structure
     // changes such that this RouteName is no longer attached to the same
     // dialog. While this is technically expressible using the semantics API,
@@ -80,6 +76,10 @@ class RouteName extends RoleManager {
     // semantics code. Since reparenting can be done with no update to either
     // the Dialog or RouteName we'd have to scan intermediate nodes for
     // structural changes.
+    if (!semanticsObject.namesRoute) {
+      return;
+    }
+
     if (semanticsObject.isLabelDirty) {
       final Dialog? dialog = _dialog;
       if (dialog != null) {

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -38,6 +38,20 @@ class Focusable extends RoleManager {
 
   @override
   void update() {
+    if (!_focusManager.isManaging && !semanticsObject.isFocusable) {
+      // Nothing to do about this node. It's neither focusable, nor being managed.
+      return;
+    }
+
+    if (!_focusManager.isManaging) {
+      // This line is only reachable iff the node is focusable but not being
+      // managed. So the focus manager is told to start managing it.
+      _focusManager.manage(semanticsObject.id, semanticsObject.element);
+    }
+    _updateFocus();
+  }
+
+  void _updateFocus() {
     _focusManager.changeFocus(semanticsObject.hasFocus && (!semanticsObject.hasEnabledState || semanticsObject.isEnabled));
   }
 
@@ -78,6 +92,9 @@ class AccessibilityFocusManager {
   final EngineSemanticsOwner _owner;
 
   _FocusTarget? _target;
+
+  /// Whether this focus manager is managing a focusable target.
+  bool get isManaging => _target != null;
 
   /// Starts managing the focus of the given [element].
   ///

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -30,9 +30,7 @@ import 'semantics.dart';
 class Focusable extends RoleManager {
   Focusable(SemanticsObject semanticsObject)
       : _focusManager = AccessibilityFocusManager(semanticsObject.owner),
-        super(Role.focusable, semanticsObject) {
-    _focusManager.manage(semanticsObject.id, semanticsObject.element);
-  }
+        super(Role.focusable, semanticsObject);
 
   final AccessibilityFocusManager _focusManager;
 
@@ -137,6 +135,7 @@ class AccessibilityFocusManager {
   /// Stops managing the focus of the current element, if any.
   void stopManaging() {
     final _FocusTarget? target = _target;
+    _target = null;
 
     if (target == null) {
       /// Nothing is being managed. Just return.
@@ -145,7 +144,11 @@ class AccessibilityFocusManager {
 
     target.element.removeEventListener('focus', target.domFocusListener);
     target.element.removeEventListener('blur', target.domBlurListener);
-    _target = null;
+
+    // Blur the element after removing listeners. If this method is being called
+    // it indicates that the framework already knows that this node should not
+    // have focus, and there's no need to notify it.
+    target.element.blur();
   }
 
   void _setFocusFromDom(bool acquireFocus) {

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -38,21 +38,14 @@ class Focusable extends RoleManager {
 
   @override
   void update() {
-    if (!_focusManager.isManaging && !semanticsObject.isFocusable) {
-      // Nothing to do about this node. It's neither focusable, nor being managed.
-      return;
+    if (semanticsObject.isFocusable) {
+      if (!_focusManager.isManaging) {
+        _focusManager.manage(semanticsObject.id, semanticsObject.element);
+      }
+      _focusManager.changeFocus(semanticsObject.hasFocus && (!semanticsObject.hasEnabledState || semanticsObject.isEnabled));
+    } else {
+      _focusManager.stopManaging();
     }
-
-    if (!_focusManager.isManaging) {
-      // This line is only reachable iff the node is focusable but not being
-      // managed. So the focus manager is told to start managing it.
-      _focusManager.manage(semanticsObject.id, semanticsObject.element);
-    }
-    _updateFocus();
-  }
-
-  void _updateFocus() {
-    _focusManager.changeFocus(semanticsObject.hasFocus && (!semanticsObject.hasEnabledState || semanticsObject.isEnabled));
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -68,7 +68,6 @@ class LabelAndValue extends RoleManager {
 
   void _cleanUpDom() {
     semanticsObject.element.removeAttribute('aria-label');
-    semanticsObject.clearAriaRole();
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/semantics/live_region.dart
+++ b/lib/web_ui/lib/src/engine/semantics/live_region.dart
@@ -22,6 +22,10 @@ class LiveRegion extends RoleManager {
 
   @override
   void update() {
+    if (!semanticsObject.isLiveRegion) {
+      return;
+    }
+
     // Avoid announcing the same message over and over.
     if (_lastAnnouncement != semanticsObject.label) {
       _lastAnnouncement = semanticsObject.label;

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -413,14 +413,6 @@ enum Role {
   routeName,
 }
 
-/// Creates a secondary [RoleManager] for a [SemanticsObject].
-///
-/// The implementation is expected to inspect the semantics object (flags,
-/// actions, etc) and determine whether it _should_ have this secondary role.
-/// If the node should _not_ have this role, the funtion would return `null`.
-/// Otherwise, the function would instantiate the role manager and return it.
-typedef RoleManagerFactory = RoleManager? Function(SemanticsObject);
-
 /// Responsible for setting the `role` ARIA attribute and for attaching zero or
 /// more secondary [RoleManager]s to a [SemanticsObject].
 abstract class PrimaryRoleManager {
@@ -451,63 +443,35 @@ abstract class PrimaryRoleManager {
   List<RoleManager>? get secondaryRoleManagers => _secondaryRoleManagers;
   List<RoleManager>? _secondaryRoleManagers;
 
-  /// Factories for role managers that have not yet been instantiated.
-  Map<Role, RoleManagerFactory>? _secondaryRoleFactories;
-
   /// Identifiers of secondary roles used by this primary role manager.
   ///
   /// This is only meant to be used in tests.
   @visibleForTesting
   List<Role> get debugSecondaryRoles => _secondaryRoleManagers?.map((RoleManager manager) => manager.role).toList() ?? const <Role>[];
 
-  /// Adds generic focus management features, if applicable.
+  /// Adds generic focus management features.
   void addFocusManagement() {
-    addSecondaryRole(Role.focusable, (SemanticsObject semanticsObject) {
-      if (semanticsObject.isFocusable) {
-        return Focusable(semanticsObject);
-      }
-      return null;
-    });
+    addSecondaryRole(Focusable(semanticsObject));
   }
 
-  /// Adds generic live region features, if applicable.
+  /// Adds generic live region features.
   void addLiveRegion() {
-    addSecondaryRole(Role.liveRegion, (SemanticsObject semanticsObject) {
-      if (semanticsObject.isLiveRegion) {
-        return LiveRegion(semanticsObject);
-      }
-      return null;
-    });
+    addSecondaryRole(LiveRegion(semanticsObject));
   }
 
-  /// Adds generic route name features, if applicable.
+  /// Adds generic route name features.
   void addRouteName() {
-    addSecondaryRole(Role.routeName, (SemanticsObject semanticsObject) {
-      if (semanticsObject.namesRoute) {
-        return RouteName(semanticsObject);
-      }
-      return null;
-    });
+    addSecondaryRole(RouteName(semanticsObject));
   }
 
-  /// Adds generic label features, if applicable.
+  /// Adds generic label features.
   void addLabelAndValue() {
-    addSecondaryRole(Role.labelAndValue, (SemanticsObject semanticsObject) {
-      if (semanticsObject.hasLabel || semanticsObject.hasValue || semanticsObject.hasTooltip) {
-        return LabelAndValue(semanticsObject);
-      }
-      return null;
-    });
+    addSecondaryRole(LabelAndValue(semanticsObject));
   }
 
   /// Adds generic functionality for handling taps and clicks.
   void addTappable() {
-    addSecondaryRole(Role.tappable, (SemanticsObject semanticsObject) {
-      if (semanticsObject.isTappable) {
-        return Tappable(semanticsObject);
-      }
-      return null;
-    });
+    addSecondaryRole(Tappable(semanticsObject));
   }
 
   /// Adds a secondary role to this primary role manager.
@@ -515,16 +479,13 @@ abstract class PrimaryRoleManager {
   /// This method should be called by concrete implementations of
   /// [PrimaryRoleManager] during initialization.
   @protected
-  void addSecondaryRole(Role role, RoleManagerFactory roleManagerFactory) {
-    _secondaryRoleFactories ??= <Role, RoleManagerFactory>{};
-    final Map<Role, RoleManagerFactory> secondaryRoleFactories = _secondaryRoleFactories!;
-
+  void addSecondaryRole(RoleManager secondaryRoleManager) {
     assert(
-      !secondaryRoleFactories.containsKey(role),
-      'Cannot add secondary role $role. This semantic node already has this role.',
+      _secondaryRoleManagers?.any((RoleManager manager) => manager.role == secondaryRoleManager.role) != true,
+      'Cannot add secondary role ${secondaryRoleManager.role}. This object already has this secondary role.',
     );
-
-    secondaryRoleFactories[role] = roleManagerFactory;
+    _secondaryRoleManagers ??= <RoleManager>[];
+    _secondaryRoleManagers!.add(secondaryRoleManager);
   }
 
   /// Called immediately after the fields of the [semanticsObject] are updated
@@ -538,23 +499,6 @@ abstract class PrimaryRoleManager {
   /// the object.
   @mustCallSuper
   void update() {
-    final Map<Role, RoleManagerFactory>? secondaryRoleFactories = _secondaryRoleFactories;
-    if (secondaryRoleFactories != null && secondaryRoleFactories.isNotEmpty) {
-      secondaryRoleFactories.forEach((Role role, RoleManagerFactory roleFactory) {
-        final RoleManager? secondaryRoleManager = roleFactory(semanticsObject);
-        if (secondaryRoleManager != null) {
-          _secondaryRoleManagers ??= <RoleManager>[];
-          _secondaryRoleManagers!.add(secondaryRoleManager);
-        }
-      });
-
-      // A role manager should only be added once. So remove any factories that
-      // contributed a role manager.
-      _secondaryRoleManagers?.forEach((RoleManager roleManager) {
-        secondaryRoleFactories.remove(roleManager.role);
-      });
-    }
-
     final List<RoleManager>? secondaryRoles = _secondaryRoleManagers;
     if (secondaryRoles == null) {
       return;
@@ -577,7 +521,7 @@ abstract class PrimaryRoleManager {
   /// gesture mode changes.
   @mustCallSuper
   void dispose() {
-    semanticsObject.clearAriaRole();
+    semanticsObject.element.removeAttribute('role');
     _isDisposed = true;
   }
 }
@@ -1508,11 +1452,6 @@ class SemanticsObject {
   /// Sets the `role` ARIA attribute.
   void setAriaRole(String ariaRoleName) {
     element.setAttribute('role', ariaRoleName);
-  }
-
-  /// Removes the `role` HTML attribue, if any.
-  void clearAriaRole() {
-    element.removeAttribute('role');
   }
 
   /// The primary role of this node.

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -40,8 +40,7 @@ class Tappable extends RoleManager {
 
   @override
   void update() {
-    final DomElement element = semanticsObject.element;
-    if (semanticsObject.enabledState() == EnabledState.disabled || !semanticsObject.isTappable) {
+    if (!semanticsObject.isTappable || semanticsObject.enabledState() == EnabledState.disabled) {
       _stopListening();
     } else {
       if (_clickListener == null) {
@@ -52,7 +51,7 @@ class Tappable extends RoleManager {
           EnginePlatformDispatcher.instance.invokeOnSemanticsAction(
               semanticsObject.id, ui.SemanticsAction.tap, null);
         });
-        element.addEventListener('click', _clickListener);
+        semanticsObject.element.addEventListener('click', _clickListener);
       }
     }
   }

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -118,7 +118,7 @@ void _testRoleManagerLifecycle() {
         node.primaryRole?.debugSecondaryRoles,
         containsAll(<Role>[Role.focusable, Role.tappable, Role.labelAndValue]),
       );
-      expect(tester.getSemanticsObject(0).element.tabIndex, 0);
+      expect(tester.getSemanticsObject(0).element.tabIndex, -1);
     }
 
     // Check that roles apply their functionality upon update.
@@ -127,6 +127,7 @@ void _testRoleManagerLifecycle() {
       tester.updateNode(
         id: 0,
         label: 'a label',
+        isFocusable: true,
         isButton: true,
         rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
       );
@@ -2737,28 +2738,62 @@ void _testFocusable() {
     expect(element.tabIndex, -1);
     domDocument.body!.append(element);
 
+    // Start managing element
     manager.manage(1, element);
     expect(element.tabIndex, 0);
     expect(capturedActions, isEmpty);
+    expect(domDocument.activeElement, isNot(element));
 
+    // Request focus
     manager.changeFocus(true);
     pumpSemantics(); // triggers post-update callbacks
+    expect(domDocument.activeElement, element);
     expect(capturedActions, <CapturedAction>[
       (1, ui.SemanticsAction.didGainAccessibilityFocus, null),
     ]);
     capturedActions.clear();
 
+    // Give up focus
     manager.changeFocus(false);
     pumpSemantics(); // triggers post-update callbacks
     expect(capturedActions, <CapturedAction>[
       (1, ui.SemanticsAction.didLoseAccessibilityFocus, null),
     ]);
     capturedActions.clear();
+    expect(domDocument.activeElement, isNot(element));
 
-    manager.stopManaging();
+    // Request focus again
     manager.changeFocus(true);
     pumpSemantics(); // triggers post-update callbacks
-    expect(capturedActions, isEmpty);
+    expect(domDocument.activeElement, element);
+    expect(capturedActions, <CapturedAction>[
+      (1, ui.SemanticsAction.didGainAccessibilityFocus, null),
+    ]);
+    capturedActions.clear();
+
+    // Stop managing
+    manager.stopManaging();
+    pumpSemantics(); // triggers post-update callbacks
+    expect(
+      reason: 'Even though the element was blurred after stopManaging there '
+              'should be no notification to the framework because the framework '
+              'should already know. Otherwise, it would not have asked to stop '
+              'managing the node.',
+      capturedActions,
+      isEmpty,
+    );
+    expect(domDocument.activeElement, isNot(element));
+
+    // Attempt to request focus when not managing an element.
+    manager.changeFocus(true);
+    pumpSemantics(); // triggers post-update callbacks
+    expect(
+      reason: 'Attempting to request focus on a node that is not managed should '
+              'not result in any notifications to the framework.',
+      capturedActions,
+      isEmpty,
+    );
+    expect(domDocument.activeElement, isNot(element));
 
     semantics().semanticsEnabled = false;
   });

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -95,81 +95,16 @@ void runSemanticsTests() {
 }
 
 void _testRoleManagerLifecycle() {
-  test('Secondary role managers are added upon node creation', () {
+  test('Secondary role managers are added upon node initialization', () {
     semantics()
       ..debugOverrideTimestampFunction(() => _testTime)
       ..semanticsEnabled = true;
 
-    final SemanticsTester tester = SemanticsTester(semantics());
-    tester.updateNode(
-      id: 0,
-      isFocusable: true,
-      label: 'this is a label',
-      hasTap: true,
-      hasEnabledState: true,
-      isEnabled: true,
-      isButton: true,
-      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
-    );
-    tester.apply();
-
-    expectSemanticsTree('''
-<sem role="button" aria-label="this is a label" style="$rootSemanticStyle"></sem>
-''');
-
-    final SemanticsObject node = semantics().debugSemanticsTree![0]!;
-    expect(node.primaryRole?.role, PrimaryRole.button);
-    expect(
-      node.primaryRole?.debugSecondaryRoles,
-      containsAll(<Role>[Role.focusable, Role.tappable, Role.labelAndValue]),
-    );
-    expect(tester.getSemanticsObject(0).element.tabIndex, 0);
-
-    semantics().semanticsEnabled = false;
-  });
-
-  test('Secondary role managers are added upon node update', () {
-    semantics()
-      ..debugOverrideTimestampFunction(() => _testTime)
-      ..semanticsEnabled = true;
-
-    // Create without a label
+    // Check that roles are initialized immediately
     {
       final SemanticsTester tester = SemanticsTester(semantics());
       tester.updateNode(
         id: 0,
-        isFocusable: true,
-        label: 'this is a label',
-        hasTap: true,
-        hasEnabledState: true,
-        isEnabled: true,
-        isButton: true,
-        rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
-      );
-      tester.apply();
-
-      expectSemanticsTree('''
-<sem role="button" aria-label="this is a label" style="$rootSemanticStyle"></sem>
-''');
-
-      final SemanticsObject node = semantics().debugSemanticsTree![0]!;
-      expect(node.primaryRole?.role, PrimaryRole.button);
-      expect(
-        node.primaryRole?.debugSecondaryRoles,
-        containsAll(<Role>[Role.focusable, Role.tappable]),
-      );
-      expect(tester.getSemanticsObject(0).element.tabIndex, 0);
-    }
-
-    // Update with a label
-    {
-      final SemanticsTester tester = SemanticsTester(semantics());
-      tester.updateNode(
-        id: 0,
-        isFocusable: true,
-        hasTap: true,
-        hasEnabledState: true,
-        isEnabled: true,
         isButton: true,
         rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
       );
@@ -181,7 +116,29 @@ void _testRoleManagerLifecycle() {
       expect(node.primaryRole?.role, PrimaryRole.button);
       expect(
         node.primaryRole?.debugSecondaryRoles,
-        containsAll(<Role>[Role.focusable, Role.tappable]),
+        containsAll(<Role>[Role.focusable, Role.tappable, Role.labelAndValue]),
+      );
+      expect(tester.getSemanticsObject(0).element.tabIndex, 0);
+    }
+
+    // Check that roles apply their functionality upon update.
+    {
+      final SemanticsTester tester = SemanticsTester(semantics());
+      tester.updateNode(
+        id: 0,
+        label: 'a label',
+        isButton: true,
+        rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+      );
+      tester.apply();
+
+      expectSemanticsTree('<sem aria-label="a label" role="button" style="$rootSemanticStyle"></sem>');
+
+      final SemanticsObject node = semantics().debugSemanticsTree![0]!;
+      expect(node.primaryRole?.role, PrimaryRole.button);
+      expect(
+        node.primaryRole?.debugSecondaryRoles,
+        containsAll(<Role>[Role.focusable, Role.tappable, Role.labelAndValue]),
       );
       expect(tester.getSemanticsObject(0).element.tabIndex, 0);
     }


### PR DESCRIPTION
Always add secondary role managers irrespective of the initial state of the semantic node, and have role manager decide whether it applies to the node or not.

Fixes https://github.com/flutter/flutter/issues/130546