### PR TITLE
[Impeller] moved to one staging buffer pool

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -73,8 +73,7 @@ static PoolVMA CreateBufferPool(VmaAllocator allocator) {
 
   VmaPoolCreateInfo pool_create_info = {};
   pool_create_info.memoryTypeIndex = memTypeIndex;
-  pool_create_info.flags = VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT |
-                           VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT;
+  pool_create_info.flags = VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT;
 
   VmaPool pool = {};
   result = vk::Result{::vmaCreatePool(allocator, &pool_create_info, &pool)};

--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -161,10 +161,8 @@ AllocatorVK::AllocatorVK(std::weak_ptr<Context> context,
     VALIDATION_LOG << "Could not create memory allocator";
     return;
   }
-  for (size_t i = 0u; i < staging_buffer_pools_.size(); i++) {
-    staging_buffer_pools_[i].reset(CreateBufferPool(allocator));
-    created_buffer_pools_ &= staging_buffer_pools_[i].is_valid();
-  }
+  staging_buffer_pool_.reset(CreateBufferPool(allocator));
+  created_buffer_pool_ &= staging_buffer_pool_.is_valid();
   allocator_.reset(allocator);
   supports_memoryless_textures_ = capabilities.SupportsMemorylessTextures();
   is_valid_ = true;
@@ -460,12 +458,9 @@ std::shared_ptr<DeviceBuffer> AllocatorVK::OnCreateBuffer(
   allocation_info.preferredFlags = static_cast<VkMemoryPropertyFlags>(
       ToVKBufferMemoryPropertyFlags(desc.storage_mode));
   allocation_info.flags = ToVmaAllocationBufferCreateFlags(desc.storage_mode);
-  if (created_buffer_pools_ && desc.storage_mode == StorageMode::kHostVisible &&
+  if (created_buffer_pool_ && desc.storage_mode == StorageMode::kHostVisible &&
       raster_thread_id_ == std::this_thread::get_id()) {
-    allocation_info.pool =
-        staging_buffer_pools_[frame_count_ % staging_buffer_pools_.size()]
-            .get()
-            .pool;
+    allocation_info.pool = staging_buffer_pool_.get().pool;
   }
 
   VkBuffer buffer = {};

--- a/impeller/renderer/backend/vulkan/allocator_vk.h
+++ b/impeller/renderer/backend/vulkan/allocator_vk.h
@@ -26,18 +26,16 @@ class AllocatorVK final : public Allocator {
  private:
   friend class ContextVK;
 
-  static constexpr size_t kPoolCount = 3;
-
   fml::RefPtr<vulkan::VulkanProcTable> vk_;
   UniqueAllocatorVMA allocator_;
-  std::array<UniquePoolVMA, kPoolCount> staging_buffer_pools_;
+  UniquePoolVMA staging_buffer_pool_;
   std::weak_ptr<Context> context_;
   std::weak_ptr<DeviceHolder> device_holder_;
   ISize max_texture_size_;
   bool is_valid_ = false;
   bool supports_memoryless_textures_ = false;
   // TODO(jonahwilliams): figure out why CI can't create these buffer pools.
-  bool created_buffer_pools_ = true;
+  bool created_buffer_pool_ = true;
   uint32_t frame_count_ = 0;
   std::thread::id raster_thread_id_;
 


### PR DESCRIPTION
I measured the pool usage while using the wonderous app after having consolidated the pools by printing capturing the pool usage after every call of `vmaCreateBuffer`.  The max number of allocations ever seen in this pool were 1288704 B.  Each of these pools are 32 MB.  So this change removes 64MB from the baseline memory usage of a Vulkan Flutter engine.  Worse case for a swapchain of 3 would be roughly 3 * 1.2 MB which is well within the limits of the 32 MB buffer.

Using one pool also increases the likelihood that a buffer will have been more recently used which leads to better memory performance.

This is safe to do since buffers will only be placed back into the pool after they are disposed of.

## patch used for measuring
```diff
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -474,6 +474,15 @@ std::shared_ptr<DeviceBuffer> AllocatorVK::OnCreateBuffer(
                                              &buffer_allocation_info  //
                                              )};
 
+  VmaStatistics pool_stats;
+  ::vmaGetPoolStatistics(allocator_.get(), staging_buffer_pool_.get().pool,
+                         &pool_stats);
+  static uint64_t s_max = 0;
+  if (pool_stats.allocationBytes > s_max) {
+    s_max = pool_stats.allocationBytes;
+    FML_LOG(ERROR) << "pool max: " << s_max;
+  }
+
   if (result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Unable to allocate a device buffer: "
                    << vk::to_string(result);
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
