### PR TITLE
Move ViewConfiguration ownership to FlutterView

### DIFF
--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -539,33 +539,7 @@ void hooksTests() async {
   });
 
   await test('PlatformDispatcher.view getter returns view with provided ID', () {
-    const int viewId = 123456789;
-    _callHook(
-      '_updateWindowMetrics',
-      21,
-      viewId, // window Id
-      1.0, // devicePixelRatio
-      800.0, // width
-      600.0, // height
-      50.0, // paddingTop
-      0.0, // paddingRight
-      40.0, // paddingBottom
-      0.0, // paddingLeft
-      0.0, // insetTop
-      0.0, // insetRight
-      0.0, // insetBottom
-      0.0, // insetLeft
-      0.0, // systemGestureInsetTop
-      0.0, // systemGestureInsetRight
-      0.0, // systemGestureInsetBottom
-      0.0, // systemGestureInsetLeft
-      22.0, // physicalTouchSlop
-      <double>[],  // display features bounds
-      <int>[],     // display features types
-      <int>[],     // display features states
-      0, // Display ID
-    );
-
+    const int viewId = 0;
     expectEquals(PlatformDispatcher.instance.view(id: viewId)?.viewId, viewId);
   });
 

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1368,16 +1368,15 @@ class _PlatformConfiguration {
 /// An immutable view configuration.
 class _ViewConfiguration {
   const _ViewConfiguration({
-    required this.devicePixelRatio,
-    required this.geometry,
-    required this.visible,
-    required this.viewInsets,
-    required this.viewPadding,,
-    required this.systemGestureInsets,,
-    required this.padding,,
-    required this.gestureSettings,
-    required this.displayFeatures,
-    required this.displayId,
+    this.devicePixelRatio = 1.0,
+    this.geometry = Rect.zero,
+    this.viewInsets = ViewPadding.zero,
+    this.viewPadding = ViewPadding.zero,
+    this.systemGestureInsets = ViewPadding.zero,
+    this.padding = ViewPadding.zero,
+    this.gestureSettings = const GestureSettings(),
+    this.displayFeatures = const <DisplayFeature>[],
+    this.displayId = 0,
   });
 
   /// The identifier for a display for this view, in
@@ -1390,9 +1389,6 @@ class _ViewConfiguration {
   /// The geometry requested for the view on the screen or within its parent
   /// window, in logical pixels.
   final Rect geometry;
-
-  /// Whether or not the view is currently visible on the screen.
-  final bool visible;
 
   /// The number of physical pixels on each side of the display rectangle into
   /// which the view can render, but over which the operating system will likely

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -66,7 +66,10 @@ typedef ErrorCallback = bool Function(Object exception, StackTrace stackTrace);
 // A gesture setting value that indicates it has not been set by the engine.
 const double _kUnsetGestureSetting = -1.0;
 
-// The view ID of PlatformDispatcher.implicitView.
+// The view ID of PlatformDispatcher.implicitView. This is an
+// implementation detail that may change at any time. Apps
+// should always use PlatformDispatcher.implicitView to determine
+// the current implicit view, if any.
 //
 // Keep this in sync with kImplicitViewId in window/platform_configuration.cc.
 const int _kImplicitViewId = 0;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -283,7 +283,7 @@ class PlatformDispatcher {
     List<int> displayFeaturesState,
     int displayId,
   ) {
-    final _ViewConfiguration _viewConfiguration = _ViewConfiguration(
+    final _ViewConfiguration viewConfiguration = _ViewConfiguration(
       devicePixelRatio: devicePixelRatio,
       geometry: Rect.fromLTWH(0.0, 0.0, width, height),
       viewPadding: ViewPadding._(
@@ -326,10 +326,10 @@ class PlatformDispatcher {
     if (id == _kImplicitViewId && view == null) {
       // TODO(goderbauer): Remove the implicit creation of the implicit view
       //   when we have an addView API and the implicit view is added via that.
-      _views[id] = FlutterView._(id, this, _viewConfiguration);
+      _views[id] = FlutterView._(id, this, viewConfiguration);
     } else {
       assert(view != null);
-      view!._viewConfiguration = _viewConfiguration;
+      view!._viewConfiguration = viewConfiguration;
     }
 
     _invoke(onMetricsChanged, _onMetricsChangedZone);

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -86,7 +86,7 @@ class Display {
 /// that in the [padding], which is always safe to use for such
 /// calculations.
 class FlutterView {
-  FlutterView._(this.viewId, this.platformDispatcher);
+  FlutterView._(this.viewId, this.platformDispatcher, this._viewConfiguration);
 
   /// The opaque ID for this view.
   final int viewId;
@@ -96,10 +96,7 @@ class FlutterView {
   final PlatformDispatcher platformDispatcher;
 
   /// The configuration of this view.
-  _ViewConfiguration get _viewConfiguration {
-    assert(platformDispatcher._viewConfigurations.containsKey(viewId));
-    return platformDispatcher._viewConfigurations[viewId]!;
-  }
+  _ViewConfiguration _viewConfiguration;
 
   /// The [Display] this view is drawn in.
   Display get display {
@@ -373,6 +370,9 @@ class FlutterView {
 
   @Native<Void Function(Pointer<Void>)>(symbol: 'PlatformConfigurationNativeApi::UpdateSemantics')
   external static void _updateSemantics(_NativeSemanticsUpdate update);
+
+  @override
+  String toString() => 'FlutterView(id: $viewId)';
 }
 
 /// Deprecated. Will be removed in a future version of Flutter.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -405,8 +405,15 @@ class SingletonFlutterWindow extends FlutterView {
     'Deprecated to prepare for the upcoming multi-window support. '
     'This feature was deprecated after v3.7.0-32.0.pre.'
   )
-  SingletonFlutterWindow._(super.windowId, super.platformDispatcher)
-      : super._();
+  SingletonFlutterWindow._() : super._(
+    _kImplicitViewId,
+    PlatformDispatcher.instance,
+    const _ViewConfiguration(),
+  );
+
+  // Shares a configuration with the FlutterView with the same ID.
+  @override
+  _ViewConfiguration get _viewConfiguration => platformDispatcher._views[viewId]?._viewConfiguration ?? super._viewConfiguration;
 
   /// A callback that is invoked whenever the [devicePixelRatio],
   /// [physicalSize], [padding], [viewInsets], [PlatformDispatcher.views], or
@@ -1016,7 +1023,7 @@ enum Brightness {
   'Deprecated to prepare for the upcoming multi-window support. '
   'This feature was deprecated after v3.7.0-32.0.pre.'
 )
-final SingletonFlutterWindow window = SingletonFlutterWindow._(0, PlatformDispatcher.instance);
+final SingletonFlutterWindow window = SingletonFlutterWindow._();
 
 /// Additional data available on each flutter frame.
 class FrameData {

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -411,7 +411,7 @@ class SingletonFlutterWindow extends FlutterView {
     const _ViewConfiguration(),
   );
 
-  // Shares a configuration with the FlutterView with the same ID.
+  // Gets its configuration from the FlutterView with the same ID.
   @override
   _ViewConfiguration get _viewConfiguration => platformDispatcher._views[viewId]?._viewConfiguration ?? super._viewConfiguration;
 

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -411,7 +411,7 @@ class SingletonFlutterWindow extends FlutterView {
     const _ViewConfiguration(),
   );
 
-  // Gets its configuration from the FlutterView with the same ID.
+  // Gets its configuration from the FlutterView with the same ID if it exists.
   @override
   _ViewConfiguration get _viewConfiguration => platformDispatcher._views[viewId]?._viewConfiguration ?? super._viewConfiguration;
 

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -96,7 +96,8 @@ class FlutterView {
   final PlatformDispatcher platformDispatcher;
 
   /// The configuration of this view.
-  _ViewConfiguration _viewConfiguration;
+  // TODO(goderbauer): remove ignore when https://github.com/dart-lang/linter/issues/4562 is fixed.
+  _ViewConfiguration _viewConfiguration; // ignore: prefer_final_fields
 
   /// The [Display] this view is drawn in.
   Display get display {

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -22,6 +22,7 @@
 namespace flutter {
 namespace {
 
+// Keep this in sync with _kImplicitViewId in ../platform_dispatcher.dart.
 constexpr int kImplicitViewId = 0;
 
 Dart_Handle ToByteData(const fml::Mapping& buffer) {

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -89,4 +89,10 @@ void main() {
     expect(display.refreshRate, 60);
     expect(display.size, implicitView.physicalSize);
   });
+
+  test('FlutterView.toString contains the viewId', () {
+    final FlutterView flutterView = PlatformDispatcher.instance.implicitView!;
+    expect(flutterView.viewId, 0)
+    expect(flutterView.toString(), 'FlutterView(id: $0)');
+  });
 }

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -92,7 +92,7 @@ void main() {
 
   test('FlutterView.toString contains the viewId', () {
     final FlutterView flutterView = PlatformDispatcher.instance.implicitView!;
-    expect(flutterView.viewId, 0)
+    expect(flutterView.viewId, 0);
     expect(flutterView.toString(), 'FlutterView(id: 0)');
   });
 }

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -93,6 +93,6 @@ void main() {
   test('FlutterView.toString contains the viewId', () {
     final FlutterView flutterView = PlatformDispatcher.instance.implicitView!;
     expect(flutterView.viewId, 0)
-    expect(flutterView.toString(), 'FlutterView(id: $0)');
+    expect(flutterView.toString(), 'FlutterView(id: 0)');
   });
 }


### PR DESCRIPTION
This makes the FlutterView object a little bit less brittle by not depending on the PlatformDispatcher so much.