### PR TITLE
[Impeller] Create a wrapper Impeller context for each Vulkan surface and its swapchain

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1549,6 +1549,8 @@ ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/shader_library_vk.cc +
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/shader_library_vk.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/shared_object_vk.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/shared_object_vk.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/surface_context_vk.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/surface_context_vk.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/surface_vk.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/surface_vk.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/vulkan/swapchain_image_vk.cc + ../../../flutter/LICENSE
@@ -4240,6 +4242,8 @@ FILE: ../../../flutter/impeller/renderer/backend/vulkan/shader_library_vk.cc
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/shader_library_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/shared_object_vk.cc
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/shared_object_vk.h
+FILE: ../../../flutter/impeller/renderer/backend/vulkan/surface_context_vk.cc
+FILE: ../../../flutter/impeller/renderer/backend/vulkan/surface_context_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/surface_vk.cc
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/surface_vk.h
 FILE: ../../../flutter/impeller/renderer/backend/vulkan/swapchain_image_vk.cc

--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -79,6 +79,8 @@ impeller_component("vulkan") {
     "shader_library_vk.h",
     "shared_object_vk.cc",
     "shared_object_vk.h",
+    "surface_context_vk.cc",
+    "surface_context_vk.h",
     "surface_vk.cc",
     "surface_vk.h",
     "swapchain_image_vk.cc",

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -32,6 +32,7 @@ class CommandEncoderVK;
 class DebugReportVK;
 class FenceWaiterVK;
 class ResourceManagerVK;
+class SurfaceContextVK;
 
 class ContextVK final : public Context,
                         public BackendCast<ContextVK, Context>,
@@ -127,13 +128,7 @@ class ContextVK final : public Context,
   const std::shared_ptr<fml::ConcurrentTaskRunner>
   GetConcurrentWorkerTaskRunner() const;
 
-  [[nodiscard]] bool SetWindowSurface(vk::UniqueSurfaceKHR surface);
-
-  std::unique_ptr<Surface> AcquireNextSurface();
-
-#ifdef FML_OS_ANDROID
-  vk::UniqueSurfaceKHR CreateAndroidSurface(ANativeWindow* window) const;
-#endif  // FML_OS_ANDROID
+  std::shared_ptr<SurfaceContextVK> CreateSurfaceContext();
 
   const std::shared_ptr<QueueVK>& GetGraphicsQueue() const;
 
@@ -164,7 +159,6 @@ class ContextVK final : public Context,
   std::shared_ptr<SamplerLibraryVK> sampler_library_;
   std::shared_ptr<PipelineLibraryVK> pipeline_library_;
   QueuesVK queues_;
-  std::shared_ptr<SwapchainVK> swapchain_;
   std::shared_ptr<const Capabilities> device_capabilities_;
   std::shared_ptr<FenceWaiterVK> fence_waiter_;
   std::shared_ptr<ResourceManagerVK> resource_manager_;

--- a/impeller/renderer/backend/vulkan/surface_context_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.cc
@@ -1,0 +1,107 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/surface_context_vk.h"
+
+#include "flutter/fml/trace_event.h"
+#include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/swapchain_vk.h"
+
+namespace impeller {
+
+SurfaceContextVK::SurfaceContextVK(const std::shared_ptr<ContextVK>& parent)
+    : parent_(parent) {}
+
+SurfaceContextVK::~SurfaceContextVK() = default;
+
+Context::BackendType SurfaceContextVK::GetBackendType() const {
+  return parent_->GetBackendType();
+}
+
+std::string SurfaceContextVK::DescribeGpuModel() const {
+  return parent_->DescribeGpuModel();
+}
+
+bool SurfaceContextVK::IsValid() const {
+  return parent_->IsValid();
+}
+
+std::shared_ptr<Allocator> SurfaceContextVK::GetResourceAllocator() const {
+  return parent_->GetResourceAllocator();
+}
+
+std::shared_ptr<ShaderLibrary> SurfaceContextVK::GetShaderLibrary() const {
+  return parent_->GetShaderLibrary();
+}
+
+std::shared_ptr<SamplerLibrary> SurfaceContextVK::GetSamplerLibrary() const {
+  return parent_->GetSamplerLibrary();
+}
+
+std::shared_ptr<PipelineLibrary> SurfaceContextVK::GetPipelineLibrary() const {
+  return parent_->GetPipelineLibrary();
+}
+
+std::shared_ptr<CommandBuffer> SurfaceContextVK::CreateCommandBuffer() const {
+  return parent_->CreateCommandBuffer();
+}
+
+const std::shared_ptr<const Capabilities>& SurfaceContextVK::GetCapabilities()
+    const {
+  return parent_->GetCapabilities();
+}
+
+void SurfaceContextVK::Shutdown() {
+  parent_->Shutdown();
+}
+
+bool SurfaceContextVK::SetWindowSurface(vk::UniqueSurfaceKHR surface) {
+  auto swapchain = SwapchainVK::Create(parent_, std::move(surface));
+  if (!swapchain) {
+    VALIDATION_LOG << "Could not create swapchain.";
+    return false;
+  }
+  swapchain_ = std::move(swapchain);
+  return true;
+}
+
+std::unique_ptr<Surface> SurfaceContextVK::AcquireNextSurface() {
+  TRACE_EVENT0("impeller", __FUNCTION__);
+  auto surface = swapchain_ ? swapchain_->AcquireNextDrawable() : nullptr;
+  auto pipeline_library = parent_->GetPipelineLibrary();
+  if (surface && pipeline_library) {
+    impeller::PipelineLibraryVK::Cast(*pipeline_library)
+        .DidAcquireSurfaceFrame();
+  }
+  auto allocator = parent_->GetResourceAllocator();
+  if (allocator) {
+    allocator->DidAcquireSurfaceFrame();
+  }
+  return surface;
+}
+
+#ifdef FML_OS_ANDROID
+
+vk::UniqueSurfaceKHR SurfaceContextVK::CreateAndroidSurface(
+    ANativeWindow* window) const {
+  if (!parent_->GetInstance()) {
+    return vk::UniqueSurfaceKHR{VK_NULL_HANDLE};
+  }
+
+  auto create_info = vk::AndroidSurfaceCreateInfoKHR().setWindow(window);
+  auto surface_res =
+      parent_->GetInstance().createAndroidSurfaceKHRUnique(create_info);
+
+  if (surface_res.result != vk::Result::eSuccess) {
+    VALIDATION_LOG << "Could not create Android surface, error: "
+                   << vk::to_string(surface_res.result);
+    return vk::UniqueSurfaceKHR{VK_NULL_HANDLE};
+  }
+
+  return std::move(surface_res.value);
+}
+
+#endif  // FML_OS_ANDROID
+
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/surface_context_vk.h
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.h
@@ -1,0 +1,70 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+
+#include "impeller/base/backend_cast.h"
+#include "impeller/renderer/backend/vulkan/vk.h"
+#include "impeller/renderer/context.h"
+
+namespace impeller {
+
+class ContextVK;
+class Surface;
+class SwapchainVK;
+
+class SurfaceContextVK : public Context,
+                         public BackendCast<SurfaceContextVK, Context> {
+ public:
+  SurfaceContextVK(const std::shared_ptr<ContextVK>& parent);
+
+  // |Context|
+  ~SurfaceContextVK() override;
+
+  // |Context|
+  BackendType GetBackendType() const override;
+
+  // |Context|
+  std::string DescribeGpuModel() const override;
+
+  // |Context|
+  bool IsValid() const override;
+
+  // |Context|
+  std::shared_ptr<Allocator> GetResourceAllocator() const override;
+
+  // |Context|
+  std::shared_ptr<ShaderLibrary> GetShaderLibrary() const override;
+
+  // |Context|
+  std::shared_ptr<SamplerLibrary> GetSamplerLibrary() const override;
+
+  // |Context|
+  std::shared_ptr<PipelineLibrary> GetPipelineLibrary() const override;
+
+  // |Context|
+  std::shared_ptr<CommandBuffer> CreateCommandBuffer() const override;
+
+  // |Context|
+  const std::shared_ptr<const Capabilities>& GetCapabilities() const override;
+
+  // |Context|
+  void Shutdown() override;
+
+  [[nodiscard]] bool SetWindowSurface(vk::UniqueSurfaceKHR surface);
+
+  std::unique_ptr<Surface> AcquireNextSurface();
+
+#ifdef FML_OS_ANDROID
+  vk::UniqueSurfaceKHR CreateAndroidSurface(ANativeWindow* window) const;
+#endif  // FML_OS_ANDROID
+
+ private:
+  std::shared_ptr<ContextVK> parent_;
+  std::shared_ptr<SwapchainVK> swapchain_;
+};
+
+}  // namespace impeller

--- a/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -7,7 +7,8 @@
 #include "flutter/fml/make_copyable.h"
 #include "flutter/impeller/display_list/dl_dispatcher.h"
 #include "flutter/impeller/renderer/renderer.h"
-#include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/surface_context_vk.h"
+#include "impeller/renderer/surface.h"
 
 namespace flutter {
 
@@ -54,7 +55,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     return nullptr;
   }
 
-  auto& context_vk = impeller::ContextVK::Cast(*impeller_context_);
+  auto& context_vk = impeller::SurfaceContextVK::Cast(*impeller_context_);
   std::unique_ptr<impeller::Surface> surface = context_vk.AcquireNextSurface();
 
   SurfaceFrame::SubmitCallback submit_callback =

--- a/shell/platform/android/android_surface_vulkan_impeller.h
+++ b/shell/platform/android/android_surface_vulkan_impeller.h
@@ -6,7 +6,7 @@
 
 #include "flutter/fml/concurrent_message_loop.h"
 #include "flutter/fml/macros.h"
-#include "flutter/impeller/renderer/context.h"
+#include "flutter/impeller/renderer/backend/vulkan/surface_context_vk.h"
 #include "flutter/shell/platform/android/android_context_vulkan_impeller.h"
 #include "flutter/shell/platform/android/surface/android_native_window.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
@@ -46,7 +46,7 @@ class AndroidSurfaceVulkanImpeller : public AndroidSurface {
   bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
 
  private:
-  std::shared_ptr<AndroidContextVulkanImpeller> android_context_;
+  std::shared_ptr<impeller::SurfaceContextVK> surface_context_vk_;
   fml::RefPtr<AndroidNativeWindow> native_window_;
   bool is_valid_ = false;
 


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/41059 the Android context and surface were changed to share one impeller::ContextVK across all instances of AndroidSurfaceVulkanImpeller.  However, the ContextVK holds a reference to the current swapchain.  If an app uses multiple AndroidSurfaceVulkanImpeller instances (e.g. for platform views), then one surface may overwrite the ContextVK's swapchain while another surface is trying to render.

This patch allows each surface to get its own impeller::Context instance holding a swapchain tied to that surface.  The per-surface contexts will delegate most operations to the shared parent ContextVK.
