### PR TITLE
Uncap framerate for `iOSAppOnMac`

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -44,10 +44,16 @@ void VsyncWaiterIOS::AwaitVSync() {
   if (fml::TaskRunnerChecker::RunsOnTheSameThread(
           task_runners_.GetRasterTaskRunner()->GetTaskQueueId(),
           task_runners_.GetPlatformTaskRunner()->GetTaskQueueId())) {
-    // Pressure tested on iPhone 13 pro, the oldest iPhone that supports refresh rate greater than
-    // 60fps. A flutter app can handle fast scrolling on 80 fps with 6 PlatformViews in the scene at
-    // the same time.
-    new_max_refresh_rate = 80;
+    BOOL isRunningOnMac = NO;
+    if (@available(iOS 14.0, *)) {
+      isRunningOnMac = [NSProcessInfo processInfo].iOSAppOnMac;
+    }
+    if (!isRunningOnMac) {
+      // Pressure tested on iPhone 13 pro, the oldest iPhone that supports refresh rate greater than
+      // 60fps. A flutter app can handle fast scrolling on 80 fps with 6 PlatformViews in the scene
+      // at the same time.
+      new_max_refresh_rate = 80;
+    }
   }
   if (fabs(new_max_refresh_rate - max_refresh_rate_) > kRefreshRateDiffToIgnore) {
     max_refresh_rate_ = new_max_refresh_rate;


### PR DESCRIPTION
Right now framerate when platform views are on screen is capped to 80 fps on iOS devices. I tried uncapping the framerate and ran the test app in https://github.com/flutter/flutter/issues/116640 on my M1 Max MBP and didn't notice any of the same slowdowns. `iOSAppOnMac` is only available on Apple Silicon Macs, so the performance baseline is really high. I think it's safe to remove the cap here.

### 120 Hz / ProMotion minimum specs

| Category | Device | SoC | CPU | GPU |
|--|--|--|--|--|
iOS | iPhone 13 Pro | A15 | 2P+4e | 5 EU |
Mac with built-in ProMotion | MacBook Pro 2021 | M1 Pro | 6P+2e |  14 EU |
Mac with external 120Hz display | MacBook Air 2020 | M1 | 4P+4e | 7 EU |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
