### PR TITLE
[Impeller] fix some OpenGL Linux desktop issues.

### DIFF
--- a/impeller/renderer/backend/gles/description_gles.cc
+++ b/impeller/renderer/backend/gles/description_gles.cc
@@ -90,10 +90,10 @@ DescriptionGLES::DescriptionGLES(const ProcTableGLES& gl)
       extensions_.insert(extension);
     }
   } else {
-    size_t extension_count = 0u;
+    int extension_count = 0;
     gl.GetIntegerv(GL_NUM_EXTENSIONS, &extension_count);
-    for (auto i = 0u; i < extension_count; i++) {
-      extensions_.insert(GetGLStringi(GL_EXTENSIONS, i));
+    for (auto i = 0; i < extension_count; i++) {
+      extensions_.insert(GetGLStringi(gl, GL_EXTENSIONS, i));
     }
   }
 

--- a/impeller/renderer/backend/gles/description_gles.cc
+++ b/impeller/renderer/backend/gles/description_gles.cc
@@ -26,6 +26,16 @@ static std::string GetGLString(const ProcTableGLES& gl, GLenum name) {
   return reinterpret_cast<const char*>(str);
 }
 
+static std::string GetGLStringi(const ProcTableGLES& gl,
+                                GLenum name,
+                                int index) {
+  auto str = gl.GetStringi(name, index);
+  if (str == nullptr) {
+    return "";
+  }
+  return reinterpret_cast<const char*>(str);
+}
+
 static bool DetermineIfES(const std::string& version) {
   return HasPrefix(version, "OpenGL ES");
 }
@@ -70,14 +80,22 @@ DescriptionGLES::DescriptionGLES(const ProcTableGLES& gl)
       renderer_(GetGLString(gl, GL_RENDERER)),
       gl_version_string_(GetGLString(gl, GL_VERSION)),
       sl_version_string_(GetGLString(gl, GL_SHADING_LANGUAGE_VERSION)) {
-  const auto extensions = GetGLString(gl, GL_EXTENSIONS);
-  std::stringstream extensions_stream(extensions);
-  std::string extension;
-  while (std::getline(extensions_stream, extension, ' ')) {
-    extensions_.insert(extension);
-  }
-
   is_es_ = DetermineIfES(gl_version_string_);
+
+  if (is_es_) {
+    const auto extensions = GetGLString(gl, GL_EXTENSIONS);
+    std::stringstream extensions_stream(extensions);
+    std::string extension;
+    while (std::getline(extensions_stream, extension, ' ')) {
+      extensions_.insert(extension);
+    }
+  } else {
+    size_t extension_count = 0u;
+    gl.GetIntegerv(GL_NUM_EXTENSIONS, &extension_count);
+    for (auto i = 0u; i < extension_count; i++) {
+      extensions_.insert(GetGLStringi(GL_EXTENSIONS, i));
+    }
+  }
 
   auto gl_version = DetermineVersion(gl_version_string_);
   if (!gl_version.has_value()) {

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -139,6 +139,7 @@ struct GLProc {
   PROC(GetShaderInfoLog);                    \
   PROC(GetShaderiv);                         \
   PROC(GetString);                           \
+  PROC(GetStringi);                          \
   PROC(GetUniformLocation);                  \
   PROC(IsBuffer);                            \
   PROC(IsFramebuffer);                       \

--- a/shell/platform/embedder/embedder_surface_gl_impeller.cc
+++ b/shell/platform/embedder/embedder_surface_gl_impeller.cc
@@ -57,6 +57,10 @@ EmbedderSurfaceGLImpeller::EmbedderSurfaceGLImpeller(
       !gl_dispatch_table_.gl_proc_resolver) {
     return;
   }
+  // Certain GL backends need to made current before any GL
+  // state can be accessed.
+  gl_dispatch_table_.gl_make_current_callback();
+
   std::vector<std::shared_ptr<fml::Mapping>> shader_mappings = {
       std::make_shared<fml::NonOwnedMapping>(
           impeller_entity_shaders_gles_data,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/130514

The context wasn't current so we couldn't get the GL version.

The extension lookup was throwing an invalid enum error, the desktop opengl docs say to use a different method.
