### PR TITLE
[Impeller] Update guidance on how to try Impeller on macOS Desktop.

### DIFF
--- a/impeller/README.md
+++ b/impeller/README.md
@@ -152,13 +152,13 @@ states of completion:
 
 ## Try Impeller in Flutter
 
-Impeller is available under the `--enable-impeller` flag on iOS and Android.
-This flag can be specified to `flutter run`.
+Impeller is available under the `--enable-impeller` flag on iOS, Android, and
+macOS Desktop. This flag can be specified to `flutter run`.
 
 If the application needs to be launched with Impeller enabled without using the
 Flutter tool, follow the platform specific steps below.
 
-### iOS
+### iOS and macOS Desktop
 
 To your `Info.plist` file, add under the top-level `<dict>` tag:
 ```


### PR DESCRIPTION
The website was updated in https://github.com/flutter/website/pull/9114/files