### PR TITLE
Remove extends JSTypedArray from JSUint8Array1

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -204,7 +204,7 @@ Future<Uint8List> readChunked(HttpFetchPayload payload, int contentLength, WebOn
   final JSUint8Array result = createUint8ArrayFromLength(contentLength);
   int position = 0;
   int cumulativeBytesLoaded = 0;
-  await payload.read<JSUint8Array1>((JSUint8Array1 chunk) {
+  await payload.read<JSUint8Array>((JSUint8Array chunk) {
     cumulativeBytesLoaded += chunk.length.toDartInt;
     chunkCallback(cumulativeBytesLoaded, contentLength);
     result.set(chunk, position.toJS);

--- a/lib/web_ui/lib/src/engine/js_interop/js_typed_data.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_typed_data.dart
@@ -15,7 +15,7 @@ extension TypedArrayExtension on JSTypedArray {
 // the dart sdk yet
 @JS('Uint8Array')
 @staticInterop
-class JSUint8Array1 extends JSTypedArray {
+class JSUint8Array1 {
   external factory JSUint8Array1._create1(JSAny bufferOrLength);
   external factory JSUint8Array1._create3(
     JSArrayBuffer buffer,


### PR DESCRIPTION
Any user @staticInterop types should only subtype the dart:js_interop types JSObject and or JSAny as user @staticInterop types erase to JSObject.

In the future, the other JS types will be added as extension types, allowing users to implement them with their own extension types.

Allows https://dart-review.googlesource.com/c/sdk/+/316865/1 to be landed.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.
