### PR TITLE
[Impeller] Run clangd tidy, opting out in 2 cases.

### DIFF
--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "flutter/fml/build_config.h"
-#include "flutter/fml/string_conversion.h"
 #include "flutter/fml/trace_event.h"
 #include "impeller/base/validation.h"
 #include "impeller/renderer/backend/vulkan/allocator_vk.h"
@@ -28,11 +27,8 @@
 #include "impeller/renderer/backend/vulkan/command_pool_vk.h"
 #include "impeller/renderer/backend/vulkan/debug_report_vk.h"
 #include "impeller/renderer/backend/vulkan/fence_waiter_vk.h"
-#include "impeller/renderer/backend/vulkan/formats_vk.h"
 #include "impeller/renderer/backend/vulkan/resource_manager_vk.h"
 #include "impeller/renderer/backend/vulkan/surface_context_vk.h"
-#include "impeller/renderer/backend/vulkan/surface_vk.h"
-#include "impeller/renderer/backend/vulkan/vk.h"
 #include "impeller/renderer/capabilities.h"
 
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -17,11 +17,8 @@
 #include "impeller/renderer/backend/vulkan/queue_vk.h"
 #include "impeller/renderer/backend/vulkan/sampler_library_vk.h"
 #include "impeller/renderer/backend/vulkan/shader_library_vk.h"
-#include "impeller/renderer/backend/vulkan/swapchain_vk.h"
-#include "impeller/renderer/backend/vulkan/vk.h"
 #include "impeller/renderer/capabilities.h"
 #include "impeller/renderer/context.h"
-#include "impeller/renderer/surface.h"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/debug_report_vk.cc
+++ b/impeller/renderer/backend/vulkan/debug_report_vk.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/renderer/backend/vulkan/debug_report_vk.h"
 
+#include "impeller/base/validation.h"
 #include "impeller/renderer/backend/vulkan/capabilities_vk.h"
 
 namespace impeller {

--- a/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/trace_event.h"
 #include "impeller/base/allocation.h"
+#include "impeller/base/validation.h"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/device_holder.h
+++ b/impeller/renderer/backend/vulkan/device_holder.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "impeller/renderer/backend/vulkan/vk.h"
+#include "impeller/renderer/backend/vulkan/vk.h"  // IWYU pragma: keep.
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -9,6 +9,7 @@
 
 #include "flutter/fml/thread.h"
 #include "flutter/fml/trace_event.h"
+#include "impeller/base/validation.h"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
@@ -9,6 +9,7 @@
 #include <sstream>
 
 #include "flutter/fml/mapping.h"
+#include "impeller/base/validation.h"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
+++ b/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
@@ -6,10 +6,8 @@
 
 #include "flutter/fml/file.h"
 #include "flutter/fml/macros.h"
-#include "impeller/base/thread.h"
 #include "impeller/renderer/backend/vulkan/capabilities_vk.h"
 #include "impeller/renderer/backend/vulkan/device_holder.h"
-#include "impeller/renderer/backend/vulkan/vk.h"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/vk.h
+++ b/impeller/renderer/backend/vulkan/vk.h
@@ -6,7 +6,6 @@
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
-#include "impeller/base/validation.h"
 
 #define VK_NO_PROTOTYPES
 
@@ -66,6 +65,6 @@
   { [[maybe_unused]] auto res = (ignored); }
 #define VULKAN_HPP_NO_EXCEPTIONS
 
-#include "vulkan/vulkan.hpp"
+#include "vulkan/vulkan.hpp"  // IWYU pragma: keep.
 
 static_assert(VK_HEADER_VERSION >= 215, "Vulkan headers must not be too old.");


### PR DESCRIPTION
Many `#include`s, particularly in the `impeller/renderer/backend/vulkan/...` directory, had existing `clangd` lint violations.

The most frequent and easiest to fix appears to be https://clangd.llvm.org/guides/include-cleaner.

---

Note that I used `// IWYU pragma: keep.` in two places where `clangd` wasn't able to tell something was in use. In other cases you'll see additions because files were relying on transitive includes that are removed in this PR, but there should be 0 behavioral changes!