### PR TITLE
[Darwin] Move FlutterBinaryMessengerRelay to common

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2567,6 +2567,9 @@ ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Headers/FlutterC
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Headers/FlutterDartProject.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelayTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChannels.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm + ../../../flutter/LICENSE
@@ -2576,6 +2579,8 @@ ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterSt
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterTestUtils.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterTestUtils.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.h + ../../../flutter/LICENSE
@@ -2595,9 +2600,6 @@ ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterView
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.mm + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelayTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache_Internal.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponder.h + ../../../flutter/LICENSE
@@ -5296,6 +5298,9 @@ FILE: ../../../flutter/shell/platform/darwin/common/framework/Headers/FlutterCod
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Headers/FlutterDartProject.h
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
+FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h
+FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.mm
+FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelayTest.mm
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
@@ -5305,6 +5310,8 @@ FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStan
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.cc
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodecHelper.h
 FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h
+FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterTestUtils.h
+FILE: ../../../flutter/shell/platform/darwin/common/framework/Source/FlutterTestUtils.mm
 FILE: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h
 FILE: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm
 FILE: ../../../flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.h
@@ -5325,9 +5332,6 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Info.plist
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
-FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h
-FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.mm
-FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelayTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponder.h

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -37,6 +37,7 @@ source_set("framework_common") {
   cflags_objcc = flutter_cflags_objcc_arc
 
   sources = [
+    "framework/Source/FlutterBinaryMessengerRelay.mm",
     "framework/Source/FlutterChannels.mm",
     "framework/Source/FlutterCodecs.mm",
     "framework/Source/FlutterNSBundleUtils.h",
@@ -69,6 +70,8 @@ executable("framework_common_unittests") {
   testonly = true
 
   sources = [
+    "framework/Source/FlutterBinaryMessengerRelayTest.mm",
+    "framework/Source/FlutterTestUtils.mm",
     "framework/Source/flutter_codecs_unittest.mm",
     "framework/Source/flutter_standard_codec_unittest.mm",
   ]
@@ -82,6 +85,7 @@ executable("framework_common_unittests") {
     ":framework_common_fixtures",
     "//flutter/testing",
     "//third_party/dart/runtime:libdart_jit",
+    "//third_party/ocmock:ocmock",
   ]
 
   public_configs = [ "//flutter:config" ]

--- a/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#ifndef SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERBINARYMESSENGERRELAY_H_
+#define SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERBINARYMESSENGERRELAY_H_
+
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 
@@ -12,3 +15,5 @@ FLUTTER_DARWIN_EXPORT
 @property(nonatomic, assign) NSObject<FlutterBinaryMessenger>* parent;
 - (instancetype)initWithParent:(NSObject<FlutterBinaryMessenger>*)parent;
 @end
+
+#endif  // SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERBINARYMESSENGERRELAY_H_

--- a/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.mm
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h"
+#import "flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h"
 
 #include "flutter/fml/logging.h"
+
+FLUTTER_ASSERT_ARC
 
 @implementation FlutterBinaryMessengerRelay
 #pragma mark - FlutterBinaryMessenger

--- a/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelayTest.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelayTest.mm
@@ -2,35 +2,31 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h"
+#import "flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h"
 
 #import <OCMock/OCMock.h>
-#import <XCTest/XCTest.h>
 
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/common/framework/Source/FlutterTestUtils.h"
+#import "flutter/testing/testing.h"
+#include "gtest/gtest.h"
 
 FLUTTER_ASSERT_ARC
 
 @protocol FlutterTaskQueue <NSObject>
 @end
 
-@interface FlutterBinaryMessengerRelayTest : XCTestCase
+@interface FlutterBinaryMessengerRelayTest : NSObject
 @end
 
 @implementation FlutterBinaryMessengerRelayTest
-
-- (void)setUp {
-}
-
-- (void)tearDown {
-}
 
 - (void)testCreate {
   id messenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   FlutterBinaryMessengerRelay* relay =
       [[FlutterBinaryMessengerRelay alloc] initWithParent:messenger];
-  XCTAssertNotNil(relay);
-  XCTAssertEqual(messenger, relay.parent);
+  EXPECT_NE(relay, nil);
+  EXPECT_EQ(messenger, relay.parent);
 }
 
 - (void)testPassesCallOn {
@@ -78,3 +74,33 @@ FLUTTER_ASSERT_ARC
 }
 
 @end
+
+TEST(FlutterBinaryMessengerRelayTest, Create) {
+  ASSERT_FALSE(FLTThrowsObjcException(^{
+    [[FlutterBinaryMessengerRelayTest alloc] testCreate];
+  }));
+}
+
+TEST(FlutterBinaryMessengerRelayTest, PassesCallOn) {
+  ASSERT_FALSE(FLTThrowsObjcException(^{
+    [[FlutterBinaryMessengerRelayTest alloc] testPassesCallOn];
+  }));
+}
+
+TEST(FlutterBinaryMessengerRelayTest, DoesntPassCallOn) {
+  ASSERT_FALSE(FLTThrowsObjcException(^{
+    [[FlutterBinaryMessengerRelayTest alloc] testDoesntPassCallOn];
+  }));
+}
+
+TEST(FlutterBinaryMessengerRelayTest, SetMessageHandlerWithTaskQueue) {
+  ASSERT_FALSE(FLTThrowsObjcException(^{
+    [[FlutterBinaryMessengerRelayTest alloc] testSetMessageHandlerWithTaskQueue];
+  }));
+}
+
+TEST(FlutterBinaryMessengerRelayTest, SetMakeBackgroundTaskQueue) {
+  ASSERT_FALSE(FLTThrowsObjcException(^{
+    [[FlutterBinaryMessengerRelayTest alloc] testMakeBackgroundTaskQueue];
+  }));
+}

--- a/shell/platform/darwin/common/framework/Source/FlutterTestUtils.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterTestUtils.h
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERTESTUTILS_H_
+#define SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERTESTUTILS_H_
+
+#import <Foundation/Foundation.h>
+
+/// Returns YES if the block throws an exception.
+BOOL FLTThrowsObjcException(dispatch_block_t block);
+
+#endif  // SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERTESTUTILS_H_

--- a/shell/platform/darwin/common/framework/Source/FlutterTestUtils.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterTestUtils.mm
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/common/framework/Source/FlutterTestUtils.h"
+
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+
+FLUTTER_ASSERT_ARC
+
+BOOL FLTThrowsObjcException(dispatch_block_t block) {
+  @try {
+    block();
+  } @catch (...) {
+    return YES;
+  }
+  return NO;
+}

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -75,7 +75,6 @@ source_set("flutter_framework_source") {
 
   sources = [
     "framework/Source/FlutterAppDelegate.mm",
-    "framework/Source/FlutterBinaryMessengerRelay.mm",
     "framework/Source/FlutterCallbackCache.mm",
     "framework/Source/FlutterCallbackCache_Internal.h",
     "framework/Source/FlutterChannelKeyResponder.h",
@@ -283,7 +282,6 @@ shared_library("ios_test_flutter") {
   ]
   sources = [
     "framework/Source/FlutterAppDelegateTest.mm",
-    "framework/Source/FlutterBinaryMessengerRelayTest.mm",
     "framework/Source/FlutterChannelKeyResponderTest.mm",
     "framework/Source/FlutterDartProjectTest.mm",
     "framework/Source/FlutterEmbedderKeyResponderTest.mm",

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -19,7 +19,7 @@
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/common/variable_refresh_rate_display.h"
 #import "flutter/shell/platform/darwin/common/command_line.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h"
+#import "flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterIndirectScribbleDelegate.h"

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -11,7 +11,7 @@
 #import "flutter/common/settings.h"
 #include "flutter/fml/synchronization/sync_switch.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h"
+#import "flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h"
+#import "flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -15,7 +15,7 @@
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/runtime/ptrace_check.h"
 #include "flutter/shell/common/thread_host.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h"
+#import "flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterChannelKeyResponder.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEmbedderKeyResponder.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"


### PR DESCRIPTION
Migrates FlutterBinaryMessengerRelay to
//flutter/shell/platform/darwin/common so that it can be used in a followup patch on macOS, to fix a memory leak due to a retain cycle.

Migrates the unit tests to be compatible with gtest, which is used by the darwin/common unit tests.

Issue: https://github.com/flutter/flutter/issues/116445


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
