### PR TITLE
Revert "Build iOS unittest target in unopt builds"

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -264,6 +264,7 @@ source_set("ios_test_flutter_mrc") {
 }
 
 shared_library("ios_test_flutter") {
+  testonly = true
   visibility = [ ":*" ]
   cflags = [
     "-fvisibility=default",
@@ -303,6 +304,7 @@ shared_library("ios_test_flutter") {
     "framework/Source/connection_collection_test.mm",
   ]
   deps = [
+    ":flutter_framework",
     ":flutter_framework_source",
     ":flutter_framework_source_arc",
     ":ios_gpu_configuration",
@@ -465,8 +467,4 @@ action("flutter_framework") {
   ]
 
   deps = [ ":universal_flutter_framework" ]
-
-  if (is_debug) {
-    deps += [ ":ios_test_flutter" ]
-  }
 }


### PR DESCRIPTION
Reverts flutter/engine#44301

```
Traceback (most recent call last):
  File "/Volumes/Work/s/w/ir/cache/builder/src/flutter/testing/run_tests.py", line 1286, in <module>
    sys.exit(main())
  File "/Volumes/Work/s/w/ir/cache/builder/src/flutter/testing/run_tests.py", line 1269, in main
    run_objc_tests(args.ios_variant, args.objc_filter)
  File "/Volumes/Work/s/w/ir/cache/builder/src/flutter/testing/run_tests.py", line 721, in run_objc_tests
    ensure_ios_tests_are_built(ios_out_dir)
  File "/Volumes/Work/s/w/ir/cache/builder/src/flutter/testing/run_tests.py", line 625, in ensure_ios_tests_are_built
    assert flutter_dylib_time <= ios_test_lib_time, final_message
AssertionError: /Volumes/Work/s/w/ir/cache/builder/src/out/ios_debug_sim_arm64_extension_safe/libios_test_flutter.dylib is older than /Volumes/Work/s/w/ir/cache/builder/src/out/ios_debug_sim_arm64_extension_safe/libFlutter.dylib. Please run the following commands: 
gn --ios --unoptimized --runtime-mode=debug --no-lto --simulator
ninja -C /Volumes/Work/s/w/ir/cache/builder/src/out/ios_debug_sim_arm64_extension_safe ios_test_flutter
```

It failed we in run_test.py we check if the ios_test is built after the framework, which is not true anymore after moving the test inside the build target.