### PR TITLE
[Impeller] [Vulkan] Add reset command buffer bit to command pools.

### DIFF
--- a/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -72,7 +72,8 @@ CommandPoolVK::CommandPoolVK(const ContextVK* context)
   vk::CommandPoolCreateInfo pool_info;
 
   pool_info.queueFamilyIndex = context->GetGraphicsQueue()->GetIndex().family;
-  pool_info.flags = vk::CommandPoolCreateFlagBits::eTransient;
+  pool_info.flags = vk::CommandPoolCreateFlagBits::eTransient |
+                    vk::CommandPoolCreateFlagBits::eResetCommandBuffer;
   auto pool = context->GetDevice().createCommandPoolUnique(pool_info);
   if (pool.result != vk::Result::eSuccess) {
     return;


### PR DESCRIPTION
Without this bit, we're holding it wrong. From the docs:

> VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT allows any command buffer allocated from a pool to be individually reset to the initial state; either by calling vkResetCommandBuffer, or via the implicit reset when calling vkBeginCommandBuffer. If this flag is not set on a pool, then vkResetCommandBuffer must not be called for any command buffer allocated from that pool.

This means our reset calls later are getting ignored.

Fixes https://github.com/flutter/flutter/issues/131001
