### PR TITLE
Refactor: fix typo "setup" -> "set up"

### DIFF
--- a/impeller/docs/read_frame_captures.md
+++ b/impeller/docs/read_frame_captures.md
@@ -211,7 +211,7 @@ function pipeline configuration.
 
 ![alt_text](assets/read_frame_captures/image7.png "image_tooltip")
 
-You will get intimately familiar with this view when you setup a new pipeline
+You will get intimately familiar with this view when you set up a new pipeline
 state object in Impeller or try to reason about the correctness of one of the
 pipeline state object variants.
 

--- a/impeller/docs/renderdoc_frame_capture.md
+++ b/impeller/docs/renderdoc_frame_capture.md
@@ -2,7 +2,7 @@
 
 [RenderDoc](https://renderdoc.org/) is a graphics debugger that can be used to capture frames. With Impeller starting to support gles and Vulkan backends, RenderDoc can provide insights into the application's frames.
 
-1. First step is to setup RenderDoc. Follow the instructions [here](https://renderdoc.org/docs/getting_started/quick_start.html). For the purposes of this guide it is assumed that you are able to get RenderDoc running.
+1. First step is to set up RenderDoc. Follow the instructions [here](https://renderdoc.org/docs/getting_started/quick_start.html). For the purposes of this guide it is assumed that you are able to get RenderDoc running.
 2. The next step would be to run the application you wish the capture the frames of. Typically these would be one of the playground tests. To build these, do:
 
 ```bash

--- a/impeller/docs/xcode_frame_capture.md
+++ b/impeller/docs/xcode_frame_capture.md
@@ -89,7 +89,7 @@ that some of those diagnostics need Xcode to be able to re-compile the
 translation units in the engine. But, it doesn’t know how to do that, only
 GN/Ninja does. So some of those will be unavailable.
 
-Any Impeller test that setup up a Playground will now automatically have GPU
+Any Impeller test that sets up a Playground will now automatically have GPU
 frame capture enabled.
 
 # Select the Playground Enabled Test to Profile

--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -108,7 +108,7 @@ PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
 
   vk::UniqueSurfaceKHR surface{vk_surface, context->GetInstance()};
   if (!context->SetWindowSurface(std::move(surface))) {
-    VALIDATION_LOG << "Could not setup surface for context.";
+    VALIDATION_LOG << "Could not set up surface for context.";
     return;
   }
 

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -125,8 +125,8 @@ void Playground::SetupContext(PlaygroundBackend backend) {
 
 void Playground::SetupWindow() {
   if (!context_) {
-    FML_LOG(WARNING)
-        << "Asked to setup a window with no context (call SetupContext first).";
+    FML_LOG(WARNING) << "Asked to set up a window with no context (call "
+                        "SetupContext first).";
     return;
   }
   auto renderer = std::make_unique<Renderer>(context_);

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -79,7 +79,7 @@ ContextMTL::ContextMTL(
       is_gpu_disabled_sync_switch_(std::move(is_gpu_disabled_sync_switch)) {
   // Validate device.
   if (!device_) {
-    VALIDATION_LOG << "Could not setup valid Metal device.";
+    VALIDATION_LOG << "Could not set up valid Metal device.";
     return;
   }
 
@@ -135,7 +135,7 @@ ContextMTL::ContextMTL(
     resource_allocator_ = std::shared_ptr<AllocatorMTL>(
         new AllocatorMTL(device_, "Impeller Permanents Allocator"));
     if (!resource_allocator_) {
-      VALIDATION_LOG << "Could not setup the resource allocator.";
+      VALIDATION_LOG << "Could not set up the resource allocator.";
       return;
     }
   }
@@ -219,7 +219,7 @@ static id<MTLDevice> CreateMetalDevice() {
 static id<MTLCommandQueue> CreateMetalCommandQueue(id<MTLDevice> device) {
   auto command_queue = device.newCommandQueue;
   if (!command_queue) {
-    VALIDATION_LOG << "Could not setup the command queue.";
+    VALIDATION_LOG << "Could not set up the command queue.";
     return nullptr;
   }
   command_queue.label = @"Impeller Command Queue";

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -227,7 +227,7 @@ void ContextVK::Setup(Settings settings) {
       std::make_unique<DebugReportVK>(*caps, device_holder->instance.get());
 
   if (!debug_report->IsValid()) {
-    VALIDATION_LOG << "Could not setup debug report.";
+    VALIDATION_LOG << "Could not set up debug report.";
     return;
   }
 
@@ -417,7 +417,7 @@ void ContextVK::Setup(Settings settings) {
 
   //----------------------------------------------------------------------------
   /// Label all the relevant objects. This happens after setup so that the debug
-  /// messengers have had a chance to be setup.
+  /// messengers have had a chance to be set up.
   ///
   SetDebugName(GetDevice(), device_holder_->device.get(), "ImpellerDevice");
 }

--- a/impeller/renderer/backend/vulkan/queue_vk.cc
+++ b/impeller/renderer/backend/vulkan/queue_vk.cc
@@ -43,7 +43,7 @@ QueuesVK::QueuesVK(const vk::Device& device,
   auto vk_compute = device.getQueue(compute.family, compute.index);
   auto vk_transfer = device.getQueue(transfer.family, transfer.index);
 
-  // Always setup the graphics queue.
+  // Always set up the graphics queue.
   graphics_queue = std::make_shared<QueueVK>(graphics, vk_graphics);
   ContextVK::SetDebugName(device, vk_graphics, "ImpellerGraphicsQ");
 

--- a/impeller/renderer/command_buffer.h
+++ b/impeller/renderer/command_buffer.h
@@ -34,7 +34,7 @@ class CommandBufferMock;
 ///
 ///             A command buffer is only meant to be used on a single thread. If
 ///             a frame workload needs to be encoded from multiple threads,
-///             setup and record into multiple command buffers. The order of
+///             set up and record into multiple command buffers. The order of
 ///             submission of commands encoded in multiple command buffers can
 ///             be controlled via either the order in which the command buffers
 ///             were created, or, using the `ReserveSpotInQueue` command which

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -406,12 +406,12 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
                           callback);
   };
 
-  auto setup_io_manager_and_decode = [&]() {
+  auto set_up_io_manager_and_decode = [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
     runners.GetUITaskRunner()->PostTask(decode_image);
   };
 
-  runners.GetIOTaskRunner()->PostTask(setup_io_manager_and_decode);
+  runners.GetIOTaskRunner()->PostTask(set_up_io_manager_and_decode);
   latch.Wait();
 }
 
@@ -706,12 +706,12 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
                           callback);
   };
 
-  auto setup_io_manager_and_decode = [&]() {
+  auto set_up_io_manager_and_decode = [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
     runners.GetUITaskRunner()->PostTask(decode_image);
   };
 
-  runners.GetIOTaskRunner()->PostTask(setup_io_manager_and_decode);
+  runners.GetIOTaskRunner()->PostTask(set_up_io_manager_and_decode);
 
   latch.Wait();
 
@@ -766,13 +766,13 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
                           callback);
   };
 
-  auto setup_io_manager_and_decode = [&]() {
+  auto set_up_io_manager_and_decode = [&]() {
     io_manager =
         std::make_unique<TestIOManager>(runners.GetIOTaskRunner(), false);
     runners.GetUITaskRunner()->PostTask(decode_image);
   };
 
-  runners.GetIOTaskRunner()->PostTask(setup_io_manager_and_decode);
+  runners.GetIOTaskRunner()->PostTask(set_up_io_manager_and_decode);
 
   latch.Wait();
 }

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -618,7 +618,7 @@ void Shell::RunEngine(
     platform_runner->PostTask(
         [result_callback, run_result]() { result_callback(run_result); });
   };
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   fml::TaskRunner::RunNowOrPostTask(
@@ -642,7 +642,7 @@ void Shell::RunEngine(
 }
 
 std::optional<DartErrorCode> Shell::GetUIIsolateLastError() const {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   if (!weak_engine_) {
@@ -662,7 +662,7 @@ std::optional<DartErrorCode> Shell::GetUIIsolateLastError() const {
 }
 
 bool Shell::EngineHasLivePorts() const {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   if (!weak_engine_) {
@@ -673,14 +673,14 @@ bool Shell::EngineHasLivePorts() const {
 }
 
 bool Shell::IsSetup() const {
-  return is_setup_;
+  return is_set_up_;
 }
 
 bool Shell::Setup(std::unique_ptr<PlatformView> platform_view,
                   std::unique_ptr<Engine> engine,
                   std::unique_ptr<Rasterizer> rasterizer,
                   const std::shared_ptr<ShellIOManager>& io_manager) {
-  if (is_setup_) {
+  if (is_set_up_) {
     return false;
   }
 
@@ -723,7 +723,7 @@ bool Shell::Setup(std::unique_ptr<PlatformView> platform_view,
                                       });
   }
 
-  is_setup_ = true;
+  is_set_up_ = true;
 
   PersistentCache::GetCacheForProcess()->AddWorkerTaskRunner(
       task_runners_.GetIOTaskRunner());
@@ -752,22 +752,22 @@ const fml::RefPtr<fml::RasterThreadMerger> Shell::GetParentRasterThreadMerger()
 }
 
 fml::TaskRunnerAffineWeakPtr<Rasterizer> Shell::GetRasterizer() const {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   return weak_rasterizer_;
 }
 
 fml::WeakPtr<Engine> Shell::GetEngine() {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   return weak_engine_;
 }
 
 fml::WeakPtr<PlatformView> Shell::GetPlatformView() {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   return weak_platform_view_;
 }
 
 fml::WeakPtr<ShellIOManager> Shell::GetIOManager() {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   return io_manager_->GetWeakPtr();
 }
 
@@ -778,7 +778,7 @@ DartVM* Shell::GetDartVM() {
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
   TRACE_EVENT0("flutter", "Shell::OnPlatformViewCreated");
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   // Prevent any request to change the thread configuration for raster and
@@ -869,7 +869,7 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewDestroyed() {
   TRACE_EVENT0("flutter", "Shell::OnPlatformViewDestroyed");
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   // Prevent any request to change the thread configuration for raster and
@@ -943,7 +943,7 @@ void Shell::OnPlatformViewDestroyed() {
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewScheduleFrame() {
   TRACE_EVENT0("flutter", "Shell::OnPlatformViewScheduleFrame");
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetUITaskRunner()->PostTask([engine = engine_->GetWeakPtr()]() {
@@ -956,7 +956,7 @@ void Shell::OnPlatformViewScheduleFrame() {
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewSetViewportMetrics(int64_t view_id,
                                              const ViewportMetrics& metrics) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   if (metrics.device_pixel_ratio <= 0 || metrics.physical_width <= 0 ||
@@ -996,7 +996,7 @@ void Shell::OnPlatformViewSetViewportMetrics(int64_t view_id,
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewDispatchPlatformMessage(
     std::unique_ptr<PlatformMessage> message) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   if (!task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread()) {
     std::scoped_lock lock(misbehaving_message_channels_mutex_);
@@ -1031,7 +1031,7 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
     std::unique_ptr<PointerDataPacket> packet) {
   TRACE_EVENT0("flutter", "Shell::OnPlatformViewDispatchPointerDataPacket");
   TRACE_FLOW_BEGIN("flutter", "PointerEvent", next_pointer_flow_id_);
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
   task_runners_.GetUITaskRunner()->PostTask(
       fml::MakeCopyable([engine = weak_engine_, packet = std::move(packet),
@@ -1047,7 +1047,7 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
 void Shell::OnPlatformViewDispatchSemanticsAction(int32_t node_id,
                                                   SemanticsAction action,
                                                   fml::MallocMapping args) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetUITaskRunner()->PostTask(
@@ -1061,7 +1061,7 @@ void Shell::OnPlatformViewDispatchSemanticsAction(int32_t node_id,
 
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewSetSemanticsEnabled(bool enabled) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetUITaskRunner()->PostTask(
@@ -1074,7 +1074,7 @@ void Shell::OnPlatformViewSetSemanticsEnabled(bool enabled) {
 
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewSetAccessibilityFeatures(int32_t flags) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetUITaskRunner()->PostTask(
@@ -1088,7 +1088,7 @@ void Shell::OnPlatformViewSetAccessibilityFeatures(int32_t flags) {
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewRegisterTexture(
     std::shared_ptr<flutter::Texture> texture) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetRasterTaskRunner()->PostTask(
@@ -1103,7 +1103,7 @@ void Shell::OnPlatformViewRegisterTexture(
 
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewUnregisterTexture(int64_t texture_id) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetRasterTaskRunner()->PostTask(
@@ -1118,7 +1118,7 @@ void Shell::OnPlatformViewUnregisterTexture(int64_t texture_id) {
 
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   // Tell the rasterizer that one of its textures has a new frame available.
@@ -1149,7 +1149,7 @@ void Shell::OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) {
 
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewSetNextFrameCallback(const fml::closure& closure) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetRasterTaskRunner()->PostTask(
@@ -1168,7 +1168,7 @@ const Settings& Shell::OnPlatformViewGetSettings() const {
 // |Animator::Delegate|
 void Shell::OnAnimatorBeginFrame(fml::TimePoint frame_target_time,
                                  uint64_t frame_number) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   // record the target time for use by rasterizer.
@@ -1183,7 +1183,7 @@ void Shell::OnAnimatorBeginFrame(fml::TimePoint frame_target_time,
 
 // |Animator::Delegate|
 void Shell::OnAnimatorNotifyIdle(fml::TimeDelta deadline) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   if (engine_) {
@@ -1194,7 +1194,7 @@ void Shell::OnAnimatorNotifyIdle(fml::TimeDelta deadline) {
 
 void Shell::OnAnimatorUpdateLatestFrameTargetTime(
     fml::TimePoint frame_target_time) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
 
   // record the target time for use by rasterizer.
   {
@@ -1209,7 +1209,7 @@ void Shell::OnAnimatorUpdateLatestFrameTargetTime(
 
 // |Animator::Delegate|
 void Shell::OnAnimatorDraw(std::shared_ptr<LayerTreePipeline> pipeline) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
 
   auto discard_callback = [this](flutter::LayerTree& tree) {
     std::scoped_lock<std::mutex> lock(resize_mutex_);
@@ -1240,7 +1240,7 @@ void Shell::OnAnimatorDraw(std::shared_ptr<LayerTreePipeline> pipeline) {
 // |Animator::Delegate|
 void Shell::OnAnimatorDrawLastLayerTree(
     std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
 
   auto task = fml::MakeCopyable(
       [rasterizer = rasterizer_->GetWeakPtr(),
@@ -1256,7 +1256,7 @@ void Shell::OnAnimatorDrawLastLayerTree(
 // |Engine::Delegate|
 void Shell::OnEngineUpdateSemantics(SemanticsNodeUpdates update,
                                     CustomAccessibilityActionUpdates actions) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetPlatformTaskRunner()->PostTask(
@@ -1271,7 +1271,7 @@ void Shell::OnEngineUpdateSemantics(SemanticsNodeUpdates update,
 // |Engine::Delegate|
 void Shell::OnEngineHandlePlatformMessage(
     std::unique_ptr<PlatformMessage> message) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   if (message->channel() == kSkiaChannel) {
@@ -1366,7 +1366,7 @@ void Shell::HandleEngineSkiaMessage(std::unique_ptr<PlatformMessage> message) {
 
 // |Engine::Delegate|
 void Shell::OnPreEngineRestart() {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   fml::AutoResetWaitableEvent latch;
@@ -1471,7 +1471,7 @@ void Shell::RequestDartDeferredLibrary(intptr_t loading_unit_id) {
 }
 
 void Shell::ReportTimings() {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetRasterTaskRunner()->RunsTasksOnCurrentThread());
 
   auto timings = std::move(unreported_timings_);
@@ -1491,7 +1491,7 @@ size_t Shell::UnreportedFramesCount() const {
 }
 
 void Shell::OnFrameRasterized(const FrameTiming& timing) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetRasterTaskRunner()->RunsTasksOnCurrentThread());
 
   // The C++ callback defined in settings.h and set by Flutter runner. This is
@@ -1579,7 +1579,7 @@ fml::TimePoint Shell::GetLatestFrameTargetTime() const {
 // |ServiceProtocol::Handler|
 fml::RefPtr<fml::TaskRunner> Shell::GetServiceProtocolHandlerTaskRunner(
     std::string_view method) const {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   auto found = service_protocol_handlers_.find(method);
   if (found != service_protocol_handlers_.end()) {
     return found->second.first;
@@ -1785,7 +1785,7 @@ double Shell::GetMainDisplayRefreshRate() {
 void Shell::RegisterImageDecoder(ImageGeneratorFactory factory,
                                  int32_t priority) {
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
 
   fml::TaskRunner::RunNowOrPostTask(
       task_runners_.GetUITaskRunner(),
@@ -2047,7 +2047,7 @@ Rasterizer::Screenshot Shell::Screenshot(
 }
 
 fml::Status Shell::WaitForFirstFrame(fml::TimeDelta timeout) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   if (task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread() ||
       task_runners_.GetRasterTaskRunner()->RunsTasksOnCurrentThread()) {
     return fml::Status(fml::StatusCode::kFailedPrecondition,
@@ -2075,7 +2075,7 @@ fml::Status Shell::WaitForFirstFrame(fml::TimeDelta timeout) {
 }
 
 bool Shell::ReloadSystemFonts() {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   if (!engine_) {
@@ -2120,7 +2120,7 @@ void Shell::SetGpuAvailability(GpuAvailability availability) {
 }
 
 void Shell::OnDisplayUpdates(std::vector<std::unique_ptr<Display>> displays) {
-  FML_DCHECK(is_setup_);
+  FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   std::vector<DisplayData> display_data;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -448,7 +448,7 @@ class Shell final : public PlatformView::Delegate,
                                                         // pair
                      >
       service_protocol_handlers_;
-  bool is_setup_ = false;
+  bool is_set_up_ = false;
   bool is_added_to_service_protocol_ = false;
   uint64_t next_pointer_flow_id_ = 0;
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -186,7 +186,7 @@ import java.util.List;
     // When "retain instance" is true, the FlutterEngine will survive configuration
     // changes. Therefore, we create a new one only if one does not already exist.
     if (flutterEngine == null) {
-      setupFlutterEngine();
+      setUpFlutterEngine();
     }
 
     if (host.shouldAttachEngineToActivity()) {
@@ -268,7 +268,7 @@ import java.util.List;
    * then a new {@link FlutterEngine} is instantiated.
    */
   @VisibleForTesting
-  /* package */ void setupFlutterEngine() {
+  /* package */ void setUpFlutterEngine() {
     Log.v(TAG, "Setting up FlutterEngine.");
 
     // First, check if the host wants to use a cached FlutterEngine.

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/util/GeneratedPluginRegister.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/util/GeneratedPluginRegister.java
@@ -15,10 +15,10 @@ public class GeneratedPluginRegister {
    * Registers all plugins that an app lists in its pubspec.yaml.
    *
    * <p>In order to allow each plugin to listen to calls from Dart via Platform Channels, each
-   * plugin is given a chance to initialize and setup Platform Channel listeners in {@link
+   * plugin is given a chance to initialize and set up Platform Channel listeners in {@link
    * io.flutter.embedding.engine.plugins.FlutterPlugin#onAttachedToEngine(io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding)}.
    *
-   * <p>The list of plugins that need to be setup is not known to the Flutter engine. The Flutter
+   * <p>The list of plugins that need to be set up is not known to the Flutter engine. The Flutter
    * tools generates it at build time based on the plugin dependencies specified in the Flutter
    * project's pubspec.yaml.
    *

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -605,7 +605,7 @@ public class FlutterActivityTest {
     @SuppressLint("MissingSuperCall")
     protected void onCreate(@Nullable Bundle savedInstanceState) {
       super.delegate = new FlutterActivityAndFragmentDelegate(this);
-      super.delegate.setupFlutterEngine();
+      super.delegate.setUpFlutterEngine();
     }
 
     @Nullable

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -556,7 +556,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 // If you add a channel, be sure to also update `resetChannels`.
 // Channels get a reference to the engine, and therefore need manual
 // cleanup for proper collection.
-- (void)setupChannels {
+- (void)setUpChannels {
   // This will be invoked once the shell is done setting up and the isolate ID
   // for the UI isolate is available.
   fml::WeakPtr<FlutterEngine> weakSelf = [self getWeakPtr];
@@ -643,7 +643,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   FlutterTextInputPlugin* textInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:self];
   _textInputPlugin.reset(textInputPlugin);
   textInputPlugin.indirectScribbleDelegate = self;
-  [textInputPlugin setupIndirectScribbleInteraction:self.viewController];
+  [textInputPlugin setUpIndirectScribbleInteraction:self.viewController];
 
   FlutterUndoManagerPlugin* undoManagerPlugin =
       [[FlutterUndoManagerPlugin alloc] initWithDelegate:self];
@@ -735,10 +735,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                                           entrypointArgs:entrypointArgs]);
 }
 
-- (void)setupShell:(std::unique_ptr<flutter::Shell>)shell
+- (void)setUpShell:(std::unique_ptr<flutter::Shell>)shell
     withVMServicePublication:(BOOL)doesVMServicePublication {
   _shell = std::move(shell);
-  [self setupChannels];
+  [self setUpChannels];
   [self onLocaleUpdated:nil];
   [self updateDisplays];
   _publisher.reset([[FlutterDartVMServicePublisher alloc]
@@ -873,7 +873,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   } else {
     // TODO(vashworth): Remove once done debugging https://github.com/flutter/flutter/issues/129836
     FML_LOG(INFO) << "Enabled VM Service Publication: " << settings.enable_vm_service_publication;
-    [self setupShell:std::move(shell)
+    [self setUpShell:std::move(shell)
         withVMServicePublication:settings.enable_vm_service_publication];
     if ([FlutterEngine isProfilerEnabled]) {
       [self startProfiler];
@@ -1407,7 +1407,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   result->_profiler = _profiler;
   result->_profiler_metrics = _profiler_metrics;
   result->_isGpuDisabled = _isGpuDisabled;
-  [result setupShell:std::move(shell) withVMServicePublication:NO];
+  [result setUpShell:std::move(shell) withVMServicePublication:NO];
   return [result autorelease];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSInteger, FlutterScribbleInteractionStatus) {
  * These are used by the UIIndirectScribbleInteractionDelegate methods to handle focusing on the
  * correct element.
  */
-- (void)setupIndirectScribbleInteraction:(id<FlutterViewResponder>)viewResponder;
+- (void)setUpIndirectScribbleInteraction:(id<FlutterViewResponder>)viewResponder;
 - (void)resetViewResponder;
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -2712,7 +2712,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
 #pragma mark - Methods related to Scribble support
 
-- (void)setupIndirectScribbleInteraction:(id<FlutterViewResponder>)viewResponder {
+- (void)setUpIndirectScribbleInteraction:(id<FlutterViewResponder>)viewResponder {
   if (_viewResponder != viewResponder) {
     if (@available(iOS 14.0, *)) {
       UIView* parentView = viewResponder.view;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -278,7 +278,7 @@ typedef struct MouseState {
   _orientationPreferences = UIInterfaceOrientationMaskAll;
   _statusBarStyle = UIStatusBarStyleDefault;
 
-  [self setupNotificationCenterObservers];
+  [self setUpNotificationCenterObservers];
 }
 
 - (FlutterEngine*)engine {
@@ -289,7 +289,7 @@ typedef struct MouseState {
   return _weakFactory->GetWeakPtr();
 }
 
-- (void)setupNotificationCenterObservers {
+- (void)setUpNotificationCenterObservers {
   NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
   [center addObserver:self
              selector:@selector(onOrientationPreferencesUpdated:)
@@ -791,7 +791,7 @@ static void SendFakeTouchEvent(FlutterEngine* engine,
     [self.keyboardManager addSecondaryResponder:textInputPlugin];
   }
   if ([_engine.get() viewController] == self) {
-    [textInputPlugin setupIndirectScribbleInteraction:self];
+    [textInputPlugin setUpIndirectScribbleInteraction:self];
   }
 }
 
@@ -1653,7 +1653,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
       [flutterViewController updateViewportMetricsIfNeeded];
     }
   };
-  [self setupKeyboardAnimationVsyncClient:keyboardAnimationCallback];
+  [self setUpKeyboardAnimationVsyncClient:keyboardAnimationCallback];
   VSyncClient* currentVsyncClient = _keyboardAnimationVSyncClient;
 
   [UIView animateWithDuration:duration
@@ -1664,7 +1664,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
         // Setup keyboard animation interpolation.
         CAAnimation* keyboardAnimation =
             [[self keyboardAnimationView].layer animationForKey:@"position"];
-        [self setupKeyboardSpringAnimationIfNeeded:keyboardAnimation];
+        [self setUpKeyboardSpringAnimationIfNeeded:keyboardAnimation];
       }
       completion:^(BOOL finished) {
         if (_keyboardAnimationVSyncClient == currentVsyncClient) {
@@ -1678,7 +1678,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
       }];
 }
 
-- (void)setupKeyboardSpringAnimationIfNeeded:(CAAnimation*)keyboardAnimation {
+- (void)setUpKeyboardSpringAnimationIfNeeded:(CAAnimation*)keyboardAnimation {
   // If keyboard animation is null or not a spring animation, fallback to DisplayLink tracking.
   if (keyboardAnimation == nil || ![keyboardAnimation isKindOfClass:[CASpringAnimation class]]) {
     _keyboardSpringAnimation.reset();
@@ -1696,13 +1696,13 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
                 toValue:self.targetViewInsetBottom]);
 }
 
-- (void)setupKeyboardAnimationVsyncClient:
+- (void)setUpKeyboardAnimationVsyncClient:
     (FlutterKeyboardAnimationCallback)keyboardAnimationCallback {
   if (!keyboardAnimationCallback) {
     return;
   }
   NSAssert(_keyboardAnimationVSyncClient == nil,
-           @"_keyboardAnimationVSyncClient must be nil when setup");
+           @"_keyboardAnimationVSyncClient must be nil when setting up.");
 
   // Make sure the new viewport metrics get sent after the begin frame event has processed.
   fml::scoped_nsprotocol<FlutterKeyboardAnimationCallback> animationCallback(

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -138,8 +138,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 - (void)startKeyBoardAnimation:(NSTimeInterval)duration;
 - (UIView*)keyboardAnimationView;
 - (SpringAnimation*)keyboardSpringAnimation;
-- (void)setupKeyboardSpringAnimationIfNeeded:(CAAnimation*)keyboardAnimation;
-- (void)setupKeyboardAnimationVsyncClient:
+- (void)setUpKeyboardSpringAnimationIfNeeded:(CAAnimation*)keyboardAnimation;
+- (void)setUpKeyboardAnimationVsyncClient:
     (FlutterKeyboardAnimationCallback)keyboardAnimationCallback;
 - (void)ensureViewportMetricsIsCorrect;
 - (void)invalidateKeyboardAnimationVSyncClient;
@@ -174,7 +174,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   self.messageSent = nil;
 }
 
-- (id)setupMockMainScreenAndView:(FlutterViewController*)viewControllerMock
+- (id)setUpMockMainScreenAndView:(FlutterViewController*)viewControllerMock
                        viewFrame:(CGRect)viewFrame
                   convertedFrame:(CGRect)convertedFrame {
   OCMStub([viewControllerMock mainScreenIfViewLoaded]).andReturn(UIScreen.mainScreen);
@@ -212,7 +212,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   CAAnimation* keyboardAnimation =
       [[viewControllerMock keyboardAnimationView].layer animationForKey:@"position"];
 
-  OCMVerify([viewControllerMock setupKeyboardSpringAnimationIfNeeded:keyboardAnimation]);
+  OCMVerify([viewControllerMock setUpKeyboardSpringAnimationIfNeeded:keyboardAnimation]);
 }
 
 - (void)testSetupKeyboardSpringAnimationIfNeeded {
@@ -223,10 +223,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                                                  bundle:nil];
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
   CGRect viewFrame = UIScreen.mainScreen.bounds;
-  [self setupMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
+  [self setUpMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
 
   // Null check.
-  [viewControllerMock setupKeyboardSpringAnimationIfNeeded:nil];
+  [viewControllerMock setUpKeyboardSpringAnimationIfNeeded:nil];
   SpringAnimation* keyboardSpringAnimation = [viewControllerMock keyboardSpringAnimation];
   XCTAssertTrue(keyboardSpringAnimation == nil);
 
@@ -236,7 +236,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   nonSpringAnimation.fromValue = [NSNumber numberWithFloat:0.0];
   nonSpringAnimation.toValue = [NSNumber numberWithFloat:1.0];
   nonSpringAnimation.keyPath = @"position";
-  [viewControllerMock setupKeyboardSpringAnimationIfNeeded:nonSpringAnimation];
+  [viewControllerMock setUpKeyboardSpringAnimationIfNeeded:nonSpringAnimation];
   keyboardSpringAnimation = [viewControllerMock keyboardSpringAnimation];
 
   XCTAssertTrue(keyboardSpringAnimation == nil);
@@ -249,7 +249,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   springAnimation.keyPath = @"position";
   springAnimation.fromValue = [NSValue valueWithCGPoint:CGPointMake(0, 0)];
   springAnimation.toValue = [NSValue valueWithCGPoint:CGPointMake(100, 100)];
-  [viewControllerMock setupKeyboardSpringAnimationIfNeeded:springAnimation];
+  [viewControllerMock setUpKeyboardSpringAnimationIfNeeded:springAnimation];
   keyboardSpringAnimation = [viewControllerMock keyboardSpringAnimation];
   XCTAssertTrue(keyboardSpringAnimation != nil);
 }
@@ -262,7 +262,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                                                  bundle:nil];
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
   CGRect viewFrame = UIScreen.mainScreen.bounds;
-  [self setupMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
+  [self setUpMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
 
   BOOL isLocal = YES;
   CGFloat screenHeight = UIScreen.mainScreen.bounds.size.height;
@@ -348,7 +348,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                                                  bundle:nil];
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
   CGRect viewFrame = UIScreen.mainScreen.bounds;
-  [self setupMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
+  [self setUpMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
 
   CGFloat screenWidth = UIScreen.mainScreen.bounds.size.width;
   CGFloat screenHeight = UIScreen.mainScreen.bounds.size.height;
@@ -446,7 +446,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
-  [viewController setupKeyboardAnimationVsyncClient:^(fml::TimePoint){
+  [viewController setUpKeyboardAnimationVsyncClient:^(fml::TimePoint){
   }];
   [engine destroyContext];
 }
@@ -474,7 +474,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
     [expectation fulfill];
   };
   CFTimeInterval startTime = CACurrentMediaTime();
-  [viewController setupKeyboardAnimationVsyncClient:callback];
+  [viewController setUpKeyboardAnimationVsyncClient:callback];
   [self waitForExpectationsWithTimeout:5.0 handler:nil];
   XCTAssertTrue(fulfillTime - startTime > delayTime);
 }
@@ -488,7 +488,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
   CGRect viewFrame = UIScreen.mainScreen.bounds;
-  [self setupMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
+  [self setUpMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
 
   CGFloat screenWidth = UIScreen.mainScreen.bounds.size.width;
   CGFloat screenHeight = UIScreen.mainScreen.bounds.size.height;
@@ -618,7 +618,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   CGRect viewOrigFrame = CGRectMake(0, 0, 320, screenHeight - 40);
   CGRect convertedViewFrame = CGRectMake(20, 20, 320, screenHeight - 40);
   CGRect keyboardFrame = CGRectMake(20, screenHeight - 320, screenWidth, 300);
-  id mockView = [self setupMockMainScreenAndView:viewControllerMock
+  id mockView = [self setUpMockMainScreenAndView:viewControllerMock
                                        viewFrame:viewOrigFrame
                                   convertedFrame:convertedViewFrame];
   id mockTraitCollection = OCMClassMock([UITraitCollection class]);
@@ -647,7 +647,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   CGRect convertedViewFrame = CGRectMake(20, 20, 320, screenHeight - 40);
   CGRect keyboardFrame = CGRectMake(20, screenHeight - 320, screenWidth, 300);
 
-  [self setupMockMainScreenAndView:viewControllerMock
+  [self setUpMockMainScreenAndView:viewControllerMock
                          viewFrame:viewOrigFrame
                     convertedFrame:convertedViewFrame];
 
@@ -677,7 +677,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                     @"UIKeyboardIsLocalUserInfoKey" : @(isLocal)
                                   }];
   FlutterViewController* viewControllerMock = OCMPartialMock(viewController);
-  [self setupMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
+  [self setUpMockMainScreenAndView:viewControllerMock viewFrame:viewFrame convertedFrame:viewFrame];
   viewControllerMock.targetViewInsetBottom = 0;
   XCTestExpectation* expectation = [self expectationWithDescription:@"update viewport"];
   OCMStub([viewControllerMock updateViewportMetricsIfNeeded]).andDo(^(NSInvocation* invocation) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest_mrc.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest_mrc.mm
@@ -32,7 +32,7 @@ FLUTTER_ASSERT_NOT_ARC
 @property(nonatomic, retain) VSyncClient* touchRateCorrectionVSyncClient;
 
 - (void)createTouchRateCorrectionVSyncClientIfNeeded;
-- (void)setupKeyboardAnimationVsyncClient:
+- (void)setUpKeyboardAnimationVsyncClient:
     (FlutterKeyboardAnimationCallback)keyboardAnimationCallback;
 - (void)startKeyBoardAnimation:(NSTimeInterval)duration;
 - (void)triggerTouchRateCorrectionIfNeeded:(NSSet*)touches;
@@ -58,7 +58,7 @@ FLUTTER_ASSERT_NOT_ARC
                                                                                  bundle:nil];
   FlutterKeyboardAnimationCallback callback = ^(fml::TimePoint targetTime) {
   };
-  [viewController setupKeyboardAnimationVsyncClient:callback];
+  [viewController setUpKeyboardAnimationVsyncClient:callback];
   XCTAssertNotNil(viewController.keyboardAnimationVSyncClient);
   CADisplayLink* link = [viewController.keyboardAnimationVSyncClient getDisplayLink];
   XCTAssertNotNil(link);
@@ -196,7 +196,7 @@ FLUTTER_ASSERT_NOT_ARC
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
                                                                                  bundle:nil];
-  [viewController setupKeyboardAnimationVsyncClient:nil];
+  [viewController setUpKeyboardAnimationVsyncClient:nil];
   XCTAssertNil(viewController.keyboardAnimationVSyncClient);
 }
 


### PR DESCRIPTION
There are several places in the engine using the word "setup" incorrectly. I have changed them to "set up"

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
