### PR TITLE
Disable text rounding hack by default

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3026,11 +3026,14 @@ abstract class ParagraphBuilder {
   ///
   /// Do not rely on this getter as it exists for migration purposes only and
   /// will soon be removed.
+  @Deprecated('''
+    The shouldDisableRoundingHack flag is for internal migration purposes only and should not be used.
+  ''')
   static bool get shouldDisableRoundingHack {
-    return const bool.hasEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK')
+    return const bool.fromEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK', defaultValue: true)
         || _roundingHackDisabledInDebugMode;
   }
-  static bool _roundingHackDisabledInDebugMode = false;
+  static bool _roundingHackDisabledInDebugMode = true;
 
   /// Only works in debug mode. Do not call this method as it is for migration
   /// purposes only and will soon be removed.

--- a/lib/web_ui/lib/text.dart
+++ b/lib/web_ui/lib/text.dart
@@ -687,10 +687,10 @@ abstract class ParagraphBuilder {
     engine.renderer.createParagraphBuilder(style);
 
   static bool get shouldDisableRoundingHack {
-    return const bool.hasEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK')
+    return const bool.fromEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK', defaultValue: true)
         || _roundingHackDisabledInDebugMode;
   }
-  static bool _roundingHackDisabledInDebugMode = false;
+  static bool _roundingHackDisabledInDebugMode = true;
   static void setDisableRoundingHack(bool disableRoundingHack) {
     assert(() {
       _roundingHackDisabledInDebugMode = disableRoundingHack;

--- a/lib/web_ui/test/canvaskit/text_test.dart
+++ b/lib/web_ui/test/canvaskit/text_test.dart
@@ -156,16 +156,16 @@ void testMain() {
       ui.ParagraphBuilder.setDisableRoundingHack(roundingHackWasDisabled);
     });
 
-    test('rounding hack applied by default', () {
+    test('rounding hack disabled by default', () {
       const double fontSize = 1.25;
       const String text = '12345';
       assert((fontSize * text.length).truncate() != fontSize * text.length);
-      expect(ui.ParagraphBuilder.shouldDisableRoundingHack, isFalse);
+      expect(ui.ParagraphBuilder.shouldDisableRoundingHack, isTrue);
       final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle(fontSize: fontSize, fontFamily: 'FlutterTest'));
       builder.addText(text);
       final ui.Paragraph paragraph = builder.build()
         ..layout(const ui.ParagraphConstraints(width: text.length * fontSize));
-      expect(paragraph.computeLineMetrics().length, greaterThan(1));
+      expect(paragraph.computeLineMetrics().length, 1);
     });
 
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520

--- a/lib/web_ui/test/html/text/canvas_paragraph_test.dart
+++ b/lib/web_ui/test/html/text/canvas_paragraph_test.dart
@@ -776,7 +776,19 @@ Future<void> testMain() async {
     expect(paragraph.longestLine, 50.0);
   });
 
-  test('$CanvasParagraph.width should be a whole integer', () {
+  test('$CanvasParagraph.width should be a whole integer when shouldDisableRoundingHack is false', () {
+    if (ui.ParagraphBuilder.shouldDisableRoundingHack) {
+      // Try applying the rounding hack if it's disabled. This may not work if
+      // the 'SKPARAGRAPH_REMOVE_ROUNDING_HACK' dart environment declaration
+      // is set to 'false'.
+      ui.ParagraphBuilder.setDisableRoundingHack(false);
+      addTearDown(() => ui.ParagraphBuilder.setDisableRoundingHack(true));
+    }
+    // The paragraph width is only rounded to a whole integer if
+    // shouldDisableRoundingHack is false.
+    if (ui.ParagraphBuilder.shouldDisableRoundingHack) {
+      return;
+    }
     final ui.Paragraph paragraph = plain(ahemStyle, 'abc');
     paragraph.layout(const ui.ParagraphConstraints(width: 30.8));
 

--- a/testing/dart/paragraph_test.dart
+++ b/testing/dart/paragraph_test.dart
@@ -246,6 +246,7 @@ void main() {
     const double fontSize = 1.25;
     const String text = '12345';
     assert((fontSize * text.length).truncate() != fontSize * text.length);
+    // ignore: deprecated_member_use
     final bool roundingHackWasDisabled = ParagraphBuilder.shouldDisableRoundingHack;
     ParagraphBuilder.setDisableRoundingHack(true);
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(fontSize: fontSize));
@@ -263,15 +264,16 @@ void main() {
     ParagraphBuilder.setDisableRoundingHack(roundingHackWasDisabled);
   });
 
-  test('rounding hack applied by default', () {
+  test('rounding hack disabled by default', () {
     const double fontSize = 1.25;
     const String text = '12345';
     assert((fontSize * text.length).truncate() != fontSize * text.length);
-    expect(ParagraphBuilder.shouldDisableRoundingHack, isFalse);
+    // ignore: deprecated_member_use
+    expect(ParagraphBuilder.shouldDisableRoundingHack, isTrue);
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(fontSize: fontSize));
     builder.addText(text);
     final Paragraph paragraph = builder.build()
       ..layout(const ParagraphConstraints(width: text.length * fontSize));
-    expect(paragraph.computeLineMetrics().length, greaterThan(1));
+    expect(paragraph.computeLineMetrics().length, 1);
   });
 }


### PR DESCRIPTION
This depends on https://github.com/flutter/flutter/pull/132094 and customer_testing migration.

I'll announce this change and add a g3 fix after this lands.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
