### PR TITLE
[Flutter GPU] Export symbols from engine, stub for testing on CI.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1717,6 +1717,9 @@ ORIGIN: ../../../flutter/impeller/typographer/text_run.cc + ../../../flutter/LIC
 ORIGIN: ../../../flutter/impeller/typographer/text_run.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/typographer/typeface.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/typographer/typeface.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/gpu.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/gpu.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/gpu.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/io/dart_io.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/io/dart_io.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/snapshot/snapshot.h + ../../../flutter/LICENSE
@@ -4423,6 +4426,9 @@ FILE: ../../../flutter/impeller/typographer/text_run.cc
 FILE: ../../../flutter/impeller/typographer/text_run.h
 FILE: ../../../flutter/impeller/typographer/typeface.cc
 FILE: ../../../flutter/impeller/typographer/typeface.h
+FILE: ../../../flutter/lib/gpu/gpu.cc
+FILE: ../../../flutter/lib/gpu/gpu.dart
+FILE: ../../../flutter/lib/gpu/gpu.h
 FILE: ../../../flutter/lib/io/dart_io.cc
 FILE: ../../../flutter/lib/io/dart_io.h
 FILE: ../../../flutter/lib/snapshot/libraries_experimental.json

--- a/common/exported_symbols.sym
+++ b/common/exported_symbols.sym
@@ -5,4 +5,6 @@
   kDartVmSnapshotInstructions;
   kDartIsolateSnapshotData;
   kDartIsolateSnapshotInstructions;
+  FlutterGpu*;
+  kFlutterGpu*;
 };

--- a/common/exported_symbols.sym
+++ b/common/exported_symbols.sym
@@ -5,6 +5,6 @@
   kDartVmSnapshotInstructions;
   kDartIsolateSnapshotData;
   kDartIsolateSnapshotInstructions;
-  FlutterGpu*;
-  kFlutterGpu*;
+  InternalFlutterGpu*;
+  kInternalFlutterGpu*;
 };

--- a/common/exported_symbols_mac.sym
+++ b/common/exported_symbols_mac.sym
@@ -4,3 +4,5 @@ _kDartVmSnapshotData
 _kDartVmSnapshotInstructions
 _kDartIsolateSnapshotData
 _kDartIsolateSnapshotInstructions
+_FlutterGpu*
+_kFlutterGpu*

--- a/common/exported_symbols_mac.sym
+++ b/common/exported_symbols_mac.sym
@@ -4,5 +4,5 @@ _kDartVmSnapshotData
 _kDartVmSnapshotInstructions
 _kDartIsolateSnapshotData
 _kDartIsolateSnapshotInstructions
-_FlutterGpu*
-_kFlutterGpu*
+_InternalFlutterGpu*
+_kInternalFlutterGpu*

--- a/lib/gpu/BUILD.gn
+++ b/lib/gpu/BUILD.gn
@@ -1,0 +1,51 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/common/config.gni")
+import("//flutter/impeller/tools/impeller.gni")
+import("//flutter/testing/testing.gni")
+
+source_set("gpu") {
+  cflags = [
+    # Dart gives us doubles. Skia and Impeller work in floats.
+    # If Dart gives us a double > FLT_MAX or < -FLT_MAX, implicit conversion
+    # will convert it to either inf/-inf or FLT_MAX/-FLT_MAX (undefined
+    # behavior). This can result in surprising and difficult to debug behavior
+    # for Flutter application developers, so it should be explicitly handled
+    # via SafeNarrow.
+    "-Wimplicit-float-conversion",
+  ]
+
+  if (is_win) {
+    # This causes build failures in third_party dependencies on Windows.
+    cflags += [ "-Wno-implicit-int-float-conversion" ]
+  }
+
+  public_configs = [ "//flutter:config" ]
+
+  public_deps = []
+
+  if (!defined(defines)) {
+    defines = []
+  }
+
+  sources = [
+    "gpu.cc",
+    "gpu.h",
+  ]
+  deps = [
+    "//flutter/impeller",
+    "//flutter/impeller/display_list:skia_conversions",
+    "//flutter/lib/ui",
+    "//flutter/third_party/tonic",
+  ]
+
+  if (is_win) {
+    # Required for M_PI and others.
+    defines += [ "_USE_MATH_DEFINES" ]
+  }
+}
+
+if (enable_unittests) {
+}

--- a/lib/gpu/gpu.cc
+++ b/lib/gpu/gpu.cc
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/gpu/gpu.h"
+#include "flutter/fml/memory/ref_ptr.h"
+#include "flutter/lib/ui/dart_wrapper.h"
+#include "flutter/lib/ui/ui_dart_state.h"
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "third_party/tonic/converter/dart_converter.h"
+#include "third_party/tonic/dart_state.h"
+#include "third_party/tonic/dart_wrappable.h"
+#include "third_party/tonic/dart_wrapper_info.h"
+#include "third_party/tonic/logging/dart_invoke.h"
+
+namespace flutter {
+
+IMPLEMENT_WRAPPERTYPEINFO(gpu, FlutterGpuTestClass);
+
+}  // namespace flutter
+
+uint32_t FlutterGpuTestProc() {
+  return 1;
+}
+
+Dart_Handle FlutterGpuTestProcWithCallback(Dart_Handle callback) {
+  flutter::UIDartState::ThrowIfUIOperationsProhibited();
+  if (!Dart_IsClosure(callback)) {
+    return tonic::ToDart("Callback must be a function");
+  }
+
+  tonic::DartInvoke(callback, {tonic::ToDart(1234)});
+
+  return Dart_Null();
+}
+
+void FlutterGpuTestClass_Create(Dart_Handle wrapper) {
+  auto res = fml::MakeRefCounted<flutter::FlutterGpuTestClass>();
+  res->AssociateWithDartWrapper(wrapper);
+  FML_LOG(ERROR) << "FlutterGpuTestClass Wrapped.";
+}
+
+void FlutterGpuTestClass_Method(flutter::FlutterGpuTestClass* self,
+                                int something) {
+  FML_LOG(ERROR) << "Something: " << something;
+}

--- a/lib/gpu/gpu.cc
+++ b/lib/gpu/gpu.cc
@@ -24,12 +24,12 @@ FlutterGpuTestClass::~FlutterGpuTestClass() = default;
 }  // namespace flutter
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
-uint32_t FlutterGpuTestProc() {
+uint32_t InternalFlutterGpuTestProc() {
   return 1;
 }
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
-Dart_Handle FlutterGpuTestProcWithCallback(Dart_Handle callback) {
+Dart_Handle InternalFlutterGpuTestProcWithCallback(Dart_Handle callback) {
   flutter::UIDartState::ThrowIfUIOperationsProhibited();
   if (!Dart_IsClosure(callback)) {
     return tonic::ToDart("Callback must be a function");
@@ -41,15 +41,15 @@ Dart_Handle FlutterGpuTestProcWithCallback(Dart_Handle callback) {
 }
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
-void FlutterGpuTestClass_Create(Dart_Handle wrapper) {
+void InternalFlutterGpuTestClass_Create(Dart_Handle wrapper) {
   auto res = fml::MakeRefCounted<flutter::FlutterGpuTestClass>();
   res->AssociateWithDartWrapper(wrapper);
   FML_LOG(ERROR) << "FlutterGpuTestClass Wrapped.";
 }
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
-void FlutterGpuTestClass_Method(flutter::FlutterGpuTestClass* self,
-                                int something) {
+void InternalFlutterGpuTestClass_Method(flutter::FlutterGpuTestClass* self,
+                                        int something) {
   FML_LOG(ERROR) << "Something: " << something;
 }
 

--- a/lib/gpu/gpu.cc
+++ b/lib/gpu/gpu.cc
@@ -15,14 +15,20 @@
 
 namespace flutter {
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 IMPLEMENT_WRAPPERTYPEINFO(gpu, FlutterGpuTestClass);
+
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
+FlutterGpuTestClass::~FlutterGpuTestClass() = default;
 
 }  // namespace flutter
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 uint32_t FlutterGpuTestProc() {
   return 1;
 }
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 Dart_Handle FlutterGpuTestProcWithCallback(Dart_Handle callback) {
   flutter::UIDartState::ThrowIfUIOperationsProhibited();
   if (!Dart_IsClosure(callback)) {
@@ -34,13 +40,21 @@ Dart_Handle FlutterGpuTestProcWithCallback(Dart_Handle callback) {
   return Dart_Null();
 }
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 void FlutterGpuTestClass_Create(Dart_Handle wrapper) {
   auto res = fml::MakeRefCounted<flutter::FlutterGpuTestClass>();
   res->AssociateWithDartWrapper(wrapper);
   FML_LOG(ERROR) << "FlutterGpuTestClass Wrapped.";
 }
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 void FlutterGpuTestClass_Method(flutter::FlutterGpuTestClass* self,
                                 int something) {
   FML_LOG(ERROR) << "Something: " << something;
+}
+
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
+void FlutterGpuTestClass_Dispose(flutter::FlutterGpuTestClass* self,
+                                 int something) {
+  self->ClearDartWrapper();
 }

--- a/lib/gpu/gpu.cc
+++ b/lib/gpu/gpu.cc
@@ -44,13 +44,13 @@ Dart_Handle InternalFlutterGpuTestProcWithCallback(Dart_Handle callback) {
 void InternalFlutterGpuTestClass_Create(Dart_Handle wrapper) {
   auto res = fml::MakeRefCounted<flutter::FlutterGpuTestClass>();
   res->AssociateWithDartWrapper(wrapper);
-  FML_LOG(ERROR) << "FlutterGpuTestClass Wrapped.";
+  FML_LOG(INFO) << "FlutterGpuTestClass Wrapped.";
 }
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 void InternalFlutterGpuTestClass_Method(flutter::FlutterGpuTestClass* self,
                                         int something) {
-  FML_LOG(ERROR) << "Something: " << something;
+  FML_LOG(INFO) << "Something: " << something;
 }
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.

--- a/lib/gpu/gpu.dart
+++ b/lib/gpu/gpu.dart
@@ -31,8 +31,11 @@ base class FlutterGpuTestClass extends NativeFieldWrapperClass1 {
   external void _constructor();
 
   /// This is a method that will supply a pointer to the C data counterpart when
-  /// calling the function
+  /// calling the gunction
   @Native<Void Function(Pointer<Void>, Int)>(
       symbol: 'FlutterGpuTestClass_Method')
   external void coolMethod(int something);
+
+  @Native<Void Function(Pointer<Void>)>(symbol: 'FlutterGpuTestClass_Dispose')
+  external void dispose();
 }

--- a/lib/gpu/gpu.dart
+++ b/lib/gpu/gpu.dart
@@ -1,0 +1,38 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+import 'dart:ffi';
+import 'dart:nativewrappers';
+
+/// This is a simple test fuction.
+@Native<Int32 Function()>(symbol: 'FlutterGpuTestProc')
+external int testProc();
+
+/// This is a test callback that follows the same pattern as much of dart:ui --
+/// immediately returning an error string and supplying an asynchronous result
+/// via callback later.
+typedef Callback<T> = void Function(T result);
+@Native<Handle Function(Handle)>(symbol: 'FlutterGpuTestProcWithCallback')
+external String? testProcWithCallback(Callback<int> callback);
+
+/// This is a test of NativeFieldWrapperClass1, which is commonly used in
+/// dart:ui to enable Dart to dictate the lifetime of a C counterpart.
+base class FlutterGpuTestClass extends NativeFieldWrapperClass1 {
+  FlutterGpuTestClass() {
+    _constructor();
+  }
+
+  /// This "constructor" is used to instantiate and wrap the C counterpart.
+  /// This is a common pattern in dart:ui.
+  @Native<Void Function(Handle)>(symbol: 'FlutterGpuTestClass_Create')
+  external void _constructor();
+
+  /// This is a method that will supply a pointer to the C data counterpart when
+  /// calling the function
+  @Native<Void Function(Pointer<Void>, Int)>(
+      symbol: 'FlutterGpuTestClass_Method')
+  external void coolMethod(int something);
+}

--- a/lib/gpu/gpu.dart
+++ b/lib/gpu/gpu.dart
@@ -8,14 +8,15 @@ import 'dart:ffi';
 import 'dart:nativewrappers';
 
 /// This is a simple test fuction.
-@Native<Int32 Function()>(symbol: 'FlutterGpuTestProc')
+@Native<Int32 Function()>(symbol: 'InternalFlutterGpuTestProc')
 external int testProc();
 
 /// This is a test callback that follows the same pattern as much of dart:ui --
 /// immediately returning an error string and supplying an asynchronous result
 /// via callback later.
 typedef Callback<T> = void Function(T result);
-@Native<Handle Function(Handle)>(symbol: 'FlutterGpuTestProcWithCallback')
+@Native<Handle Function(Handle)>(
+    symbol: 'InternalFlutterGpuTestProcWithCallback')
 external String? testProcWithCallback(Callback<int> callback);
 
 /// This is a test of NativeFieldWrapperClass1, which is commonly used in
@@ -27,15 +28,12 @@ base class FlutterGpuTestClass extends NativeFieldWrapperClass1 {
 
   /// This "constructor" is used to instantiate and wrap the C counterpart.
   /// This is a common pattern in dart:ui.
-  @Native<Void Function(Handle)>(symbol: 'FlutterGpuTestClass_Create')
+  @Native<Void Function(Handle)>(symbol: 'InternalFlutterGpuTestClass_Create')
   external void _constructor();
 
   /// This is a method that will supply a pointer to the C data counterpart when
   /// calling the gunction
   @Native<Void Function(Pointer<Void>, Int)>(
-      symbol: 'FlutterGpuTestClass_Method')
+      symbol: 'InternalFlutterGpuTestClass_Method')
   external void coolMethod(int something);
-
-  @Native<Void Function(Pointer<Void>)>(symbol: 'FlutterGpuTestClass_Dispose')
-  external void dispose();
 }

--- a/lib/gpu/gpu.h
+++ b/lib/gpu/gpu.h
@@ -36,20 +36,21 @@ extern "C" {
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 FLUTTER_EXPORT
-extern uint32_t FlutterGpuTestProc();
+extern uint32_t InternalFlutterGpuTestProc();
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 FLUTTER_EXPORT
-extern Dart_Handle FlutterGpuTestProcWithCallback(Dart_Handle callback);
+extern Dart_Handle InternalFlutterGpuTestProcWithCallback(Dart_Handle callback);
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 FLUTTER_EXPORT
-extern void FlutterGpuTestClass_Create(Dart_Handle wrapper);
+extern void InternalFlutterGpuTestClass_Create(Dart_Handle wrapper);
 
 // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 FLUTTER_EXPORT
-extern void FlutterGpuTestClass_Method(flutter::FlutterGpuTestClass* self,
-                                       int something);
+extern void InternalFlutterGpuTestClass_Method(
+    flutter::FlutterGpuTestClass* self,
+    int something);
 
 }  // extern "C"
 

--- a/lib/gpu/gpu.h
+++ b/lib/gpu/gpu.h
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_GPU_GPU_H_
+#define FLUTTER_LIB_GPU_GPU_H_
+
+#include <cstdint>
+
+#include "flutter/lib/ui/dart_wrapper.h"
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "third_party/tonic/dart_state.h"
+#include "third_party/tonic/dart_wrapper_info.h"
+
+#if FML_OS_WIN
+#define FLUTTER_EXPORT __declspec(dllexport)
+#else  // FML_OS_WIN
+#define FLUTTER_EXPORT __attribute__((visibility("default")))
+#endif  // FML_OS_WIN
+
+namespace flutter {
+
+class FlutterGpuTestClass
+    : public RefCountedDartWrappable<FlutterGpuTestClass> {
+  DEFINE_WRAPPERTYPEINFO();
+
+ public:
+};
+
+}  // namespace flutter
+
+extern "C" {
+
+FLUTTER_EXPORT
+extern uint32_t FlutterGpuTestProc();
+
+FLUTTER_EXPORT
+extern Dart_Handle FlutterGpuTestProcWithCallback(Dart_Handle callback);
+
+FLUTTER_EXPORT
+extern void FlutterGpuTestClass_Create(Dart_Handle wrapper);
+
+FLUTTER_EXPORT
+extern void FlutterGpuTestClass_Method(flutter::FlutterGpuTestClass* self,
+                                       int something);
+
+}  // extern "C"
+
+#endif  // FLUTTER_LIB_GPU_GPU_H_

--- a/lib/gpu/gpu.h
+++ b/lib/gpu/gpu.h
@@ -20,26 +20,33 @@
 
 namespace flutter {
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 class FlutterGpuTestClass
     : public RefCountedDartWrappable<FlutterGpuTestClass> {
   DEFINE_WRAPPERTYPEINFO();
+  FML_FRIEND_MAKE_REF_COUNTED(FlutterGpuTestClass);
 
  public:
+  ~FlutterGpuTestClass() override;
 };
 
 }  // namespace flutter
 
 extern "C" {
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 FLUTTER_EXPORT
 extern uint32_t FlutterGpuTestProc();
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 FLUTTER_EXPORT
 extern Dart_Handle FlutterGpuTestProcWithCallback(Dart_Handle callback);
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 FLUTTER_EXPORT
 extern void FlutterGpuTestClass_Create(Dart_Handle wrapper);
 
+// TODO(131346): Remove this once we migrate the Dart GPU API into this space.
 FLUTTER_EXPORT
 extern void FlutterGpuTestClass_Method(flutter::FlutterGpuTestClass* self,
                                        int something);

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -90,6 +90,7 @@ source_set("runtime") {
   }
 
   public_deps = [
+    "//flutter/lib/gpu",
     "//flutter/lib/ui",
     "//third_party/rapidjson",
   ]

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -17,6 +17,7 @@ tests = [
   "fragment_shader_test.dart",
   "geometry_test.dart",
   "gesture_settings_test.dart",
+  "gpu_test.dart",
   "gradient_test.dart",
   "http_allow_http_connections_test.dart",
   "http_disallow_http_connections_test.dart",

--- a/testing/dart/gpu_test.dart
+++ b/testing/dart/gpu_test.dart
@@ -1,0 +1,20 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: avoid_relative_lib_imports
+
+import 'dart:ui';
+
+import 'package:litetest/litetest.dart';
+import '../../lib/gpu/gpu.dart' as gpu;
+
+void main() {
+  test('no crash', () async {
+    final int result = gpu.testProc();
+    expect(result, 1);
+
+    final gpu.FlutterGpuTestClass a = gpu.FlutterGpuTestClass();
+    a.coolMethod(9847);
+  });
+}

--- a/testing/dart/gpu_test.dart
+++ b/testing/dart/gpu_test.dart
@@ -4,8 +4,6 @@
 
 // ignore_for_file: avoid_relative_lib_imports
 
-import 'dart:ui';
-
 import 'package:litetest/litetest.dart';
 import '../../lib/gpu/gpu.dart' as gpu;
 

--- a/testing/dart/gpu_test.dart
+++ b/testing/dart/gpu_test.dart
@@ -10,9 +10,15 @@ import 'package:litetest/litetest.dart';
 import '../../lib/gpu/gpu.dart' as gpu;
 
 void main() {
+  // TODO(131346): Remove this once we migrate the Dart GPU API into this space.
   test('no crash', () async {
     final int result = gpu.testProc();
     expect(result, 1);
+
+    final String? message = gpu.testProcWithCallback((int result) {
+      expect(result, 1234);
+    });
+    expect(message, null);
 
     final gpu.FlutterGpuTestClass a = gpu.FlutterGpuTestClass();
     a.coolMethod(9847);

--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -95,10 +95,11 @@ int _checkIos(String outPath, String nmPath, Iterable<String> builds) {
     }
     final Iterable<NmEntry> unexpectedEntries = NmEntry.parse(nmResult.stdout as String).where((NmEntry entry) {
       final bool cSymbol = (entry.type == '(__DATA,__common)' || entry.type == '(__DATA,__const)')
-          && (entry.name.startsWith('_Flutter') || entry.name.startsWith('_InternalFlutter'));
+          && entry.name.startsWith('_Flutter');
+      final bool cInternalSymbol = entry.type == '(__TEXT,__text)' && entry.name.startsWith('_InternalFlutter');
       final bool objcSymbol = entry.type == '(__DATA,__objc_data)'
           && (entry.name.startsWith(r'_OBJC_METACLASS_$_Flutter') || entry.name.startsWith(r'_OBJC_CLASS_$_Flutter'));
-      return !(cSymbol || objcSymbol);
+      return !(cSymbol || cInternalSymbol || objcSymbol);
     });
     if (unexpectedEntries.isNotEmpty) {
       print('ERROR: $libFlutter exports unexpected symbols:');

--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -94,9 +94,11 @@ int _checkIos(String outPath, String nmPath, Iterable<String> builds) {
       continue;
     }
     final Iterable<NmEntry> unexpectedEntries = NmEntry.parse(nmResult.stdout as String).where((NmEntry entry) {
-      return !(((entry.type == '(__DATA,__common)' || entry.type == '(__DATA,__const)') && entry.name.startsWith('_Flutter'))
-          || (entry.type == '(__DATA,__objc_data)'
-              && (entry.name.startsWith(r'_OBJC_METACLASS_$_Flutter') || entry.name.startsWith(r'_OBJC_CLASS_$_Flutter'))));
+      final bool cSymbol = (entry.type == '(__DATA,__common)' || entry.type == '(__DATA,__const)')
+          && (entry.name.startsWith('_Flutter') || entry.name.startsWith('_InternalFlutter'));
+      final bool objcSymbol = entry.type == '(__DATA,__objc_data)'
+          && (entry.name.startsWith(r'_OBJC_METACLASS_$_Flutter') || entry.name.startsWith(r'_OBJC_CLASS_$_Flutter'));
+      return !(cSymbol || objcSymbol);
     });
     if (unexpectedEntries.isNotEmpty) {
       print('ERROR: $libFlutter exports unexpected symbols:');
@@ -275,7 +277,9 @@ int _checkLinux(String outPath, String nmPath, Iterable<String> builds) {
       }
       if (!(entry.name.startsWith('Flutter')
             || entry.name.startsWith('__Flutter')
-            || entry.name.startsWith('kFlutter'))) {
+            || entry.name.startsWith('kFlutter')
+            || entry.name.startsWith('InternalFlutter')
+            || entry.name.startsWith('kInternalFlutter'))) {
         print('ERROR: $libFlutter exports an unexpected symbol name: ($entry)');
         print(' Library has $entries.');
         failures++;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/131346

Stubs a minimal test of the FFI utilities that `dart:ui` uses, but using public symbols exported from the engine library. If this goes well, I'll move the stuff from `dart:ui` into here and begin landing parts of the API with test coverage.