### PR TITLE
[Linux] Expose channel buffers 'resize' and 'overflow' control commands

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -158,6 +158,7 @@ source_set("flutter_linux_sources") {
   ]
 
   deps = [
+    "//flutter/fml:fml",
     "//flutter/shell/platform/common:common_cpp_enums",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_switches",

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -158,7 +158,7 @@ source_set("flutter_linux_sources") {
   ]
 
   deps = [
-    "//flutter/fml:fml",
+    "//flutter/fml",
     "//flutter/shell/platform/common:common_cpp_enums",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_switches",

--- a/shell/platform/linux/fl_binary_messenger.cc
+++ b/shell/platform/linux/fl_binary_messenger.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h"
 #include "flutter/shell/platform/linux/fl_binary_messenger_private.h"
 
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/fl_method_codec_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
@@ -344,6 +345,7 @@ static void resize_channel_response_cb(GObject* object,
 static void resize_channel(FlBinaryMessenger* messenger,
                            const gchar* channel,
                            int64_t new_size) {
+  FML_DCHECK(new_size >= 0);
   g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
   g_autoptr(FlValue) args = fl_value_new_list();
   fl_value_append_take(args, fl_value_new_string(channel));

--- a/shell/platform/linux/fl_binary_messenger.cc
+++ b/shell/platform/linux/fl_binary_messenger.cc
@@ -14,6 +14,8 @@
 #include <gmodule.h>
 
 static constexpr char kControlChannelName[] = "dev.flutter/channel-buffers";
+static constexpr char kResizeMethod[] = "resize";
+static constexpr char kOverflowMethod[] = "overflow";
 
 G_DEFINE_QUARK(fl_binary_messenger_codec_error_quark,
                fl_binary_messenger_codec_error)
@@ -318,26 +320,26 @@ static GBytes* send_on_channel_finish(FlBinaryMessenger* messenger,
 
 static void resize_channel(FlBinaryMessenger* messenger,
                            const gchar* channel,
-                           int new_size) {
+                           int64_t new_size) {
   g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
   g_autoptr(FlValue) args = fl_value_new_list();
   fl_value_append_take(args, fl_value_new_string(channel));
   fl_value_append_take(args, fl_value_new_int(new_size));
   g_autoptr(GBytes) message = fl_method_codec_encode_method_call(
-      FL_METHOD_CODEC(codec), "resize", args, nullptr);
+      FL_METHOD_CODEC(codec), kResizeMethod, args, nullptr);
   fl_binary_messenger_send_on_channel(messenger, kControlChannelName, message,
                                       nullptr, nullptr, nullptr);
 }
 
-static void allow_channel_overflow(FlBinaryMessenger* messenger,
-                                   const gchar* channel,
-                                   bool allowed) {
+static void set_allow_channel_overflow(FlBinaryMessenger* messenger,
+                                       const gchar* channel,
+                                       bool allowed) {
   g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
   g_autoptr(FlValue) args = fl_value_new_list();
   fl_value_append_take(args, fl_value_new_string(channel));
   fl_value_append_take(args, fl_value_new_bool(allowed));
   g_autoptr(GBytes) message = fl_method_codec_encode_method_call(
-      FL_METHOD_CODEC(codec), "overflow", args, nullptr);
+      FL_METHOD_CODEC(codec), kOverflowMethod, args, nullptr);
   fl_binary_messenger_send_on_channel(messenger, kControlChannelName, message,
                                       nullptr, nullptr, nullptr);
 }
@@ -354,7 +356,7 @@ static void fl_binary_messenger_impl_iface_init(
   iface->send_on_channel = send_on_channel;
   iface->send_on_channel_finish = send_on_channel_finish;
   iface->resize_channel = resize_channel;
-  iface->allow_channel_overflow = allow_channel_overflow;
+  iface->set_allow_channel_overflow = set_allow_channel_overflow;
 }
 
 static void fl_binary_messenger_impl_init(FlBinaryMessengerImpl* self) {
@@ -433,19 +435,19 @@ G_MODULE_EXPORT GBytes* fl_binary_messenger_send_on_channel_finish(
 
 G_MODULE_EXPORT void fl_binary_messenger_resize_channel(FlBinaryMessenger* self,
                                                         const gchar* channel,
-                                                        int new_size) {
+                                                        int64_t new_size) {
   g_return_if_fail(FL_IS_BINARY_MESSENGER(self));
 
   return FL_BINARY_MESSENGER_GET_IFACE(self)->resize_channel(self, channel,
                                                              new_size);
 }
 
-G_MODULE_EXPORT void fl_binary_messenger_allow_channel_overflow(
+G_MODULE_EXPORT void fl_binary_messenger_set_allow_channel_overflow(
     FlBinaryMessenger* self,
     const gchar* channel,
     bool allowed) {
   g_return_if_fail(FL_IS_BINARY_MESSENGER(self));
 
-  return FL_BINARY_MESSENGER_GET_IFACE(self)->allow_channel_overflow(
+  return FL_BINARY_MESSENGER_GET_IFACE(self)->set_allow_channel_overflow(
       self, channel, allowed);
 }

--- a/shell/platform/linux/fl_binary_messenger_test.cc
+++ b/shell/platform/linux/fl_binary_messenger_test.cc
@@ -8,9 +8,13 @@
 #include <pthread.h>
 #include <cstring>
 
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/linux/fl_binary_messenger_private.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_method_channel.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_method_codec.h"
 #include "flutter/shell/platform/linux/testing/fl_test.h"
 #include "flutter/shell/platform/linux/testing/mock_binary_messenger_response_handle.h"
 #include "flutter/shell/platform/linux/testing/mock_renderer.h"
@@ -126,12 +130,26 @@ static GBytes* send_on_channel_finish(FlBinaryMessenger* messenger,
   return g_bytes_new(text, strlen(text));
 }
 
+static void resize_channel(FlBinaryMessenger* messenger,
+                           const gchar* channel,
+                           int new_size) {
+  // Fake implementation. Do nothing.
+}
+
+static void allow_channel_overflow(FlBinaryMessenger* messenger,
+                                   const gchar* channel,
+                                   bool allowed) {
+  // Fake implementation. Do nothing.
+}
+
 static void fl_fake_binary_messenger_iface_init(
     FlBinaryMessengerInterface* iface) {
   iface->set_message_handler_on_channel = set_message_handler_on_channel;
   iface->send_response = send_response;
   iface->send_on_channel = send_on_channel;
   iface->send_on_channel_finish = send_on_channel_finish;
+  iface->resize_channel = resize_channel;
+  iface->allow_channel_overflow = allow_channel_overflow;
 }
 
 static void fl_fake_binary_messenger_init(FlFakeBinaryMessenger* self) {}
@@ -385,6 +403,104 @@ TEST(FlBinaryMessengerTest, ReceiveMessage) {
   // Blocks here until response_cb is called.
   g_main_loop_run(loop);
 }
+
+// MOCK_ENGINE_PROC is leaky by design.
+// NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
+
+// Checks if the 'resize' command is sent and is well-formed.
+TEST(FlBinaryMessengerTest, ResizeChannel) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
+
+  bool called = false;
+
+  FlutterEngineSendPlatformMessageFnPtr old_handler =
+      embedder_api->SendPlatformMessage;
+  embedder_api->SendPlatformMessage = MOCK_ENGINE_PROC(
+      SendPlatformMessage,
+      ([&called, old_handler](auto engine,
+                              const FlutterPlatformMessage* message) {
+        // Expect to receive a message on the "control" channel.
+        if (strcmp(message->channel, "dev.flutter/channel-buffers") != 0) {
+          return old_handler(engine, message);
+        }
+
+        called = true;
+
+        // The expected content was created from the following Dart code:
+        //   MethodCall call = MethodCall('resize', ['flutter/test',3]);
+        //   StandardMethodCodec().encodeMethodCall(call).buffer.asUint8List();
+        const int expected_message_size = 29;
+        EXPECT_EQ(message->message_size,
+                  static_cast<size_t>(expected_message_size));
+        int expected[expected_message_size] = {
+            7,   6,   114, 101, 115, 105, 122, 101, 12,  2,
+            7,   12,  102, 108, 117, 116, 116, 101, 114, 47,
+            116, 101, 115, 116, 3,   3,   0,   0,   0};
+        for (size_t i = 0; i < expected_message_size; i++) {
+          EXPECT_EQ(message->message[i], expected[i]);
+        }
+
+        return kSuccess;
+      }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+
+  FlBinaryMessenger* messenger = fl_binary_messenger_new(engine);
+  fl_binary_messenger_resize_channel(messenger, "flutter/test", 3);
+
+  EXPECT_TRUE(called);
+}
+
+// Checks if the 'overflow' command is sent and is well-formed.
+TEST(FlBinaryMessengerTest, AllowOverflowChannel) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
+
+  bool called = false;
+
+  FlutterEngineSendPlatformMessageFnPtr old_handler =
+      embedder_api->SendPlatformMessage;
+  embedder_api->SendPlatformMessage = MOCK_ENGINE_PROC(
+      SendPlatformMessage,
+      ([&called, old_handler](auto engine,
+                              const FlutterPlatformMessage* message) {
+        // Expect to receive a message on the "control" channel.
+        if (strcmp(message->channel, "dev.flutter/channel-buffers") != 0) {
+          return old_handler(engine, message);
+        }
+
+        called = true;
+
+        // The expected content was created from the following Dart code:
+        //   MethodCall call = MethodCall('overflow',['flutter/test', true]);
+        //   StandardMethodCodec().encodeMethodCall(call).buffer.asUint8List();
+        const int expected_message_size = 27;
+        EXPECT_EQ(message->message_size,
+                  static_cast<size_t>(expected_message_size));
+        int expected[expected_message_size] = {
+            7,   8,   111, 118, 101, 114, 102, 108, 111, 119, 12,  2,   7, 12,
+            102, 108, 117, 116, 116, 101, 114, 47,  116, 101, 115, 116, 1};
+        for (size_t i = 0; i < expected_message_size; i++) {
+          EXPECT_EQ(message->message[i], expected[i]);
+        }
+
+        return kSuccess;
+      }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+
+  FlBinaryMessenger* messenger = fl_binary_messenger_new(engine);
+  fl_binary_messenger_allow_channel_overflow(messenger, "flutter/test", true);
+
+  EXPECT_TRUE(called);
+}
+
+// NOLINTEND(clang-analyzer-core.StackAddressEscape)
 
 struct RespondsOnBackgroundThreadInfo {
   FlBinaryMessenger* messenger;

--- a/shell/platform/linux/fl_binary_messenger_test.cc
+++ b/shell/platform/linux/fl_binary_messenger_test.cc
@@ -132,13 +132,13 @@ static GBytes* send_on_channel_finish(FlBinaryMessenger* messenger,
 
 static void resize_channel(FlBinaryMessenger* messenger,
                            const gchar* channel,
-                           int new_size) {
+                           int64_t new_size) {
   // Fake implementation. Do nothing.
 }
 
-static void allow_channel_overflow(FlBinaryMessenger* messenger,
-                                   const gchar* channel,
-                                   bool allowed) {
+static void set_allow_channel_overflow(FlBinaryMessenger* messenger,
+                                       const gchar* channel,
+                                       bool allowed) {
   // Fake implementation. Do nothing.
 }
 
@@ -149,7 +149,7 @@ static void fl_fake_binary_messenger_iface_init(
   iface->send_on_channel = send_on_channel;
   iface->send_on_channel_finish = send_on_channel_finish;
   iface->resize_channel = resize_channel;
-  iface->allow_channel_overflow = allow_channel_overflow;
+  iface->set_allow_channel_overflow = set_allow_channel_overflow;
 }
 
 static void fl_fake_binary_messenger_init(FlFakeBinaryMessenger* self) {}
@@ -495,7 +495,8 @@ TEST(FlBinaryMessengerTest, AllowOverflowChannel) {
   EXPECT_EQ(error, nullptr);
 
   FlBinaryMessenger* messenger = fl_binary_messenger_new(engine);
-  fl_binary_messenger_allow_channel_overflow(messenger, "flutter/test", true);
+  fl_binary_messenger_set_allow_channel_overflow(messenger, "flutter/test",
+                                                 true);
 
   EXPECT_TRUE(called);
 }

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -215,6 +215,20 @@ static GBytes* fl_mock_key_binary_messenger_send_on_channel_finish(
   return static_cast<GBytes*>(g_task_propagate_pointer(G_TASK(result), error));
 }
 
+static void fl_mock_binary_messenger_resize_channel(
+    FlBinaryMessenger* messenger,
+    const gchar* channel,
+    int new_size) {
+  // Mock implementation. Do nothing.
+}
+
+static void fl_mock_binary_messenger_allow_channel_overflow(
+    FlBinaryMessenger* messenger,
+    const gchar* channel,
+    bool allowed) {
+  // Mock implementation. Do nothing.
+}
+
 static void fl_mock_key_binary_messenger_iface_init(
     FlBinaryMessengerInterface* iface) {
   iface->set_message_handler_on_channel =
@@ -236,6 +250,9 @@ static void fl_mock_key_binary_messenger_iface_init(
   iface->send_on_channel = fl_mock_key_binary_messenger_send_on_channel;
   iface->send_on_channel_finish =
       fl_mock_key_binary_messenger_send_on_channel_finish;
+  iface->resize_channel = fl_mock_binary_messenger_resize_channel;
+  iface->allow_channel_overflow =
+      fl_mock_binary_messenger_allow_channel_overflow;
 }
 
 static void fl_mock_key_binary_messenger_init(FlMockKeyBinaryMessenger* self) {}

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -218,11 +218,11 @@ static GBytes* fl_mock_key_binary_messenger_send_on_channel_finish(
 static void fl_mock_binary_messenger_resize_channel(
     FlBinaryMessenger* messenger,
     const gchar* channel,
-    int new_size) {
+    int64_t new_size) {
   // Mock implementation. Do nothing.
 }
 
-static void fl_mock_binary_messenger_allow_channel_overflow(
+static void fl_mock_binary_messenger_set_allow_channel_overflow(
     FlBinaryMessenger* messenger,
     const gchar* channel,
     bool allowed) {
@@ -251,8 +251,8 @@ static void fl_mock_key_binary_messenger_iface_init(
   iface->send_on_channel_finish =
       fl_mock_key_binary_messenger_send_on_channel_finish;
   iface->resize_channel = fl_mock_binary_messenger_resize_channel;
-  iface->allow_channel_overflow =
-      fl_mock_binary_messenger_allow_channel_overflow;
+  iface->set_allow_channel_overflow =
+      fl_mock_binary_messenger_set_allow_channel_overflow;
 }
 
 static void fl_mock_key_binary_messenger_init(FlMockKeyBinaryMessenger* self) {}

--- a/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
+++ b/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
@@ -96,11 +96,11 @@ struct _FlBinaryMessengerInterface {
 
   void (*resize_channel)(FlBinaryMessenger* messenger,
                          const gchar* channel,
-                         int new_size);
+                         int64_t new_size);
 
-  void (*allow_channel_overflow)(FlBinaryMessenger* messenger,
-                                 const gchar* channel,
-                                 bool allowed);
+  void (*set_allow_channel_overflow)(FlBinaryMessenger* messenger,
+                                     const gchar* channel,
+                                     bool allowed);
 };
 
 struct _FlBinaryMessengerResponseHandleClass {
@@ -184,7 +184,7 @@ void fl_binary_messenger_send_on_channel(FlBinaryMessenger* messenger,
 
 /**
  * fl_binary_messenger_send_on_channel_finish:
- * @binary_messenger: an #FlBinaryMessenger.
+ * @messenger: an #FlBinaryMessenger.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  * to ignore.
@@ -207,11 +207,11 @@ GBytes* fl_binary_messenger_send_on_channel_finish(FlBinaryMessenger* messenger,
  */
 void fl_binary_messenger_resize_channel(FlBinaryMessenger* messenger,
                                         const gchar* channel,
-                                        int new_size);
+                                        int64_t new_size);
 
 /**
- * fl_binary_messenger_allow_channel_overflow:
- * @binary_messenger: an #FlBinaryMessenger.
+ * fl_binary_messenger_set_allow_channel_overflow:
+ * @messenger: an #FlBinaryMessenger.
  * @channel: channel to be allowed to overflow silently.
  * @allowed: when true the channel is expected to overflow and warning messages
  * will not be shown.
@@ -219,9 +219,10 @@ void fl_binary_messenger_resize_channel(FlBinaryMessenger* messenger,
  * Sends a message to the control channel asking to allow or disallow a channel
  * to overflow silently.
  */
-void fl_binary_messenger_allow_channel_overflow(FlBinaryMessenger* messenger,
-                                                const gchar* channel,
-                                                bool allowed);
+void fl_binary_messenger_set_allow_channel_overflow(
+    FlBinaryMessenger* messenger,
+    const gchar* channel,
+    bool allowed);
 
 G_END_DECLS
 

--- a/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
+++ b/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
@@ -9,6 +9,8 @@
 #error "Only <flutter_linux/flutter_linux.h> can be included directly."
 #endif
 
+#include "fl_value.h"
+
 #include <gio/gio.h>
 #include <glib-object.h>
 #include <gmodule.h>
@@ -91,6 +93,14 @@ struct _FlBinaryMessengerInterface {
   GBytes* (*send_on_channel_finish)(FlBinaryMessenger* messenger,
                                     GAsyncResult* result,
                                     GError** error);
+
+  void (*resize_channel)(FlBinaryMessenger* messenger,
+                         const gchar* channel,
+                         int new_size);
+
+  void (*allow_channel_overflow)(FlBinaryMessenger* messenger,
+                                 const gchar* channel,
+                                 bool allowed);
 };
 
 struct _FlBinaryMessengerResponseHandleClass {
@@ -186,6 +196,32 @@ void fl_binary_messenger_send_on_channel(FlBinaryMessenger* messenger,
 GBytes* fl_binary_messenger_send_on_channel_finish(FlBinaryMessenger* messenger,
                                                    GAsyncResult* result,
                                                    GError** error);
+
+/**
+ * fl_binary_messenger_resize_channel:
+ * @binary_messenger: an #FlBinaryMessenger.
+ * @channel: channel to be resize.
+ * @new_size: the new size for the channel buffer.
+ *
+ * Sends a message to the control channel asking to resize a channel buffer.
+ */
+void fl_binary_messenger_resize_channel(FlBinaryMessenger* messenger,
+                                        const gchar* channel,
+                                        int new_size);
+
+/**
+ * fl_binary_messenger_allow_channel_overflow:
+ * @binary_messenger: an #FlBinaryMessenger.
+ * @channel: channel to be allowed to overflow silently.
+ * @allowed: when true the channel is expected to overflow and warning messages
+ * will not be shown.
+ *
+ * Sends a message to the control channel asking to allow or disallow a channel
+ * to overflow silently.
+ */
+void fl_binary_messenger_allow_channel_overflow(FlBinaryMessenger* messenger,
+                                                const gchar* channel,
+                                                bool allowed);
 
 G_END_DECLS
 

--- a/shell/platform/linux/testing/mock_binary_messenger.cc
+++ b/shell/platform/linux/testing/mock_binary_messenger.cc
@@ -125,20 +125,20 @@ static GBytes* fl_mock_binary_messenger_send_on_channel_finish(
 static void fl_mock_binary_messenger_resize_channel(
     FlBinaryMessenger* messenger,
     const gchar* channel,
-    int new_size) {
+    int64_t new_size) {
   g_return_if_fail(FL_IS_MOCK_BINARY_MESSENGER(messenger));
   FlMockBinaryMessenger* self = FL_MOCK_BINARY_MESSENGER(messenger);
   self->mock->fl_binary_messenger_resize_channel(messenger, channel, new_size);
 }
 
-static void fl_mock_binary_messenger_allow_channel_overflow(
+static void fl_mock_binary_messenger_set_allow_channel_overflow(
     FlBinaryMessenger* messenger,
     const gchar* channel,
     bool allowed) {
   g_return_if_fail(FL_IS_MOCK_BINARY_MESSENGER(messenger));
   FlMockBinaryMessenger* self = FL_MOCK_BINARY_MESSENGER(messenger);
-  self->mock->fl_binary_messenger_allow_channel_overflow(messenger, channel,
-                                                         allowed);
+  self->mock->fl_binary_messenger_set_allow_channel_overflow(messenger, channel,
+                                                             allowed);
 }
 
 static void fl_mock_binary_messenger_iface_init(
@@ -150,8 +150,8 @@ static void fl_mock_binary_messenger_iface_init(
   iface->send_on_channel_finish =
       fl_mock_binary_messenger_send_on_channel_finish;
   iface->resize_channel = fl_mock_binary_messenger_resize_channel;
-  iface->allow_channel_overflow =
-      fl_mock_binary_messenger_allow_channel_overflow;
+  iface->set_allow_channel_overflow =
+      fl_mock_binary_messenger_set_allow_channel_overflow;
 }
 
 static void fl_mock_binary_messenger_init(FlMockBinaryMessenger* self) {}

--- a/shell/platform/linux/testing/mock_binary_messenger.cc
+++ b/shell/platform/linux/testing/mock_binary_messenger.cc
@@ -122,6 +122,25 @@ static GBytes* fl_mock_binary_messenger_send_on_channel_finish(
                                                                 result, error);
 }
 
+static void fl_mock_binary_messenger_resize_channel(
+    FlBinaryMessenger* messenger,
+    const gchar* channel,
+    int new_size) {
+  g_return_if_fail(FL_IS_MOCK_BINARY_MESSENGER(messenger));
+  FlMockBinaryMessenger* self = FL_MOCK_BINARY_MESSENGER(messenger);
+  self->mock->fl_binary_messenger_resize_channel(messenger, channel, new_size);
+}
+
+static void fl_mock_binary_messenger_allow_channel_overflow(
+    FlBinaryMessenger* messenger,
+    const gchar* channel,
+    bool allowed) {
+  g_return_if_fail(FL_IS_MOCK_BINARY_MESSENGER(messenger));
+  FlMockBinaryMessenger* self = FL_MOCK_BINARY_MESSENGER(messenger);
+  self->mock->fl_binary_messenger_allow_channel_overflow(messenger, channel,
+                                                         allowed);
+}
+
 static void fl_mock_binary_messenger_iface_init(
     FlBinaryMessengerInterface* iface) {
   iface->set_message_handler_on_channel =
@@ -130,6 +149,9 @@ static void fl_mock_binary_messenger_iface_init(
   iface->send_on_channel = fl_mock_binary_messenger_send_on_channel;
   iface->send_on_channel_finish =
       fl_mock_binary_messenger_send_on_channel_finish;
+  iface->resize_channel = fl_mock_binary_messenger_resize_channel;
+  iface->allow_channel_overflow =
+      fl_mock_binary_messenger_allow_channel_overflow;
 }
 
 static void fl_mock_binary_messenger_init(FlMockBinaryMessenger* self) {}

--- a/shell/platform/linux/testing/mock_binary_messenger.h
+++ b/shell/platform/linux/testing/mock_binary_messenger.h
@@ -51,9 +51,9 @@ class MockBinaryMessenger {
   MOCK_METHOD3(fl_binary_messenger_resize_channel,
                void(FlBinaryMessenger* messenger,
                     const gchar* channel,
-                    int new_size));
+                    int64_t new_size));
 
-  MOCK_METHOD3(fl_binary_messenger_allow_channel_overflow,
+  MOCK_METHOD3(fl_binary_messenger_set_allow_channel_overflow,
                void(FlBinaryMessenger* messenger,
                     const gchar* channel,
                     bool allowed));

--- a/shell/platform/linux/testing/mock_binary_messenger.h
+++ b/shell/platform/linux/testing/mock_binary_messenger.h
@@ -48,6 +48,16 @@ class MockBinaryMessenger {
                        GAsyncResult* result,
                        GError** error));
 
+  MOCK_METHOD3(fl_binary_messenger_resize_channel,
+               void(FlBinaryMessenger* messenger,
+                    const gchar* channel,
+                    int new_size));
+
+  MOCK_METHOD3(fl_binary_messenger_allow_channel_overflow,
+               void(FlBinaryMessenger* messenger,
+                    const gchar* channel,
+                    bool allowed));
+
   bool HasMessageHandler(const gchar* channel) const;
 
   void SetMessageHandler(const gchar* channel,


### PR DESCRIPTION
## Description

This PR adds two helper functions to invoke the 'resize' and 'overflow' commands exposed by the control channel.
See:

https://github.com/flutter/engine/blob/93e8901490e78c7ba7e319cce4470d9c6478c6dc/lib/ui/channel_buffers.dart#L302-L309

## Related Issue

Linux implementation for https://github.com/flutter/flutter/issues/132386

## Tests

Adds two tests.