### PR TITLE
Change a raw string in non-breaking way to fix syntax highlighting.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -608,7 +608,7 @@ def to_gn_args(args):
 
   if args.use_glfw_swiftshader:
     if get_host_os() == 'mac':
-      gn_args['glfw_vulkan_library'] = r'\"libvulkan.dylib\"'
+      gn_args['glfw_vulkan_library'] = r"\"libvulkan.dylib\""
 
   # ANGLE is exclusively used for:
   #  - Windows at runtime


### PR DESCRIPTION
This has no change on the semantics of the Python programming, but fixes syntax highlighting in VSCode:

**Before**:
<img width="630" alt="Screenshot 2023-07-26 at 3 22 51 PM" src="https://github.com/flutter/engine/assets/168174/6301cc76-92a5-45ac-a124-2dbaba8caad2">

**After**:
<img width="632" alt="Screenshot 2023-07-26 at 3 23 06 PM" src="https://github.com/flutter/engine/assets/168174/0af25dc8-7b91-4744-a550-c7606d4117a0">

Happy to revert if this isn't worth landing.