### PR TITLE
[Impeller] Fix pipeline stats traced to the timeline.

### DIFF
--- a/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
@@ -205,7 +205,10 @@ static void ReportPipelineCreationFeedbackToTrace(
     gPipelineCacheMisses++;
   }
   gPipelines++;
+  static constexpr int64_t kImpellerPipelineTraceID = 1988;
   FML_TRACE_COUNTER("impeller",                                   //
+                    "PipelineCache",                              // series name
+                    kImpellerPipelineTraceID,                     // series ID
                     "PipelineCacheHits", gPipelineCacheHits,      //
                     "PipelineCacheMisses", gPipelineCacheMisses,  //
                     "TotalPipelines", gPipelines                  //


### PR DESCRIPTION
The trace counter was missing the series name and ID.