### PR TITLE
[Impeller] Give a fixed timeout for acquireNextImageKHR.

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -343,10 +343,10 @@ SwapchainImplVK::AcquireResult SwapchainImplVK::AcquireNextDrawable() {
   /// Get the next image index.
   ///
   auto [acq_result, index] = context.GetDevice().acquireNextImageKHR(
-      *swapchain_,                           // swapchain
-      std::numeric_limits<uint64_t>::max(),  // timeout (nanoseconds)
-      *sync->render_ready,                   // signal semaphore
-      nullptr                                // fence
+      *swapchain_,          // swapchain
+      1'000'000'000,        // timeout (ns) 1000ms
+      *sync->render_ready,  // signal semaphore
+      nullptr               // fence
   );
 
   if (acq_result == vk::Result::eSuboptimalKHR) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/131610

Since we're not blocking on presentation, we can have multiple images pending. This is generally good, but for the backpressure from acquireNextImageKHR to be valid it needs to have a finite timeout.

Pick a somewhat arbitrary but fairly long ms duration. See also: https://github.com/flutter/flutter/issues/131698
