### PR TITLE
[Impeller] Set 'enable_vulkan_validation_layers' if --unopt and Vulkan is enabled.

### DIFF
--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -149,7 +149,8 @@ void ContextVK::Setup(Settings settings) {
   // 2. We are in a combination of debug mode, and running on Android.
   // (It's possible 2 is overly conservative and we can simplify this)
   auto enable_validation = settings.enable_validation;
-#if defined(FML_DEBUG) && !defined(NDEBUG)
+
+#if defined(FML_OS_ANDROID) && !defined(NDEBUG)
   enable_validation = true;
 #endif
 
@@ -286,8 +287,8 @@ void ContextVK::Setup(Settings settings) {
   auto enabled_device_extensions =
       caps->GetEnabledDeviceExtensions(device_holder->physical_device);
   if (!enabled_device_extensions.has_value()) {
-    // This shouldn't happen since we already did device selection. But doesn't
-    // hurt to check again.
+    // This shouldn't happen since we already did device selection. But
+    // doesn't hurt to check again.
     return;
   }
 
@@ -429,8 +430,8 @@ void ContextVK::Setup(Settings settings) {
   is_valid_ = true;
 
   //----------------------------------------------------------------------------
-  /// Label all the relevant objects. This happens after setup so that the debug
-  /// messengers have had a chance to be set up.
+  /// Label all the relevant objects. This happens after setup so that the
+  /// debug messengers have had a chance to be set up.
   ///
   SetDebugName(GetDevice(), device_holder_->device.get(), "ImpellerDevice");
 }

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -144,8 +144,17 @@ void ContextVK::Setup(Settings settings) {
   auto& dispatcher = VULKAN_HPP_DEFAULT_DISPATCHER;
   dispatcher.init(settings.proc_address_callback);
 
-  auto caps = std::shared_ptr<CapabilitiesVK>(
-      new CapabilitiesVK(settings.enable_validation));
+  // Enable Vulkan validation if either:
+  // 1. The user has explicitly enabled it.
+  // 2. We are in a combination of debug mode, and running on Android.
+  // (It's possible 2 is overly conservative and we can simplify this)
+  auto enable_validation = settings.enable_validation;
+#if defined(FML_DEBUG) && !defined(NDEBUG)
+  enable_validation = true;
+#endif
+
+  auto caps =
+      std::shared_ptr<CapabilitiesVK>(new CapabilitiesVK(enable_validation));
 
   if (!caps->IsValid()) {
     VALIDATION_LOG << "Could not determine device capabilities.";

--- a/tools/gn
+++ b/tools/gn
@@ -593,7 +593,6 @@ def to_gn_args(args):
   if args.enable_impeller_vulkan:
     gn_args['impeller_enable_vulkan'] = True
     
-
   if args.enable_impeller_opengles:
     gn_args['impeller_enable_opengles'] = True
 

--- a/tools/gn
+++ b/tools/gn
@@ -592,9 +592,6 @@ def to_gn_args(args):
 
   if args.enable_impeller_vulkan:
     gn_args['impeller_enable_vulkan'] = True
-    # As of 2023-07-26, --unopt adds "glGetError" calls for the OpenGL backend,
-    # so if --unopt is specified, we also automatically enable Vulkan validation
-    # layers (https://github.com/KhronosGroup/Vulkan-ValidationLayers).
     if args.unoptimized:
       gn_args['enable_vulkan_validation_layers'] = True
 

--- a/tools/gn
+++ b/tools/gn
@@ -563,7 +563,7 @@ def to_gn_args(args):
   if args.fstack_protector:
     gn_args['use_fstack_protector'] = True
 
-  if args.enable_vulkan_validation_layers:
+  if args.enable_vulkan_validation_layers or args.unoptimized:
     if args.target_os == 'android':
       gn_args['android_api_level'] = 26
     gn_args['enable_vulkan_validation_layers'] = True
@@ -592,8 +592,7 @@ def to_gn_args(args):
 
   if args.enable_impeller_vulkan:
     gn_args['impeller_enable_vulkan'] = True
-    if args.unoptimized:
-      gn_args['enable_vulkan_validation_layers'] = True
+    
 
   if args.enable_impeller_opengles:
     gn_args['impeller_enable_opengles'] = True

--- a/tools/gn
+++ b/tools/gn
@@ -592,6 +592,11 @@ def to_gn_args(args):
 
   if args.enable_impeller_vulkan:
     gn_args['impeller_enable_vulkan'] = True
+    # As of 2023-07-26, --unopt adds "glGetError" calls for the OpenGL backend,
+    # so if --unopt is specified, we also automatically enable Vulkan validation
+    # layers (https://github.com/KhronosGroup/Vulkan-ValidationLayers).
+    if args.unoptimized:
+      gn_args['enable_vulkan_validation_layers'] = True
 
   if args.enable_impeller_opengles:
     gn_args['impeller_enable_opengles'] = True

--- a/tools/gn
+++ b/tools/gn
@@ -563,7 +563,7 @@ def to_gn_args(args):
   if args.fstack_protector:
     gn_args['use_fstack_protector'] = True
 
-  if args.enable_vulkan_validation_layers
+  if args.enable_vulkan_validation_layers:
     if args.target_os == 'android':
       gn_args['android_api_level'] = 26
     gn_args['enable_vulkan_validation_layers'] = True

--- a/tools/gn
+++ b/tools/gn
@@ -592,7 +592,7 @@ def to_gn_args(args):
 
   if args.enable_impeller_vulkan:
     gn_args['impeller_enable_vulkan'] = True
-    
+
   if args.enable_impeller_opengles:
     gn_args['impeller_enable_opengles'] = True
 

--- a/tools/gn
+++ b/tools/gn
@@ -563,9 +563,13 @@ def to_gn_args(args):
   if args.fstack_protector:
     gn_args['use_fstack_protector'] = True
 
-  if args.enable_vulkan_validation_layers or args.unoptimized:
+  if args.enable_vulkan_validation_layers
     if args.target_os == 'android':
       gn_args['android_api_level'] = 26
+    gn_args['enable_vulkan_validation_layers'] = True
+
+  # Enable Vulkan validation layer automatically on debug builds for arm64.
+  if args.unoptimized and args.target_os == 'android' and args.android_cpu == 'arm64':
     gn_args['enable_vulkan_validation_layers'] = True
 
   # Enable pointer compression on 64-bit mobile targets. iOS is excluded due to


### PR DESCRIPTION
Context:

> @matanlurey:
> Would it make sense for `--unopt` to imply `--enable-vulkan-validation-layers` if `--enable-vulkan` is set?
> The reason I ask is because it does seem to imply `glGetError` checks, which (I could be wrong) is roughly similar?

> @chinmaygarde:
> Makes sense.

... so uh, here it is (let me know if we prefer anything different).