### PR TITLE
Minor fixes for C++20 compatibility

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -88,7 +88,7 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
         delegate_.GetParentRasterThreadMerger(), platform_id, gpu_id);
   }
   if (raster_thread_merger_) {
-    raster_thread_merger_->SetMergeUnmergeCallback([&]() {
+    raster_thread_merger_->SetMergeUnmergeCallback([this]() {
       // Clear the GL context after the thread configuration has changed.
       if (surface_) {
         surface_->ClearRenderContext();

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -88,7 +88,7 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
         delegate_.GetParentRasterThreadMerger(), platform_id, gpu_id);
   }
   if (raster_thread_merger_) {
-    raster_thread_merger_->SetMergeUnmergeCallback([=]() {
+    raster_thread_merger_->SetMergeUnmergeCallback([&]() {
       // Clear the GL context after the thread configuration has changed.
       if (surface_) {
         surface_->ClearRenderContext();

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -156,12 +156,13 @@ static BOOL _forceSoftwareRendering;
       32,                                 // size_t bitsPerPixel,
       4 * screenshot.frame_size.width(),  // size_t bytesPerRow
       colorspace,                         // CGColorSpaceRef space
-      static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedLast |
-                                kCGBitmapByteOrder32Big),  // CGBitmapInfo bitmapInfo
-      image_data_provider,                                 // CGDataProviderRef provider
-      nullptr,                                             // const CGFloat* decode
-      false,                                               // bool shouldInterpolate
-      kCGRenderingIntentDefault                            // CGColorRenderingIntent intent
+      static_cast<CGBitmapInfo>(
+          static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) |
+          static_cast<uint32_t>(kCGBitmapByteOrder32Big)),  // CGBitmapInfo bitmapInfo
+      image_data_provider,                                  // CGDataProviderRef provider
+      nullptr,                                              // const CGFloat* decode
+      false,                                                // bool shouldInterpolate
+      kCGRenderingIntentDefault                             // CGColorRenderingIntent intent
       ));
 
   const CGRect frame_rect =


### PR DESCRIPTION
Fixes the following errors when building with a C++20 toolchain.

I don't really know C++ that well so any pointers would be appreciated. 

For the change to the lambda, we can't follow the recommendation to capture `*this` explicitly because that wouldn't compile under C++17. This PR changes the semantics slightly to capture `surface_` by reference, which might be still okay?

For b/289776142

```
error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
   93 |       if (surface_) {
      |           ^
note: add an explicit capture of 'this' to capture '*this' by reference
   91 |     raster_thread_merger_->SetMergeUnmergeCallback([=]() {
      |                                                     ^
      |                                                      , this
```

```
error: bitwise operation between different enumeration types ('CGImageAlphaInfo' and '(unnamed enum at third_party/apple_sdks/xcode_14_2/iphonesimulator/System/Library/Frameworks/CoreGraphics.framework/Headers/CGImage.h:53:9)') is deprecated [-Werror,-Wdeprecated-anon-enum-enum-conversion]
  159 |       static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedLast |
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  160 |                                 kCGBitmapByteOrder32Big),  // CGBitmapInfo bitmapInfo
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

