### PR TITLE
[iOS][A11Y] fix hittest with non-SemanticsObject

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -93,12 +93,6 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
 }  // namespace
 
-@interface NSObject (FlutterSemantics)
-
-- (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event;
-
-@end
-
 @interface FlutterSwitchSemanticsObject ()
 @property(nonatomic, readonly) UISwitch* nativeSwitch;
 @end
@@ -578,13 +572,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // IOS 16. Overrides this method to focus the first eligiable semantics
 // object in hit test order.
 - (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  id hittest = [self search:point];
-  if (![hittest isKindOfClass:[SemanticsObject class]]) {
-    // If hittest result is not a SemanticsObject (e.g. PlatformView),
-    // call the default hittest method to find the hittest result inside the "hittest".
-    return [(NSObject*)hittest _accessibilityHitTest:point withEvent:event];
-  }
-  return hittest;
+  return [self search:point];
 }
 
 // iOS calls this method when this item is swipe-to-focusd in VoiceOver.
@@ -890,17 +878,9 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   [super dealloc];
 }
 
-- (id)nativeAccessibility {
-  return _platformView;
-}
-
-- (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  return [_platformView _accessibilityHitTest:point withEvent:event];
-}
-
-- (BOOL)isFocusable {
-  return YES;
-}
+// - (id)nativeAccessibility {
+//   return _platformView;
+// }
 
 - (BOOL)isAccessibilityElement {
   return NO;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -878,12 +878,8 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   [super dealloc];
 }
 
-// - (id)nativeAccessibility {
-//   return _platformView;
-// }
-
-- (BOOL)isAccessibilityElement {
-  return NO;
+- (id)nativeAccessibility {
+  return _platformView;
 }
 
 #pragma mark - UIAccessibilityContainer overrides

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -89,23 +89,6 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
 }  // namespace
 }  // namespace flutter
 
-@interface FakePlatformView : UIView
-
-@property(nonatomic, strong, readonly) UIView* subview;
-
-@end
-
-@implementation FakePlatformView
-
-- (id)_accessibilityHitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  if (_subview) {
-    _subview = [[UIView alloc] init];
-  }
-  return _subview;
-}
-
-@end
-
 @interface SemanticsObjectTest : XCTestCase
 @end
 
@@ -220,15 +203,14 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   XCTAssertNil(hitTestResult);
 }
 
-- (void)testAccessibilityHitTestSearchPlatformViewSubtree {
+- (void)testAccessibilityHitTestSearchCanReturnPlatformView {
   fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
       new flutter::MockAccessibilityBridge());
   fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
   SemanticsObject* object0 = [[SemanticsObject alloc] initWithBridge:bridge uid:0];
   SemanticsObject* object1 = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
   SemanticsObject* object3 = [[SemanticsObject alloc] initWithBridge:bridge uid:3];
-  FakePlatformView* platformView =
-      [[FakePlatformView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  UIView* platformView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
   FlutterPlatformViewSemanticsContainer* platformViewSemanticsContainer =
       [[FlutterPlatformViewSemanticsContainer alloc] initWithBridge:bridge
                                                                 uid:1
@@ -264,13 +246,9 @@ class MockAccessibilityBridgeNoWindow : public AccessibilityBridgeIos {
   [object3 setSemanticsNode:&node3];
 
   CGPoint point = CGPointMake(10, 10);
-  // id partialMockPlatformView = OCMPartialMock(platformView);
-  // OCMStub([partialMockPlatformView _accessibilityHitTest:point
-  // withEvent:nil]).andReturn(subView);
   id hitTestResult = [object0 _accessibilityHitTest:point withEvent:nil];
 
-  // Focus to object2 because it's the first object in hit test order
-  XCTAssertEqual(hitTestResult, platformView.subview);
+  XCTAssertEqual(hitTestResult, platformView);
 }
 
 - (void)testAccessibilityScrollToVisible {


### PR DESCRIPTION
PlatformViewSemanticsContainer did not implement the nativeAccessibility method, leads to a nil object being returned. 

Fixes https://github.com/flutter/flutter/issues/131014

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
