### PR TITLE
Improve logging in the clang-tidy script

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -664,7 +664,7 @@ deps = {
   Var('github_git') + '/google/process.dart.git' + '@' + '0c9aeac86dcc4e3a6cf760b76fed507107e244d5', # 4.2.1
 
   'src/third_party/pkg/process_runner':
-  Var('github_git') + '/google/process_runner.git' + '@' + 'd632ea0bfd814d779fcc53a361ed33eaf3620a0b', # 4.0.1
+  Var('github_git') + '/google/process_runner.git' + '@' + 'f24c69efdcaf109168f23d381fa281453d2bc9b1', # 4.1.2
 
   'src/third_party/pkg/quiver':
   Var('github_git') + '/google/quiver-dart.git' + '@' + '90b92bee895e507d435012356a8b5c5f17eafa52', # 3.2.1


### PR DESCRIPTION
* Add timestamps to process pool status logs
* Log the remaining job names when only a few jobs are pending

See https://github.com/flutter/flutter/issues/131689
