### PR TITLE
[Impeller] Cache Polyline and tessellation for Path

### DIFF
--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -17,25 +17,27 @@ namespace impeller {
 
 /// Given a convex polyline, create a triangle fan structure.
 std::pair<std::vector<Point>, std::vector<uint16_t>> TessellateConvex(
-    Path::Polyline polyline) {
+    const Path::Polyline& polyline) {
   std::vector<Point> output;
   std::vector<uint16_t> indices;
 
-  for (auto j = 0u; j < polyline.contours.size(); j++) {
+  const auto& points = polyline.points();
+
+  for (auto j = 0u; j < polyline.contours().size(); j++) {
     auto [start, end] = polyline.GetContourPointBounds(j);
-    auto center = polyline.points[start];
+    auto center = points[start];
 
     // Some polygons will not self close and an additional triangle
     // must be inserted, others will self close and we need to avoid
     // inserting an extra triangle.
-    if (polyline.points[end - 1] == polyline.points[start]) {
+    if (points[end - 1] == points[start]) {
       end--;
     }
     output.emplace_back(center);
-    output.emplace_back(polyline.points[start + 1]);
+    output.emplace_back(points[start + 1]);
 
     for (auto i = start + 2; i < end; i++) {
-      const auto& point_b = polyline.points[i];
+      const auto& point_b = points[i];
       output.emplace_back(point_b);
 
       indices.emplace_back(0);

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -49,7 +49,7 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
 /// @brief Given a polyline created from a convex filled path, perform a
 /// tessellation.
 std::pair<std::vector<Point>, std::vector<uint16_t>> TessellateConvex(
-    Path::Polyline polyline);
+    const Path::Polyline& polyline);
 
 class Geometry {
  public:

--- a/impeller/geometry/geometry_benchmarks.cc
+++ b/impeller/geometry/geometry_benchmarks.cc
@@ -30,7 +30,7 @@ static void BM_Polyline(benchmark::State& state, Args&&... args) {
   size_t single_point_count = 0u;
   while (state.KeepRunning()) {
     auto polyline = path.CreatePolyline(1.0f);
-    single_point_count = polyline.points.size();
+    single_point_count = polyline.points().size();
     point_count += single_point_count;
     if (tessellate) {
       tess.Tessellate(

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -600,8 +600,8 @@ TEST(GeometryTest, EmptyPath) {
   ASSERT_POINT_NEAR(c.destination, Point());
 
   Path::Polyline polyline = path.CreatePolyline(1.0f);
-  ASSERT_TRUE(polyline.points.empty());
-  ASSERT_TRUE(polyline.contours.empty());
+  ASSERT_TRUE(polyline.points().empty());
+  ASSERT_TRUE(polyline.contours().empty());
 }
 
 TEST(GeometryTest, SimplePath) {
@@ -2016,13 +2016,13 @@ TEST(GeometryTest, PathCreatePolyLineDoesNotDuplicatePoints) {
 
   auto polyline = path.CreatePolyline(1.0f);
 
-  ASSERT_EQ(polyline.contours.size(), 2u);
-  ASSERT_EQ(polyline.points.size(), 5u);
-  ASSERT_EQ(polyline.points[0].x, 10);
-  ASSERT_EQ(polyline.points[1].x, 20);
-  ASSERT_EQ(polyline.points[2].x, 30);
-  ASSERT_EQ(polyline.points[3].x, 40);
-  ASSERT_EQ(polyline.points[4].x, 50);
+  ASSERT_EQ(polyline.contours().size(), 2u);
+  ASSERT_EQ(polyline.points().size(), 5u);
+  ASSERT_EQ(polyline.points()[0].x, 10);
+  ASSERT_EQ(polyline.points()[1].x, 20);
+  ASSERT_EQ(polyline.points()[2].x, 30);
+  ASSERT_EQ(polyline.points()[3].x, 40);
+  ASSERT_EQ(polyline.points()[4].x, 50);
 }
 
 TEST(GeometryTest, PathBuilderSetsCorrectContourPropertiesForAddCommands) {
@@ -2101,12 +2101,12 @@ TEST(GeometryTest, PathCreatePolylineGeneratesCorrectContourData) {
                                 .Close()
                                 .TakePath()
                                 .CreatePolyline(1.0f);
-  ASSERT_EQ(polyline.points.size(), 6u);
-  ASSERT_EQ(polyline.contours.size(), 2u);
-  ASSERT_EQ(polyline.contours[0].is_closed, false);
-  ASSERT_EQ(polyline.contours[0].start_index, 0u);
-  ASSERT_EQ(polyline.contours[1].is_closed, true);
-  ASSERT_EQ(polyline.contours[1].start_index, 2u);
+  ASSERT_EQ(polyline.points().size(), 6u);
+  ASSERT_EQ(polyline.contours().size(), 2u);
+  ASSERT_EQ(polyline.contours()[0].is_closed, false);
+  ASSERT_EQ(polyline.contours()[0].start_index, 0u);
+  ASSERT_EQ(polyline.contours()[1].is_closed, true);
+  ASSERT_EQ(polyline.contours()[1].start_index, 2u);
 }
 
 TEST(GeometryTest, PolylineGetContourPointBoundsReturnsCorrectRanges) {
@@ -2132,15 +2132,15 @@ TEST(GeometryTest, PathAddRectPolylineHasCorrectContourData) {
                                 .AddRect(Rect::MakeLTRB(50, 60, 70, 80))
                                 .TakePath()
                                 .CreatePolyline(1.0f);
-  ASSERT_EQ(polyline.contours.size(), 1u);
-  ASSERT_TRUE(polyline.contours[0].is_closed);
-  ASSERT_EQ(polyline.contours[0].start_index, 0u);
-  ASSERT_EQ(polyline.points.size(), 5u);
-  ASSERT_EQ(polyline.points[0], Point(50, 60));
-  ASSERT_EQ(polyline.points[1], Point(70, 60));
-  ASSERT_EQ(polyline.points[2], Point(70, 80));
-  ASSERT_EQ(polyline.points[3], Point(50, 80));
-  ASSERT_EQ(polyline.points[4], Point(50, 60));
+  ASSERT_EQ(polyline.contours().size(), 1u);
+  ASSERT_TRUE(polyline.contours()[0].is_closed);
+  ASSERT_EQ(polyline.contours()[0].start_index, 0u);
+  ASSERT_EQ(polyline.points().size(), 5u);
+  ASSERT_EQ(polyline.points()[0], Point(50, 60));
+  ASSERT_EQ(polyline.points()[1], Point(70, 60));
+  ASSERT_EQ(polyline.points()[2], Point(70, 80));
+  ASSERT_EQ(polyline.points()[3], Point(50, 80));
+  ASSERT_EQ(polyline.points()[4], Point(50, 60));
 }
 
 TEST(GeometryTest, PathPolylineDuplicatesAreRemovedForSameContour) {
@@ -2157,19 +2157,19 @@ TEST(GeometryTest, PathPolylineDuplicatesAreRemovedForSameContour) {
           .LineTo({0, 100})  // Insert duplicate at end of contour.
           .TakePath()
           .CreatePolyline(1.0f);
-  ASSERT_EQ(polyline.contours.size(), 2u);
-  ASSERT_EQ(polyline.contours[0].start_index, 0u);
-  ASSERT_TRUE(polyline.contours[0].is_closed);
-  ASSERT_EQ(polyline.contours[1].start_index, 4u);
-  ASSERT_FALSE(polyline.contours[1].is_closed);
-  ASSERT_EQ(polyline.points.size(), 7u);
-  ASSERT_EQ(polyline.points[0], Point(50, 50));
-  ASSERT_EQ(polyline.points[1], Point(100, 50));
-  ASSERT_EQ(polyline.points[2], Point(100, 100));
-  ASSERT_EQ(polyline.points[3], Point(50, 50));
-  ASSERT_EQ(polyline.points[4], Point(50, 50));
-  ASSERT_EQ(polyline.points[5], Point(0, 50));
-  ASSERT_EQ(polyline.points[6], Point(0, 100));
+  ASSERT_EQ(polyline.contours().size(), 2u);
+  ASSERT_EQ(polyline.contours()[0].start_index, 0u);
+  ASSERT_TRUE(polyline.contours()[0].is_closed);
+  ASSERT_EQ(polyline.contours()[1].start_index, 4u);
+  ASSERT_FALSE(polyline.contours()[1].is_closed);
+  ASSERT_EQ(polyline.points().size(), 7u);
+  ASSERT_EQ(polyline.points()[0], Point(50, 50));
+  ASSERT_EQ(polyline.points()[1], Point(100, 50));
+  ASSERT_EQ(polyline.points()[2], Point(100, 100));
+  ASSERT_EQ(polyline.points()[3], Point(50, 50));
+  ASSERT_EQ(polyline.points()[4], Point(50, 50));
+  ASSERT_EQ(polyline.points()[5], Point(0, 50));
+  ASSERT_EQ(polyline.points()[6], Point(0, 100));
 }
 
 TEST(GeometryTest, MatrixPrinting) {

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -6,7 +6,6 @@
 
 #include <functional>
 #include <optional>
-#include <set>
 #include <tuple>
 #include <vector>
 
@@ -51,6 +50,9 @@ enum class Convexity {
 ///             Creating paths that describe complex shapes is usually done by a
 ///             path builder.
 ///
+///             Paths are internally reference counted. A copied path will
+///             share underlying storage with the original path.
+///             To make an independent copy use Path::Clone().
 class Path {
  public:
   enum class ComponentType {
@@ -75,41 +77,94 @@ class Path {
 
   /// One or more contours represented as a series of points and indices in
   /// the point vector representing the start of a new contour.
-  struct Polyline {
-    /// Points in the polyline, which may represent multiple contours specified
-    /// by indices in |breaks|.
-    std::vector<Point> points;
-    std::vector<PolylineContour> contours;
-
-    /// Convenience method to compute the start (inclusive) and end (exclusive)
-    /// point of the given contour index.
+  class Polyline {
+   public:
+    Polyline(std::vector<Point>&& points,
+             std::vector<PolylineContour>&& countours,
+             Scalar scale)
+        : state_(std::make_shared<State>()) {
+      state_->points = std::move(points);
+      state_->contours = std::move(countours);
+      state_->scale = scale;
+    }
+    /// Points in the polyline, which may represent multiple contours
+    /// specified by indices in |breaks|.
+    const std::vector<Point>& points() const { return state_->points; }
+    const std::vector<PolylineContour>& contours() const {
+      return state_->contours;
+    }
+    /// Convenience method to compute the start (inclusive) and end
+    /// (exclusive) point of the given contour index.
     ///
     /// The contour_index parameter is clamped to contours.size().
     std::tuple<size_t, size_t> GetContourPointBounds(
-        size_t contour_index) const;
+        size_t contour_index) const {
+      return state_->GetContourPointBounds(contour_index);
+    }
+
+   private:
+    friend class Tessellator;
+    friend class Path;
+
+    struct State {
+      std::vector<Point> points;
+      std::vector<PolylineContour> contours;
+      std::tuple<size_t, size_t> GetContourPointBounds(
+          size_t contour_index) const;
+      Scalar scale;
+
+      struct TesselatorData {
+        std::vector<float> vertices;
+        std::vector<uint16_t> indices;
+      };
+      std::unordered_map<FillType, TesselatorData> tesselator_cache_;
+    };
+    std::shared_ptr<State> state_;
   };
 
   Path();
 
   ~Path();
 
-  size_t GetComponentCount(std::optional<ComponentType> type = {}) const;
+  /// Creates a clone of this path. Modifications of cloned paths do not affect
+  /// the original.
+  Path Clone() const {
+    Path copy;
+    *copy.state_ = *state_;
+    return copy;
+  }
 
-  void SetFillType(FillType fill);
+  size_t GetComponentCount(std::optional<ComponentType> type = {}) const {
+    return state_->GetComponentCount(type);
+  }
 
-  FillType GetFillType() const;
+  void SetFillType(FillType fill) { state_->SetFillType(fill); }
 
-  bool IsConvex() const;
+  FillType GetFillType() const { return state_->GetFillType(); }
 
-  Path& AddLinearComponent(Point p1, Point p2);
+  bool IsConvex() const { return state_->IsConvex(); }
 
-  Path& AddQuadraticComponent(Point p1, Point cp, Point p2);
+  Path& AddLinearComponent(Point p1, Point p2) {
+    state_->AddLinearComponent(p1, p2);
+    return *this;
+  }
 
-  Path& AddCubicComponent(Point p1, Point cp1, Point cp2, Point p2);
+  Path& AddQuadraticComponent(Point p1, Point cp, Point p2) {
+    state_->AddQuadraticComponent(p1, cp, p2);
+    return *this;
+  }
 
-  Path& AddContourComponent(Point destination, bool is_closed = false);
+  Path& AddCubicComponent(Point p1, Point cp1, Point cp2, Point p2) {
+    state_->AddCubicComponent(p1, cp1, cp2, p2);
+    return *this;
+  }
 
-  void SetContourClosed(bool is_closed);
+  Path& AddContourComponent(Point destination, bool is_closed = false) {
+    state_->AddContourComponent(destination, is_closed);
+    return *this;
+  }
+
+  void SetContourClosed(bool is_closed) { state_->SetContourClosed(is_closed); }
 
   template <class T>
   using Applier = std::function<void(size_t index, const T& component)>;
@@ -117,65 +172,166 @@ class Path {
       const Applier<LinearPathComponent>& linear_applier,
       const Applier<QuadraticPathComponent>& quad_applier,
       const Applier<CubicPathComponent>& cubic_applier,
-      const Applier<ContourComponent>& contour_applier) const;
+      const Applier<ContourComponent>& contour_applier) const {
+    state_->EnumerateComponents(linear_applier, quad_applier, cubic_applier,
+                                contour_applier);
+  }
 
   bool GetLinearComponentAtIndex(size_t index,
-                                 LinearPathComponent& linear) const;
+                                 LinearPathComponent& linear) const {
+    return state_->GetLinearComponentAtIndex(index, linear);
+  }
 
   bool GetQuadraticComponentAtIndex(size_t index,
-                                    QuadraticPathComponent& quadratic) const;
+                                    QuadraticPathComponent& quadratic) const {
+    return state_->GetQuadraticComponentAtIndex(index, quadratic);
+  }
 
-  bool GetCubicComponentAtIndex(size_t index, CubicPathComponent& cubic) const;
+  bool GetCubicComponentAtIndex(size_t index, CubicPathComponent& cubic) const {
+    return state_->GetCubicComponentAtIndex(index, cubic);
+  }
 
   bool GetContourComponentAtIndex(size_t index,
-                                  ContourComponent& contour) const;
+                                  ContourComponent& contour) const {
+    return state_->GetContourComponentAtIndex(index, contour);
+  }
 
   bool UpdateLinearComponentAtIndex(size_t index,
-                                    const LinearPathComponent& linear);
+                                    const LinearPathComponent& linear) {
+    return state_->UpdateLinearComponentAtIndex(index, linear);
+  }
 
-  bool UpdateQuadraticComponentAtIndex(size_t index,
-                                       const QuadraticPathComponent& quadratic);
+  bool UpdateQuadraticComponentAtIndex(
+      size_t index,
+      const QuadraticPathComponent& quadratic) {
+    return state_->UpdateQuadraticComponentAtIndex(index, quadratic);
+  }
 
-  bool UpdateCubicComponentAtIndex(size_t index, CubicPathComponent& cubic);
+  bool UpdateCubicComponentAtIndex(size_t index, CubicPathComponent& cubic) {
+    return state_->UpdateCubicComponentAtIndex(index, cubic);
+  }
 
   bool UpdateContourComponentAtIndex(size_t index,
-                                     const ContourComponent& contour);
+                                     const ContourComponent& contour) {
+    return state_->UpdateContourComponentAtIndex(index, contour);
+  }
 
   /// Callers must provide the scale factor for how this path will be
   /// transformed.
   ///
   /// It is suitable to use the max basis length of the matrix used to transform
   /// the path. If the provided scale is 0, curves will revert to lines.
-  Polyline CreatePolyline(Scalar scale) const;
+  Polyline CreatePolyline(Scalar scale) const {
+    return state_->CreatePolyline(scale);
+  }
 
-  std::optional<Rect> GetBoundingBox() const;
+  std::optional<Rect> GetBoundingBox() const {
+    return state_->GetBoundingBox();
+  }
 
-  std::optional<Rect> GetTransformedBoundingBox(const Matrix& transform) const;
+  std::optional<Rect> GetTransformedBoundingBox(const Matrix& transform) const {
+    return state_->GetTransformedBoundingBox(transform);
+  }
 
-  std::optional<std::pair<Point, Point>> GetMinMaxCoveragePoints() const;
+  std::optional<std::pair<Point, Point>> GetMinMaxCoveragePoints() const {
+    return state_->GetMinMaxCoveragePoints();
+  }
 
  private:
   friend class PathBuilder;
 
-  void SetConvexity(Convexity value);
+  void SetConvexity(Convexity value) { state_->SetConvexity(value); }
 
-  struct ComponentIndexPair {
-    ComponentType type = ComponentType::kLinear;
-    size_t index = 0;
+  struct State {
+    struct ComponentIndexPair {
+      ComponentType type = ComponentType::kLinear;
+      size_t index = 0;
 
-    ComponentIndexPair() {}
+      ComponentIndexPair() {}
 
-    ComponentIndexPair(ComponentType a_type, size_t a_index)
-        : type(a_type), index(a_index) {}
+      ComponentIndexPair(ComponentType a_type, size_t a_index)
+          : type(a_type), index(a_index) {}
+    };
+
+    size_t GetComponentCount(std::optional<ComponentType> type = {}) const;
+
+    void SetFillType(FillType fill);
+
+    FillType GetFillType() const;
+
+    bool IsConvex() const;
+
+    void AddLinearComponent(Point p1, Point p2);
+
+    void AddQuadraticComponent(Point p1, Point cp, Point p2);
+
+    void AddCubicComponent(Point p1, Point cp1, Point cp2, Point p2);
+
+    void AddContourComponent(Point destination, bool is_closed = false);
+
+    void SetContourClosed(bool is_closed);
+
+    template <class T>
+    using Applier = std::function<void(size_t index, const T& component)>;
+    void EnumerateComponents(
+        const Applier<LinearPathComponent>& linear_applier,
+        const Applier<QuadraticPathComponent>& quad_applier,
+        const Applier<CubicPathComponent>& cubic_applier,
+        const Applier<ContourComponent>& contour_applier) const;
+
+    bool GetLinearComponentAtIndex(size_t index,
+                                   LinearPathComponent& linear) const;
+
+    bool GetQuadraticComponentAtIndex(size_t index,
+                                      QuadraticPathComponent& quadratic) const;
+
+    bool GetCubicComponentAtIndex(size_t index,
+                                  CubicPathComponent& cubic) const;
+
+    bool GetContourComponentAtIndex(size_t index,
+                                    ContourComponent& contour) const;
+
+    bool UpdateLinearComponentAtIndex(size_t index,
+                                      const LinearPathComponent& linear);
+
+    bool UpdateQuadraticComponentAtIndex(
+        size_t index,
+        const QuadraticPathComponent& quadratic);
+
+    bool UpdateCubicComponentAtIndex(size_t index, CubicPathComponent& cubic);
+
+    bool UpdateContourComponentAtIndex(size_t index,
+                                       const ContourComponent& contour);
+
+    Polyline CreatePolyline(Scalar scale) const;
+
+    std::optional<Rect> GetBoundingBox() const;
+
+    std::optional<Rect> GetTransformedBoundingBox(
+        const Matrix& transform) const;
+
+    std::optional<std::pair<Point, Point>> GetMinMaxCoveragePoints() const;
+
+    void SetConvexity(Convexity value);
+
+    FillType fill_ = FillType::kNonZero;
+    Convexity convexity_ = Convexity::kUnknown;
+    std::vector<ComponentIndexPair> components_;
+    std::vector<LinearPathComponent> linears_;
+    std::vector<QuadraticPathComponent> quads_;
+    std::vector<CubicPathComponent> cubics_;
+    std::vector<ContourComponent> contours_;
+
+    void InvalidateCache() {
+      cached_bounding_box_.reset();
+      cached_polyline_.reset();
+    }
+
+    mutable std::optional<std::optional<Rect>> cached_bounding_box_;
+    mutable std::optional<Polyline> cached_polyline_;
   };
 
-  FillType fill_ = FillType::kNonZero;
-  Convexity convexity_ = Convexity::kUnknown;
-  std::vector<ComponentIndexPair> components_;
-  std::vector<LinearPathComponent> linears_;
-  std::vector<QuadraticPathComponent> quads_;
-  std::vector<CubicPathComponent> cubics_;
-  std::vector<ContourComponent> contours_;
+  std::shared_ptr<State> state_;
 };
 
 }  // namespace impeller

--- a/impeller/geometry/path_builder.cc
+++ b/impeller/geometry/path_builder.cc
@@ -13,13 +13,14 @@ PathBuilder::PathBuilder() = default;
 PathBuilder::~PathBuilder() = default;
 
 Path PathBuilder::CopyPath(FillType fill) const {
-  auto path = prototype_;
+  auto path = prototype_.Clone();
   path.SetFillType(fill);
   return path;
 }
 
 Path PathBuilder::TakePath(FillType fill) {
   auto path = prototype_;
+  prototype_ = Path();
   path.SetFillType(fill);
   path.SetConvexity(convexity_);
   return path;

--- a/impeller/tessellator/tessellator.h
+++ b/impeller/tessellator/tessellator.h
@@ -64,6 +64,10 @@ class Tessellator {
                                  const BuilderCallback& callback) const;
 
  private:
+  Tessellator::Result DoTessellate(FillType fill_type,
+                                   const Path::Polyline& polyline,
+                                   const BuilderCallback& callback) const;
+
   CTessellator c_tessellator_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Tessellator);

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -20,7 +20,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
         [](const float* vertices, size_t vertices_size, const uint16_t* indices,
            size_t indices_size) { return true; });
 
-    ASSERT_EQ(polyline.points.size(), 0u);
+    ASSERT_EQ(polyline.points().size(), 0u);
     ASSERT_EQ(result, Tessellator::Result::kInputError);
   }
 
@@ -33,7 +33,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
         FillType::kPositive, polyline,
         [](const float* vertices, size_t vertices_size, const uint16_t* indices,
            size_t indices_size) { return true; });
-    ASSERT_EQ(polyline.points.size(), 1u);
+    ASSERT_EQ(polyline.points().size(), 1u);
     ASSERT_EQ(result, Tessellator::Result::kSuccess);
   }
 
@@ -47,7 +47,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
         [](const float* vertices, size_t vertices_size, const uint16_t* indices,
            size_t indices_size) { return true; });
 
-    ASSERT_EQ(polyline.points.size(), 2u);
+    ASSERT_EQ(polyline.points().size(), 2u);
     ASSERT_EQ(result, Tessellator::Result::kSuccess);
   }
 
@@ -65,7 +65,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
         [](const float* vertices, size_t vertices_size, const uint16_t* indices,
            size_t indices_size) { return true; });
 
-    ASSERT_EQ(polyline.points.size(), 2000u);
+    ASSERT_EQ(polyline.points().size(), 2000u);
     ASSERT_EQ(result, Tessellator::Result::kSuccess);
   }
 
@@ -79,7 +79,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
         [](const float* vertices, size_t vertices_size, const uint16_t* indices,
            size_t indices_size) { return false; });
 
-    ASSERT_EQ(polyline.points.size(), 2u);
+    ASSERT_EQ(polyline.points().size(), 2u);
     ASSERT_EQ(result, Tessellator::Result::kInputError);
   }
 }


### PR DESCRIPTION
This is a follow-up PR for https://github.com/flutter/engine/pull/44324.

Results for the [static_path_tessellation](https://github.com/flutter/flutter/pull/131837) macrobenchmark on iPhone 13 Pro (A15):

| Renderer | average_frame_build_time_millis |  worst_frame_build_time_millis |
|--|--|--|
| Impeller - Cache Disabled |  0.47708099688473554 | 1.369 |
| Impeller - Cache Enabled | 0.49306597222222226 | 1.596 |
| Skia - No Raster Cache |  0.4640437500000002 | 1.309 |

| Renderer | average_frame_rasterizer_time_millis | worst_frame_rasterizer_time_millis
|--|--|--|
| Impeller - Cache Disabled | 6.347621527777779 | 6.632 |
| Impeller - Cache Enabled |  **0.6700383275261321** | 0.93 |
| Skia - No Raster Cache | 0.5126250000000006 | 0.973 |

I had to run the perf test with background thread spinning (see https://github.com/flutter/flutter/pull/131837) otherwise the variant with cache enabled actually regressed in `average_frame_build_time_millis` because iOS let the CPU run at lower speed.

After https://github.com/flutter/engine/pull/44248 `Paths` are now retained by entity pass created from UI canvas, so we can cache the polyline, bounds and tessellation result per path:

- `Path` and `Polyline` are made internally reference counted. This is to ensure predictable behavior regarding their instances.
- `Path` will cache `Polyline` and bounds.
- `Polyline` stores cached tessellation data.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
