### PR TITLE
[Darwin] Enable ARC in darwin/common unit tests

### DIFF
--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -73,6 +73,10 @@ executable("framework_common_unittests") {
     "framework/Source/flutter_standard_codec_unittest.mm",
   ]
 
+  cflags_objcc = flutter_cflags_objcc_arc
+
+  ldflags = [ "-ObjC" ]
+
   deps = [
     ":framework_common",
     ":framework_common_fixtures",

--- a/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
@@ -2,14 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#if !__has_feature(objc_arc)
-#error ARC must be enabled!
-#endif
-
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+
+FLUTTER_ASSERT_ARC
 
 @protocol FlutterTaskQueue <NSObject>
 @end

--- a/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.mm
@@ -4,6 +4,10 @@
 
 #include <Foundation/Foundation.h>
 
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+
+FLUTTER_ASSERT_ARC
+
 NSBundle* FLTFrameworkBundleInternal(NSString* bundleID, NSURL* searchURL) {
   NSDirectoryEnumerator<NSURL*>* frameworkEnumerator = [NSFileManager.defaultManager
                  enumeratorAtURL:searchURL

--- a/shell/platform/darwin/common/framework/Source/flutter_codecs_unittest.mm
+++ b/shell/platform/darwin/common/framework/Source/flutter_codecs_unittest.mm
@@ -6,6 +6,8 @@
 
 #include "gtest/gtest.h"
 
+FLUTTER_ASSERT_ARC
+
 TEST(FlutterStringCodec, CanEncodeAndDecodeNil) {
   FlutterStringCodec* codec = [FlutterStringCodec sharedInstance];
   ASSERT_TRUE([codec encode:nil] == nil);

--- a/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
+++ b/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
@@ -6,7 +6,7 @@
 
 #include "gtest/gtest.h"
 
-FLUTTER_ASSERT_NOT_ARC
+FLUTTER_ASSERT_ARC
 
 @interface Pair : NSObject
 @property(atomic, readonly, strong, nullable) NSObject* left;
@@ -18,16 +18,10 @@ FLUTTER_ASSERT_NOT_ARC
 - (instancetype)initWithLeft:(NSObject*)left right:(NSObject*)right {
   self = [super init];
   if (self) {
-    _left = [left retain];
-    _right = [right retain];
+    _left = left;
+    _right = right;
   }
   return self;
-}
-
-- (void)dealloc {
-  [_left release];
-  [_right release];
-  [super dealloc];
 }
 @end
 
@@ -71,7 +65,7 @@ static const UInt8 kPAIR = 129;
       return [NSDate dateWithTimeIntervalSince1970:time];
     }
     case kPAIR: {
-      return [[[Pair alloc] initWithLeft:[self readValue] right:[self readValue]] autorelease];
+      return [[Pair alloc] initWithLeft:[self readValue] right:[self readValue]];
     }
     default:
       return [super readValueOfType:type];
@@ -86,10 +80,10 @@ static const UInt8 kPAIR = 129;
 
 @implementation ExtendedReaderWriter
 - (FlutterStandardWriter*)writerWithData:(NSMutableData*)data {
-  return [[[ExtendedWriter alloc] initWithData:data] autorelease];
+  return [[ExtendedWriter alloc] initWithData:data];
 }
 - (FlutterStandardReader*)readerWithData:(NSData*)data {
-  return [[[ExtendedReader alloc] initWithData:data] autorelease];
+  return [[ExtendedReader alloc] initWithData:data];
 }
 @end
 
@@ -341,10 +335,10 @@ TEST(FlutterStandardCodec, HandlesErrorEnvelopes) {
 }
 
 TEST(FlutterStandardCodec, HandlesSubclasses) {
-  ExtendedReaderWriter* extendedReaderWriter = [[[ExtendedReaderWriter alloc] init] autorelease];
+  ExtendedReaderWriter* extendedReaderWriter = [[ExtendedReaderWriter alloc] init];
   FlutterStandardMessageCodec* codec =
       [FlutterStandardMessageCodec codecWithReaderWriter:extendedReaderWriter];
-  Pair* pair = [[[Pair alloc] initWithLeft:@1 right:@2] autorelease];
+  Pair* pair = [[Pair alloc] initWithLeft:@1 right:@2];
   NSData* encoded = [codec encode:pair];
   Pair* decoded = [codec decode:encoded];
   ASSERT_TRUE([pair.left isEqual:decoded.left]);


### PR DESCRIPTION
The end goal is for all Objective-C code to be compiled with ARC enabled. The common framework code is already compiled with ARC enabled; this enables it for the tests as well.

This is prework before migrating FlutterBinaryMessengerRelay to the common Darwin code.

Issue: https://github.com/flutter/flutter/issues/116445

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
