### PR TITLE
[do not merge] google testing verify early exit on neutral state

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -10,6 +10,7 @@ import("//flutter/shell/gpu/gpu.gni")
 import("//flutter/shell/platform/embedder/embedder.gni")
 import("//flutter/testing/testing.gni")
 
+# Making changes to test neutral state in google testing.
 declare_args() {
   embedder_enable_software = shell_enable_software
   embedder_enable_vulkan = shell_enable_vulkan


### PR DESCRIPTION
similar to https://github.com/flutter/flutter/pull/130046 and https://github.com/flutter/flutter/pull/127895
this PR is used as an integration test to verify the logics we landed in cl/550076135

When the PR only includs file changes that do not need to be rolled into google 3, Google testing should report a neutral state and return the state early.