### PR TITLE
Add the 'affects: desktop' label to labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,12 @@
 # found in the LICENSE file.
 
 # See https://github.com/actions/labeler/blob/main/README.md for docs.
+'affects: desktop':
+  - shell/platform/darwin/common/**/*
+  - shell/platform/darwin/macos/**/*
+  - shell/platform/linux/**/*
+  - shell/platform/windows/**/*
+
 embedder:
   - shell/platform/embedder
 


### PR DESCRIPTION
The desktop team uses the [`affects: desktop`](https://github.com/flutter/engine/pulls?q=is%3Aopen+label%3A%22affects%3A+desktop%22+sort%3Aupdated-desc) label to [triage](https://github.com/flutter/flutter/wiki/Triage#desktop-platforms-team-team-desktop) pull requests.