### PR TITLE
Use utf8.encode() instead of longer const Utf8Encoder.convert()

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3338,7 +3338,7 @@ Future<void> loadFontFromList(Uint8List list, {String? fontFamily}) {
   ).then((_) => _sendFontChangeMessage());
 }
 
-final ByteData _fontChangeMessage = utf8.encoder.convert(
+final ByteData _fontChangeMessage = utf8.encode(
   json.encode(<String, Object?>{'type': 'fontsChange'})
 ).buffer.asByteData();
 

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -1001,7 +1001,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   void _setAppLifecycleState(ui.AppLifecycleState state) {
     sendPlatformMessage(
       'flutter/lifecycle',
-      Uint8List.fromList(utf8.encode(state.toString())).buffer.asByteData(),
+      ByteData.sublistView(utf8.encode(state.toString())),
       null,
     );
   }

--- a/lib/web_ui/lib/src/engine/services/message_codecs.dart
+++ b/lib/web_ui/lib/src/engine/services/message_codecs.dart
@@ -39,7 +39,7 @@ class StringCodec implements MessageCodec<String> {
 
   @override
   ByteData encodeMessage(String message) {
-    final Uint8List encoded = utf8.encoder.convert(message);
+    final Uint8List encoded = utf8.encode(message);
     return encoded.buffer.asByteData();
   }
 }
@@ -320,7 +320,7 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
       }
     } else if (value is String) {
       buffer.putUint8(_valueString);
-      final List<int> bytes = utf8.encoder.convert(value);
+      final List<int> bytes = utf8.encode(value);
       writeSize(buffer, bytes.length);
       buffer.putUint8List(bytes as Uint8List);
     } else if (value is Uint8List) {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_memory.dart
@@ -26,8 +26,7 @@ external void stackRestore(StackPointer pointer);
 
 class StackScope {
   Pointer<Int8> convertStringToNative(String string) {
-    final Utf8Encoder utf8Encoder = utf8.encoder;
-    final Uint8List encoded = utf8Encoder.convert(string);
+    final Uint8List encoded = utf8.encode(string);
     final Pointer<Int8> pointer = allocInt8Array(encoded.length + 1);
     for (int i = 0; i < encoded.length; i++) {
       pointer[i] = encoded[i];

--- a/lib/web_ui/lib/ui_web/src/ui_web/asset_manager.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/asset_manager.dart
@@ -92,7 +92,7 @@ class AssetManager {
 
     if (response.status == 404 && asset == 'AssetManifest.json') {
       printWarning('Asset manifest does not exist at `$url` - ignoring.');
-      return Uint8List.fromList(utf8.encode('{}')).buffer.asByteData();
+      return ByteData.sublistView(utf8.encode('{}'));
     }
 
     return (await response.payload.asByteBuffer()).asByteData();

--- a/lib/web_ui/test/canvaskit/fragment_program_test.dart
+++ b/lib/web_ui/test/canvaskit/fragment_program_test.dart
@@ -186,7 +186,7 @@ void testMain() {
   });
 
   test('FragmentProgram can be created from JSON IPLR bundle', () {
-    final Uint8List data = const Utf8Encoder().convert(kJsonIPLR);
+    final Uint8List data = utf8.encode(kJsonIPLR);
     final CkFragmentProgram program = CkFragmentProgram.fromBytes('test', data);
 
     expect(program.effect, isNotNull);

--- a/lib/web_ui/test/common/fake_asset_manager.dart
+++ b/lib/web_ui/test/common/fake_asset_manager.dart
@@ -90,7 +90,7 @@ class FakeAssetScope {
 FakeAssetManager fakeAssetManager = FakeAssetManager();
 
 ByteData stringAsUtf8Data(String string) {
-  return ByteData.view(Uint8List.fromList(utf8.encode(string)).buffer);
+  return ByteData.sublistView(utf8.encode(string));
 }
 
 const String ahemFontFamily = 'Ahem';

--- a/lib/web_ui/test/engine/channel_buffers_test.dart
+++ b/lib/web_ui/test/engine/channel_buffers_test.dart
@@ -23,7 +23,7 @@ void main() {
 }
 
 ByteData _makeByteData(String str) {
-  final Uint8List list = const Utf8Encoder().convert(str);
+  final Uint8List list = utf8.encode(str);
   final ByteBuffer buffer = list.buffer;
   return ByteData.view(buffer);
 }

--- a/lib/web_ui/test/ui/fragment_shader_test.dart
+++ b/lib/web_ui/test/ui/fragment_shader_test.dart
@@ -53,7 +53,7 @@ Future<void> testMain() async {
     assetScope = fakeAssetManager.pushAssetScope();
     assetScope.setAsset(
       'voronoi_shader',
-      Uint8List.fromList(utf8.encode(kVoronoiShaderSksl)).buffer.asByteData()
+      ByteData.sublistView(utf8.encode(kVoronoiShaderSksl))
     );
   });
 

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -69,7 +69,7 @@ Future<void> testMain() async {
     assetScope = fakeAssetManager.pushAssetScope();
     assetScope.setAsset(
       'glitch_shader',
-      Uint8List.fromList(utf8.encode(kGlitchShaderSksl)).buffer.asByteData()
+      ByteData.sublistView(utf8.encode(kGlitchShaderSksl))
     );
   });
 

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -167,7 +167,7 @@ void testSkiaResourceCacheSendsResponse() {
                           }''';
   PlatformDispatcher.instance.sendPlatformMessage(
     'flutter/skia',
-    Uint8List.fromList(utf8.encode(jsonRequest)).buffer.asByteData(),
+    ByteData.sublistView(utf8.encode(jsonRequest)),
     callback,
   );
 }
@@ -294,7 +294,7 @@ void canAccessResourceFromAssetDir() async {
   notifySetAssetBundlePath();
   window.sendPlatformMessage(
     'flutter/assets',
-    Uint8List.fromList(utf8.encode('kernel_blob.bin')).buffer.asByteData(),
+    ByteData.sublistView(utf8.encode('kernel_blob.bin')),
     (ByteData? byteData) {
       notifyCanAccessResource(byteData != null);
     },

--- a/shell/platform/fuchsia/dart-pkg/zircon/test/zircon_tests.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/test/zircon_tests.dart
@@ -13,7 +13,7 @@ import 'package:litetest/litetest.dart';
 /// Helper method to turn a [String] into a [ByteData] containing the
 /// text of the string encoded as UTF-8.
 ByteData utf8Bytes(final String text) {
-  return ByteData.view(Uint8List.fromList(utf8.encode(text)).buffer);
+  return ByteData.sublistView(utf8.encode(text));
 }
 
 // Take from zircon constants in zircon/errors.h, zircon/rights.h, zircon/types.h

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/lib/parent_view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/lib/parent_view.dart
@@ -169,13 +169,11 @@ class ChildView {
       ],
     };
 
-    final ByteData createViewMessage = utf8.encoder
-        .convert(json.encode(<String, Object>{
-          'method': 'View.create',
-          'args': args,
-        }))
-        .buffer
-        .asByteData();
+    final ByteData createViewMessage =
+        ByteData.sublistView(utf8.encode(json.encode(<String, Object>{
+      'method': 'View.create',
+      'args': args,
+    })));
 
     final platformViewsChannel = 'flutter/platform_views';
 

--- a/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/lib/mouse-input-view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/lib/mouse-input-view.dart
@@ -108,7 +108,7 @@ class MyApp {
       double wheelXPhysicalPixel,
       double wheelYPhysicalPixel}) {
     print('mouse-input-view reporting mouse input to MouseInputListener');
-    final message = utf8.encode(json.encode({
+    final message = ByteData.sublistView(utf8.encode(json.encode({
         'method': 'MouseInputListener.ReportMouseInput',
         'local_x': localX,
         'local_y': localY,
@@ -118,9 +118,7 @@ class MyApp {
         'phase': 'asdf',
         'wheel_x_physical_pixel': wheelXPhysicalPixel,
         'wheel_y_physical_pixel': wheelYPhysicalPixel,
-      }))
-      .buffer
-      .asByteData();
+      })));
     PlatformDispatcher.instance
         .sendPlatformMessage('fuchsia/input_test', message, null);
   }

--- a/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/lib/mouse-input-view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/lib/mouse-input-view.dart
@@ -108,20 +108,19 @@ class MyApp {
       double wheelXPhysicalPixel,
       double wheelYPhysicalPixel}) {
     print('mouse-input-view reporting mouse input to MouseInputListener');
-    final message = utf8.encoder
-        .convert(json.encode({
-          'method': 'MouseInputListener.ReportMouseInput',
-          'local_x': localX,
-          'local_y': localY,
-          'time_received': timeReceived,
-          'component_name': 'touch-input-view',
-          'buttons': buttons,
-          'phase': 'asdf',
-          'wheel_x_physical_pixel': wheelXPhysicalPixel,
-          'wheel_y_physical_pixel': wheelYPhysicalPixel,
-        }))
-        .buffer
-        .asByteData();
+    final message = utf8.encode(json.encode({
+        'method': 'MouseInputListener.ReportMouseInput',
+        'local_x': localX,
+        'local_y': localY,
+        'time_received': timeReceived,
+        'component_name': 'touch-input-view',
+        'buttons': buttons,
+        'phase': 'asdf',
+        'wheel_x_physical_pixel': wheelXPhysicalPixel,
+        'wheel_y_physical_pixel': wheelYPhysicalPixel,
+      }))
+      .buffer
+      .asByteData();
     PlatformDispatcher.instance
         .sendPlatformMessage('fuchsia/input_test', message, null);
   }

--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/lib/text_input_view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/lib/text_input_view.dart
@@ -91,7 +91,7 @@ class TestApp {
   void _reportTextInput(String text) {
     print('text-input-view reporting keyboard input to KeyboardInputListener');
 
-    final message = utf8.encoder.convert(json.encode({
+    final message = utf8.encode(json.encode({
       'method': 'KeyboardInputListener.ReportTextInput',
       'text': text,
     })).buffer.asByteData();

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/lib/embedding-flutter-view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/lib/embedding-flutter-view.dart
@@ -168,7 +168,7 @@ class TestApp {
 
   void _reportTouchInput({double localX, double localY, int timeReceived}) {
     print('embedding-flutter-view reporting touch input to TouchInputListener');
-    final message = utf8.encoder.convert(json.encode({
+    final message = utf8.encode(json.encode({
       'method': 'TouchInputListener.ReportTouchInput',
       'local_x': localX,
       'local_y': localY,
@@ -204,7 +204,7 @@ class ChildView {
       ],
     };
 
-    final ByteData createViewMessage = utf8.encoder.convert(
+    final ByteData createViewMessage = utf8.encode(
       json.encode(<String, Object>{
         'method': 'View.create',
         'args': args,

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/lib/touch-input-view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/lib/touch-input-view.dart
@@ -82,7 +82,7 @@ class TestApp {
 
   void _reportTouchInput({double localX, double localY, int timeReceived}) {
     print('touch-input-view reporting touch input to TouchInputListener');
-    final message = utf8.encoder.convert(json.encode({
+    final message = utf8.encode(json.encode({
       'method': 'TouchInputListener.ReportTouchInput',
       'local_x': localX,
       'local_y': localY,

--- a/shell/platform/windows/fixtures/main.dart
+++ b/shell/platform/windows/fixtures/main.dart
@@ -92,7 +92,7 @@ void exitTestExit() async {
   final Completer<ByteData?> closed = Completer<ByteData?>();
   ui.channelBuffers.setListener('flutter/platform', (ByteData? data, ui.PlatformMessageResponseCallback callback) async {
     final String jsonString = json.encode(<Map<String, String>>[{'response': 'exit'}]);
-    final ByteData responseData = ByteData.sublistView(Uint8List.fromList(utf8.encode(jsonString)));
+    final ByteData responseData = ByteData.sublistView(utf8.encode(jsonString));
     callback(responseData);
     closed.complete(data);
   });
@@ -104,7 +104,7 @@ void exitTestCancel() async {
   final Completer<ByteData?> closed = Completer<ByteData?>();
   ui.channelBuffers.setListener('flutter/platform', (ByteData? data, ui.PlatformMessageResponseCallback callback) async {
     final String jsonString = json.encode(<Map<String, String>>[{'response': 'cancel'}]);
-    final ByteData responseData = ByteData.sublistView(Uint8List.fromList(utf8.encode(jsonString)));
+    final ByteData responseData = ByteData.sublistView(utf8.encode(jsonString));
     callback(responseData);
     closed.complete(data);
   });
@@ -120,9 +120,7 @@ void exitTestCancel() async {
     });
   ui.PlatformDispatcher.instance.sendPlatformMessage(
     'flutter/platform',
-    ByteData.sublistView(
-      Uint8List.fromList(utf8.encode(jsonString))
-    ),
+    ByteData.sublistView(utf8.encode(jsonString)),
     (ByteData? reply) {
       exited.complete(reply);
     });

--- a/testing/dart/assets_test.dart
+++ b/testing/dart/assets_test.dart
@@ -68,7 +68,7 @@ void main() {
 
   test('Tester can still load through dart:ui', () async {
     /// Manually load font asset through dart.
-    final Uint8List encoded = utf8.encoder.convert(Uri(path: Uri.encodeFull('Roboto-Medium.ttf')).path);
+    final Uint8List encoded = utf8.encode(Uri(path: Uri.encodeFull('Roboto-Medium.ttf')).path);
     final Completer<Uint8List> result = Completer<Uint8List>();
     PlatformDispatcher.instance.sendPlatformMessage('flutter/assets', encoded.buffer.asByteData(), (ByteData? data) {
       result.complete(data!.buffer.asUint8List());

--- a/testing/dart/channel_buffers_test.dart
+++ b/testing/dart/channel_buffers_test.dart
@@ -12,7 +12,7 @@ import 'dart:ui' as ui;
 import 'package:litetest/litetest.dart';
 
 ByteData _makeByteData(String str) {
-  final Uint8List list = const Utf8Encoder().convert(str);
+  final Uint8List list = utf8.encode(str);
   final ByteBuffer buffer = list.buffer;
   return ByteData.view(buffer);
 }

--- a/testing/scenario_app/lib/main.dart
+++ b/testing/scenario_app/lib/main.dart
@@ -56,7 +56,7 @@ void _handleDriverMessage(ByteData? data, PlatformMessageResponseCallback? callb
 
 Future<void> _handleWriteTimelineMessage(ByteData? data, PlatformMessageResponseCallback? callback) async {
   final String timelineData = await _getTimelineData();
-  callback!(Uint8List.fromList(utf8.encode(timelineData)).buffer.asByteData());
+  callback!(ByteData.sublistView(utf8.encode(timelineData)));
 }
 
 Future<String> _getTimelineData() async {

--- a/testing/scenario_app/lib/src/channel_util.dart
+++ b/testing/scenario_app/lib/src/channel_util.dart
@@ -35,7 +35,7 @@ void sendJsonMessage({
     channel,
     // This recreates a combination of OptionalMethodChannel, JSONMethodCodec,
     // and _DefaultBinaryMessenger in the framework.
-    utf8.encoder.convert(
+    utf8.encode(
       const JsonCodec().encode(json)
     ).buffer.asByteData(),
     callback,


### PR DESCRIPTION
The change in [0] has propagated now everywhere, so we can use 
`utf8.encode()` instead of the longer `const Utf8Encoder.convert()`.

Also it cleans up code like

```
  Uint8List bytes;
  bytes.buffer.asByteData();
```

as that is not guaranteed to be correct, the correct version would be

```
  Uint8List bytes;
  bytes.buffer.asByteData(bytes.offsetInBytes, bytes.length);
```

a shorter hand for that is:

```
  Uint8List bytes;
  ByteData.sublistView(bytes);
```

[0] https://github.com/dart-lang/sdk/issues/52801