### PR TITLE
[Impeller] reduced the size of Command by having one map for all slots

### DIFF
--- a/impeller/renderer/backend/vulkan/compute_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/compute_pass_vk.cc
@@ -102,7 +102,9 @@ static bool AllocateAndBindDescriptorSets(const ContextVK& context,
         return false;
       }
 
-      const SampledImageSlot& slot = bindings.sampled_images.at(index);
+      const SampledImageSlot* slot =
+          std::get_if<SampledImageSlot>(&bindings.slots.at(index));
+      FML_DCHECK(slot);
 
       vk::DescriptorImageInfo image_info;
       image_info.imageLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
@@ -111,10 +113,10 @@ static bool AllocateAndBindDescriptorSets(const ContextVK& context,
 
       vk::WriteDescriptorSet write_set;
       write_set.dstSet = vk_desc_set.value();
-      write_set.dstBinding = slot.binding;
+      write_set.dstBinding = slot->binding;
       write_set.descriptorCount = 1u;
       write_set.descriptorType = vk::DescriptorType::eCombinedImageSampler;
-      write_set.pImageInfo = &(images[slot.binding] = image_info);
+      write_set.pImageInfo = &(images[slot->binding] = image_info);
 
       writes.push_back(write_set);
     }
@@ -154,24 +156,26 @@ static bool AllocateAndBindDescriptorSets(const ContextVK& context,
       buffer_info.offset = offset;
       buffer_info.range = view.resource.range.length;
 
-      const ShaderUniformSlot& uniform = bindings.uniforms.at(buffer_index);
+      const ShaderUniformSlot* uniform =
+          std::get_if<ShaderUniformSlot>(&bindings.slots.at(buffer_index));
+      FML_DCHECK(uniform);
       auto layout_it = std::find_if(desc_set.begin(), desc_set.end(),
                                     [&uniform](DescriptorSetLayout& layout) {
-                                      return layout.binding == uniform.binding;
+                                      return layout.binding == uniform->binding;
                                     });
       if (layout_it == desc_set.end()) {
         VALIDATION_LOG << "Failed to get descriptor set layout for binding "
-                       << uniform.binding;
+                       << uniform->binding;
         return false;
       }
       auto layout = *layout_it;
 
       vk::WriteDescriptorSet write_set;
       write_set.dstSet = vk_desc_set.value();
-      write_set.dstBinding = uniform.binding;
+      write_set.dstBinding = uniform->binding;
       write_set.descriptorCount = 1u;
       write_set.descriptorType = ToVKDescriptorType(layout.descriptor_type);
-      write_set.pBufferInfo = &(buffers[uniform.binding] = buffer_info);
+      write_set.pBufferInfo = &(buffers[uniform->binding] = buffer_info);
 
       writes.push_back(write_set);
     }

--- a/impeller/renderer/command.cc
+++ b/impeller/renderer/command.cc
@@ -12,6 +12,12 @@
 
 namespace impeller {
 
+// Care should be taken when increasing the size of Command since many are
+// allocated per frame.
+#if FML_OS_MACOSX
+static_assert(sizeof(Command) == 392);
+#endif
+
 bool Command::BindVertices(const VertexBuffer& buffer) {
   if (buffer.index_type == IndexType::kUnknown) {
     VALIDATION_LOG << "Cannot bind vertex buffer with an unknown index type.";
@@ -61,11 +67,15 @@ bool Command::DoBindResource(ShaderStage stage,
 
   switch (stage) {
     case ShaderStage::kVertex:
-      vertex_bindings.uniforms[slot.ext_res_0] = slot;
+      FML_DCHECK(vertex_bindings.slots.find(slot.ext_res_0) ==
+                 vertex_bindings.slots.end());
+      vertex_bindings.slots[slot.ext_res_0] = slot;
       vertex_bindings.buffers[slot.ext_res_0] = BufferResource(metadata, view);
       return true;
     case ShaderStage::kFragment:
-      fragment_bindings.uniforms[slot.ext_res_0] = slot;
+      FML_DCHECK(fragment_bindings.slots.find(slot.ext_res_0) ==
+                 fragment_bindings.slots.end());
+      fragment_bindings.slots[slot.ext_res_0] = slot;
       fragment_bindings.buffers[slot.ext_res_0] =
           BufferResource(metadata, view);
       return true;
@@ -125,11 +135,15 @@ bool Command::BindResource(ShaderStage stage,
   switch (stage) {
     case ShaderStage::kVertex:
       vertex_bindings.samplers[slot.sampler_index] = {&metadata, sampler};
-      vertex_bindings.sampled_images[slot.sampler_index] = slot;
+      FML_DCHECK(vertex_bindings.slots.find(slot.sampler_index) ==
+                 vertex_bindings.slots.end());
+      vertex_bindings.slots[slot.sampler_index] = slot;
       return true;
     case ShaderStage::kFragment:
       fragment_bindings.samplers[slot.sampler_index] = {&metadata, sampler};
-      fragment_bindings.sampled_images[slot.sampler_index] = slot;
+      FML_DCHECK(fragment_bindings.slots.find(slot.sampler_index) ==
+                 fragment_bindings.slots.end());
+      fragment_bindings.slots[slot.sampler_index] = slot;
       return true;
     case ShaderStage::kCompute:
       VALIDATION_LOG << "Use ComputeCommands for compute shader stages.";

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -54,10 +54,11 @@ struct Resource {
 using BufferResource = Resource<BufferView>;
 using TextureResource = Resource<std::shared_ptr<const Texture>>;
 using SamplerResource = Resource<std::shared_ptr<const Sampler>>;
+using Slots =
+    std::map<size_t, std::variant<ShaderUniformSlot, SampledImageSlot>>;
 
 struct Bindings {
-  std::map<size_t, ShaderUniformSlot> uniforms;
-  std::map<size_t, SampledImageSlot> sampled_images;
+  Slots slots;
   std::map<size_t, BufferResource> buffers;
   std::map<size_t, TextureResource> textures;
   std::map<size_t, SamplerResource> samplers;

--- a/impeller/renderer/compute_command.cc
+++ b/impeller/renderer/compute_command.cc
@@ -23,7 +23,8 @@ bool ComputeCommand::BindResource(ShaderStage stage,
     return false;
   }
 
-  bindings.uniforms[slot.ext_res_0] = slot;
+  FML_DCHECK(bindings.slots.find(slot.ext_res_0) == bindings.slots.end());
+  bindings.slots[slot.ext_res_0] = slot;
   bindings.buffers[slot.ext_res_0] = {&metadata, view};
   return true;
 }


### PR DESCRIPTION
This reduces the sizeof(Command) from 440 B to 392 B (-11%).

Let me know if there are any tests or measurements you'd like to see.

issue: https://github.com/flutter/flutter/issues/131787

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
