### PR TITLE
[Impeller] Add a way to query the gfx backend type.

### DIFF
--- a/impeller/aiks/testing/context_mock.h
+++ b/impeller/aiks/testing/context_mock.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "gmock/gmock-function-mocker.h"
 #include "gmock/gmock.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/context.h"
@@ -63,6 +64,8 @@ class CommandBufferMock : public CommandBuffer {
 class ContextMock : public Context {
  public:
   MOCK_CONST_METHOD0(DescribeGpuModel, std::string());
+
+  MOCK_CONST_METHOD0(GetBackendType, Context::BackendType());
 
   MOCK_CONST_METHOD0(IsValid, bool());
 

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -86,6 +86,10 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
 
 ContextGLES::~ContextGLES() = default;
 
+Context::BackendType ContextGLES::GetBackendType() const {
+  return Context::BackendType::kOpenGLES;
+}
+
 const ReactorGLES::Ref& ContextGLES::GetReactor() const {
   return reactor_;
 }

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -28,6 +28,9 @@ class ContextGLES final : public Context,
   // |Context|
   ~ContextGLES() override;
 
+  // |Context|
+  BackendType GetBackendType() const override;
+
   const ReactorGLES::Ref& GetReactor() const;
 
   std::optional<ReactorGLES::WorkerID> AddReactorWorker(

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -52,6 +52,9 @@ class ContextMTL final : public Context,
   // |Context|
   ~ContextMTL() override;
 
+  // |Context|
+  BackendType GetBackendType() const override;
+
   id<MTLDevice> GetMTLDevice() const;
 
   // |Context|

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -286,6 +286,10 @@ std::shared_ptr<ContextMTL> ContextMTL::Create(
 
 ContextMTL::~ContextMTL() = default;
 
+Context::BackendType ContextMTL::GetBackendType() const {
+  return Context::BackendType::kMetal;
+}
+
 // |Context|
 std::string ContextMTL::DescribeGpuModel() const {
   return std::string([[device_ name] UTF8String]);

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -120,6 +120,10 @@ ContextVK::~ContextVK() {
   CommandPoolVK::ClearAllPools(this);
 }
 
+Context::BackendType ContextVK::GetBackendType() const {
+  return Context::BackendType::kVulkan;
+}
+
 void ContextVK::Setup(Settings settings) {
   TRACE_EVENT0("impeller", "ContextVK::Setup");
 

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -56,6 +56,9 @@ class ContextVK final : public Context,
   ~ContextVK() override;
 
   // |Context|
+  BackendType GetBackendType() const override;
+
+  // |Context|
   std::string DescribeGpuModel() const override;
 
   // |Context|

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -43,10 +43,31 @@ class Allocator;
 ///             `//impeller/renderer/backend`.
 class Context {
  public:
+  enum class BackendType {
+    kMetal,
+    kOpenGLES,
+    kVulkan,
+  };
+
   //----------------------------------------------------------------------------
   /// @brief      Destroys an Impeller context.
   ///
   virtual ~Context();
+
+  //----------------------------------------------------------------------------
+  /// @brief      Get the graphics backend of an Impeller context.
+  ///
+  ///             This is useful for cases where a renderer needs to track and
+  ///             lookup backend-specific resources, like shaders or uniform
+  ///             layout information.
+  ///
+  ///             It's not recommended to use this as a substitute for
+  ///             per-backend capability checking. Instead, check for specific
+  ///             capabilities via `GetCapabilities()`.
+  ///
+  /// @return     The graphics backend of the `Context`.
+  ///
+  virtual BackendType GetBackendType() const = 0;
 
   // TODO(129920): Refactor and move to capabilities.
   virtual std::string DescribeGpuModel() const = 0;

--- a/impeller/renderer/testing/mocks.h
+++ b/impeller/renderer/testing/mocks.h
@@ -86,6 +86,8 @@ class MockCommandBuffer : public CommandBuffer {
 
 class MockImpellerContext : public Context {
  public:
+  MOCK_CONST_METHOD0(GetBackendType, Context::BackendType());
+
   MOCK_CONST_METHOD0(DescribeGpuModel, std::string());
 
   MOCK_CONST_METHOD0(IsValid, bool());

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -113,6 +113,8 @@ class TestImpellerContext : public impeller::Context {
  public:
   TestImpellerContext() = default;
 
+  BackendType GetBackendType() const override { return BackendType::kMetal; }
+
   std::string DescribeGpuModel() const override { return "TestGpu"; }
 
   bool IsValid() const override { return true; }


### PR DESCRIPTION
I've been trying to avoid this, but since the context type may vary through runtime decisions, we just need something like this to select which shader data to pull from the Dart GPU bundle at runtime. One alternative would be to add a special omni shader concept to the HAL, but that seems worse than just letting renderers key with a backend enum sometimes.

Cautioned against using it for cap checks in the doc string.