### PR TITLE
Add Expanded/Collapsed state for `SubmenuButton`

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -283,6 +283,8 @@ class SemanticsFlag {
   static const int _kIsSliderIndex = 1 << 23;
   static const int _kIsKeyboardKeyIndex = 1 << 24;
   static const int _kIsCheckStateMixedIndex = 1 << 25;
+  static const int _kHasExpandedStateIndex = 1 << 26;
+  static const int _kIsExpandedIndex = 1 << 27;
   // READ THIS: if you add a flag here, you MUST update the numSemanticsFlags
   // value in testing/dart/semantics_test.dart, or tests will fail. Also,
   // please update the Flag enum in
@@ -527,6 +529,27 @@ class SemanticsFlag {
   /// navigate to the next page when reaching the end of the current one.
   static const SemanticsFlag hasImplicitScrolling = SemanticsFlag._(_kHasImplicitScrollingIndex, 'hasImplicitScrolling');
 
+  /// The semantics node has the quality of either being "expanded" or "collapsed".
+  ///
+  /// For example, a submenu button widget has expanded state.
+  ///
+  /// See also:
+  ///
+  ///   * [SemanticsFlag.isExpanded], which controls whether the node is "expanded" or "collapsed".
+  static const SemanticsFlag hasExpandedState = SemanticsFlag._(_kHasExpandedStateIndex, 'hasExpandedState');
+  
+  /// Whether a semantics node is expanded.
+  ///
+  /// If true, the semantics node is "expanded". If false, the semantics node is
+  /// "collapsed".
+  ///
+  /// For example, if a submenu button shows its children, [isExpanded] is true.
+  /// 
+  /// See also:
+  ///
+  ///   * [SemanticsFlag.hasExpandedState], which enables an expanded/collapsed state.
+  static const SemanticsFlag isExpanded = SemanticsFlag._(_kIsExpandedIndex, 'isExpanded');
+
   /// The possible semantics flags.
   ///
   /// The map's key is the [index] of the flag and the value is the flag itself.
@@ -557,6 +580,8 @@ class SemanticsFlag {
     _kIsSliderIndex: isSlider,
     _kIsKeyboardKeyIndex: isKeyboardKey,
     _kIsCheckStateMixedIndex: isCheckStateMixed,
+    _kHasExpandedStateIndex: hasExpandedState,
+    _kIsExpandedIndex: isExpanded,
   };
 
   static List<SemanticsFlag> get values => _kFlagById.values.toList(growable: false);

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -537,7 +537,7 @@ class SemanticsFlag {
   ///
   ///   * [SemanticsFlag.isExpanded], which controls whether the node is "expanded" or "collapsed".
   static const SemanticsFlag hasExpandedState = SemanticsFlag._(_kHasExpandedStateIndex, 'hasExpandedState');
-  
+
   /// Whether a semantics node is expanded.
   ///
   /// If true, the semantics node is "expanded". If false, the semantics node is

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -544,7 +544,7 @@ class SemanticsFlag {
   /// "collapsed".
   ///
   /// For example, if a submenu button shows its children, [isExpanded] is true.
-  /// 
+  ///
   /// See also:
   ///
   ///   * [SemanticsFlag.hasExpandedState], which enables an expanded/collapsed state.

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -531,7 +531,7 @@ class SemanticsFlag {
 
   /// The semantics node has the quality of either being "expanded" or "collapsed".
   ///
-  /// For example, a submenu button widget has expanded state.
+  /// For example, a [SubmenuButton] widget has expanded state.
   ///
   /// See also:
   ///
@@ -543,7 +543,7 @@ class SemanticsFlag {
   /// If true, the semantics node is "expanded". If false, the semantics node is
   /// "collapsed".
   ///
-  /// For example, if a submenu button shows its children, [isExpanded] is true.
+  /// For example, if a [SubmenuButton] shows its children, [isExpanded] is true.
   ///
   /// See also:
   ///

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -88,6 +88,8 @@ enum class SemanticsFlags : int32_t {
   kIsSlider = 1 << 23,
   kIsKeyboardKey = 1 << 24,
   kIsCheckStateMixed = 1 << 25,
+  kHasExpandedState = 1 << 26,
+  kIsExpanded = 1 << 27,
 };
 
 const int kScrollableSemanticsFlags =

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -121,6 +121,8 @@ class SemanticsFlag {
   static const int _kIsSliderIndex = 1 << 23;
   static const int _kIsKeyboardKeyIndex = 1 << 24;
   static const int _kIsCheckStateMixedIndex = 1 << 25;
+  static const int _kHasExpandedStateIndex = 1 << 26;
+  static const int _kIsExpandedIndex = 1 << 27;
 
   static const SemanticsFlag hasCheckedState = SemanticsFlag._(_kHasCheckedStateIndex, 'hasCheckedState');
   static const SemanticsFlag isChecked = SemanticsFlag._(_kIsCheckedIndex, 'isChecked');
@@ -148,6 +150,8 @@ class SemanticsFlag {
   static const SemanticsFlag isToggled = SemanticsFlag._(_kIsToggledIndex, 'isToggled');
   static const SemanticsFlag hasImplicitScrolling = SemanticsFlag._(_kHasImplicitScrollingIndex, 'hasImplicitScrolling');
   static const SemanticsFlag isCheckStateMixed = SemanticsFlag._(_kIsCheckStateMixedIndex, 'isCheckStateMixed');
+  static const SemanticsFlag hasExpandedState = SemanticsFlag._(_kHasExpandedStateIndex, 'hasExpandedState');
+  static const SemanticsFlag isExpanded = SemanticsFlag._(_kIsExpandedIndex, 'isExpanded');
 
   static const Map<int, SemanticsFlag> _kFlagById = <int, SemanticsFlag>{
     _kHasCheckedStateIndex: hasCheckedState,
@@ -176,6 +180,8 @@ class SemanticsFlag {
     _kIsSliderIndex: isSlider,
     _kIsKeyboardKeyIndex: isKeyboardKey,
     _kIsCheckStateMixedIndex: isCheckStateMixed,
+    _kHasExpandedStateIndex: hasExpandedState,
+    _kIsExpandedIndex: isExpanded,
   };
 
   static List<SemanticsFlag> get values => _kFlagById.values.toList(growable: false);

--- a/lib/web_ui/test/engine/semantics/semantics_api_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_api_test.dart
@@ -18,7 +18,7 @@ void main() {
 
 void testMain() {
   // This must match the number of flags in lib/ui/semantics.dart
-  const int numSemanticsFlags = 26;
+  const int numSemanticsFlags = 28;
   test('SemanticsFlag.values refers to all flags.', () async {
     expect(SemanticsFlag.values.length, equals(numSemanticsFlags));
     for (int index = 0; index < numSemanticsFlags; ++index) {

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2169,7 +2169,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     IS_LINK(1 << 22),
     IS_SLIDER(1 << 23),
     IS_KEYBOARD_KEY(1 << 24),
-    IS_CHECK_STATE_MIXED(1 << 25);
+    IS_CHECK_STATE_MIXED(1 << 25),
+    HAS_EXPANDED_STATE(1 << 26),
+    IS_EXPANDED(1 << 27);
 
     final int value;
 

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -353,6 +353,12 @@ void AccessibilityBridge::SetStateFromFlutterUpdate(ui::AXNodeData& node_data,
                                                     const SemanticsNode& node) {
   FlutterSemanticsFlag flags = node.flags;
   FlutterSemanticsAction actions = node.actions;
+  if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState && 
+      flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsExpanded) {
+    node_data.AddState(ax::mojom::State::kExpanded);
+  } else if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState) {
+    node_data.AddState(ax::mojom::State::kCollapsed);
+  }
   if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField &&
       (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly) == 0) {
     node_data.AddState(ax::mojom::State::kEditable);

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -356,7 +356,7 @@ void AccessibilityBridge::SetStateFromFlutterUpdate(ui::AXNodeData& node_data,
   if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState &&
       flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsExpanded) {
     node_data.AddState(ax::mojom::State::kExpanded);
-  } else if (flags & 
+  } else if (flags &
              FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState) {
     node_data.AddState(ax::mojom::State::kCollapsed);
   }

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -356,7 +356,8 @@ void AccessibilityBridge::SetStateFromFlutterUpdate(ui::AXNodeData& node_data,
   if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState &&
       flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsExpanded) {
     node_data.AddState(ax::mojom::State::kExpanded);
-  } else if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState) {
+  } else if (flags & 
+             FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState) {
     node_data.AddState(ax::mojom::State::kCollapsed);
   }
   if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField &&

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -353,7 +353,7 @@ void AccessibilityBridge::SetStateFromFlutterUpdate(ui::AXNodeData& node_data,
                                                     const SemanticsNode& node) {
   FlutterSemanticsFlag flags = node.flags;
   FlutterSemanticsAction actions = node.actions;
-  if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState && 
+  if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState &&
       flags & FlutterSemanticsFlag::kFlutterSemanticsFlagIsExpanded) {
     node_data.AddState(ax::mojom::State::kExpanded);
   } else if (flags & FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState) {

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -236,6 +236,11 @@ typedef enum {
   kFlutterSemanticsFlagIsKeyboardKey = 1 << 24,
   /// Whether the semantics node represents a tristate checkbox in mixed state.
   kFlutterSemanticsFlagIsCheckStateMixed = 1 << 25,
+  /// The semantics node has the quality of either being "expanded" or
+  /// "collapsed".
+  kFlutterSemanticsFlagHasExpandedState = 1 << 26,
+  /// Whether a semantic node that hasExpandedState is currently expanded.
+  kFlutterSemanticsFlagIsExpanded = 1 << 27,
 } FlutterSemanticsFlag;
 
 typedef enum {

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -199,7 +199,7 @@ TEST(FlutterWindowsViewTest, SubmenuNativeState) {
     EXPECT_NE(std::wcsstr(native_state.bstrVal, L"expanded=true"), nullptr);
   }
 
-  // Test unchecked too.
+  // Test collapsed too.
   root.flags = static_cast<FlutterSemanticsFlag>(
       FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState);
   bridge->AddFlutterSemanticsNodeUpdate(root);

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -134,7 +134,7 @@ class MockAngleSurfaceManager : public AngleSurfaceManager {
 
 // Ensure that submenu buttons have their expanded/collapsed status set
 // apropriately.
-TEST(FlutterWindowsViewTest, SubmenuNativeState) {
+TEST(FlutterWindowsViewTest, SubMenuExpandedState) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
   EngineModifier modifier(engine.get());
   modifier.embedder_api().UpdateSemanticsEnabled =

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -132,6 +132,111 @@ class MockAngleSurfaceManager : public AngleSurfaceManager {
 
 }  // namespace
 
+// Ensure that submenu buttons have their expanded/collapsed status set apropriately
+TEST(FlutterWindowsViewTest, SubmenuNativeState) {
+    std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  EngineModifier modifier(engine.get());
+  modifier.embedder_api().UpdateSemanticsEnabled =
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine, bool enabled) {
+        return kSuccess;
+      };
+
+  auto window_binding_handler =
+      std::make_unique<NiceMock<MockWindowBindingHandler>>();
+  FlutterWindowsView view(std::move(window_binding_handler));
+  view.SetEngine(std::move(engine));
+
+  // Enable semantics to instantiate accessibility bridge.
+  view.OnUpdateSemanticsEnabled(true);
+
+  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  ASSERT_TRUE(bridge);
+
+  FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
+  root.id = 0;
+  root.label = "root";
+  root.hint = "";
+  root.value = "";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.child_count = 0;
+  root.custom_accessibility_actions_count = 0;
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState |
+      FlutterSemanticsFlag::kFlutterSemanticsFlagIsExpanded);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+
+  bridge->CommitUpdates();
+
+  {
+    auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+    // EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
+    EXPECT_TRUE(root_node->GetData().HasState(ax::mojom::State::kExpanded));
+
+    // Get the IAccessible for the root node.
+    IAccessible* native_view = root_node->GetNativeViewAccessible();
+    ASSERT_TRUE(native_view != nullptr);
+
+    // Look up against the node itself (not one of its children).
+    VARIANT varchild = {};
+    varchild.vt = VT_I4;
+
+    // Verify the submenu is expanded.
+    varchild.lVal = CHILDID_SELF;
+    VARIANT native_state = {};
+    ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
+    EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_EXPANDED);
+
+    // Perform similar tests for UIA value;
+    IRawElementProviderSimple* uia_node;
+    native_view->QueryInterface(IID_PPV_ARGS(&uia_node));
+    ASSERT_TRUE(SUCCEEDED(uia_node->GetPropertyValue(
+        UIA_ExpandCollapseExpandCollapseStatePropertyId, &native_state)));
+    EXPECT_EQ(native_state.lVal, ExpandCollapseState_Expanded);
+
+    ASSERT_TRUE(SUCCEEDED(uia_node->GetPropertyValue(
+        UIA_AriaPropertiesPropertyId, &native_state)));
+    EXPECT_NE(std::wcsstr(native_state.bstrVal, L"expanded=true"), nullptr);
+  }
+
+  // Test unchecked too.
+  root.flags = static_cast<FlutterSemanticsFlag>(
+      FlutterSemanticsFlag::kFlutterSemanticsFlagHasExpandedState);
+  bridge->AddFlutterSemanticsNodeUpdate(root);
+  bridge->CommitUpdates();
+
+  {
+    auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+    // EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
+    EXPECT_TRUE(root_node->GetData().HasState(ax::mojom::State::kCollapsed));
+
+    // Get the IAccessible for the root node.
+    IAccessible* native_view = root_node->GetNativeViewAccessible();
+    ASSERT_TRUE(native_view != nullptr);
+
+    // Look up against the node itself (not one of its children).
+    VARIANT varchild = {};
+    varchild.vt = VT_I4;
+
+    // Verify the submenu is collapsed.
+    varchild.lVal = CHILDID_SELF;
+    VARIANT native_state = {};
+    ASSERT_TRUE(SUCCEEDED(native_view->get_accState(varchild, &native_state)));
+    EXPECT_TRUE(native_state.lVal & STATE_SYSTEM_COLLAPSED);
+
+    // Perform similar tests for UIA value;
+    IRawElementProviderSimple* uia_node;
+    native_view->QueryInterface(IID_PPV_ARGS(&uia_node));
+    ASSERT_TRUE(SUCCEEDED(uia_node->GetPropertyValue(
+        UIA_ExpandCollapseExpandCollapseStatePropertyId, &native_state)));
+    EXPECT_EQ(native_state.lVal, ExpandCollapseState_Collapsed);
+
+    ASSERT_TRUE(SUCCEEDED(uia_node->GetPropertyValue(
+        UIA_AriaPropertiesPropertyId, &native_state)));
+    EXPECT_NE(std::wcsstr(native_state.bstrVal, L"expanded=false"), nullptr);
+  }
+}
+
 // The view's surface must be destroyed after the engine is shutdown.
 // See: https://github.com/flutter/flutter/issues/124463
 TEST(FlutterWindowsViewTest, Shutdown) {

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -149,7 +149,7 @@ TEST(FlutterWindowsViewTest, SubmenuNativeState) {
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
 
-  auto bridge = view.GetEngine()->accessibility_bridge().lock();
+  auto bridge = view.accessibility_bridge().lock();
   ASSERT_TRUE(bridge);
 
   FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
@@ -170,7 +170,6 @@ TEST(FlutterWindowsViewTest, SubmenuNativeState) {
 
   {
     auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
-    // EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
     EXPECT_TRUE(root_node->GetData().HasState(ax::mojom::State::kExpanded));
 
     // Get the IAccessible for the root node.
@@ -207,7 +206,6 @@ TEST(FlutterWindowsViewTest, SubmenuNativeState) {
 
   {
     auto root_node = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
-    // EXPECT_EQ(root_node->GetData().role, ax::mojom::Role::kCheckBox);
     EXPECT_TRUE(root_node->GetData().HasState(ax::mojom::State::kCollapsed));
 
     // Get the IAccessible for the root node.

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -132,9 +132,10 @@ class MockAngleSurfaceManager : public AngleSurfaceManager {
 
 }  // namespace
 
-// Ensure that submenu buttons have their expanded/collapsed status set apropriately
+// Ensure that submenu buttons have their expanded/collapsed status set
+// apropriately.
 TEST(FlutterWindowsViewTest, SubmenuNativeState) {
-    std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
   EngineModifier modifier(engine.get());
   modifier.embedder_api().UpdateSemanticsEnabled =
       [](FLUTTER_API_SYMBOL(FlutterEngine) engine, bool enabled) {

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -11,7 +11,7 @@ import 'package:litetest/litetest.dart';
 
 void main() {
   // This must match the number of flags in lib/ui/semantics.dart
-  const int numSemanticsFlags = 26;
+  const int numSemanticsFlags = 28;
   test('SemanticsFlag.values refers to all flags.', () async {
     expect(SemanticsFlag.values.length, equals(numSemanticsFlags));
     for (int index = 0; index < numSemanticsFlags; ++index) {


### PR DESCRIPTION
This PR is to add support for the expanded/collapsed-state semantics flag to the engine. After adding another PR to Flutter, we will be able to support the expanded/collapsed state in semantics for submenu buttons.

Related to [#127617](https://github.com/flutter/flutter/issues/127617) in flutter

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
