### PR TITLE
[Impeller] Dart GPU: Add dart:gpu package.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1710,6 +1710,10 @@ ORIGIN: ../../../flutter/impeller/typographer/text_run.cc + ../../../flutter/LIC
 ORIGIN: ../../../flutter/impeller/typographer/text_run.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/typographer/typeface.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/typographer/typeface.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/dart_gpu.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/dart_gpu.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/gpu.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/gpu_empty_stub.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/io/dart_io.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/io/dart_io.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/snapshot/snapshot.h + ../../../flutter/LICENSE
@@ -4406,6 +4410,10 @@ FILE: ../../../flutter/impeller/typographer/text_run.cc
 FILE: ../../../flutter/impeller/typographer/text_run.h
 FILE: ../../../flutter/impeller/typographer/typeface.cc
 FILE: ../../../flutter/impeller/typographer/typeface.h
+FILE: ../../../flutter/lib/gpu/dart_gpu.cc
+FILE: ../../../flutter/lib/gpu/dart_gpu.h
+FILE: ../../../flutter/lib/gpu/gpu.dart
+FILE: ../../../flutter/lib/gpu/gpu_empty_stub.dart
 FILE: ../../../flutter/lib/io/dart_io.cc
 FILE: ../../../flutter/lib/io/dart_io.h
 FILE: ../../../flutter/lib/snapshot/libraries_experimental.json

--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui;
-import 'dart:gpu' as gpu;
+//import 'dart:gpu';
 
 void main() {}
 

--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui;
-//import 'dart:gpu';
+import 'dart:gpu' as gpu;
 
 void main() {}
 

--- a/lib/gpu/BUILD.gn
+++ b/lib/gpu/BUILD.gn
@@ -1,0 +1,53 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/fuchsia/sdk.gni")
+import("//flutter/common/config.gni")
+import("//flutter/impeller/tools/impeller.gni")
+import("//flutter/shell/config.gni")
+import("//flutter/testing/testing.gni")
+
+source_set("gpu") {
+  cflags = [
+    # Dart gives us doubles. Skia and Impeller work in floats.
+    # If Dart gives us a double > FLT_MAX or < -FLT_MAX, implicit conversion
+    # will convert it to either inf/-inf or FLT_MAX/-FLT_MAX (undefined
+    # behavior). This can result in surprising and difficult to debug behavior
+    # for Flutter application developers, so it should be explicitly handled
+    # via SafeNarrow.
+    "-Wimplicit-float-conversion",
+  ]
+
+  if (is_win) {
+    # This causes build failures in third_party dependencies on Windows.
+    cflags += [ "-Wno-implicit-int-float-conversion" ]
+  }
+
+  sources = [
+    "dart_gpu.cc",
+    "dart_gpu.h",
+  ]
+
+  public_configs = [ "//flutter:config" ]
+
+  public_deps = [
+    "//flutter/flow",
+    "//flutter/shell/common:platform_message_handler",
+    "//flutter/third_party/txt",
+  ]
+
+  deps = [
+    "//flutter/assets",
+    "//flutter/common",
+    "//flutter/common/graphics",
+    "//flutter/display_list",
+    "//flutter/fml",
+    "//flutter/impeller",
+    "//flutter/impeller/runtime_stage",
+    "//flutter/runtime:dart_plugin_registrant",
+    "//flutter/runtime:test_font",
+    "//flutter/third_party/tonic",
+    "//third_party/dart/runtime/bin:dart_io_api",
+  ]
+}

--- a/lib/gpu/BUILD.gn
+++ b/lib/gpu/BUILD.gn
@@ -29,6 +29,10 @@ source_set("gpu") {
     "dart_gpu.h",
   ]
 
+  if (impeller_enable_3d) {
+    defines = [ "IMPELLER_ENABLE_3D" ]
+  }
+
   public_configs = [ "//flutter:config" ]
 
   public_deps = [

--- a/lib/gpu/dart_gpu.cc
+++ b/lib/gpu/dart_gpu.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(bdero): INCOMPLETE TEST STUB! Do not merge!
-
 #include "flutter/lib/gpu/dart_gpu.h"
 
 #include <mutex>
@@ -47,13 +45,18 @@ void* ResolveFfiNativeFunction(const char* name, uintptr_t args) {
 }
 
 void InitDispatcherMap() {
+#ifdef IMPELLER_ENABLE_3D
   FFI_FUNCTION_LIST(FFI_FUNCTION_INSERT)
   FFI_METHOD_LIST(FFI_METHOD_INSERT)
+#endif
 }
 
 }  // anonymous namespace
 
 void DartGPU::InitForIsolate(const Settings& settings) {
+  return;  // TODO(bdero): Remove this once `dart:gpu` is added to the library
+           //              list upstream.
+
   if (!settings.enable_impeller) {
     return;
   }

--- a/lib/gpu/dart_gpu.cc
+++ b/lib/gpu/dart_gpu.cc
@@ -1,0 +1,75 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(bdero): INCOMPLETE TEST STUB! Do not merge!
+
+#include "flutter/lib/gpu/dart_gpu.h"
+
+#include <mutex>
+#include <string_view>
+
+#include "flutter/common/settings.h"
+#include "flutter/fml/build_config.h"
+#include "third_party/tonic/converter/dart_converter.h"
+#include "third_party/tonic/dart_args.h"
+#include "third_party/tonic/logging/dart_error.h"
+
+using tonic::ToDart;
+
+namespace flutter {
+
+#define FFI_FUNCTION_LIST(V) /* Constructors */
+
+#define FFI_METHOD_LIST(V) /* Methods */
+
+#define FFI_FUNCTION_INSERT(FUNCTION, ARGS)     \
+  g_function_dispatchers.insert(std::make_pair( \
+      std::string_view(#FUNCTION),              \
+      reinterpret_cast<void*>(                  \
+          tonic::FfiDispatcher<void, decltype(&FUNCTION), &FUNCTION>::Call)));
+
+#define FFI_METHOD_INSERT(CLASS, METHOD, ARGS)                                 \
+  g_function_dispatchers.insert(                                               \
+      std::make_pair(std::string_view(#CLASS "::" #METHOD),                    \
+                     reinterpret_cast<void*>(                                  \
+                         tonic::FfiDispatcher<CLASS, decltype(&CLASS::METHOD), \
+                                              &CLASS::METHOD>::Call)));
+
+namespace {
+
+std::once_flag g_dispatchers_init_flag;
+std::unordered_map<std::string_view, void*> g_function_dispatchers;
+
+void* ResolveFfiNativeFunction(const char* name, uintptr_t args) {
+  auto it = g_function_dispatchers.find(name);
+  return (it != g_function_dispatchers.end()) ? it->second : nullptr;
+}
+
+void InitDispatcherMap() {
+  FFI_FUNCTION_LIST(FFI_FUNCTION_INSERT)
+  FFI_METHOD_LIST(FFI_METHOD_INSERT)
+}
+
+}  // anonymous namespace
+
+void DartGPU::InitForIsolate(const Settings& settings) {
+  if (!settings.enable_impeller) {
+    return;
+  }
+  std::call_once(g_dispatchers_init_flag, InitDispatcherMap);
+
+  auto dart_gpu = Dart_LookupLibrary(ToDart("dart:gpu"));
+  if (Dart_IsError(dart_gpu)) {
+    Dart_PropagateError(dart_gpu);
+  }
+
+  // Set up FFI Native resolver for dart:ui.
+  Dart_Handle result =
+      Dart_SetFfiNativeResolver(dart_gpu, ResolveFfiNativeFunction);
+  if (Dart_IsError(result)) {
+    Dart_PropagateError(result);
+  }
+}
+
+}  // namespace flutter

--- a/lib/gpu/dart_gpu.gni
+++ b/lib/gpu/dart_gpu.gni
@@ -1,0 +1,5 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+dart_gpu_files = [ "//flutter/lib/gpu/gpu.dart" ]

--- a/lib/gpu/dart_gpu.h
+++ b/lib/gpu/dart_gpu.h
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(bdero): INCOMPLETE TEST STUB! Do not merge!
-
 #ifndef FLUTTER_LIB_GPU_DART_GPU_H_
 #define FLUTTER_LIB_GPU_DART_GPU_H_
 

--- a/lib/gpu/dart_gpu.h
+++ b/lib/gpu/dart_gpu.h
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(bdero): INCOMPLETE TEST STUB! Do not merge!
+
+#ifndef FLUTTER_LIB_GPU_DART_GPU_H_
+#define FLUTTER_LIB_GPU_DART_GPU_H_
+
+#include "flutter/common/settings.h"
+#include "flutter/fml/macros.h"
+
+namespace flutter {
+
+class DartGPU {
+ public:
+  static void InitForIsolate(const Settings& settings);
+
+ private:
+  FML_DISALLOW_IMPLICIT_CONSTRUCTORS(DartGPU);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_LIB_GPU_DART_UI_H_

--- a/lib/gpu/gpu.dart
+++ b/lib/gpu/gpu.dart
@@ -1,0 +1,168 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(bdero): INCOMPLETE TEST STUB! Do not merge!
+
+// ignore_for_file: public_member_api_docs
+
+library dart.gpu;
+
+import 'dart:nativewrappers';
+
+enum BlendOperation { add, subtract, reverseSubtract }
+
+enum BlendFactor {
+  zero,
+  one,
+  sourceColor,
+  oneMinusSourceColor,
+  sourceAlpha,
+  oneMinusSourceAlpha,
+  destinationColor,
+  oneMinusDestinationColor,
+  destinationAlpha,
+  oneMinusDestinationAlpha,
+  sourceAlphaSaturated,
+  blendColor,
+  oneMinusBlendColor,
+  blendAlpha,
+  oneMinusBlendAlpha,
+}
+
+class BlendOptions {
+  const BlendOptions({
+    this.colorOperation = BlendOperation.add,
+    this.sourceColorFactor = BlendFactor.one,
+    this.destinationColorFactor = BlendFactor.oneMinusSourceAlpha,
+    this.alphaOperation = BlendOperation.add,
+    this.sourceAlphaFactor = BlendFactor.one,
+    this.destinationAlphaFactor = BlendFactor.oneMinusSourceAlpha,
+  });
+
+  final BlendOperation colorOperation;
+  final BlendFactor sourceColorFactor;
+  final BlendFactor destinationColorFactor;
+  final BlendOperation alphaOperation;
+  final BlendFactor sourceAlphaFactor;
+  final BlendFactor destinationAlphaFactor;
+}
+
+enum StencilOperation {
+  keep,
+  zero,
+  setToReferenceValue,
+  incrementClamp,
+  decrementClamp,
+  invert,
+  incrementWrap,
+  decrementWrap,
+}
+
+enum CompareFunction {
+  never,
+  always,
+  less,
+  equal,
+  lessEqual,
+  greater,
+  notEqual,
+  greaterEqual,
+}
+
+class StencilOptions {
+  const StencilOptions({
+    this.operation = StencilOperation.incrementClamp,
+    this.compare = CompareFunction.always,
+  });
+
+  final StencilOperation operation;
+  final CompareFunction compare;
+}
+
+enum ShaderType {
+  unknown,
+  voidType,
+  booleanType,
+  signedByteType,
+  unsignedByteType,
+  signedShortType,
+  unsignedShortType,
+  signedIntType,
+  unsignedIntType,
+  signedInt64Type,
+  unsignedInt64Type,
+  atomicCounterType,
+  halfFloatType,
+  floatType,
+  doubleType,
+  structType,
+  imageType,
+  sampledImageType,
+  samplerType,
+}
+
+class VertexAttribute {
+  const VertexAttribute({
+    this.name = '',
+    this.location = 0,
+    this.set = 0,
+    this.binding = 0,
+    this.type = ShaderType.floatType,
+    this.elements = 2,
+  });
+
+  final String name;
+  final int location;
+  final int set;
+  final int binding;
+  final ShaderType type;
+  final int elements;
+}
+
+class UniformSlot {
+  const UniformSlot({
+    this.name = '',
+    this.set = 0,
+    this.extRes0 = 0,
+    this.binding = 0,
+  });
+
+  final String name;
+  final int set;
+  final int extRes0;
+  final int binding;
+}
+
+class Shader {}
+
+class RasterPipeline {}
+
+/// A handle to a graphics context.
+///
+/// This class is created by the engine, and should not be instantiated
+/// or extended directly.
+///
+/// To obtain the default graphics context, use [getContext].
+@pragma('vm:entry-point')
+class Context extends NativeFieldWrapperClass1 {
+  @pragma('vm:entry-point')
+  Context._();
+
+  //registerShaderLibrary() async
+
+  Future<RasterPipeline> createRasterPipeline({
+    required Shader vertex,
+    required Shader fragment,
+    BlendOptions blendOptions = const BlendOptions(),
+    StencilOptions stencilOptions = const StencilOptions(),
+    List<VertexAttribute> vertexLayout = const <VertexAttribute>[],
+    List<UniformSlot> uniformLayout = const <UniformSlot>[],
+  }) async {
+    return RasterPipeline();
+  }
+}
+
+Context getContext() {
+  return Context._();
+}

--- a/lib/gpu/gpu_empty_stub.dart
+++ b/lib/gpu/gpu_empty_stub.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: public_member_api_docs
-
 library dart.gpu;
+
+// Remove this file and use `gpu.dart` instead once this library is ready for
+// preview.

--- a/lib/snapshot/libraries.json
+++ b/lib/snapshot/libraries.json
@@ -11,6 +11,9 @@
     "libraries": {
       "ui": {
         "uri": "../../lib/ui/ui.dart"
+      },
+      "gpu": {
+        "uri": "../../lib/gpu/gpu.dart"
       }
     }
   }

--- a/lib/snapshot/libraries.json
+++ b/lib/snapshot/libraries.json
@@ -13,7 +13,7 @@
         "uri": "../../lib/ui/ui.dart"
       },
       "gpu": {
-        "uri": "../../lib/gpu/gpu.dart"
+        "uri": "../../lib/gpu/gpu_empty_stub.dart"
       }
     }
   }

--- a/lib/snapshot/libraries.yaml
+++ b/lib/snapshot/libraries.yaml
@@ -17,5 +17,7 @@ flutter:
   libraries:
     ui:
       uri: "../../lib/ui/ui.dart"
+    gpu:
+      uri: "../../lib/gpu/gpu.dart"
 
 

--- a/lib/snapshot/libraries_experimental.json
+++ b/lib/snapshot/libraries_experimental.json
@@ -11,6 +11,9 @@
       "libraries": {
         "ui": {
           "uri": "../../lib/ui/experiments/ui.dart"
+        },
+        "gpu": {
+          "uri": "../../lib/gpu/gpu.dart"
         }
       }
     }

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -90,6 +90,7 @@ source_set("runtime") {
   }
 
   public_deps = [
+    "//flutter/lib/gpu",
     "//flutter/lib/ui",
     "//third_party/rapidjson",
   ]

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -11,6 +11,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/posix_wrappers.h"
 #include "flutter/fml/trace_event.h"
+#include "flutter/lib/gpu/dart_gpu.h"
 #include "flutter/lib/io/dart_io.h"
 #include "flutter/lib/ui/dart_runtime_hooks.h"
 #include "flutter/lib/ui/dart_ui.h"
@@ -461,6 +462,8 @@ bool DartIsolate::LoadLibraries() {
                          domain_network_policy_);
 
   DartUI::InitForIsolate(GetIsolateGroupData().GetSettings());
+
+  DartGPU::InitForIsolate(GetIsolateGroupData().GetSettings());
 
   const bool is_service_isolate = Dart_IsServiceIsolate(isolate());
 

--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -4,6 +4,8 @@
 
 import("//build/fuchsia/sdk.gni")
 import("//flutter/build/dart/rules.gni")
+import("//flutter/impeller/tools/impeller.gni")
+import("//flutter/lib/gpu/dart_gpu.gni")
 import("//flutter/lib/ui/dart_ui.gni")
 import("//flutter/web_sdk/web_sdk.gni")
 import("//third_party/dart/sdk/lib/_http/http_sources.gni")
@@ -188,6 +190,12 @@ web_ui_ui_web_with_output("copy_dart_ui_web") {
   output_dir = "$root_gen_dir/dart-pkg/sky_engine/lib/ui_web/"
 }
 
+copy("copy_dart_gpu") {
+  sources = dart_gpu_files
+
+  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/gpu/{{source_file_part}}" ]
+}
+
 copy("copy_allowed_experiments") {
   sources = [ "//third_party/dart/sdk/lib/_internal/allowed_experiments.json" ]
 
@@ -275,6 +283,10 @@ dart_pkg("sky_engine") {
     ":copy_dart_ui",
     ":copy_dart_ui_web",
   ]
+
+  if (impeller_enable_3d) {
+    deps += [ ":copy_dart_gpu" ]
+  }
 
   if (!is_fuchsia) {
     deps += [ ":copy_sky_engine_authors" ]


### PR DESCRIPTION
Part of: https://github.com/flutter/flutter/issues/131346

Sets up the `dart:gpu` in the engine.

After this lands, we can add it to the library list in: https://github.com/dart-lang/sdk/blob/main/pkg/vm/lib/target/flutter.dart