### PR TITLE
Do not log exceptions from JNI lookups of APIs that are known to be unavailable on older devices

### DIFF
--- a/fml/platform/android/jni_util.cc
+++ b/fml/platform/android/jni_util.cc
@@ -185,11 +185,13 @@ bool HasException(JNIEnv* env) {
   return env->ExceptionCheck() != JNI_FALSE;
 }
 
-bool ClearException(JNIEnv* env) {
+bool ClearException(JNIEnv* env, bool silent) {
   if (!HasException(env)) {
     return false;
   }
-  env->ExceptionDescribe();
+  if (!silent) {
+    env->ExceptionDescribe();
+  }
   env->ExceptionClear();
   return true;
 }

--- a/fml/platform/android/jni_util.h
+++ b/fml/platform/android/jni_util.h
@@ -42,7 +42,7 @@ ScopedJavaLocalRef<jobjectArray> VectorToBufferArray(
 
 bool HasException(JNIEnv* env);
 
-bool ClearException(JNIEnv* env);
+bool ClearException(JNIEnv* env, bool silent = false);
 
 bool CheckException(JNIEnv* env);
 std::string GetJavaExceptionInfo(JNIEnv* env, jthrowable java_throwable);

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -1194,7 +1194,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
 
   if (g_image_get_hardware_buffer_method == nullptr) {
     // Continue on as this method may not exist at API <= 29.
-    fml::jni::ClearException(env);
+    fml::jni::ClearException(env, true);
   }
 
   g_image_close_method = env->GetMethodID(g_image_class->obj(), "close", "()V");
@@ -1214,11 +1214,11 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
         env->GetMethodID(g_hardware_buffer_class->obj(), "close", "()V");
     if (g_hardware_buffer_close_method == nullptr) {
       // Continue on as this class may not exist at API <= 26.
-      fml::jni::ClearException(env);
+      fml::jni::ClearException(env, true);
     }
   } else {
     // Continue on as this class may not exist at API <= 26.
-    fml::jni::ClearException(env);
+    fml::jni::ClearException(env, true);
   }
 
   g_compute_platform_resolved_locale_method = env->GetMethodID(


### PR DESCRIPTION
These exceptions are benign but were being logged every time an app is launched on a device with an Android API level below 26.
