### PR TITLE
Update CompositionAwareMixin to correctly compute composingBase in Web engine

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ TheOneWithTheBraid <the-one@with-the-braid.cf>
 Twin Sun, LLC <google-contrib@twinsunsolutions.com>
 Qixing Cao <qixing.cao.83@gmail.com>
 LinXunFeng <linxunfeng@yeah.net>
+Amir Panahandeh <amirpanahandeh@gmail.com>

--- a/lib/web_ui/lib/src/engine/text_editing/composition_aware_mixin.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/composition_aware_mixin.dart
@@ -75,7 +75,7 @@ mixin CompositionAwareMixin {
       return editingState;
     }
 
-    final int composingBase = editingState.baseOffset! - composingText!.length;
+    final int composingBase = editingState.extentOffset! - composingText!.length;
 
     if (composingBase < 0) {
       return editingState;

--- a/lib/web_ui/lib/src/engine/text_editing/composition_aware_mixin.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/composition_aware_mixin.dart
@@ -71,7 +71,7 @@ mixin CompositionAwareMixin {
   }
 
   EditingState determineCompositionState(EditingState editingState) {
-    if (editingState.baseOffset == null || composingText == null || editingState.text == null) {
+    if (editingState.extentOffset == null || composingText == null || editingState.text == null) {
       return editingState;
     }
 

--- a/lib/web_ui/test/engine/composition_test.dart
+++ b/lib/web_ui/test/engine/composition_test.dart
@@ -106,7 +106,7 @@ Future<void> testMain() async {
     });
 
     group('determine composition state', () {
-      test('should return new composition state if valid new composition', () {
+      test('should return new composition state - compositing middle of text', () {
         const int baseOffset = 100;
         const String composingText = 'composeMe';
 
@@ -127,6 +127,30 @@ Future<void> testMain() async {
             editingState.copyWith(
                 composingBaseOffset: expectedComposingBase,
                 composingExtentOffset: expectedComposingBase + composingText.length));
+      });
+
+      test('should return new composition state - compositing from beginning of text', () {
+        const String composingText = '今日は';
+
+        final EditingState editingState = EditingState(
+          text: '今日は',
+          baseOffset: 0,
+          extentOffset: 3,
+        );
+
+        final _MockWithCompositionAwareMixin mockWithCompositionAwareMixin =
+            _MockWithCompositionAwareMixin();
+        mockWithCompositionAwareMixin.composingText = composingText;
+
+        const int expectedComposingBase = 0;
+
+        expect(
+            mockWithCompositionAwareMixin
+                .determineCompositionState(editingState),
+            editingState.copyWith(
+                composingBaseOffset: expectedComposingBase,
+                composingExtentOffset:
+                    expectedComposingBase + composingText.length));
       });
     });
   });


### PR DESCRIPTION
It fixes an issue in `CompositionAwareMixin` causing wrong deltas being computed and reported to input clients resulting in wrong state when compositing text in rich text editors like [Fleather](https://github.com/fleather-editor/fleather) and possibly others.

Reported deltas on Mac:
```console
TextEditingDeltaInsertion: start: 0, end: 0, data: k
TextEditingDeltaInsertion: start: 1, end: 0, data: y
TextEditingDeltaReplacement: start: 0, end: 2, data: きょ
TextEditingDeltaInsertion: start: 2, end: 0, data: う
TextEditingDeltaInsertion: start: 3, end: 0, data: h
TextEditingDeltaReplacement: start: 0, end: 4, data: きょうは
TextEditingDeltaReplacement: start: 0, end: 4, data: 今日は
```

Reported deltas on Web (Before):
```console
TextEditingDeltaInsertion: start: 0, end: 0, data: k
TextEditingDeltaInsertion: start: 1, end: 0, data: y
TextEditingDeltaReplacement: start: 0, end: 2, data: きょ
TextEditingDeltaInsertion: start: 2, end: 0, data: う
TextEditingDeltaInsertion: start: 3, end: 0, data: h
TextEditingDeltaReplacement: start: 0, end: 4, data: きょうは
TextEditingDeltaInsertion: start: 4, end: 0, data: 今日は
```

Reported deltas on Web (After):
```console
TextEditingDeltaInsertion: start: 0, end: 0, data: k
TextEditingDeltaInsertion: start: 1, end: 0, data: y
TextEditingDeltaReplacement: start: 0, end: 2, data: きょ
TextEditingDeltaInsertion: start: 2, end: 0, data: う
TextEditingDeltaInsertion: start: 3, end: 0, data: h
TextEditingDeltaReplacement: start: 0, end: 4, data: きょうは
TextEditingDeltaReplacement: start: 0, end: 4, data: 今日は
```


* Fixes https://github.com/flutter/flutter/issues/131335
* Fixes https://github.com/fleather-editor/fleather/issues/150

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
