### PR TITLE
allow `ParagraphBuilder.shouldDisableRoundingHack` to actually be set to false in tests

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3029,21 +3029,13 @@ abstract class ParagraphBuilder {
   @Deprecated('''
     The shouldDisableRoundingHack flag is for internal migration purposes only and should not be used.
   ''')
-  static bool get shouldDisableRoundingHack {
-    return const bool.fromEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK', defaultValue: true)
-        && _roundingHackDisabledInDebugMode;
-  }
-  static bool _roundingHackDisabledInDebugMode = true;
-
-  /// Only works in debug mode. Do not call this method as it is for migration
-  /// purposes only and will soon be removed.
+  static bool get shouldDisableRoundingHack => _shouldDisableRoundingHack;
+  static bool _shouldDisableRoundingHack = true;
+  /// Do not call this method as it is for migration purposes only and will soon
+  /// be removed.
+  // ignore: use_setters_to_change_properties
   static void setDisableRoundingHack(bool disableRoundingHack) {
-    // bool.hasEnvironment does not work in internal tests so an additional flag
-    // is needed for tests.
-    assert(() {
-      _roundingHackDisabledInDebugMode = disableRoundingHack;
-      return true;
-    }());
+    _shouldDisableRoundingHack = disableRoundingHack;
   }
 
   /// The number of placeholders currently in the paragraph.

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3031,7 +3031,7 @@ abstract class ParagraphBuilder {
   ''')
   static bool get shouldDisableRoundingHack {
     return const bool.fromEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK', defaultValue: true)
-        || _roundingHackDisabledInDebugMode;
+        && _roundingHackDisabledInDebugMode;
   }
   static bool _roundingHackDisabledInDebugMode = true;
 

--- a/lib/web_ui/lib/text.dart
+++ b/lib/web_ui/lib/text.dart
@@ -686,16 +686,11 @@ abstract class ParagraphBuilder {
   factory ParagraphBuilder(ParagraphStyle style) =>
     engine.renderer.createParagraphBuilder(style);
 
-  static bool get shouldDisableRoundingHack {
-    return const bool.fromEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK', defaultValue: true)
-        && _roundingHackDisabledInDebugMode;
-  }
-  static bool _roundingHackDisabledInDebugMode = true;
+  static bool get shouldDisableRoundingHack => _shouldDisableRoundingHack;
+  static bool _shouldDisableRoundingHack = true;
+  // ignore: use_setters_to_change_properties
   static void setDisableRoundingHack(bool disableRoundingHack) {
-    assert(() {
-      _roundingHackDisabledInDebugMode = disableRoundingHack;
-      return true;
-    }());
+    _shouldDisableRoundingHack = disableRoundingHack;
   }
 
   void pushStyle(TextStyle style);

--- a/lib/web_ui/lib/text.dart
+++ b/lib/web_ui/lib/text.dart
@@ -688,7 +688,7 @@ abstract class ParagraphBuilder {
 
   static bool get shouldDisableRoundingHack {
     return const bool.fromEnvironment('SKPARAGRAPH_REMOVE_ROUNDING_HACK', defaultValue: true)
-        || _roundingHackDisabledInDebugMode;
+        && _roundingHackDisabledInDebugMode;
   }
   static bool _roundingHackDisabledInDebugMode = true;
   static void setDisableRoundingHack(bool disableRoundingHack) {

--- a/lib/web_ui/test/canvaskit/text_test.dart
+++ b/lib/web_ui/test/canvaskit/text_test.dart
@@ -124,21 +124,12 @@ void testMain() {
       });
     });
 
-    test('applyRoundingHack works', () {
-      bool assertsEnabled = false;
-      assert(() {
-        assertsEnabled = true;
-        return true;
-      }());
-      if (!assertsEnabled){
-        return;
-      }
+    test('rounding hack disabled by default', () {
+      expect(ui.ParagraphBuilder.shouldDisableRoundingHack, isTrue);
 
       const double fontSize = 1.25;
       const String text = '12345';
       assert((fontSize * text.length).truncate() != fontSize * text.length);
-      final bool roundingHackWasDisabled = ui.ParagraphBuilder.shouldDisableRoundingHack;
-      ui.ParagraphBuilder.setDisableRoundingHack(true);
       final ui.ParagraphBuilder builder = ui.ParagraphBuilder(
         ui.ParagraphStyle(fontSize: fontSize, fontFamily: 'FlutterTest'),
       );
@@ -153,19 +144,32 @@ void testMain() {
         case final List<ui.LineMetrics> metrics:
           expect(metrics, hasLength(1));
       }
-      ui.ParagraphBuilder.setDisableRoundingHack(roundingHackWasDisabled);
     });
 
-    test('rounding hack disabled by default', () {
+    test('setDisableRoundinghHack to false works in tests', () {
+      bool assertsEnabled = false;
+      assert(() {
+        assertsEnabled = true;
+        return true;
+      }());
+      if (!assertsEnabled){
+        return;
+      }
+
+      if (ui.ParagraphBuilder.shouldDisableRoundingHack) {
+        ui.ParagraphBuilder.setDisableRoundingHack(false);
+        addTearDown(() => ui.ParagraphBuilder.setDisableRoundingHack(true));
+      }
+
+      assert(!ui.ParagraphBuilder.shouldDisableRoundingHack);
       const double fontSize = 1.25;
       const String text = '12345';
       assert((fontSize * text.length).truncate() != fontSize * text.length);
-      expect(ui.ParagraphBuilder.shouldDisableRoundingHack, isTrue);
       final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle(fontSize: fontSize, fontFamily: 'FlutterTest'));
       builder.addText(text);
       final ui.Paragraph paragraph = builder.build()
         ..layout(const ui.ParagraphConstraints(width: text.length * fontSize));
-      expect(paragraph.computeLineMetrics().length, 1);
+      expect(paragraph.computeLineMetrics().length, greaterThan(1));
     });
 
     // TODO(hterkelsen): https://github.com/flutter/flutter/issues/71520

--- a/lib/web_ui/test/html/text/canvas_paragraph_test.dart
+++ b/lib/web_ui/test/html/text/canvas_paragraph_test.dart
@@ -778,17 +778,12 @@ Future<void> testMain() async {
 
   test('$CanvasParagraph.width should be a whole integer when shouldDisableRoundingHack is false', () {
     if (ui.ParagraphBuilder.shouldDisableRoundingHack) {
-      // Try applying the rounding hack if it's disabled. This may not work if
-      // the 'SKPARAGRAPH_REMOVE_ROUNDING_HACK' dart environment declaration
-      // is set to 'false'.
       ui.ParagraphBuilder.setDisableRoundingHack(false);
       addTearDown(() => ui.ParagraphBuilder.setDisableRoundingHack(true));
     }
     // The paragraph width is only rounded to a whole integer if
     // shouldDisableRoundingHack is false.
-    if (ui.ParagraphBuilder.shouldDisableRoundingHack) {
-      return;
-    }
+    assert(!ui.ParagraphBuilder.shouldDisableRoundingHack);
     final ui.Paragraph paragraph = plain(ahemStyle, 'abc');
     paragraph.layout(const ui.ParagraphConstraints(width: 30.8));
 

--- a/testing/dart/paragraph_test.dart
+++ b/testing/dart/paragraph_test.dart
@@ -234,7 +234,7 @@ void main() {
     }
   });
 
-  test('disableRoundingHack works in tests', () {
+  test('can set disableRoundingHack to false in tests', () {
     bool assertsEnabled = false;
     assert(() {
       assertsEnabled = true;
@@ -248,20 +248,20 @@ void main() {
     assert((fontSize * text.length).truncate() != fontSize * text.length);
     // ignore: deprecated_member_use
     final bool roundingHackWasDisabled = ParagraphBuilder.shouldDisableRoundingHack;
-    ParagraphBuilder.setDisableRoundingHack(true);
+    if (roundingHackWasDisabled) {
+      ParagraphBuilder.setDisableRoundingHack(false);
+    }
+    // ignore: deprecated_member_use
+    assert(!ParagraphBuilder.shouldDisableRoundingHack);
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(fontSize: fontSize));
     builder.addText(text);
     final Paragraph paragraph = builder.build()
       ..layout(const ParagraphConstraints(width: text.length * fontSize));
+    expect(paragraph.computeLineMetrics().length, greaterThan(1));
 
-    expect(paragraph.maxIntrinsicWidth, text.length * fontSize);
-    switch (paragraph.computeLineMetrics()) {
-      case [LineMetrics(width: final double width)]:
-        expect(width, text.length * fontSize);
-      case final List<LineMetrics> metrics:
-        expect(metrics, hasLength(1));
+    if (roundingHackWasDisabled) {
+      ParagraphBuilder.setDisableRoundingHack(true);
     }
-    ParagraphBuilder.setDisableRoundingHack(roundingHackWasDisabled);
   });
 
   test('rounding hack disabled by default', () {
@@ -274,6 +274,12 @@ void main() {
     builder.addText(text);
     final Paragraph paragraph = builder.build()
       ..layout(const ParagraphConstraints(width: text.length * fontSize));
-    expect(paragraph.computeLineMetrics().length, 1);
+    expect(paragraph.maxIntrinsicWidth, text.length * fontSize);
+    switch (paragraph.computeLineMetrics()) {
+      case [LineMetrics(width: final double width)]:
+        expect(width, text.length * fontSize);
+      case final List<LineMetrics> metrics:
+        expect(metrics, hasLength(1));
+    }
   });
 }


### PR DESCRIPTION


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
