### PR TITLE
[CP] Remove windows_arm_host_engine from release builder

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -531,7 +531,6 @@ targets:
       # Don't run this on release branches
       - main
     properties:
-      release_build: "true"
       config_name: windows_arm_host_engine
     drone_dimensions:
       - os=Windows


### PR DESCRIPTION
Skip windows arm on release branches. This broke during the migration to the release builders.
