### PR TITLE
[POC][WIP] Platform view synchronized touch

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -105,7 +105,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (void)dispatch:(dispatch_block_t)block {
   fml::TaskRunner::RunNowOrPostTask(_taskRunner,
                                     [block_copy = Block_copy(block)]() { block_copy(); });
-  // dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), block);
 }
 @end
 
@@ -162,7 +161,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   fml::scoped_nsobject<FlutterMethodChannel> _restorationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _platformChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _platformViewsChannel;
-  fml::scoped_nsobject<FlutterMethodChannel> _platformViewsBackgroundChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _textInputChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _undoManagerChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _scribbleChannel;
@@ -586,7 +584,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   _restorationChannel.reset();
   _platformChannel.reset();
   _platformViewsChannel.reset();
-  _platformViewsBackgroundChannel.reset();
   _textInputChannel.reset();
   _undoManagerChannel.reset();
   _scribbleChannel.reset();
@@ -650,13 +647,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
   _platformViewsChannel.reset([[FlutterMethodChannel alloc]
          initWithName:@"flutter/platform_views"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterStandardMethodCodec sharedInstance]]);
-
-  _platformViewTaskQueue =
-      [[[PlatformViewChannelTaskQueue alloc] initWithTaskRunner:[self uiTaskRunner]] retain];
-  _platformViewsBackgroundChannel.reset([[FlutterMethodChannel alloc]
-         initWithName:@"flutter/platform_views_background"
       binaryMessenger:self.binaryMessenger
                 codec:[FlutterStandardMethodCodec sharedInstance]
             taskQueue:_platformViewTaskQueue]);
@@ -761,13 +751,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
         setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
           if (!weakPlatformViewsController.expired()) {
             weakPlatformViewsController.lock()->OnMethodCall(call, result);
-          }
-        }];
-
-    [_platformViewsBackgroundChannel.get()
-        setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
-          if (!weakPlatformViewsController.expired()) {
-            weakPlatformViewsController.lock()->OnBackgroundMethodCall(call, result);
           }
         }];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -162,6 +162,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   fml::scoped_nsobject<FlutterMethodChannel> _restorationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _platformChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _platformViewsChannel;
+  fml::scoped_nsobject<FlutterMethodChannel> _platformViewsBackgroundChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _textInputChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _undoManagerChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _scribbleChannel;
@@ -585,6 +586,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   _restorationChannel.reset();
   _platformChannel.reset();
   _platformViewsChannel.reset();
+  _platformViewsBackgroundChannel.reset();
   _textInputChannel.reset();
   _undoManagerChannel.reset();
   _scribbleChannel.reset();
@@ -646,10 +648,15 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
       binaryMessenger:self.binaryMessenger
                 codec:[FlutterJSONMethodCodec sharedInstance]]);
 
-  _platformViewTaskQueue =
-      [[[PlatformViewChannelTaskQueue alloc] initWithTaskRunner:[self uiTaskRunner]] retain];
   _platformViewsChannel.reset([[FlutterMethodChannel alloc]
          initWithName:@"flutter/platform_views"
+      binaryMessenger:self.binaryMessenger
+                codec:[FlutterStandardMethodCodec sharedInstance]]);
+
+  _platformViewTaskQueue =
+      [[[PlatformViewChannelTaskQueue alloc] initWithTaskRunner:[self uiTaskRunner]] retain];
+  _platformViewsBackgroundChannel.reset([[FlutterMethodChannel alloc]
+         initWithName:@"flutter/platform_views_background"
       binaryMessenger:self.binaryMessenger
                 codec:[FlutterStandardMethodCodec sharedInstance]
             taskQueue:_platformViewTaskQueue]);
@@ -754,6 +761,13 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
         setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
           if (!weakPlatformViewsController.expired()) {
             weakPlatformViewsController.lock()->OnMethodCall(call, result);
+          }
+        }];
+
+    [_platformViewsBackgroundChannel.get()
+        setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
+          if (!weakPlatformViewsController.expired()) {
+            weakPlatformViewsController.lock()->OnBackgroundMethodCall(call, result);
           }
         }];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -255,6 +255,8 @@ class FlutterPlatformViewsController {
 
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 
+  void OnBackgroundMethodCall(FlutterMethodCall* call, FlutterResult& result);
+
   // Returns the platform view id if the platform view (or any of its descendant view) is the first
   // responder. Returns -1 if no such platform view is found.
   long FindFirstResponderPlatformViewId();
@@ -279,6 +281,9 @@ class FlutterPlatformViewsController {
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);
   void OnAcceptGesture(FlutterMethodCall* call, FlutterResult& result);
   void OnRejectGesture(FlutterMethodCall* call, FlutterResult& result);
+  void OnHitTestResult(FlutterMethodCall* call,
+                       FlutterResult& result,
+                       BOOL platformViewConsumesTouches);
   // Dispose the views in `views_to_dispose_`.
   void DisposeViews();
 
@@ -419,6 +424,8 @@ class FlutterPlatformViewsController {
                  (fml::WeakPtr<flutter::FlutterPlatformViewsController>)platformViewsController
     gestureRecognizersBlockingPolicy:
         (FlutterPlatformViewGestureRecognizersBlockingPolicy)blockingPolicy;
+
+- (void)respondToHitTestResult:(BOOL)platformViewConsumesTouches;
 
 // Stop delaying any active touch sequence (and let it arrive the embedded view).
 - (void)releaseGesture;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -266,8 +266,12 @@ class FlutterPlatformViewsController {
   // Pushes the view id of a visted platform view to the list of visied platform views.
   void PushVisitedPlatformView(int64_t view_id) { visited_platform_views_.push_back(view_id); }
 
+  std::mutex& HitTestMutex() { return hit_test_mutex_; }
+
  private:
   static const size_t kMaxLayerAllocations = 2;
+  std::mutex hit_test_mutex_;
+  std::mutex method_channel_mutex_;
 
   using LayersMap = std::map<int64_t, std::vector<std::shared_ptr<FlutterPlatformViewLayer>>>;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -272,7 +272,6 @@ class FlutterPlatformViewsController {
  private:
   static const size_t kMaxLayerAllocations = 2;
   std::mutex platform_thread_mutex_;
-  std::mutex method_channel_mutex_;
 
   using LayersMap = std::map<int64_t, std::vector<std::shared_ptr<FlutterPlatformViewLayer>>>;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -255,8 +255,6 @@ class FlutterPlatformViewsController {
 
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 
-  void OnBackgroundMethodCall(FlutterMethodCall* call, FlutterResult& result);
-
   // Returns the platform view id if the platform view (or any of its descendant view) is the first
   // responder. Returns -1 if no such platform view is found.
   long FindFirstResponderPlatformViewId();
@@ -268,11 +266,12 @@ class FlutterPlatformViewsController {
   // Pushes the view id of a visted platform view to the list of visied platform views.
   void PushVisitedPlatformView(int64_t view_id) { visited_platform_views_.push_back(view_id); }
 
-  std::mutex& HitTestMutex() { return hit_test_mutex_; }
+  void BlockPlatformThread();
+  void ReleasePlatformThread();
 
  private:
   static const size_t kMaxLayerAllocations = 2;
-  std::mutex hit_test_mutex_;
+  std::mutex platform_thread_mutex_;
   std::mutex method_channel_mutex_;
 
   using LayersMap = std::map<int64_t, std::vector<std::shared_ptr<FlutterPlatformViewLayer>>>;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -517,12 +517,14 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
   return pointer_data;
 }
 
-static void SendFakeTouchEvent(UIScreen* screen,
-                               FlutterEngine* engine,
-                               CGPoint location,
-                               flutter::PointerData::Change change) {
+- (void)sendFakeTouchEventWithLocation:(CGPoint)location
+                                change:(flutter::PointerData::Change)change {
+  UIScreen* screen = [self flutterScreenIfViewLoaded];
+  if (!screen) {
+    return;
+  }
   const CGFloat scale = screen.scale;
-  flutter::PointerData pointer_data = [[engine viewController] generatePointerDataForFake];
+  flutter::PointerData pointer_data = [[_engine.get() viewController] generatePointerDataForFake];
   pointer_data.physical_x = location.x * scale;
   pointer_data.physical_y = location.y * scale;
   auto packet = std::make_unique<flutter::PointerDataPacket>(/*count=*/1);
@@ -538,8 +540,8 @@ static void SendFakeTouchEvent(UIScreen* screen,
   CGPoint statusBarPoint = CGPointZero;
   UIScreen* screen = [self flutterScreenIfViewLoaded];
   if (screen) {
-    SendFakeTouchEvent(screen, _engine.get(), statusBarPoint, flutter::PointerData::Change::kDown);
-    SendFakeTouchEvent(screen, _engine.get(), statusBarPoint, flutter::PointerData::Change::kUp);
+    [self sendFakeTouchEventWithLocation:statusBarPoint change:flutter::PointerData::Change::kDown];
+    [self sendFakeTouchEventWithLocation:statusBarPoint change:flutter::PointerData::Change::kUp];
   }
   return NO;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -528,7 +528,7 @@ static void SendFakeTouchEvent(UIScreen* screen,
   auto packet = std::make_unique<flutter::PointerDataPacket>(/*count=*/1);
   pointer_data.change = change;
   packet->SetPointerData(0, pointer_data);
-  [engine dispatchPointerDataPacket:std::move(packet)];
+  [_engine.get() dispatchPointerDataPacket:std::move(packet)];
 }
 
 - (BOOL)scrollViewShouldScrollToTop:(UIScrollView*)scrollView {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERVIEWCONTROLLER_INTERNAL_H_
 
 #include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/lib/ui/window/pointer_data.h"
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeySecondaryResponder.h"
@@ -65,6 +66,9 @@ typedef void (^FlutterKeyboardAnimationCallback)(fml::TimePoint);
 - (void)addInternalPlugins;
 - (void)deregisterNotifications;
 - (int32_t)accessibilityFlags;
+- (UIWindowScene*)windowSceneIfViewLoaded API_AVAILABLE(ios(13.0));
+- (void)sendFakeTouchEventWithLocation:(CGPoint)location
+                                change:(flutter::PointerData::Change)change;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -66,7 +66,6 @@ typedef void (^FlutterKeyboardAnimationCallback)(fml::TimePoint);
 - (void)addInternalPlugins;
 - (void)deregisterNotifications;
 - (int32_t)accessibilityFlags;
-- (UIWindowScene*)windowSceneIfViewLoaded API_AVAILABLE(ios(13.0));
 - (void)sendFakeTouchEventWithLocation:(CGPoint)location
                                 change:(flutter::PointerData::Change)change;
 


### PR DESCRIPTION
**This PR is not intended to land.** 

This is a quick prototype to demonstrate synchronously blocking the gestures on PlatformView.

I wired up everything as fast as possible to share this solution. There are places where threadings don't work properly, but those are not the point of this PR. 

https://github.com/flutter/flutter/issues/30143

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
