### PR TITLE
Android 13 VSync presentation timing

### DIFF
--- a/common/constants.h
+++ b/common/constants.h
@@ -33,6 +33,10 @@ constexpr double kMegaByteSizeInBytes = (1 << 20);
 // implicit view if the target ID is `kFlutterImplicitViewId`, unless specified
 // otherwise.
 constexpr int64_t kFlutterImplicitViewId = 0;
+
+// If this is the vsync ID recorded for a frame, it should not be applied as
+// part of any vsync transaction.
+constexpr int64_t kInvalidVSyncId = 0;
 }  // namespace flutter
 
 #endif  // FLUTTER_COMMON_CONSTANTS_H_

--- a/flow/surface_frame.h
+++ b/flow/surface_frame.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 
+#include "flutter/common/constants.h"
 #include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/display_list/dl_builder.h"
 #include "flutter/display_list/skia/dl_sk_canvas.h"
@@ -87,6 +88,10 @@ class SurfaceFrame {
     //
     // Defaults to true, which is generally a safe value.
     bool frame_boundary = true;
+
+    // Identifier for the platform to indicate when this frame should be
+    // presented.
+    int64_t vsync_id = kInvalidVSyncId;
   };
 
   bool Submit();

--- a/fml/trace_event.cc
+++ b/fml/trace_event.cc
@@ -180,6 +180,32 @@ void TraceEvent2(TraceArg category_group,
   );
 }
 
+void TraceEvent4(TraceArg category_group,
+                 TraceArg name,
+                 size_t flow_id_count,
+                 const uint64_t* flow_ids,
+                 TraceArg arg1_name,
+                 TraceArg arg1_val,
+                 TraceArg arg2_name,
+                 TraceArg arg2_val,
+                 TraceArg arg3_name,
+                 TraceArg arg3_val,
+                 TraceArg arg4_name,
+                 TraceArg arg4_val) {
+  const char* arg_names[] = {arg1_name, arg2_name, arg3_name, arg4_name};
+  const char* arg_values[] = {arg1_val, arg2_val, arg3_val, arg4_val};
+  FlutterTimelineEvent(name,                            // label
+                       gTimelineMicrosSource.load()(),  // timestamp0
+                       0,              // timestamp1_or_async_id
+                       flow_id_count,  // flow_id_count
+                       reinterpret_cast<const int64_t*>(flow_ids),  // flow_ids
+                       Dart_Timeline_Event_Begin,  // event type
+                       4,                          // argument_count
+                       arg_names,                  // argument_names
+                       arg_values                  // argument_values
+  );
+}
+
 void TraceEventEnd(TraceArg name) {
   FlutterTimelineEvent(name,                            // label
                        gTimelineMicrosSource.load()(),  // timestamp0
@@ -425,6 +451,19 @@ void TraceEvent2(TraceArg category_group,
                  TraceArg arg1_val,
                  TraceArg arg2_name,
                  TraceArg arg2_val) {}
+
+void TraceEvent4(TraceArg category_group,
+                 TraceArg name,
+                 size_t flow_id_count,
+                 const uint64_t* flow_ids,
+                 TraceArg arg1_name,
+                 TraceArg arg1_val,
+                 TraceArg arg2_name,
+                 TraceArg arg2_val,
+                 TraceArg arg3_name,
+                 TraceArg arg3_val,
+                 TraceArg arg4_name,
+                 TraceArg arg4_val) {}
 
 void TraceEventEnd(TraceArg name) {}
 

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -149,6 +149,14 @@
                               arg2_name, arg2_val);                        \
   __FML__AUTO_TRACE_END(name)
 
+#define TRACE_EVENT4(category_group, name, arg1_name, arg1_val, arg2_name, \
+                     arg2_val, arg3_name, arg3_val, arg4_name, arg4_val)   \
+  ::fml::tracing::TraceEvent4(category_group, name, /*flow_id_count=*/0,   \
+                              /*flow_ids=*/nullptr, arg1_name, arg1_val,   \
+                              arg2_name, arg2_val, arg3_name, arg3_val,    \
+                              arg4_name, arg4_val);                        \
+  __FML__AUTO_TRACE_END(name)
+
 #define TRACE_EVENT_ASYNC_BEGIN0_WITH_FLOW_IDS(category_group, name, id, \
                                                flow_id_count, flow_ids)  \
   ::fml::tracing::TraceEventAsyncBegin0(category_group, name, id,        \
@@ -205,6 +213,16 @@
   const auto __arg2_val_str = std::to_string(arg2_val);                        \
   TRACE_EVENT2(category_group, name, arg1_name, __arg1_val_str.c_str(),        \
                arg2_name, __arg2_val_str.c_str());
+
+#define TRACE_EVENT4_INT(category_group, name, arg1_name, arg1_val, arg2_name, \
+                         arg2_val, arg3_name, arg3_val, arg4_name, arg4_val)   \
+  const auto __arg1_val_str = std::to_string(arg1_val);                        \
+  const auto __arg2_val_str = std::to_string(arg2_val);                        \
+  const auto __arg3_val_str = std::to_string(arg3_val);                        \
+  const auto __arg4_val_str = std::to_string(arg4_val);                        \
+  TRACE_EVENT4(category_group, name, arg1_name, __arg1_val_str.c_str(),        \
+               arg2_name, __arg2_val_str.c_str(), arg3_name,                   \
+               __arg3_val_str.c_str(), arg4_name, __arg4_val_str.c_str());
 
 namespace fml {
 namespace tracing {
@@ -307,14 +325,16 @@ void TraceCounter(TraceArg category,
                   Args... args) {
 #if FLUTTER_TIMELINE_ENABLED
   auto split = SplitArguments(args...);
-  TraceTimelineEvent(category, name, identifier, /*flow_id_count=*/0,
+  TraceTimelineEvent(category, name, identifier,
+                     /*flow_id_count=*/0,
                      /*flow_ids=*/nullptr, Dart_Timeline_Event_Counter,
                      split.first, split.second);
 #endif  // FLUTTER_TIMELINE_ENABLED
 }
 
-// HACK: Used to NOP FML_TRACE_COUNTER macro without triggering unused var
-// warnings at usage sites.
+// HACK: Used to NOP FML_TRACE_COUNTER macro
+// without triggering unused var warnings at usage
+// sites.
 template <typename... Args>
 void TraceCounterNopHACK(TraceArg category,
                          TraceArg name,
@@ -354,6 +374,19 @@ void TraceEvent2(TraceArg category_group,
                  TraceArg arg1_val,
                  TraceArg arg2_name,
                  TraceArg arg2_val);
+
+void TraceEvent4(TraceArg category_group,
+                 TraceArg name,
+                 size_t flow_id_count,
+                 const uint64_t* flow_ids,
+                 TraceArg arg1_name,
+                 TraceArg arg1_val,
+                 TraceArg arg2_name,
+                 TraceArg arg2_val,
+                 TraceArg arg3_name,
+                 TraceArg arg3_val,
+                 TraceArg arg4_name,
+                 TraceArg arg4_val);
 
 void TraceEventEnd(TraceArg name);
 

--- a/impeller/toolkit/android/choreographer.h
+++ b/impeller/toolkit/android/choreographer.h
@@ -12,6 +12,22 @@
 
 namespace impeller::android {
 
+enum class ChoreographerSupportStatus {
+  // Unavailable, API level < 24.
+  kUnsupported,
+  // Available with postFrameCallback64 or postFrameCallback.
+  kSupported,
+  // Available with postVsyncCallback.
+  kSupportedVsync,
+};
+
+// TODO(moffatman) document
+struct ChoreographerVsyncTimings {
+  std::chrono::time_point<std::chrono::steady_clock> start;
+  std::chrono::time_point<std::chrono::steady_clock> target;
+  int64_t id;
+};
+
 //------------------------------------------------------------------------------
 /// @brief      This class describes access to the choreographer instance for
 ///             the current thread. Choreographers are only available on API
@@ -23,7 +39,7 @@ namespace impeller::android {
 ///
 class Choreographer {
  public:
-  static bool IsAvailableOnPlatform();
+  static ChoreographerSupportStatus GetPlatformSupport();
 
   //----------------------------------------------------------------------------
   /// @brief      Create or get the thread local instance of a choreographer. A
@@ -58,6 +74,8 @@ class Choreographer {
   ///
   using FrameTimePoint = std::chrono::time_point<FrameClock>;
   using FrameCallback = std::function<void(FrameTimePoint)>;
+  // TODO: Need a new struct type here
+  using VsyncCallback = std::function<void(ChoreographerVsyncTimings)>;
 
   //----------------------------------------------------------------------------
   /// @brief      Posts a frame callback. The time that the frame is being
@@ -72,6 +90,9 @@ class Choreographer {
   ///             See `IsAvailableOnPlatform`.
   ///
   bool PostFrameCallback(FrameCallback callback) const;
+
+  // TODO(moffatman): document
+  bool PostVsyncCallback(VsyncCallback callback, size_t latency) const;
 
  private:
   AChoreographer* instance_ = nullptr;

--- a/impeller/toolkit/android/proc_table.h
+++ b/impeller/toolkit/android/proc_table.h
@@ -34,34 +34,41 @@ namespace impeller::android {
 ///             directly. Instead, rely on the handle wrappers (`Choreographer`,
 ///             `HardwareBuffer`, etc..).
 ///
-#define FOR_EACH_ANDROID_PROC(INVOKE)                            \
-  INVOKE(AChoreographer_getInstance, 24)                         \
-  INVOKE(AChoreographer_postFrameCallback, 24)                   \
-  INVOKE(AChoreographer_postFrameCallback64, 29)                 \
-  INVOKE(AHardwareBuffer_acquire, 26)                            \
-  INVOKE(AHardwareBuffer_allocate, 26)                           \
-  INVOKE(AHardwareBuffer_describe, 26)                           \
-  INVOKE(AHardwareBuffer_fromHardwareBuffer, 26)                 \
-  INVOKE(AHardwareBuffer_getId, 31)                              \
-  INVOKE(AHardwareBuffer_isSupported, 29)                        \
-  INVOKE(AHardwareBuffer_lock, 26)                               \
-  INVOKE(AHardwareBuffer_release, 26)                            \
-  INVOKE(AHardwareBuffer_unlock, 26)                             \
-  INVOKE(ANativeWindow_acquire, 0)                               \
-  INVOKE(ANativeWindow_getHeight, 0)                             \
-  INVOKE(ANativeWindow_getWidth, 0)                              \
-  INVOKE(ANativeWindow_release, 0)                               \
-  INVOKE(ASurfaceControl_createFromWindow, 29)                   \
-  INVOKE(ASurfaceControl_release, 29)                            \
-  INVOKE(ASurfaceTransaction_apply, 29)                          \
-  INVOKE(ASurfaceTransaction_create, 29)                         \
-  INVOKE(ASurfaceTransaction_delete, 29)                         \
-  INVOKE(ASurfaceTransaction_reparent, 29)                       \
-  INVOKE(ASurfaceTransaction_setBuffer, 29)                      \
-  INVOKE(ASurfaceTransaction_setColor, 29)                       \
-  INVOKE(ASurfaceTransaction_setOnComplete, 29)                  \
-  INVOKE(ASurfaceTransactionStats_getPreviousReleaseFenceFd, 29) \
-  INVOKE(ATrace_isEnabled, 23)                                   \
+#define FOR_EACH_ANDROID_PROC(INVOKE)                                        \
+  INVOKE(AChoreographer_getInstance, 24)                                     \
+  INVOKE(AChoreographer_postFrameCallback, 24)                               \
+  INVOKE(AChoreographer_postFrameCallback64, 29)                             \
+  INVOKE(AChoreographer_postVsyncCallback, 33)                               \
+  INVOKE(AChoreographerFrameCallbackData_getFrameTimeNanos, 33)              \
+  INVOKE(AChoreographerFrameCallbackData_getPreferredFrameTimelineIndex, 33) \
+  INVOKE(AChoreographerFrameCallbackData_getFrameTimelinesLength, 33)        \
+  INVOKE(AChoreographerFrameCallbackData_getFrameTimelineDeadlineNanos, 33)  \
+  INVOKE(AChoreographerFrameCallbackData_getFrameTimelineVsyncId, 33)        \
+  INVOKE(AHardwareBuffer_acquire, 26)                                        \
+  INVOKE(AHardwareBuffer_allocate, 26)                                       \
+  INVOKE(AHardwareBuffer_describe, 26)                                       \
+  INVOKE(AHardwareBuffer_fromHardwareBuffer, 26)                             \
+  INVOKE(AHardwareBuffer_getId, 31)                                          \
+  INVOKE(AHardwareBuffer_isSupported, 29)                                    \
+  INVOKE(AHardwareBuffer_lock, 26)                                           \
+  INVOKE(AHardwareBuffer_release, 26)                                        \
+  INVOKE(AHardwareBuffer_unlock, 26)                                         \
+  INVOKE(ANativeWindow_acquire, 0)                                           \
+  INVOKE(ANativeWindow_getHeight, 0)                                         \
+  INVOKE(ANativeWindow_getWidth, 0)                                          \
+  INVOKE(ANativeWindow_release, 0)                                           \
+  INVOKE(ASurfaceControl_createFromWindow, 29)                               \
+  INVOKE(ASurfaceControl_release, 29)                                        \
+  INVOKE(ASurfaceTransaction_apply, 29)                                      \
+  INVOKE(ASurfaceTransaction_create, 29)                                     \
+  INVOKE(ASurfaceTransaction_delete, 29)                                     \
+  INVOKE(ASurfaceTransaction_reparent, 29)                                   \
+  INVOKE(ASurfaceTransaction_setBuffer, 29)                                  \
+  INVOKE(ASurfaceTransaction_setColor, 29)                                   \
+  INVOKE(ASurfaceTransaction_setFrameTimeline, 33)                           \
+  INVOKE(ASurfaceTransaction_setOnComplete, 29)                              \
+  INVOKE(ASurfaceTransactionStats_getPreviousReleaseFenceFd, 29)             \
+  INVOKE(ATrace_isEnabled, 23)                                               \
   INVOKE(eglGetNativeClientBufferANDROID, 0)
 
 template <class T>

--- a/impeller/toolkit/android/toolkit_android_unittests.cc
+++ b/impeller/toolkit/android/toolkit_android_unittests.cc
@@ -101,14 +101,17 @@ TEST(ToolkitAndroidTest, SurfacControlsAreAvailable) {
 }
 
 TEST(ToolkitAndroidTest, ChoreographerIsAvailable) {
-  if (!Choreographer::IsAvailableOnPlatform()) {
+  if (Choreographer::GetPlatformSupport() ==
+      ChoreographerSupportStatus::kUnsupported) {
     GTEST_SKIP() << "Choreographer is not supported on this platform.";
   }
-  ASSERT_TRUE(Choreographer::IsAvailableOnPlatform());
+  ASSERT_TRUE(Choreographer::GetPlatformSupport() !=
+              ChoreographerSupportStatus::kUnsupported);
 }
 
 TEST(ToolkitAndroidTest, CanPostAndNotWaitForFrameCallbacks) {
-  if (!Choreographer::IsAvailableOnPlatform()) {
+  if (Choreographer::GetPlatformSupport() ==
+      ChoreographerSupportStatus::kUnsupported) {
     GTEST_SKIP() << "Choreographer is not supported on this platform.";
   }
   const auto& choreographer = Choreographer::GetInstance();
@@ -117,7 +120,8 @@ TEST(ToolkitAndroidTest, CanPostAndNotWaitForFrameCallbacks) {
 }
 
 TEST(ToolkitAndroidTest, CanPostAndWaitForFrameCallbacks) {
-  if (!Choreographer::IsAvailableOnPlatform()) {
+  if (Choreographer::GetPlatformSupport() ==
+      ChoreographerSupportStatus::kUnsupported) {
     GTEST_SKIP() << "Choreographer is not supported on this platform.";
   }
   if ((true)) {

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -736,7 +736,8 @@ class Rasterizer final : public SnapshotDelegate,
       int64_t view_id,
       flutter::LayerTree& layer_tree,
       float device_pixel_ratio,
-      std::optional<fml::TimePoint> presentation_time);
+      std::optional<fml::TimePoint> presentation_time,
+      int64_t vsync_id);
 
   ViewRecord& EnsureViewRecord(int64_t view_id);
 

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -135,10 +135,14 @@ TEST(RasterizerTest, create) {
 }
 
 static std::unique_ptr<FrameTimingsRecorder> CreateFinishedBuildRecorder(
-    fml::TimePoint timestamp) {
+    fml::TimePoint timestamp,
+    int64_t vsync_id = kInvalidVSyncId) {
   std::unique_ptr<FrameTimingsRecorder> recorder =
       std::make_unique<FrameTimingsRecorder>();
-  recorder->RecordVsync(timestamp, timestamp);
+  recorder->RecordVsync({.start = timestamp,
+                         .target = timestamp,
+                         .next_start = timestamp,
+                         .id = vsync_id});
   recorder->RecordBuildStart(timestamp);
   recorder->RecordBuildEnd(timestamp);
   return recorder;
@@ -1246,6 +1250,7 @@ TEST(RasterizerTest, presentationTimeSetWhenVsyncTargetInFuture) {
   const auto first_timestamp = fml::TimePoint::Now() + millis_16;
   auto second_timestamp = first_timestamp + millis_16;
   std::vector<fml::TimePoint> timestamps = {first_timestamp, second_timestamp};
+  std::vector<int64_t> vsync_ids = {1001, 1002};
 
   int frames_submitted = 0;
   fml::CountDownLatch submit_latch(2);
@@ -1260,10 +1265,12 @@ TEST(RasterizerTest, presentationTimeSetWhenVsyncTargetInFuture) {
             /*submit_callback=*/
             [&](const SurfaceFrame& frame, DlCanvas*) {
               const auto pres_time = *frame.submit_info().presentation_time;
+              const auto vsync_id = frame.submit_info().vsync_id;
               const auto diff = pres_time - first_timestamp;
               int num_frames_submitted = frames_submitted++;
               EXPECT_EQ(diff.ToMilliseconds(),
                         num_frames_submitted * millis_16.ToMilliseconds());
+              EXPECT_EQ(vsync_id, num_frames_submitted + 1000);
               submit_latch.CountDown();
               return true;
             },
@@ -1283,7 +1290,7 @@ TEST(RasterizerTest, presentationTimeSetWhenVsyncTargetInFuture) {
       auto layer_tree_item = std::make_unique<FrameItem>(
           SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                              kDevicePixelRatio),
-          CreateFinishedBuildRecorder(timestamps[i]));
+          CreateFinishedBuildRecorder(timestamps[i], vsync_ids[i]));
       PipelineProduceResult result =
           pipeline->Produce().Complete(std::move(layer_tree_item));
       EXPECT_TRUE(result.success);

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -2064,7 +2064,11 @@ bool Shell::OnServiceProtocolRenderFrameWithRasterStats(
     // set before build-end.
     auto frame_timings_recorder = std::make_unique<FrameTimingsRecorder>();
     const auto now = fml::TimePoint::Now();
-    frame_timings_recorder->RecordVsync(now, now);
+    // deadline and next_start will not be used.
+    frame_timings_recorder->RecordVsync({.start = now,
+                                         .target = now,
+                                         .next_start = now,
+                                         .id = kInvalidVSyncId});
     frame_timings_recorder->RecordBuildStart(now);
     frame_timings_recorder->RecordBuildEnd(now);
 

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -187,7 +187,10 @@ void ShellTest::SetViewportMetrics(Shell* shell, double width, double height) {
               frame_begin_time + fml::TimeDelta::FromSecondsF(1.0 / 60.0);
           std::unique_ptr<FrameTimingsRecorder> recorder =
               std::make_unique<FrameTimingsRecorder>();
-          recorder->RecordVsync(frame_begin_time, frame_end_time);
+          recorder->RecordVsync({.start = frame_begin_time,
+                                 .target = frame_end_time,
+                                 .next_start = frame_end_time,
+                                 .id = kInvalidVSyncId});
           engine->animator_->BeginFrame(std::move(recorder));
           engine->animator_->EndFrame();
         }
@@ -229,7 +232,10 @@ void ShellTest::PumpOneFrame(Shell* shell, FrameContent frame_content) {
             frame_begin_time + fml::TimeDelta::FromSecondsF(1.0 / 60.0);
         std::unique_ptr<FrameTimingsRecorder> recorder =
             std::make_unique<FrameTimingsRecorder>();
-        recorder->RecordVsync(frame_begin_time, frame_end_time);
+        recorder->RecordVsync({.start = frame_begin_time,
+                               .target = frame_end_time,
+                               .next_start = frame_end_time,
+                               .id = kInvalidVSyncId});
         engine->animator_->BeginFrame(std::move(recorder));
 
         // The BeginFrame phase and the EndFrame phase must be performed in a

--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <unordered_map>
 
+#include "flutter/common/constants.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/flow/frame_timings.h"
 #include "flutter/fml/time/time_point.h"
@@ -70,8 +71,7 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
 
   // Schedules the callback on the UI task runner. Needs to be invoked as close
   // to the `frame_start_time` as possible.
-  void FireCallback(fml::TimePoint frame_start_time,
-                    fml::TimePoint frame_target_time,
+  void FireCallback(FrameTimingsRecorder::VSyncInfo vsync_info,
                     bool pause_secondary_tasks = true);
 
  private:

--- a/shell/common/vsync_waiter_fallback.cc
+++ b/shell/common/vsync_waiter_fallback.cc
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include "flutter/common/constants.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/trace_event.h"
@@ -52,7 +53,10 @@ void VsyncWaiterFallback::AwaitVSync() {
   task_runners_.GetUITaskRunner()->PostTaskForTime(
       [frame_start_time, frame_target_time, weak_this]() {
         if (auto vsync_waiter = weak_this.lock()) {
-          vsync_waiter->FireCallback(frame_start_time, frame_target_time,
+          vsync_waiter->FireCallback({.start = frame_start_time,
+                                      .target = frame_target_time,
+                                      .next_start = frame_target_time,
+                                      .id = kInvalidVSyncId},
                                      !vsync_waiter->for_testing_);
         }
       },

--- a/shell/common/vsync_waiters_test.cc
+++ b/shell/common/vsync_waiters_test.cc
@@ -51,7 +51,11 @@ void ShellTestVsyncWaiter::AwaitVSync() {
     //
     // For example, HandlesActualIphoneXsInputEvents will fail without this.
     task_runners_.GetPlatformTaskRunner()->PostTask([this]() {
-      FireCallback(fml::TimePoint::Now(), fml::TimePoint::Now());
+      FireCallback({.start = fml::TimePoint::Now(),
+                    .target = fml::TimePoint::Now(),
+                    .next_start = fml::TimePoint::Now(),
+                    .id = kInvalidVSyncId},
+                   0);
     });
   });
 }
@@ -59,8 +63,13 @@ void ShellTestVsyncWaiter::AwaitVSync() {
 void ConstantFiringVsyncWaiter::AwaitVSync() {
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
   auto async_wait = std::async([this]() {
-    task_runners_.GetPlatformTaskRunner()->PostTask(
-        [this]() { FireCallback(kFrameBeginTime, kFrameTargetTime); });
+    task_runners_.GetPlatformTaskRunner()->PostTask([this]() {
+      FireCallback({.start = kFrameBeginTime,
+                    .target = kFrameTargetTime,
+                    .next_start = kFrameTargetTime,
+                    .id = kInvalidVSyncId},
+                   0);
+    });
   });
 }
 

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -46,6 +46,10 @@ struct GLPresentInfo {
   // The buffer damage refers to the region that needs to be set as damaged
   // within the frame buffer.
   const std::optional<SkIRect>& buffer_damage;
+
+  // Opaque identifier to pass to the platform compositor to help it present
+  // this frame at the correct time.
+  int64_t vsync_id = kInvalidVSyncId;
 };
 
 class GPUSurfaceGLDelegate {

--- a/shell/gpu/gpu_surface_gl_skia.cc
+++ b/shell/gpu/gpu_surface_gl_skia.cc
@@ -281,6 +281,7 @@ bool GPUSurfaceGLSkia::PresentSurface(const SurfaceFrame& frame,
       .frame_damage = frame.submit_info().frame_damage,
       .presentation_time = frame.submit_info().presentation_time,
       .buffer_damage = frame.submit_info().buffer_damage,
+      .vsync_id = frame.submit_info().vsync_id,
   };
   if (!delegate_->GLContextPresent(present_info)) {
     return false;

--- a/shell/platform/android/android_surface_gl_impeller.cc
+++ b/shell/platform/android/android_surface_gl_impeller.cc
@@ -7,6 +7,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/impeller/toolkit/egl/surface.h"
 #include "flutter/shell/gpu/gpu_surface_gl_impeller.h"
+#include "flutter/shell/platform/android/surface/android_surface_transaction.h"
 
 namespace flutter {
 
@@ -136,7 +137,16 @@ bool AndroidSurfaceGLImpeller::GLContextPresent(
   if (!onscreen_surface_) {
     return false;
   }
-  return onscreen_surface_->Present();
+  auto& transaction = AndroidSurfaceTransaction::GetInstance();
+  if (present_info.vsync_id) {
+    transaction.Begin();
+    transaction.SetVsyncId(present_info.vsync_id);
+  }
+  bool ret = onscreen_surface_->Present();
+  if (present_info.vsync_id) {
+    transaction.End();
+  }
+  return ret;
 }
 
 // |GPUSurfaceGLDelegate|

--- a/shell/platform/android/android_surface_gl_skia.cc
+++ b/shell/platform/android/android_surface_gl_skia.cc
@@ -11,6 +11,7 @@
 #include "flutter/fml/memory/ref_ptr.h"
 #include "flutter/shell/platform/android/android_egl_surface.h"
 #include "flutter/shell/platform/android/android_shell_holder.h"
+#include "flutter/shell/platform/android/surface/android_surface_transaction.h"
 
 namespace flutter {
 
@@ -158,7 +159,16 @@ bool AndroidSurfaceGLSkia::GLContextPresent(const GLPresentInfo& present_info) {
   if (present_info.presentation_time) {
     onscreen_surface_->SetPresentationTime(*present_info.presentation_time);
   }
-  return onscreen_surface_->SwapBuffers(present_info.frame_damage);
+  auto& transaction = AndroidSurfaceTransaction::GetInstance();
+  if (present_info.vsync_id) {
+    transaction.Begin();
+    transaction.SetVsyncId(present_info.vsync_id);
+  }
+  bool ret = onscreen_surface_->SwapBuffers(present_info.frame_damage);
+  if (present_info.vsync_id) {
+    transaction.End();
+  }
+  return ret;
 }
 
 GLFBOInfo AndroidSurfaceGLSkia::GLContextFBO(GLFrameInfo frame_info) const {

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -13,6 +13,7 @@
 #include "flutter/shell/platform/android/external_view_embedder/surface_pool.h"
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
+#include "flutter/shell/platform/android/surface/android_surface_transaction.h"
 
 namespace flutter {
 
@@ -32,7 +33,8 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
       const AndroidContext& android_context,
       std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
       std::shared_ptr<AndroidSurfaceFactory> surface_factory,
-      const TaskRunners& task_runners);
+      const TaskRunners& task_runners,
+      AndroidSurfaceTransaction& android_surface_transaction);
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
@@ -127,6 +129,9 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // The number of platform views in the previous frame.
   int64_t previous_frame_view_count_;
+
+  // Allows to set vsync id on submitted frames.
+  AndroidSurfaceTransaction& android_surface_transaction_;
 
   // Destroys the surfaces created from the surface factory.
   // This method schedules a task on the platform thread, and waits for

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -33,6 +33,7 @@
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
 #include "flutter/shell/platform/android/platform_message_response_android.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
+#include "flutter/shell/platform/android/surface/android_surface_transaction.h"
 #include "flutter/shell/platform/android/surface/snapshot_surface_producer.h"
 #include "flutter/shell/platform/android/vsync_waiter_android.h"
 
@@ -360,7 +361,8 @@ std::unique_ptr<Surface> PlatformViewAndroid::CreateRenderingSurface() {
 std::shared_ptr<ExternalViewEmbedder>
 PlatformViewAndroid::CreateExternalViewEmbedder() {
   return std::make_shared<AndroidExternalViewEmbedder>(
-      *android_context_, jni_facade_, surface_factory_, task_runners_);
+      *android_context_, jni_facade_, surface_factory_, task_runners_,
+      AndroidSurfaceTransaction::GetInstance());
 }
 
 // |PlatformView|

--- a/shell/platform/android/surface/BUILD.gn
+++ b/shell/platform/android/surface/BUILD.gn
@@ -8,6 +8,8 @@ source_set("surface") {
   sources = [
     "android_surface.cc",
     "android_surface.h",
+    "android_surface_transaction.cc",
+    "android_surface_transaction.h",
     "snapshot_surface_producer.cc",
     "snapshot_surface_producer.h",
   ]

--- a/shell/platform/android/surface/android_surface_transaction.cc
+++ b/shell/platform/android/surface/android_surface_transaction.cc
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/logging.h"
+#if FML_OS_ANDROID
+#include "flutter/fml/platform/android/ndk_helpers.h"
+#endif  // FML_OS_ANDROID
+#include "flutter/common/constants.h"
+#include "flutter/shell/platform/android/surface/android_surface_transaction.h"
+
+namespace flutter {
+
+AndroidSurfaceTransaction& AndroidSurfaceTransaction::GetInstance() {
+  static AndroidSurfaceTransactionImpl instance;
+  return instance;
+}
+
+void AndroidSurfaceTransactionImpl::Begin() {
+#if FML_OS_ANDROID
+  FML_DCHECK(!pending_transaction_);
+  if (NDKHelpers::SurfaceControlAndTransactionSupported()) {
+    pending_transaction_ = NDKHelpers::ASurfaceTransaction_create();
+  }
+#endif  // FML_OS_ANDROID
+}
+
+void AndroidSurfaceTransactionImpl::SetVsyncId(int64_t vsync_id) {
+#if FML_OS_ANDROID
+  if (NDKHelpers::SurfaceControlAndTransactionSupported()) {
+    FML_DCHECK(pending_transaction_);
+    if (vsync_id != kInvalidVSyncId) {
+      NDKHelpers::ASurfaceTransaction_setFrameTimeline(pending_transaction_,
+                                                       vsync_id);
+    }
+  }
+#endif  // FML_OS_ANDROID
+}
+
+void AndroidSurfaceTransactionImpl::End() {
+#if FML_OS_ANDROID
+  if (NDKHelpers::SurfaceControlAndTransactionSupported()) {
+    FML_DCHECK(pending_transaction_);
+    NDKHelpers::ASurfaceTransaction_apply(pending_transaction_);
+    NDKHelpers::ASurfaceTransaction_delete(pending_transaction_);
+    pending_transaction_ = nullptr;
+  }
+#endif  // FML_OS_ANDROID
+}
+
+}  // namespace flutter

--- a/shell/platform/android/surface/android_surface_transaction.h
+++ b/shell/platform/android/surface/android_surface_transaction.h
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_ANDROID_SURFACE_ANDROID_SURFACE_TRANSACTION_H_
+#define FLUTTER_SHELL_PLATFORM_ANDROID_SURFACE_ANDROID_SURFACE_TRANSACTION_H_
+
+#include "flutter/fml/macros.h"
+
+#ifdef FML_OS_ANDROID
+#include <android/surface_control.h>
+#endif  // FML_OS_ANDROID
+
+#include <cstdint>
+
+namespace flutter {
+
+//------------------------------------------------------------------------------
+/// The Android SurfaceTransaction API is used by `AndroidSurface` to
+/// synchronize frame presentation times. It's only available on API 29+.
+///
+class AndroidSurfaceTransaction {
+ public:
+  static AndroidSurfaceTransaction& GetInstance();
+  virtual void Begin() = 0;
+  virtual void SetVsyncId(int64_t vsync_id) = 0;
+  virtual void End() = 0;
+};
+
+class AndroidSurfaceTransactionImpl : public AndroidSurfaceTransaction {
+ public:
+  void Begin() override;
+  void SetVsyncId(int64_t vsync_id) override;
+  void End() override;
+
+ private:
+  AndroidSurfaceTransactionImpl(){};
+
+#if FML_OS_ANDROID
+  ASurfaceTransaction* pending_transaction_ = nullptr;
+#endif  // FML_OS_ANDROID
+
+  friend class AndroidSurfaceTransaction;
+  FML_DISALLOW_COPY_AND_ASSIGN(AndroidSurfaceTransactionImpl);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_ANDROID_SURFACE_ANDROID_SURFACE_TRANSACTION_H_

--- a/shell/platform/android/vsync_waiter_android.h
+++ b/shell/platform/android/vsync_waiter_android.h
@@ -5,16 +5,16 @@
 #ifndef FLUTTER_SHELL_PLATFORM_ANDROID_VSYNC_WAITER_ANDROID_H_
 #define FLUTTER_SHELL_PLATFORM_ANDROID_VSYNC_WAITER_ANDROID_H_
 
+#include <android/choreographer.h>
 #include <jni.h>
 
 #include <memory>
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/common/vsync_waiter.h"
+#include "impeller/toolkit/android/choreographer.h"
 
 namespace flutter {
-
-class AndroidChoreographer;
 
 class VsyncWaiterAndroid final : public VsyncWaiter {
  public:
@@ -28,7 +28,18 @@ class VsyncWaiterAndroid final : public VsyncWaiter {
   // |VsyncWaiter|
   void AwaitVSync() override;
 
-  static void OnVsyncFromNDK(int64_t frame_nanos, void* data);
+  void Loop();
+
+  static fml::TimePoint NormalizeFrameTime(fml::TimePoint frame_time);
+
+  static void OnVsyncFromNDK(int64_t vsync_nanos, void* data);
+  // This needs to match a deprecated NDK interface.
+  static void OnVsyncFromNDK32(long frame_nanos,  // NOLINT
+                               void* data);
+
+  static void OnVsyncFromNDK33(
+      impeller::android::ChoreographerVsyncTimings timings,
+      void* data);
 
   static void OnVsyncFromJava(JNIEnv* env,
                               jclass jcaller,
@@ -36,14 +47,16 @@ class VsyncWaiterAndroid final : public VsyncWaiter {
                               jlong refreshPeriodNanos,
                               jlong java_baton);
 
-  static void ConsumePendingCallback(std::weak_ptr<VsyncWaiter>* weak_this,
-                                     fml::TimePoint frame_start_time,
-                                     fml::TimePoint frame_target_time);
+  static void ConsumePendingCallback(
+      std::weak_ptr<VsyncWaiterAndroid>* weak_this,
+      FrameTimingsRecorder::VSyncInfo vsync_info);
 
   static void OnUpdateRefreshRate(JNIEnv* env,
                                   jclass jcaller,
                                   jfloat refresh_rate);
 
+  bool awaiting_ = false;
+  bool looping_ = false;
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterAndroid);
 };
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1820,8 +1820,10 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   fml::scoped_nsprotocol<FlutterKeyboardAnimationCallback> animationCallback(
       [keyboardAnimationCallback copy]);
   auto uiCallback = [animationCallback](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
-    fml::TimeDelta frameInterval = recorder->GetVsyncTargetTime() - recorder->GetVsyncStartTime();
-    fml::TimePoint keyboardAnimationTargetTime = recorder->GetVsyncTargetTime() + frameInterval;
+    fml::TimeDelta frameInterval =
+        recorder->GetCurrentVSyncInfo().target - recorder->GetCurrentVSyncInfo().start;
+    fml::TimePoint keyboardAnimationTargetTime =
+        recorder->GetCurrentVSyncInfo().target + frameInterval;
     dispatch_async(dispatch_get_main_queue(), ^(void) {
       animationCallback.get()(keyboardAnimationTargetTime);
     });

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -30,9 +30,7 @@ namespace flutter {
 VsyncWaiterIOS::VsyncWaiterIOS(const flutter::TaskRunners& task_runners)
     : VsyncWaiter(task_runners) {
   auto callback = [this](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
-    const fml::TimePoint start_time = recorder->GetVsyncStartTime();
-    const fml::TimePoint target_time = recorder->GetVsyncTargetTime();
-    FireCallback(start_time, target_time, true);
+    FireCallback(recorder->GetCurrentVSyncInfo(), true);
   };
   client_ = [[VSyncClient alloc] initWithTaskRunner:task_runners_.GetUITaskRunner()
                                            callback:callback];
@@ -127,7 +125,10 @@ double VsyncWaiterIOS::GetRefreshRate() const {
 
   _refreshRate = round(1 / (frame_target_time - frame_start_time).ToSecondsF());
 
-  recorder->RecordVsync(frame_start_time, frame_target_time);
+  recorder->RecordVsync({.start = frame_start_time,
+                         .target = frame_target_time,
+                         .next_start = frame_target_time,
+                         .id = flutter::kInvalidVSyncId});
   if (_allowPauseAfterVsync) {
     link.paused = YES;
   }

--- a/shell/platform/embedder/vsync_waiter_embedder.cc
+++ b/shell/platform/embedder/vsync_waiter_embedder.cc
@@ -42,7 +42,11 @@ bool VsyncWaiterEmbedder::OnEmbedderVsync(
         auto vsync_waiter = weak_waiter->lock();
         delete weak_waiter;
         if (vsync_waiter) {
-          vsync_waiter->FireCallback(frame_start_time, frame_target_time);
+          vsync_waiter->FireCallback({.start = frame_start_time,
+                                      .target = frame_target_time,
+                                      .next_start = frame_target_time,
+                                      .id = kInvalidVSyncId},
+                                     0);
         }
       },
       frame_start_time);

--- a/shell/platform/fuchsia/flutter/vsync_waiter.cc
+++ b/shell/platform/fuchsia/flutter/vsync_waiter.cc
@@ -36,7 +36,10 @@ VsyncWaiter::VsyncWaiter(AwaitVsyncCallback await_vsync_callback,
             // Note: It is VERY important to set |pause_secondary_tasks| to
             // false, else Animator will almost immediately crash on Fuchsia.
             // FML_LOG(INFO) << "CRASH:: VsyncWaiter about to FireCallback";
-            weak_this->FireCallback(frame_start, frame_end,
+            weak_this->FireCallback({.start = frame_start,
+                                     .target = frame_end,
+                                     .next_start = frame_end,
+                                     .id = flutter::kInvalidVSyncId},
                                     /*pause_secondary_tasks*/ false);
           }
         },

--- a/shell/platform/fuchsia/flutter/vsync_waiter_unittest.cc
+++ b/shell/platform/fuchsia/flutter/vsync_waiter_unittest.cc
@@ -52,7 +52,7 @@ TEST(VSyncWaiterFuchsia, FrameScheduledForStartTime) {
     vsync_waiter.AsyncWaitForVsync(
         [&](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
           const auto now = fml::TimePoint::Now();
-          EXPECT_GT(now, recorder->GetVsyncStartTime());
+          EXPECT_GT(now, recorder->GetCurrentVSyncInfo().start);
           latch.Signal();
         });
   });


### PR DESCRIPTION
Implements the Android 13+ APIs for Choreographer and SurfaceTransaction needed to get and set Vsync-IDs on each frame. This is an alternative to setting presentation timestamps on surfaces to present which shouldn't have the downside of requiring some magic/manual timing tweaks. When we set the vsync-ids on each surface, it can help deal with jank arriving from uneven rendering times in the engine. [More information from Android documentation.](https://developer.android.com/games/sdk/frame-pacing#short_game_frames_lead_to_stuttering) This is mainly because we may do an `eglSwapBuffers` more than once in the same vsync-period from the compositor's perspective, and it will only show the second one. I've found it leads to a big improvement in subjective performance on 120fps devices. 

It also contains a change to `VsyncWaiterAndroid`, where a frame callback is always requested following the previous frame, instead of waiting for `AwaitVsync()` to be called. This is because I observed some cases where Choreographer would not inform us of the next frame if we registered our callback soon (~1ms) before its arrival. This resulted in frames being missed for no reason, adding jank.

## ~~Open Question - Automatic Latency Selection~~

<details>
<summary>Resolved issue -- dropped the automatic latency selection</summary>
This PR contains automatic switching from +0-frame latency (frames sent to Android to be presented 1 frame after the vsync), and +1-frame latency (frames sent to Android to be presented 2 frames after the vsync signal). This would give the benefit of the lowest latency possible when the device is fast enough to never take more than 1 frame period to compose a frame. Being aware of our own expected latency also helps the engine make better decisions (e.g. how long to expect the UI thread to be idle for). But latency switching is kind of complex and this implementation is purely reactive (e.g. padding the pipeline following a slot frame). It would be a lot cleaner just to always accept +1 frame latency. Would appreciate some feedback on the Flutter team's standards and goals here for latency.
</details>

## Note - Buffer stuffing and instrumentation

When we run with +1-frame latency, we are providing two frames in advance to the Android compositor. Depending on the device, it might have a limited number of buffers available, so even if we finish rendering to the surface at 3ms, `eglSwapBuffers` will block until 8.33 ms, when the currently visible surface is swapped out. Basically, Android is applying backpressure to the engine, which is not a bad thing, but does mean the instrumentation/timeline looks weird. I moved some of the instrumentation around so that the "raster" ends before `eglSwapBuffers`. If we don't have this change, the bars will be pinned to the frame time, in a way that doesn't say much about the actual performance.

### Possible Follow-up

- Implement for Impeller on Android
- ~~Do some further testing on iOS. We can use some different calls in Metal to present with a timestamp (hopefully we shouldn't have the same timestamp issues as in Android (https://github.com/flutter/flutter/issues/112603)). But this problem doesn't seem to be as reported on iOS. Maybe iOS already has a backpressure/sequential presentation approach?~~

#### Fixes

https://github.com/flutter/flutter/issues/108979

#### May resolve

- https://github.com/flutter/flutter/issues/129150
- https://github.com/flutter/flutter/issues/130306
- https://github.com/flutter/flutter/issues/81563
- https://github.com/flutter/flutter/issues/120205

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
