### PR TITLE
Migrate GL calls of GrBackend*

### DIFF
--- a/shell/gpu/gpu_surface_gl_skia.cc
+++ b/shell/gpu/gpu_surface_gl_skia.cc
@@ -19,9 +19,11 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrContextOptions.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
+#include "third_party/skia/include/gpu/gl/GrGLTypes.h"
 
 // These are common defines present on all OpenGL headers. However, we don't
-// want to perform GL header reasolution on each platform we support. So just
+// want to perform GL header resolution on each platform we support. So just
 // define these upfront. It is unlikely we will need more. But, if we do, we can
 // add the same here.
 #define GPU_GL_RGBA8 0x8058
@@ -138,12 +140,13 @@ static sk_sp<SkSurface> WrapOnscreenSurface(GrDirectContext* context,
   framebuffer_info.fFBOID = static_cast<GrGLuint>(fbo);
   framebuffer_info.fFormat = format;
 
-  GrBackendRenderTarget render_target(size.width(),     // width
-                                      size.height(),    // height
-                                      0,                // sample count
-                                      0,                // stencil bits
-                                      framebuffer_info  // framebuffer info
-  );
+  auto render_target =
+      GrBackendRenderTargets::MakeGL(size.width(),     // width
+                                     size.height(),    // height
+                                     0,                // sample count
+                                     0,                // stencil bits
+                                     framebuffer_info  // framebuffer info
+      );
 
   sk_sp<SkColorSpace> colorspace = SkColorSpace::MakeSRGB();
   SkSurfaceProps surface_props(0, kUnknown_SkPixelGeometry);

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -16,6 +16,8 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
+#include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
+#include "third_party/skia/include/gpu/gl/GrGLTypes.h"
 
 namespace flutter {
 
@@ -60,7 +62,8 @@ void AndroidExternalTextureGL::Paint(PaintContext& context,
   }
   GrGLTextureInfo textureInfo = {GL_TEXTURE_EXTERNAL_OES, texture_name_,
                                  GL_RGBA8_OES};
-  GrBackendTexture backendTexture(1, 1, GrMipMapped::kNo, textureInfo);
+  auto backendTexture =
+      GrBackendTextures::MakeGL(1, 1, skgpu::Mipmapped::kNo, textureInfo);
   sk_sp<SkImage> image = SkImages::BorrowTextureFrom(
       context.gr_context, backendTexture, kTopLeft_GrSurfaceOrigin,
       kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);

--- a/shell/platform/android/hardware_buffer_external_texture_gl.cc
+++ b/shell/platform/android/hardware_buffer_external_texture_gl.cc
@@ -18,6 +18,8 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
+#include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
+#include "third_party/skia/include/gpu/gl/GrGLTypes.h"
 
 namespace flutter {
 
@@ -54,7 +56,8 @@ void HardwareBufferExternalTextureGL::Paint(PaintContext& context,
   }
   GrGLTextureInfo textureInfo = {GL_TEXTURE_EXTERNAL_OES,
                                  texture_.get().texture_name, GL_RGBA8_OES};
-  GrBackendTexture backendTexture(1, 1, GrMipMapped::kNo, textureInfo);
+  auto backendTexture =
+      GrBackendTextures::MakeGL(1, 1, skgpu::Mipmapped::kNo, textureInfo);
   sk_sp<SkImage> image = SkImages::BorrowTextureFrom(
       context.gr_context, backendTexture, kTopLeft_GrSurfaceOrigin,
       kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -68,6 +68,8 @@ extern const intptr_t kPlatformStrongDillSize;
 // embedder/BUILD.gn variable impeller_supports_rendering is disabled.
 #ifdef SHELL_ENABLE_GL
 #include "flutter/shell/platform/embedder/embedder_external_texture_gl.h"
+#include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
+#include "third_party/skia/include/gpu/gl/GrGLTypes.h"
 #ifdef IMPELLER_SUPPORTS_RENDERING
 #include "flutter/shell/platform/embedder/embedder_render_target_impeller.h"  // nogncheck
 #include "flutter/shell/platform/embedder/embedder_surface_gl_impeller.h"  // nogncheck
@@ -742,10 +744,10 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
   texture_info.fID = texture->name;
   texture_info.fFormat = texture->format;
 
-  GrBackendTexture backend_texture(config.size.width,   //
-                                   config.size.height,  //
-                                   GrMipMapped::kNo,    //
-                                   texture_info         //
+  auto backend_texture = GrBackendTextures::MakeGL(config.size.width,      //
+                                                   config.size.height,     //
+                                                   skgpu::Mipmapped::kNo,  //
+                                                   texture_info            //
   );
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
@@ -783,13 +785,13 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
   framebuffer_info.fFormat = framebuffer->target;
   framebuffer_info.fFBOID = framebuffer->name;
 
-  GrBackendRenderTarget backend_render_target(
-      config.size.width,   // width
-      config.size.height,  // height
-      1,                   // sample count
-      0,                   // stencil bits
-      framebuffer_info     // framebuffer info
-  );
+  auto backend_render_target =
+      GrBackendRenderTargets::MakeGL(config.size.width,   // width
+                                     config.size.height,  // height
+                                     1,                   // sample count
+                                     0,                   // stencil bits
+                                     framebuffer_info     // framebuffer info
+      );
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 

--- a/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -15,6 +15,8 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
+#include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
+#include "third_party/skia/include/gpu/gl/GrGLTypes.h"
 
 namespace flutter {
 
@@ -77,8 +79,8 @@ sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTexture(
     height = texture->height;
   }
 
-  GrBackendTexture gr_backend_texture(width, height, GrMipMapped::kNo,
-                                      gr_texture_info);
+  auto gr_backend_texture = GrBackendTextures::MakeGL(
+      width, height, skgpu::Mipmapped::kNo, gr_texture_info);
   SkImages::TextureReleaseProc release_proc = texture->destruction_callback;
   auto image =
       SkImages::BorrowTextureFrom(context,                   // context

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -13,6 +13,8 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
+#include "third_party/skia/include/gpu/gl/GrGLTypes.h"
 
 #include <cstdlib>
 #include <memory>
@@ -111,7 +113,8 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
   }
 
   GrGLFramebufferInfo framebuffer_info = {};
-  if (!render_target.getGLFramebufferInfo(&framebuffer_info)) {
+  if (!GrBackendRenderTargets::GetGLFramebufferInfo(render_target,
+                                                    &framebuffer_info)) {
     FML_LOG(ERROR) << "Could not access backend framebuffer info.";
     return false;
   }
@@ -164,7 +167,7 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(
   }
 
   GrGLTextureInfo texture_info = {};
-  if (!render_texture.getGLTextureInfo(&texture_info)) {
+  if (!GrBackendTextures::GetGLTextureInfo(render_texture, &texture_info)) {
     FML_LOG(ERROR) << "Could not access backend texture info.";
     return false;
   }

--- a/testing/test_gl_surface.cc
+++ b/testing/test_gl_surface.cc
@@ -19,7 +19,9 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
 #include "third_party/skia/include/gpu/gl/GrGLAssembleInterface.h"
+#include "third_party/skia/include/gpu/gl/GrGLTypes.h"
 
 namespace flutter {
 namespace testing {
@@ -351,13 +353,13 @@ sk_sp<SkSurface> TestGLSurface::GetOnscreenSurface() {
   framebuffer_info.fFormat = 0x93A1;  // GL_BGRA8;
 #endif
 
-  GrBackendRenderTarget backend_render_target(
-      width,            // width
-      height,           // height
-      1,                // sample count
-      8,                // stencil bits
-      framebuffer_info  // framebuffer info
-  );
+  auto backend_render_target =
+      GrBackendRenderTargets::MakeGL(width,            // width
+                                     height,           // height
+                                     1,                // sample count
+                                     8,                // stencil bits
+                                     framebuffer_info  // framebuffer info
+      );
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 


### PR DESCRIPTION
In https://skia-review.googlesource.com/c/skia/+/701398 Skia refactored GrBackend* to not require #ifdefs. This changes
callsites in Flutter to use static functions instead of methods that were conditionally compiled on those classes.

There should be no functional change with these. As I was updating these callsites, I saw uses of the deprecated GrMipMapped enum and used the updated skgpu::Mipmapped (the former is an alias to the latter).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
