### PR TITLE
Enforce Animator::Render to be called within BeginFrame

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -142,14 +142,8 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree,
   has_rendered_ = true;
   last_layer_tree_size_ = layer_tree->frame_size();
 
-  if (!frame_timings_recorder_) {
-    // Framework can directly call render with a built scene.
-    frame_timings_recorder_ = std::make_unique<FrameTimingsRecorder>();
-    const fml::TimePoint placeholder_time = fml::TimePoint::Now();
-    frame_timings_recorder_->RecordVsync(placeholder_time, placeholder_time);
-    frame_timings_recorder_->RecordBuildStart(placeholder_time);
-  }
-
+  FML_DCHECK(frame_timings_recorder_)
+      << "Render called outside of BeginFrame().";
   TRACE_EVENT_WITH_FRAME_NUMBER(frame_timings_recorder_, "flutter",
                                 "Animator::Render", /*flow_id_count=*/0,
                                 /*flow_ids=*/nullptr);

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -82,9 +82,9 @@ class Animator final {
   // rendering.
   void EnqueueTraceFlowId(uint64_t trace_flow_id);
 
- private:
   void BeginFrame(std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder);
 
+ private:
   bool CanReuseLastLayerTree();
 
   void DrawLastLayerTree(

--- a/shell/common/animator_unittests.cc
+++ b/shell/common/animator_unittests.cc
@@ -158,6 +158,10 @@ TEST_F(ShellTest, AnimatorDoesNotNotifyIdleBeforeRender) {
         ASSERT_FALSE(delegate.notify_idle_called_);
         auto layer_tree = std::make_unique<LayerTree>(LayerTree::Config(),
                                                       SkISize::Make(600, 800));
+        std::unique_ptr<FrameTimingsRecorder> recorder =
+            std::make_unique<FrameTimingsRecorder>();
+        recorder->RecordVsync(fml::TimePoint::Now(), fml::TimePoint::Now());
+        animator->BeginFrame(std::move(recorder));
         animator->Render(std::move(layer_tree), 1.0);
         task_runners.GetPlatformTaskRunner()->PostTask(flush_vsync_task);
       },

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -172,16 +172,26 @@ void ShellTest::NotifyIdle(Shell* shell, fml::TimeDelta deadline) {
   latch.Wait();
 }
 
+void ShellTest::PumpOneFrameWithoutHelp(Shell* shell,
+                                        double width,
+                                        double height,
+                                        LayerTreeBuilder builder) {
+  PumpOneFrame(shell, {1.0, width, height, 22, 0}, std::move(builder),
+               /*animator_render=*/false);
+}
+
 void ShellTest::PumpOneFrame(Shell* shell,
                              double width,
                              double height,
                              LayerTreeBuilder builder) {
-  PumpOneFrame(shell, {1.0, width, height, 22, 0}, std::move(builder));
+  PumpOneFrame(shell, {1.0, width, height, 22, 0}, std::move(builder),
+               /*animator_render=*/true);
 }
 
 void ShellTest::PumpOneFrame(Shell* shell,
                              const flutter::ViewportMetrics& viewport_metrics,
-                             LayerTreeBuilder builder) {
+                             LayerTreeBuilder builder,
+                             bool animator_render) {
   // Set viewport to nonempty, and call Animator::BeginFrame to make the layer
   // tree pipeline nonempty. Without either of this, the layer tree below
   // won't be rasterized.
@@ -199,6 +209,10 @@ void ShellTest::PumpOneFrame(Shell* shell,
         latch.Signal();
       });
   latch.Wait();
+
+  if (!animator_render) {
+    return;
+  }
 
   latch.Reset();
   // Call |Render| to rasterize a layer tree and trigger |OnFrameRasterized|

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -81,13 +81,18 @@ class ShellTest : public FixtureTest {
   static void SetViewportMetrics(Shell* shell, double width, double height);
   static void NotifyIdle(Shell* shell, fml::TimeDelta deadline);
 
+  static void PumpOneFrameWithoutHelp(Shell* shell,
+                                      double width = 1,
+                                      double height = 1,
+                                      LayerTreeBuilder = {});
   static void PumpOneFrame(Shell* shell,
                            double width = 1,
                            double height = 1,
                            LayerTreeBuilder = {});
   static void PumpOneFrame(Shell* shell,
                            const flutter::ViewportMetrics& viewport_metrics,
-                           LayerTreeBuilder = {});
+                           LayerTreeBuilder = {},
+                           bool animator_render = true);
   static void DispatchFakePointerData(Shell* shell);
   static void DispatchPointerData(Shell* shell,
                                   std::unique_ptr<PointerDataPacket> packet);

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2565,7 +2565,7 @@ TEST_F(ShellTest, OnServiceProtocolRenderFrameWithRasterStatsWorks) {
   configuration.SetEntrypoint("scene_with_red_box");
 
   RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get());
+  PumpOneFrameWithoutHelp(shell.get());
 
   ServiceProtocol::Handler::ServiceProtocolMap empty_params;
   rapidjson::Document document;


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
