### PR TITLE
[Impeller] Skip rect clips that do nothing.

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -132,6 +132,7 @@
 ../../../flutter/impeller/docs
 ../../../flutter/impeller/entity/contents/filters/inputs/filter_input_unittests.cc
 ../../../flutter/impeller/entity/entity_unittests.cc
+../../../flutter/impeller/entity/geometry/geometry_unittests.cc
 ../../../flutter/impeller/fixtures
 ../../../flutter/impeller/geometry/README.md
 ../../../flutter/impeller/geometry/geometry_unittests.cc

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1979,7 +1979,7 @@ TEST_P(AiksTest, OpacityPeepHoleApplicationTest) {
       ColorFilter::MakeBlend(BlendMode::kSourceOver, Color::Blue());
 
   // Paint has color filter, can't elide.
-  auto delegate = std::make_shared<OpacityPeepholePassDelegate>(paint, rect);
+  auto delegate = std::make_shared<OpacityPeepholePassDelegate>(paint);
   ASSERT_FALSE(delegate->CanCollapseIntoParentPass(entity_pass.get()));
 
   paint.color_filter = nullptr;
@@ -1991,14 +1991,14 @@ TEST_P(AiksTest, OpacityPeepHoleApplicationTest) {
   };
 
   // Paint has image filter, can't elide.
-  delegate = std::make_shared<OpacityPeepholePassDelegate>(paint, rect);
+  delegate = std::make_shared<OpacityPeepholePassDelegate>(paint);
   ASSERT_FALSE(delegate->CanCollapseIntoParentPass(entity_pass.get()));
 
   paint.image_filter = nullptr;
   paint.color = Color::Red();
 
   // Paint has no alpha, can't elide;
-  delegate = std::make_shared<OpacityPeepholePassDelegate>(paint, rect);
+  delegate = std::make_shared<OpacityPeepholePassDelegate>(paint);
   ASSERT_FALSE(delegate->CanCollapseIntoParentPass(entity_pass.get()));
 
   // Positive test.
@@ -2008,7 +2008,7 @@ TEST_P(AiksTest, OpacityPeepHoleApplicationTest) {
   entity_pass->AddEntity(entity);
   paint.color = Color::Red().WithAlpha(0.5);
 
-  delegate = std::make_shared<OpacityPeepholePassDelegate>(paint, rect);
+  delegate = std::make_shared<OpacityPeepholePassDelegate>(paint);
   ASSERT_TRUE(delegate->CanCollapseIntoParentPass(entity_pass.get()));
 }
 

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2114,6 +2114,30 @@ TEST_P(AiksTest, DrawRectAbsorbsClearsNegative) {
   ASSERT_EQ(render_pass->GetCommands().size(), 2llu);
 }
 
+TEST_P(AiksTest, ClipRectElidesNoOpClips) {
+  Canvas canvas(Rect(0, 0, 100, 100));
+  canvas.ClipRect(Rect(0, 0, 100, 100));
+  canvas.ClipRect(Rect(-100, -100, 300, 300));
+  canvas.DrawPaint({.color = Color::Red(), .blend_mode = BlendMode::kSource});
+  canvas.DrawPaint({.color = Color::CornflowerBlue().WithAlpha(0.75),
+                    .blend_mode = BlendMode::kSourceOver});
+
+  Picture picture = canvas.EndRecordingAsPicture();
+  auto expected = Color::Red().Blend(Color::CornflowerBlue().WithAlpha(0.75),
+                                     BlendMode::kSourceOver);
+  ASSERT_EQ(picture.pass->GetClearColor(), expected);
+
+  std::shared_ptr<ContextSpy> spy = ContextSpy::Make();
+  std::shared_ptr<Context> real_context = GetContext();
+  std::shared_ptr<ContextMock> mock_context = spy->MakeContext(real_context);
+  AiksContext renderer(mock_context);
+  std::shared_ptr<Image> image = picture.ToImage(renderer, {300, 300});
+
+  ASSERT_EQ(spy->render_passes_.size(), 1llu);
+  std::shared_ptr<RenderPass> render_pass = spy->render_passes_[0];
+  ASSERT_EQ(render_pass->GetCommands().size(), 0llu);
+}
+
 TEST_P(AiksTest, CollapsedDrawPaintInSubpass) {
   Canvas canvas;
   canvas.DrawPaint(

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -17,16 +17,10 @@ namespace impeller {
 /// PaintPassDelegate
 /// ----------------------------------------------
 
-PaintPassDelegate::PaintPassDelegate(Paint paint, std::optional<Rect> coverage)
-    : paint_(std::move(paint)), coverage_(coverage) {}
+PaintPassDelegate::PaintPassDelegate(Paint paint) : paint_(std::move(paint)) {}
 
 // |EntityPassDelgate|
 PaintPassDelegate::~PaintPassDelegate() = default;
-
-// |EntityPassDelgate|
-std::optional<Rect> PaintPassDelegate::GetCoverageRect() {
-  return coverage_;
-}
 
 // |EntityPassDelgate|
 bool PaintPassDelegate::CanElide() {
@@ -56,18 +50,11 @@ std::shared_ptr<Contents> PaintPassDelegate::CreateContentsForSubpassTarget(
 /// OpacityPeepholePassDelegate
 /// ----------------------------------------------
 
-OpacityPeepholePassDelegate::OpacityPeepholePassDelegate(
-    Paint paint,
-    std::optional<Rect> coverage)
-    : paint_(std::move(paint)), coverage_(coverage) {}
+OpacityPeepholePassDelegate::OpacityPeepholePassDelegate(Paint paint)
+    : paint_(std::move(paint)) {}
 
 // |EntityPassDelgate|
 OpacityPeepholePassDelegate::~OpacityPeepholePassDelegate() = default;
-
-// |EntityPassDelgate|
-std::optional<Rect> OpacityPeepholePassDelegate::GetCoverageRect() {
-  return coverage_;
-}
 
 // |EntityPassDelgate|
 bool OpacityPeepholePassDelegate::CanElide() {
@@ -77,6 +64,11 @@ bool OpacityPeepholePassDelegate::CanElide() {
 // |EntityPassDelgate|
 bool OpacityPeepholePassDelegate::CanCollapseIntoParentPass(
     EntityPass* entity_pass) {
+  // Passes with absorbed clips can not be safely collapsed.
+  if (!entity_pass->GetBoundsLimit().has_value()) {
+    return false;
+  }
+
   // OpacityPeepholePassDelegate will only get used if the pass's blend mode is
   // SourceOver, so no need to check here.
   if (paint_.color.alpha <= 0.0 || paint_.color.alpha >= 1.0 ||

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -65,7 +65,7 @@ bool OpacityPeepholePassDelegate::CanElide() {
 bool OpacityPeepholePassDelegate::CanCollapseIntoParentPass(
     EntityPass* entity_pass) {
   // Passes with absorbed clips can not be safely collapsed.
-  if (!entity_pass->GetBoundsLimit().has_value()) {
+  if (entity_pass->GetBoundsLimit().has_value()) {
     return false;
   }
 

--- a/impeller/aiks/paint_pass_delegate.h
+++ b/impeller/aiks/paint_pass_delegate.h
@@ -16,13 +16,10 @@ class EntityPass;
 
 class PaintPassDelegate final : public EntityPassDelegate {
  public:
-  PaintPassDelegate(Paint paint, std::optional<Rect> coverage);
+  explicit PaintPassDelegate(Paint paint);
 
   // |EntityPassDelgate|
   ~PaintPassDelegate() override;
-
-  // |EntityPassDelegate|
-  std::optional<Rect> GetCoverageRect() override;
 
   // |EntityPassDelgate|
   bool CanElide() override;
@@ -37,7 +34,6 @@ class PaintPassDelegate final : public EntityPassDelegate {
 
  private:
   const Paint paint_;
-  const std::optional<Rect> coverage_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PaintPassDelegate);
 };
@@ -49,13 +45,10 @@ class PaintPassDelegate final : public EntityPassDelegate {
 /// cannot forward to child subpass delegates.
 class OpacityPeepholePassDelegate final : public EntityPassDelegate {
  public:
-  OpacityPeepholePassDelegate(Paint paint, std::optional<Rect> coverage);
+  explicit OpacityPeepholePassDelegate(Paint paint);
 
   // |EntityPassDelgate|
   ~OpacityPeepholePassDelegate() override;
-
-  // |EntityPassDelegate|
-  std::optional<Rect> GetCoverageRect() override;
 
   // |EntityPassDelgate|
   bool CanElide() override;
@@ -70,7 +63,6 @@ class OpacityPeepholePassDelegate final : public EntityPassDelegate {
 
  private:
   const Paint paint_;
-  const std::optional<Rect> coverage_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(OpacityPeepholePassDelegate);
 };

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -270,6 +270,7 @@ impeller_component("entity_unittests") {
     "entity_playground.cc",
     "entity_playground.h",
     "entity_unittests.cc",
+    "geometry/geometry_unittests.cc",
   ]
 
   deps = [

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -137,11 +137,12 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
     return std::nullopt;
   }
 
-  if (!bounds_limit_.has_value()) {
+  if (!subpass.bounds_limit_.has_value()) {
     return entities_coverage;
   }
-  auto bounds_limit = bounds_limit_->TransformBounds(subpass.xformation_);
-  return entities_coverage->Intersection(bounds_limit);
+  auto user_bounds_coverage =
+      subpass.bounds_limit_->TransformBounds(subpass.xformation_);
+  return entities_coverage->Intersection(user_bounds_coverage);
 }
 
 EntityPass* EntityPass::GetSuperpass() const {

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -62,6 +62,14 @@ void EntityPass::SetDelegate(std::unique_ptr<EntityPassDelegate> delegate) {
   delegate_ = std::move(delegate);
 }
 
+void EntityPass::SetBoundsLimit(std::optional<Rect> bounds_limit) {
+  bounds_limit_ = bounds_limit;
+}
+
+std::optional<Rect> EntityPass::GetBoundsLimit() const {
+  return bounds_limit_;
+}
+
 void EntityPass::AddEntity(Entity entity) {
   if (entity.GetBlendMode() == BlendMode::kSourceOver &&
       entity.GetContents()->IsOpaque()) {
@@ -129,20 +137,11 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
     return std::nullopt;
   }
 
-  // The delegates don't have an opinion on what the entity coverage has to be.
-  // Just use that as-is.
-  auto delegate_coverage = subpass.delegate_->GetCoverageRect();
-  if (!delegate_coverage.has_value()) {
+  if (!bounds_limit_.has_value()) {
     return entities_coverage;
   }
-  // The delegate coverage hint is in given in local space, so apply the subpass
-  // transformation.
-  delegate_coverage = delegate_coverage->TransformBounds(subpass.xformation_);
-
-  // If the delegate tells us the coverage is smaller than it needs to be, then
-  // great. OTOH, if the delegate is being wasteful, limit coverage to what is
-  // actually needed.
-  return entities_coverage->Intersection(delegate_coverage.value());
+  auto bounds_limit = bounds_limit_->TransformBounds(subpass.xformation_);
+  return entities_coverage->Intersection(bounds_limit);
 }
 
 EntityPass* EntityPass::GetSuperpass() const {

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -63,7 +63,7 @@ class EntityPass {
   ///         it.
   void SetBoundsLimit(std::optional<Rect> bounds_limit);
 
-  /// @brief  Set the bounds limit, which is provided by the user when creating
+  /// @brief  Get the bounds limit, which is provided by the user when creating
   ///         a SaveLayer.
   std::optional<Rect> GetBoundsLimit() const;
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -54,8 +54,17 @@ class EntityPass {
 
   void SetDelegate(std::unique_ptr<EntityPassDelegate> delgate);
 
+  /// @brief  Set the bounds limit, which is provided by the user when creating
+  ///         a SaveLayer. This is a hint that allows the user to communicate
+  ///         that it's OK to not render content outside of the bounds.
+  ///
+  ///         For consistency with Skia, we effectively treat this like a
+  ///         rectangle clip by forcing the subpass texture size to never exceed
+  ///         it.
   void SetBoundsLimit(std::optional<Rect> bounds_limit);
 
+  /// @brief  Set the bounds limit, which is provided by the user when creating
+  ///         a SaveLayer.
   std::optional<Rect> GetBoundsLimit() const;
 
   size_t GetSubpassesDepth() const;

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -54,6 +54,10 @@ class EntityPass {
 
   void SetDelegate(std::unique_ptr<EntityPassDelegate> delgate);
 
+  void SetBoundsLimit(std::optional<Rect> bounds_limit);
+
+  std::optional<Rect> GetBoundsLimit() const;
+
   size_t GetSubpassesDepth() const;
 
   std::unique_ptr<EntityPass> Clone() const;
@@ -223,6 +227,7 @@ class EntityPass {
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   bool flood_clip_ = false;
   bool enable_offscreen_debug_checkerboard_ = false;
+  std::optional<Rect> bounds_limit_;
 
   /// These values are incremented whenever something is added to the pass that
   /// requires reading from the backdrop texture. Currently, this can happen in

--- a/impeller/entity/entity_pass_delegate.cc
+++ b/impeller/entity/entity_pass_delegate.cc
@@ -19,9 +19,6 @@ class DefaultEntityPassDelegate final : public EntityPassDelegate {
   ~DefaultEntityPassDelegate() override = default;
 
   // |EntityPassDelegate|
-  std::optional<Rect> GetCoverageRect() override { return std::nullopt; }
-
-  // |EntityPassDelegate|
   bool CanElide() override { return false; }
 
   // |EntityPassDelegate|

--- a/impeller/entity/entity_pass_delegate.h
+++ b/impeller/entity/entity_pass_delegate.h
@@ -20,8 +20,6 @@ class EntityPassDelegate {
 
   EntityPassDelegate();
 
-  virtual std::optional<Rect> GetCoverageRect() = 0;
-
   virtual ~EntityPassDelegate();
 
   virtual bool CanElide() = 0;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -70,8 +70,7 @@ TEST_P(EntityTest, CanCreateEntity) {
 
 class TestPassDelegate final : public EntityPassDelegate {
  public:
-  explicit TestPassDelegate(std::optional<Rect> coverage, bool collapse = false)
-      : coverage_(coverage), collapse_(collapse) {}
+  explicit TestPassDelegate(bool collapse = false) : collapse_(collapse) {}
 
   // |EntityPassDelegate|
   ~TestPassDelegate() override = default;
@@ -104,12 +103,12 @@ auto CreatePassWithRectPath(Rect rect,
   entity.SetContents(SolidColorContents::Make(
       PathBuilder{}.AddRect(rect).TakePath(), Color::Red()));
   subpass->AddEntity(entity);
-  subpass->SetDelegate(
-      std::make_unique<TestPassDelegate>(bounds_hint, collapse));
+  subpass->SetDelegate(std::make_unique<TestPassDelegate>(collapse));
+  subpass->SetBoundsLimit(bounds_hint);
   return subpass;
 }
 
-TEST_P(EntityTest, EntityPassCoverageRespectsDelegateBoundsHint) {
+TEST_P(EntityTest, EntityPassRespectsSubpassBoundsLimit) {
   EntityPass pass;
 
   auto subpass0 = CreatePassWithRectPath(Rect::MakeLTRB(0, 0, 100, 100),

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -76,9 +76,6 @@ class TestPassDelegate final : public EntityPassDelegate {
   // |EntityPassDelegate|
   ~TestPassDelegate() override = default;
 
-  // |EntityPassDelegate|
-  std::optional<Rect> GetCoverageRect() override { return coverage_; }
-
   // |EntityPassDelgate|
   bool CanElide() override { return false; }
 

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -6,7 +6,9 @@
 
 namespace impeller {
 
-FillPathGeometry::FillPathGeometry(const Path& path) : path_(path) {}
+FillPathGeometry::FillPathGeometry(const Path& path,
+                                   std::optional<Rect> inner_rect)
+    : path_(path), inner_rect_(inner_rect) {}
 
 FillPathGeometry::~FillPathGeometry() = default;
 
@@ -145,6 +147,18 @@ GeometryVertexType FillPathGeometry::GetVertexType() const {
 std::optional<Rect> FillPathGeometry::GetCoverage(
     const Matrix& transform) const {
   return path_.GetTransformedBoundingBox(transform);
+}
+
+bool FillPathGeometry::CoversArea(const Matrix& transform,
+                                  const Rect& rect) const {
+  if (!inner_rect_.has_value()) {
+    return false;
+  }
+  if (!transform.IsTranslationScaleOnly()) {
+    return false;
+  }
+  Rect coverage = inner_rect_->TransformBounds(transform);
+  return coverage.Contains(rect);
 }
 
 }  // namespace impeller

--- a/impeller/entity/geometry/fill_path_geometry.h
+++ b/impeller/entity/geometry/fill_path_geometry.h
@@ -4,16 +4,23 @@
 
 #pragma once
 
+#include <optional>
+
 #include "impeller/entity/geometry/geometry.h"
+#include "impeller/geometry/rect.h"
 
 namespace impeller {
 
 /// @brief A geometry that is created from a filled path object.
 class FillPathGeometry : public Geometry {
  public:
-  explicit FillPathGeometry(const Path& path);
+  explicit FillPathGeometry(const Path& path,
+                            std::optional<Rect> inner_rect = std::nullopt);
 
   ~FillPathGeometry();
+
+  // |Geometry|
+  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
 
  private:
   // |Geometry|
@@ -35,6 +42,7 @@ class FillPathGeometry : public Geometry {
                                      RenderPass& pass) override;
 
   Path path_;
+  std::optional<Rect> inner_rect_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FillPathGeometry);
 };

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -4,11 +4,14 @@
 
 #include "impeller/entity/geometry/geometry.h"
 
+#include <optional>
+
 #include "impeller/entity/geometry/cover_geometry.h"
 #include "impeller/entity/geometry/fill_path_geometry.h"
 #include "impeller/entity/geometry/point_field_geometry.h"
 #include "impeller/entity/geometry/rect_geometry.h"
 #include "impeller/entity/geometry/stroke_path_geometry.h"
+#include "impeller/geometry/rect.h"
 
 namespace impeller {
 
@@ -107,8 +110,10 @@ GeometryResult Geometry::GetPositionUVBuffer(Rect texture_coverage,
   return {};
 }
 
-std::unique_ptr<Geometry> Geometry::MakeFillPath(const Path& path) {
-  return std::make_unique<FillPathGeometry>(path);
+std::unique_ptr<Geometry> Geometry::MakeFillPath(
+    const Path& path,
+    std::optional<Rect> inner_rect) {
+  return std::make_unique<FillPathGeometry>(path, inner_rect);
 }
 
 std::unique_ptr<Geometry> Geometry::MakePointField(std::vector<Point> points,

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -1,5 +1,4 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
-// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -1,4 +1,5 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -57,7 +58,9 @@ class Geometry {
 
   virtual ~Geometry();
 
-  static std::unique_ptr<Geometry> MakeFillPath(const Path& path);
+  static std::unique_ptr<Geometry> MakeFillPath(
+      const Path& path,
+      std::optional<Rect> inner_rect = std::nullopt);
 
   static std::unique_ptr<Geometry> MakeStrokePath(
       const Path& path,
@@ -88,8 +91,16 @@ class Geometry {
 
   virtual std::optional<Rect> GetCoverage(const Matrix& transform) const = 0;
 
-  /// @return `true` if this geometry will completely cover all fragments in
-  /// `rect` when the `transform` is applied to it.
+  /// @brief    Determines if this geometry, transformed by the given
+  ///           `transform`, will completely cover all surface area of the given
+  ///           `rect`.
+  ///
+  ///           This is a conservative estimate useful for certain
+  ///           optimizations.
+  ///
+  /// @returns  `true` if the transformed geometry is guaranteed to cover the
+  ///           given `rect`. May return `false` in many undetected cases where
+  ///           the transformed geometry does in fact cover the `rect`.
   virtual bool CoversArea(const Matrix& transform, const Rect& rect) const;
 };
 

--- a/impeller/entity/geometry/geometry_unittests.cc
+++ b/impeller/entity/geometry/geometry_unittests.cc
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"
+#include "impeller/entity/geometry/geometry.h"
+#include "impeller/geometry/path_builder.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(EntityGeometryTest, RectGeometryCoversArea) {
+  auto geometry = Geometry::MakeRect(Rect::MakeLTRB(0, 0, 100, 100));
+  ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(0, 0, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(-1, 0, 100, 100)));
+  ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(1, 1, 100, 100)));
+  ASSERT_TRUE(geometry->CoversArea({}, Rect()));
+}
+
+TEST(EntityGeometryTest, FillPathGeometryCoversArea) {
+  auto path = PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath();
+  auto geometry = Geometry::MakeFillPath(
+      path, /* inner rect */ Rect::MakeLTRB(0, 0, 100, 100));
+  ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(0, 0, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(-1, 0, 100, 100)));
+  ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(1, 1, 100, 100)));
+  ASSERT_TRUE(geometry->CoversArea({}, Rect()));
+}
+
+TEST(EntityGeometryTest, FillPathGeometryCoversAreaNoInnerRect) {
+  auto path = PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath();
+  auto geometry = Geometry::MakeFillPath(path);
+  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(0, 0, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(-1, 0, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(1, 1, 100, 100)));
+  ASSERT_FALSE(geometry->CoversArea({}, Rect()));
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/131100

* Skip rect clips that we know won't further restrict the clip shape.
* Don't append clips to enforce subpass bounds. We currently don't collapse passes when subpass clips are added anyhow, so just a restriction to subpass collapsing in order to keep the current behavior intact.
* Small refactor to reduce confusion: Just place the subpass bounds limit into `EntityPass` itself instead of the delegate.

Built on https://github.com/flutter/engine/pull/43946 (because iOS currently fails validation without it).

Gallery home screen before/after:

![compare](https://github.com/flutter/engine/assets/919017/34608633-6b3b-4979-be2b-f2685b32168f)
