### PR TITLE
[Impeller] presentKHR from background worker.

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -384,7 +384,7 @@ SwapchainImplVK::AcquireResult SwapchainImplVK::AcquireNextDrawable() {
       )};
 }
 
-bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK> image,
+bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
                               uint32_t index) {
   auto context_strong = context_.lock();
   if (!context_strong) {

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -384,7 +384,7 @@ SwapchainImplVK::AcquireResult SwapchainImplVK::AcquireNextDrawable() {
       )};
 }
 
-bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
+bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK> image,
                               uint32_t index) {
   auto context_strong = context_.lock();
   if (!context_strong) {
@@ -392,88 +392,97 @@ bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
   }
 
   const auto& context = ContextVK::Cast(*context_strong);
+  context.GetConcurrentWorkerTaskRunner()->PostTask(
+      [&, index, image, current_frame = current_frame_] {
+        auto context_strong = context_.lock();
+        if (!context_strong) {
+          return;
+        }
+        const auto& context = ContextVK::Cast(*context_strong);
+        const auto& sync = synchronizers_[current_frame];
 
-  const auto& sync = synchronizers_[current_frame_];
+        //----------------------------------------------------------------------------
+        /// Transition the image to color-attachment-optimal.
+        ///
+        sync->final_cmd_buffer = context.CreateCommandBuffer();
+        if (!sync->final_cmd_buffer) {
+          return;
+        }
 
-  //----------------------------------------------------------------------------
-  /// Transition the image to color-attachment-optimal.
-  ///
-  sync->final_cmd_buffer = context.CreateCommandBuffer();
-  if (!sync->final_cmd_buffer) {
-    return false;
-  }
+        auto vk_final_cmd_buffer =
+            CommandBufferVK::Cast(*sync->final_cmd_buffer)
+                .GetEncoder()
+                ->GetCommandBuffer();
+        {
+          BarrierVK barrier;
+          barrier.new_layout = vk::ImageLayout::ePresentSrcKHR;
+          barrier.cmd_buffer = vk_final_cmd_buffer;
+          barrier.src_access = vk::AccessFlagBits::eColorAttachmentWrite;
+          barrier.src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
+          barrier.dst_access = {};
+          barrier.dst_stage = vk::PipelineStageFlagBits::eBottomOfPipe;
 
-  auto vk_final_cmd_buffer = CommandBufferVK::Cast(*sync->final_cmd_buffer)
-                                 .GetEncoder()
-                                 ->GetCommandBuffer();
-  {
-    BarrierVK barrier;
-    barrier.new_layout = vk::ImageLayout::ePresentSrcKHR;
-    barrier.cmd_buffer = vk_final_cmd_buffer;
-    barrier.src_access = vk::AccessFlagBits::eColorAttachmentWrite;
-    barrier.src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
-    barrier.dst_access = {};
-    barrier.dst_stage = vk::PipelineStageFlagBits::eBottomOfPipe;
+          if (!image->SetLayout(barrier)) {
+            return;
+          }
 
-    if (!image->SetLayout(barrier)) {
-      return false;
-    }
+          if (vk_final_cmd_buffer.end() != vk::Result::eSuccess) {
+            return;
+          }
+        }
 
-    if (vk_final_cmd_buffer.end() != vk::Result::eSuccess) {
-      return false;
-    }
-  }
+        //----------------------------------------------------------------------------
+        /// Signal that the presentation semaphore is ready.
+        ///
+        {
+          vk::SubmitInfo submit_info;
+          vk::PipelineStageFlags wait_stage =
+              vk::PipelineStageFlagBits::eColorAttachmentOutput;
+          submit_info.setWaitDstStageMask(wait_stage);
+          submit_info.setWaitSemaphores(*sync->render_ready);
+          submit_info.setSignalSemaphores(*sync->present_ready);
+          submit_info.setCommandBuffers(vk_final_cmd_buffer);
+          auto result =
+              context.GetGraphicsQueue()->Submit(submit_info, *sync->acquire);
+          if (result != vk::Result::eSuccess) {
+            VALIDATION_LOG << "Could not wait on render semaphore: "
+                           << vk::to_string(result);
+            return;
+          }
+        }
 
-  //----------------------------------------------------------------------------
-  /// Signal that the presentation semaphore is ready.
-  ///
-  {
-    vk::SubmitInfo submit_info;
-    vk::PipelineStageFlags wait_stage =
-        vk::PipelineStageFlagBits::eColorAttachmentOutput;
-    submit_info.setWaitDstStageMask(wait_stage);
-    submit_info.setWaitSemaphores(*sync->render_ready);
-    submit_info.setSignalSemaphores(*sync->present_ready);
-    submit_info.setCommandBuffers(vk_final_cmd_buffer);
-    auto result =
-        context.GetGraphicsQueue()->Submit(submit_info, *sync->acquire);
-    if (result != vk::Result::eSuccess) {
-      VALIDATION_LOG << "Could not wait on render semaphore: "
-                     << vk::to_string(result);
-      return false;
-    }
-  }
+        //----------------------------------------------------------------------------
+        /// Present the image.
+        ///
+        uint32_t indices[] = {static_cast<uint32_t>(index)};
 
-  //----------------------------------------------------------------------------
-  /// Present the image.
-  ///
-  uint32_t indices[] = {static_cast<uint32_t>(index)};
+        vk::PresentInfoKHR present_info;
+        present_info.setSwapchains(*swapchain_);
+        present_info.setImageIndices(indices);
+        present_info.setWaitSemaphores(*sync->present_ready);
 
-  vk::PresentInfoKHR present_info;
-  present_info.setSwapchains(*swapchain_);
-  present_info.setImageIndices(indices);
-  present_info.setWaitSemaphores(*sync->present_ready);
-
-  switch (auto result = present_queue_.presentKHR(present_info)) {
-    case vk::Result::eErrorOutOfDateKHR:
-      // Caller will recreate the impl on acquisition, not submission.
-      [[fallthrough]];
-    case vk::Result::eErrorSurfaceLostKHR:
-      // Vulkan guarantees that the set of queue operations will still complete
-      // successfully.
-      [[fallthrough]];
-    case vk::Result::eSuccess:
-      is_rotated_ = false;
-      return true;
-    case vk::Result::eSuboptimalKHR:
-      is_rotated_ = true;
-      return true;
-    default:
-      VALIDATION_LOG << "Could not present queue: " << vk::to_string(result);
-      return false;
-  }
-  FML_UNREACHABLE();
-  return false;
+        switch (auto result = present_queue_.presentKHR(present_info)) {
+          case vk::Result::eErrorOutOfDateKHR:
+            // Caller will recreate the impl on acquisition, not submission.
+            [[fallthrough]];
+          case vk::Result::eErrorSurfaceLostKHR:
+            // Vulkan guarantees that the set of queue operations will still
+            // complete successfully.
+            [[fallthrough]];
+          case vk::Result::eSuccess:
+            is_rotated_ = false;
+            return;
+          case vk::Result::eSuboptimalKHR:
+            is_rotated_ = true;
+            return;
+          default:
+            VALIDATION_LOG << "Could not present queue: "
+                           << vk::to_string(result);
+            return;
+        }
+        FML_UNREACHABLE();
+      });
+  return true;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
@@ -77,7 +77,7 @@ class SwapchainImplVK final
                   bool was_rotated,
                   vk::SwapchainKHR old_swapchain);
 
-  bool Present(const std::shared_ptr<SwapchainImageVK>& image, uint32_t index);
+  bool Present(const std::shared_ptr<SwapchainImageVK> image, uint32_t index);
 
   void WaitIdle() const;
 

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
@@ -77,7 +77,7 @@ class SwapchainImplVK final
                   bool was_rotated,
                   vk::SwapchainKHR old_swapchain);
 
-  bool Present(const std::shared_ptr<SwapchainImageVK> image, uint32_t index);
+  bool Present(const std::shared_ptr<SwapchainImageVK>& image, uint32_t index);
 
   void WaitIdle() const;
 


### PR DESCRIPTION
Testing with validation enabled shows no crashes or validation warnings on Pixel 6 or S10. I believe this is safe since we are correctly synchronized in the acquireNextImage via the presentation semaphore. The only loss is that we will finish the raster task before we know that presentation is failed.

Having said that, we can end up waiting multiple ms for the layout transition and presentation, so that doesn't seem worth it.
