### PR TITLE
Fix drawVertices documentation

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -5442,8 +5442,8 @@ abstract class Canvas {
   /// specified in the `vertices` using the `blendMode` parameter. For the
   /// purposes of this blending, the colors from the `paint` parameter are
   /// considered the source, and the colors from the `vertices` are considered
-  /// the destination. [BlendMode.dstOver] ignores the `paint` and uses only the
-  /// colors of the `vertices`; [BlendMode.srcOver] ignores the colors of the
+  /// the destination. [BlendMode.dst] ignores the `paint` and uses only the
+  /// colors of the `vertices`; [BlendMode.src] ignores the colors of the
   /// `vertices` and uses only the colors in the `paint`.
   ///
   /// All parameters must not be null.


### PR DESCRIPTION
Update the blend mode section of the documentation to specify the correct blend modes.

Fixes https://github.com/flutter/flutter/issues/130747
