### PR TITLE
[Impeller] trimmed 3 bytes off of each Glyph

### DIFF
--- a/impeller/typographer/glyph.h
+++ b/impeller/typographer/glyph.h
@@ -39,6 +39,8 @@ struct Glyph {
       : index(p_index), type(p_type), bounds(p_bounds) {}
 };
 
+// Many Glyph instances are instantiated, so care should be taken when
+// increasing the size.
 static_assert(sizeof(Glyph) == 20);
 
 }  // namespace impeller

--- a/impeller/typographer/glyph.h
+++ b/impeller/typographer/glyph.h
@@ -17,7 +17,7 @@ namespace impeller {
 /// @brief      The glyph index in the typeface.
 ///
 struct Glyph {
-  enum class Type {
+  enum class Type : uint8_t {
     kPath,
     kBitmap,
   };
@@ -38,6 +38,8 @@ struct Glyph {
   Glyph(uint16_t p_index, Type p_type, Rect p_bounds)
       : index(p_index), type(p_type), bounds(p_bounds) {}
 };
+
+static_assert(sizeof(Glyph) == 20);
 
 }  // namespace impeller
 


### PR DESCRIPTION
While profiling Impeller I saw that we were allocating ~80MB/s of `GlyphPosition`s.  This should shave off 13MB/s by making Glyphs 20 bytes instead of 24.

<img width="1220" alt="Screenshot 2023-07-26 at 4 51 24 PM" src="https://github.com/flutter/engine/assets/30870216/9e65e8bf-9333-4dd1-aa0b-be771412d07b">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
