### PR TITLE
Make toJS'd function use JS types

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
@@ -21,7 +21,8 @@ import 'package:ui/src/engine.dart';
 /// 5. The finalizer function is called with the SkPaint as the sole argument.
 /// 6. We call `delete` on SkPaint.
 DomFinalizationRegistry _finalizationRegistry = createDomFinalizationRegistry(
-  (UniqueRef<Object> uniq) {
+  (JSBoxedDartObject boxedUniq) {
+    final UniqueRef<Object> uniq = boxedUniq.toDart as UniqueRef<Object>;
     uniq.collect();
   }.toJS
 );
@@ -33,7 +34,7 @@ NativeMemoryFinalizationRegistry nativeMemoryFinalizationRegistry = NativeMemory
 class NativeMemoryFinalizationRegistry {
   void register(Object owner, UniqueRef<Object> ref) {
     if (browserSupportsFinalizationRegistry) {
-      _finalizationRegistry.register(owner, ref);
+      _finalizationRegistry.register(owner, ref.toJSBox);
     }
   }
 }


### PR DESCRIPTION
JSFunction's should only accept and return JS types.

Allows landing of external restrictions here: https://dart-review.googlesource.com/c/sdk/+/316867/9
