### PR TITLE
[Impeller] Switched Command::label to LightweightString

### DIFF
--- a/fml/lightweight_string.h
+++ b/fml/lightweight_string.h
@@ -1,0 +1,84 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_LIGHTWEIGHT_STRING_H_
+#define FLUTTER_FML_LIGHTWEIGHT_STRING_H_
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "flutter/fml/logging.h"
+#include "flutter/fml/macros.h"
+
+namespace fml {
+
+/// An 16 byte string that does not copy string literals.
+class LightweightString {
+ public:
+  LightweightString() {
+    str_.c = nullptr;
+    is_owned_ = false;
+  }
+
+  LightweightString(const LightweightString& str) {
+    if (str.is_owned_) {
+      str_.c = strdup(str.str_.cc);
+      is_owned_ = true;
+    } else {
+      str_.cc = str.str_.cc;
+      is_owned_ = false;
+    }
+  }
+
+  template <size_t N>
+  constexpr LightweightString(const char (&s)[N]) {
+    str_.cc = s;
+    is_owned_ = false;
+  }
+
+  LightweightString(const std::string& str) {
+    str_.c = strdup(str.c_str());
+    is_owned_ = true;
+  }
+
+  ~LightweightString() {
+    if (is_owned_) {
+      free(str_.c);
+    }
+  }
+
+  const char* c_str() const { return str_.cc; }
+
+  bool empty() const { return str_.cc == nullptr; }
+
+  LightweightString& operator=(const LightweightString& str) {
+    if (is_owned_) {
+      free(str_.c);
+    }
+    if (str.is_owned_) {
+      str_.c = strdup(str.str_.cc);
+      is_owned_ = true;
+    } else {
+      str_.cc = str.str_.cc;
+      is_owned_ = false;
+    }
+    return *this;
+  }
+
+ private:
+  typedef union {
+    char* c;
+    const char* cc;
+  } StrPtr;
+
+  StrPtr str_;
+  uint8_t is_owned_;
+};
+
+static_assert(sizeof(LightweightString) < sizeof(std::string));
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_LIGHTWEIGHT_STRING_H_

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -138,9 +138,10 @@ bool TextureContents::Render(const ContentContext& renderer,
   frame_info.alpha = GetOpacity();
 
   Command cmd;
-  cmd.label = "Texture Fill";
-  if (!label_.empty()) {
-    cmd.label += ": " + label_;
+  if (label_.empty()) {
+    cmd.label = "Texture Fill";
+  } else {
+    cmd.label = "Texture Fill: " + label_;
   }
 
   auto pipeline_options = OptionsFromPassAndEntity(pass, entity);

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -139,7 +139,11 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
   frame_info.alpha = GetOpacityFactor();
 
   Command cmd;
-  cmd.label = uses_emulated_tile_mode ? "TiledTextureFill" : "TextureFill";
+  if (uses_emulated_tile_mode) {
+    cmd.label = "TiledTextureFill";
+  } else {
+    cmd.label = "TextureFill";
+  }
   cmd.stencil_reference = entity.GetStencilDepth();
 
   auto options = OptionsFromPassAndEntity(pass, entity);

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -247,7 +247,7 @@ struct RenderPassData {
     fml::ScopedCleanupClosure pop_cmd_debug_marker(
         [&gl]() { gl.PopDebugGroup(); });
     if (!command.label.empty()) {
-      gl.PushDebugGroup(command.label);
+      gl.PushDebugGroup(command.label.c_str());
     } else {
       pop_cmd_debug_marker.Release();
     }

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 
+#include "flutter/fml/lightweight_string.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "impeller/core/buffer_view.h"
@@ -119,7 +120,7 @@ struct Command : public ResourceBinder {
   //----------------------------------------------------------------------------
   /// The debugging label to use for the command.
   ///
-  std::string label;
+  fml::LightweightString label;
   //----------------------------------------------------------------------------
   /// The reference value to use in stenciling operations. Stencil configuration
   /// is part of pipeline setup and can be read from the pipelines descriptor.
@@ -204,5 +205,13 @@ struct Command : public ResourceBinder {
                       T metadata,
                       const BufferView& view);
 };
+
+// Many Commands are allocated per frame so care should be taken when increasing
+// their size.
+#if defined(__SIZEOF_POINTER__)
+#if __SIZEOF_POINTER__ == 8
+static_assert(sizeof(Command) == 432);
+#endif
+#endif
 
 }  // namespace impeller


### PR DESCRIPTION
While profiling gallery it was noted that 160 MB/s was getting allocated from Commands.  This remove 8 bytes per Command and the string duplication for each command.  For example, 10 bytes per "TextFrame" command.

So, that works out to about 7 MB / s.  It's not a huge savings but it's just wasted memory that can exacerbate memory fragmentation.

There isn't a good way to force string literals be used in C++ for instance variables that I could figure out.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
