### PR TITLE
Add application:openURLs: forwarding on macOS

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2748,6 +2748,7 @@ ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterApp
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate_Internal.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegate.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegateTest.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegate_Internal.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.h + ../../../flutter/LICENSE
@@ -5493,6 +5494,7 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDe
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegate.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegateTest.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegate_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.h

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2744,6 +2744,7 @@ ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/Accessibil
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegateTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate_Internal.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegate.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegateTest.mm + ../../../flutter/LICENSE
@@ -5488,6 +5489,7 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/Accessibilit
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMac.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegateTest.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegate.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegateTest.mm

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -169,6 +169,7 @@ executable("flutter_desktop_darwin_unittests") {
 
   sources = [
     "framework/Source/AccessibilityBridgeMacTest.mm",
+    "framework/Source/FlutterAppDelegateTest.mm",
     "framework/Source/FlutterAppLifecycleDelegateTest.mm",
     "framework/Source/FlutterChannelKeyResponderTest.mm",
     "framework/Source/FlutterCompositorTest.mm",

--- a/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h
@@ -56,13 +56,13 @@ FLUTTER_DARWIN_EXPORT
 /**
  * The application menu in the menu bar.
  */
-@property(weak, nonatomic) IBOutlet NSMenu* applicationMenu;
+@property(weak, nonatomic, nullable) IBOutlet NSMenu* applicationMenu;
 
 /**
  * The primary application window containing a FlutterViewController. This is
  * primarily intended for use in single-window applications.
  */
-@property(weak, nonatomic) IBOutlet NSWindow* mainFlutterWindow;
+@property(weak, nonatomic, nullable) IBOutlet NSWindow* mainFlutterWindow;
 
 @end
 

--- a/shell/platform/darwin/macos/framework/Headers/FlutterAppLifecycleDelegate.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterAppLifecycleDelegate.h
@@ -91,7 +91,17 @@ FLUTTER_DARWIN_EXPORT
  * Called when the |FlutterAppDelegate| gets the applicationDidUnhide
  * notification.
  */
-- (void)handleDidChangeOcclusionState:(NSNotification*)notification API_AVAILABLE(macos(10.9));
+- (void)handleDidChangeOcclusionState:(NSNotification*)notification;
+
+/**
+ * Called when the |FlutterAppDelegate| gets the application:openURLs:
+ * callback.
+ *
+ * Implementers should return YES if they handle the URLs, otherwise NO.
+ * Delegates will be called in order of registration, and once a delegate
+ * returns YES, no further delegates will reiceve this callback.
+ */
+- (BOOL)handleOpenURLs:(NSArray<NSURL*>*)urls;
 
 /**
  * Called when the |FlutterAppDelegate| gets the applicationWillTerminate

--- a/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate.mm
@@ -9,6 +9,7 @@
 
 #include "flutter/fml/logging.h"
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterAppLifecycleDelegate.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegate_Internal.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 
 @interface FlutterAppDelegate ()
@@ -44,11 +45,11 @@
 #pragma mark - Delegate handling
 
 - (void)addApplicationLifecycleDelegate:(NSObject<FlutterAppLifecycleDelegate>*)delegate {
-  [[self lifecycleRegistrar] addDelegate:delegate];
+  [self.lifecycleRegistrar addDelegate:delegate];
 }
 
 - (void)removeApplicationLifecycleDelegate:(NSObject<FlutterAppLifecycleDelegate>*)delegate {
-  [[self lifecycleRegistrar] removeDelegate:delegate];
+  [self.lifecycleRegistrar removeDelegate:delegate];
 }
 
 #pragma mark Private Methods
@@ -60,6 +61,17 @@
     applicationName = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleName"];
   }
   return applicationName;
+}
+
+#pragma mark NSApplicationDelegate
+
+- (void)application:(NSApplication*)application openURLs:(NSArray<NSURL*>*)urls {
+  for (NSObject<FlutterAppLifecycleDelegate>* delegate in self.lifecycleRegistrar.delegates) {
+    if ([delegate respondsToSelector:@selector(handleOpenURLs:)] &&
+        [delegate handleOpenURLs:urls]) {
+      return;
+    }
+  }
 }
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication* _Nonnull)sender {

--- a/shell/platform/darwin/macos/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterAppDelegateTest.mm
@@ -1,0 +1,71 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h"
+
+#import "flutter/testing/testing.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+@interface AppDelegateNoopFlutterAppLifecycleDelegate : NSObject <FlutterAppLifecycleDelegate>
+@property(nonatomic, copy, nullable) NSArray<NSURL*>* receivedURLs;
+@end
+
+@implementation AppDelegateNoopFlutterAppLifecycleDelegate
+@end
+
+@interface AppDelegateTestFlutterAppLifecycleDelegate : NSObject <FlutterAppLifecycleDelegate>
+@property(nonatomic, copy, nullable) NSArray<NSURL*>* receivedURLs;
+@end
+
+@implementation AppDelegateTestFlutterAppLifecycleDelegate
+
+- (BOOL)handleOpenURLs:(NSArray<NSURL*>*)urls {
+  self.receivedURLs = [urls copy];
+  return YES;
+}
+
+@end
+
+namespace flutter::testing {
+
+TEST(FlutterAppDelegateTest, DoesNotCallDelegatesWithoutHandler) {
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  AppDelegateNoopFlutterAppLifecycleDelegate* noopDelegate =
+      [[AppDelegateNoopFlutterAppLifecycleDelegate alloc] init];
+  [appDelegate addApplicationLifecycleDelegate:noopDelegate];
+
+  [appDelegate application:NSApplication.sharedApplication openURLs:@[]];
+  // No EXPECT, since the test is that the call doesn't throw due to calling without checking that
+  // the method is implemented.
+}
+
+TEST(FlutterAppDelegateTest, ReceivesOpenURLs) {
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  AppDelegateTestFlutterAppLifecycleDelegate* delegate =
+      [[AppDelegateTestFlutterAppLifecycleDelegate alloc] init];
+  [appDelegate addApplicationLifecycleDelegate:delegate];
+
+  NSArray<NSURL*>* URLs = @[ [NSURL URLWithString:@"https://flutter.dev"] ];
+  [appDelegate application:NSApplication.sharedApplication openURLs:URLs];
+
+  EXPECT_EQ([delegate receivedURLs], URLs);
+}
+
+TEST(FlutterAppDelegateTest, OperURLsStopsAfterHandled) {
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  AppDelegateTestFlutterAppLifecycleDelegate* firstDelegate =
+      [[AppDelegateTestFlutterAppLifecycleDelegate alloc] init];
+  AppDelegateTestFlutterAppLifecycleDelegate* secondDelegate =
+      [[AppDelegateTestFlutterAppLifecycleDelegate alloc] init];
+  [appDelegate addApplicationLifecycleDelegate:firstDelegate];
+  [appDelegate addApplicationLifecycleDelegate:secondDelegate];
+
+  NSArray<NSURL*>* URLs = @[ [NSURL URLWithString:@"https://flutter.dev"] ];
+  [appDelegate application:NSApplication.sharedApplication openURLs:URLs];
+
+  EXPECT_EQ([firstDelegate receivedURLs], URLs);
+  EXPECT_EQ([secondDelegate receivedURLs], nil);
+}
+
+}  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegate_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterAppLifecycleDelegate_Internal.h
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERAPPLIFECYCLEDELEGATE_INTERNAL_H_
+#define SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERAPPLIFECYCLEDELEGATE_INTERNAL_H_
+
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterAppLifecycleDelegate.h"
+
+@interface FlutterAppLifecycleRegistrar ()
+/**
+ * Registered delegates. Exposed to allow FlutterAppDelegate to share the delegate list for
+ * handling non-notification delegation.
+ */
+@property(nonatomic, strong) NSPointerArray* delegates;
+@end
+
+#endif  // SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERAPPLIFECYCLEDELEGATE_INTERNAL_H_

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -1232,7 +1232,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
  * Called when the |FlutterAppDelegate| gets the applicationDidUnhide
  * notification.
  */
-- (void)handleDidChangeOcclusionState:(NSNotification*)notification API_AVAILABLE(macos(10.9)) {
+- (void)handleDidChangeOcclusionState:(NSNotification*)notification {
   NSApplicationOcclusionState occlusionState = [[NSApplication sharedApplication] occlusionState];
   if (occlusionState & NSApplicationOcclusionStateVisible) {
     _visible = YES;


### PR DESCRIPTION
Wires `application:openURLs:` into the exisiting delegation system, allowing plugins to handle URL callbacks (as on iOS).

Since there is no notification-based version of this delegate method, this adds it directly to the app delegate, restructring the helper class slightly to allow internal sharing of the delegate list.

Fixes https://github.com/flutter/flutter/issues/41471

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
