### PR TITLE
Hide some log lines from release builds

### DIFF
--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -18,8 +18,8 @@ void PlatformViewLayer::Preroll(PrerollContext* context) {
                                     size_.height()));
 
   if (context->view_embedder == nullptr) {
-    FML_LOG(ERROR) << "Trying to embed a platform view but the PrerollContext "
-                      "does not support embedding";
+    FML_DLOG(ERROR) << "Trying to embed a platform view but the PrerollContext "
+                       "does not support embedding";
     return;
   }
   context->has_platform_view = true;
@@ -36,8 +36,8 @@ void PlatformViewLayer::Preroll(PrerollContext* context) {
 
 void PlatformViewLayer::Paint(PaintContext& context) const {
   if (context.view_embedder == nullptr) {
-    FML_LOG(ERROR) << "Trying to embed a platform view but the PaintContext "
-                      "does not support embedding";
+    FML_DLOG(ERROR) << "Trying to embed a platform view but the PaintContext "
+                       "does not support embedding";
     return;
   }
   DlCanvas* canvas = context.view_embedder->CompositeEmbeddedView(view_id_);


### PR DESCRIPTION
These lines are appearing in framework tests but do not appear to have significant diagnostic value.
