### PR TITLE
[Impeller] Allow overriding version profiles when specified in shaders.

### DIFF
--- a/lib/ui/fixtures/shaders/general_shaders/uniform_arrays.frag
+++ b/lib/ui/fixtures/shaders/general_shaders/uniform_arrays.frag
@@ -1,5 +1,3 @@
-#version 100 core
-
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.


### PR DESCRIPTION
This is a hack to allow shaders to override the forced source version. Unfortunately, shaderc doesn't only exposes a way to _force_ the version -- it doesn't allow us to set a _default_ version.

We can thaw this and make it more robust if we need this in the future.