### PR TITLE
[Impeller] Use basis of effect transform in MatrixFilter.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2908,15 +2908,22 @@ TEST_P(AiksTest, DrawPictureWithText) {
 
 TEST_P(AiksTest, MatrixBackdropFilter) {
   Canvas canvas;
-  canvas.SaveLayer({}, std::nullopt,
-                   [](const FilterInput::Ref& input,
-                      const Matrix& effect_transform, bool is_subpass) {
-                     return FilterContents::MakeMatrixFilter(
-                         input, Matrix::MakeTranslation(Vector2(100, 100)), {},
-                         Matrix(), true);
-                   });
-  canvas.DrawCircle(Point(100, 100), 100,
-                    {.color = Color::Green(), .blend_mode = BlendMode::kPlus});
+  canvas.DrawPaint({.color = Color::Black()});
+  canvas.SaveLayer({}, std::nullopt);
+  {
+    canvas.DrawCircle(
+        Point(200, 200), 100,
+        {.color = Color::Green(), .blend_mode = BlendMode::kPlus});
+    // Should render a second intersecting circle, offset by 100, 100.
+    canvas.SaveLayer({}, std::nullopt,
+                     [](const FilterInput::Ref& input,
+                        const Matrix& effect_transform, bool is_subpass) {
+                       return FilterContents::MakeMatrixFilter(
+                           input, Matrix::MakeTranslation(Vector2(100, 100)),
+                           {}, Matrix(), true);
+                     });
+    canvas.Restore();
+  }
   canvas.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2911,16 +2911,21 @@ TEST_P(AiksTest, MatrixBackdropFilter) {
   canvas.DrawPaint({.color = Color::Black()});
   canvas.SaveLayer({}, std::nullopt);
   {
-    canvas.DrawCircle(
-        Point(200, 200), 100,
-        {.color = Color::Green(), .blend_mode = BlendMode::kPlus});
-    // Should render a second intersecting circle, offset by 100, 100.
+    canvas.DrawCircle(Point(200, 200), 100,
+                      {.color = Color::Green().WithAlpha(0.5),
+                       .blend_mode = BlendMode::kPlus});
+    // Should render a second circle, centered on the bottom-right-most edge of
+    // the circle.
     canvas.SaveLayer({}, std::nullopt,
                      [](const FilterInput::Ref& input,
                         const Matrix& effect_transform, bool is_subpass) {
+                       Matrix matrix =
+                           Matrix::MakeTranslation(Vector2(1, 1) *
+                                                   (100 + 100 * k1OverSqrt2)) *
+                           Matrix::MakeScale(Vector2(1, 1) * 0.2) *
+                           Matrix::MakeTranslation(Vector2(-100, -100));
                        return FilterContents::MakeMatrixFilter(
-                           input, Matrix::MakeTranslation(Vector2(100, 100)),
-                           {}, Matrix(), true);
+                           input, matrix, {}, Matrix(), true);
                      });
     canvas.Restore();
   }

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -34,11 +34,45 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  auto& transform = is_subpass_ ? effect_transform : entity.GetTransformation();
-  snapshot->transform = transform *           //
-                        matrix_ *             //
-                        transform.Invert() *  //
-                        snapshot->transform;
+  if (is_subpass_) {
+    // There are two special quirks with how Matrix filters behave when used as
+    // subpass backdrop filters:
+    //
+    // 1. For subpass backdrop filters, the snapshot transform is always just a
+    //    translation that positions the parent pass texture correctly relative
+    //    to the subpass texture. However, this translation always needs to be
+    //    applied in screen space.
+    //
+    //    Since we know the snapshot transform will always have an identity
+    //    basis in this case, we safely reverse the order and apply the filter's
+    //    matrix within the snapshot transform space.
+    //
+    // 2. The filter's matrix needs to be applied within the space defined by
+    //    the scene's current transformation matrix (CTM). For example: If the
+    //    CTM is scaled up, then translations applied by the matrix should be
+    //    magnified accordingly.
+    //
+    //    To accomplish this, we sandwitch the filter's matrix within the CTM in
+    //    both cases. But notice that for the subpass backdrop filter case, we
+    //    use the "effect transform" instead of the Entity's transform!
+    //
+    //    That's because in the subpass backdrop filter case, the Entity's
+    //    transform isn't actually the captured CTM of the scene like it usually
+    //    is; instead, it's just a screen space translation that offsets the
+    //    backdrop texture (as mentioned above). And so we sneak the subpass's
+    //    captured CTM in through the effect transform.
+    //
+
+    snapshot->transform = snapshot->transform *  //
+                          effect_transform *     //
+                          matrix_ *              //
+                          effect_transform.Invert();
+  } else {
+    snapshot->transform = entity.GetTransformation() *           //
+                          matrix_ *                              //
+                          entity.GetTransformation().Invert() *  //
+                          snapshot->transform;
+  }
   snapshot->sampler_descriptor = sampler_descriptor_;
   return Entity::FromSnapshot(snapshot, entity.GetBlendMode(),
                               entity.GetStencilDepth());

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -34,45 +34,28 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
     return std::nullopt;
   }
 
-  if (is_subpass_) {
-    // There are two special quirks with how Matrix filters behave when used as
-    // subpass backdrop filters:
-    //
-    // 1. For subpass backdrop filters, the snapshot transform is always just a
-    //    translation that positions the parent pass texture correctly relative
-    //    to the subpass texture. However, this translation always needs to be
-    //    applied in screen space.
-    //
-    //    Since we know the snapshot transform will always have an identity
-    //    basis in this case, we safely reverse the order and apply the filter's
-    //    matrix within the snapshot transform space.
-    //
-    // 2. The filter's matrix needs to be applied within the space defined by
-    //    the scene's current transformation matrix (CTM). For example: If the
-    //    CTM is scaled up, then translations applied by the matrix should be
-    //    magnified accordingly.
-    //
-    //    To accomplish this, we sandwitch the filter's matrix within the CTM in
-    //    both cases. But notice that for the subpass backdrop filter case, we
-    //    use the "effect transform" instead of the Entity's transform!
-    //
-    //    That's because in the subpass backdrop filter case, the Entity's
-    //    transform isn't actually the captured CTM of the scene like it usually
-    //    is; instead, it's just a screen space translation that offsets the
-    //    backdrop texture (as mentioned above). And so we sneak the subpass's
-    //    captured CTM in through the effect transform.
-    //
+  // The filter's matrix needs to be applied within the space defined by the
+  // scene's current transformation matrix (CTM). For example: If the CTM is
+  // scaled up, then translations applied by the matrix should be magnified
+  // accordingly.
+  //
+  // To accomplish this, we sandwitch the filter's matrix within the CTM in both
+  // cases. But notice that for the subpass backdrop filter case, we use the
+  // "effect transform" instead of the Entity's transform!
+  //
+  // That's because in the subpass backdrop filter case, the Entity's transform
+  // isn't actually the captured CTM of the scene like it usually is; instead,
+  // it's just a screen space translation that offsets the backdrop texture (as
+  // mentioned above). And so we sneak the subpass's captured CTM in through the
+  // effect transform.
 
-    snapshot->transform = snapshot->transform *  //
-                          effect_transform *     //
-                          matrix_ *              //
-                          effect_transform.Invert();
-  } else {
-    snapshot->transform = entity.GetTransformation() *           //
-                          matrix_ *                              //
-                          entity.GetTransformation().Invert() *  //
-                          snapshot->transform;
-  }
+  auto transform = is_subpass_ ? effect_transform.Basis()
+                               : entity.GetTransformation().Basis();
+  snapshot->transform = transform *           //
+                        matrix_ *             //
+                        transform.Invert() *  //
+                        snapshot->transform;
+
   snapshot->sampler_descriptor = sampler_descriptor_;
   return Entity::FromSnapshot(snapshot, entity.GetBlendMode(),
                               entity.GetStencilDepth());


### PR DESCRIPTION
Follow-up/reland of https://github.com/flutter/engine/pull/43943.

Resolves https://github.com/flutter/flutter/issues/130355.
Doesn't regress https://github.com/flutter/flutter/issues/131182.

I've updated the golden to better reproduce the problem at hand; the second circle is a scaled down copy of the backdrop. If the matrix filter is handling the transform correctly, the circle is centered over the bottom-right-most edge (4:30) of the circle:
![image](https://github.com/flutter/engine/assets/919017/3f2e099d-9d43-4ee6-8efe-3203edad47ad)


Before:

https://github.com/flutter/engine/assets/919017/d12d67bd-7e60-4389-87d3-fc4162d9b90e

After:

https://github.com/flutter/engine/assets/919017/a611a0d4-0b2d-4171-8170-b6a3781034e1
