### PR TITLE
[Impeller] size command pools to npot of command count.

### DIFF
--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -284,12 +284,13 @@ bool CommandEncoderVK::IsTracking(
 }
 
 std::optional<vk::DescriptorSet> CommandEncoderVK::AllocateDescriptorSet(
-    const vk::DescriptorSetLayout& layout) {
+    const vk::DescriptorSetLayout& layout,
+    size_t command_count) {
   if (!IsValid()) {
     return std::nullopt;
   }
 
-  return tracked_objects_->GetDescriptorPool().AllocateDescriptorSet(layout);
+  return tracked_objects_->GetDescriptorPool().AllocateDescriptorSet(layout, command_count);
 }
 
 void CommandEncoderVK::PushDebugGroup(const char* label) const {

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -290,7 +290,8 @@ std::optional<vk::DescriptorSet> CommandEncoderVK::AllocateDescriptorSet(
     return std::nullopt;
   }
 
-  return tracked_objects_->GetDescriptorPool().AllocateDescriptorSet(layout, command_count);
+  return tracked_objects_->GetDescriptorPool().AllocateDescriptorSet(
+      layout, command_count);
 }
 
 void CommandEncoderVK::PushDebugGroup(const char* label) const {

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -79,7 +79,8 @@ class CommandEncoderVK {
   void InsertDebugMarker(const char* label) const;
 
   std::optional<vk::DescriptorSet> AllocateDescriptorSet(
-      const vk::DescriptorSetLayout& layout);
+      const vk::DescriptorSetLayout& layout,
+      size_t command_count);
 
  private:
   friend class ContextVK;

--- a/impeller/renderer/backend/vulkan/compute_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/compute_pass_vk.cc
@@ -69,10 +69,11 @@ static bool UpdateBindingLayouts(const std::vector<ComputeCommand>& commands,
 static bool AllocateAndBindDescriptorSets(const ContextVK& context,
                                           const ComputeCommand& command,
                                           CommandEncoderVK& encoder,
-                                          const ComputePipelineVK& pipeline) {
+                                          const ComputePipelineVK& pipeline,
+                                          size_t command_count) {
   auto desc_set = pipeline.GetDescriptor().GetDescriptorSetLayouts();
-  auto vk_desc_set =
-      encoder.AllocateDescriptorSet(pipeline.GetDescriptorSetLayout());
+  auto vk_desc_set = encoder.AllocateDescriptorSet(
+      pipeline.GetDescriptorSetLayout(), command_count);
   if (!vk_desc_set) {
     return false;
   }
@@ -82,7 +83,6 @@ static bool AllocateAndBindDescriptorSets(const ContextVK& context,
   std::unordered_map<uint32_t, vk::DescriptorBufferInfo> buffers;
   std::unordered_map<uint32_t, vk::DescriptorImageInfo> images;
   std::vector<vk::WriteDescriptorSet> writes;
-
   auto bind_images = [&encoder,     //
                       &images,      //
                       &writes,      //
@@ -241,10 +241,11 @@ bool ComputePassVK::OnEncodeCommands(const Context& context,
 
       cmd_buffer.bindPipeline(vk::PipelineBindPoint::eCompute,
                               pipeline_vk.GetPipeline());
-      if (!AllocateAndBindDescriptorSets(vk_context,  //
-                                         command,     //
-                                         *encoder,    //
-                                         pipeline_vk  //
+      if (!AllocateAndBindDescriptorSets(vk_context,       //
+                                         command,          //
+                                         *encoder,         //
+                                         pipeline_vk,      //
+                                         commands_.size()  //
                                          )) {
         return false;
       }

--- a/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -23,10 +23,7 @@ static vk::UniqueDescriptorPool CreatePool(const vk::Device& device,
   std::vector<vk::DescriptorPoolSize> pools = {
       {vk::DescriptorType::eCombinedImageSampler, pool_count},
       {vk::DescriptorType::eUniformBuffer, pool_count},
-      {vk::DescriptorType::eStorageBuffer, pool_count},
-      {vk::DescriptorType::eSampledImage, pool_count},
-      {vk::DescriptorType::eSampler, pool_count},
-  };
+      {vk::DescriptorType::eStorageBuffer, pool_count}};
 
   vk::DescriptorPoolCreateInfo pool_info;
   pool_info.setMaxSets(pools.size() * pool_count);
@@ -37,6 +34,15 @@ static vk::UniqueDescriptorPool CreatePool(const vk::Device& device,
     VALIDATION_LOG << "Unable to create a descriptor pool";
   }
   return std::move(pool);
+}
+
+std::optional<vk::DescriptorSet> DescriptorPoolVK::AllocateDescriptorSet(
+    const vk::DescriptorSetLayout& layout,
+    size_t command_count) {
+  if (pools_.empty()) {
+    pool_size_ = command_count;
+  }
+  return AllocateDescriptorSet(layout);
 }
 
 std::optional<vk::DescriptorSet> DescriptorPoolVK::AllocateDescriptorSet(

--- a/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
@@ -33,9 +33,13 @@ class DescriptorPoolVK {
   ~DescriptorPoolVK();
 
   std::optional<vk::DescriptorSet> AllocateDescriptorSet(
-      const vk::DescriptorSetLayout& layout);
+      const vk::DescriptorSetLayout& layout,
+      size_t command_count);
 
  private:
+  std::optional<vk::DescriptorSet> AllocateDescriptorSet(
+      const vk::DescriptorSetLayout& layout);
+
   std::weak_ptr<const DeviceHolder> device_holder_;
   uint32_t pool_size_ = 31u;
   std::queue<vk::UniqueDescriptorPool> pools_;

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -284,11 +284,12 @@ static bool UpdateBindingLayouts(const std::vector<Command>& commands,
 static bool AllocateAndBindDescriptorSets(const ContextVK& context,
                                           const Command& command,
                                           CommandEncoderVK& encoder,
-                                          const PipelineVK& pipeline) {
+                                          const PipelineVK& pipeline,
+                                          size_t command_count) {
   auto desc_set =
       pipeline.GetDescriptor().GetVertexDescriptor()->GetDescriptorSetLayouts();
-  auto vk_desc_set =
-      encoder.AllocateDescriptorSet(pipeline.GetDescriptorSetLayout());
+  auto vk_desc_set = encoder.AllocateDescriptorSet(
+      pipeline.GetDescriptorSetLayout(), command_count);
   if (!vk_desc_set) {
     return false;
   }
@@ -445,7 +446,8 @@ static bool EncodeCommand(const Context& context,
                           const Command& command,
                           CommandEncoderVK& encoder,
                           PassBindingsCache& command_buffer_cache,
-                          const ISize& target_size) {
+                          const ISize& target_size,
+                          size_t command_count) {
   if (command.vertex_count == 0u || command.instance_count == 0u) {
     return true;
   }
@@ -465,7 +467,8 @@ static bool EncodeCommand(const Context& context,
   if (!AllocateAndBindDescriptorSets(ContextVK::Cast(context),  //
                                      command,                   //
                                      encoder,                   //
-                                     pipeline_vk                //
+                                     pipeline_vk,               //
+                                     command_count              //
                                      )) {
     return false;
   }
@@ -628,7 +631,7 @@ bool RenderPassVK::OnEncodeCommands(const Context& context) const {
       }
 
       if (!EncodeCommand(context, command, *encoder, pass_bindings_cache_,
-                         target_size)) {
+                         target_size, commands_.size())) {
         return false;
       }
     }


### PR DESCRIPTION
Also removes pools for eSampledImage and eSampler as they appear to be unused in our generated headers.

This may have a minor impact on performance as from experimentation we will re-allocate fewer command pools.
