### PR TITLE
Manual clang roll to ebd0b8a0472b865b7eb6e1a32af97ae31d829033

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -39,7 +39,7 @@ vars = {
   # The list of revisions for these tools comes from Fuchsia, here:
   # https://fuchsia.googlesource.com/integration/+/HEAD/toolchain
   # If there are problems with the toolchain, contact fuchsia-toolchain@.
-  'clang_version': 'git_revision:6d667d4b261e81f325756fdfd5bb43b3b3d2451d',
+  'clang_version': 'git_revision:ebd0b8a0472b865b7eb6e1a32af97ae31d829033',
 
   # The goma version and the clang version can be tightly coupled. If goma
   # stops working on a clang roll, this may need to be updated using the value


### PR DESCRIPTION
This is expected to be good-to-go following the fix in https://github.com/flutter/engine/pull/44157

