### PR TITLE
[Impeller] Fix text scaling issues again, this time with perspective when a save layer is involved

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2877,6 +2877,35 @@ TEST_P(AiksTest, CanCanvasDrawPicture) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, DrawPictureWithText) {
+  Canvas subcanvas;
+  ASSERT_TRUE(RenderTextInCanvas(
+      GetContext(), subcanvas,
+      "the quick brown fox jumped over the lazy dog!.?", "Roboto-Regular.ttf"));
+  subcanvas.Translate({0, 10});
+  subcanvas.Scale(Vector2(3, 3));
+  ASSERT_TRUE(RenderTextInCanvas(
+      GetContext(), subcanvas,
+      "the quick brown fox jumped over the very big lazy dog!.?",
+      "Roboto-Regular.ttf"));
+  auto picture = subcanvas.EndRecordingAsPicture();
+
+  Canvas canvas;
+  canvas.Scale(Vector2(.2, .2));
+  canvas.Save();
+  canvas.Translate({200, 200});
+  canvas.Scale(Vector2(3.5, 3.5));  // The text must not be blurry after this.
+  canvas.DrawPicture(picture);
+  canvas.Restore();
+
+  canvas.Scale(Vector2(1.5, 1.5));
+  ASSERT_TRUE(RenderTextInCanvas(
+      GetContext(), canvas,
+      "the quick brown fox jumped over the smaller lazy dog!.?",
+      "Roboto-Regular.ttf"));
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, MatrixBackdropFilter) {
   Canvas canvas;
   canvas.SaveLayer({}, std::nullopt,

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2952,5 +2952,41 @@ APPLY_COLOR_FILTER_GRADIENT_TEST(Radial);
 APPLY_COLOR_FILTER_GRADIENT_TEST(Conical);
 APPLY_COLOR_FILTER_GRADIENT_TEST(Sweep);
 
+TEST_P(AiksTest, DrawScaledTextWithPerspectiveNoSaveLayer) {
+  Canvas canvas;
+  // clang-format off
+  canvas.Transform(Matrix(
+       2.000000,       0.000000,   0.000000,  0.000000,
+       1.445767,       2.637070,  -0.507928,  0.001524,
+      -2.451887,      -0.534662,   0.861399, -0.002584,
+    1063.481934,    1025.951416, -48.300270,  1.144901
+  ));
+  // clang-format on
+
+  ASSERT_TRUE(RenderTextInCanvas(GetContext(), canvas, "Hello world",
+                                 "Roboto-Regular.ttf"));
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, DrawScaledTextWithPerspectiveSaveLayer) {
+  Canvas canvas;
+  Paint save_paint;
+  canvas.SaveLayer(save_paint);
+  // clang-format off
+  canvas.Transform(Matrix(
+       2.000000,       0.000000,   0.000000,  0.000000,
+       1.445767,       2.637070,  -0.507928,  0.001524,
+      -2.451887,      -0.534662,   0.861399, -0.002584,
+    1063.481934,    1025.951416, -48.300270,  1.144901
+  ));
+  // clang-format on
+
+  ASSERT_TRUE(RenderTextInCanvas(GetContext(), canvas, "Hello world",
+                                 "Roboto-Regular.ttf"));
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -42,7 +42,6 @@ void Canvas::Initialize(std::optional<Rect> cull_rect) {
   base_pass_ = std::make_unique<EntityPass>();
   current_pass_ = base_pass_.get();
   xformation_stack_.emplace_back(CanvasStackEntry{.cull_rect = cull_rect});
-  lazy_glyph_atlas_ = std::make_shared<LazyGlyphAtlas>();
   FML_DCHECK(GetSaveCount() == 1u);
   FML_DCHECK(base_pass_->GetSubpassesDepth() == 1u);
 }
@@ -51,7 +50,6 @@ void Canvas::Reset() {
   base_pass_ = nullptr;
   current_pass_ = nullptr;
   xformation_stack_ = {};
-  lazy_glyph_atlas_ = nullptr;
 }
 
 void Canvas::Save() {
@@ -516,15 +514,12 @@ void Canvas::SaveLayer(const Paint& paint,
 void Canvas::DrawTextFrame(const TextFrame& text_frame,
                            Point position,
                            const Paint& paint) {
-  lazy_glyph_atlas_->AddTextFrame(text_frame);
-
   Entity entity;
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetBlendMode(paint.blend_mode);
 
   auto text_contents = std::make_shared<TextContents>();
   text_contents->SetTextFrame(text_frame);
-  text_contents->SetGlyphAtlas(lazy_glyph_atlas_);
 
   if (paint.color_source.GetType() != ColorSource::Type::kColor) {
     auto color_text_contents = std::make_shared<ColorSourceTextContents>();

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -162,7 +162,6 @@ class Canvas {
   std::unique_ptr<EntityPass> base_pass_;
   EntityPass* current_pass_ = nullptr;
   std::deque<CanvasStackEntry> xformation_stack_;
-  std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas_;
   std::optional<Rect> initial_cull_rect_;
 
   void Initialize(std::optional<Rect> cull_rect);

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -1104,8 +1104,7 @@ void DlDispatcher::drawDisplayList(
 void DlDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                 SkScalar x,
                                 SkScalar y) {
-  Scalar scale = canvas_.GetCurrentTransformation().GetMaxBasisLengthXY();
-  const auto text_frame = TextFrameFromTextBlob(blob, scale);
+  const auto text_frame = TextFrameFromTextBlob(blob);
   if (paint_.style == Paint::Style::kStroke) {
     auto path = skia_conversions::PathDataFromTextBlob(blob);
     auto bounds = text_frame.GetBounds();

--- a/impeller/entity/contents/color_source_text_contents.cc
+++ b/impeller/entity/contents/color_source_text_contents.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/entity/contents/color_source_text_contents.h"
 
+#include "color_source_text_contents.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/renderer/render_pass.h"
@@ -31,6 +32,12 @@ std::optional<Rect> ColorSourceTextContents::GetCoverage(
 
 void ColorSourceTextContents::SetTextPosition(Point position) {
   position_ = position;
+}
+
+void ColorSourceTextContents::PopulateGlyphAtlas(
+    const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
+    Scalar scale) const {
+  text_contents_->PopulateGlyphAtlas(lazy_glyph_atlas, scale);
 }
 
 bool ColorSourceTextContents::Render(const ContentContext& renderer,

--- a/impeller/entity/contents/color_source_text_contents.cc
+++ b/impeller/entity/contents/color_source_text_contents.cc
@@ -36,7 +36,7 @@ void ColorSourceTextContents::SetTextPosition(Point position) {
 
 void ColorSourceTextContents::PopulateGlyphAtlas(
     const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
-    Scalar scale) const {
+    Scalar scale) {
   text_contents_->PopulateGlyphAtlas(lazy_glyph_atlas, scale);
 }
 

--- a/impeller/entity/contents/color_source_text_contents.h
+++ b/impeller/entity/contents/color_source_text_contents.h
@@ -33,6 +33,11 @@ class ColorSourceTextContents final : public Contents {
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |Contents|
+  void PopulateGlyphAtlas(
+      const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
+      Scalar scale) const override;
+
+  // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
               RenderPass& pass) const override;

--- a/impeller/entity/contents/color_source_text_contents.h
+++ b/impeller/entity/contents/color_source_text_contents.h
@@ -35,7 +35,7 @@ class ColorSourceTextContents final : public Contents {
   // |Contents|
   void PopulateGlyphAtlas(
       const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
-      Scalar scale) const override;
+      Scalar scale) override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -696,8 +696,18 @@ class ContentContext {
                                        const SubpassCallback& subpass_callback,
                                        bool msaa_enabled = true) const;
 
+  void SetLazyGlyphAtlas(
+      const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas) {
+    lazy_glyph_atlas_ = lazy_glyph_atlas;
+  }
+
+  std::shared_ptr<LazyGlyphAtlas> GetLazyGlyphAtlas() const {
+    return lazy_glyph_atlas_;
+  }
+
  private:
   std::shared_ptr<Context> context_;
+  std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas_;
 
   template <class T>
   using Variants = std::unordered_map<ContentContextOptions,

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -54,10 +54,11 @@ class Contents {
 
   virtual ~Contents();
 
-  /// @brief  Add any text data to the specified lazy atlas.
+  /// @brief  Add any text data to the specified lazy atlas. The scale parameter
+  ///         must be used again later when drawing the text.
   virtual void PopulateGlyphAtlas(
       const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
-      Scalar scale) const {}
+      Scalar scale) {}
 
   virtual bool Render(const ContentContext& renderer,
                       const Entity& entity,

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -14,6 +14,7 @@
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/renderer/snapshot.h"
+#include "impeller/typographer/lazy_glyph_atlas.h"
 
 namespace impeller {
 
@@ -52,6 +53,11 @@ class Contents {
   Contents();
 
   virtual ~Contents();
+
+  /// @brief  Add any text data to the specified lazy atlas.
+  virtual void PopulateGlyphAtlas(
+      const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
+      Scalar scale) const {}
 
   virtual bool Render(const ContentContext& renderer,
                       const Entity& entity,

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -77,8 +77,9 @@ std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
 
 void TextContents::PopulateGlyphAtlas(
     const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
-    Scalar scale) const {
+    Scalar scale) {
   lazy_glyph_atlas->AddTextFrame(frame_, scale);
+  scale_ = scale;
 }
 
 bool TextContents::Render(const ContentContext& renderer,
@@ -90,7 +91,6 @@ bool TextContents::Render(const ContentContext& renderer,
   }
 
   auto type = frame_.GetAtlasType();
-  auto scale = entity.DeriveTextScale();
   auto atlas =
       ResolveAtlas(type, renderer.GetLazyGlyphAtlas(),
                    renderer.GetGlyphAtlasContext(type), renderer.GetContext());
@@ -180,7 +180,7 @@ bool TextContents::Render(const ContentContext& renderer,
         for (const auto& run : frame_.GetRuns()) {
           const Font& font = run.GetFont();
           for (const auto& glyph_position : run.GetGlyphPositions()) {
-            FontGlyphPair font_glyph_pair{font, glyph_position.glyph, scale};
+            FontGlyphPair font_glyph_pair{font, glyph_position.glyph, scale_};
             auto maybe_atlas_glyph_bounds =
                 atlas->FindFontGlyphBounds(font_glyph_pair);
             if (!maybe_atlas_glyph_bounds.has_value()) {

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -28,14 +28,14 @@ class TextContents final : public Contents {
 
   void SetTextFrame(const TextFrame& frame);
 
-  void SetGlyphAtlas(std::shared_ptr<LazyGlyphAtlas> atlas);
-
   void SetColor(Color color);
 
   Color GetColor() const;
 
+  // |Contents|
   bool CanInheritOpacity(const Entity& entity) const override;
 
+  // |Contents|
   void SetInheritedOpacity(Scalar opacity) override;
 
   void SetOffset(Vector2 offset);
@@ -46,6 +46,11 @@ class TextContents final : public Contents {
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |Contents|
+  void PopulateGlyphAtlas(
+      const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
+      Scalar scale) const override;
+
+  // |Contents|
   bool Render(const ContentContext& renderer,
               const Entity& entity,
               RenderPass& pass) const override;
@@ -54,11 +59,11 @@ class TextContents final : public Contents {
   TextFrame frame_;
   Color color_;
   Scalar inherited_opacity_ = 1.0;
-  mutable std::shared_ptr<LazyGlyphAtlas> lazy_atlas_;
   Vector2 offset_;
 
   std::shared_ptr<GlyphAtlas> ResolveAtlas(
       GlyphAtlas::Type type,
+      const std::shared_ptr<LazyGlyphAtlas>& lazy_atlas,
       std::shared_ptr<GlyphAtlasContext> atlas_context,
       std::shared_ptr<Context> context) const;
 

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -48,7 +48,7 @@ class TextContents final : public Contents {
   // |Contents|
   void PopulateGlyphAtlas(
       const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
-      Scalar scale) const override;
+      Scalar scale) override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,
@@ -57,6 +57,7 @@ class TextContents final : public Contents {
 
  private:
   TextFrame frame_;
+  Scalar scale_;
   Color color_;
   Scalar inherited_opacity_ = 1.0;
   Vector2 offset_;

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -57,7 +57,7 @@ class TextContents final : public Contents {
 
  private:
   TextFrame frame_;
-  Scalar scale_;
+  Scalar scale_ = 1.0;
   Color color_;
   Scalar inherited_opacity_ = 1.0;
   Vector2 offset_;

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -166,4 +166,8 @@ bool Entity::Render(const ContentContext& renderer,
   return contents_->Render(renderer, *this, parent_pass);
 }
 
+Scalar Entity::DeriveTextScale() const {
+  return GetTransformation().GetMaxBasisLengthXY();
+}
+
 }  // namespace impeller

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -94,6 +94,8 @@ class Entity {
 
   std::optional<Color> AsBackgroundColor(ISize target_size) const;
 
+  Scalar DeriveTextScale() const;
+
  private:
   Matrix transformation_;
   std::shared_ptr<Contents> contents_;

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <variant>
 
+#include "flutter/fml/closure.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/trace_event.h"
@@ -251,6 +252,18 @@ bool EntityPass::Render(ContentContext& renderer,
     VALIDATION_LOG << "The root RenderTarget must have a color attachment.";
     return false;
   }
+
+  renderer.SetLazyGlyphAtlas(std::make_shared<LazyGlyphAtlas>());
+  fml::ScopedCleanupClosure reset_lazy_glyph_atlas(
+      [&renderer]() { renderer.SetLazyGlyphAtlas(nullptr); });
+
+  IterateAllEntities([lazy_glyph_atlas =
+                          renderer.GetLazyGlyphAtlas()](const Entity& entity) {
+    if (auto contents = entity.GetContents()) {
+      contents->PopulateGlyphAtlas(lazy_glyph_atlas, entity.DeriveTextScale());
+    }
+    return true;
+  });
 
   StencilCoverageStack stencil_coverage_stack = {StencilCoverageLayer{
       .coverage = Rect::MakeSize(root_render_target.GetRenderTargetSize()),
@@ -872,6 +885,28 @@ void EntityPass::IterateAllEntities(
     }
     if (auto subpass = std::get_if<std::unique_ptr<EntityPass>>(&element)) {
       subpass->get()->IterateAllEntities(iterator);
+      continue;
+    }
+    FML_UNREACHABLE();
+  }
+}
+
+void EntityPass::IterateAllEntities(
+    const std::function<bool(const Entity&)>& iterator) const {
+  if (!iterator) {
+    return;
+  }
+
+  for (const auto& element : elements_) {
+    if (auto entity = std::get_if<Entity>(&element)) {
+      if (!iterator(*entity)) {
+        return;
+      }
+      continue;
+    }
+    if (auto subpass = std::get_if<std::unique_ptr<EntityPass>>(&element)) {
+      const EntityPass* entity_pass = subpass->get();
+      entity_pass->IterateAllEntities(iterator);
       continue;
     }
     FML_UNREACHABLE();

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -79,6 +79,12 @@ class EntityPass {
   ///         of child passes. The iteration order is depth-first.
   void IterateAllEntities(const std::function<bool(Entity&)>& iterator);
 
+  /// @brief  Iterate all entities in this pass, recursively including entities
+  ///         of child passes. The iteration order is depth-first and does not
+  ///         allow modification of the entities.
+  void IterateAllEntities(
+      const std::function<bool(const Entity&)>& iterator) const;
+
   /// @brief  Iterate entities in this pass up until the first subpass is found.
   ///         This is useful for limiting look-ahead optimizations.
   ///

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2184,7 +2184,7 @@ TEST_P(EntityTest, InheritOpacityTest) {
   auto blob = SkTextBlob::MakeFromString("A", font);
   auto frame = TextFrameFromTextBlob(blob);
   auto lazy_glyph_atlas = std::make_shared<LazyGlyphAtlas>();
-  lazy_glyph_atlas->AddTextFrame(frame);
+  lazy_glyph_atlas->AddTextFrame(frame, 1.0f);
 
   auto text_contents = std::make_shared<TextContents>();
   text_contents->SetTextFrame(frame);

--- a/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -17,7 +17,7 @@
 
 namespace impeller {
 
-static Font ToFont(const SkTextBlobRunIterator& run, Scalar scale) {
+static Font ToFont(const SkTextBlobRunIterator& run) {
   auto& font = run.font();
   auto typeface = std::make_shared<TypefaceSkia>(font.refTypefaceOrDefault());
 
@@ -25,7 +25,6 @@ static Font ToFont(const SkTextBlobRunIterator& run, Scalar scale) {
   font.getMetrics(&sk_metrics);
 
   Font::Metrics metrics;
-  metrics.scale = scale;
   metrics.point_size = font.getSize();
   metrics.embolden = font.isEmbolden();
   metrics.skewX = font.getSkewX();
@@ -38,7 +37,7 @@ static Rect ToRect(const SkRect& rect) {
   return Rect::MakeLTRB(rect.fLeft, rect.fTop, rect.fRight, rect.fBottom);
 }
 
-TextFrame TextFrameFromTextBlob(const sk_sp<SkTextBlob>& blob, Scalar scale) {
+TextFrame TextFrameFromTextBlob(const sk_sp<SkTextBlob>& blob) {
   if (!blob) {
     return {};
   }
@@ -46,7 +45,7 @@ TextFrame TextFrameFromTextBlob(const sk_sp<SkTextBlob>& blob, Scalar scale) {
   TextFrame frame;
 
   for (SkTextBlobRunIterator run(blob.get()); !run.done(); run.next()) {
-    TextRun text_run(ToFont(run, scale));
+    TextRun text_run(ToFont(run));
 
     // TODO(jonahwilliams): ask Skia for a public API to look this up.
     // https://github.com/flutter/flutter/issues/112005

--- a/impeller/typographer/backends/skia/text_frame_skia.h
+++ b/impeller/typographer/backends/skia/text_frame_skia.h
@@ -10,7 +10,6 @@
 
 namespace impeller {
 
-TextFrame TextFrameFromTextBlob(const sk_sp<SkTextBlob>& blob,
-                                Scalar scale = 1.0f);
+TextFrame TextFrameFromTextBlob(const sk_sp<SkTextBlob>& blob);
 
 }  // namespace impeller

--- a/impeller/typographer/backends/skia/text_render_context_skia.cc
+++ b/impeller/typographer/backends/skia/text_render_context_skia.cc
@@ -40,23 +40,6 @@ TextRenderContextSkia::TextRenderContextSkia(std::shared_ptr<Context> context)
 
 TextRenderContextSkia::~TextRenderContextSkia() = default;
 
-static FontGlyphPair::Set CollectUniqueFontGlyphPairs(
-    GlyphAtlas::Type type,
-    const TextRenderContext::FrameIterator& frame_iterator) {
-  TRACE_EVENT0("impeller", __FUNCTION__);
-  FontGlyphPair::Set set;
-  while (const TextFrame* frame = frame_iterator()) {
-    for (const TextRun& run : frame->GetRuns()) {
-      const Font& font = run.GetFont();
-      for (const TextRun::GlyphPosition& glyph_position :
-           run.GetGlyphPositions()) {
-        set.insert({font, glyph_position.glyph});
-      }
-    }
-  }
-  return set;
-}
-
 static size_t PairsFitInAtlasOfSize(
     const FontGlyphPair::Set& pairs,
     const ISize& atlas_size,
@@ -73,8 +56,7 @@ static size_t PairsFitInAtlasOfSize(
   for (auto it = pairs.begin(); it != pairs.end(); ++i, ++it) {
     const auto& pair = *it;
 
-    const auto glyph_size =
-        ISize::Ceil((pair.glyph.bounds * pair.font.GetMetrics().scale).size);
+    const auto glyph_size = ISize::Ceil((pair.glyph.bounds * pair.scale).size);
     IPoint16 location_in_atlas;
     if (!rect_packer->addRect(glyph_size.width + kPadding,   //
                               glyph_size.height + kPadding,  //
@@ -111,8 +93,7 @@ static bool CanAppendToExistingAtlas(
   for (size_t i = 0; i < extra_pairs.size(); i++) {
     const FontGlyphPair& pair = extra_pairs[i];
 
-    const auto glyph_size =
-        ISize::Ceil((pair.glyph.bounds * pair.font.GetMetrics().scale).size);
+    const auto glyph_size = ISize::Ceil((pair.glyph.bounds * pair.scale).size);
     IPoint16 location_in_atlas;
     if (!rect_packer->addRect(glyph_size.width + kPadding,   //
                               glyph_size.height + kPadding,  //
@@ -176,8 +157,8 @@ static void DrawGlyph(SkCanvas* canvas,
                       const Rect& location,
                       bool has_color) {
   const auto& metrics = font_glyph.font.GetMetrics();
-  const auto position = SkPoint::Make(location.origin.x / metrics.scale,
-                                      location.origin.y / metrics.scale);
+  const auto position = SkPoint::Make(location.origin.x / font_glyph.scale,
+                                      location.origin.y / font_glyph.scale);
   SkGlyphID glyph_id = font_glyph.glyph.index;
 
   SkFont sk_font(
@@ -192,7 +173,7 @@ static void DrawGlyph(SkCanvas* canvas,
   SkPaint glyph_paint;
   glyph_paint.setColor(glyph_color);
   canvas->resetMatrix();
-  canvas->scale(metrics.scale, metrics.scale);
+  canvas->scale(font_glyph.scale, font_glyph.scale);
   canvas->drawGlyphs(
       1u,         // count
       &glyph_id,  // glyphs
@@ -331,25 +312,19 @@ static std::shared_ptr<Texture> UploadGlyphTextureAtlas(
 std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
     GlyphAtlas::Type type,
     std::shared_ptr<GlyphAtlasContext> atlas_context,
-    FrameIterator frame_iterator) const {
+    const FontGlyphPair::Set& font_glyph_pairs) const {
   TRACE_EVENT0("impeller", __FUNCTION__);
   if (!IsValid()) {
     return nullptr;
   }
   std::shared_ptr<GlyphAtlas> last_atlas = atlas_context->GetGlyphAtlas();
 
-  // ---------------------------------------------------------------------------
-  // Step 1: Collect unique font-glyph pairs in the frame.
-  // ---------------------------------------------------------------------------
-
-  FontGlyphPair::Set font_glyph_pairs =
-      CollectUniqueFontGlyphPairs(type, frame_iterator);
   if (font_glyph_pairs.empty()) {
     return last_atlas;
   }
 
   // ---------------------------------------------------------------------------
-  // Step 2: Determine if the atlas type and font glyph pairs are compatible
+  // Step 1: Determine if the atlas type and font glyph pairs are compatible
   //         with the current atlas and reuse if possible.
   // ---------------------------------------------------------------------------
   FontGlyphPairRefVector new_glyphs;
@@ -363,7 +338,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   }
 
   // ---------------------------------------------------------------------------
-  // Step 3: Determine if the additional missing glyphs can be appended to the
+  // Step 2: Determine if the additional missing glyphs can be appended to the
   //         existing bitmap without recreating the atlas. This requires that
   //         the type is identical.
   // ---------------------------------------------------------------------------
@@ -376,7 +351,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
     // added.
 
     // ---------------------------------------------------------------------------
-    // Step 4: Record the positions in the glyph atlas of the newly added
+    // Step 3a: Record the positions in the glyph atlas of the newly added
     // glyphs.
     // ---------------------------------------------------------------------------
     for (size_t i = 0, count = glyph_positions.size(); i < count; i++) {
@@ -384,7 +359,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
     }
 
     // ---------------------------------------------------------------------------
-    // Step 5: Draw new font-glyph pairs into the existing bitmap.
+    // Step 4a: Draw new font-glyph pairs into the existing bitmap.
     // ---------------------------------------------------------------------------
     auto bitmap = atlas_context->GetBitmap();
     if (!UpdateAtlasBitmap(*last_atlas, bitmap, new_glyphs)) {
@@ -392,7 +367,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
     }
 
     // ---------------------------------------------------------------------------
-    // Step 6: Update the existing texture with the updated bitmap.
+    // Step 5a: Update the existing texture with the updated bitmap.
     // ---------------------------------------------------------------------------
     if (!UpdateGlyphTextureAtlas(bitmap, last_atlas->GetTexture())) {
       return nullptr;
@@ -402,7 +377,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   // A new glyph atlas must be created.
 
   // ---------------------------------------------------------------------------
-  // Step 4: Get the optimum size of the texture atlas.
+  // Step 3b: Get the optimum size of the texture atlas.
   // ---------------------------------------------------------------------------
   auto glyph_atlas = std::make_shared<GlyphAtlas>(type);
   auto atlas_size = OptimumAtlasSizeForFontGlyphPairs(
@@ -413,7 +388,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
     return nullptr;
   }
   // ---------------------------------------------------------------------------
-  // Step 5: Find location of font-glyph pairs in the atlas. We have this from
+  // Step 4b: Find location of font-glyph pairs in the atlas. We have this from
   // the last step. So no need to do create another rect packer. But just do a
   // sanity check of counts. This could also be just an assertion as only a
   // construction issue would cause such a failure.
@@ -423,7 +398,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   }
 
   // ---------------------------------------------------------------------------
-  // Step 6: Record the positions in the glyph atlas.
+  // Step 5b: Record the positions in the glyph atlas.
   // ---------------------------------------------------------------------------
   {
     size_t i = 0;
@@ -434,7 +409,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   }
 
   // ---------------------------------------------------------------------------
-  // Step 7: Draw font-glyph pairs in the correct spot in the atlas.
+  // Step 6b: Draw font-glyph pairs in the correct spot in the atlas.
   // ---------------------------------------------------------------------------
   auto bitmap = CreateAtlasBitmap(*glyph_atlas, atlas_size);
   if (!bitmap) {
@@ -443,7 +418,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   atlas_context->UpdateBitmap(bitmap);
 
   // ---------------------------------------------------------------------------
-  // Step 8: Upload the atlas as a texture.
+  // Step 7b: Upload the atlas as a texture.
   // ---------------------------------------------------------------------------
   PixelFormat format;
   switch (type) {
@@ -461,7 +436,7 @@ std::shared_ptr<GlyphAtlas> TextRenderContextSkia::CreateGlyphAtlas(
   }
 
   // ---------------------------------------------------------------------------
-  // Step 9: Record the texture in the glyph atlas.
+  // Step 8b: Record the texture in the glyph atlas.
   // ---------------------------------------------------------------------------
   glyph_atlas->SetTexture(std::move(texture));
 

--- a/impeller/typographer/backends/skia/text_render_context_skia.h
+++ b/impeller/typographer/backends/skia/text_render_context_skia.h
@@ -19,7 +19,7 @@ class TextRenderContextSkia : public TextRenderContext {
   std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
       GlyphAtlas::Type type,
       std::shared_ptr<GlyphAtlasContext> atlas_context,
-      FrameIterator iterator) const override;
+      const FontGlyphPair::Set& font_glyph_pairs) const override;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(TextRenderContextSkia);

--- a/impeller/typographer/font.h
+++ b/impeller/typographer/font.h
@@ -29,12 +29,6 @@ class Font : public Comparable<Font> {
   ///
   struct Metrics {
     //--------------------------------------------------------------------------
-    /// The scaling factor that should be used when rendering this font to an
-    /// atlas. This should normally be set in accordance with the transformation
-    /// matrix that will be used to position glyph geometry.
-    ///
-    Scalar scale = 1.0f;
-    //--------------------------------------------------------------------------
     /// The point size of the font.
     ///
     Scalar point_size = 12.0f;
@@ -43,8 +37,8 @@ class Font : public Comparable<Font> {
     Scalar scaleX = 1.0f;
 
     constexpr bool operator==(const Metrics& o) const {
-      return scale == o.scale && point_size == o.point_size &&
-             embolden == o.embolden && skewX == o.skewX && scaleX == o.scaleX;
+      return point_size == o.point_size && embolden == o.embolden &&
+             skewX == o.skewX && scaleX == o.scaleX;
     }
   };
 
@@ -80,6 +74,6 @@ class Font : public Comparable<Font> {
 template <>
 struct std::hash<impeller::Font::Metrics> {
   constexpr std::size_t operator()(const impeller::Font::Metrics& m) const {
-    return fml::HashCombine(m.scale, m.point_size);
+    return fml::HashCombine(m.point_size, m.skewX, m.scaleX);
   }
 };

--- a/impeller/typographer/font_glyph_pair.h
+++ b/impeller/typographer/font_glyph_pair.h
@@ -16,28 +16,29 @@
 namespace impeller {
 
 //------------------------------------------------------------------------------
-/// @brief      A font along with a glyph in that font. Used in glyph atlases as
-///             keys.
+/// @brief      A font along with a glyph in that font rendered at a particular
+///             scale. Used in glyph atlases as keys.
 ///
 struct FontGlyphPair {
   struct Hash;
   struct Equal;
 
   using Set = std::unordered_set<FontGlyphPair, Hash, Equal>;
-  using Vector = std::vector<FontGlyphPair>;
 
   Font font;
   Glyph glyph;
+  Scalar scale;
 
   struct Hash {
     std::size_t operator()(const FontGlyphPair& p) const {
-      return fml::HashCombine(p.font.GetHash(), p.glyph.index, p.glyph.type);
+      return fml::HashCombine(p.font.GetHash(), p.glyph.index, p.glyph.type,
+                              p.scale);
     }
   };
   struct Equal {
     bool operator()(const FontGlyphPair& lhs, const FontGlyphPair& rhs) const {
       return lhs.font.IsEqual(rhs.font) && lhs.glyph.index == rhs.glyph.index &&
-             lhs.glyph.type == rhs.glyph.type;
+             lhs.glyph.type == rhs.glyph.type && lhs.scale == rhs.scale;
     }
   };
 };

--- a/impeller/typographer/lazy_glyph_atlas.cc
+++ b/impeller/typographer/lazy_glyph_atlas.cc
@@ -15,12 +15,12 @@ LazyGlyphAtlas::LazyGlyphAtlas() = default;
 
 LazyGlyphAtlas::~LazyGlyphAtlas() = default;
 
-void LazyGlyphAtlas::AddTextFrame(const TextFrame& frame) {
+void LazyGlyphAtlas::AddTextFrame(const TextFrame& frame, Scalar scale) {
   FML_DCHECK(atlas_map_.empty());
   if (frame.GetAtlasType() == GlyphAtlas::Type::kAlphaBitmap) {
-    alpha_frames_.emplace_back(frame);
+    frame.CollectUniqueFontGlyphPairs(alpha_set_, scale);
   } else {
-    color_frames_.emplace_back(frame);
+    frame.CollectUniqueFontGlyphPairs(color_set_, scale);
   }
 }
 
@@ -39,19 +39,9 @@ std::shared_ptr<GlyphAtlas> LazyGlyphAtlas::CreateOrGetGlyphAtlas(
   if (!text_context || !text_context->IsValid()) {
     return nullptr;
   }
-  size_t i = 0;
-  auto frames =
-      type == GlyphAtlas::Type::kAlphaBitmap ? alpha_frames_ : color_frames_;
-  TextRenderContext::FrameIterator iterator = [&]() -> const TextFrame* {
-    if (i >= frames.size()) {
-      return nullptr;
-    }
-    const auto& result = frames[i];
-    i++;
-    return &result;
-  };
+  auto& set = type == GlyphAtlas::Type::kAlphaBitmap ? alpha_set_ : color_set_;
   auto atlas =
-      text_context->CreateGlyphAtlas(type, std::move(atlas_context), iterator);
+      text_context->CreateGlyphAtlas(type, std::move(atlas_context), set);
   if (!atlas || !atlas->IsValid()) {
     VALIDATION_LOG << "Could not create valid atlas.";
     return nullptr;

--- a/impeller/typographer/lazy_glyph_atlas.h
+++ b/impeller/typographer/lazy_glyph_atlas.h
@@ -19,7 +19,7 @@ class LazyGlyphAtlas {
 
   ~LazyGlyphAtlas();
 
-  void AddTextFrame(const TextFrame& frame);
+  void AddTextFrame(const TextFrame& frame, Scalar scale);
 
   std::shared_ptr<GlyphAtlas> CreateOrGetGlyphAtlas(
       GlyphAtlas::Type type,
@@ -27,8 +27,8 @@ class LazyGlyphAtlas {
       std::shared_ptr<Context> context) const;
 
  private:
-  std::vector<TextFrame> alpha_frames_;
-  std::vector<TextFrame> color_frames_;
+  FontGlyphPair::Set alpha_set_;
+  FontGlyphPair::Set color_set_;
   mutable std::unordered_map<GlyphAtlas::Type, std::shared_ptr<GlyphAtlas>>
       atlas_map_;
 

--- a/impeller/typographer/text_frame.cc
+++ b/impeller/typographer/text_frame.cc
@@ -79,4 +79,15 @@ bool TextFrame::MaybeHasOverlapping() const {
   return false;
 }
 
+void TextFrame::CollectUniqueFontGlyphPairs(FontGlyphPair::Set& set,
+                                            Scalar scale) const {
+  for (const TextRun& run : GetRuns()) {
+    const Font& font = run.GetFont();
+    for (const TextRun::GlyphPosition& glyph_position :
+         run.GetGlyphPositions()) {
+      set.insert({font, glyph_position.glyph, scale});
+    }
+  }
+}
+
 }  // namespace impeller

--- a/impeller/typographer/text_frame.h
+++ b/impeller/typographer/text_frame.h
@@ -22,6 +22,8 @@ class TextFrame {
 
   ~TextFrame();
 
+  void CollectUniqueFontGlyphPairs(FontGlyphPair::Set& set, Scalar scale) const;
+
   //----------------------------------------------------------------------------
   /// @brief      The conservative bounding box for this text frame.
   ///

--- a/impeller/typographer/text_render_context.cc
+++ b/impeller/typographer/text_render_context.cc
@@ -26,19 +26,4 @@ const std::shared_ptr<Context>& TextRenderContext::GetContext() const {
   return context_;
 }
 
-std::shared_ptr<GlyphAtlas> TextRenderContext::CreateGlyphAtlas(
-    GlyphAtlas::Type type,
-    std::shared_ptr<GlyphAtlasContext> atlas_context,
-    const TextFrame& frame) const {
-  size_t count = 0;
-  FrameIterator iterator = [&]() -> const TextFrame* {
-    count++;
-    if (count == 1) {
-      return &frame;
-    }
-    return nullptr;
-  };
-  return CreateGlyphAtlas(type, std::move(atlas_context), iterator);
-}
-
 }  // namespace impeller

--- a/impeller/typographer/text_render_context.h
+++ b/impeller/typographer/text_render_context.h
@@ -37,20 +37,13 @@ class TextRenderContext {
   ///
   const std::shared_ptr<Context>& GetContext() const;
 
-  using FrameIterator = std::function<const TextFrame*(void)>;
-
   // TODO(dnfield): Callers should not need to know which type of atlas to
   // create. https://github.com/flutter/flutter/issues/111640
 
   virtual std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
       GlyphAtlas::Type type,
       std::shared_ptr<GlyphAtlasContext> atlas_context,
-      FrameIterator iterator) const = 0;
-
-  std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
-      GlyphAtlas::Type type,
-      std::shared_ptr<GlyphAtlasContext> atlas_context,
-      const TextFrame& frame) const;
+      const FontGlyphPair::Set& font_glyph_pairs) const = 0;
 
  protected:
   //----------------------------------------------------------------------------

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -23,6 +23,17 @@ namespace testing {
 using TypographerTest = PlaygroundTest;
 INSTANTIATE_PLAYGROUND_SUITE(TypographerTest);
 
+static std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
+    const TextRenderContext* context,
+    GlyphAtlas::Type type,
+    Scalar scale,
+    const std::shared_ptr<GlyphAtlasContext>& atlas_context,
+    const TextFrame& frame) {
+  FontGlyphPair::Set set;
+  frame.CollectUniqueFontGlyphPairs(set, scale);
+  return context->CreateGlyphAtlas(type, atlas_context, set);
+}
+
 TEST_P(TypographerTest, CanConvertTextBlob) {
   SkFont font;
   auto blob = SkTextBlob::MakeFromString(
@@ -49,8 +60,8 @@ TEST_P(TypographerTest, CanCreateGlyphAtlas) {
   auto blob = SkTextBlob::MakeFromString("hello", sk_font);
   ASSERT_TRUE(blob);
   auto atlas =
-      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-                                TextFrameFromTextBlob(blob));
+      CreateGlyphAtlas(context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
+                       atlas_context, TextFrameFromTextBlob(blob));
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
   ASSERT_EQ(atlas->GetType(), GlyphAtlas::Type::kAlphaBitmap);
@@ -102,13 +113,13 @@ TEST_P(TypographerTest, LazyAtlasTracksColor) {
 
   LazyGlyphAtlas lazy_atlas;
 
-  lazy_atlas.AddTextFrame(frame);
+  lazy_atlas.AddTextFrame(frame, 1.0f);
 
   frame = TextFrameFromTextBlob(SkTextBlob::MakeFromString("😀 ", emoji_font));
 
   ASSERT_TRUE(frame.GetAtlasType() == GlyphAtlas::Type::kColorBitmap);
 
-  lazy_atlas.AddTextFrame(frame);
+  lazy_atlas.AddTextFrame(frame, 1.0f);
 
   // Creates different atlases for color and alpha bitmap.
   auto color_context = std::make_shared<GlyphAtlasContext>();
@@ -130,8 +141,8 @@ TEST_P(TypographerTest, GlyphAtlasWithOddUniqueGlyphSize) {
   auto blob = SkTextBlob::MakeFromString("AGH", sk_font);
   ASSERT_TRUE(blob);
   auto atlas =
-      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-                                TextFrameFromTextBlob(blob));
+      CreateGlyphAtlas(context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
+                       atlas_context, TextFrameFromTextBlob(blob));
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
 
@@ -147,8 +158,8 @@ TEST_P(TypographerTest, GlyphAtlasIsRecycledIfUnchanged) {
   auto blob = SkTextBlob::MakeFromString("spooky skellingtons", sk_font);
   ASSERT_TRUE(blob);
   auto atlas =
-      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-                                TextFrameFromTextBlob(blob));
+      CreateGlyphAtlas(context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
+                       atlas_context, TextFrameFromTextBlob(blob));
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
   ASSERT_EQ(atlas, atlas_context->GetGlyphAtlas());
@@ -156,8 +167,8 @@ TEST_P(TypographerTest, GlyphAtlasIsRecycledIfUnchanged) {
   // now attempt to re-create an atlas with the same text blob.
 
   auto next_atlas =
-      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-                                TextFrameFromTextBlob(blob));
+      CreateGlyphAtlas(context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
+                       atlas_context, TextFrameFromTextBlob(blob));
   ASSERT_EQ(atlas, next_atlas);
   ASSERT_EQ(atlas_context->GetGlyphAtlas(), atlas);
 }
@@ -166,7 +177,6 @@ TEST_P(TypographerTest, GlyphAtlasWithLotsOfdUniqueGlyphSize) {
   auto context = TextRenderContext::Create(GetContext());
   auto atlas_context = std::make_shared<GlyphAtlasContext>();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font;
 
   const char* test_string =
       "QWERTYUIOPASDFGHJKLZXCVBNMqewrtyuiopasdfghjklzxcvbnm,.<>[]{};':"
@@ -174,22 +184,17 @@ TEST_P(TypographerTest, GlyphAtlasWithLotsOfdUniqueGlyphSize) {
       "œ∑´®†¥¨ˆøπ““‘‘åß∂ƒ©˙∆˚¬…æ≈ç√∫˜µ≤≥≥≥≥÷¡™£¢∞§¶•ªº–≠⁄€‹›ﬁﬂ‡°·‚—±Œ„´‰Á¨Ø∏”’/"
       "* Í˝ */¸˛Ç◊ı˜Â¯˘¿";
 
+  SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString(test_string, sk_font);
   ASSERT_TRUE(blob);
 
-  TextFrame frame;
-  size_t count = 0;
-  const int size_count = 8;
-  TextRenderContext::FrameIterator iterator = [&]() -> const TextFrame* {
-    if (count < size_count) {
-      count++;
-      frame = TextFrameFromTextBlob(blob, 0.6 * count);
-      return &frame;
-    }
-    return nullptr;
+  FontGlyphPair::Set set;
+  size_t size_count = 8;
+  for (size_t index = 0; index < size_count; index += 1) {
+    TextFrameFromTextBlob(blob).CollectUniqueFontGlyphPairs(set, 0.6 * index);
   };
   auto atlas = context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap,
-                                         atlas_context, iterator);
+                                         std::move(atlas_context), set);
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
 
@@ -217,8 +222,8 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledIfUnchanged) {
   auto blob = SkTextBlob::MakeFromString("spooky 1", sk_font);
   ASSERT_TRUE(blob);
   auto atlas =
-      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-                                TextFrameFromTextBlob(blob));
+      CreateGlyphAtlas(context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
+                       atlas_context, TextFrameFromTextBlob(blob));
   auto old_packer = atlas_context->GetRectPacker();
 
   ASSERT_NE(atlas, nullptr);
@@ -231,8 +236,8 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledIfUnchanged) {
 
   auto blob2 = SkTextBlob::MakeFromString("spooky 2", sk_font);
   auto next_atlas =
-      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-                                TextFrameFromTextBlob(blob2));
+      CreateGlyphAtlas(context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
+                       atlas_context, TextFrameFromTextBlob(blob2));
   ASSERT_EQ(atlas, next_atlas);
   auto* second_texture = next_atlas->GetTexture().get();
 
@@ -250,8 +255,8 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
   auto blob = SkTextBlob::MakeFromString("spooky 1", sk_font);
   ASSERT_TRUE(blob);
   auto atlas =
-      context->CreateGlyphAtlas(GlyphAtlas::Type::kAlphaBitmap, atlas_context,
-                                TextFrameFromTextBlob(blob));
+      CreateGlyphAtlas(context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
+                       atlas_context, TextFrameFromTextBlob(blob));
   auto old_packer = atlas_context->GetRectPacker();
 
   ASSERT_NE(atlas, nullptr);
@@ -265,8 +270,8 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
 
   auto blob2 = SkTextBlob::MakeFromString("spooky 1", sk_font);
   auto next_atlas =
-      context->CreateGlyphAtlas(GlyphAtlas::Type::kColorBitmap, atlas_context,
-                                TextFrameFromTextBlob(blob2));
+      CreateGlyphAtlas(context.get(), GlyphAtlas::Type::kColorBitmap, 1.0f,
+                       atlas_context, TextFrameFromTextBlob(blob2));
   ASSERT_NE(atlas, next_atlas);
   auto* second_texture = next_atlas->GetTexture().get();
 


### PR DESCRIPTION
Alternative to https://github.com/flutter/engine/pull/43662

Records the basis vector of the current CTM into text contents and reuses that rather than trying to get it again at render time. That method breaks if perspective is involved in the CTM and a subpass gets translated, which can modify the scale (and rotation) of the matrix.

We're definitely not doing things quite right with perspective here, but the real fix to that is to either record the fully transformed glyph into the atlas or to use SDF/path based rendering.

Fixes https://github.com/flutter/flutter/issues/130476

I still have some concerns about how `EntityPass::Render` is a mix of mutations and constness but we can try to address that independently. 

I expect this to re-improve the regression noted in https://github.com/flutter/flutter/issues/130594