### PR TITLE
[Impeller] Add gradient dithering for Radial/Sweep/Conical gradients

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -450,6 +450,35 @@ TEST_P(AiksTest, CanRenderLinearGradientWithDitheringEnabled) {
 }  // namespace
 
 namespace {
+void CanRenderRadialGradientWithDithering(AiksTest* aiks_test,
+                                          bool use_dithering) {
+  Canvas canvas;
+  Paint paint;
+  canvas.Translate({100.0, 100.0, 0});
+
+  // #FFF -> #000
+  std::vector<Color> colors = {Color{1.0, 1.0, 1.0, 1.0},
+                               Color{0.0, 0.0, 0.0, 1.0}};
+  std::vector<Scalar> stops = {0.0, 1.0};
+
+  paint.color_source = ColorSource::MakeRadialGradient(
+      {600, 600}, 600, std::move(colors), std::move(stops),
+      Entity::TileMode::kClamp, {});
+  paint.dither = use_dithering;
+  canvas.DrawRect({0, 0, 1200, 1200}, paint);
+  ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+}  // namespace
+
+TEST_P(AiksTest, CanRenderRadialGradientWithDitheringDisabled) {
+  CanRenderRadialGradientWithDithering(this, false);
+}
+
+TEST_P(AiksTest, CanRenderRadialGradientWithDitheringEnabled) {
+  CanRenderRadialGradientWithDithering(this, true);
+}
+
+namespace {
 void CanRenderLinearGradientWithOverlappingStops(AiksTest* aiks_test,
                                                  Entity::TileMode tile_mode) {
   Canvas canvas;

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -419,9 +419,8 @@ TEST_P(AiksTest, CanRenderLinearGradientDecalWithColorFilter) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
-namespace {
-void CanRenderLinearGradientWithDithering(AiksTest* aiks_test,
-                                          bool use_dithering) {
+static void CanRenderLinearGradientWithDithering(AiksTest* aiks_test,
+                                                 bool use_dithering) {
   Canvas canvas;
   Paint paint;
   canvas.Translate({100.0, 100.0, 0});
@@ -439,7 +438,6 @@ void CanRenderLinearGradientWithDithering(AiksTest* aiks_test,
   canvas.DrawRect({0, 0, 800, 500}, paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
-}  // namespace
 
 TEST_P(AiksTest, CanRenderLinearGradientWithDitheringDisabled) {
   CanRenderLinearGradientWithDithering(this, false);
@@ -449,9 +447,8 @@ TEST_P(AiksTest, CanRenderLinearGradientWithDitheringEnabled) {
   CanRenderLinearGradientWithDithering(this, true);
 }  // namespace
 
-namespace {
-void CanRenderRadialGradientWithDithering(AiksTest* aiks_test,
-                                          bool use_dithering) {
+static void CanRenderRadialGradientWithDithering(AiksTest* aiks_test,
+                                                 bool use_dithering) {
   Canvas canvas;
   Paint paint;
   canvas.Translate({100.0, 100.0, 0});
@@ -468,7 +465,6 @@ void CanRenderRadialGradientWithDithering(AiksTest* aiks_test,
   canvas.DrawRect({0, 0, 1200, 1200}, paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
-}  // namespace
 
 TEST_P(AiksTest, CanRenderRadialGradientWithDitheringDisabled) {
   CanRenderRadialGradientWithDithering(this, false);
@@ -478,9 +474,8 @@ TEST_P(AiksTest, CanRenderRadialGradientWithDitheringEnabled) {
   CanRenderRadialGradientWithDithering(this, true);
 }
 
-namespace {
-void CanRenderSweepGradientWithDithering(AiksTest* aiks_test,
-                                         bool use_dithering) {
+static void CanRenderSweepGradientWithDithering(AiksTest* aiks_test,
+                                                bool use_dithering) {
   Canvas canvas;
   canvas.Scale(aiks_test->GetContentScale());
   Paint paint;
@@ -499,7 +494,6 @@ void CanRenderSweepGradientWithDithering(AiksTest* aiks_test,
   canvas.DrawRect({0, 0, 600, 600}, paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
-}  // namespace
 
 TEST_P(AiksTest, CanRenderSweepGradientWithDitheringDisabled) {
   CanRenderSweepGradientWithDithering(this, false);
@@ -507,6 +501,35 @@ TEST_P(AiksTest, CanRenderSweepGradientWithDitheringDisabled) {
 
 TEST_P(AiksTest, CanRenderSweepGradientWithDitheringEnabled) {
   CanRenderSweepGradientWithDithering(this, true);
+}
+
+static void CanRenderConicalGradientWithDithering(AiksTest* aiks_test,
+                                                  bool use_dithering) {
+  Canvas canvas;
+  canvas.Scale(aiks_test->GetContentScale());
+  Paint paint;
+  canvas.Translate({100.0, 100.0, 0});
+
+  // #FFF -> #000
+  std::vector<Color> colors = {Color{1.0, 1.0, 1.0, 1.0},
+                               Color{0.0, 0.0, 0.0, 1.0}};
+  std::vector<Scalar> stops = {0.0, 1.0};
+
+  paint.color_source = ColorSource::MakeConicalGradient(
+      {100, 100}, 100, std::move(colors), std::move(stops), {0, 1}, 0,
+      Entity::TileMode::kMirror, {});
+  paint.dither = use_dithering;
+
+  canvas.DrawRect({0, 0, 600, 600}, paint);
+  ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, CanRenderConicalGradientWithDitheringDisabled) {
+  CanRenderConicalGradientWithDithering(this, false);
+}
+
+TEST_P(AiksTest, CanRenderConicalGradientWithDitheringEnabled) {
+  CanRenderConicalGradientWithDithering(this, true);
 }
 
 namespace {

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -479,6 +479,37 @@ TEST_P(AiksTest, CanRenderRadialGradientWithDitheringEnabled) {
 }
 
 namespace {
+void CanRenderSweepGradientWithDithering(AiksTest* aiks_test,
+                                         bool use_dithering) {
+  Canvas canvas;
+  canvas.Scale(aiks_test->GetContentScale());
+  Paint paint;
+  canvas.Translate({100.0, 100.0, 0});
+
+  // #FFF -> #000
+  std::vector<Color> colors = {Color{1.0, 1.0, 1.0, 1.0},
+                               Color{0.0, 0.0, 0.0, 1.0}};
+  std::vector<Scalar> stops = {0.0, 1.0};
+
+  paint.color_source = ColorSource::MakeSweepGradient(
+      {100, 100}, Degrees(45), Degrees(135), std::move(colors),
+      std::move(stops), Entity::TileMode::kMirror, {});
+  paint.dither = use_dithering;
+
+  canvas.DrawRect({0, 0, 600, 600}, paint);
+  ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+}  // namespace
+
+TEST_P(AiksTest, CanRenderSweepGradientWithDitheringDisabled) {
+  CanRenderSweepGradientWithDithering(this, false);
+}
+
+TEST_P(AiksTest, CanRenderSweepGradientWithDitheringEnabled) {
+  CanRenderSweepGradientWithDithering(this, true);
+}
+
+namespace {
 void CanRenderLinearGradientWithOverlappingStops(AiksTest* aiks_test,
                                                  Entity::TileMode tile_mode) {
   Canvas canvas;

--- a/impeller/aiks/color_source.cc
+++ b/impeller/aiks/color_source.cc
@@ -119,6 +119,7 @@ ColorSource ColorSource::MakeRadialGradient(Point center,
     contents->SetStops(stops);
     contents->SetCenterAndRadius(center, radius);
     contents->SetTileMode(tile_mode);
+    contents->SetDither(paint.dither);
     contents->SetEffectTransform(effect_transform);
 
     auto radius_pt = Point(radius, radius);

--- a/impeller/aiks/color_source.cc
+++ b/impeller/aiks/color_source.cc
@@ -151,6 +151,7 @@ ColorSource ColorSource::MakeSweepGradient(Point center,
     contents->SetColors(colors);
     contents->SetStops(stops);
     contents->SetTileMode(tile_mode);
+    contents->SetDither(paint.dither);
     contents->SetEffectTransform(effect_transform);
 
     return contents;

--- a/impeller/aiks/color_source.cc
+++ b/impeller/aiks/color_source.cc
@@ -88,6 +88,7 @@ ColorSource ColorSource::MakeConicalGradient(Point center,
     contents->SetStops(stops);
     contents->SetCenterAndRadius(center, radius);
     contents->SetTileMode(tile_mode);
+    contents->SetDither(paint.dither);
     contents->SetEffectTransform(effect_transform);
     contents->SetFocus(focus_center, focus_radius);
 

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -76,6 +76,7 @@ bool ConicalGradientContents::RenderSSBO(const ContentContext& renderer,
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
   frag_info.decal_border_color = decal_border_color_;
   frag_info.alpha = GetOpacityFactor();
+  frag_info.dither = dither_;
   if (focus_) {
     frag_info.focus = focus_.value();
     frag_info.focus_radius = focus_radius_;

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -29,6 +29,10 @@ void ConicalGradientContents::SetTileMode(Entity::TileMode tile_mode) {
   tile_mode_ = tile_mode;
 }
 
+void ConicalGradientContents::SetDither(bool dither) {
+  dither_ = dither;
+}
+
 void ConicalGradientContents::SetColors(std::vector<Color> colors) {
   colors_ = std::move(colors);
 }

--- a/impeller/entity/contents/conical_gradient_contents.h
+++ b/impeller/entity/contents/conical_gradient_contents.h
@@ -45,6 +45,8 @@ class ConicalGradientContents final : public ColorSourceContents {
 
   void SetTileMode(Entity::TileMode tile_mode);
 
+  void SetDither(bool dither);
+
   void SetFocus(std::optional<Point> focus, Scalar radius);
 
  private:
@@ -63,6 +65,7 @@ class ConicalGradientContents final : public ColorSourceContents {
   Color decal_border_color_ = Color::BlackTransparent();
   std::optional<Point> focus_;
   Scalar focus_radius_ = 0.0f;
+  bool dither_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ConicalGradientContents);
 };

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -29,6 +29,10 @@ void RadialGradientContents::SetTileMode(Entity::TileMode tile_mode) {
   tile_mode_ = tile_mode;
 }
 
+void RadialGradientContents::SetDither(bool dither) {
+  dither_ = dither;
+}
+
 void RadialGradientContents::SetColors(std::vector<Color> colors) {
   colors_ = std::move(colors);
 }
@@ -78,6 +82,7 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
   frag_info.decal_border_color = decal_border_color_;
   frag_info.alpha = GetOpacityFactor();
+  frag_info.dither = dither_;
 
   auto& host_buffer = pass.GetTransientsBuffer();
   auto colors = CreateGradientColors(colors_, stops_);

--- a/impeller/entity/contents/radial_gradient_contents.h
+++ b/impeller/entity/contents/radial_gradient_contents.h
@@ -48,6 +48,8 @@ class RadialGradientContents final : public ColorSourceContents {
 
   void SetTileMode(Entity::TileMode tile_mode);
 
+  void SetDither(bool dither);
+
  private:
   bool RenderTexture(const ContentContext& renderer,
                      const Entity& entity,
@@ -62,6 +64,7 @@ class RadialGradientContents final : public ColorSourceContents {
   std::vector<Scalar> stops_;
   Entity::TileMode tile_mode_;
   Color decal_border_color_ = Color::BlackTransparent();
+  bool dither_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RadialGradientContents);
 };

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -42,6 +42,10 @@ void SweepGradientContents::SetTileMode(Entity::TileMode tile_mode) {
   tile_mode_ = tile_mode;
 }
 
+void SweepGradientContents::SetDither(bool dither) {
+  dither_ = dither;
+}
+
 const std::vector<Color>& SweepGradientContents::GetColors() const {
   return colors_;
 }
@@ -84,6 +88,7 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
   frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
   frag_info.decal_border_color = decal_border_color_;
   frag_info.alpha = GetOpacityFactor();
+  frag_info.dither = dither_;
 
   auto& host_buffer = pass.GetTransientsBuffer();
   auto colors = CreateGradientColors(colors_, stops_);

--- a/impeller/entity/contents/sweep_gradient_contents.h
+++ b/impeller/entity/contents/sweep_gradient_contents.h
@@ -45,6 +45,8 @@ class SweepGradientContents final : public ColorSourceContents {
 
   void SetTileMode(Entity::TileMode tile_mode);
 
+  void SetDither(bool dither);
+
   const std::vector<Color>& GetColors() const;
 
   const std::vector<Scalar>& GetStops() const;
@@ -65,6 +67,7 @@ class SweepGradientContents final : public ColorSourceContents {
   std::vector<Scalar> stops_;
   Entity::TileMode tile_mode_;
   Color decal_border_color_ = Color::BlackTransparent();
+  bool dither_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(SweepGradientContents);
 };

--- a/impeller/entity/shaders/conical_gradient_fill.frag
+++ b/impeller/entity/shaders/conical_gradient_fill.frag
@@ -22,7 +22,6 @@ uniform FragInfo {
   vec2 half_texel;
   vec2 focus;
   float focus_radius;
-  bool dither;
 }
 frag_info;
 
@@ -47,8 +46,4 @@ void main() {
                                  frag_info.tile_mode,                      //
                                  frag_info.decal_border_color);
   frag_color = IPPremultiply(frag_color) * frag_info.alpha;
-
-  if (frag_info.dither) {
-    frag_color = IPOrderedDither8x8(frag_color, v_position);
-  }
 }

--- a/impeller/entity/shaders/conical_gradient_fill.frag
+++ b/impeller/entity/shaders/conical_gradient_fill.frag
@@ -5,7 +5,6 @@
 precision mediump float;
 
 #include <impeller/color.glsl>
-#include <impeller/dithering.glsl>
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/entity/shaders/conical_gradient_fill.frag
+++ b/impeller/entity/shaders/conical_gradient_fill.frag
@@ -5,6 +5,7 @@
 precision mediump float;
 
 #include <impeller/color.glsl>
+#include <impeller/dithering.glsl>
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
@@ -21,6 +22,7 @@ uniform FragInfo {
   vec2 half_texel;
   vec2 focus;
   float focus_radius;
+  bool dither;
 }
 frag_info;
 
@@ -45,4 +47,8 @@ void main() {
                                  frag_info.tile_mode,                      //
                                  frag_info.decal_border_color);
   frag_color = IPPremultiply(frag_color) * frag_info.alpha;
+
+  if (frag_info.dither) {
+    frag_color = IPOrderedDither8x8(frag_color, v_position);
+  }
 }

--- a/impeller/entity/shaders/conical_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/conical_gradient_ssbo_fill.frag
@@ -5,6 +5,7 @@
 precision mediump float;
 
 #include <impeller/color.glsl>
+#include <impeller/dithering.glsl>
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>

--- a/impeller/entity/shaders/conical_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/conical_gradient_ssbo_fill.frag
@@ -28,6 +28,7 @@ uniform FragInfo {
   int colors_length;
   vec2 focus;
   float focus_radius;
+  bool dither;
 }
 frag_info;
 
@@ -63,4 +64,8 @@ void main() {
     }
   }
   frag_color = IPPremultiply(result_color) * frag_info.alpha;
+
+  if (frag_info.dither) {
+    frag_color = IPOrderedDither8x8(frag_color, v_position);
+  }
 }

--- a/impeller/entity/shaders/radial_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/radial_gradient_ssbo_fill.frag
@@ -5,6 +5,7 @@
 precision mediump float;
 
 #include <impeller/color.glsl>
+#include <impeller/dithering.glsl>
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
@@ -26,6 +27,7 @@ uniform FragInfo {
   vec4 decal_border_color;
   float alpha;
   int colors_length;
+  bool dither;
 }
 frag_info;
 
@@ -59,4 +61,8 @@ void main() {
     }
   }
   frag_color = IPPremultiply(result_color) * frag_info.alpha;
+
+  if (frag_info.dither) {
+    frag_color = IPOrderedDither8x8(frag_color, v_position);
+  }
 }

--- a/impeller/entity/shaders/sweep_gradient_ssbo_fill.frag
+++ b/impeller/entity/shaders/sweep_gradient_ssbo_fill.frag
@@ -4,6 +4,7 @@
 
 #include <impeller/color.glsl>
 #include <impeller/constants.glsl>
+#include <impeller/dithering.glsl>
 #include <impeller/gradient.glsl>
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
@@ -26,6 +27,7 @@ uniform FragInfo {
   vec4 decal_border_color;
   float alpha;
   int colors_length;
+  bool dither;
 }
 frag_info;
 
@@ -60,4 +62,8 @@ void main() {
     }
   }
   frag_color = IPPremultiply(result_color) * frag_info.alpha;
+
+  if (frag_info.dither) {
+    frag_color = IPOrderedDither8x8(frag_color, v_position);
+  }
 }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -2147,9 +2147,9 @@
               "varying"
             ],
             "shortest_path_cycles": [
-              0.1875,
+              0.21875,
               0.0625,
-              0.1875,
+              0.21875,
               0.0,
               0.0,
               0.25,
@@ -2159,10 +2159,10 @@
               "load_store"
             ],
             "total_cycles": [
-              1.3125,
-              0.8125,
-              1.3125,
-              0.375,
+              1.4874999523162842,
+              0.875,
+              1.4874999523162842,
+              0.875,
               4.0,
               0.25,
               0.0
@@ -2170,8 +2170,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 36,
-          "work_registers_used": 15
+          "uniform_registers_used": 46,
+          "work_registers_used": 20
         }
       }
     }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -12440,7 +12440,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 52,
+          "fp16_arithmetic": 55,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -12468,9 +12468,9 @@
               "varying"
             ],
             "shortest_path_cycles": [
+              0.203125,
               0.171875,
-              0.171875,
-              0.171875,
+              0.203125,
               0.0625,
               0.0,
               0.25,
@@ -12480,10 +12480,10 @@
               "load_store"
             ],
             "total_cycles": [
-              0.609375,
-              0.375,
-              0.609375,
-              0.125,
+              0.78125,
+              0.4375,
+              0.78125,
+              0.625,
               4.0,
               0.25,
               0.0
@@ -12491,8 +12491,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 14,
-          "work_registers_used": 15
+          "uniform_registers_used": 22,
+          "work_registers_used": 20
         }
       }
     }
@@ -13277,7 +13277,7 @@
             "shortest_path_cycles": [
               0.390625,
               0.390625,
-              0.25,
+              0.28125,
               0.3125,
               0.0,
               0.25,
@@ -13287,10 +13287,10 @@
               "load_store"
             ],
             "total_cycles": [
-              0.6875,
-              0.65625,
-              0.6875,
-              0.375,
+              0.875,
+              0.71875,
+              0.84375,
+              0.875,
               4.0,
               0.25,
               0.0
@@ -13298,8 +13298,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
-          "work_registers_used": 19
+          "uniform_registers_used": 30,
+          "work_registers_used": 23
         }
       }
     }


### PR DESCRIPTION
Partial work towards https://github.com/flutter/flutter/issues/131450 similar to https://github.com/flutter/engine/pull/44181.

---

Run the Playground locally:

```bash
$ENGINE/out/host_debug_unopt/impeller_unittests \
  --enable_playground \
  --gtest_filter="*CanRender*GradientWithDithering*"
```

## Radial

### Before

<img width="1014" alt="Screenshot 2023-08-03 at 10 08 53 AM" src="https://github.com/flutter/engine/assets/168174/d53f2c0e-5c48-4ecb-8e67-d4ab28bfe488">

### After

<img width="1018" alt="Screenshot 2023-08-03 at 10 13 57 AM" src="https://github.com/flutter/engine/assets/168174/3b6e6e65-3dd3-4cb3-9950-36e2ba5c1da2">

## Sweep

### Before

<img width="1019" alt="Screenshot 2023-08-03 at 10 27 35 AM" src="https://github.com/flutter/engine/assets/168174/4e3bc82d-c0d5-43dd-952a-c11cb586fb65">

### After

<img width="1018" alt="Screenshot 2023-08-03 at 10 33 11 AM" src="https://github.com/flutter/engine/assets/168174/7e526391-cfd7-4920-89ff-fe26793b24fc"

## Conical

### Before

<img width="1019" alt="Screenshot 2023-08-08 at 11 55 43 AM" src="https://github.com/flutter/engine/assets/168174/944709f4-8163-4de3-bfc5-eaf30b978529">

### After

<img width="1016" alt="Screenshot 2023-08-08 at 1 11 40 PM" src="https://github.com/flutter/engine/assets/168174/60ad67a4-b409-4136-a753-b8608f46fbf2">