### PR TITLE
Add EGL Surface backing store

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1314,7 +1314,7 @@ CreateEmbedderRenderTarget(
           };
 
           if (enable_impeller) {
-            /// TODO: Implement
+            // TODO: Implement.
             FML_LOG(ERROR) << "Unimplemented";
             break;
           } else {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1220,8 +1220,8 @@ static std::unique_ptr<flutter::EmbedderRenderTarget>
 MakeRenderTargetFromSkSurface(FlutterBackingStore backing_store,
                               sk_sp<SkSurface> skia_surface,
                               fml::closure on_release) {
-  return MakeRenderTargetFromSkSurface(backing_store, skia_surface, on_release,
-                                       nullptr, nullptr);
+  return MakeRenderTargetFromSkSurface(backing_store, std::move(skia_surface),
+                                       std::move(on_release), nullptr, nullptr);
 }
 
 static std::unique_ptr<flutter::EmbedderRenderTarget>

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -842,13 +842,13 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
   framebuffer_info.fFormat = GL_BGRA8_EXT;
   framebuffer_info.fFBOID = 0;
 
-  auto backend_render_target = GrBackendRenderTargets::MakeGL(
-      config.size.width,   // width
-      config.size.height,  // height
-      1,                   // sample count
-      0,                   // stencil bits
-      framebuffer_info     // framebuffer info
-  );
+  auto backend_render_target =
+      GrBackendRenderTargets::MakeGL(config.size.width,   // width
+                                     config.size.height,  // height
+                                     1,                   // sample count
+                                     0,                   // stencil bits
+                                     framebuffer_info     // framebuffer info
+      );
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -842,7 +842,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
   framebuffer_info.fFormat = GL_BGRA8_EXT;
   framebuffer_info.fFBOID = 0;
 
-  GrBackendRenderTarget backend_render_target(
+  auto backend_render_target = GrBackendRenderTargets::MakeGL(
       config.size.width,   // width
       config.size.height,  // height
       1,                   // sample count

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1314,7 +1314,8 @@ CreateEmbedderRenderTarget(
           };
 
           if (enable_impeller) {
-            // TODO: Implement.
+            // TODO(https://github.com/flutter/flutter/issues/151670): Implement
+            //  GL Surface backing stores for Impeller.
             FML_LOG(ERROR) << "Unimplemented";
             break;
           } else {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1298,7 +1298,7 @@ CreateEmbedderRenderTarget(
           auto on_make_current =
               [callback = backing_store.open_gl.surface.make_current_callback,
                context = backing_store.open_gl.surface.user_data]()
-              -> std::pair<bool, bool> {
+              -> flutter::EmbedderRenderTarget::SetCurrentResult {
             bool invalidate_api_state = false;
             bool ok = callback(context, &invalidate_api_state);
             return {ok, invalidate_api_state};
@@ -1307,7 +1307,7 @@ CreateEmbedderRenderTarget(
           auto on_clear_current =
               [callback = backing_store.open_gl.surface.clear_current_callback,
                context = backing_store.open_gl.surface.user_data]()
-              -> std::pair<bool, bool> {
+              -> flutter::EmbedderRenderTarget::SetCurrentResult {
             bool invalidate_api_state = false;
             bool ok = callback(context, &invalidate_api_state);
             return {ok, invalidate_api_state};

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1289,28 +1289,29 @@ CreateEmbedderRenderTarget(
                 collect_callback.Release());
             break;
           }
+        }
 
-          case kFlutterOpenGLTargetTypeSurface: {
-            auto skia_surface = MakeSkSurfaceFromBackingStore(
-                context, config, &backing_store.open_gl.surface);
+        case kFlutterOpenGLTargetTypeSurface: {
+          auto skia_surface = MakeSkSurfaceFromBackingStore(
+              context, config, &backing_store.open_gl.surface);
 
-            auto make_current_callback =
-                backing_store.open_gl.surface.make_current_callback;
-            auto make_current_context = backing_store.open_gl.surface.user_data;
+          auto make_current_callback =
+              backing_store.open_gl.surface.make_current_callback;
+          auto make_current_context = backing_store.open_gl.surface.user_data;
 
-            auto on_make_current = [=] {
-              make_current_callback(make_current_context);
-            };
+          auto on_make_current = [=] {
+            make_current_callback(make_current_context);
+          };
 
-            render_target = MakeRenderTargetFromSkSurface(
-                backing_store, std::move(skia_surface),
-                collect_callback.Release(), on_make_current);
-            break;
-          }
+          render_target = MakeRenderTargetFromSkSurface(
+              backing_store, std::move(skia_surface),
+              collect_callback.Release(), on_make_current);
+          break;
         }
       }
       break;
     }
+
     case kFlutterBackingStoreTypeSoftware: {
       auto skia_surface = MakeSkSurfaceFromBackingStore(
           context, config, &backing_store.software);

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -437,7 +437,7 @@ typedef struct {
   /// @attention required. (non-null)
   FlutterOpenGLSurfaceCallback make_current_callback;
 
-  /// Callback invoked (on an engine managed thread) when the current surface
+  /// Callback invoked (on an engine-managed thread) when the current surface
   /// can be cleared.
   ///
   /// Should return true if the operation succeeded, false if an error ocurred.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -304,6 +304,9 @@ typedef enum {
   /// Specifies an OpenGL frame-buffer target type. Framebuffers are specified
   /// using the FlutterOpenGLFramebuffer struct.
   kFlutterOpenGLTargetTypeFramebuffer,
+  /// Specifies an OpenGL on-screen surface target type. Surfaces are specified
+  /// using the FlutterOpenGLSurface struct.
+  kFlutterOpenGLTargetTypeSurface,
 } FlutterOpenGLTargetType;
 
 /// A pixel format to be used for software rendering.
@@ -407,6 +410,21 @@ typedef struct {
   /// collect the framebuffer.
   VoidCallback destruction_callback;
 } FlutterOpenGLFramebuffer;
+
+typedef struct {
+  size_t struct_size;
+
+  /// User data to be returned on the invocation of the destruction callback.
+  void* user_data;
+
+  /// Callback invoked (on an engine managed thread) that asks the embedder to
+  /// make the window surface current.
+  VoidCallback make_current_callback;
+
+  /// Callback invoked (on an engine managed thread) that asks the embedder to
+  /// collect the framebuffer.
+  VoidCallback destruction_callback;
+} FlutterOpenGLSurface;
 
 typedef bool (*BoolCallback)(void* /* user data */);
 typedef FlutterTransformation (*TransformationCallback)(void* /* user data */);
@@ -1619,6 +1637,9 @@ typedef struct {
     /// A framebuffer for Flutter to render into. The embedder must ensure that
     /// the framebuffer is complete.
     FlutterOpenGLFramebuffer framebuffer;
+    /// A surface for Flutter to render into. Basically a wrapper around
+    /// a closure that'll be called when the surface should be made current.
+    FlutterOpenGLSurface surface;
   };
 } FlutterOpenGLBackingStore;
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -431,7 +431,6 @@ typedef struct {
   /// The second parameter 'opengl state changed' should be set to true if
   /// any OpenGL API state has changed and flutter should not assume any native
   /// API state is the same as before this callback was called.
-  ///
   /// In that case, Flutter will invalidate the internal OpenGL API state cache,
   /// which is a somewhat expensive operation.
   ///

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -411,18 +411,53 @@ typedef struct {
   VoidCallback destruction_callback;
 } FlutterOpenGLFramebuffer;
 
+typedef bool (*FlutterOpenGLSurfaceCallback)(void* /* user data */,
+                                             bool* /* opengl state changed */);
+
 typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterOpenGLSurface).
   size_t struct_size;
 
   /// User data to be returned on the invocation of the destruction callback.
   void* user_data;
 
   /// Callback invoked (on an engine managed thread) that asks the embedder to
-  /// make the window surface current.
-  VoidCallback make_current_callback;
+  /// make the surface current.
+  ///
+  /// Should return true if the operation succeeded, false if the surface could
+  /// not be made current and rendering should be cancelled.
+  ///
+  /// The second parameter 'opengl state changed' should be set to true if
+  /// any OpenGL API state has changed and flutter should not assume any native
+  /// API state is the same as before this callback was called.
+  ///
+  /// In that case, flutter will invalidate the internal OpenGL API state cache,
+  /// which is a somewhat expensive operation.
+  ///
+  /// @attention required. (non-null)
+  FlutterOpenGLSurfaceCallback make_current_callback;
+
+  /// Callback invoked (on an engine managed thread) when the current surface
+  /// can be cleared.
+  ///
+  /// Should return true if the operation succeeded, false if an error ocurred.
+  /// That error will be logged but otherwise not handled by the engine.
+  ///
+  /// The second parameter 'opengl state changed' is the same as with the
+  /// @ref make_current_callback.
+  ///
+  /// The embedder might clear the surface here after it was previously made
+  /// current. That's not required however, it's also possible to clear it in
+  /// the destruction callback. There's no way to signal opengl state
+  /// changes in the destruction callback though.
+  ///
+  /// @attention required. (non-null)
+  FlutterOpenGLSurfaceCallback clear_current_callback;
 
   /// Callback invoked (on an engine managed thread) that asks the embedder to
-  /// collect the framebuffer.
+  /// collect the surface.
+  ///
+  /// @attention required. (non-null)
   VoidCallback destruction_callback;
 } FlutterOpenGLSurface;
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -448,7 +448,7 @@ typedef struct {
   ///
   /// The embedder might clear the surface here after it was previously made
   /// current. That's not required however, it's also possible to clear it in
-  /// the destruction callback. There's no way to signal opengl state
+  /// the destruction callback. There's no way to signal OpenGL state
   /// changes in the destruction callback though.
   ///
   /// @attention required. (non-null)

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -429,8 +429,7 @@ typedef struct {
   /// not be made current and rendering should be cancelled.
   ///
   /// The second parameter 'opengl state changed' should be set to true if
-  /// any OpenGL API state has changed and flutter should not assume any native
-  /// API state is the same as before this callback was called.
+  /// any OpenGL API state is different than before this callback was called.
   /// In that case, Flutter will invalidate the internal OpenGL API state cache,
   /// which is a somewhat expensive operation.
   ///

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -422,7 +422,7 @@ typedef struct {
   /// destruction callbacks.
   void* user_data;
 
-  /// Callback invoked (on an engine managed thread) that asks the embedder to
+  /// Callback invoked (on an engine-managed thread) that asks the embedder to
   /// make the surface current.
   ///
   /// Should return true if the operation succeeded, false if the surface could

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -432,7 +432,7 @@ typedef struct {
   /// any OpenGL API state has changed and flutter should not assume any native
   /// API state is the same as before this callback was called.
   ///
-  /// In that case, flutter will invalidate the internal OpenGL API state cache,
+  /// In that case, Flutter will invalidate the internal OpenGL API state cache,
   /// which is a somewhat expensive operation.
   ///
   /// @attention required. (non-null)

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -418,7 +418,8 @@ typedef struct {
   /// The size of this struct. Must be sizeof(FlutterOpenGLSurface).
   size_t struct_size;
 
-  /// User data to be returned on the invocation of the destruction callback.
+  /// User data to be passed to the make_current, clear_current and
+  /// destruction callback.
   void* user_data;
 
   /// Callback invoked (on an engine managed thread) that asks the embedder to

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -419,7 +419,7 @@ typedef struct {
   size_t struct_size;
 
   /// User data to be passed to the make_current, clear_current and
-  /// destruction callback.
+  /// destruction callbacks.
   void* user_data;
 
   /// Callback invoked (on an engine managed thread) that asks the embedder to

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -454,7 +454,7 @@ typedef struct {
   /// @attention required. (non-null)
   FlutterOpenGLSurfaceCallback clear_current_callback;
 
-  /// Callback invoked (on an engine managed thread) that asks the embedder to
+  /// Callback invoked (on an engine-managed thread) that asks the embedder to
   /// collect the surface.
   ///
   /// @attention required. (non-null)

--- a/shell/platform/embedder/embedder_external_view.cc
+++ b/shell/platform/embedder/embedder_external_view.cc
@@ -172,7 +172,7 @@ bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
     return false;
   }
 
-  // clear the current render target (most likely EGLSurface) at the
+  // Clear the current render target (most likely EGLSurface) at the
   // end of this scope.
   fml::ScopedCleanupClosure clear_current_surface([&]() {
     auto [ok, invalidate_api_state] = render_target.MaybeClearCurrent();

--- a/shell/platform/embedder/embedder_external_view.cc
+++ b/shell/platform/embedder/embedder_external_view.cc
@@ -143,6 +143,12 @@ bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
     return false;
   }
 
+  bool invalidate_gl_state = render_target.MaybeMakeCurrent();
+  // TODO(ardera): Implement
+  // if (invalidate_gl_state) {
+  //   skia_surface->recordingContext()->asDirectContext()->resetContext(kAll_GrBackendState);
+  // }
+
   FML_DCHECK(render_target.GetRenderTargetSize() == render_surface_size_);
 
   auto canvas = skia_surface->getCanvas();

--- a/shell/platform/embedder/embedder_external_view.cc
+++ b/shell/platform/embedder/embedder_external_view.cc
@@ -7,6 +7,8 @@
 #include "flutter/display_list/dl_builder.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/common/dl_op_spy.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/GrRecordingContext.h"
 
 #ifdef IMPELLER_SUPPORTS_RENDERING
 #include "impeller/display_list/dl_dispatcher.h"  // nogncheck
@@ -88,8 +90,25 @@ const EmbeddedViewParams* EmbedderExternalView::GetEmbeddedViewParams() const {
   return embedded_view_params_.get();
 }
 
+static void InvalidateApiState(SkSurface& skia_surface) {
+  auto recording_context = skia_surface.recordingContext();
+
+  // Should never happen.
+  FML_DCHECK(recording_context) << "Recording context was null.";
+
+  auto direct_context = recording_context->asDirectContext();
+  if (direct_context == nullptr) {
+    // Can happen when using software rendering.
+    // Print an error but otherwise continue in that case.
+    FML_LOG(ERROR) << "Embedder asked to invalidate cached graphics API state "
+                      "but flutter is not using a graphics API.";
+  } else {
+    direct_context->resetContext(kAll_GrBackendState);
+  }
+}
+
 bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
-                                  bool clear_surface) {
+                                  bool clear_surface) { 
   TRACE_EVENT0("flutter", "EmbedderExternalView::Render");
   TryEndRecording();
   FML_DCHECK(HasEngineRenderedContents())
@@ -143,11 +162,27 @@ bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
     return false;
   }
 
-  bool invalidate_gl_state = render_target.MaybeMakeCurrent();
-  // TODO(ardera): Implement
-  // if (invalidate_gl_state) {
-  //   skia_surface->recordingContext()->asDirectContext()->resetContext(kAll_GrBackendState);
-  // }
+  auto [ok, invalidate_api_state] = render_target.MaybeMakeCurrent();
+
+  if (invalidate_api_state) {
+    InvalidateApiState(*skia_surface);
+  }
+  if (!ok) {
+    FML_LOG(ERROR) << "Could not make the surface current.";
+    return false;
+  }
+
+  // clear the current render target (most likely EGLSurface) at the
+  // end of this scope.
+  fml::ScopedCleanupClosure clear_surface([&]() {
+    auto [ok, invalidate_api_state] = render_target.MaybeClearCurrent();
+    if (invalidate_api_state) {
+      InvalidateApiState(*skia_surface);
+    }
+    if (!ok) {
+      FML_LOG(ERROR) << "Could not clear the current surface.";
+    }
+  });
 
   FML_DCHECK(render_target.GetRenderTargetSize() == render_surface_size_);
 

--- a/shell/platform/embedder/embedder_external_view.cc
+++ b/shell/platform/embedder/embedder_external_view.cc
@@ -90,6 +90,9 @@ const EmbeddedViewParams* EmbedderExternalView::GetEmbeddedViewParams() const {
   return embedded_view_params_.get();
 }
 
+// TODO(https://github.com/flutter/flutter/issues/151670): Implement this for
+//  Impeller as well.
+#if !SLIMPELLER
 static void InvalidateApiState(SkSurface& skia_surface) {
   auto recording_context = skia_surface.recordingContext();
 
@@ -106,6 +109,7 @@ static void InvalidateApiState(SkSurface& skia_surface) {
     direct_context->resetContext(kAll_GrBackendState);
   }
 }
+#endif
 
 bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
                                   bool clear_surface) {

--- a/shell/platform/embedder/embedder_external_view.cc
+++ b/shell/platform/embedder/embedder_external_view.cc
@@ -108,7 +108,7 @@ static void InvalidateApiState(SkSurface& skia_surface) {
 }
 
 bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
-                                  bool clear_surface) { 
+                                  bool clear_surface) {
   TRACE_EVENT0("flutter", "EmbedderExternalView::Render");
   TryEndRecording();
   FML_DCHECK(HasEngineRenderedContents())
@@ -174,7 +174,7 @@ bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
 
   // clear the current render target (most likely EGLSurface) at the
   // end of this scope.
-  fml::ScopedCleanupClosure clear_surface([&]() {
+  fml::ScopedCleanupClosure clear_current_surface([&]() {
     auto [ok, invalidate_api_state] = render_target.MaybeClearCurrent();
     if (invalidate_api_state) {
       InvalidateApiState(*skia_surface);

--- a/shell/platform/embedder/embedder_external_view.cc
+++ b/shell/platform/embedder/embedder_external_view.cc
@@ -101,7 +101,7 @@ static void InvalidateApiState(SkSurface& skia_surface) {
     // Can happen when using software rendering.
     // Print an error but otherwise continue in that case.
     FML_LOG(ERROR) << "Embedder asked to invalidate cached graphics API state "
-                      "but flutter is not using a graphics API.";
+                      "but Flutter is not using a graphics API.";
   } else {
     direct_context->resetContext(kAll_GrBackendState);
   }

--- a/shell/platform/embedder/embedder_render_target.h
+++ b/shell/platform/embedder/embedder_render_target.h
@@ -77,6 +77,18 @@ class EmbedderRenderTarget {
   ///
   const FlutterBackingStore* GetBackingStore() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Sometimes render targets are actually (for example)
+  ///             EGL surfaces instead of framebuffers or textures.
+  ///             In that case, we can't fully wrap them as SkSurfaces, instead,
+  ///             the embedder will provide a callback that should be called
+  ///             when the target surface should be made current.
+  ///
+  /// @return     True if any GL (not EGL) state has changed and skia should
+  ///             not assume any GL state values are the same as before
+  ///             MaybeMakeCurrent was called.
+  virtual bool MaybeMakeCurrent() const { return false; }
+
  protected:
   //----------------------------------------------------------------------------
   /// @brief      Creates a render target whose backing store is managed by the

--- a/shell/platform/embedder/embedder_render_target.h
+++ b/shell/platform/embedder/embedder_render_target.h
@@ -27,7 +27,19 @@ namespace flutter {
 ///
 class EmbedderRenderTarget {
  public:
-  using MakeOrClearCurrentCallback = std::function<std::pair<bool, bool>()>;
+  struct SetCurrentResult {
+    /// This is true if the operation succeeded (even if it was a no-op),
+    /// false if the surface could not be made current / the current surface
+    /// could not be cleared.
+    bool success;
+
+    /// This is true if any native graphics API (e.g. GL, but not EGL) state has
+    /// changed and Skia/Impeller should not assume any GL state values are the
+    /// same as before the context change operation was attempted.
+    bool gl_state_trampled;
+  };
+
+  using MakeOrClearCurrentCallback = std::function<SetCurrentResult()>;
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys this instance of the render target and invokes the
@@ -88,30 +100,14 @@ class EmbedderRenderTarget {
   ///             the embedder will provide a callback that should be called
   ///             when the target surface should be made current.
   ///
-  /// @return     A pair of booleans. The first bool is true if the operation
-  ///             succeeded (even if it was a no-op), false if the target could
-  ///             not be make current.
-  ///             The second boolean is true if any native graphics API
-  ///             (e.g. GL, but not EGL) state has changed and skia/impeller
-  ///             should not assume any GL state values are the same as before
-  ///             MaybeMakeCurrent was called.
-  virtual std::pair<bool, bool> MaybeMakeCurrent() const {
-    return {true, false};
-  }
+  /// @return     The result of the operation.
+  virtual SetCurrentResult MaybeMakeCurrent() const { return {true, false}; }
 
   //----------------------------------------------------------------------------
   /// @brief      Clear the current render target. @see MaybeMakeCurrent
   ///
-  /// @return     A pair of booleans. The first bool is true if the operation
-  ///             succeeded (even if it was a no-op), false if the target could
-  ///             not be cleared.
-  ///             The second boolean is true if any native graphics API
-  ///             (e.g. GL, but not EGL) state has changed and skia/impeller
-  ///             should not assume any GL state values are the same as before
-  ///             MaybeClearCurrent was called.
-  virtual std::pair<bool, bool> MaybeClearCurrent() const {
-    return {true, false};
-  }
+  /// @return     The result of the operation.
+  virtual SetCurrentResult MaybeClearCurrent() const { return {true, false}; }
 
  protected:
   //----------------------------------------------------------------------------

--- a/shell/platform/embedder/embedder_render_target.h
+++ b/shell/platform/embedder/embedder_render_target.h
@@ -27,6 +27,8 @@ namespace flutter {
 ///
 class EmbedderRenderTarget {
  public:
+  using MakeOrClearCurrentCallback = std::function<std::pair<bool, bool>()>;
+
   //----------------------------------------------------------------------------
   /// @brief      Destroys this instance of the render target and invokes the
   ///             callback for the embedder to release its resource associated
@@ -78,16 +80,38 @@ class EmbedderRenderTarget {
   const FlutterBackingStore* GetBackingStore() const;
 
   //----------------------------------------------------------------------------
-  /// @brief      Sometimes render targets are actually (for example)
+  /// @brief      Make the render target current.
+  ///
+  ///             Sometimes render targets are actually (for example)
   ///             EGL surfaces instead of framebuffers or textures.
   ///             In that case, we can't fully wrap them as SkSurfaces, instead,
   ///             the embedder will provide a callback that should be called
   ///             when the target surface should be made current.
   ///
-  /// @return     True if any GL (not EGL) state has changed and skia should
-  ///             not assume any GL state values are the same as before
+  /// @return     A pair of booleans. The first bool is true if the operation
+  ///             succeeded (even if it was a no-op), false if the target could
+  ///             not be make current.
+  ///             The second boolean is true if any native graphics API
+  ///             (e.g. GL, but not EGL) state has changed and skia/impeller
+  ///             should not assume any GL state values are the same as before
   ///             MaybeMakeCurrent was called.
-  virtual bool MaybeMakeCurrent() const { return false; }
+  virtual std::pair<bool, bool> MaybeMakeCurrent() const {
+    return {true, false};
+  }
+
+  //----------------------------------------------------------------------------
+  /// @brief      Clear the current render target. @see MaybeMakeCurrent
+  ///
+  /// @return     A pair of booleans. The first bool is true if the operation
+  ///             succeeded (even if it was a no-op), false if the target could
+  ///             not be cleared.
+  ///             The second boolean is true if any native graphics API
+  ///             (e.g. GL, but not EGL) state has changed and skia/impeller
+  ///             should not assume any GL state values are the same as before
+  ///             MaybeClearCurrent was called.
+  virtual std::pair<bool, bool> MaybeClearCurrent() const {
+    return {true, false};
+  }
 
  protected:
   //----------------------------------------------------------------------------

--- a/shell/platform/embedder/embedder_render_target_skia.cc
+++ b/shell/platform/embedder/embedder_render_target_skia.cc
@@ -11,9 +11,11 @@ namespace flutter {
 EmbedderRenderTargetSkia::EmbedderRenderTargetSkia(
     FlutterBackingStore backing_store,
     sk_sp<SkSurface> render_surface,
-    fml::closure on_release)
+    fml::closure on_release,
+    fml::closure on_make_current)
     : EmbedderRenderTarget(backing_store, std::move(on_release)),
-      render_surface_(std::move(render_surface)) {
+      render_surface_(std::move(render_surface)),
+      on_make_current_(std::move(on_make_current)) {
   FML_DCHECK(render_surface_);
 }
 

--- a/shell/platform/embedder/embedder_render_target_skia.cc
+++ b/shell/platform/embedder/embedder_render_target_skia.cc
@@ -41,7 +41,8 @@ SkISize EmbedderRenderTargetSkia::GetRenderTargetSize() const {
   return SkISize::Make(render_surface_->width(), render_surface_->height());
 }
 
-std::pair<bool, bool> EmbedderRenderTargetSkia::MaybeMakeCurrent() const {
+EmbedderRenderTarget::SetCurrentResult
+EmbedderRenderTargetSkia::MaybeMakeCurrent() const {
   if (on_make_current_ != nullptr) {
     return on_make_current_();
   }
@@ -49,7 +50,8 @@ std::pair<bool, bool> EmbedderRenderTargetSkia::MaybeMakeCurrent() const {
   return {true, false};
 }
 
-std::pair<bool, bool> EmbedderRenderTargetSkia::MaybeClearCurrent() const {
+EmbedderRenderTarget::SetCurrentResult
+EmbedderRenderTargetSkia::MaybeClearCurrent() const {
   if (on_clear_current_ != nullptr) {
     return on_clear_current_();
   }

--- a/shell/platform/embedder/embedder_render_target_skia.cc
+++ b/shell/platform/embedder/embedder_render_target_skia.cc
@@ -12,10 +12,12 @@ EmbedderRenderTargetSkia::EmbedderRenderTargetSkia(
     FlutterBackingStore backing_store,
     sk_sp<SkSurface> render_surface,
     fml::closure on_release,
-    fml::closure on_make_current)
+    MakeOrClearCurrentCallback on_make_current,
+    MakeOrClearCurrentCallback on_clear_current)
     : EmbedderRenderTarget(backing_store, std::move(on_release)),
       render_surface_(std::move(render_surface)),
-      on_make_current_(std::move(on_make_current)) {
+      on_make_current_(std::move(on_make_current)),
+      on_clear_current_(std::move(on_clear_current)) {
   FML_DCHECK(render_surface_);
 }
 
@@ -37,6 +39,22 @@ EmbedderRenderTargetSkia::GetAiksContext() const {
 
 SkISize EmbedderRenderTargetSkia::GetRenderTargetSize() const {
   return SkISize::Make(render_surface_->width(), render_surface_->height());
+}
+
+std::pair<bool, bool> EmbedderRenderTargetSkia::MaybeMakeCurrent() const {
+  if (on_make_current_ != nullptr) {
+    return on_make_current_();
+  }
+
+  return {true, false};
+}
+
+std::pair<bool, bool> EmbedderRenderTargetSkia::MaybeClearCurrent() const {
+  if (on_clear_current_ != nullptr) {
+    return on_clear_current_();
+  }
+
+  return {true, false};
 }
 
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_render_target_skia.h
+++ b/shell/platform/embedder/embedder_render_target_skia.h
@@ -31,6 +31,7 @@ class EmbedderRenderTargetSkia final : public EmbedderRenderTarget {
   // |EmbedderRenderTarget|
   SkISize GetRenderTargetSize() const override;
 
+  // |EmbedderRenderTarget|
   bool MaybeMakeCurrent() const override {
     if (on_make_current_ != nullptr) {
       on_make_current_();

--- a/shell/platform/embedder/embedder_render_target_skia.h
+++ b/shell/platform/embedder/embedder_render_target_skia.h
@@ -13,7 +13,8 @@ class EmbedderRenderTargetSkia final : public EmbedderRenderTarget {
  public:
   EmbedderRenderTargetSkia(FlutterBackingStore backing_store,
                            sk_sp<SkSurface> render_surface,
-                           fml::closure on_release);
+                           fml::closure on_release,
+                           fml::closure on_make_current);
 
   // |EmbedderRenderTarget|
   ~EmbedderRenderTargetSkia() override;
@@ -30,8 +31,21 @@ class EmbedderRenderTargetSkia final : public EmbedderRenderTarget {
   // |EmbedderRenderTarget|
   SkISize GetRenderTargetSize() const override;
 
+  bool MaybeMakeCurrent() const override {
+    if (on_make_current_ != nullptr) {
+      on_make_current_();
+
+      /// TODO: Implement return value
+      return false;
+    }
+
+    return false;
+  }
+
  private:
   sk_sp<SkSurface> render_surface_;
+
+  fml::closure on_make_current_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderRenderTargetSkia);
 };

--- a/shell/platform/embedder/embedder_render_target_skia.h
+++ b/shell/platform/embedder/embedder_render_target_skia.h
@@ -33,10 +33,10 @@ class EmbedderRenderTargetSkia final : public EmbedderRenderTarget {
   SkISize GetRenderTargetSize() const override;
 
   // |EmbedderRenderTarget|
-  std::pair<bool, bool> MaybeMakeCurrent() const override;
+  SetCurrentResult MaybeMakeCurrent() const override;
 
   // |EmbedderRenderTarget|
-  std::pair<bool, bool> MaybeClearCurrent() const override;
+  SetCurrentResult MaybeClearCurrent() const override;
 
  private:
   sk_sp<SkSurface> render_surface_;

--- a/shell/platform/embedder/embedder_render_target_skia.h
+++ b/shell/platform/embedder/embedder_render_target_skia.h
@@ -14,7 +14,8 @@ class EmbedderRenderTargetSkia final : public EmbedderRenderTarget {
   EmbedderRenderTargetSkia(FlutterBackingStore backing_store,
                            sk_sp<SkSurface> render_surface,
                            fml::closure on_release,
-                           fml::closure on_make_current);
+                           MakeOrClearCurrentCallback on_make_current,
+                           MakeOrClearCurrentCallback on_clear_current);
 
   // |EmbedderRenderTarget|
   ~EmbedderRenderTargetSkia() override;
@@ -32,21 +33,16 @@ class EmbedderRenderTargetSkia final : public EmbedderRenderTarget {
   SkISize GetRenderTargetSize() const override;
 
   // |EmbedderRenderTarget|
-  bool MaybeMakeCurrent() const override {
-    if (on_make_current_ != nullptr) {
-      on_make_current_();
+  std::pair<bool, bool> MaybeMakeCurrent() const override;
 
-      /// TODO: Implement return value
-      return false;
-    }
-
-    return false;
-  }
+  // |EmbedderRenderTarget|
+  std::pair<bool, bool> MaybeClearCurrent() const override;
 
  private:
   sk_sp<SkSurface> render_surface_;
 
-  fml::closure on_make_current_;
+  MakeOrClearCurrentCallback on_make_current_;
+  MakeOrClearCurrentCallback on_clear_current_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderRenderTargetSkia);
 };

--- a/shell/platform/embedder/tests/embedder_assertions.h
+++ b/shell/platform/embedder/tests/embedder_assertions.h
@@ -67,6 +67,13 @@ inline bool operator==(const FlutterOpenGLFramebuffer& a,
          a.destruction_callback == b.destruction_callback;
 }
 
+inline bool operator==(const FlutterOpenGLSurface& a,
+                       const FlutterOpenGLSurface& b) {
+  return a.make_current_callback == b.make_current_callback &&
+         a.user_data == b.user_data &&
+         a.destruction_callback == b.destruction_callback;
+}
+
 inline bool operator==(const FlutterMetalTexture& a,
                        const FlutterMetalTexture& b) {
   return a.texture_id == b.texture_id && a.texture == b.texture;
@@ -98,6 +105,8 @@ inline bool operator==(const FlutterOpenGLBackingStore& a,
       return a.texture == b.texture;
     case kFlutterOpenGLTargetTypeFramebuffer:
       return a.framebuffer == b.framebuffer;
+    case kFlutterOpenGLTargetTypeSurface:
+      return a.surface == b.surface;
   }
 
   return false;
@@ -297,6 +306,14 @@ inline std::ostream& operator<<(std::ostream& out,
 }
 
 inline std::ostream& operator<<(std::ostream& out,
+                                const FlutterOpenGLSurface& item) {
+  return out << "(FlutterOpenGLSurface) Make Current Callback: "
+             << reinterpret_cast<void*>(item.make_current_callback)
+             << " User Data: " << item.user_data << " Destruction Callback: "
+             << reinterpret_cast<void*>(item.destruction_callback);
+}
+
+inline std::ostream& operator<<(std::ostream& out,
                                 const FlutterMetalTexture& item) {
   return out << "(FlutterMetalTexture) Texture ID: " << std::hex
              << item.texture_id << std::dec << " Handle: 0x" << std::hex
@@ -368,6 +385,8 @@ inline std::string FlutterOpenGLTargetTypeToString(
       return "kFlutterOpenGLTargetTypeTexture";
     case kFlutterOpenGLTargetTypeFramebuffer:
       return "kFlutterOpenGLTargetTypeFramebuffer";
+    case kFlutterOpenGLTargetTypeSurface:
+      return "kFlutterOpenGLTargetTypeSurface";
   }
   return "Unknown";
 }
@@ -405,6 +424,9 @@ inline std::ostream& operator<<(std::ostream& out,
       break;
     case kFlutterOpenGLTargetTypeFramebuffer:
       out << item.framebuffer;
+      break;
+    case kFlutterOpenGLTargetTypeSurface:
+      out << item.surface;
       break;
   }
   return out;

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -407,11 +407,17 @@ void EmbedderConfigBuilder::SetRenderTargetType(
     EmbedderTestBackingStoreProducer::RenderTargetType type,
     FlutterSoftwarePixelFormat software_pixfmt) {
   auto& compositor = context_.GetCompositor();
+
+  auto producer = std::make_unique<EmbedderTestBackingStoreProducer>(
+      compositor.GetGrContext(), type, software_pixfmt);
+
+#ifdef SHELL_ENABLE_GL
+  producer->SetEGLContext(context_.egl_context_);
+#endif
+
   // TODO(wrightgeorge): figure out a better way of plumbing through the
   // GrDirectContext
-  compositor.SetBackingStoreProducer(
-      std::make_unique<EmbedderTestBackingStoreProducer>(
-          compositor.GetGrContext(), type, software_pixfmt));
+  compositor.SetBackingStoreProducer(std::move(producer));
 }
 
 UniqueEngine EmbedderConfigBuilder::LaunchEngine() const {

--- a/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -4806,6 +4806,330 @@ TEST_F(EmbedderTest, CanRenderWithImpellerOpenGL) {
   ASSERT_FALSE(present_called);
 }
 
+TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLSurface) {
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+
+  EmbedderConfigBuilder builder(context);
+  builder.SetOpenGLRendererConfig(SkISize::Make(800, 600));
+  builder.SetCompositor();
+  builder.SetDartEntrypoint("can_composite_platform_views");
+
+  builder.SetRenderTargetType(
+      EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLSurface);
+
+  fml::CountDownLatch latch(3);
+  context.GetCompositor().SetNextPresentCallback(
+      [&](const FlutterLayer** layers, size_t layers_count) {
+        ASSERT_EQ(layers_count, 3u);
+
+        {
+          FlutterBackingStore backing_store = *layers[0]->backing_store;
+          backing_store.struct_size = sizeof(backing_store);
+          backing_store.type = kFlutterBackingStoreTypeOpenGL;
+          backing_store.did_update = true;
+          backing_store.open_gl.type = kFlutterOpenGLTargetTypeSurface;
+
+          FlutterRect paint_region_rects[] = {
+              FlutterRectMakeLTRB(0, 0, 800, 600),
+          };
+          FlutterRegion paint_region = {
+              .struct_size = sizeof(FlutterRegion),
+              .rects_count = 1,
+              .rects = paint_region_rects,
+          };
+          FlutterBackingStorePresentInfo present_info = {
+              .struct_size = sizeof(FlutterBackingStorePresentInfo),
+              .paint_region = &paint_region,
+          };
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypeBackingStore;
+          layer.backing_store = &backing_store;
+          layer.size = FlutterSizeMake(800.0, 600.0);
+          layer.offset = FlutterPointMake(0, 0);
+          layer.backing_store_present_info = &present_info;
+          ASSERT_EQ(*layers[0], layer);
+        }
+
+        {
+          FlutterPlatformView platform_view = *layers[1]->platform_view;
+          platform_view.struct_size = sizeof(platform_view);
+          platform_view.identifier = 42;
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypePlatformView;
+          layer.platform_view = &platform_view;
+          layer.size = FlutterSizeMake(123.0, 456.0);
+          layer.offset = FlutterPointMake(1.0, 2.0);
+
+          ASSERT_EQ(*layers[1], layer);
+        }
+
+        {
+          FlutterBackingStore backing_store = *layers[2]->backing_store;
+          backing_store.struct_size = sizeof(backing_store);
+          backing_store.type = kFlutterBackingStoreTypeOpenGL;
+          backing_store.did_update = true;
+          backing_store.open_gl.type = kFlutterOpenGLTargetTypeSurface;
+
+          FlutterRect paint_region_rects[] = {
+              FlutterRectMakeLTRB(2, 3, 800, 600),
+          };
+          FlutterRegion paint_region = {
+              .struct_size = sizeof(FlutterRegion),
+              .rects_count = 1,
+              .rects = paint_region_rects,
+          };
+          FlutterBackingStorePresentInfo present_info = {
+              .struct_size = sizeof(FlutterBackingStorePresentInfo),
+              .paint_region = &paint_region,
+          };
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypeBackingStore;
+          layer.backing_store = &backing_store;
+          layer.size = FlutterSizeMake(800.0, 600.0);
+          layer.offset = FlutterPointMake(0.0, 0.0);
+          layer.backing_store_present_info = &present_info;
+
+          ASSERT_EQ(*layers[2], layer);
+        }
+
+        latch.CountDown();
+      });
+
+  context.AddNativeCallback(
+      "SignalNativeTest",
+      CREATE_NATIVE_ENTRY(
+          [&latch](Dart_NativeArguments args) { latch.CountDown(); }));
+
+  auto engine = builder.LaunchEngine();
+
+  // Send a window metrics events so frames may be scheduled.
+  FlutterWindowMetricsEvent event = {};
+  event.struct_size = sizeof(event);
+  event.width = 800;
+  event.height = 600;
+  event.pixel_ratio = 1.0;
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
+            kSuccess);
+  ASSERT_TRUE(engine.is_valid());
+
+  latch.Wait();
+}
+
+TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownSceneToOpenGLSurfaces) {
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+
+  EmbedderConfigBuilder builder(context);
+  builder.SetOpenGLRendererConfig(SkISize::Make(800, 600));
+  builder.SetCompositor();
+  builder.SetDartEntrypoint("can_composite_platform_views_with_known_scene");
+
+  builder.SetRenderTargetType(
+      EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLSurface);
+
+  fml::CountDownLatch latch(5);
+
+  auto scene_image = context.GetNextSceneImage();
+
+  context.GetCompositor().SetNextPresentCallback(
+      [&](const FlutterLayer** layers, size_t layers_count) {
+        ASSERT_EQ(layers_count, 5u);
+
+        // Layer Root
+        {
+          FlutterBackingStore backing_store = *layers[0]->backing_store;
+          backing_store.type = kFlutterBackingStoreTypeOpenGL;
+          backing_store.did_update = true;
+          backing_store.open_gl.type = kFlutterOpenGLTargetTypeSurface;
+
+          FlutterRect paint_region_rects[] = {
+              FlutterRectMakeLTRB(0, 0, 800, 600),
+          };
+          FlutterRegion paint_region = {
+              .struct_size = sizeof(FlutterRegion),
+              .rects_count = 1,
+              .rects = paint_region_rects,
+          };
+          FlutterBackingStorePresentInfo present_info = {
+              .struct_size = sizeof(FlutterBackingStorePresentInfo),
+              .paint_region = &paint_region,
+          };
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypeBackingStore;
+          layer.backing_store = &backing_store;
+          layer.size = FlutterSizeMake(800.0, 600.0);
+          layer.offset = FlutterPointMake(0.0, 0.0);
+          layer.backing_store_present_info = &present_info;
+
+          ASSERT_EQ(*layers[0], layer);
+        }
+
+        // Layer 1
+        {
+          FlutterPlatformView platform_view = *layers[1]->platform_view;
+          platform_view.struct_size = sizeof(platform_view);
+          platform_view.identifier = 1;
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypePlatformView;
+          layer.platform_view = &platform_view;
+          layer.size = FlutterSizeMake(50.0, 150.0);
+          layer.offset = FlutterPointMake(20.0, 20.0);
+
+          ASSERT_EQ(*layers[1], layer);
+        }
+
+        // Layer 2
+        {
+          FlutterBackingStore backing_store = *layers[2]->backing_store;
+          backing_store.type = kFlutterBackingStoreTypeOpenGL;
+          backing_store.did_update = true;
+          backing_store.open_gl.type = kFlutterOpenGLTargetTypeSurface;
+
+          FlutterRect paint_region_rects[] = {
+              FlutterRectMakeLTRB(30, 30, 80, 180),
+          };
+          FlutterRegion paint_region = {
+              .struct_size = sizeof(FlutterRegion),
+              .rects_count = 1,
+              .rects = paint_region_rects,
+          };
+          FlutterBackingStorePresentInfo present_info = {
+              .struct_size = sizeof(FlutterBackingStorePresentInfo),
+              .paint_region = &paint_region,
+          };
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypeBackingStore;
+          layer.backing_store = &backing_store;
+          layer.size = FlutterSizeMake(800.0, 600.0);
+          layer.offset = FlutterPointMake(0.0, 0.0);
+          layer.backing_store_present_info = &present_info;
+
+          ASSERT_EQ(*layers[2], layer);
+        }
+
+        // Layer 3
+        {
+          FlutterPlatformView platform_view = *layers[3]->platform_view;
+          platform_view.struct_size = sizeof(platform_view);
+          platform_view.identifier = 2;
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypePlatformView;
+          layer.platform_view = &platform_view;
+          layer.size = FlutterSizeMake(50.0, 150.0);
+          layer.offset = FlutterPointMake(40.0, 40.0);
+
+          ASSERT_EQ(*layers[3], layer);
+        }
+
+        // Layer 4
+        {
+          FlutterBackingStore backing_store = *layers[4]->backing_store;
+          backing_store.type = kFlutterBackingStoreTypeOpenGL;
+          backing_store.did_update = true;
+          backing_store.open_gl.type = kFlutterOpenGLTargetTypeSurface;
+
+          FlutterRect paint_region_rects[] = {
+              FlutterRectMakeLTRB(50, 50, 100, 200),
+          };
+          FlutterRegion paint_region = {
+              .struct_size = sizeof(FlutterRegion),
+              .rects_count = 1,
+              .rects = paint_region_rects,
+          };
+          FlutterBackingStorePresentInfo present_info = {
+              .struct_size = sizeof(FlutterBackingStorePresentInfo),
+              .paint_region = &paint_region,
+          };
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypeBackingStore;
+          layer.backing_store = &backing_store;
+          layer.size = FlutterSizeMake(800.0, 600.0);
+          layer.offset = FlutterPointMake(0.0, 0.0);
+          layer.backing_store_present_info = &present_info;
+
+          ASSERT_EQ(*layers[4], layer);
+        }
+
+        latch.CountDown();
+      });
+
+  context.GetCompositor().SetPlatformViewRendererCallback(
+      [&](const FlutterLayer& layer,
+          GrDirectContext* context) -> sk_sp<SkImage> {
+        auto surface = CreateRenderSurface(layer, context);
+        auto canvas = surface->getCanvas();
+        FML_CHECK(canvas != nullptr);
+
+        switch (layer.platform_view->identifier) {
+          case 1: {
+            SkPaint paint;
+            // See dart test for total order.
+            paint.setColor(SK_ColorGREEN);
+            paint.setAlpha(127);
+            const auto& rect =
+                SkRect::MakeWH(layer.size.width, layer.size.height);
+            canvas->drawRect(rect, paint);
+            latch.CountDown();
+          } break;
+          case 2: {
+            SkPaint paint;
+            // See dart test for total order.
+            paint.setColor(SK_ColorMAGENTA);
+            paint.setAlpha(127);
+            const auto& rect =
+                SkRect::MakeWH(layer.size.width, layer.size.height);
+            canvas->drawRect(rect, paint);
+            latch.CountDown();
+          } break;
+          default:
+            // Asked to render an unknown platform view.
+            FML_CHECK(false)
+                << "Test was asked to composite an unknown platform view.";
+        }
+
+        return surface->makeImageSnapshot();
+      });
+
+  context.AddNativeCallback(
+      "SignalNativeTest",
+      CREATE_NATIVE_ENTRY(
+          [&latch](Dart_NativeArguments args) { latch.CountDown(); }));
+
+  auto engine = builder.LaunchEngine();
+
+  // Send a window metrics events so frames may be scheduled.
+  FlutterWindowMetricsEvent event = {};
+  event.struct_size = sizeof(event);
+  event.width = 800;
+  event.height = 600;
+  event.pixel_ratio = 1.0;
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
+            kSuccess);
+  ASSERT_TRUE(engine.is_valid());
+
+  latch.Wait();
+
+  ASSERT_TRUE(ImageMatchesFixture("compositor.png", scene_image));
+
+  // There should no present calls on the root surface.
+  ASSERT_EQ(context.GetSurfacePresentCount(), 0u);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     EmbedderTestGlVk,
     EmbedderTestMultiBackend,

--- a/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -4819,7 +4819,8 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLSurface) {
 
   fml::CountDownLatch latch(3);
   context.GetCompositor().SetNextPresentCallback(
-      [&](const FlutterLayer** layers, size_t layers_count) {
+      [&](FlutterViewId view_id, const FlutterLayer** layers,
+          size_t layers_count) {
         ASSERT_EQ(layers_count, 3u);
 
         {
@@ -4937,7 +4938,8 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownSceneToOpenGLSurfaces) {
   auto scene_image = context.GetNextSceneImage();
 
   context.GetCompositor().SetNextPresentCallback(
-      [&](const FlutterLayer** layers, size_t layers_count) {
+      [&](FlutterViewId view_id, const FlutterLayer** layers,
+          size_t layers_count) {
         ASSERT_EQ(layers_count, 5u);
 
         // Layer Root

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -157,8 +157,6 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
   backing_store_out->open_gl.type = kFlutterOpenGLTargetTypeFramebuffer;
   backing_store_out->open_gl.framebuffer.target = framebuffer_info.fFormat;
   backing_store_out->open_gl.framebuffer.name = framebuffer_info.fFBOID;
-  // The balancing unref is in the destruction callback.
-  surface->ref();
   backing_store_out->open_gl.framebuffer.user_data = userdata;
   backing_store_out->open_gl.framebuffer.destruction_callback =
       [](void* user_data) { delete reinterpret_cast<GLUserData*>(user_data); };

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -80,7 +80,7 @@ void EmbedderTestBackingStoreProducer::SetEGLContext(
   // Ideally this would be set in the constructor, however we can't do that
   // without introducing different constructors depending on different graphics
   // APIs, which is a bit ugly.
-  test_egl_context_ = context;
+  test_egl_context_ = std::move(context);
 }
 #endif
 

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -150,7 +150,7 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
     return false;
   }
 
-  auto userdata = new GLUserData{nullptr, surface};
+  auto userdata = new UserData(surface);
 
   backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
   backing_store_out->user_data = userdata;
@@ -159,7 +159,7 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
   backing_store_out->open_gl.framebuffer.name = framebuffer_info.fFBOID;
   backing_store_out->open_gl.framebuffer.user_data = userdata;
   backing_store_out->open_gl.framebuffer.destruction_callback =
-      [](void* user_data) { delete reinterpret_cast<GLUserData*>(user_data); };
+      [](void* user_data) { delete reinterpret_cast<UserData*>(user_data); };
 
   return true;
 #else
@@ -203,7 +203,7 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(
     return false;
   }
 
-  auto userdata = new GLUserData{nullptr, surface};
+  auto userdata = new UserData(surface);
 
   backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
   backing_store_out->user_data = userdata;
@@ -213,7 +213,7 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(
   backing_store_out->open_gl.texture.format = texture_info.fFormat;
   backing_store_out->open_gl.texture.user_data = userdata;
   backing_store_out->open_gl.texture.destruction_callback =
-      [](void* user_data) { delete reinterpret_cast<GLUserData*>(user_data); };
+      [](void* user_data) { delete reinterpret_cast<UserData*>(user_data); };
 
   return true;
 #else
@@ -232,7 +232,7 @@ bool EmbedderTestBackingStoreProducer::CreateSurface(
 
   auto make_current = [](void* userdata, bool* invalidate_state) -> bool {
     *invalidate_state = false;
-    return reinterpret_cast<GLUserData*>(userdata)->gl_surface->MakeCurrent();
+    return reinterpret_cast<UserData*>(userdata)->gl_surface->MakeCurrent();
   };
 
   auto clear_current = [](void* userdata, bool* invalidate_state) -> bool {
@@ -243,15 +243,12 @@ bool EmbedderTestBackingStoreProducer::CreateSurface(
   };
 
   auto destruction_callback = [](void* userdata) {
-    delete reinterpret_cast<GLUserData*>(userdata);
+    delete reinterpret_cast<UserData*>(userdata);
   };
 
   auto sk_surface = surface->GetOnscreenSurface();
 
-  auto userdata = new GLUserData{
-      std::move(surface),
-      sk_surface,
-  };
+  auto userdata = new UserData(sk_surface, nullptr, std::move(surface));
 
   backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
   backing_store_out->user_data = userdata;
@@ -286,7 +283,7 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware(
     return false;
   }
 
-  auto userdata = new SWUserData{surface};
+  auto userdata = new UserData(surface);
 
   backing_store_out->type = kFlutterBackingStoreTypeSoftware;
   backing_store_out->user_data = userdata;
@@ -295,7 +292,7 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware(
   backing_store_out->software.height = pixmap.height();
   backing_store_out->software.user_data = userdata;
   backing_store_out->software.destruction_callback = [](void* user_data) {
-    delete reinterpret_cast<SWUserData*>(user_data);
+    delete reinterpret_cast<UserData*>(user_data);
   };
 
   return true;
@@ -323,7 +320,7 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware2(
     return false;
   }
 
-  auto userdata = new SWUserData{surface};
+  auto userdata = new UserData(surface);
 
   backing_store_out->type = kFlutterBackingStoreTypeSoftware2;
   backing_store_out->user_data = userdata;
@@ -334,7 +331,7 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware2(
   backing_store_out->software2.height = pixmap.height();
   backing_store_out->software2.user_data = userdata;
   backing_store_out->software2.destruction_callback = [](void* user_data) {
-    delete reinterpret_cast<SWUserData*>(user_data);
+    delete reinterpret_cast<UserData*>(user_data);
   };
   backing_store_out->software2.pixel_format = software_pixfmt_;
 
@@ -440,21 +437,14 @@ bool EmbedderTestBackingStoreProducer::CreateVulkanImage(
 
   // Collect all allocated resources in the destruction_callback.
   {
-    UserData* user_data = new UserData();
-    user_data->image = image;
-    user_data->surface = surface.get();
-
+    auto user_data = new UserData(surface, image);
     backing_store_out->user_data = user_data;
     backing_store_out->vulkan.user_data = user_data;
     backing_store_out->vulkan.destruction_callback = [](void* user_data) {
       UserData* d = reinterpret_cast<UserData*>(user_data);
-      d->surface->unref();
       delete d->image;
       delete d;
     };
-
-    // The balancing unref is in the destruction callback.
-    surface->ref();
   }
 
   return true;

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -150,14 +150,14 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
     return false;
   }
 
-  auto userdata = new UserData(surface);
+  auto user_data = new UserData(surface);
 
   backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
-  backing_store_out->user_data = userdata;
+  backing_store_out->user_data = user_data;
   backing_store_out->open_gl.type = kFlutterOpenGLTargetTypeFramebuffer;
   backing_store_out->open_gl.framebuffer.target = framebuffer_info.fFormat;
   backing_store_out->open_gl.framebuffer.name = framebuffer_info.fFBOID;
-  backing_store_out->open_gl.framebuffer.user_data = userdata;
+  backing_store_out->open_gl.framebuffer.user_data = user_data;
   backing_store_out->open_gl.framebuffer.destruction_callback =
       [](void* user_data) { delete reinterpret_cast<UserData*>(user_data); };
 
@@ -203,15 +203,15 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(
     return false;
   }
 
-  auto userdata = new UserData(surface);
+  auto user_data = new UserData(surface);
 
   backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
-  backing_store_out->user_data = userdata;
+  backing_store_out->user_data = user_data;
   backing_store_out->open_gl.type = kFlutterOpenGLTargetTypeTexture;
   backing_store_out->open_gl.texture.target = texture_info.fTarget;
   backing_store_out->open_gl.texture.name = texture_info.fID;
   backing_store_out->open_gl.texture.format = texture_info.fFormat;
-  backing_store_out->open_gl.texture.user_data = userdata;
+  backing_store_out->open_gl.texture.user_data = user_data;
   backing_store_out->open_gl.texture.destruction_callback =
       [](void* user_data) { delete reinterpret_cast<UserData*>(user_data); };
 
@@ -230,30 +230,30 @@ bool EmbedderTestBackingStoreProducer::CreateSurface(
       test_egl_context_,
       SkSize::Make(config->size.width, config->size.height).toRound());
 
-  auto make_current = [](void* userdata, bool* invalidate_state) -> bool {
+  auto make_current = [](void* user_data, bool* invalidate_state) -> bool {
     *invalidate_state = false;
-    return reinterpret_cast<UserData*>(userdata)->gl_surface->MakeCurrent();
+    return reinterpret_cast<UserData*>(user_data)->gl_surface->MakeCurrent();
   };
 
-  auto clear_current = [](void* userdata, bool* invalidate_state) -> bool {
+  auto clear_current = [](void* user_data, bool* invalidate_state) -> bool {
     *invalidate_state = false;
     // return
-    // reinterpret_cast<GLUserData*>(userdata)->gl_surface->ClearCurrent();
+    // reinterpret_cast<GLUserData*>(user_data)->gl_surface->ClearCurrent();
     return true;
   };
 
-  auto destruction_callback = [](void* userdata) {
-    delete reinterpret_cast<UserData*>(userdata);
+  auto destruction_callback = [](void* user_data) {
+    delete reinterpret_cast<UserData*>(user_data);
   };
 
   auto sk_surface = surface->GetOnscreenSurface();
 
-  auto userdata = new UserData(sk_surface, nullptr, std::move(surface));
+  auto user_data = new UserData(sk_surface, nullptr, std::move(surface));
 
   backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
-  backing_store_out->user_data = userdata;
+  backing_store_out->user_data = user_data;
   backing_store_out->open_gl.type = kFlutterOpenGLTargetTypeSurface;
-  backing_store_out->open_gl.surface.user_data = userdata;
+  backing_store_out->open_gl.surface.user_data = user_data;
   backing_store_out->open_gl.surface.make_current_callback = make_current;
   backing_store_out->open_gl.surface.clear_current_callback = clear_current;
   backing_store_out->open_gl.surface.destruction_callback =
@@ -283,14 +283,14 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware(
     return false;
   }
 
-  auto userdata = new UserData(surface);
+  auto user_data = new UserData(surface);
 
   backing_store_out->type = kFlutterBackingStoreTypeSoftware;
-  backing_store_out->user_data = userdata;
+  backing_store_out->user_data = user_data;
   backing_store_out->software.allocation = pixmap.addr();
   backing_store_out->software.row_bytes = pixmap.rowBytes();
   backing_store_out->software.height = pixmap.height();
-  backing_store_out->software.user_data = userdata;
+  backing_store_out->software.user_data = user_data;
   backing_store_out->software.destruction_callback = [](void* user_data) {
     delete reinterpret_cast<UserData*>(user_data);
   };
@@ -320,16 +320,16 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware2(
     return false;
   }
 
-  auto userdata = new UserData(surface);
+  auto user_data = new UserData(surface);
 
   backing_store_out->type = kFlutterBackingStoreTypeSoftware2;
-  backing_store_out->user_data = userdata;
+  backing_store_out->user_data = user_data;
   backing_store_out->software2.struct_size =
       sizeof(FlutterSoftwareBackingStore2);
   backing_store_out->software2.allocation = pixmap.writable_addr();
   backing_store_out->software2.row_bytes = pixmap.rowBytes();
   backing_store_out->software2.height = pixmap.height();
-  backing_store_out->software2.user_data = userdata;
+  backing_store_out->software2.user_data = user_data;
   backing_store_out->software2.destruction_callback = [](void* user_data) {
     delete reinterpret_cast<UserData*>(user_data);
   };

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -29,11 +29,11 @@
 #ifdef SHELL_ENABLE_METAL
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
-#endif // SHELL_ENABLE_METAL
+#endif  // SHELL_ENABLE_METAL
 
 #ifdef SHELL_ENABLE_GL
 #include "flutter/testing/test_gl_surface.h"
-#endif // SHELL_ENABLE_GL
+#endif  // SHELL_ENABLE_GL
 
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
 // NOLINTBEGIN(bugprone-unchecked-optional-access)

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -288,7 +288,7 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware(
     return false;
   }
 
-  auto userdata = new GLUserData{nullptr, surface};
+  auto userdata = new SWUserData{surface};
 
   backing_store_out->type = kFlutterBackingStoreTypeSoftware;
   backing_store_out->user_data = userdata;
@@ -297,7 +297,7 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware(
   backing_store_out->software.height = pixmap.height();
   backing_store_out->software.user_data = userdata;
   backing_store_out->software.destruction_callback = [](void* user_data) {
-    delete reinterpret_cast<GLUserData*>(user_data);
+    delete reinterpret_cast<SWUserData*>(user_data);
   };
 
   return true;
@@ -325,7 +325,7 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware2(
     return false;
   }
 
-  auto userdata = new GLUserData{nullptr, surface};
+  auto userdata = new SWUserData{surface};
 
   backing_store_out->type = kFlutterBackingStoreTypeSoftware2;
   backing_store_out->user_data = userdata;
@@ -336,7 +336,7 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware2(
   backing_store_out->software2.height = pixmap.height();
   backing_store_out->software2.user_data = userdata;
   backing_store_out->software2.destruction_callback = [](void* user_data) {
-    delete reinterpret_cast<GLUserData*>(user_data);
+    delete reinterpret_cast<SWUserData*>(user_data);
   };
   backing_store_out->software2.pixel_format = software_pixfmt_;
 

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -29,7 +29,11 @@
 #ifdef SHELL_ENABLE_METAL
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
-#endif
+#endif // SHELL_ENABLE_METAL
+
+#ifdef SHELL_ENABLE_GL
+#include "flutter/testing/test_gl_surface.h"
+#endif // SHELL_ENABLE_GL
 
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
@@ -44,6 +48,10 @@ EmbedderTestBackingStoreProducer::EmbedderTestBackingStoreProducer(
     : context_(std::move(context)),
       type_(type),
       software_pixfmt_(software_pixfmt)
+#ifdef SHELL_ENABLE_GL
+      ,
+      test_egl_context_(nullptr)
+#endif
 #ifdef SHELL_ENABLE_METAL
       ,
       test_metal_context_(std::make_unique<TestMetalContext>())
@@ -66,6 +74,16 @@ EmbedderTestBackingStoreProducer::EmbedderTestBackingStoreProducer(
 
 EmbedderTestBackingStoreProducer::~EmbedderTestBackingStoreProducer() = default;
 
+#ifdef SHELL_ENABLE_GL
+void EmbedderTestBackingStoreProducer::SetEGLContext(
+    std::shared_ptr<TestEGLContext> context) {
+  // Ideally this would be set in the constructor, however we can't do that
+  // without introducing different constructors depending on different graphics
+  // APIs, which is a bit ugly.
+  test_egl_context_ = context;
+}
+#endif
+
 bool EmbedderTestBackingStoreProducer::Create(
     const FlutterBackingStoreConfig* config,
     FlutterBackingStore* renderer_out) {
@@ -79,6 +97,8 @@ bool EmbedderTestBackingStoreProducer::Create(
       return CreateTexture(config, renderer_out);
     case RenderTargetType::kOpenGLFramebuffer:
       return CreateFramebuffer(config, renderer_out);
+    case RenderTargetType::kOpenGLSurface:
+      return CreateSurface(config, renderer_out);
 #endif
 #ifdef SHELL_ENABLE_METAL
     case RenderTargetType::kMetalTexture:
@@ -130,16 +150,18 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
     return false;
   }
 
+  auto userdata = new GLUserData{nullptr, surface};
+
   backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
-  backing_store_out->user_data = surface.get();
+  backing_store_out->user_data = userdata;
   backing_store_out->open_gl.type = kFlutterOpenGLTargetTypeFramebuffer;
   backing_store_out->open_gl.framebuffer.target = framebuffer_info.fFormat;
   backing_store_out->open_gl.framebuffer.name = framebuffer_info.fFBOID;
   // The balancing unref is in the destruction callback.
   surface->ref();
-  backing_store_out->open_gl.framebuffer.user_data = surface.get();
+  backing_store_out->open_gl.framebuffer.user_data = userdata;
   backing_store_out->open_gl.framebuffer.destruction_callback =
-      [](void* user_data) { reinterpret_cast<SkSurface*>(user_data)->unref(); };
+      [](void* user_data) { delete reinterpret_cast<GLUserData*>(user_data); };
 
   return true;
 #else
@@ -183,17 +205,64 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(
     return false;
   }
 
+  auto userdata = new GLUserData{nullptr, surface};
+
   backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
-  backing_store_out->user_data = surface.get();
+  backing_store_out->user_data = userdata;
   backing_store_out->open_gl.type = kFlutterOpenGLTargetTypeTexture;
   backing_store_out->open_gl.texture.target = texture_info.fTarget;
   backing_store_out->open_gl.texture.name = texture_info.fID;
   backing_store_out->open_gl.texture.format = texture_info.fFormat;
-  // The balancing unref is in the destruction callback.
-  surface->ref();
-  backing_store_out->open_gl.texture.user_data = surface.get();
+  backing_store_out->open_gl.texture.user_data = userdata;
   backing_store_out->open_gl.texture.destruction_callback =
-      [](void* user_data) { reinterpret_cast<SkSurface*>(user_data)->unref(); };
+      [](void* user_data) { delete reinterpret_cast<GLUserData*>(user_data); };
+
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool EmbedderTestBackingStoreProducer::CreateSurface(
+    const FlutterBackingStoreConfig* config,
+    FlutterBackingStore* backing_store_out) {
+#ifdef SHELL_ENABLE_GL
+  FML_CHECK(test_egl_context_);
+  auto surface = std::make_unique<TestGLOnscreenOnlySurface>(
+      test_egl_context_,
+      SkSize::Make(config->size.width, config->size.height).toRound());
+
+  auto make_current = [](void* userdata, bool* invalidate_state) -> bool {
+    *invalidate_state = false;
+    return reinterpret_cast<GLUserData*>(userdata)->gl_surface->MakeCurrent();
+  };
+
+  auto clear_current = [](void* userdata, bool* invalidate_state) -> bool {
+    *invalidate_state = false;
+    // return
+    // reinterpret_cast<GLUserData*>(userdata)->gl_surface->ClearCurrent();
+    return true;
+  };
+
+  auto destruction_callback = [](void* userdata) {
+    delete reinterpret_cast<GLUserData*>(userdata);
+  };
+
+  auto sk_surface = surface->GetOnscreenSurface();
+
+  auto userdata = new GLUserData{
+      std::move(surface),
+      sk_surface,
+  };
+
+  backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
+  backing_store_out->user_data = userdata;
+  backing_store_out->open_gl.type = kFlutterOpenGLTargetTypeSurface;
+  backing_store_out->open_gl.surface.user_data = userdata;
+  backing_store_out->open_gl.surface.make_current_callback = make_current;
+  backing_store_out->open_gl.surface.clear_current_callback = clear_current;
+  backing_store_out->open_gl.surface.destruction_callback =
+      destruction_callback;
 
   return true;
 #else
@@ -219,16 +288,16 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware(
     return false;
   }
 
+  auto userdata = new GLUserData{nullptr, surface};
+
   backing_store_out->type = kFlutterBackingStoreTypeSoftware;
-  backing_store_out->user_data = surface.get();
+  backing_store_out->user_data = userdata;
   backing_store_out->software.allocation = pixmap.addr();
   backing_store_out->software.row_bytes = pixmap.rowBytes();
   backing_store_out->software.height = pixmap.height();
-  // The balancing unref is in the destruction callback.
-  surface->ref();
-  backing_store_out->software.user_data = surface.get();
+  backing_store_out->software.user_data = userdata;
   backing_store_out->software.destruction_callback = [](void* user_data) {
-    reinterpret_cast<SkSurface*>(user_data)->unref();
+    delete reinterpret_cast<GLUserData*>(user_data);
   };
 
   return true;
@@ -256,19 +325,18 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware2(
     return false;
   }
 
+  auto userdata = new GLUserData{nullptr, surface};
+
   backing_store_out->type = kFlutterBackingStoreTypeSoftware2;
-  backing_store_out->user_data = surface.get();
+  backing_store_out->user_data = userdata;
   backing_store_out->software2.struct_size =
       sizeof(FlutterSoftwareBackingStore2);
-  backing_store_out->software2.user_data = surface.get();
   backing_store_out->software2.allocation = pixmap.writable_addr();
   backing_store_out->software2.row_bytes = pixmap.rowBytes();
   backing_store_out->software2.height = pixmap.height();
-  // The balancing unref is in the destruction callback.
-  surface->ref();
-  backing_store_out->software2.user_data = surface.get();
+  backing_store_out->software2.user_data = userdata;
   backing_store_out->software2.destruction_callback = [](void* user_data) {
-    reinterpret_cast<SkSurface*>(user_data)->unref();
+    delete reinterpret_cast<GLUserData*>(user_data);
   };
   backing_store_out->software2.pixel_format = software_pixfmt_;
 

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -35,10 +35,16 @@ class EmbedderTestBackingStoreProducer {
     FlutterVulkanImage* image;
   };
 
+  struct SWUserData {
+    sk_sp<SkSurface> surface;
+  };
+
+#ifdef SHELL_ENABLE_GL
   struct GLUserData {
     std::unique_ptr<TestGLOnscreenOnlySurface> gl_surface;
     sk_sp<SkSurface> surface;
   };
+#endif
 
   enum class RenderTargetType {
     kSoftwareBuffer,
@@ -56,7 +62,9 @@ class EmbedderTestBackingStoreProducer {
                                        kFlutterSoftwarePixelFormatNative32);
   ~EmbedderTestBackingStoreProducer();
 
+#ifdef SHELL_ENABLE_GL
   void SetEGLContext(std::shared_ptr<TestEGLContext> context);
+#endif
 
   bool Create(const FlutterBackingStoreConfig* config,
               FlutterBackingStore* renderer_out);

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -33,10 +33,11 @@ class EmbedderTestBackingStoreProducer {
   struct UserData {
     UserData() : surface(nullptr), image(nullptr){};
 
-    UserData(sk_sp<SkSurface> surface) : surface(surface), image(nullptr){};
+    explicit UserData(sk_sp<SkSurface> surface)
+        : surface(std::move(surface)), image(nullptr){};
 
     UserData(sk_sp<SkSurface> surface, FlutterVulkanImage* vk_image)
-        : surface(surface), image(vk_image){};
+        : surface(std::move(surface)), image(vk_image){};
 
     sk_sp<SkSurface> surface;
     FlutterVulkanImage* image;
@@ -44,7 +45,7 @@ class EmbedderTestBackingStoreProducer {
     UserData(sk_sp<SkSurface> surface,
              FlutterVulkanImage* vk_image,
              std::unique_ptr<TestGLOnscreenOnlySurface> gl_surface)
-        : surface(surface),
+        : surface(std::move(surface)),
           image(vk_image),
           gl_surface(std::move(gl_surface)){};
 

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -31,20 +31,26 @@ namespace testing {
 class EmbedderTestBackingStoreProducer {
  public:
   struct UserData {
-    SkSurface* surface;
+    UserData() : surface(nullptr), image(nullptr){};
+
+    UserData(sk_sp<SkSurface> surface) : surface(surface), image(nullptr){};
+
+    UserData(sk_sp<SkSurface> surface, FlutterVulkanImage* vk_image)
+        : surface(surface), image(vk_image){};
+
+    sk_sp<SkSurface> surface;
     FlutterVulkanImage* image;
-  };
-
-  struct SWUserData {
-    sk_sp<SkSurface> surface;
-  };
-
 #ifdef SHELL_ENABLE_GL
-  struct GLUserData {
+    UserData(sk_sp<SkSurface> surface,
+             FlutterVulkanImage* vk_image,
+             std::unique_ptr<TestGLOnscreenOnlySurface> gl_surface)
+        : surface(surface),
+          image(vk_image),
+          gl_surface(std::move(gl_surface)){};
+
     std::unique_ptr<TestGLOnscreenOnlySurface> gl_surface;
-    sk_sp<SkSurface> surface;
-  };
 #endif
+  };
 
   enum class RenderTargetType {
     kSoftwareBuffer,

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -21,6 +21,10 @@
 #include "flutter/testing/test_vulkan_context.h"  // nogncheck
 #endif
 
+#ifdef SHELL_ENABLE_GL
+#include "flutter/testing/test_gl_surface.h"
+#endif
+
 namespace flutter {
 namespace testing {
 
@@ -31,11 +35,17 @@ class EmbedderTestBackingStoreProducer {
     FlutterVulkanImage* image;
   };
 
+  struct GLUserData {
+    std::unique_ptr<TestGLOnscreenOnlySurface> gl_surface;
+    sk_sp<SkSurface> surface;
+  };
+
   enum class RenderTargetType {
     kSoftwareBuffer,
     kSoftwareBuffer2,
     kOpenGLFramebuffer,
     kOpenGLTexture,
+    kOpenGLSurface,
     kMetalTexture,
     kVulkanImage,
   };
@@ -46,6 +56,8 @@ class EmbedderTestBackingStoreProducer {
                                        kFlutterSoftwarePixelFormatNative32);
   ~EmbedderTestBackingStoreProducer();
 
+  void SetEGLContext(std::shared_ptr<TestEGLContext> context);
+
   bool Create(const FlutterBackingStoreConfig* config,
               FlutterBackingStore* renderer_out);
 
@@ -54,6 +66,9 @@ class EmbedderTestBackingStoreProducer {
                          FlutterBackingStore* renderer_out);
 
   bool CreateTexture(const FlutterBackingStoreConfig* config,
+                     FlutterBackingStore* renderer_out);
+
+  bool CreateSurface(const FlutterBackingStoreConfig* config,
                      FlutterBackingStore* renderer_out);
 
   bool CreateSoftware(const FlutterBackingStoreConfig* config,
@@ -71,6 +86,10 @@ class EmbedderTestBackingStoreProducer {
   sk_sp<GrDirectContext> context_;
   RenderTargetType type_;
   FlutterSoftwarePixelFormat software_pixfmt_;
+
+#ifdef SHELL_ENABLE_GL
+  std::shared_ptr<TestEGLContext> test_egl_context_;
+#endif
 
 #ifdef SHELL_ENABLE_METAL
   std::unique_ptr<TestMetalContext> test_metal_context_;

--- a/shell/platform/embedder/tests/embedder_test_compositor_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_gl.cc
@@ -60,7 +60,7 @@ bool EmbedderTestCompositorGL::UpdateOffscrenComposition(
     switch (layer->type) {
       case kFlutterLayerContentTypeBackingStore: {
         auto gl_user_data =
-            reinterpret_cast<EmbedderTestBackingStoreProducer::GLUserData*>(
+            reinterpret_cast<EmbedderTestBackingStoreProducer::UserData*>(
                 layer->backing_store->user_data);
 
         if (gl_user_data->gl_surface != nullptr) {

--- a/shell/platform/embedder/tests/embedder_test_compositor_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_gl.cc
@@ -58,12 +58,29 @@ bool EmbedderTestCompositorGL::UpdateOffscrenComposition(
     SkIPoint canvas_offset = SkIPoint::Make(0, 0);
 
     switch (layer->type) {
-      case kFlutterLayerContentTypeBackingStore:
-        layer_image =
-            reinterpret_cast<SkSurface*>(layer->backing_store->user_data)
-                ->makeImageSnapshot();
+      case kFlutterLayerContentTypeBackingStore: {
+        auto gl_user_data =
+            reinterpret_cast<EmbedderTestBackingStoreProducer::GLUserData*>(
+                layer->backing_store->user_data);
 
+        if (gl_user_data->gl_surface != nullptr) {
+          // This backing store is a OpenGL Surface.
+          // We need to make it current so we can snapshot it.
+
+          gl_user_data->gl_surface->MakeCurrent();
+
+          // GetRasterSurfaceSnapshot() does two
+          // gl_surface->makeImageSnapshot()'s. Doing a single
+          // ->makeImageSnapshot() will not work.
+          layer_image = gl_user_data->gl_surface->GetRasterSurfaceSnapshot();
+        } else {
+          layer_image = gl_user_data->surface->makeImageSnapshot();
+        }
+
+        // We don't clear the current surface here because we need the
+        // EGL context to be current for surface->makeImageSnapshot() below.
         break;
+      }
       case kFlutterLayerContentTypePlatformView:
         layer_image =
             platform_view_renderer_callback_

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.cc
@@ -48,7 +48,7 @@ bool EmbedderTestCompositorSoftware::UpdateOffscrenComposition(
     switch (layer->type) {
       case kFlutterLayerContentTypeBackingStore:
         layer_image =
-            reinterpret_cast<EmbedderTestBackingStoreProducer::GLUserData*>(
+            reinterpret_cast<EmbedderTestBackingStoreProducer::SWUserData*>(
                 layer->backing_store->user_data)
                 ->surface->makeImageSnapshot();
 

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.cc
@@ -48,7 +48,7 @@ bool EmbedderTestCompositorSoftware::UpdateOffscrenComposition(
     switch (layer->type) {
       case kFlutterLayerContentTypeBackingStore:
         layer_image =
-            reinterpret_cast<EmbedderTestBackingStoreProducer::SWUserData*>(
+            reinterpret_cast<EmbedderTestBackingStoreProducer::UserData*>(
                 layer->backing_store->user_data)
                 ->surface->makeImageSnapshot();
 

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.cc
@@ -48,9 +48,9 @@ bool EmbedderTestCompositorSoftware::UpdateOffscrenComposition(
     switch (layer->type) {
       case kFlutterLayerContentTypeBackingStore:
         layer_image =
-            reinterpret_cast<EmbedderTestBackingStoreProducer::GLUserData*>(layer->backing_store->user_data)
-                ->surface
-                ->makeImageSnapshot();
+            reinterpret_cast<EmbedderTestBackingStoreProducer::GLUserData*>(
+                layer->backing_store->user_data)
+                ->surface->makeImageSnapshot();
 
         break;
       case kFlutterLayerContentTypePlatformView:

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.cc
@@ -48,7 +48,8 @@ bool EmbedderTestCompositorSoftware::UpdateOffscrenComposition(
     switch (layer->type) {
       case kFlutterLayerContentTypeBackingStore:
         layer_image =
-            reinterpret_cast<SkSurface*>(layer->backing_store->user_data)
+            reinterpret_cast<EmbedderTestBackingStoreProducer::GLUserData*>(layer->backing_store->user_data)
+                ->surface
                 ->makeImageSnapshot();
 
         break;

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -122,6 +122,10 @@ class EmbedderTestContext {
   fml::RefPtr<TestVulkanContext> vulkan_context_ = nullptr;
 #endif
 
+#ifdef SHELL_ENABLE_GL
+  std::shared_ptr<TestEGLContext> egl_context_ = nullptr;
+#endif
+
   std::string assets_path_;
   ELFAOTSymbols aot_symbols_;
   std::unique_ptr<fml::Mapping> vm_snapshot_data_;

--- a/shell/platform/embedder/tests/embedder_test_context_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_context_gl.cc
@@ -20,7 +20,9 @@ namespace flutter {
 namespace testing {
 
 EmbedderTestContextGL::EmbedderTestContextGL(std::string assets_path)
-    : EmbedderTestContext(std::move(assets_path)) {}
+    : EmbedderTestContext(std::move(assets_path)) {
+  egl_context_ = std::make_shared<TestEGLContext>();
+}
 
 EmbedderTestContextGL::~EmbedderTestContextGL() {
   SetGLGetFBOCallback(nullptr);
@@ -28,7 +30,7 @@ EmbedderTestContextGL::~EmbedderTestContextGL() {
 
 void EmbedderTestContextGL::SetupSurface(SkISize surface_size) {
   FML_CHECK(!gl_surface_);
-  gl_surface_ = std::make_unique<TestGLSurface>(surface_size);
+  gl_surface_ = std::make_unique<TestGLSurface>(egl_context_, surface_size);
 }
 
 bool EmbedderTestContextGL::GLMakeCurrent() {

--- a/shell/platform/embedder/tests/embedder_test_context_gl.h
+++ b/shell/platform/embedder/tests/embedder_test_context_gl.h
@@ -67,6 +67,8 @@ class EmbedderTestContextGL : public EmbedderTestContext {
  protected:
   virtual void SetupCompositor() override;
 
+  void SetupCompositorUsingGLSurfaces();
+
  private:
   // This allows the builder to access the hooks.
   friend class EmbedderConfigBuilder;

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2735,8 +2735,9 @@ static void expectSoftwareRenderingOutputMatches(
         ASSERT_EQ(layers[0]->backing_store->type,
                   kFlutterBackingStoreTypeSoftware2);
         matches = SurfacePixelDataMatchesBytes(
-            static_cast<SkSurface*>(
-                layers[0]->backing_store->software2.user_data),
+            reinterpret_cast<EmbedderTestBackingStoreProducer::GLUserData*>(
+                layers[0]->backing_store->software2.user_data)
+                ->surface.get(),
             bytes);
         latch.Signal();
       });

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2735,7 +2735,7 @@ static void expectSoftwareRenderingOutputMatches(
         ASSERT_EQ(layers[0]->backing_store->type,
                   kFlutterBackingStoreTypeSoftware2);
         matches = SurfacePixelDataMatchesBytes(
-            reinterpret_cast<EmbedderTestBackingStoreProducer::SWUserData*>(
+            reinterpret_cast<EmbedderTestBackingStoreProducer::UserData*>(
                 layers[0]->backing_store->software2.user_data)
                 ->surface.get(),
             bytes);

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2735,7 +2735,7 @@ static void expectSoftwareRenderingOutputMatches(
         ASSERT_EQ(layers[0]->backing_store->type,
                   kFlutterBackingStoreTypeSoftware2);
         matches = SurfacePixelDataMatchesBytes(
-            reinterpret_cast<EmbedderTestBackingStoreProducer::GLUserData*>(
+            reinterpret_cast<EmbedderTestBackingStoreProducer::SWUserData*>(
                 layers[0]->backing_store->software2.user_data)
                 ->surface.get(),
             bytes);

--- a/testing/test_gl_surface.cc
+++ b/testing/test_gl_surface.cc
@@ -130,15 +130,14 @@ static EGLDisplay CreateSwangleDisplay() {
       display_config);
 }
 
-TestGLSurface::TestGLSurface(SkISize surface_size)
-    : surface_size_(surface_size) {
-  display_ = CreateSwangleDisplay();
-  FML_CHECK(display_ != EGL_NO_DISPLAY);
+TestEGLContext::TestEGLContext() {
+  display = CreateSwangleDisplay();
+  FML_CHECK(display != EGL_NO_DISPLAY);
 
-  auto result = ::eglInitialize(display_, nullptr, nullptr);
+  auto result = ::eglInitialize(display, nullptr, nullptr);
   FML_CHECK(result == EGL_TRUE) << GetEGLError();
 
-  EGLConfig config = {0};
+  config = {0};
 
   EGLint num_config = 0;
   const EGLint attribute_list[] = {EGL_RED_SIZE,
@@ -157,38 +156,9 @@ TestGLSurface::TestGLSurface(SkISize surface_size)
                                    EGL_OPENGL_ES2_BIT,
                                    EGL_NONE};
 
-  result = ::eglChooseConfig(display_, attribute_list, &config, 1, &num_config);
+  result = ::eglChooseConfig(display, attribute_list, &config, 1, &num_config);
   FML_CHECK(result == EGL_TRUE) << GetEGLError();
   FML_CHECK(num_config == 1) << GetEGLError();
-
-  {
-    const EGLint onscreen_surface_attributes[] = {
-        EGL_WIDTH,  surface_size_.width(),   //
-        EGL_HEIGHT, surface_size_.height(),  //
-        EGL_NONE,
-    };
-
-    onscreen_surface_ = ::eglCreatePbufferSurface(
-        display_,                    // display connection
-        config,                      // config
-        onscreen_surface_attributes  // surface attributes
-    );
-    FML_CHECK(onscreen_surface_ != EGL_NO_SURFACE) << GetEGLError();
-  }
-
-  {
-    const EGLint offscreen_surface_attributes[] = {
-        EGL_WIDTH,  1,  //
-        EGL_HEIGHT, 1,  //
-        EGL_NONE,
-    };
-    offscreen_surface_ = ::eglCreatePbufferSurface(
-        display_,                     // display connection
-        config,                       // config
-        offscreen_surface_attributes  // surface attributes
-    );
-    FML_CHECK(offscreen_surface_ != EGL_NO_SURFACE) << GetEGLError();
-  }
 
   {
     const EGLint context_attributes[] = {
@@ -197,50 +167,68 @@ TestGLSurface::TestGLSurface(SkISize surface_size)
         EGL_NONE                     //
     };
 
-    onscreen_context_ =
-        ::eglCreateContext(display_,           // display connection
+    onscreen_context =
+        ::eglCreateContext(display,            // display connection
                            config,             // config
                            EGL_NO_CONTEXT,     // sharegroup
                            context_attributes  // context attributes
         );
-    FML_CHECK(onscreen_context_ != EGL_NO_CONTEXT) << GetEGLError();
+    FML_CHECK(onscreen_context != EGL_NO_CONTEXT) << GetEGLError();
 
-    offscreen_context_ =
-        ::eglCreateContext(display_,           // display connection
+    offscreen_context =
+        ::eglCreateContext(display,            // display connection
                            config,             // config
-                           onscreen_context_,  // sharegroup
+                           onscreen_context,   // sharegroup
                            context_attributes  // context attributes
         );
-    FML_CHECK(offscreen_context_ != EGL_NO_CONTEXT) << GetEGLError();
+    FML_CHECK(offscreen_context != EGL_NO_CONTEXT) << GetEGLError();
   }
 }
 
-TestGLSurface::~TestGLSurface() {
-  context_ = nullptr;
-
-  auto result = ::eglDestroyContext(display_, onscreen_context_);
+TestEGLContext::~TestEGLContext() {
+  auto result = ::eglDestroyContext(display, onscreen_context);
   FML_CHECK(result == EGL_TRUE) << GetEGLError();
 
-  result = ::eglDestroyContext(display_, offscreen_context_);
+  result = ::eglDestroyContext(display, offscreen_context);
   FML_CHECK(result == EGL_TRUE) << GetEGLError();
 
-  result = ::eglDestroySurface(display_, onscreen_surface_);
-  FML_CHECK(result == EGL_TRUE) << GetEGLError();
-
-  result = ::eglDestroySurface(display_, offscreen_surface_);
-  FML_CHECK(result == EGL_TRUE) << GetEGLError();
-
-  result = ::eglTerminate(display_);
+  result = ::eglTerminate(display);
   FML_CHECK(result == EGL_TRUE);
 }
 
-const SkISize& TestGLSurface::GetSurfaceSize() const {
+TestGLOnscreenOnlySurface::TestGLOnscreenOnlySurface(
+    std::shared_ptr<TestEGLContext> context,
+    SkISize size)
+    : surface_size_(size), egl_context_(context) {
+  const EGLint attributes[] = {
+      EGL_WIDTH,  size.width(),   //
+      EGL_HEIGHT, size.height(),  //
+      EGL_NONE,
+  };
+
+  onscreen_surface_ =
+      ::eglCreatePbufferSurface(egl_context_->display,  // display connection
+                                egl_context_->config,   // config
+                                attributes              // surface attributes
+      );
+  FML_CHECK(onscreen_surface_ != EGL_NO_SURFACE) << GetEGLError();
+}
+
+TestGLOnscreenOnlySurface::~TestGLOnscreenOnlySurface() {
+  skia_context_ = nullptr;
+
+  auto result = ::eglDestroySurface(egl_context_->display, onscreen_surface_);
+  FML_CHECK(result == EGL_TRUE) << GetEGLError();
+}
+
+const SkISize& TestGLOnscreenOnlySurface::GetSurfaceSize() const {
   return surface_size_;
 }
 
-bool TestGLSurface::MakeCurrent() {
-  auto result = ::eglMakeCurrent(display_, onscreen_surface_, onscreen_surface_,
-                                 onscreen_context_);
+bool TestGLOnscreenOnlySurface::MakeCurrent() {
+  auto result =
+      ::eglMakeCurrent(egl_context_->display, onscreen_surface_,
+                       onscreen_surface_, egl_context_->onscreen_context);
 
   if (result == EGL_FALSE) {
     FML_LOG(ERROR) << "Could not make the context current. " << GetEGLError();
@@ -249,9 +237,9 @@ bool TestGLSurface::MakeCurrent() {
   return result == EGL_TRUE;
 }
 
-bool TestGLSurface::ClearCurrent() {
-  auto result = ::eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                                 EGL_NO_CONTEXT);
+bool TestGLOnscreenOnlySurface::ClearCurrent() {
+  auto result = ::eglMakeCurrent(egl_context_->display, EGL_NO_SURFACE,
+                                 EGL_NO_SURFACE, EGL_NO_CONTEXT);
 
   if (result == EGL_FALSE) {
     FML_LOG(ERROR) << "Could not clear the current context. " << GetEGLError();
@@ -260,8 +248,8 @@ bool TestGLSurface::ClearCurrent() {
   return result == EGL_TRUE;
 }
 
-bool TestGLSurface::Present() {
-  auto result = ::eglSwapBuffers(display_, onscreen_surface_);
+bool TestGLOnscreenOnlySurface::Present() {
+  auto result = ::eglSwapBuffers(egl_context_->display, onscreen_surface_);
 
   if (result == EGL_FALSE) {
     FML_LOG(ERROR) << "Could not swap buffers. " << GetEGLError();
@@ -270,23 +258,12 @@ bool TestGLSurface::Present() {
   return result == EGL_TRUE;
 }
 
-uint32_t TestGLSurface::GetFramebuffer(uint32_t width, uint32_t height) const {
+uint32_t TestGLOnscreenOnlySurface::GetFramebuffer(uint32_t width,
+                                                   uint32_t height) const {
   return GetWindowFBOId();
 }
 
-bool TestGLSurface::MakeResourceCurrent() {
-  auto result = ::eglMakeCurrent(display_, offscreen_surface_,
-                                 offscreen_surface_, offscreen_context_);
-
-  if (result == EGL_FALSE) {
-    FML_LOG(ERROR) << "Could not make the resource context current. "
-                   << GetEGLError();
-  }
-
-  return result == EGL_TRUE;
-}
-
-void* TestGLSurface::GetProcAddress(const char* name) const {
+void* TestGLOnscreenOnlySurface::GetProcAddress(const char* name) const {
   if (name == nullptr) {
     return nullptr;
   }
@@ -297,15 +274,15 @@ void* TestGLSurface::GetProcAddress(const char* name) const {
   return reinterpret_cast<void*>(symbol);
 }
 
-sk_sp<GrDirectContext> TestGLSurface::GetGrContext() {
-  if (context_) {
-    return context_;
+sk_sp<GrDirectContext> TestGLOnscreenOnlySurface::GetGrContext() {
+  if (skia_context_) {
+    return skia_context_;
   }
 
   return CreateGrContext();
 }
 
-sk_sp<GrDirectContext> TestGLSurface::CreateGrContext() {
+sk_sp<GrDirectContext> TestGLOnscreenOnlySurface::CreateGrContext() {
   if (!MakeCurrent()) {
     return nullptr;
   }
@@ -325,7 +302,8 @@ sk_sp<GrDirectContext> TestGLSurface::CreateGrContext() {
 
   GrGLGetProc get_proc = [](void* context, const char name[]) -> GrGLFuncPtr {
     return reinterpret_cast<GrGLFuncPtr>(
-        reinterpret_cast<TestGLSurface*>(context)->GetProcAddress(name));
+        reinterpret_cast<TestGLOnscreenOnlySurface*>(context)->GetProcAddress(
+            name));
   };
 
   std::string version(c_version);
@@ -337,11 +315,11 @@ sk_sp<GrDirectContext> TestGLSurface::CreateGrContext() {
     return nullptr;
   }
 
-  context_ = GrDirectContexts::MakeGL(interface);
-  return context_;
+  skia_context_ = GrDirectContexts::MakeGL(interface);
+  return skia_context_;
 }
 
-sk_sp<SkSurface> TestGLSurface::GetOnscreenSurface() {
+sk_sp<SkSurface> TestGLOnscreenOnlySurface::GetOnscreenSurface() {
   FML_CHECK(::eglGetCurrentContext() != EGL_NO_CONTEXT);
 
   GrGLFramebufferInfo framebuffer_info = {};
@@ -384,7 +362,7 @@ sk_sp<SkSurface> TestGLSurface::GetOnscreenSurface() {
   return surface;
 }
 
-sk_sp<SkImage> TestGLSurface::GetRasterSurfaceSnapshot() {
+sk_sp<SkImage> TestGLOnscreenOnlySurface::GetRasterSurfaceSnapshot() {
   auto surface = GetOnscreenSurface();
 
   if (!surface) {
@@ -412,8 +390,47 @@ sk_sp<SkImage> TestGLSurface::GetRasterSurfaceSnapshot() {
   return host_snapshot;
 }
 
-uint32_t TestGLSurface::GetWindowFBOId() const {
+uint32_t TestGLOnscreenOnlySurface::GetWindowFBOId() const {
   return 0u;
+}
+
+TestGLSurface::TestGLSurface(SkISize surface_size)
+    : TestGLSurface(std::make_shared<TestEGLContext>(), surface_size) {}
+
+TestGLSurface::TestGLSurface(std::shared_ptr<TestEGLContext> egl_context,
+                             SkISize surface_size)
+    : TestGLOnscreenOnlySurface(egl_context, surface_size) {
+  {
+    const EGLint offscreen_surface_attributes[] = {
+        EGL_WIDTH,  1,  //
+        EGL_HEIGHT, 1,  //
+        EGL_NONE,
+    };
+    offscreen_surface_ = ::eglCreatePbufferSurface(
+        egl_context_->display,        // display connection
+        egl_context_->config,         // config
+        offscreen_surface_attributes  // surface attributes
+    );
+    FML_CHECK(offscreen_surface_ != EGL_NO_SURFACE) << GetEGLError();
+  }
+}
+
+TestGLSurface::~TestGLSurface() {
+  auto result = ::eglDestroySurface(egl_context_->display, offscreen_surface_);
+  FML_CHECK(result == EGL_TRUE) << GetEGLError();
+}
+
+bool TestGLSurface::MakeResourceCurrent() {
+  auto result =
+      ::eglMakeCurrent(egl_context_->display, offscreen_surface_,
+                       offscreen_surface_, egl_context_->offscreen_context);
+
+  if (result == EGL_FALSE) {
+    FML_LOG(ERROR) << "Could not make the resource context current. "
+                   << GetEGLError();
+  }
+
+  return result == EGL_TRUE;
 }
 
 }  // namespace testing

--- a/testing/test_gl_surface.cc
+++ b/testing/test_gl_surface.cc
@@ -199,7 +199,7 @@ TestEGLContext::~TestEGLContext() {
 TestGLOnscreenOnlySurface::TestGLOnscreenOnlySurface(
     std::shared_ptr<TestEGLContext> context,
     SkISize size)
-    : surface_size_(size), egl_context_(context) {
+    : surface_size_(size), egl_context_(std::move(context)) {
   const EGLint attributes[] = {
       EGL_WIDTH,  size.width(),   //
       EGL_HEIGHT, size.height(),  //
@@ -399,7 +399,7 @@ TestGLSurface::TestGLSurface(SkISize surface_size)
 
 TestGLSurface::TestGLSurface(std::shared_ptr<TestEGLContext> egl_context,
                              SkISize surface_size)
-    : TestGLOnscreenOnlySurface(egl_context, surface_size) {
+    : TestGLOnscreenOnlySurface(std::move(egl_context), surface_size) {
   {
     const EGLint offscreen_surface_attributes[] = {
         EGL_WIDTH,  1,  //


### PR DESCRIPTION
Allows using an EGL surface as a flutter backing store. Way more convenient for GBM than hacking gbm bo's into GL FBOs.

This resolves https://github.com/flutter/flutter/issues/58363

Currently, the embedder API assumes that the compositor (if it exists) will let flutter render into FBOs or Textures and then composite the whole thing onto the actual (EGL) window surface. I think this assumption is also documented a bit in https://github.com/flutter/flutter/issues/38466

However, in my case, I want let the hardware do the composition (using the linux KMS API), and render each flutter layer into it's own EGL surface.

It's possible to hack around this by creating your own GBM BOs, importing those as EGL images, then importing those as GL Render Buffers and attaching those to GL FBOs and that works (tested it). However, that's basically reimplementing 50% of the whole GBM/EGL "window" system integration for no reason.

This PR adds:
1. To the embedder API:
   - a new kind of OpenGL Backing store: `FlutterOpenGLSurface`
     - consisting of just a `make_current` and destruction callback (plus userdata)
     - the make_current callback should make the target surface current, i.e. `eglMakeCurrent(..., surf, surf)`
     - will be called by the engine before rendering onto the backing store
2. Some wiring to call make_current before rendering into the backing store

## TODO:

- [ ] Actually handle the return value of the make current callback
- [ ] Tests

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
