### PR TITLE
[ios][autocorrection]disable auto-correction highlight in iOS 17

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1632,10 +1632,21 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
   if (_scribbleInteractionStatus == FlutterScribbleInteractionStatusNone &&
       _scribbleFocusStatus == FlutterScribbleFocusStatusUnfocused) {
-    [self.textInputDelegate flutterTextInputView:self
-            showAutocorrectionPromptRectForStart:start
-                                             end:end
-                                      withClient:_textInputClient];
+    if (@available(iOS 17.0, *)) {
+      // Disable auto-correction highlight feature for iOS 17.
+      // In iOS 17, whenever a character is inserted or deleted, the system will always query
+      // the rect for every single character of the current word.
+      // GitHub Issue: https://github.com/flutter/flutter/issues/128406
+    } else {
+      // This tells the framework to show the highlight for incorrectly spelled word that is
+      // about to be auto-corrected.
+      // There is no other UITextInput API that informs about the auto-correction highlight.
+      // So we simply add the call here as a workaround.
+      [self.textInputDelegate flutterTextInputView:self
+              showAutocorrectionPromptRectForStart:start
+                                               end:end
+                                        withClient:_textInputClient];
+    }
   }
 
   NSUInteger first = start;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -314,6 +314,11 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testAutocorrectionPromptRectAppears {
+  // Auto-correction prompt is disabled in iOS 17.
+  if (@available(iOS 17.0, *)) {
+    return;
+  }
+
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
   [inputView firstRectForRange:[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)]];
 
@@ -353,6 +358,11 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testAutocorrectionPromptRectDoesNotAppearDuringScribble {
+  // Auto-correction prompt is disabled in iOS 17.
+  if (@available(iOS 17.0, *)) {
+    return;
+  }
+
   if (@available(iOS 14.0, *)) {
     FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
 


### PR DESCRIPTION
This PR disables the "auto-correction highlight" feature introduced in https://github.com/flutter/flutter/pull/45354 and https://github.com/flutter/engine/pull/13959/ 

Note that auto-correction still works, it's only the "highlight" part is disabled. 

(CC: @LongCatIsLooong who was the original author)

## Why remove this feature?

The original PR uses `UITextInput::firstRectForRange` API for auto-correction, since Apple does not provide any other API when auto-correction should show up, so that PR used this API as a workaround. 

In iOS 17, Apple changed a few `UITextInput` behaviors:  
- UIKit does not query `UITextInput::firstRectForRange` for text range of the auto-corrected word. 
- But instead, it repeatedly queries every single character of the current word (after entering or deleting a character), regardless whether the word should be auto-corrected or not. 

I have tried all other `UITextInput` APIs that takes a text range, and none are suitable for auto-correction feature. As a result, I have to disable this feature for iOS 17 for now. 

I have created a new issue (TODO) to find other approaches to re-enable this feature. 

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/128406

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
