### PR TITLE
[Impeller] no-op fragment program on Android until it works. (#43657)

### DIFF
--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -44,6 +44,13 @@ bool RuntimeEffectContents::CanInheritOpacity(const Entity& entity) const {
 bool RuntimeEffectContents::Render(const ContentContext& renderer,
                                    const Entity& entity,
                                    RenderPass& pass) const {
+// TODO(jonahwilliams): FragmentProgram API is not fully wired up on Android.
+// Disable until this is complete so that integration tests and benchmarks can
+// run m3 applications.
+#ifdef FML_OS_ANDROID
+  return true;
+#endif
+
   auto context = renderer.GetContext();
   auto library = context->GetShaderLibrary();
 


### PR DESCRIPTION
The framework has switched into mat3 by default, which means the fragment program ink sparkle has replaced the default ink splash. Since this is not implemented, all of the impeller benchmarks are crashing.

