### PR TITLE
Excludes entity_pass.cc from clang-tidy due to timeouts

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// FLUTTER_NOLINT: https://github.com/flutter/flutter/issues/132129
+
 #include "impeller/entity/entity_pass.h"
 
 #include <memory>


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/132129
