### PR TITLE
[darwin] Move common targets to common/BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -187,7 +187,7 @@ group("unittests") {
     if (is_mac) {
       public_deps += [
         "//flutter/impeller/golden_tests:impeller_golden_tests",
-        "//flutter/shell/platform/darwin/common:flutter_channels_unittests",
+        "//flutter/shell/platform/darwin/common:framework_shared_unittests",
         "//flutter/third_party/spring_animation:spring_animation_unittests",
       ]
     }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -187,7 +187,7 @@ group("unittests") {
     if (is_mac) {
       public_deps += [
         "//flutter/impeller/golden_tests:impeller_golden_tests",
-        "//flutter/shell/platform/darwin:flutter_channels_unittests",
+        "//flutter/shell/platform/darwin/common:flutter_channels_unittests",
         "//flutter/third_party/spring_animation:spring_animation_unittests",
       ]
     }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -187,7 +187,7 @@ group("unittests") {
     if (is_mac) {
       public_deps += [
         "//flutter/impeller/golden_tests:impeller_golden_tests",
-        "//flutter/shell/platform/darwin/common:framework_shared_unittests",
+        "//flutter/shell/platform/darwin/common:framework_common_unittests",
         "//flutter/third_party/spring_animation:spring_animation_unittests",
       ]
     }

--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -5,7 +5,6 @@
 assert(is_mac || is_ios)
 
 import("//flutter/shell/platform/config.gni")
-import("//flutter/testing/testing.gni")
 
 group("darwin") {
   if (is_ios) {
@@ -17,71 +16,4 @@ group("darwin") {
       deps += [ "macos" ]
     }
   }
-}
-
-source_set("flutter_channels") {
-  cflags_objc = flutter_cflags_objc
-  cflags_objcc = flutter_cflags_objcc
-
-  sources = [
-    "common/buffer_conversions.h",
-    "common/buffer_conversions.mm",
-  ]
-
-  deps = [ "//flutter/fml" ]
-
-  public_deps = [ ":flutter_channels_arc" ]
-
-  public_configs = [ "//flutter:config" ]
-}
-
-source_set("flutter_channels_arc") {
-  cflags_objc = flutter_cflags_objc_arc
-  cflags_objcc = flutter_cflags_objcc_arc
-
-  sources = [
-    "common/framework/Headers/FlutterBinaryMessenger.h",
-    "common/framework/Headers/FlutterChannels.h",
-    "common/framework/Headers/FlutterCodecs.h",
-    "common/framework/Headers/FlutterMacros.h",
-    "common/framework/Source/FlutterChannels.mm",
-    "common/framework/Source/FlutterCodecs.mm",
-    "common/framework/Source/FlutterStandardCodec.mm",
-    "common/framework/Source/FlutterStandardCodecHelper.cc",
-    "common/framework/Source/FlutterStandardCodec_Internal.h",
-  ]
-
-  public = [
-    "common/framework/Headers/FlutterBinaryMessenger.h",
-    "common/framework/Headers/FlutterChannels.h",
-    "common/framework/Headers/FlutterCodecs.h",
-    "common/framework/Headers/FlutterMacros.h",
-    "common/framework/Source/FlutterStandardCodec_Internal.h",
-  ]
-
-  public_configs = [ "//flutter:config" ]
-
-  deps = [ "//flutter/fml" ]
-}
-
-test_fixtures("flutter_channels_fixtures") {
-  fixtures = []
-}
-
-executable("flutter_channels_unittests") {
-  testonly = true
-
-  sources = [
-    "common/framework/Source/flutter_codecs_unittest.mm",
-    "common/framework/Source/flutter_standard_codec_unittest.mm",
-  ]
-
-  deps = [
-    ":flutter_channels",
-    ":flutter_channels_fixtures",
-    "//flutter/testing",
-    "//third_party/dart/runtime:libdart_jit",
-  ]
-
-  public_configs = [ "//flutter:config" ]
 }

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -65,7 +65,7 @@ test_fixtures("flutter_channels_fixtures") {
 }
 
 # Unit tests for channels.
-executable("flutter_channels_unittests") {
+executable("framework_shared_unittests") {
   testonly = true
 
   sources = [

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -6,7 +6,7 @@ assert(is_mac || is_ios)
 
 import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
-import("framework_shared.gni")
+import("framework_common.gni")
 
 source_set("common") {
   cflags_objc = flutter_cflags_objc
@@ -32,7 +32,7 @@ config("framework_relative_headers") {
 }
 
 # Framework code shared between iOS and macOS.
-source_set("framework_shared") {
+source_set("framework_common") {
   cflags_objc = flutter_cflags_objc_arc
   cflags_objcc = flutter_cflags_objcc_arc
 
@@ -46,7 +46,7 @@ source_set("framework_shared") {
     "framework/Source/FlutterStandardCodec_Internal.h",
   ]
 
-  public = framework_shared_headers
+  public = framework_common_headers
 
   public += [ "framework/Source/FlutterNSBundleUtils.h" ]
 
@@ -60,12 +60,12 @@ source_set("framework_shared") {
   deps = [ "//flutter/fml" ]
 }
 
-test_fixtures("flutter_channels_fixtures") {
+test_fixtures("framework_common_fixtures") {
   fixtures = []
 }
 
 # Unit tests for channels.
-executable("framework_shared_unittests") {
+executable("framework_common_unittests") {
   testonly = true
 
   sources = [
@@ -74,8 +74,8 @@ executable("framework_shared_unittests") {
   ]
 
   deps = [
-    ":flutter_channels_fixtures",
-    ":framework_shared",
+    ":framework_common",
+    ":framework_common_fixtures",
     "//flutter/testing",
     "//third_party/dart/runtime:libdart_jit",
   ]

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -2,7 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+assert(is_mac || is_ios)
+
 import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
 import("framework_shared.gni")
 
 source_set("common") {
@@ -55,4 +58,27 @@ source_set("framework_shared") {
   ]
 
   deps = [ "//flutter/fml" ]
+}
+
+test_fixtures("flutter_channels_fixtures") {
+  fixtures = []
+}
+
+# Unit tests for channels.
+executable("flutter_channels_unittests") {
+  testonly = true
+
+  sources = [
+    "framework/Source/flutter_codecs_unittest.mm",
+    "framework/Source/flutter_standard_codec_unittest.mm",
+  ]
+
+  deps = [
+    ":flutter_channels_fixtures",
+    ":framework_shared",
+    "//flutter/testing",
+    "//third_party/dart/runtime:libdart_jit",
+  ]
+
+  public_configs = [ "//flutter:config" ]
 }

--- a/shell/platform/darwin/common/framework_common.gni
+++ b/shell/platform/darwin/common/framework_common.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-framework_shared_headers =
+framework_common_headers =
     get_path_info([
                     "framework/Headers/FlutterMacros.h",
                     "framework/Headers/FlutterBinaryMessenger.h",

--- a/shell/platform/darwin/graphics/BUILD.gn
+++ b/shell/platform/darwin/graphics/BUILD.gn
@@ -23,7 +23,7 @@ source_set("graphics") {
     "//flutter/display_list",
     "//flutter/fml",
     "//flutter/shell/common",
-    "//flutter/shell/platform/darwin/common:framework_shared",
+    "//flutter/shell/platform/darwin/common:framework_common",
   ]
 
   if (impeller_supports_rendering) {

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -9,7 +9,7 @@ import("//build/toolchain/clang.gni")
 import("//flutter/common/config.gni")
 import("//flutter/shell/config.gni")
 import("//flutter/shell/gpu/gpu.gni")
-import("//flutter/shell/platform/darwin/common/framework_shared.gni")
+import("//flutter/shell/platform/darwin/common/framework_common.gni")
 import("//flutter/testing/testing.gni")
 
 _flutter_framework_dir = "$root_out_dir/Flutter.framework"
@@ -52,7 +52,7 @@ source_set("flutter_framework_source_arc") {
     ":flutter_framework_source",
     "//flutter/fml",
     "//flutter/shell/platform/common:common_cpp_input",
-    "//flutter/shell/platform/darwin/common:framework_shared",
+    "//flutter/shell/platform/darwin/common:framework_common",
     "//third_party/icu",
   ]
   public_configs = [ "//flutter:config" ]
@@ -189,7 +189,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/common",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/darwin/common",
-    "//flutter/shell/platform/darwin/common:framework_shared",
+    "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/profiling:profiling",
     "//flutter/third_party/spring_animation",
@@ -243,7 +243,7 @@ source_set("ios_test_flutter_mrc") {
     "//flutter/common:common",
     "//flutter/lib/ui:ui",
     "//flutter/shell/common:common",
-    "//flutter/shell/platform/darwin/common:framework_shared",
+    "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/third_party/tonic",
     "//flutter/third_party/txt",
@@ -308,7 +308,7 @@ shared_library("ios_test_flutter") {
     ":ios_test_flutter_mrc",
     "//flutter/common:common",
     "//flutter/lib/ui:ui",
-    "//flutter/shell/platform/darwin/common:framework_shared",
+    "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/platform/embedder:embedder_test_utils",
     "//flutter/third_party/spring_animation",
@@ -397,7 +397,7 @@ action("copy_framework_headers") {
   script = "//flutter/sky/tools/install_framework_headers.py"
   visibility = [ ":*" ]
   sources = get_path_info(_flutter_framework_headers, "abspath") +
-            framework_shared_headers
+            framework_common_headers
   outputs = []
   foreach(header, sources) {
     header_basename = get_path_info(header, "file")

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -7,7 +7,7 @@ assert(is_mac)
 import("//build/config/mac/mac_sdk.gni")
 import("//flutter/build/zip_bundle.gni")
 import("//flutter/shell/gpu/gpu.gni")
-import("//flutter/shell/platform/darwin/common/framework_shared.gni")
+import("//flutter/shell/platform/darwin/common/framework_common.gni")
 import("//flutter/shell/platform/glfw/config.gni")
 import("//flutter/testing/testing.gni")
 
@@ -121,7 +121,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/common:common_cpp_enums",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_switches",
-    "//flutter/shell/platform/darwin/common:framework_shared",
+    "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/darwin/graphics:graphics",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//third_party/skia",
@@ -204,7 +204,7 @@ executable("flutter_desktop_darwin_unittests") {
     ":flutter_framework_source",
     "//flutter/shell/platform/common:common_cpp_accessibility",
     "//flutter/shell/platform/common:common_cpp_enums",
-    "//flutter/shell/platform/darwin/common:framework_shared",
+    "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/darwin/graphics",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/platform/embedder:embedder_test_utils",
@@ -241,7 +241,7 @@ action("copy_framework_headers") {
   script = "//flutter/sky/tools/install_framework_headers.py"
   visibility = [ ":*" ]
   sources = get_path_info(_flutter_framework_headers, "abspath") +
-            framework_shared_headers
+            framework_common_headers
   outputs = []
   foreach(header, sources) {
     header_basename = get_path_info(header, "file")

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -418,7 +418,7 @@ def run_cc_tests(build_dir, executable_filter, coverage, capture_core_dump):
     unittests += [
         # The accessibility library only supports Mac and Windows.
         make_test('accessibility_unittests'),
-        make_test('flutter_channels_unittests'),
+        make_test('framework_shared_unittests'),
         make_test('spring_animation_unittests'),
     ]
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -418,7 +418,7 @@ def run_cc_tests(build_dir, executable_filter, coverage, capture_core_dump):
     unittests += [
         # The accessibility library only supports Mac and Windows.
         make_test('accessibility_unittests'),
-        make_test('framework_shared_unittests'),
+        make_test('framework_common_unittests'),
         make_test('spring_animation_unittests'),
     ]
 


### PR DESCRIPTION
Previously, some common Darwin framework targets existed in: 
//flutter/shell/platform/darwin/BUILD.gn

This moves all targets into:
//flutter/shell/platform/darwin/common/BUILD.gn

We also de-duplicate targets with existing targets.
* The `flutter_channels` target duplicates the existing `framework_shared` target.
* The `common` target already includes the buffer conversions translation units,
  which are only used by the iOS embedder.

No test changes since there are no semantic changes, just a restructuring of build targets.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
