### PR TITLE
[Windows] Return keyboard pressed state

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -631,7 +631,7 @@ FlutterWindowsEngine::CreateKeyboardKeyHandler(
     BinaryMessenger* messenger,
     KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
     KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan) {
-  auto keyboard_key_handler = std::make_unique<KeyboardKeyHandler>();
+  auto keyboard_key_handler = std::make_unique<KeyboardKeyHandler>(messenger);
   keyboard_key_handler->AddDelegate(
       std::make_unique<KeyboardKeyEmbedderHandler>(
           [this](const FlutterKeyEvent& event, FlutterKeyEventCallback callback,
@@ -641,6 +641,7 @@ FlutterWindowsEngine::CreateKeyboardKeyHandler(
           get_key_state, map_vk_to_scan));
   keyboard_key_handler->AddDelegate(
       std::make_unique<KeyboardKeyChannelHandler>(messenger));
+  keyboard_key_handler->InitKeyboardChannel();
   return keyboard_key_handler;
 }
 

--- a/shell/platform/windows/keyboard_handler_base.h
+++ b/shell/platform/windows/keyboard_handler_base.h
@@ -33,6 +33,12 @@ class KeyboardHandlerBase {
   // If needed, synthesize modifier keys events by comparing the
   // given modifiers state to the known pressing state..
   virtual void SyncModifiersIfNeeded(int modifiers_state) = 0;
+
+  // Returns the keyboard pressed state.
+  //
+  // Returns the keyboard pressed state. The map contains one entry per
+  // pressed keys, mapping from the logical key to the physical key.
+  virtual std::map<uint64_t, uint64_t> GetPressedState() = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_key_channel_handler.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler.cc
@@ -110,7 +110,15 @@ KeyboardKeyChannelHandler::KeyboardKeyChannelHandler(
 KeyboardKeyChannelHandler::~KeyboardKeyChannelHandler() = default;
 
 void KeyboardKeyChannelHandler::SyncModifiersIfNeeded(int modifiers_state) {
-  // Do nothing
+  // Do nothing.
+}
+
+std::map<uint64_t, uint64_t> KeyboardKeyChannelHandler::GetPressedState() {
+  // Returns an empty state because it will never be called.
+  // KeyboardKeyEmbedderHandler is the only KeyboardKeyHandlerDelegate to handle
+  // GetPressedState() calls.
+  std::map<uint64_t, uint64_t> empty_state;
+  return empty_state;
 }
 
 void KeyboardKeyChannelHandler::KeyboardHook(

--- a/shell/platform/windows/keyboard_key_channel_handler.h
+++ b/shell/platform/windows/keyboard_key_channel_handler.h
@@ -41,6 +41,8 @@ class KeyboardKeyChannelHandler
 
   void SyncModifiersIfNeeded(int modifiers_state);
 
+  std::map<uint64_t, uint64_t> GetPressedState();
+
  private:
   // The Flutter system channel for key event messages.
   std::unique_ptr<flutter::BasicMessageChannel<rapidjson::Document>> channel_;

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -350,6 +350,10 @@ void KeyboardKeyEmbedderHandler::KeyboardHook(
   }
 }
 
+std::map<uint64_t, uint64_t> KeyboardKeyEmbedderHandler::GetPressedState() {
+  return pressingRecords_;
+}
+
 void KeyboardKeyEmbedderHandler::UpdateLastSeenCriticalKey(
     int virtual_key,
     uint64_t physical_key,

--- a/shell/platform/windows/keyboard_key_embedder_handler.h
+++ b/shell/platform/windows/keyboard_key_embedder_handler.h
@@ -73,6 +73,8 @@ class KeyboardKeyEmbedderHandler
 
   void SyncModifiersIfNeeded(int modifiers_state) override;
 
+  std::map<uint64_t, uint64_t> GetPressedState() override;
+
  private:
   struct PendingResponse {
     std::function<void(bool, uint64_t)> callback;


### PR DESCRIPTION
## Description

This PR updates the Windows engine in order to answer to keyboard pressed state queries from the framework (as implemented in https://github.com/flutter/flutter/pull/122885).

## Related Issue

Windows engine implementation for https://github.com/flutter/flutter/issues/87391.

Similar to:
- Linux: https://github.com/flutter/engine/pull/42346
- Android: https://github.com/flutter/engine/pull/42758
- macOS: https://github.com/flutter/engine/pull/42878

## Tests

Adds 2 tests.
