### PR TITLE
[CP] [ci.yaml] Skip windows arm on releases

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -669,7 +669,6 @@ targets:
       - main
     properties:
       add_recipes_cq: "true"
-      release_build: "true"
       config_name: windows_arm_host_engine
     drone_dimensions:
       - os=Windows


### PR DESCRIPTION
CP of https://github.com/flutter/engine/pull/43771

Skip windows arm on release branches. This broke during the migration to the release builders.