### PR TITLE
Reset Dart VM optimization level to 2

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -402,7 +402,7 @@ def to_gn_args(args):
   if args.dart_optimization_level:
     gn_args['dart_default_optimization_level'] = args.dart_optimization_level
   elif gn_args['target_os'] in ['android', 'ios']:
-    gn_args['dart_default_optimization_level'] = 'z'
+    gn_args['dart_default_optimization_level'] = '2'
 
   gn_args['flutter_use_fontconfig'] = args.enable_fontconfig
   gn_args['dart_component_kind'


### PR DESCRIPTION
Partial revert of https://github.com/flutter/engine/pull/43743

Setting the optimization level to `-Oz` reduced compressed binary size by 200KB, but regressed performance by 10-15% across the board (frame build time, gen_snapshot runtime, hot reload time, etc.)