### PR TITLE
[Impeller] Fix clip pipeline validation failure; add dedicated clip shaders.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1305,6 +1305,8 @@ ORIGIN: ../../../flutter/impeller/entity/shaders/blending/ios/framebuffer_blend_
 ORIGIN: ../../../flutter/impeller/entity/shaders/blending/porter_duff_blend.frag + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/border_mask_blur.frag + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/border_mask_blur.vert + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/entity/shaders/clip.frag + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/entity/shaders/clip.vert + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/color_matrix_color_filter.frag + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/color_matrix_color_filter.vert + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/shaders/conical_gradient_fill.frag + ../../../flutter/LICENSE
@@ -3997,6 +3999,8 @@ FILE: ../../../flutter/impeller/entity/shaders/blending/ios/framebuffer_blend_so
 FILE: ../../../flutter/impeller/entity/shaders/blending/porter_duff_blend.frag
 FILE: ../../../flutter/impeller/entity/shaders/border_mask_blur.frag
 FILE: ../../../flutter/impeller/entity/shaders/border_mask_blur.vert
+FILE: ../../../flutter/impeller/entity/shaders/clip.frag
+FILE: ../../../flutter/impeller/entity/shaders/clip.vert
 FILE: ../../../flutter/impeller/entity/shaders/color_matrix_color_filter.frag
 FILE: ../../../flutter/impeller/entity/shaders/color_matrix_color_filter.vert
 FILE: ../../../flutter/impeller/entity/shaders/conical_gradient_fill.frag

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -34,6 +34,8 @@ impeller_shaders("entity_shaders") {
     "shaders/blending/blend.vert",
     "shaders/border_mask_blur.frag",
     "shaders/border_mask_blur.vert",
+    "shaders/clip.frag",
+    "shaders/clip.vert",
     "shaders/color_matrix_color_filter.frag",
     "shaders/color_matrix_color_filter.vert",
     "shaders/conical_gradient_fill.frag",

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -85,10 +85,8 @@ bool ClipContents::Render(const ContentContext& renderer,
 
   Command cmd;
 
-  // The color really doesn't matter.
-  info.color = Color::SkyBlue();
-
-  auto options = OptionsFromPassAndEntity(pass, entity);
+  auto options = OptionsFromPass(pass);
+  options.blend_mode = BlendMode::kDestination;
   cmd.stencil_reference = entity.GetStencilDepth();
   options.stencil_compare = CompareFunction::kEqual;
   options.stencil_operation = StencilOperation::kIncrementClamp;
@@ -182,7 +180,8 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
 
   Command cmd;
   cmd.label = "Restore Clip";
-  auto options = OptionsFromPassAndEntity(pass, entity);
+  auto options = OptionsFromPass(pass);
+  options.blend_mode = BlendMode::kDestination;
   options.stencil_compare = CompareFunction::kLess;
   options.stencil_operation = StencilOperation::kSetToReferenceValue;
   options.primitive_type = PrimitiveType::kTriangleStrip;
@@ -204,7 +203,6 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
 
   VS::FrameInfo info;
   info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
-  info.color = Color::SkyBlue();
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
   pass.AddCommand(std::move(cmd));

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -29,104 +29,102 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
 
   desc.SetSampleCount(sample_count);
 
-  auto* color0_ref = desc.GetColorAttachmentDescriptor(0u);
-  if (color0_ref) {
-    ColorAttachmentDescriptor color0 = *color0_ref;
-    color0.format = color_attachment_pixel_format;
-    color0.alpha_blend_op = BlendOperation::kAdd;
-    color0.color_blend_op = BlendOperation::kAdd;
+  ColorAttachmentDescriptor color0 = *desc.GetColorAttachmentDescriptor(0u);
+  color0.format = color_attachment_pixel_format;
+  color0.alpha_blend_op = BlendOperation::kAdd;
+  color0.color_blend_op = BlendOperation::kAdd;
 
-    switch (pipeline_blend) {
-      case BlendMode::kClear:
-        color0.dst_alpha_blend_factor = BlendFactor::kZero;
-        color0.dst_color_blend_factor = BlendFactor::kZero;
-        color0.src_alpha_blend_factor = BlendFactor::kZero;
-        color0.src_color_blend_factor = BlendFactor::kZero;
-        break;
-      case BlendMode::kSource:
-        color0.blending_enabled = false;
-        color0.dst_alpha_blend_factor = BlendFactor::kZero;
-        color0.dst_color_blend_factor = BlendFactor::kZero;
-        color0.src_alpha_blend_factor = BlendFactor::kOne;
-        color0.src_color_blend_factor = BlendFactor::kOne;
-        break;
-      case BlendMode::kDestination:
-        color0.dst_alpha_blend_factor = BlendFactor::kOne;
-        color0.dst_color_blend_factor = BlendFactor::kOne;
-        color0.src_alpha_blend_factor = BlendFactor::kZero;
-        color0.src_color_blend_factor = BlendFactor::kZero;
-        break;
-      case BlendMode::kSourceOver:
-        color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
-        color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
-        color0.src_alpha_blend_factor = BlendFactor::kOne;
-        color0.src_color_blend_factor = BlendFactor::kOne;
-        break;
-      case BlendMode::kDestinationOver:
-        color0.dst_alpha_blend_factor = BlendFactor::kOne;
-        color0.dst_color_blend_factor = BlendFactor::kOne;
-        color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
-        color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
-        break;
-      case BlendMode::kSourceIn:
-        color0.dst_alpha_blend_factor = BlendFactor::kZero;
-        color0.dst_color_blend_factor = BlendFactor::kZero;
-        color0.src_alpha_blend_factor = BlendFactor::kDestinationAlpha;
-        color0.src_color_blend_factor = BlendFactor::kDestinationAlpha;
-        break;
-      case BlendMode::kDestinationIn:
-        color0.dst_alpha_blend_factor = BlendFactor::kSourceAlpha;
-        color0.dst_color_blend_factor = BlendFactor::kSourceAlpha;
-        color0.src_alpha_blend_factor = BlendFactor::kZero;
-        color0.src_color_blend_factor = BlendFactor::kZero;
-        break;
-      case BlendMode::kSourceOut:
-        color0.dst_alpha_blend_factor = BlendFactor::kZero;
-        color0.dst_color_blend_factor = BlendFactor::kZero;
-        color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
-        color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
-        break;
-      case BlendMode::kDestinationOut:
-        color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
-        color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
-        color0.src_alpha_blend_factor = BlendFactor::kZero;
-        color0.src_color_blend_factor = BlendFactor::kZero;
-        break;
-      case BlendMode::kSourceATop:
-        color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
-        color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
-        color0.src_alpha_blend_factor = BlendFactor::kDestinationAlpha;
-        color0.src_color_blend_factor = BlendFactor::kDestinationAlpha;
-        break;
-      case BlendMode::kDestinationATop:
-        color0.dst_alpha_blend_factor = BlendFactor::kSourceAlpha;
-        color0.dst_color_blend_factor = BlendFactor::kSourceAlpha;
-        color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
-        color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
-        break;
-      case BlendMode::kXor:
-        color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
-        color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
-        color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
-        color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
-        break;
-      case BlendMode::kPlus:
-        color0.dst_alpha_blend_factor = BlendFactor::kOne;
-        color0.dst_color_blend_factor = BlendFactor::kOne;
-        color0.src_alpha_blend_factor = BlendFactor::kOne;
-        color0.src_color_blend_factor = BlendFactor::kOne;
-        break;
-      case BlendMode::kModulate:
-        color0.dst_alpha_blend_factor = BlendFactor::kSourceAlpha;
-        color0.dst_color_blend_factor = BlendFactor::kSourceColor;
-        color0.src_alpha_blend_factor = BlendFactor::kZero;
-        color0.src_color_blend_factor = BlendFactor::kZero;
-        break;
-      default:
-        FML_UNREACHABLE();
-    }
-    desc.SetColorAttachmentDescriptor(0u, color0);
+  switch (pipeline_blend) {
+    case BlendMode::kClear:
+      color0.dst_alpha_blend_factor = BlendFactor::kZero;
+      color0.dst_color_blend_factor = BlendFactor::kZero;
+      color0.src_alpha_blend_factor = BlendFactor::kZero;
+      color0.src_color_blend_factor = BlendFactor::kZero;
+      break;
+    case BlendMode::kSource:
+      color0.blending_enabled = false;
+      color0.dst_alpha_blend_factor = BlendFactor::kZero;
+      color0.dst_color_blend_factor = BlendFactor::kZero;
+      color0.src_alpha_blend_factor = BlendFactor::kOne;
+      color0.src_color_blend_factor = BlendFactor::kOne;
+      break;
+    case BlendMode::kDestination:
+      color0.dst_alpha_blend_factor = BlendFactor::kOne;
+      color0.dst_color_blend_factor = BlendFactor::kOne;
+      color0.src_alpha_blend_factor = BlendFactor::kZero;
+      color0.src_color_blend_factor = BlendFactor::kZero;
+      break;
+    case BlendMode::kSourceOver:
+      color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+      color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+      color0.src_alpha_blend_factor = BlendFactor::kOne;
+      color0.src_color_blend_factor = BlendFactor::kOne;
+      break;
+    case BlendMode::kDestinationOver:
+      color0.dst_alpha_blend_factor = BlendFactor::kOne;
+      color0.dst_color_blend_factor = BlendFactor::kOne;
+      color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+      color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+      break;
+    case BlendMode::kSourceIn:
+      color0.dst_alpha_blend_factor = BlendFactor::kZero;
+      color0.dst_color_blend_factor = BlendFactor::kZero;
+      color0.src_alpha_blend_factor = BlendFactor::kDestinationAlpha;
+      color0.src_color_blend_factor = BlendFactor::kDestinationAlpha;
+      break;
+    case BlendMode::kDestinationIn:
+      color0.dst_alpha_blend_factor = BlendFactor::kSourceAlpha;
+      color0.dst_color_blend_factor = BlendFactor::kSourceAlpha;
+      color0.src_alpha_blend_factor = BlendFactor::kZero;
+      color0.src_color_blend_factor = BlendFactor::kZero;
+      break;
+    case BlendMode::kSourceOut:
+      color0.dst_alpha_blend_factor = BlendFactor::kZero;
+      color0.dst_color_blend_factor = BlendFactor::kZero;
+      color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+      color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+      break;
+    case BlendMode::kDestinationOut:
+      color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+      color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+      color0.src_alpha_blend_factor = BlendFactor::kZero;
+      color0.src_color_blend_factor = BlendFactor::kZero;
+      break;
+    case BlendMode::kSourceATop:
+      color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+      color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+      color0.src_alpha_blend_factor = BlendFactor::kDestinationAlpha;
+      color0.src_color_blend_factor = BlendFactor::kDestinationAlpha;
+      break;
+    case BlendMode::kDestinationATop:
+      color0.dst_alpha_blend_factor = BlendFactor::kSourceAlpha;
+      color0.dst_color_blend_factor = BlendFactor::kSourceAlpha;
+      color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+      color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+      break;
+    case BlendMode::kXor:
+      color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+      color0.dst_color_blend_factor = BlendFactor::kOneMinusSourceAlpha;
+      color0.src_alpha_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+      color0.src_color_blend_factor = BlendFactor::kOneMinusDestinationAlpha;
+      break;
+    case BlendMode::kPlus:
+      color0.dst_alpha_blend_factor = BlendFactor::kOne;
+      color0.dst_color_blend_factor = BlendFactor::kOne;
+      color0.src_alpha_blend_factor = BlendFactor::kOne;
+      color0.src_color_blend_factor = BlendFactor::kOne;
+      break;
+    case BlendMode::kModulate:
+      color0.dst_alpha_blend_factor = BlendFactor::kSourceAlpha;
+      color0.dst_color_blend_factor = BlendFactor::kSourceColor;
+      color0.src_alpha_blend_factor = BlendFactor::kZero;
+      color0.src_color_blend_factor = BlendFactor::kZero;
+      break;
+    default:
+      FML_UNREACHABLE();
   }
+  desc.SetColorAttachmentDescriptor(0u, color0);
+
   if (!has_stencil_attachment) {
     desc.ClearStencilAttachments();
   }
@@ -322,22 +320,15 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
   if (maybe_pipeline_desc.has_value()) {
     auto clip_pipeline_descriptor = maybe_pipeline_desc.value();
     clip_pipeline_descriptor.SetLabel("Clip Pipeline");
-
     // Disable write to all color attachments.
-    if (context_->GetCapabilities()
-            ->SupportsPipelinesWithNoColorAttachments()) {
-      clip_pipeline_descriptor.SetColorAttachmentDescriptors({});
-    } else {
-      auto color_attachments =
-          clip_pipeline_descriptor.GetColorAttachmentDescriptors();
-      for (auto& color_attachment : color_attachments) {
-        color_attachment.second.write_mask =
-            static_cast<uint64_t>(ColorWriteMask::kNone);
-      }
-      clip_pipeline_descriptor.SetColorAttachmentDescriptors(
-          std::move(color_attachments));
+    auto color_attachments =
+        clip_pipeline_descriptor.GetColorAttachmentDescriptors();
+    for (auto& color_attachment : color_attachments) {
+      color_attachment.second.write_mask =
+          static_cast<uint64_t>(ColorWriteMask::kNone);
     }
-
+    clip_pipeline_descriptor.SetColorAttachmentDescriptors(
+        std::move(color_attachments));
     clip_pipelines_[default_options_] =
         std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor);
   } else {

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -150,10 +150,10 @@ static std::unique_ptr<PipelineT> CreateDefaultPipeline(
     return nullptr;
   }
   // Apply default ContentContextOptions to the descriptor.
-  const auto default_color_fmt =
+  const auto default_color_format =
       context.GetCapabilities()->GetDefaultColorFormat();
   ContentContextOptions{.sample_count = SampleCount::kCount4,
-                        .color_attachment_pixel_format = default_color_fmt}
+                        .color_attachment_pixel_format = default_color_format}
       .ApplyToPipelineDescriptor(*desc);
   return std::make_unique<PipelineT>(context, desc);
 }
@@ -315,25 +315,29 @@ ContentContext::ContentContext(std::shared_ptr<Context> context)
         context_->GetPipelineLibrary()->GetPipeline(uv_pipeline_desc).Get();
   }
 
-  auto maybe_pipeline_desc =
-      solid_fill_pipelines_[default_options_]->GetDescriptor();
-  if (maybe_pipeline_desc.has_value()) {
-    auto clip_pipeline_descriptor = maybe_pipeline_desc.value();
-    clip_pipeline_descriptor.SetLabel("Clip Pipeline");
-    // Disable write to all color attachments.
-    auto color_attachments =
-        clip_pipeline_descriptor.GetColorAttachmentDescriptors();
-    for (auto& color_attachment : color_attachments) {
-      color_attachment.second.write_mask =
-          static_cast<uint64_t>(ColorWriteMask::kNone);
-    }
-    clip_pipeline_descriptor.SetColorAttachmentDescriptors(
-        std::move(color_attachments));
-    clip_pipelines_[default_options_] =
-        std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor);
-  } else {
+  /// Setup default clip pipeline.
+
+  auto clip_pipeline_descriptor =
+      ClipPipeline::Builder::MakeDefaultPipelineDescriptor(*context_);
+  if (!clip_pipeline_descriptor.has_value()) {
     return;
   }
+  ContentContextOptions{
+      .sample_count = SampleCount::kCount4,
+      .color_attachment_pixel_format =
+          context_->GetCapabilities()->GetDefaultColorFormat()}
+      .ApplyToPipelineDescriptor(*clip_pipeline_descriptor);
+  // Disable write to all color attachments.
+  auto clip_color_attachments =
+      clip_pipeline_descriptor->GetColorAttachmentDescriptors();
+  for (auto& color_attachment : clip_color_attachments) {
+    color_attachment.second.write_mask =
+        static_cast<uint64_t>(ColorWriteMask::kNone);
+  }
+  clip_pipeline_descriptor->SetColorAttachmentDescriptors(
+      std::move(clip_color_attachments));
+  clip_pipelines_[default_options_] =
+      std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor);
 
   is_valid_ = true;
 }

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -27,6 +27,8 @@
 #include "impeller/entity/blend.vert.h"
 #include "impeller/entity/border_mask_blur.frag.h"
 #include "impeller/entity/border_mask_blur.vert.h"
+#include "impeller/entity/clip.frag.h"
+#include "impeller/entity/clip.vert.h"
 #include "impeller/entity/color_matrix_color_filter.frag.h"
 #include "impeller/entity/color_matrix_color_filter.vert.h"
 #include "impeller/entity/conical_gradient_fill.frag.h"
@@ -179,8 +181,7 @@ using PorterDuffBlendPipeline =
     RenderPipelineT<BlendVertexShader, PorterDuffBlendFragmentShader>;
 // Instead of requiring new shaders for clips, the solid fill stages are used
 // to redirect writing to the stencil instead of color attachments.
-using ClipPipeline =
-    RenderPipelineT<SolidFillVertexShader, SolidFillFragmentShader>;
+using ClipPipeline = RenderPipelineT<ClipVertexShader, ClipFragmentShader>;
 
 using GeometryColorPipeline =
     RenderPipelineT<PositionColorVertexShader, VerticesFragmentShader>;

--- a/impeller/entity/shaders/clip.frag
+++ b/impeller/entity/shaders/clip.frag
@@ -1,0 +1,9 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+precision mediump float;
+
+#include <impeller/types.glsl>
+
+void main() {}

--- a/impeller/entity/shaders/clip.vert
+++ b/impeller/entity/shaders/clip.vert
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <impeller/types.glsl>
+
+uniform FrameInfo {
+  mat4 mvp;
+}
+frame_info;
+
+in vec2 position;
+
+void main() {
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+}

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -77,7 +77,6 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
             .SetSupportsReadFromOnscreenTexture(false)
             .SetSupportsDecalTileMode(false)
             .SetSupportsMemorylessTextures(false)
-            .SetSupportsPipelinesWithNoColorAttachments(false)
             .Build();
   }
 

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -257,8 +257,8 @@ struct RenderPassData {
     const auto* color_attachment =
         pipeline.GetDescriptor().GetLegacyCompatibleColorAttachment();
     if (!color_attachment) {
-      VALIDATION_LOG << "The OpenGLES backend requires pipelines to have color "
-                        "attachments.";
+      VALIDATION_LOG
+          << "Color attachment is too complicated for a legacy renderer.";
       return false;
     }
 

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -65,7 +65,6 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetSupportsReadFromResolve(true)
       .SetSupportsReadFromOnscreenTexture(true)
       .SetSupportsMemorylessTextures(true)
-      .SetSupportsPipelinesWithNoColorAttachments(true)
       .Build();
 }
 

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -431,7 +431,6 @@ bool CapabilitiesVK::SupportsReadFromOnscreenTexture() const {
   return false;
 }
 
-// |Capabilities|
 bool CapabilitiesVK::SupportsDecalTileMode() const {
   return true;
 }
@@ -439,11 +438,6 @@ bool CapabilitiesVK::SupportsDecalTileMode() const {
 // |Capabilities|
 bool CapabilitiesVK::SupportsMemorylessTextures() const {
   return supports_memoryless_textures_;
-}
-
-// |Capabilities|
-bool CapabilitiesVK::SupportsPipelinesWithNoColorAttachments() const {
-  return true;
 }
 
 // |Capabilities|

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -443,7 +443,7 @@ bool CapabilitiesVK::SupportsMemorylessTextures() const {
 
 // |Capabilities|
 bool CapabilitiesVK::SupportsPipelinesWithNoColorAttachments() const {
-  return false;
+  return true;
 }
 
 // |Capabilities|

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -94,9 +94,6 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsMemorylessTextures() const override;
 
   // |Capabilities|
-  bool SupportsPipelinesWithNoColorAttachments() const override;
-
-  // |Capabilities|
   PixelFormat GetDefaultColorFormat() const override;
 
   // |Capabilities|

--- a/impeller/renderer/capabilities.cc
+++ b/impeller/renderer/capabilities.cc
@@ -76,14 +76,8 @@ class StandardCapabilities final : public Capabilities {
     return default_stencil_format_;
   }
 
-  // |Capabilities|
   bool SupportsMemorylessTextures() const override {
     return supports_memoryless_textures_;
-  }
-
-  // |Capabilities|
-  bool SupportsPipelinesWithNoColorAttachments() const override {
-    return supports_pipelines_with_no_color_attachments_;
   }
 
  private:
@@ -99,7 +93,6 @@ class StandardCapabilities final : public Capabilities {
                        bool supports_read_from_resolve,
                        bool supports_decal_tile_mode,
                        bool supports_memoryless_textures,
-                       bool supports_pipelines_with_no_color_attachments,
                        PixelFormat default_color_format,
                        PixelFormat default_stencil_format)
       : has_threading_restrictions_(has_threading_restrictions),
@@ -115,8 +108,6 @@ class StandardCapabilities final : public Capabilities {
         supports_read_from_resolve_(supports_read_from_resolve),
         supports_decal_tile_mode_(supports_decal_tile_mode),
         supports_memoryless_textures_(supports_memoryless_textures),
-        supports_pipelines_with_no_color_attachments_(
-            supports_pipelines_with_no_color_attachments),
         default_color_format_(default_color_format),
         default_stencil_format_(default_stencil_format) {}
 
@@ -134,7 +125,6 @@ class StandardCapabilities final : public Capabilities {
   bool supports_read_from_resolve_ = false;
   bool supports_decal_tile_mode_ = false;
   bool supports_memoryless_textures_ = false;
-  bool supports_pipelines_with_no_color_attachments_ = false;
   PixelFormat default_color_format_ = PixelFormat::kUnknown;
   PixelFormat default_stencil_format_ = PixelFormat::kUnknown;
 
@@ -225,12 +215,6 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsMemorylessTextures(
   return *this;
 }
 
-CapabilitiesBuilder&
-CapabilitiesBuilder::SetSupportsPipelinesWithNoColorAttachments(bool value) {
-  supports_pipelines_with_no_color_attachments_ = value;
-  return *this;
-}
-
 std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
   return std::unique_ptr<StandardCapabilities>(new StandardCapabilities(  //
       has_threading_restrictions_,                                        //
@@ -245,7 +229,6 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       supports_read_from_resolve_,                                        //
       supports_decal_tile_mode_,                                          //
       supports_memoryless_textures_,                                      //
-      supports_pipelines_with_no_color_attachments_,                      //
       default_color_format_.value_or(PixelFormat::kUnknown),              //
       default_stencil_format_.value_or(PixelFormat::kUnknown)             //
       ));

--- a/impeller/renderer/capabilities.h
+++ b/impeller/renderer/capabilities.h
@@ -39,8 +39,6 @@ class Capabilities {
 
   virtual bool SupportsMemorylessTextures() const = 0;
 
-  virtual bool SupportsPipelinesWithNoColorAttachments() const = 0;
-
   virtual PixelFormat GetDefaultColorFormat() const = 0;
 
   virtual PixelFormat GetDefaultStencilFormat() const = 0;
@@ -85,8 +83,6 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetSupportsMemorylessTextures(bool value);
 
-  CapabilitiesBuilder& SetSupportsPipelinesWithNoColorAttachments(bool value);
-
   std::unique_ptr<Capabilities> Build();
 
  private:
@@ -102,7 +98,6 @@ class CapabilitiesBuilder {
   bool supports_read_from_resolve_ = false;
   bool supports_decal_tile_mode_ = false;
   bool supports_memoryless_textures_ = false;
-  bool supports_pipelines_with_no_color_attachments_ = false;
   std::optional<PixelFormat> default_color_format_ = std::nullopt;
   std::optional<PixelFormat> default_stencil_format_ = std::nullopt;
 

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -1709,6 +1709,140 @@
       }
     }
   },
+  "flutter/impeller/entity/clip.frag.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/clip.frag.vkspv",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.015625,
+              0.0,
+              0.015625,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.015625,
+              0.0,
+              0.015625,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.015625,
+              0.0,
+              0.015625,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 0
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/clip.vert.vkspv": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/clip.vert.vkspv",
+      "has_uniform_computation": true,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 0,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.125,
+              0.125,
+              0.0,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.125,
+              0.125,
+              0.0,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.125,
+              0.125,
+              0.0,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 28,
+          "work_registers_used": 32
+        }
+      }
+    }
+  },
   "flutter/impeller/entity/color_matrix_color_filter.frag.vkspv": {
     "Mali-G78": {
       "core": "Mali-G78",
@@ -6345,6 +6479,230 @@
           },
           "thread_occupancy": 100,
           "uniform_registers_used": 2,
+          "work_registers_used": 2
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/gles/clip.frag.gles": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/gles/clip.frag.gles",
+      "has_side_effects": false,
+      "has_uniform_computation": false,
+      "modifies_coverage": false,
+      "reads_color_buffer": false,
+      "type": "Fragment",
+      "uses_late_zs_test": false,
+      "uses_late_zs_update": false,
+      "variants": {
+        "Main": {
+          "fp16_arithmetic": null,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "longest_path_cycles": [
+              0.015625,
+              0.0,
+              0.015625,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "varying",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "shortest_path_cycles": [
+              0.015625,
+              0.0,
+              0.015625,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arith_total",
+              "arith_cvt"
+            ],
+            "total_cycles": [
+              0.015625,
+              0.0,
+              0.015625,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 1
+        }
+      }
+    },
+    "Mali-T880": {
+      "core": "Mali-T880",
+      "filename": "flutter/impeller/entity/gles/clip.frag.gles",
+      "has_uniform_computation": false,
+      "type": "Fragment",
+      "variants": {
+        "Main": {
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "arithmetic"
+            ],
+            "longest_path_cycles": [
+              1.0,
+              0.0,
+              0.0
+            ],
+            "pipelines": [
+              "arithmetic",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "arithmetic"
+            ],
+            "shortest_path_cycles": [
+              1.0,
+              0.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "arithmetic"
+            ],
+            "total_cycles": [
+              0.6666666865348816,
+              0.0,
+              0.0
+            ]
+          },
+          "thread_occupancy": 100,
+          "uniform_registers_used": 0,
+          "work_registers_used": 2
+        }
+      }
+    }
+  },
+  "flutter/impeller/entity/gles/clip.vert.gles": {
+    "Mali-G78": {
+      "core": "Mali-G78",
+      "filename": "flutter/impeller/entity/gles/clip.vert.gles",
+      "has_uniform_computation": false,
+      "type": "Vertex",
+      "variants": {
+        "Position": {
+          "fp16_arithmetic": 0,
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              0.140625,
+              0.140625,
+              0.0,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "pipelines": [
+              "arith_total",
+              "arith_fma",
+              "arith_cvt",
+              "arith_sfu",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              0.140625,
+              0.140625,
+              0.0,
+              0.0,
+              2.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              0.140625,
+              0.140625,
+              0.0,
+              0.0,
+              2.0,
+              0.0
+            ]
+          },
+          "stack_spill_bytes": 0,
+          "thread_occupancy": 100,
+          "uniform_registers_used": 20,
+          "work_registers_used": 32
+        }
+      }
+    },
+    "Mali-T880": {
+      "core": "Mali-T880",
+      "filename": "flutter/impeller/entity/gles/clip.vert.gles",
+      "has_uniform_computation": false,
+      "type": "Vertex",
+      "variants": {
+        "Main": {
+          "has_stack_spilling": false,
+          "performance": {
+            "longest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "longest_path_cycles": [
+              2.640000104904175,
+              3.0,
+              0.0
+            ],
+            "pipelines": [
+              "arithmetic",
+              "load_store",
+              "texture"
+            ],
+            "shortest_path_bound_pipelines": [
+              "load_store"
+            ],
+            "shortest_path_cycles": [
+              2.640000104904175,
+              3.0,
+              0.0
+            ],
+            "total_bound_pipelines": [
+              "load_store"
+            ],
+            "total_cycles": [
+              2.6666667461395264,
+              3.0,
+              0.0
+            ]
+          },
+          "thread_occupancy": 100,
+          "uniform_registers_used": 5,
           "work_registers_used": 2
         }
       }


### PR DESCRIPTION
Turns out removing the color attachment is failing Metal validation on iOS due to the pipeline color attachments mismatching the framebuffer (even though it winds up rendering correctly).

So this patch replaces the mechanism with a better default config, including:
* dedicated shaders that are less expensive than Solid Fill
* destination blending

I'll take another swing at trying to get it to work if the iOS benchmarks pop back up a bit from this. For now, this fixes the validation failure and should make clips a tad faster on Vulkan and GLES.