### PR TITLE
[web:a11y] fix interactions between scrolling and focus

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -515,6 +515,10 @@ extension DomNodeExtension on DomNode {
       removeChild(firstChild!);
     }
   }
+
+  @JS('getRootNode')
+  external DomNode _getRootNode();
+  DomNode getRootNode() => _getRootNode();
 }
 
 @JS()

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -1060,3 +1060,25 @@ class OffScreenCanvas {
       !isSafari
       && js_util.hasProperty(domWindow, 'OffscreenCanvas');
 }
+
+/// Determines the shadow scope of the `scopeSibling` then finds the currently
+/// focused (a.k.a. active) element inside it.
+///
+/// The shadow scope is either the subtree under the nearest ancestor shadow
+/// root of the `scopeSibling` element, or the entire document of the page.
+///
+/// If no element is currently active on the page, returns null.
+///
+/// If an element is currently active on the page but that element is in a
+/// different shadow scope, returns null.
+///
+/// If `scopeSibling` is detached from the document, returns null.
+DomElement? getActiveElementInNearestShadowScope(DomNode scopeSibling) {
+  final DomNode root = scopeSibling.getRootNode();
+  if (root is DomDocument) {
+    return root.activeElement;
+  } else if (root is DomShadowRoot) {
+    return root.activeElement;
+  }
+  return null;
+}

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -40,7 +40,7 @@ class LabelAndValue extends RoleManager {
     final bool shouldDisplayValue = hasValue && !semanticsObject.isIncrementable;
 
     if (!hasLabel && !shouldDisplayValue && !hasTooltip) {
-      _cleanUpDom();
+      semanticsObject.element.removeAttribute('aria-label');
       return;
     }
 
@@ -64,15 +64,5 @@ class LabelAndValue extends RoleManager {
 
     semanticsObject.element
         .setAttribute('aria-label', combinedValue.toString());
-  }
-
-  void _cleanUpDom() {
-    semanticsObject.element.removeAttribute('aria-label');
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-    _cleanUpDom();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/130950

Some screen readers, in particular TalkBack on Android, want to scroll to the element that is programmatically focused (more details in the issue). Sometimes, the web engine calls `domElement.focus()` on elements that are scrolled out of the visible viewport, which causes undesired scrolls in the opposite direction from where the user wants to scroll. Additionally, when the currently focused element is removed from the page, TalkBack focuses on the entire `<body>` tag.

To fix the issue, this PR makes the DOM focus more stable as follows:

* When removing a semantics node from the tree, if that node is currently focused, leave a "tombstone", which is the original element with all its attributes intact, but with role managers disposed, the element shifted out of the view and sized to zero, and made `aria-hidden="true"`. Since the element remains focused, it does not cause TalkBack to scroll to anything new.
* When detaching an `AccessibilityFocusManager` from an element, do not `blur()` the element. It is not safe to blur it because, unless another element requests focus, no element will be focused, which will also cause talkback to focus on `<body>`.
* `AccessibilityFocusManager` is now stateful. If it requested the focus on an element before, it won't request it again, unless it was blurred and it is not already focused. This is because requesting focus on an already focused element causes the screen reader to scroll to that element, but the act of shifting focus is not the signal that drives scrolling in Flutter.

Role managers were updated to not do too much clean-up, because the tombstone should continue to look like the original element to the screen reader. Otherwise, changing the role or other ARIA attributes on a focused element risks the screen reader to read the changes out loud.