### PR TITLE
[Embedder] Refactor how semantic updates are mapped

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2845,6 +2845,8 @@ ORIGIN: ../../../flutter/shell/platform/embedder/embedder_render_target_impeller
 ORIGIN: ../../../flutter/shell/platform/embedder/embedder_render_target_impeller.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/embedder/embedder_render_target_skia.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/embedder/embedder_render_target_skia.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/embedder/embedder_semantics_update.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/embedder/embedder_semantics_update.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/embedder/embedder_struct_macros.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/embedder/embedder_surface.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/embedder/embedder_surface.h + ../../../flutter/LICENSE
@@ -5581,6 +5583,8 @@ FILE: ../../../flutter/shell/platform/embedder/embedder_render_target_impeller.c
 FILE: ../../../flutter/shell/platform/embedder/embedder_render_target_impeller.h
 FILE: ../../../flutter/shell/platform/embedder/embedder_render_target_skia.cc
 FILE: ../../../flutter/shell/platform/embedder/embedder_render_target_skia.h
+FILE: ../../../flutter/shell/platform/embedder/embedder_semantics_update.cc
+FILE: ../../../flutter/shell/platform/embedder/embedder_semantics_update.h
 FILE: ../../../flutter/shell/platform/embedder/embedder_struct_macros.h
 FILE: ../../../flutter/shell/platform/embedder/embedder_surface.cc
 FILE: ../../../flutter/shell/platform/embedder/embedder_surface.h

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -78,6 +78,8 @@ template("embedder_source_set") {
       "embedder_render_target_cache.h",
       "embedder_render_target_skia.cc",
       "embedder_render_target_skia.h",
+      "embedder_semantics_update.cc",
+      "embedder_semantics_update.h",
       "embedder_struct_macros.h",
       "embedder_surface.cc",
       "embedder_surface.h",

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -56,6 +56,7 @@ extern const intptr_t kPlatformStrongDillSize;
 #include "flutter/shell/platform/embedder/embedder_platform_message_response.h"
 #include "flutter/shell/platform/embedder/embedder_render_target.h"
 #include "flutter/shell/platform/embedder/embedder_render_target_skia.h"
+#include "flutter/shell/platform/embedder/embedder_semantics_update.h"
 #include "flutter/shell/platform/embedder/embedder_struct_macros.h"
 #include "flutter/shell/platform/embedder/embedder_task_runner.h"
 #include "flutter/shell/platform/embedder/embedder_thread_host.h"
@@ -1494,214 +1495,11 @@ void PopulateAOTSnapshotMappingCallbacks(
   }
 }
 
-// Translates engine semantic nodes to embedder semantic nodes.
-FlutterSemanticsNode CreateEmbedderSemanticsNode(
-    const flutter::SemanticsNode& node) {
-  SkMatrix transform = node.transform.asM33();
-  FlutterTransformation flutter_transform{
-      transform.get(SkMatrix::kMScaleX), transform.get(SkMatrix::kMSkewX),
-      transform.get(SkMatrix::kMTransX), transform.get(SkMatrix::kMSkewY),
-      transform.get(SkMatrix::kMScaleY), transform.get(SkMatrix::kMTransY),
-      transform.get(SkMatrix::kMPersp0), transform.get(SkMatrix::kMPersp1),
-      transform.get(SkMatrix::kMPersp2)};
-
-  // Do not add new members to FlutterSemanticsNode.
-  // This would break the forward compatibility of FlutterSemanticsUpdate.
-  // All new members must be added to FlutterSemanticsNode2 instead.
-  return {
-      sizeof(FlutterSemanticsNode),
-      node.id,
-      static_cast<FlutterSemanticsFlag>(node.flags),
-      static_cast<FlutterSemanticsAction>(node.actions),
-      node.textSelectionBase,
-      node.textSelectionExtent,
-      node.scrollChildren,
-      node.scrollIndex,
-      node.scrollPosition,
-      node.scrollExtentMax,
-      node.scrollExtentMin,
-      node.elevation,
-      node.thickness,
-      node.label.c_str(),
-      node.hint.c_str(),
-      node.value.c_str(),
-      node.increasedValue.c_str(),
-      node.decreasedValue.c_str(),
-      static_cast<FlutterTextDirection>(node.textDirection),
-      FlutterRect{node.rect.fLeft, node.rect.fTop, node.rect.fRight,
-                  node.rect.fBottom},
-      flutter_transform,
-      node.childrenInTraversalOrder.size(),
-      node.childrenInTraversalOrder.data(),
-      node.childrenInHitTestOrder.data(),
-      node.customAccessibilityActions.size(),
-      node.customAccessibilityActions.data(),
-      node.platformViewId,
-      node.tooltip.c_str(),
-  };
-}
-
-// Translates engine semantic nodes to embedder semantic nodes.
-FlutterSemanticsNode2 CreateEmbedderSemanticsNode2(
-    const flutter::SemanticsNode& node) {
-  SkMatrix transform = node.transform.asM33();
-  FlutterTransformation flutter_transform{
-      transform.get(SkMatrix::kMScaleX), transform.get(SkMatrix::kMSkewX),
-      transform.get(SkMatrix::kMTransX), transform.get(SkMatrix::kMSkewY),
-      transform.get(SkMatrix::kMScaleY), transform.get(SkMatrix::kMTransY),
-      transform.get(SkMatrix::kMPersp0), transform.get(SkMatrix::kMPersp1),
-      transform.get(SkMatrix::kMPersp2)};
-  return {
-      sizeof(FlutterSemanticsNode2),
-      node.id,
-      static_cast<FlutterSemanticsFlag>(node.flags),
-      static_cast<FlutterSemanticsAction>(node.actions),
-      node.textSelectionBase,
-      node.textSelectionExtent,
-      node.scrollChildren,
-      node.scrollIndex,
-      node.scrollPosition,
-      node.scrollExtentMax,
-      node.scrollExtentMin,
-      node.elevation,
-      node.thickness,
-      node.label.c_str(),
-      node.hint.c_str(),
-      node.value.c_str(),
-      node.increasedValue.c_str(),
-      node.decreasedValue.c_str(),
-      static_cast<FlutterTextDirection>(node.textDirection),
-      FlutterRect{node.rect.fLeft, node.rect.fTop, node.rect.fRight,
-                  node.rect.fBottom},
-      flutter_transform,
-      node.childrenInTraversalOrder.size(),
-      node.childrenInTraversalOrder.data(),
-      node.childrenInHitTestOrder.data(),
-      node.customAccessibilityActions.size(),
-      node.customAccessibilityActions.data(),
-      node.platformViewId,
-      node.tooltip.c_str(),
-  };
-}
-
-// Translates engine semantic custom actions to embedder semantic custom
-// actions.
-FlutterSemanticsCustomAction CreateEmbedderSemanticsCustomAction(
-    const flutter::CustomAccessibilityAction& action) {
-  // Do not add new members to FlutterSemanticsCustomAction.
-  // This would break the forward compatibility of FlutterSemanticsUpdate.
-  // All new members must be added to FlutterSemanticsCustomAction2 instead.
-  return {
-      sizeof(FlutterSemanticsCustomAction),
-      action.id,
-      static_cast<FlutterSemanticsAction>(action.overrideId),
-      action.label.c_str(),
-      action.hint.c_str(),
-  };
-}
-
-// Translates engine semantic custom actions to embedder semantic custom
-// actions.
-FlutterSemanticsCustomAction2 CreateEmbedderSemanticsCustomAction2(
-    const flutter::CustomAccessibilityAction& action) {
-  return {
-      sizeof(FlutterSemanticsCustomAction2),
-      action.id,
-      static_cast<FlutterSemanticsAction>(action.overrideId),
-      action.label.c_str(),
-      action.hint.c_str(),
-  };
-}
-
-// Create a callback to notify the embedder of semantic updates
-// using the deprecated embedder callback 'update_semantics_callback'.
-flutter::PlatformViewEmbedder::UpdateSemanticsCallback
-CreateNewEmbedderSemanticsUpdateCallback(
-    FlutterUpdateSemanticsCallback update_semantics_callback,
-    void* user_data) {
-  return [update_semantics_callback, user_data](
-             const flutter::SemanticsNodeUpdates& nodes,
-             const flutter::CustomAccessibilityActionUpdates& actions) {
-    std::vector<FlutterSemanticsNode> embedder_nodes;
-    for (const auto& value : nodes) {
-      embedder_nodes.push_back(CreateEmbedderSemanticsNode(value.second));
-    }
-
-    std::vector<FlutterSemanticsCustomAction> embedder_custom_actions;
-    for (const auto& value : actions) {
-      embedder_custom_actions.push_back(
-          CreateEmbedderSemanticsCustomAction(value.second));
-    }
-
-    FlutterSemanticsUpdate update{
-        .struct_size = sizeof(FlutterSemanticsUpdate),
-        .nodes_count = embedder_nodes.size(),
-        .nodes = embedder_nodes.data(),
-        .custom_actions_count = embedder_custom_actions.size(),
-        .custom_actions = embedder_custom_actions.data(),
-    };
-
-    update_semantics_callback(&update, user_data);
-  };
-}
-
-// Create a callback to notify the embedder of semantic updates
-// using the new embedder callback 'update_semantics_callback2'.
-flutter::PlatformViewEmbedder::UpdateSemanticsCallback
-CreateNewEmbedderSemanticsUpdateCallback2(
-    FlutterUpdateSemanticsCallback2 update_semantics_callback,
-    void* user_data) {
-  return [update_semantics_callback, user_data](
-             const flutter::SemanticsNodeUpdates& nodes,
-             const flutter::CustomAccessibilityActionUpdates& actions) {
-    std::vector<FlutterSemanticsNode2> embedder_nodes;
-    std::vector<FlutterSemanticsCustomAction2> embedder_custom_actions;
-
-    embedder_nodes.reserve(nodes.size());
-    embedder_custom_actions.reserve(actions.size());
-
-    for (const auto& value : nodes) {
-      embedder_nodes.push_back(CreateEmbedderSemanticsNode2(value.second));
-    }
-
-    for (const auto& value : actions) {
-      embedder_custom_actions.push_back(
-          CreateEmbedderSemanticsCustomAction2(value.second));
-    }
-
-    // Provide the embedder an array of pointers to maintain full forward and
-    // backward compatibility even if new members are added to semantic structs.
-    std::vector<FlutterSemanticsNode2*> embedder_node_pointers;
-    std::vector<FlutterSemanticsCustomAction2*> embedder_custom_action_pointers;
-
-    embedder_node_pointers.reserve(embedder_nodes.size());
-    embedder_custom_action_pointers.reserve(embedder_custom_actions.size());
-
-    for (auto& node : embedder_nodes) {
-      embedder_node_pointers.push_back(&node);
-    }
-
-    for (auto& action : embedder_custom_actions) {
-      embedder_custom_action_pointers.push_back(&action);
-    }
-
-    FlutterSemanticsUpdate2 update{
-        .struct_size = sizeof(FlutterSemanticsUpdate2),
-        .node_count = embedder_node_pointers.size(),
-        .nodes = embedder_node_pointers.data(),
-        .custom_action_count = embedder_custom_action_pointers.size(),
-        .custom_actions = embedder_custom_action_pointers.data(),
-    };
-
-    update_semantics_callback(&update, user_data);
-  };
-}
-
 // Create a callback to notify the embedder of semantic updates
 // using the legacy embedder callbacks 'update_semantics_node_callback' and
 // 'update_semantics_custom_action_callback'.
 flutter::PlatformViewEmbedder::UpdateSemanticsCallback
-CreateLegacyEmbedderSemanticsUpdateCallback(
+CreateEmbedderSemanticsUpdateCallbackV1(
     FlutterUpdateSemanticsNodeCallback update_semantics_node_callback,
     FlutterUpdateSemanticsCustomActionCallback
         update_semantics_custom_action_callback,
@@ -1710,20 +1508,20 @@ CreateLegacyEmbedderSemanticsUpdateCallback(
           update_semantics_custom_action_callback,
           user_data](const flutter::SemanticsNodeUpdates& nodes,
                      const flutter::CustomAccessibilityActionUpdates& actions) {
+    flutter::EmbedderSemanticsUpdate update{nodes, actions};
+    FlutterSemanticsUpdate* update_ptr = update.get();
+
     // First, queue all node and custom action updates.
     if (update_semantics_node_callback != nullptr) {
-      for (const auto& value : nodes) {
-        const FlutterSemanticsNode embedder_node =
-            CreateEmbedderSemanticsNode(value.second);
-        update_semantics_node_callback(&embedder_node, user_data);
+      for (size_t i = 0; i < update_ptr->nodes_count; i++) {
+        update_semantics_node_callback(&update_ptr->nodes[i], user_data);
       }
     }
 
     if (update_semantics_custom_action_callback != nullptr) {
-      for (const auto& value : actions) {
-        const FlutterSemanticsCustomAction embedder_action =
-            CreateEmbedderSemanticsCustomAction(value.second);
-        update_semantics_custom_action_callback(&embedder_action, user_data);
+      for (size_t i = 0; i < update_ptr->custom_actions_count; i++) {
+        update_semantics_custom_action_callback(&update_ptr->custom_actions[i],
+                                                user_data);
       }
     }
 
@@ -1747,26 +1545,63 @@ CreateLegacyEmbedderSemanticsUpdateCallback(
   };
 }
 
+// Create a callback to notify the embedder of semantic updates
+// using the deprecated embedder callback 'update_semantics_callback'.
+flutter::PlatformViewEmbedder::UpdateSemanticsCallback
+CreateEmbedderSemanticsUpdateCallbackV2(
+    FlutterUpdateSemanticsCallback update_semantics_callback,
+    void* user_data) {
+  return [update_semantics_callback, user_data](
+             const flutter::SemanticsNodeUpdates& nodes,
+             const flutter::CustomAccessibilityActionUpdates& actions) {
+    flutter::EmbedderSemanticsUpdate update{nodes, actions};
+
+    update_semantics_callback(update.get(), user_data);
+  };
+}
+
+// Create a callback to notify the embedder of semantic updates
+// using the new embedder callback 'update_semantics_callback2'.
+flutter::PlatformViewEmbedder::UpdateSemanticsCallback
+CreateEmbedderSemanticsUpdateCallbackV3(
+    FlutterUpdateSemanticsCallback2 update_semantics_callback,
+    void* user_data) {
+  return [update_semantics_callback, user_data](
+             const flutter::SemanticsNodeUpdates& nodes,
+             const flutter::CustomAccessibilityActionUpdates& actions) {
+    flutter::EmbedderSemanticsUpdate2 update{nodes, actions};
+
+    update_semantics_callback(update.get(), user_data);
+  };
+}
+
 // Creates a callback that receives semantic updates from the engine
 // and notifies the embedder's callback(s). Returns null if the embedder
 // did not register any callbacks.
 flutter::PlatformViewEmbedder::UpdateSemanticsCallback
 CreateEmbedderSemanticsUpdateCallback(const FlutterProjectArgs* args,
                                       void* user_data) {
-  // The embedder can register the new callback, or the legacy callbacks, or
-  // nothing at all. Handle the case where the embedder registered the 'new'
-  // callback.
+  // There are three variants for the embedder API's semantic update callbacks.
+  // Register an engine callback that maps the engine's semantic updates to the
+  // embedder's desired semantic update API.
+  //
+  // Handle the case where the embedder registered the callback
+  // 'updated_semantics_callback2'
   if (SAFE_ACCESS(args, update_semantics_callback2, nullptr) != nullptr) {
-    return CreateNewEmbedderSemanticsUpdateCallback2(
+    return CreateEmbedderSemanticsUpdateCallbackV3(
         args->update_semantics_callback2, user_data);
   }
 
+  // Handle the case where the embedder registered the deprecated callback
+  // 'update_semantics_callback'.
   if (SAFE_ACCESS(args, update_semantics_callback, nullptr) != nullptr) {
-    return CreateNewEmbedderSemanticsUpdateCallback(
+    return CreateEmbedderSemanticsUpdateCallbackV2(
         args->update_semantics_callback, user_data);
   }
 
-  // Handle the case where the embedder registered 'legacy' callbacks.
+  // Handle the case where the embedder registered the deprecated callbacks
+  // 'update_semantics_node_callback' and
+  // 'update_semantics_custom_action_callback'.
   FlutterUpdateSemanticsNodeCallback update_semantics_node_callback = nullptr;
   if (SAFE_ACCESS(args, update_semantics_node_callback, nullptr) != nullptr) {
     update_semantics_node_callback = args->update_semantics_node_callback;
@@ -1782,7 +1617,7 @@ CreateEmbedderSemanticsUpdateCallback(const FlutterProjectArgs* args,
 
   if (update_semantics_node_callback != nullptr ||
       update_semantics_custom_action_callback != nullptr) {
-    return CreateLegacyEmbedderSemanticsUpdateCallback(
+    return CreateEmbedderSemanticsUpdateCallbackV1(
         update_semantics_node_callback, update_semantics_custom_action_callback,
         user_data);
   }

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1582,8 +1582,7 @@ flutter::PlatformViewEmbedder::UpdateSemanticsCallback
 CreateEmbedderSemanticsUpdateCallback(const FlutterProjectArgs* args,
                                       void* user_data) {
   // There are three variants for the embedder API's semantic update callbacks.
-  // Register an engine callback that maps the engine's semantic updates to the
-  // embedder's desired semantic update API.
+  // Create a callback that maps to the embedder's desired semantic update API.
   //
   // Handle the case where the embedder registered the callback
   // 'updated_semantics_callback2'

--- a/shell/platform/embedder/embedder_semantics_update.cc
+++ b/shell/platform/embedder/embedder_semantics_update.cc
@@ -1,0 +1,178 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/embedder/embedder_semantics_update.h"
+
+namespace flutter {
+
+EmbedderSemanticsUpdate::EmbedderSemanticsUpdate(
+    const SemanticsNodeUpdates& nodes,
+    const CustomAccessibilityActionUpdates& actions) {
+  for (const auto& value : nodes) {
+    AddNode(value.second);
+  }
+
+  for (const auto& value : actions) {
+    AddAction(value.second);
+  }
+
+  update_ = {
+      .struct_size = sizeof(FlutterSemanticsUpdate),
+      .nodes_count = nodes_.size(),
+      .nodes = nodes_.data(),
+      .custom_actions_count = actions_.size(),
+      .custom_actions = actions_.data(),
+  };
+}
+
+void EmbedderSemanticsUpdate::AddNode(const SemanticsNode& node) {
+  SkMatrix transform = node.transform.asM33();
+  FlutterTransformation flutter_transform{
+      transform.get(SkMatrix::kMScaleX), transform.get(SkMatrix::kMSkewX),
+      transform.get(SkMatrix::kMTransX), transform.get(SkMatrix::kMSkewY),
+      transform.get(SkMatrix::kMScaleY), transform.get(SkMatrix::kMTransY),
+      transform.get(SkMatrix::kMPersp0), transform.get(SkMatrix::kMPersp1),
+      transform.get(SkMatrix::kMPersp2)};
+
+  // Do not add new members to FlutterSemanticsNode.
+  // This would break the forward compatibility of FlutterSemanticsUpdate.
+  // All new members must be added to FlutterSemanticsNode2 instead.
+  nodes_.push_back({
+      sizeof(FlutterSemanticsNode),
+      node.id,
+      static_cast<FlutterSemanticsFlag>(node.flags),
+      static_cast<FlutterSemanticsAction>(node.actions),
+      node.textSelectionBase,
+      node.textSelectionExtent,
+      node.scrollChildren,
+      node.scrollIndex,
+      node.scrollPosition,
+      node.scrollExtentMax,
+      node.scrollExtentMin,
+      node.elevation,
+      node.thickness,
+      node.label.c_str(),
+      node.hint.c_str(),
+      node.value.c_str(),
+      node.increasedValue.c_str(),
+      node.decreasedValue.c_str(),
+      static_cast<FlutterTextDirection>(node.textDirection),
+      FlutterRect{node.rect.fLeft, node.rect.fTop, node.rect.fRight,
+                  node.rect.fBottom},
+      flutter_transform,
+      node.childrenInTraversalOrder.size(),
+      node.childrenInTraversalOrder.data(),
+      node.childrenInHitTestOrder.data(),
+      node.customAccessibilityActions.size(),
+      node.customAccessibilityActions.data(),
+      node.platformViewId,
+      node.tooltip.c_str(),
+  });
+}
+
+void EmbedderSemanticsUpdate::AddAction(
+    const CustomAccessibilityAction& action) {
+  // Do not add new members to FlutterSemanticsCustomAction.
+  // This would break the forward compatibility of FlutterSemanticsUpdate.
+  // All new members must be added to FlutterSemanticsCustomAction2 instead.
+  actions_.push_back({
+      sizeof(FlutterSemanticsCustomAction),
+      action.id,
+      static_cast<FlutterSemanticsAction>(action.overrideId),
+      action.label.c_str(),
+      action.hint.c_str(),
+  });
+}
+
+EmbedderSemanticsUpdate::~EmbedderSemanticsUpdate() {}
+
+EmbedderSemanticsUpdate2::EmbedderSemanticsUpdate2(
+    const SemanticsNodeUpdates& nodes,
+    const CustomAccessibilityActionUpdates& actions) {
+  nodes_.reserve(nodes.size());
+  node_pointers_.reserve(nodes.size());
+  actions_.reserve(actions.size());
+  action_pointers_.reserve(actions.size());
+
+  for (const auto& value : nodes) {
+    AddNode(value.second);
+  }
+
+  for (const auto& value : actions) {
+    AddAction(value.second);
+  }
+
+  for (size_t i = 0; i < nodes_.size(); i++) {
+    node_pointers_.push_back(&nodes_[i]);
+  }
+
+  for (size_t i = 0; i < actions_.size(); i++) {
+    action_pointers_.push_back(&actions_[i]);
+  }
+
+  update_ = {
+      .struct_size = sizeof(FlutterSemanticsUpdate2),
+      .node_count = node_pointers_.size(),
+      .nodes = node_pointers_.data(),
+      .custom_action_count = action_pointers_.size(),
+      .custom_actions = action_pointers_.data(),
+  };
+}
+
+EmbedderSemanticsUpdate2::~EmbedderSemanticsUpdate2() {}
+
+void EmbedderSemanticsUpdate2::AddNode(const SemanticsNode& node) {
+  SkMatrix transform = node.transform.asM33();
+  FlutterTransformation flutter_transform{
+      transform.get(SkMatrix::kMScaleX), transform.get(SkMatrix::kMSkewX),
+      transform.get(SkMatrix::kMTransX), transform.get(SkMatrix::kMSkewY),
+      transform.get(SkMatrix::kMScaleY), transform.get(SkMatrix::kMTransY),
+      transform.get(SkMatrix::kMPersp0), transform.get(SkMatrix::kMPersp1),
+      transform.get(SkMatrix::kMPersp2)};
+
+  nodes_.push_back({
+      sizeof(FlutterSemanticsNode2),
+      node.id,
+      static_cast<FlutterSemanticsFlag>(node.flags),
+      static_cast<FlutterSemanticsAction>(node.actions),
+      node.textSelectionBase,
+      node.textSelectionExtent,
+      node.scrollChildren,
+      node.scrollIndex,
+      node.scrollPosition,
+      node.scrollExtentMax,
+      node.scrollExtentMin,
+      node.elevation,
+      node.thickness,
+      node.label.c_str(),
+      node.hint.c_str(),
+      node.value.c_str(),
+      node.increasedValue.c_str(),
+      node.decreasedValue.c_str(),
+      static_cast<FlutterTextDirection>(node.textDirection),
+      FlutterRect{node.rect.fLeft, node.rect.fTop, node.rect.fRight,
+                  node.rect.fBottom},
+      flutter_transform,
+      node.childrenInTraversalOrder.size(),
+      node.childrenInTraversalOrder.data(),
+      node.childrenInHitTestOrder.data(),
+      node.customAccessibilityActions.size(),
+      node.customAccessibilityActions.data(),
+      node.platformViewId,
+      node.tooltip.c_str(),
+  });
+}
+
+void EmbedderSemanticsUpdate2::AddAction(
+    const CustomAccessibilityAction& action) {
+  actions_.push_back({
+      sizeof(FlutterSemanticsCustomAction2),
+      action.id,
+      static_cast<FlutterSemanticsAction>(action.overrideId),
+      action.label.c_str(),
+      action.hint.c_str(),
+  });
+}
+
+}  // namespace flutter

--- a/shell/platform/embedder/embedder_semantics_update.h
+++ b/shell/platform/embedder/embedder_semantics_update.h
@@ -1,0 +1,73 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_SEMANTICS_UPDATE_H_
+#define FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_SEMANTICS_UPDATE_H_
+
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "lib/ui/semantics/custom_accessibility_action.h"
+#include "lib/ui/semantics/semantics_node.h"
+
+namespace flutter {
+
+// A semantic update, used by the embedder API's v1 and v2 semantic update
+// callbacks.
+class EmbedderSemanticsUpdate {
+ public:
+  EmbedderSemanticsUpdate(const SemanticsNodeUpdates& nodes,
+                          const CustomAccessibilityActionUpdates& actions);
+
+  ~EmbedderSemanticsUpdate();
+
+  // Get the semantic update. The pointer is only valid while
+  // |EmbedderSemanticsUpdate| exists.
+  FlutterSemanticsUpdate* get() { return &update_; }
+
+ private:
+  FlutterSemanticsUpdate update_;
+  std::vector<FlutterSemanticsNode> nodes_;
+  std::vector<FlutterSemanticsCustomAction> actions_;
+
+  // Translates engine semantic nodes to embedder semantic nodes.
+  void AddNode(const SemanticsNode& node);
+
+  // Translates engine semantic custom actions to embedder semantic custom
+  // actions.
+  void AddAction(const CustomAccessibilityAction& action);
+
+  FML_DISALLOW_COPY_AND_ASSIGN(EmbedderSemanticsUpdate);
+};
+
+// A semantic update, used by the embedder API's v3 semantic update callback.
+class EmbedderSemanticsUpdate2 {
+ public:
+  EmbedderSemanticsUpdate2(const SemanticsNodeUpdates& nodes,
+                           const CustomAccessibilityActionUpdates& actions);
+
+  ~EmbedderSemanticsUpdate2();
+
+  // Get the semantic update. The pointer is only valid while
+  // |EmbedderSemanticsUpdate2| exists.
+  FlutterSemanticsUpdate2* get() { return &update_; }
+
+ private:
+  FlutterSemanticsUpdate2 update_;
+  std::vector<FlutterSemanticsNode2> nodes_;
+  std::vector<FlutterSemanticsNode2*> node_pointers_;
+  std::vector<FlutterSemanticsCustomAction2> actions_;
+  std::vector<FlutterSemanticsCustomAction2*> action_pointers_;
+
+  // Translates engine semantic nodes to embedder semantic nodes.
+  void AddNode(const SemanticsNode& node);
+
+  // Translates engine semantic custom actions to embedder semantic custom
+  // actions.
+  void AddAction(const CustomAccessibilityAction& action);
+
+  FML_DISALLOW_COPY_AND_ASSIGN(EmbedderSemanticsUpdate2);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_SEMANTICS_UPDATE_H_

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -93,7 +93,7 @@ TEST_F(EmbedderTest, CannotProvideMultipleSemanticsCallbacks) {
   }
 }
 
-TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
+TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV3Callbacks) {
 #if defined(OS_FUCHSIA)
   GTEST_SKIP() << "This test crashes on Fuchsia. https://fxbug.dev/87493 ";
 #else
@@ -272,7 +272,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistent) {
 #endif  // OS_FUCHSIA
 }
 
-TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
+TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV2Callbacks) {
 #if defined(OS_FUCHSIA)
   GTEST_SKIP() << "This test crashes on Fuchsia. https://fxbug.dev/87493 ";
 #else
@@ -449,7 +449,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingUnstableCallbacks) {
 #endif  // OS_FUCHSIA
 }
 
-TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingLegacyCallbacks) {
+TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV1Callbacks) {
   auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
 
   fml::AutoResetWaitableEvent signal_native_latch;


### PR DESCRIPTION
This refactors how engine semantic updates are mapped to embedder semantic updates. There are no behavioral changes.

Part of https://github.com/flutter/flutter/issues/119970, https://github.com/flutter/flutter/issues/98948

Next PR: https://github.com/flutter/engine/pull/44616

## Background
For https://github.com/flutter/flutter/issues/119970, we will need to update the embedder API to add string attributes to semantic nodes' text values. There are multiple kinds of string attributes, and each text value can have multiple string attributes. This requires gnarly mapping code that's best kept out of `embedder.cc`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
