### PR TITLE
[Impeller] Discard invalid command buffer handles after destroying a command pool

### DIFF
--- a/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -42,7 +42,7 @@ class CommandPoolVK {
   std::weak_ptr<const DeviceHolder> device_holder_;
   vk::UniqueCommandPool graphics_pool_;
   Mutex buffers_to_collect_mutex_;
-  std::set<SharedHandleVK<vk::CommandBuffer>> buffers_to_collect_
+  std::vector<vk::UniqueCommandBuffer> buffers_to_collect_
       IPLR_GUARDED_BY(buffers_to_collect_mutex_);
   bool is_valid_ = false;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/131522
