### PR TITLE
Revert "Remove more calls to SkCanvas::flush() and SkSurface::flush()"

### DIFF
--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -4141,6 +4141,8 @@ class DisplayListNopTest : public DisplayListCanvas {
     auto surface = SkSurfaces::Raster(SkImageInfo::MakeN32Premul(w, h));
     SkCanvas* canvas = surface->getCanvas();
     renderer(canvas);
+    canvas->flush();
+    surface->flushAndSubmit(true);
     return std::make_unique<RenderResult>(surface, snapshot);
   }
 
@@ -4256,11 +4258,8 @@ class DisplayListNopTest : public DisplayListCanvas {
       result_canvas->clear(SK_ColorTRANSPARENT);
       result_canvas->drawImage(test_image.get(), 0, 0);
       result_canvas->drawRect(test_bounds, sk_paint);
-      if (GrDirectContext* direct_context = GrAsDirectContext(
-              result_surface->sk_surface()->recordingContext())) {
-        return direct_context->flushAndSubmit(result_surface->sk_surface(),
-                                              true);
-      }
+      result_canvas->flush();
+      result_surface->sk_surface()->flushAndSubmit(true);
       auto result_pixels =
           std::make_unique<RenderResult>(result_surface->sk_surface());
 
@@ -4317,11 +4316,8 @@ class DisplayListNopTest : public DisplayListCanvas {
       result_canvas->drawImage(test_image_dst_data->image(), 0, 0);
       result_canvas->drawImage(test_image_src_data->image(), 0, 0,
                                SkSamplingOptions(), &sk_paint);
-      if (GrDirectContext* direct_context = GrAsDirectContext(
-              result_surface->sk_surface()->recordingContext())) {
-        return direct_context->flushAndSubmit(result_surface->sk_surface(),
-                                              true);
-      }
+      result_canvas->flush();
+      result_surface->sk_surface()->flushAndSubmit(true);
       auto result_pixels =
           std::make_unique<RenderResult>(result_surface->sk_surface());
 

--- a/lib/web_ui/skwasm/surface.cpp
+++ b/lib/web_ui/skwasm/surface.cpp
@@ -5,7 +5,6 @@
 #include "surface.h"
 
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
-#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 using namespace Skwasm;
 
@@ -172,7 +171,7 @@ void Surface::_renderPicture(const SkPicture* picture) {
   makeCurrent(_glContext);
   auto canvas = _surface->getCanvas();
   canvas->drawPicture(picture);
-  _grContext->flush(_surface);
+  _surface->flush();
 }
 
 void Surface::_rasterizeImage(SkImage* image,

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
@@ -9,8 +9,6 @@
 #include "flutter/fml/trace_event.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/GrDirectContext.h"
-#include "third_party/skia/include/gpu/GrRecordingContext.h"
 
 namespace flutter_runner {
 namespace {
@@ -489,10 +487,7 @@ void FlatlandExternalViewEmbedder::SubmitFrame(
       canvas->setMatrix(SkMatrix::I());
       canvas->clear(SK_ColorTRANSPARENT);
       canvas->drawPicture(layer->second.picture);
-      if (GrDirectContext* direct_context =
-              GrAsDirectContext(canvas->recordingContext())) {
-        return direct_context->flushAndSubmit();
-      }
+      canvas->flush();
     }
   }
 

--- a/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
@@ -14,8 +14,6 @@
 #include "flutter/fml/trace_event.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/GrDirectContext.h"
-#include "third_party/skia/include/gpu/GrRecordingContext.h"
 
 namespace flutter_runner {
 namespace {
@@ -619,10 +617,7 @@ void GfxExternalViewEmbedder::SubmitFrame(
       canvas->setMatrix(SkMatrix::I());
       canvas->clear(SK_ColorTRANSPARENT);
       canvas->drawPicture(layer->second.picture);
-      if (GrDirectContext* direct_context =
-              GrAsDirectContext(canvas->recordingContext())) {
-        return direct_context->flushAndSubmit();
-      }
+      canvas->flush();
     }
   }
 


### PR DESCRIPTION
Reverts flutter/engine#43902

Speculative revert for Fuchsia tests that began failing/timing-out on this commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Fuchsia%20FEMU/16871/overview