### PR TITLE
[Impeller] Disable color attachment removal for clips on VK

### DIFF
--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -443,7 +443,7 @@ bool CapabilitiesVK::SupportsMemorylessTextures() const {
 
 // |Capabilities|
 bool CapabilitiesVK::SupportsPipelinesWithNoColorAttachments() const {
-  return true;
+  return false;
 }
 
 // |Capabilities|


### PR DESCRIPTION
This is causing a validation failure on the Vulkan backend at ToT, as discovered by @jonahwilliams.

Need to figure out why this isn't getting hit in the Vulkan goldens.