### PR TITLE
[Windows] Delay enabling app lifecycle states until requested

### DIFF
--- a/shell/platform/windows/fixtures/main.dart
+++ b/shell/platform/windows/fixtures/main.dart
@@ -128,6 +128,21 @@ void exitTestCancel() async {
 }
 
 @pragma('vm:entry-point')
+void enableLifecycleTest() async {
+  final Completer<ByteData?> finished = Completer<ByteData?>();
+  ui.channelBuffers.setListener('flutter/lifecycle', (ByteData? data, ui.PlatformMessageResponseCallback callback) async {
+    if (data != null) {
+      ui.PlatformDispatcher.instance.sendPlatformMessage(
+        'flutter/unittest',
+        data,
+        (ByteData? reply) {
+        });
+    }
+  });
+  await finished.future;
+}
+
+@pragma('vm:entry-point')
 void customEntrypoint() {}
 
 @pragma('vm:entry-point')

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -158,8 +158,7 @@ FlutterLocale CovertToFlutterLocale(const LanguageInfo& info) {
 
 FlutterWindowsEngine::FlutterWindowsEngine(const FlutterProjectBundle& project)
     : project_(std::make_unique<FlutterProjectBundle>(project)),
-      aot_data_(nullptr, nullptr),
-      lifecycle_manager_(std::make_unique<WindowsLifecycleManager>(this)) {
+      aot_data_(nullptr, nullptr) {
   embedder_api_.struct_size = sizeof(FlutterEngineProcTable);
   FlutterEngineGetProcAddresses(&embedder_api_);
 
@@ -230,6 +229,7 @@ FlutterWindowsEngine::FlutterWindowsEngine(const FlutterProjectBundle& project)
       std::make_unique<PlatformHandler>(messenger_wrapper_.get(), this);
   settings_plugin_ = std::make_unique<SettingsPlugin>(messenger_wrapper_.get(),
                                                       task_runner_.get());
+  lifecycle_manager_ = std::make_unique<WindowsLifecycleManager>(messenger_wrapper_.get(), this);
 }
 
 FlutterWindowsEngine::~FlutterWindowsEngine() {

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -826,6 +826,9 @@ bool FlutterWindowsEngine::SendAppLifecycleStateUpdate(
 
 void FlutterWindowsEngine::SetAppLifecycleStateEnabled(bool enabled) {
   app_lifecycle_enabled_ = enabled;
+  if (enabled) {
+    SendAppLifecycleStateUpdate(lifecycle_manager_->GetLifecycleState());
+  }
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -229,7 +229,8 @@ FlutterWindowsEngine::FlutterWindowsEngine(const FlutterProjectBundle& project)
       std::make_unique<PlatformHandler>(messenger_wrapper_.get(), this);
   settings_plugin_ = std::make_unique<SettingsPlugin>(messenger_wrapper_.get(),
                                                       task_runner_.get());
-  lifecycle_manager_ = std::make_unique<WindowsLifecycleManager>(messenger_wrapper_.get(), this);
+  lifecycle_manager_ =
+      std::make_unique<WindowsLifecycleManager>(messenger_wrapper_.get(), this);
 }
 
 FlutterWindowsEngine::~FlutterWindowsEngine() {
@@ -812,12 +813,15 @@ std::optional<LRESULT> FlutterWindowsEngine::ProcessExternalWindowMessage(
   return std::nullopt;
 }
 
-bool FlutterWindowsEngine::SendAppLifecycleStateUpdate(AppLifecycleState state) {
+bool FlutterWindowsEngine::SendAppLifecycleStateUpdate(
+    AppLifecycleState state) {
   if (!app_lifecycle_enabled_) {
     return false;
   }
   const char* state_name = AppLifecycleStateToString(state);
-  return SendPlatformMessage("flutter/lifecycle", reinterpret_cast<const uint8_t*>(state_name), strlen(state_name), nullptr, nullptr);
+  return SendPlatformMessage("flutter/lifecycle",
+                             reinterpret_cast<const uint8_t*>(state_name),
+                             strlen(state_name), nullptr, nullptr);
 }
 
 void FlutterWindowsEngine::SetAppLifecycleStateEnabled(bool enabled) {

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -812,4 +812,16 @@ std::optional<LRESULT> FlutterWindowsEngine::ProcessExternalWindowMessage(
   return std::nullopt;
 }
 
+bool FlutterWindowsEngine::SendAppLifecycleStateUpdate(AppLifecycleState state) {
+  if (!app_lifecycle_enabled_) {
+    return false;
+  }
+  const char* state_name = AppLifecycleStateToString(state);
+  return SendPlatformMessage("flutter/lifecycle", reinterpret_cast<const uint8_t*>(state_name), strlen(state_name), nullptr, nullptr);
+}
+
+void FlutterWindowsEngine::SetAppLifecycleStateEnabled(bool enabled) {
+  app_lifecycle_enabled_ = enabled;
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -274,6 +274,10 @@ class FlutterWindowsEngine {
                                                       WPARAM wparam,
                                                       LPARAM lparam);
 
+  bool SendAppLifecycleStateUpdate(AppLifecycleState state);
+
+  void SetAppLifecycleStateEnabled(bool enabled);
+
   WindowsLifecycleManager* lifecycle_manager() {
     return lifecycle_manager_.get();
   }
@@ -399,6 +403,8 @@ class FlutterWindowsEngine {
   bool semantics_enabled_ = false;
 
   bool high_contrast_enabled_ = false;
+
+  bool app_lifecycle_enabled_ = false;
 
   bool enable_impeller_ = false;
 

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -1004,9 +1004,8 @@ TEST_F(FlutterWindowsEngineTest, InnerWindowHidden) {
 
 TEST_F(FlutterWindowsEngineTest, EnableLifecycleState) {
   FlutterWindowsEngineBuilder builder{GetContext()};
-  builder.SetDartEntrypoint("exitTestCancel");
+  builder.SetDartEntrypoint("enableLifecycleTest");
   bool finished = false;
-  bool did_call = false;
 
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
@@ -1017,41 +1016,39 @@ TEST_F(FlutterWindowsEngineTest, EnableLifecycleState) {
   EngineModifier modifier(engine);
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
-  ON_CALL(*handler, Quit)
-      .WillByDefault([&finished](std::optional<HWND> hwnd,
-                                 std::optional<WPARAM> wparam,
-                                 std::optional<LPARAM> lparam,
-                                 UINT exit_code) { finished = true; });
-  ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([]() { return true; });
-  EXPECT_CALL(*handler, Quit).Times(0);
+  ON_CALL(*handler, SetLifecycleState).WillByDefault([handler_ptr=handler.get()](AppLifecycleState state) {
+    handler_ptr->WindowsLifecycleManager::SetLifecycleState(state);
+  });
   modifier.SetLifecycleManager(std::move(handler));
-  engine->OnApplicationLifecycleEnabled();
 
   auto binary_messenger =
       std::make_unique<BinaryMessengerImpl>(engine->messenger());
+  // Mark the test only as completed on receiving an inactive state message.
   binary_messenger->SetMessageHandler(
-      "flutter/platform", [&did_call](const uint8_t* message,
+      "flutter/unittest", [&finished](const uint8_t* message,
                                       size_t message_size, BinaryReply reply) {
         std::string contents(message, message + message_size);
-        EXPECT_NE(contents.find("\"method\":\"System.exitApplication\""),
-                  std::string::npos);
-        EXPECT_NE(contents.find("\"type\":\"required\""), std::string::npos);
-        EXPECT_NE(contents.find("\"exitCode\":0"), std::string::npos);
-        did_call = true;
+        EXPECT_NE(contents.find("AppLifecycleState.inactive"), std::string::npos);
+        finished = true;
         char response[] = "";
         reply(reinterpret_cast<uint8_t*>(response), 0);
       });
 
   engine->Run();
 
-  engine->window_proc_delegate_manager()->OnTopLevelWindowProc(0, WM_CLOSE, 0,
-                                                               0);
+  // Test that setting the state before enabling lifecycle does nothing.
+  HWND hwnd = reinterpret_cast<HWND>(1);
+  view.OnWindowStateEvent(hwnd, WindowStateEvent::kShow);
+  view.OnWindowStateEvent(hwnd, WindowStateEvent::kHide);
+  EXPECT_FALSE(finished);
 
-  while (!did_call) {
+  // Test that we can set the state afterwards.
+  engine->SetAppLifecycleStateEnabled(true);
+  view.OnWindowStateEvent(hwnd, WindowStateEvent::kShow);
+
+  while (!finished) {
     engine->task_runner()->ProcessTasks();
   }
-
-  EXPECT_FALSE(finished);
 }
 
 }  // namespace testing

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -1016,9 +1016,10 @@ TEST_F(FlutterWindowsEngineTest, EnableLifecycleState) {
   EngineModifier modifier(engine);
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
-  ON_CALL(*handler, SetLifecycleState).WillByDefault([handler_ptr=handler.get()](AppLifecycleState state) {
-    handler_ptr->WindowsLifecycleManager::SetLifecycleState(state);
-  });
+  ON_CALL(*handler, SetLifecycleState)
+      .WillByDefault([handler_ptr = handler.get()](AppLifecycleState state) {
+        handler_ptr->WindowsLifecycleManager::SetLifecycleState(state);
+      });
   modifier.SetLifecycleManager(std::move(handler));
 
   auto binary_messenger =
@@ -1028,7 +1029,8 @@ TEST_F(FlutterWindowsEngineTest, EnableLifecycleState) {
       "flutter/unittest", [&finished](const uint8_t* message,
                                       size_t message_size, BinaryReply reply) {
         std::string contents(message, message + message_size);
-        EXPECT_NE(contents.find("AppLifecycleState.inactive"), std::string::npos);
+        EXPECT_NE(contents.find("AppLifecycleState.inactive"),
+                  std::string::npos);
         finished = true;
         char response[] = "";
         reply(reinterpret_cast<uint8_t*>(response), 0);

--- a/shell/platform/windows/windows_lifecycle_manager.cc
+++ b/shell/platform/windows/windows_lifecycle_manager.cc
@@ -189,10 +189,7 @@ void WindowsLifecycleManager::SetLifecycleState(AppLifecycleState state) {
   }
   state_ = state;
   if (engine_) {
-    const char* state_name = AppLifecycleStateToString(state);
-    engine_->SendPlatformMessage("flutter/lifecycle",
-                                 reinterpret_cast<const uint8_t*>(state_name),
-                                 strlen(state_name), nullptr, nullptr);
+    engine_->SendAppLifecycleStateUpdate(state_);
   }
 }
 

--- a/shell/platform/windows/windows_lifecycle_manager.cc
+++ b/shell/platform/windows/windows_lifecycle_manager.cc
@@ -19,25 +19,30 @@ constexpr char kEnableKey[] = "lifecycleStateEnabled";
 constexpr char kLifecycleError[] = "Lifecycle State Error";
 constexpr char kInvalidArgumentMessage[] = "Invalid argument";
 
-WindowsLifecycleManager::WindowsLifecycleManager(BinaryMessenger *messenger, FlutterWindowsEngine* engine)
+WindowsLifecycleManager::WindowsLifecycleManager(BinaryMessenger* messenger,
+                                                 FlutterWindowsEngine* engine)
     : engine_(engine), process_close_(false) {
   if (messenger) {
-    channel_ = std::make_unique<MethodChannel<rapidjson::Document>>(messenger, kChannelName, &JsonMethodCodec::GetInstance());
-    channel_->SetMethodCallHandler([this](const MethodCall<rapidjson::Document>& call, std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-      const std::string& method = call.method_name();
-      if (method.compare(kEnableMethod) == 0) {
-        const rapidjson::Value& arguments = call.arguments()[0];
-        rapidjson::Value::ConstMemberIterator itr = arguments.FindMember(kEnableKey);
-        if (itr == arguments.MemberEnd() || !itr->value.IsBool()) {
-          result->Error(kLifecycleError, kInvalidArgumentMessage);
-          return;
-        }
-        engine_->SetAppLifecycleStateEnabled(itr->value.GetBool());
-        result->Success();
-        return;
-      }
-      result->NotImplemented();
-    });
+    channel_ = std::make_unique<MethodChannel<rapidjson::Document>>(
+        messenger, kChannelName, &JsonMethodCodec::GetInstance());
+    channel_->SetMethodCallHandler(
+        [this](const MethodCall<rapidjson::Document>& call,
+               std::unique_ptr<MethodResult<rapidjson::Document>> result) {
+          const std::string& method = call.method_name();
+          if (method.compare(kEnableMethod) == 0) {
+            const rapidjson::Value& arguments = call.arguments()[0];
+            rapidjson::Value::ConstMemberIterator itr =
+                arguments.FindMember(kEnableKey);
+            if (itr == arguments.MemberEnd() || !itr->value.IsBool()) {
+              result->Error(kLifecycleError, kInvalidArgumentMessage);
+              return;
+            }
+            engine_->SetAppLifecycleStateEnabled(itr->value.GetBool());
+            result->Success();
+            return;
+          }
+          result->NotImplemented();
+        });
   }
 }
 

--- a/shell/platform/windows/windows_lifecycle_manager.h
+++ b/shell/platform/windows/windows_lifecycle_manager.h
@@ -14,6 +14,9 @@
 #include <set>
 
 #include "flutter/shell/platform/common/app_lifecycle_state.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
+#include "rapidjson/document.h"
 
 namespace flutter {
 
@@ -36,7 +39,7 @@ enum class WindowStateEvent {
 ///   is changed, including the FlutterView window.
 class WindowsLifecycleManager {
  public:
-  WindowsLifecycleManager(FlutterWindowsEngine* engine);
+  WindowsLifecycleManager(BinaryMessenger *messenger, FlutterWindowsEngine* engine);
   virtual ~WindowsLifecycleManager();
 
   // Called when the engine is notified it should quit, e.g. by an application
@@ -109,6 +112,8 @@ class WindowsLifecycleManager {
   std::mutex state_update_lock_;
 
   flutter::AppLifecycleState state_;
+
+  std::unique_ptr<MethodChannel<rapidjson::Document>> channel_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/windows_lifecycle_manager.h
+++ b/shell/platform/windows/windows_lifecycle_manager.h
@@ -39,7 +39,8 @@ enum class WindowStateEvent {
 ///   is changed, including the FlutterView window.
 class WindowsLifecycleManager {
  public:
-  WindowsLifecycleManager(BinaryMessenger *messenger, FlutterWindowsEngine* engine);
+  WindowsLifecycleManager(BinaryMessenger* messenger,
+                          FlutterWindowsEngine* engine);
   virtual ~WindowsLifecycleManager();
 
   // Called when the engine is notified it should quit, e.g. by an application

--- a/shell/platform/windows/windows_lifecycle_manager_unittests.cc
+++ b/shell/platform/windows/windows_lifecycle_manager_unittests.cc
@@ -13,7 +13,7 @@ namespace testing {
 class WindowsLifecycleManagerTest : public WindowsTest {};
 
 TEST_F(WindowsLifecycleManagerTest, StateTransitions) {
-  WindowsLifecycleManager manager(nullptr);
+  WindowsLifecycleManager manager(nullptr, nullptr);
   HWND win1 = reinterpret_cast<HWND>(1);
   HWND win2 = reinterpret_cast<HWND>(2);
 


### PR DESCRIPTION
Await a platform message before sending lifecycle state updates so we are not sending messages that do not get consumed by the framework.

https://github.com/flutter/flutter/issues/131616

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
