### PR TITLE
Revert clang back to 6d667d4b261e81f325756fdfd5bb43b3b3d2451d

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -39,7 +39,7 @@ vars = {
   # The list of revisions for these tools comes from Fuchsia, here:
   # https://fuchsia.googlesource.com/integration/+/HEAD/toolchain
   # If there are problems with the toolchain, contact fuchsia-toolchain@.
-  'clang_version': 'git_revision:020d2fb7711d70e296f19d83565f8d93d2cfda71',
+  'clang_version': 'git_revision:6d667d4b261e81f325756fdfd5bb43b3b3d2451d',
 
   # The goma version and the clang version can be tightly coupled. If goma
   # stops working on a clang roll, this may need to be updated using the value


### PR DESCRIPTION
b/294820516

https://stackoverflow.com/questions/76852785/how-to-fix-itms-90338-non-public-api-usage-issue-after-review
