### PR TITLE
[Impeller] Make the reasoning behind SupportsReadFromOnscreenTexture on Vulkan.

### DIFF
--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -428,7 +428,9 @@ bool CapabilitiesVK::SupportsReadFromResolve() const {
 
 // |Capabilities|
 bool CapabilitiesVK::SupportsReadFromOnscreenTexture() const {
-  return false;
+  // We can read from the onscreen texture but had additional restrictions on
+  // whether it is a resolve texture.
+  return SupportsReadFromOnscreenTexture();
 }
 
 bool CapabilitiesVK::SupportsDecalTileMode() const {


### PR DESCRIPTION
The background is in the commit message for
https://github.com/flutter/engine/pull/41107. I idly flipped it without thinking of the resolve aspect. The behavior is the same but the code IMO is now easier to follow.