### PR TITLE
Revert "Log dlopen errors in opt builds (#41477)"

### DIFF
--- a/fml/platform/posix/native_library_posix.cc
+++ b/fml/platform/posix/native_library_posix.cc
@@ -13,10 +13,8 @@ NativeLibrary::NativeLibrary(const char* path) {
   ::dlerror();
   handle_ = ::dlopen(path, RTLD_NOW);
   if (handle_ == nullptr) {
-    // TODO(jiahaog): Use FML_DLOG:
-    // https://github.com/flutter/flutter/issues/125523
-    FML_LOG(ERROR) << "Could not open library '" << path << "' due to error '"
-                   << ::dlerror() << "'.";
+    FML_DLOG(ERROR) << "Could not open library '" << path << "' due to error '"
+                    << ::dlerror() << "'.";
   }
 }
 


### PR DESCRIPTION
This reverts commit 321f8015b9c2f9d47585647ce036cc8743966d27.

This didn't seem to help with debugging b/276657840. Fixes https://github.com/flutter/flutter/issues/125523.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
