### PR TITLE
Apply the offset to the child bounds of an ImageFilterLayer with no filter

### DIFF
--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -64,6 +64,7 @@ void ImageFilterLayer::Preroll(PrerollContext* context) {
   PrerollChildren(context, &child_bounds);
 
   if (!filter_) {
+    child_bounds.offset(offset_);
     set_paint_bounds(child_bounds);
     return;
   }

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -711,6 +711,19 @@ TEST_F(ImageFilterLayerDiffTest, ImageFilterLayerInflatestChildSize) {
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(40, 40, 170, 170));
 }
 
+TEST_F(ImageFilterLayerTest, EmptyFilterWithOffset) {
+  const SkRect child_bounds = SkRect::MakeLTRB(10.0f, 11.0f, 19.0f, 20.0f);
+  const SkPath child_path = SkPath().addRect(child_bounds);
+  const DlPaint child_paint = DlPaint(DlColor::kYellow());
+  auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
+  const SkPoint offset = SkPoint::Make(5.0f, 6.0f);
+  auto layer = std::make_shared<ImageFilterLayer>(nullptr, offset);
+  layer->Add(mock_layer);
+
+  layer->Preroll(preroll_context());
+  EXPECT_EQ(layer->paint_bounds(), child_bounds.makeOffset(offset));
+}
+
 }  // namespace testing
 }  // namespace flutter
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/130318
