### PR TITLE
Remove dependencies on fuchsia.sys.* FIDL protocols

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/BUILD.gn
@@ -19,12 +19,13 @@ source_set("sdk_ext") {
   ]
 
   deps = [
-    "$fuchsia_sdk_root/fidl:fuchsia.sys",
     "$fuchsia_sdk_root/pkg:async-cpp",
     "../zircon",
     "//flutter/fml",
     "//flutter/third_party/tonic",
   ]
+
+  public_deps = [ "$fuchsia_sdk_root/pkg:zx" ]
 
   public_configs = [ ":sdk_ext_config" ]
 }

--- a/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.cc
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.cc
@@ -100,8 +100,7 @@ void SetReturnCode(Dart_NativeArguments arguments) {
 
 }  // namespace
 
-void Initialize(fidl::InterfaceHandle<fuchsia::sys::Environment> environment,
-                zx::channel directory_request,
+void Initialize(zx::channel directory_request,
                 std::optional<zx::eventpair> view_ref) {
   zircon::dart::Initialize();
 
@@ -116,14 +115,6 @@ void Initialize(fidl::InterfaceHandle<fuchsia::sys::Environment> environment,
       new tonic::DartClassProvider(dart_state, "dart:fuchsia"));
   dart_state->class_library().add_provider("fuchsia",
                                            std::move(fuchsia_class_provider));
-
-  // V2 components do not use the environment.
-  if (environment) {
-    result = Dart_SetField(
-        library, ToDart("_environment"),
-        ToDart(zircon::dart::Handle::Create(environment.TakeChannel())));
-    FML_CHECK(!tonic::CheckAndHandleError(result));
-  }
 
   if (directory_request) {
     result = Dart_SetField(

--- a/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.h
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.h
@@ -5,14 +5,16 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_FUCHSIA_SDK_EXT_FUCHSIA_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_FUCHSIA_SDK_EXT_FUCHSIA_H_
 
-#include <fuchsia/sys/cpp/fidl.h>
+#include <lib/zx/channel.h>
+#include <lib/zx/eventpair.h>
+
+#include <optional>
 
 namespace fuchsia {
 namespace dart {
 
 /// Initializes Dart bindings for the Fuchsia application model.
-void Initialize(fidl::InterfaceHandle<fuchsia::sys::Environment> environment,
-                zx::channel directory_request,
+void Initialize(zx::channel directory_request,
                 std::optional<zx::eventpair> view_ref);
 
 }  // namespace dart

--- a/shell/platform/fuchsia/dart_runner/builtin_libraries.cc
+++ b/shell/platform/fuchsia/dart_runner/builtin_libraries.cc
@@ -96,19 +96,16 @@ void ScheduleMicrotask(Dart_NativeArguments args) {
 
 }  // namespace
 
-void InitBuiltinLibrariesForIsolate(
-    const std::string& script_uri,
-    fdio_ns_t* namespc,
-    int stdoutfd,
-    int stderrfd,
-    fidl::InterfaceHandle<fuchsia::sys::Environment> environment,
-    zx::channel directory_request,
-    bool service_isolate) {
+void InitBuiltinLibrariesForIsolate(const std::string& script_uri,
+                                    fdio_ns_t* namespc,
+                                    int stdoutfd,
+                                    int stderrfd,
+                                    zx::channel directory_request,
+                                    bool service_isolate) {
   // dart:fuchsia --------------------------------------------------------------
   // dart runner doesn't care about scenic view ref.
   if (!service_isolate) {
-    fuchsia::dart::Initialize(std::move(environment),
-                              std::move(directory_request), std::nullopt);
+    fuchsia::dart::Initialize(std::move(directory_request), std::nullopt);
   }
 
   // dart:fuchsia.builtin ------------------------------------------------------

--- a/shell/platform/fuchsia/dart_runner/builtin_libraries.h
+++ b/shell/platform/fuchsia/dart_runner/builtin_libraries.h
@@ -5,22 +5,20 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_RUNNER_BUILTIN_LIBRARIES_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_RUNNER_BUILTIN_LIBRARIES_H_
 
-#include <fuchsia/sys/cpp/fidl.h>
 #include <lib/fdio/namespace.h>
+#include <lib/zx/channel.h>
 
 #include <memory>
 #include <string>
 
 namespace dart_runner {
 
-void InitBuiltinLibrariesForIsolate(
-    const std::string& script_uri,
-    fdio_ns_t* namespc,
-    int stdoutfd,
-    int stderrfd,
-    fidl::InterfaceHandle<fuchsia::sys::Environment> environment,
-    zx::channel directory_request,
-    bool service_isolate);
+void InitBuiltinLibrariesForIsolate(const std::string& script_uri,
+                                    fdio_ns_t* namespc,
+                                    int stdoutfd,
+                                    int stderrfd,
+                                    zx::channel directory_request,
+                                    bool service_isolate);
 
 }  // namespace dart_runner
 

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -466,9 +466,9 @@ bool DartComponentController::RunDartMain() {
   stdout_fd_ = fileno(stdout);
   stderr_fd_ = fileno(stderr);
 
-  InitBuiltinLibrariesForIsolate(
-      url_, namespace_, stdout_fd_, stderr_fd_, nullptr /* environment */,
-      dart_outgoing_dir_request_.TakeChannel(), false /* service_isolate */);
+  InitBuiltinLibrariesForIsolate(url_, namespace_, stdout_fd_, stderr_fd_,
+                                 dart_outgoing_dir_request_.TakeChannel(),
+                                 false /* service_isolate */);
 
   Dart_ExitScope();
   Dart_ExitIsolate();

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.h
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.h
@@ -7,7 +7,6 @@
 
 #include <dart/test/cpp/fidl.h>
 #include <fuchsia/component/runner/cpp/fidl.h>
-#include <fuchsia/sys/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/async/cpp/wait.h>
 #include <lib/fdio/namespace.h>

--- a/shell/platform/fuchsia/dart_runner/dart_runner.h
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.h
@@ -6,7 +6,6 @@
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_RUNNER_DART_RUNNER_H_
 
 #include <fuchsia/component/runner/cpp/fidl.h>
-#include <fuchsia/sys/cpp/fidl.h>
 #include <lib/fidl/cpp/binding_set.h>
 #include <lib/sys/cpp/component_context.h>
 

--- a/shell/platform/fuchsia/dart_runner/dart_test_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_test_component_controller.cc
@@ -523,9 +523,9 @@ fpromise::promise<> DartTestComponentController::RunDartMain() {
 
   fidl::InterfaceRequest<fuchsia::io::Directory> outgoing_dir =
       std::move(*start_info_.mutable_outgoing_dir());
-  InitBuiltinLibrariesForIsolate(
-      url_, namespace_, stdout_fd_, stderr_fd_, nullptr /* environment */,
-      outgoing_dir.TakeChannel(), false /* service_isolate */);
+  InitBuiltinLibrariesForIsolate(url_, namespace_, stdout_fd_, stderr_fd_,
+                                 outgoing_dir.TakeChannel(),
+                                 false /* service_isolate */);
 
   Dart_ExitScope();
   Dart_ExitIsolate();

--- a/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h
+++ b/shell/platform/fuchsia/dart_runner/dart_test_component_controller.h
@@ -8,7 +8,6 @@
 #include <memory>
 
 #include <fuchsia/component/runner/cpp/fidl.h>
-#include <fuchsia/sys/cpp/fidl.h>
 #include <fuchsia/test/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/async/cpp/executor.h>

--- a/shell/platform/fuchsia/dart_runner/service_isolate.cc
+++ b/shell/platform/fuchsia/dart_runner/service_isolate.cc
@@ -193,7 +193,7 @@ Dart_Isolate CreateServiceIsolate(
   SHUTDOWN_ON_ERROR(result);
 
   InitBuiltinLibrariesForIsolate(std::string(uri), nullptr, fileno(stdout),
-                                 fileno(stderr), nullptr, zx::channel(), true);
+                                 fileno(stderr), zx::channel(), true);
 
   // Make runnable.
   Dart_ExitScope();

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -155,7 +155,6 @@ template("runner_sources") {
              "$fuchsia_sdk_root/fidl:fuchsia.io",
              "$fuchsia_sdk_root/fidl:fuchsia.media",
              "$fuchsia_sdk_root/fidl:fuchsia.memorypressure",
-             "$fuchsia_sdk_root/fidl:fuchsia.sys",
              "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
              "$fuchsia_sdk_root/fidl:fuchsia.ui.composition",
              "$fuchsia_sdk_root/fidl:fuchsia.ui.pointer",

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.h
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.h
@@ -10,7 +10,6 @@
 #undef FALSE
 
 #include <fuchsia/accessibility/semantics/cpp/fidl.h>
-#include <fuchsia/sys/cpp/fidl.h>
 #include <fuchsia/ui/gfx/cpp/fidl.h>
 #include <lib/fidl/cpp/binding_set.h>
 #include <lib/sys/inspect/cpp/component.h>

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -647,8 +647,7 @@ void ComponentV2::CreateView2(fuchsia::ui::app::CreateView2Args view_args) {
       std::move(fdio_ns_),                            // FDIO namespace
       std::move(directory_request_),                  // outgoing request
       product_config_,                                // product configuration
-      std::vector<std::string>(),                     // dart entrypoint args
-      false                                           // not a v1 component
+      std::vector<std::string>()                      // dart entrypoint args
       ));
 }
 

--- a/shell/platform/fuchsia/flutter/component_v2.h
+++ b/shell/platform/fuchsia/flutter/component_v2.h
@@ -11,7 +11,6 @@
 
 #include <fuchsia/component/runner/cpp/fidl.h>
 #include <fuchsia/io/cpp/fidl.h>
-#include <fuchsia/sys/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/async/default.h>

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -59,8 +59,7 @@ class Engine final : public fuchsia::memorypressure::Watcher {
          UniqueFDIONS fdio_ns,
          fidl::InterfaceRequest<fuchsia::io::Directory> directory_request,
          FlutterRunnerProductConfiguration product_config,
-         const std::vector<std::string>& dart_entrypoint_args,
-         bool for_v1_component);
+         const std::vector<std::string>& dart_entrypoint_args);
 
   ~Engine();
 
@@ -81,8 +80,7 @@ class Engine final : public fuchsia::memorypressure::Watcher {
       UniqueFDIONS fdio_ns,
       fidl::InterfaceRequest<fuchsia::io::Directory> directory_request,
       FlutterRunnerProductConfiguration product_config,
-      const std::vector<std::string>& dart_entrypoint_args,
-      bool for_v1_component);
+      const std::vector<std::string>& dart_entrypoint_args);
 
   static void WarmupSkps(
       fml::BasicTaskRunner* concurrent_task_runner,

--- a/shell/platform/fuchsia/flutter/focus_delegate.h
+++ b/shell/platform/fuchsia/flutter/focus_delegate.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FOCUS_DELEGATE_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FOCUS_DELEGATE_H_
 
-#include <fuchsia/sys/cpp/fidl.h>
 #include <fuchsia/ui/views/cpp/fidl.h>
 
 #include <unordered_map>

--- a/shell/platform/fuchsia/flutter/isolate_configurator.cc
+++ b/shell/platform/fuchsia/flutter/isolate_configurator.cc
@@ -13,13 +13,10 @@
 
 namespace flutter_runner {
 
-IsolateConfigurator::IsolateConfigurator(
-    UniqueFDIONS fdio_ns,
-    fuchsia::sys::EnvironmentHandle environment,
-    zx::channel directory_request,
-    zx::eventpair view_ref)
+IsolateConfigurator::IsolateConfigurator(UniqueFDIONS fdio_ns,
+                                         zx::channel directory_request,
+                                         zx::eventpair view_ref)
     : fdio_ns_(std::move(fdio_ns)),
-      environment_(std::move(environment)),
       directory_request_(std::move(directory_request)),
       view_ref_(std::move(view_ref)) {}
 
@@ -43,8 +40,7 @@ bool IsolateConfigurator::ConfigureCurrentIsolate() {
 }
 
 void IsolateConfigurator::BindFuchsia() {
-  fuchsia::dart::Initialize(std::move(environment_),
-                            std::move(directory_request_),
+  fuchsia::dart::Initialize(std::move(directory_request_),
                             std::move(view_ref_));
 }
 

--- a/shell/platform/fuchsia/flutter/isolate_configurator.h
+++ b/shell/platform/fuchsia/flutter/isolate_configurator.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_ISOLATE_CONFIGURATOR_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_ISOLATE_CONFIGURATOR_H_
 
-#include <fuchsia/sys/cpp/fidl.h>
 #include <fuchsia/ui/scenic/cpp/fidl.h>
 
 #include "flutter/fml/macros.h"
@@ -19,7 +18,6 @@ namespace flutter_runner {
 class IsolateConfigurator final {
  public:
   IsolateConfigurator(UniqueFDIONS fdio_ns,
-                      fuchsia::sys::EnvironmentHandle environment,
                       zx::channel directory_request,
                       zx::eventpair view_ref);
 
@@ -32,7 +30,6 @@ class IsolateConfigurator final {
  private:
   bool used_ = false;
   UniqueFDIONS fdio_ns_;
-  fuchsia::sys::EnvironmentHandle environment_;
   zx::channel directory_request_;
   zx::eventpair view_ref_;
 

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_PLATFORM_VIEW_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_PLATFORM_VIEW_H_
 
-#include <fuchsia/sys/cpp/fidl.h>
 #include <fuchsia/ui/composition/cpp/fidl.h>
 #include <fuchsia/ui/input/cpp/fidl.h>
 #include <fuchsia/ui/input3/cpp/fidl.h>

--- a/shell/platform/fuchsia/flutter/runner.cc
+++ b/shell/platform/fuchsia/flutter/runner.cc
@@ -204,7 +204,6 @@ Runner::Runner(fml::RefPtr<fml::TaskRunner> task_runner,
 }
 
 Runner::~Runner() {
-  context_->outgoing()->RemovePublicService<fuchsia::sys::Runner>();
   context_->outgoing()
       ->RemovePublicService<fuchsia::component::runner::ComponentRunner>();
 

--- a/shell/platform/fuchsia/flutter/runner.h
+++ b/shell/platform/fuchsia/flutter/runner.h
@@ -9,7 +9,6 @@
 #include <unordered_map>
 
 #include <fuchsia/component/runner/cpp/fidl.h>
-#include <fuchsia/sys/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/sys/cpp/component_context.h>
 #include <lib/trace-engine/instrumentation.h>

--- a/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-test.cc
@@ -12,7 +12,6 @@
 #include <fuchsia/memorypressure/cpp/fidl.h>
 #include <fuchsia/metrics/cpp/fidl.h>
 #include <fuchsia/net/interfaces/cpp/fidl.h>
-#include <fuchsia/sys/cpp/fidl.h>
 #include <fuchsia/tracing/provider/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>
 #include <fuchsia/ui/display/singleton/cpp/fidl.h>

--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-test.cc
@@ -4,7 +4,6 @@
 
 #include <fuchsia/feedback/cpp/fidl.h>
 #include <fuchsia/logger/cpp/fidl.h>
-#include <fuchsia/sys/cpp/fidl.h>
 #include <fuchsia/sysmem/cpp/fidl.h>
 #include <fuchsia/tracing/provider/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>


### PR DESCRIPTION
The fuchsia.sys FIDL library, used to implement v1 components, is deprecated in the Fuchsia platform and is being removed.

Flutter now implements Components v2 but still imports the old library.

Bug: https://fxbug.dev/109013

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
