### PR TITLE
[Windows] Remove accessibility bridge helpers from the engine

### DIFF
--- a/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -178,9 +178,9 @@ ui::AXNode* AXNodeFromID(std::shared_ptr<AccessibilityBridge> bridge,
 }
 
 std::shared_ptr<AccessibilityBridgeWindowsSpy> GetAccessibilityBridgeSpy(
-    FlutterWindowsEngine* engine) {
+    FlutterWindowsView& view) {
   return std::static_pointer_cast<AccessibilityBridgeWindowsSpy>(
-      engine->accessibility_bridge().lock());
+      view.accessibility_bridge().lock());
 }
 
 void ExpectWinEventFromAXEvent(int32_t node_id,
@@ -192,7 +192,7 @@ void ExpectWinEventFromAXEvent(int32_t node_id,
   view.SetEngine(GetTestEngine());
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = GetAccessibilityBridgeSpy(view.GetEngine());
+  auto bridge = GetAccessibilityBridgeSpy(view);
   PopulateAXTree(bridge);
 
   bridge->ResetRecords();
@@ -212,7 +212,7 @@ void ExpectWinEventFromAXEventOnFocusNode(int32_t node_id,
   view.SetEngine(GetTestEngine());
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = GetAccessibilityBridgeSpy(view.GetEngine());
+  auto bridge = GetAccessibilityBridgeSpy(view);
   PopulateAXTree(bridge);
 
   bridge->ResetRecords();
@@ -237,7 +237,7 @@ TEST(AccessibilityBridgeWindows, GetParent) {
   view.SetEngine(GetTestEngine());
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   PopulateAXTree(bridge);
 
   auto node0_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -253,7 +253,7 @@ TEST(AccessibilityBridgeWindows, GetParentOnRootRetunsNullptr) {
   view.SetEngine(GetTestEngine());
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   PopulateAXTree(bridge);
 
   auto node0_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
@@ -267,7 +267,7 @@ TEST(AccessibilityBridgeWindows, DispatchAccessibilityAction) {
   view.SetEngine(GetTestEngine());
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   PopulateAXTree(bridge);
 
   FlutterSemanticsAction actual_action = kFlutterSemanticsActionTap;
@@ -303,7 +303,7 @@ TEST(AccessibilityBridgeWindows, OnAccessibilityEventFocusChanged) {
   view.SetEngine(GetTestEngine());
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = GetAccessibilityBridgeSpy(view.GetEngine());
+  auto bridge = GetAccessibilityBridgeSpy(view);
   PopulateAXTree(bridge);
 
   bridge->ResetRecords();

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -141,9 +141,6 @@ class FlutterWindowsEngine {
   // rendering using software instead of OpenGL.
   AngleSurfaceManager* surface_manager() { return surface_manager_.get(); }
 
-  // Return the AccessibilityBridgeWindows for this engine's view.
-  std::weak_ptr<AccessibilityBridgeWindows> accessibility_bridge();
-
   WindowProcDelegateManager* window_proc_delegate_manager() {
     return window_proc_delegate_manager_.get();
   }
@@ -226,10 +223,6 @@ class FlutterWindowsEngine {
 
   // Returns true if the high contrast feature is enabled.
   bool high_contrast_enabled() const { return high_contrast_enabled_; }
-
-  // Returns the native accessibility root node, or nullptr if one does not
-  // exist.
-  gfx::NativeViewAccessible GetNativeViewAccessible();
 
   // Register a root isolate create callback.
   //

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -253,7 +253,11 @@ void FlutterWindowsView::OnUpdateSemanticsEnabled(bool enabled) {
 }
 
 gfx::NativeViewAccessible FlutterWindowsView::GetNativeViewAccessible() {
-  return engine_->GetNativeViewAccessible();
+  if (!accessibility_bridge_) {
+    return nullptr;
+  }
+
+  return accessibility_bridge_->GetChildOfAXFragmentRoot();
 }
 
 void FlutterWindowsView::OnCursorRectUpdated(const Rect& rect) {
@@ -639,7 +643,7 @@ void FlutterWindowsView::NotifyWinEventWrapper(ui::AXPlatformNodeWin* node,
 }
 
 ui::AXFragmentRootDelegateWin* FlutterWindowsView::GetAxFragmentRootDelegate() {
-  return engine_->accessibility_bridge().lock().get();
+  return accessibility_bridge_.get();
 }
 
 ui::AXPlatformNodeWin* FlutterWindowsView::AlertNode() const {

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -212,7 +212,7 @@ TEST(FlutterWindowsViewTest, AddSemanticsNodeUpdate) {
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
   // Add root node.
@@ -311,7 +311,7 @@ TEST(FlutterWindowsViewTest, AddSemanticsNodeUpdateWithChildren) {
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
   // Add root node.
@@ -509,7 +509,7 @@ TEST(FlutterWindowsViewTest, NonZeroSemanticsRoot) {
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
   // Add root node.
@@ -641,7 +641,7 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
   // Add root node at origin. Size 500x500.
@@ -802,7 +802,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
   FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
@@ -948,7 +948,7 @@ TEST(FlutterWindowsViewTest, SwitchNativeState) {
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
   FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
@@ -1065,7 +1065,7 @@ TEST(FlutterWindowsViewTest, TooltipNodeData) {
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
   FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};


### PR DESCRIPTION
The ownership of the accessibility bridge was moved from `FlutterWindowsEngine` to `FlutterWindowsView`. This change moves leftover accessibility bridge helpers/logic from the engine to the view.

Addresses: https://github.com/flutter/flutter/issues/124995
Follow-up to: https://github.com/flutter/engine/pull/41308

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
