### PR TITLE
[Impeller] Fix MatrixFilter multiplication ordering for subpasses.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2908,15 +2908,22 @@ TEST_P(AiksTest, DrawPictureWithText) {
 
 TEST_P(AiksTest, MatrixBackdropFilter) {
   Canvas canvas;
-  canvas.SaveLayer({}, std::nullopt,
-                   [](const FilterInput::Ref& input,
-                      const Matrix& effect_transform, bool is_subpass) {
-                     return FilterContents::MakeMatrixFilter(
-                         input, Matrix::MakeTranslation(Vector2(100, 100)), {},
-                         Matrix(), true);
-                   });
-  canvas.DrawCircle(Point(100, 100), 100,
-                    {.color = Color::Green(), .blend_mode = BlendMode::kPlus});
+  canvas.DrawPaint({.color = Color::Black()});
+  canvas.SaveLayer({}, std::nullopt);
+  {
+    canvas.DrawCircle(
+        Point(200, 200), 100,
+        {.color = Color::Green(), .blend_mode = BlendMode::kPlus});
+    // Should render a second intersecting circle, offset by 100, 100.
+    canvas.SaveLayer({}, std::nullopt,
+                     [](const FilterInput::Ref& input,
+                        const Matrix& effect_transform, bool is_subpass) {
+                       return FilterContents::MakeMatrixFilter(
+                           input, Matrix::MakeTranslation(Vector2(100, 100)),
+                           {}, Matrix(), true);
+                     });
+    canvas.Restore();
+  }
   canvas.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -35,10 +35,10 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
   }
 
   auto& transform = is_subpass_ ? effect_transform : entity.GetTransformation();
-  snapshot->transform = transform *           //
-                        matrix_ *             //
-                        transform.Invert() *  //
-                        snapshot->transform;
+  snapshot->transform = snapshot->transform *  //
+                        transform *            //
+                        matrix_ *              //
+                        transform.Invert();
   snapshot->sampler_descriptor = sampler_descriptor_;
   return Entity::FromSnapshot(snapshot, entity.GetBlendMode(),
                               entity.GetStencilDepth());

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -34,11 +34,45 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  auto& transform = is_subpass_ ? effect_transform : entity.GetTransformation();
-  snapshot->transform = snapshot->transform *  //
-                        transform *            //
-                        matrix_ *              //
-                        transform.Invert();
+  if (is_subpass_) {
+    // There are two special quirks with how Matrix filters behave when used as
+    // subpass backdrop filters:
+    //
+    // 1. For subpass backdrop filters, the snapshot transform is always just a
+    //    translation that positions the parent pass texture correctly relative
+    //    to the subpass texture. However, this translation always needs to be
+    //    applied in screen space.
+    //
+    //    Since we know the snapshot transform will always have an identity
+    //    basis in this case, we safely reverse the order and apply the filter's
+    //    matrix within the snapshot transform space.
+    //
+    // 2. The filter's matrix needs to be applied within the space defined by
+    //    the scene's current transformation matrix (CTM). For example: If the
+    //    CTM is scaled up, then translations applied by the matrix should be
+    //    magnified accordingly.
+    //
+    //    To accomplish this, we sandwitch the filter's matrix within the CTM in
+    //    both cases. But notice that for the subpass backdrop filter case, we
+    //    use the "effect transform" instead of the Entity's transform!
+    //
+    //    That's because in the subpass backdrop filter case, the Entity's
+    //    transform isn't actually the captured CTM of the scene like it usually
+    //    is; instead, it's just a screen space translation that offsets the
+    //    backdrop texture (as mentioned above). And so we sneak the subpass's
+    //    captured CTM in through the effect transform.
+    //
+
+    snapshot->transform = snapshot->transform *  //
+                          effect_transform *     //
+                          matrix_ *              //
+                          effect_transform.Invert();
+  } else {
+    snapshot->transform = entity.GetTransformation() *           //
+                          matrix_ *                              //
+                          entity.GetTransformation().Invert() *  //
+                          snapshot->transform;
+  }
   snapshot->sampler_descriptor = sampler_descriptor_;
   return Entity::FromSnapshot(snapshot, entity.GetBlendMode(),
                               entity.GetStencilDepth());


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/130355.

When drawing a backdrop filter, we offset the backdrop entity with `-local_pass_position` in order to align the backdrop texture with the position of the pass it's being drawn to. When rendering the filter, this transform propagates to the filter snapshot. Prior to this change, that offset was being applied within the space of the backdrop filter's matrix, which is wrong! It needs to be applied in screen space.

We didn't notice this prior to the coverage hint optimization because we were previously forcing subpass sizes to match the parent whenever a backdrop filter was present.

This one was very difficult to reason through at first, and so I added a detailed comment to explain the rationale behind the behavioral differences between the backdrop filter and non-backdrop filter cases of the matrix filter.

I also updated the golden to more clearly show the coverage leak I was getting at when I filed https://github.com/flutter/flutter/issues/130355. It's not causing known issues with real widgets, however, and so I'm going to set it to the side for now.

Before:

https://github.com/flutter/engine/assets/919017/d12d67bd-7e60-4389-87d3-fc4162d9b90e

After:

https://github.com/flutter/engine/assets/919017/a611a0d4-0b2d-4171-8170-b6a3781034e1
