### PR TITLE
Reland "Remove more calls to SkCanvas::flush() and SkSurface::flush()"

### DIFF
--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -4141,8 +4141,6 @@ class DisplayListNopTest : public DisplayListCanvas {
     auto surface = SkSurfaces::Raster(SkImageInfo::MakeN32Premul(w, h));
     SkCanvas* canvas = surface->getCanvas();
     renderer(canvas);
-    canvas->flush();
-    surface->flushAndSubmit(true);
     return std::make_unique<RenderResult>(surface, snapshot);
   }
 
@@ -4258,8 +4256,11 @@ class DisplayListNopTest : public DisplayListCanvas {
       result_canvas->clear(SK_ColorTRANSPARENT);
       result_canvas->drawImage(test_image.get(), 0, 0);
       result_canvas->drawRect(test_bounds, sk_paint);
-      result_canvas->flush();
-      result_surface->sk_surface()->flushAndSubmit(true);
+      if (GrDirectContext* direct_context = GrAsDirectContext(
+              result_surface->sk_surface()->recordingContext())) {
+        return direct_context->flushAndSubmit(result_surface->sk_surface(),
+                                              true);
+      }
       auto result_pixels =
           std::make_unique<RenderResult>(result_surface->sk_surface());
 
@@ -4316,8 +4317,11 @@ class DisplayListNopTest : public DisplayListCanvas {
       result_canvas->drawImage(test_image_dst_data->image(), 0, 0);
       result_canvas->drawImage(test_image_src_data->image(), 0, 0,
                                SkSamplingOptions(), &sk_paint);
-      result_canvas->flush();
-      result_surface->sk_surface()->flushAndSubmit(true);
+      if (GrDirectContext* direct_context = GrAsDirectContext(
+              result_surface->sk_surface()->recordingContext())) {
+        return direct_context->flushAndSubmit(result_surface->sk_surface(),
+                                              true);
+      }
       auto result_pixels =
           std::make_unique<RenderResult>(result_surface->sk_surface());
 

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -4258,6 +4258,7 @@ class DisplayListNopTest : public DisplayListCanvas {
       result_canvas->drawRect(test_bounds, sk_paint);
       if (GrDirectContext* direct_context = GrAsDirectContext(
               result_surface->sk_surface()->recordingContext())) {
+        direct_context->flushAndSubmit();
         return direct_context->flushAndSubmit(result_surface->sk_surface(),
                                               true);
       }
@@ -4319,6 +4320,7 @@ class DisplayListNopTest : public DisplayListCanvas {
                                SkSamplingOptions(), &sk_paint);
       if (GrDirectContext* direct_context = GrAsDirectContext(
               result_surface->sk_surface()->recordingContext())) {
+        direct_context->flushAndSubmit();
         return direct_context->flushAndSubmit(result_surface->sk_surface(),
                                               true);
       }

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -4259,8 +4259,7 @@ class DisplayListNopTest : public DisplayListCanvas {
       if (GrDirectContext* direct_context = GrAsDirectContext(
               result_surface->sk_surface()->recordingContext())) {
         direct_context->flushAndSubmit();
-        return direct_context->flushAndSubmit(result_surface->sk_surface(),
-                                              true);
+        direct_context->flushAndSubmit(result_surface->sk_surface(), true);
       }
       auto result_pixels =
           std::make_unique<RenderResult>(result_surface->sk_surface());
@@ -4321,8 +4320,7 @@ class DisplayListNopTest : public DisplayListCanvas {
       if (GrDirectContext* direct_context = GrAsDirectContext(
               result_surface->sk_surface()->recordingContext())) {
         direct_context->flushAndSubmit();
-        return direct_context->flushAndSubmit(result_surface->sk_surface(),
-                                              true);
+        direct_context->flushAndSubmit(result_surface->sk_surface(), true);
       }
       auto result_pixels =
           std::make_unique<RenderResult>(result_surface->sk_surface());

--- a/lib/web_ui/skwasm/surface.cpp
+++ b/lib/web_ui/skwasm/surface.cpp
@@ -5,6 +5,7 @@
 #include "surface.h"
 
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 using namespace Skwasm;
 
@@ -171,7 +172,7 @@ void Surface::_renderPicture(const SkPicture* picture) {
   makeCurrent(_glContext);
   auto canvas = _surface->getCanvas();
   canvas->drawPicture(picture);
-  _surface->flush();
+  _grContext->flush(_surface);
 }
 
 void Surface::_rasterizeImage(SkImage* image,

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
@@ -9,6 +9,8 @@
 #include "flutter/fml/trace_event.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/GrRecordingContext.h"
 
 namespace flutter_runner {
 namespace {
@@ -487,7 +489,10 @@ void FlatlandExternalViewEmbedder::SubmitFrame(
       canvas->setMatrix(SkMatrix::I());
       canvas->clear(SK_ColorTRANSPARENT);
       canvas->drawPicture(layer->second.picture);
-      canvas->flush();
+      if (GrDirectContext* direct_context =
+              GrAsDirectContext(canvas->recordingContext())) {
+        return direct_context->flushAndSubmit();
+      }
     }
   }
 

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.cc
@@ -491,7 +491,7 @@ void FlatlandExternalViewEmbedder::SubmitFrame(
       canvas->drawPicture(layer->second.picture);
       if (GrDirectContext* direct_context =
               GrAsDirectContext(canvas->recordingContext())) {
-        return direct_context->flushAndSubmit();
+        direct_context->flushAndSubmit();
       }
     }
   }

--- a/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
@@ -14,6 +14,8 @@
 #include "flutter/fml/trace_event.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/GrRecordingContext.h"
 
 namespace flutter_runner {
 namespace {
@@ -617,7 +619,10 @@ void GfxExternalViewEmbedder::SubmitFrame(
       canvas->setMatrix(SkMatrix::I());
       canvas->clear(SK_ColorTRANSPARENT);
       canvas->drawPicture(layer->second.picture);
-      canvas->flush();
+      if (GrDirectContext* direct_context =
+              GrAsDirectContext(canvas->recordingContext())) {
+        return direct_context->flushAndSubmit();
+      }
     }
   }
 

--- a/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/gfx_external_view_embedder.cc
@@ -621,7 +621,7 @@ void GfxExternalViewEmbedder::SubmitFrame(
       canvas->drawPicture(layer->second.picture);
       if (GrDirectContext* direct_context =
               GrAsDirectContext(canvas->recordingContext())) {
-        return direct_context->flushAndSubmit();
+        direct_context->flushAndSubmit();
       }
     }
   }


### PR DESCRIPTION
Relanding https://github.com/flutter/engine/pull/43902 without the copy-pasta return statements which did not seem to cause a compile issue, but caused Fuchsia tests to hang.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
