### PR TITLE
[Impeller] Flutter GPU: Add context override.

### DIFF
--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -3,11 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui;
-//import 'dart:gpu';
+import '../../lib/gpu/lib/gpu.dart' as gpu;
 
 void main() {}
 
 @pragma('vm:entry-point')
-void sayHi() {
-  print('Hi');
+void instantiateDefaultContext() {
+  // ignore: unused_local_variable
+  final gpu.GpuContext context = gpu.gpuContext;
 }

--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -8,6 +8,11 @@ import '../../lib/gpu/lib/gpu.dart' as gpu;
 void main() {}
 
 @pragma('vm:entry-point')
+void sayHi() {
+  print('Hi');
+}
+
+@pragma('vm:entry-point')
 void instantiateDefaultContext() {
   // ignore: unused_local_variable
   final gpu.GpuContext context = gpu.gpuContext;

--- a/impeller/renderer/BUILD.gn
+++ b/impeller/renderer/BUILD.gn
@@ -161,6 +161,7 @@ impeller_component("renderer_dart_unittests") {
     ":renderer_dart_fixtures",
     "../fixtures:shader_fixtures",
     "../playground:playground_test",
+    "//flutter/lib/gpu",
     "//flutter/runtime:runtime",
     "//flutter/testing:fixture_test",
     "//flutter/testing:testing",

--- a/impeller/renderer/renderer_dart_unittests.cc
+++ b/impeller/renderer/renderer_dart_unittests.cc
@@ -10,6 +10,7 @@
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/backtrace.h"
 #include "flutter/fml/command_line.h"
+#include "flutter/lib/gpu/context.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/runtime/dart_isolate.h"
 #include "flutter/runtime/dart_vm_lifecycle.h"
@@ -46,7 +47,13 @@ class RendererDartTest : public PlaygroundTest,
     assert(isolate_->get()->GetPhase() == flutter::DartIsolate::Phase::Running);
   }
 
-  flutter::testing::AutoIsolateShutdown* GetIsolate() { return isolate_.get(); }
+  flutter::testing::AutoIsolateShutdown* GetIsolate() {
+    // Sneak the context into the Flutter GPU API.
+    assert(GetContext() != nullptr);
+    flutter::Context::SetOverrideContext(GetContext());
+
+    return isolate_.get();
+  }
 
  private:
   std::unique_ptr<flutter::testing::AutoIsolateShutdown> CreateDartIsolate() {
@@ -72,22 +79,16 @@ INSTANTIATE_PLAYGROUND_SUITE(RendererDartTest);
 
 TEST_P(RendererDartTest, CanRunDartInPlaygroundFrame) {
   auto isolate = GetIsolate();
+  bool result = isolate->RunInIsolateScope([]() -> bool {
+    if (tonic::CheckAndHandleError(::Dart_Invoke(
+            Dart_RootLibrary(), tonic::ToDart("instantiateDefaultContext"), 0,
+            nullptr))) {
+      return false;
+    }
+    return true;
+  });
 
-  SinglePassCallback callback = [&](RenderPass& pass) {
-    ImGui::Begin("Dart test", nullptr);
-    ImGui::Text(
-        "This test executes Dart code during the playground frame callback.");
-    ImGui::End();
-
-    return isolate->RunInIsolateScope([]() -> bool {
-      if (tonic::CheckAndHandleError(::Dart_Invoke(
-              Dart_RootLibrary(), tonic::ToDart("sayHi"), 0, nullptr))) {
-        return false;
-      }
-      return true;
-    });
-  };
-  OpenPlaygroundHere(callback);
+  ASSERT_TRUE(result);
 }
 
 }  // namespace testing

--- a/impeller/renderer/renderer_dart_unittests.cc
+++ b/impeller/renderer/renderer_dart_unittests.cc
@@ -79,6 +79,26 @@ INSTANTIATE_PLAYGROUND_SUITE(RendererDartTest);
 
 TEST_P(RendererDartTest, CanRunDartInPlaygroundFrame) {
   auto isolate = GetIsolate();
+
+  SinglePassCallback callback = [&](RenderPass& pass) {
+    ImGui::Begin("Dart test", nullptr);
+    ImGui::Text(
+        "This test executes Dart code during the playground frame callback.");
+    ImGui::End();
+
+    return isolate->RunInIsolateScope([]() -> bool {
+      if (tonic::CheckAndHandleError(::Dart_Invoke(
+              Dart_RootLibrary(), tonic::ToDart("sayHi"), 0, nullptr))) {
+        return false;
+      }
+      return true;
+    });
+  };
+  OpenPlaygroundHere(callback);
+}
+
+TEST_P(RendererDartTest, CanInstantiateFlutterGPUContext) {
+  auto isolate = GetIsolate();
   bool result = isolate->RunInIsolateScope([]() -> bool {
     if (tonic::CheckAndHandleError(::Dart_Invoke(
             Dart_RootLibrary(), tonic::ToDart("instantiateDefaultContext"), 0,

--- a/lib/gpu/context.h
+++ b/lib/gpu/context.h
@@ -16,8 +16,18 @@ class Context : public RefCountedDartWrappable<Context> {
   FML_FRIEND_MAKE_REF_COUNTED(Context);
 
  public:
+  static void SetOverrideContext(std::shared_ptr<impeller::Context> context);
+
+  static std::shared_ptr<impeller::Context> GetOverrideContext();
+
   explicit Context(std::shared_ptr<impeller::Context> context);
   ~Context() override;
+
+ protected:
+  /// An Impeller context that takes precedent over the IO state context when
+  /// set. This is used to inject the context when running with the Impeller
+  /// playground, which doesn't instantiate an Engine instance.
+  static std::shared_ptr<impeller::Context> override_context_;
 
  private:
   std::shared_ptr<impeller::Context> context_;


### PR DESCRIPTION
Adds a way to inject a context override, which allows us to test the API in the Dart playground without spinning up an Engine/Shell.