### PR TITLE
[Impeller] Plumb Paint.enableDithering to backend

### DIFF
--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -187,10 +187,7 @@ void DlDispatcher::setAntiAlias(bool aa) {
 
 // |flutter::DlOpReceiver|
 void DlDispatcher::setDither(bool dither) {
-  // TODO(https://github.com/flutter/flutter/issues/131450): Implement dither.
-  //
-  // This is intentionally left blank because we don't want to ship enabling
-  // dithering from the framework yet (it's only used in Impeller-only tests).
+  paint_.dither = dither;
 }
 
 static Paint::Style ToStyle(flutter::DlDrawStyle style) {


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/131450 and https://github.com/flutter/flutter/issues/118073.

Example from https://github.com/flutter/flutter/issues/118073:

```diff
import 'package:flutter/material.dart';

void main() {
+ Paint.enableDithering = true;
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: const MyHomePage(title: 'Flutter Demo Home Page'),
    );
  }
}

class MyHomePage extends StatefulWidget {
  const MyHomePage({super.key, required this.title});

  final String title;

  @override
  State<MyHomePage> createState() => _MyHomePageState();
}

class _MyHomePageState extends State<MyHomePage> {
  int _counter = 0;

  void _incrementCounter() {
    setState(() {
      _counter++;
    });
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text(widget.title),
      ),
      body: Center(
        child: Container(
          width: double.infinity,
          decoration: const BoxDecoration(
              gradient: LinearGradient(
                  colors: <Color>[Color(0xffcccccc), Color(0xff333333)])),
          child: Column(
            mainAxisAlignment: MainAxisAlignment.center,
            children: <Widget>[
              const Text(
                'You have pushed the button this many times:',
              ),
              Text(
                '$_counter',
                style: Theme.of(context).textTheme.headlineMedium,
              ),
            ],
          ),
        ),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: _incrementCounter,
        tooltip: 'Increment',
        child: const Icon(Icons.add),
      ), // This trailing comma makes auto-formatting nicer for build methods.
    );
  }
}
```

## Before

<img width="2028" alt="Screenshot 2023-08-08 at 5 15 40 PM" src="https://github.com/flutter/engine/assets/168174/c58106bb-f588-4019-8cf0-3dd801f0b118">

## After

<img width="2028" alt="Screenshot 2023-08-08 at 5 15 01 PM" src="https://github.com/flutter/engine/assets/168174/33c4fec8-db52-47c2-b215-c1988ce82416">