### PR TITLE
[Web] Fix insertions/deletions at inverted selection for TextEditingDeltas

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -2420,6 +2420,13 @@ class DomMouseEvent extends DomUIEvent {
   external factory DomMouseEvent.arg2(JSString type, JSAny initDict);
 }
 
+@JS('InputEvent')
+@staticInterop
+class DomInputEvent extends DomUIEvent {
+  external factory DomInputEvent.arg1(JSString type);
+  external factory DomInputEvent.arg2(JSString type, JSAny initDict);
+}
+
 extension DomMouseEventExtension on DomMouseEvent {
   @JS('clientX')
   external JSNumber get _clientX;
@@ -2470,6 +2477,14 @@ DomMouseEvent createDomMouseEvent(String type, [Map<dynamic, dynamic>? init]) {
     return DomMouseEvent.arg1(type.toJS);
   } else {
     return DomMouseEvent.arg2(type.toJS, init.toJSAnyDeep);
+  }
+}
+
+DomInputEvent createDomInputEvent(String type, [Map<dynamic, dynamic>? init]) {
+  if (init == null) {
+    return DomInputEvent.arg1(type.toJS);
+  } else {
+    return DomInputEvent.arg2(type.toJS, init.toJSAnyDeep);
   }
 }
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -561,9 +561,10 @@ class TextEditingDeltaState {
         newTextEditingDeltaState.deltaEnd = newTextEditingDeltaState.deltaStart + deletedLength;
       }
     } else if (isTextBeingChangedAtActiveSelection) {
+      final bool isPreviousSelectionInverted = lastEditingState!.baseOffset! > lastEditingState!.extentOffset!;
       // When a selection of text is replaced by a copy/paste operation we set the starting range
       // of the delta to be the beginning of the selection of the previous editing state.
-      newTextEditingDeltaState.deltaStart = lastEditingState!.baseOffset!;
+      newTextEditingDeltaState.deltaStart = isPreviousSelectionInverted ? lastEditingState!.extentOffset! : lastEditingState!.baseOffset!;
     }
 
     // If we are composing then set the delta range to the composing region we

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -561,10 +561,10 @@ class TextEditingDeltaState {
         newTextEditingDeltaState.deltaEnd = newTextEditingDeltaState.deltaStart + deletedLength;
       }
     } else if (isTextBeingChangedAtActiveSelection) {
-      final bool isPreviousSelectionInverted = lastEditingState!.baseOffset! > lastEditingState!.extentOffset!;
+      final bool isPreviousSelectionInverted = lastEditingState!.baseOffset! > lastEditingState.extentOffset!;
       // When a selection of text is replaced by a copy/paste operation we set the starting range
       // of the delta to be the beginning of the selection of the previous editing state.
-      newTextEditingDeltaState.deltaStart = isPreviousSelectionInverted ? lastEditingState!.extentOffset! : lastEditingState!.baseOffset!;
+      newTextEditingDeltaState.deltaStart = isPreviousSelectionInverted ? lastEditingState.extentOffset! : lastEditingState.baseOffset!;
     }
 
     // If we are composing then set the delta range to the composing region we

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -547,7 +547,7 @@ class TextEditingDeltaState {
     if (isTextBeingRemoved) {
       // When text is deleted outside of the composing region or is cut using the native toolbar,
       // we calculate the length of the deleted text by comparing the new and old editing state lengths.
-      // If the deletion is backward, the length is susbtracted from the [deltaEnd]
+      // If the deletion is backward, the length is subtracted from the [deltaEnd]
       // that we set when beforeinput was fired to determine the [deltaStart].
       // If the deletion is forward, [deltaStart] is set to the new editing state baseOffset
       // and [deltaEnd] is set to [deltaStart] incremented by the length of the deletion.
@@ -1412,23 +1412,24 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
 
     if (inputType != null) {
       final bool isSelectionInverted = lastEditingState!.baseOffset! > lastEditingState!.extentOffset!;
+      final int deltaOffset = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
       if (inputType.contains('delete')) {
         // The deltaStart is set in handleChange because there is where we get access
         // to the new selection baseOffset which is our new deltaStart.
         editingDeltaState.deltaText = '';
-        editingDeltaState.deltaEnd = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
+        editingDeltaState.deltaEnd = deltaOffset;
       } else if (inputType == 'insertLineBreak'){
         // event.data is null on a line break, so we manually set deltaText as a line break by setting it to '\n'.
         editingDeltaState.deltaText = '\n';
-        editingDeltaState.deltaStart = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
-        editingDeltaState.deltaEnd = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
+        editingDeltaState.deltaStart = deltaOffset;
+        editingDeltaState.deltaEnd = deltaOffset;
       } else if (eventData != null) {
         // When event.data is not null we will begin by considering this delta as an insertion
         // at the selection extentOffset. This may change due to logic in handleChange to handle
         // composition and other IME behaviors.
         editingDeltaState.deltaText = eventData;
-        editingDeltaState.deltaStart = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
-        editingDeltaState.deltaEnd = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
+        editingDeltaState.deltaStart = deltaOffset;
+        editingDeltaState.deltaEnd = deltaOffset;
       }
     }
   }

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1411,23 +1411,24 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
     final String? inputType = getJsProperty<void>(event, 'inputType') as String?;
 
     if (inputType != null) {
+      final bool isSelectionInverted = lastEditingState!.baseOffset! > lastEditingState!.extentOffset!;
       if (inputType.contains('delete')) {
         // The deltaStart is set in handleChange because there is where we get access
         // to the new selection baseOffset which is our new deltaStart.
         editingDeltaState.deltaText = '';
-        editingDeltaState.deltaEnd = lastEditingState!.extentOffset!;
+        editingDeltaState.deltaEnd = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
       } else if (inputType == 'insertLineBreak'){
         // event.data is null on a line break, so we manually set deltaText as a line break by setting it to '\n'.
         editingDeltaState.deltaText = '\n';
-        editingDeltaState.deltaStart = lastEditingState!.extentOffset!;
-        editingDeltaState.deltaEnd = lastEditingState!.extentOffset!;
+        editingDeltaState.deltaStart = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
+        editingDeltaState.deltaEnd = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
       } else if (eventData != null) {
         // When event.data is not null we will begin by considering this delta as an insertion
         // at the selection extentOffset. This may change due to logic in handleChange to handle
         // composition and other IME behaviors.
         editingDeltaState.deltaText = eventData;
-        editingDeltaState.deltaStart = lastEditingState!.extentOffset!;
-        editingDeltaState.deltaEnd = lastEditingState!.extentOffset!;
+        editingDeltaState.deltaStart = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
+        editingDeltaState.deltaEnd = isSelectionInverted ? lastEditingState!.baseOffset! : lastEditingState!.extentOffset!;
       }
     }
   }

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -1829,7 +1829,8 @@ Future<void> testMain() async {
       spy.messages.clear();
 
       hideKeyboard();
-    });
+      // TODO(Renzo-Olivares): https://github.com/flutter/flutter/issues/134271
+    }, skip: isSafari);
 
     test('Supports new line at inverted selection', () async {
       final MethodCall setClient = MethodCall(
@@ -1903,7 +1904,8 @@ Future<void> testMain() async {
       spy.messages.clear();
 
       hideKeyboard();
-    });
+      // TODO(Renzo-Olivares): https://github.com/flutter/flutter/issues/134271
+    }, skip: isSafari);
 
     test('multiTextField Autofill sync updates back to Flutter', () async {
       // Create a configuration with an AutofillGroup of four text fields.

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -1757,7 +1757,7 @@ Future<void> testMain() async {
       hideKeyboard();
     });
 
-    test('Supports deletion at inverted selection', () {
+    test('Supports deletion at inverted selection', () async {
       final MethodCall setClient = MethodCall(
           'TextInput.setClient', <dynamic>[123, createFlutterConfig('text', enableDeltaModel: true)]);
       sendFrameworkMessage(codec.encodeMethodCall(setClient));
@@ -1773,10 +1773,10 @@ Future<void> testMain() async {
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
 
-      // The "setSizeAndTransform" message has to be here before we call
-      // checkInputEditingState, since on some platforms (e.g. Desktop Safari)
-      // we don't put the input element into the DOM until we get its correct
-      // dimensions from the framework.
+      // // The "setSizeAndTransform" message has to be here before we call
+      // // checkInputEditingState, since on some platforms (e.g. Desktop Safari)
+      // // we don't put the input element into the DOM until we get its correct
+      // // dimensions from the framework.
       final MethodCall setSizeAndTransform =
           configureSetSizeAndTransformMethodCall(150, 50,
               Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
@@ -1831,7 +1831,7 @@ Future<void> testMain() async {
       hideKeyboard();
     });
 
-    test('Supports new line at inverted selection', () {
+    test('Supports new line at inverted selection', () async {
       final MethodCall setClient = MethodCall(
           'TextInput.setClient', <dynamic>[123, createFlutterConfig('text', enableDeltaModel: true)]);
       sendFrameworkMessage(codec.encodeMethodCall(setClient));

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:js_interop';
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -1773,6 +1773,17 @@ Future<void> testMain() async {
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
 
+      // The "setSizeAndTransform" message has to be here before we call
+      // checkInputEditingState, since on some platforms (e.g. Desktop Safari)
+      // we don't put the input element into the DOM until we get its correct
+      // dimensions from the framework.
+      final MethodCall setSizeAndTransform =
+          configureSetSizeAndTransformMethodCall(150, 50,
+              Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
+
+      await waitForDesktopSafariFocus();
+
       final DomHTMLInputElement input = textEditing!.strategy.domElement! as
           DomHTMLInputElement;
 
@@ -1835,6 +1846,17 @@ Future<void> testMain() async {
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
+
+      // The "setSizeAndTransform" message has to be here before we call
+      // checkInputEditingState, since on some platforms (e.g. Desktop Safari)
+      // we don't put the input element into the DOM until we get its correct
+      // dimensions from the framework.
+      final MethodCall setSizeAndTransform =
+          configureSetSizeAndTransformMethodCall(150, 50,
+              Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
+
+      await waitForDesktopSafariFocus();
 
       final DomHTMLInputElement input = textEditing!.strategy.domElement! as
           DomHTMLInputElement;

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -1773,10 +1773,10 @@ Future<void> testMain() async {
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
 
-      // // The "setSizeAndTransform" message has to be here before we call
-      // // checkInputEditingState, since on some platforms (e.g. Desktop Safari)
-      // // we don't put the input element into the DOM until we get its correct
-      // // dimensions from the framework.
+      // The "setSizeAndTransform" message has to be here before we call
+      // checkInputEditingState, since on some platforms (e.g. Desktop Safari)
+      // we don't put the input element into the DOM until we get its correct
+      // dimensions from the framework.
       final MethodCall setSizeAndTransform =
           configureSetSizeAndTransformMethodCall(150, 50,
               Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:js_interop';
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
@@ -21,6 +22,17 @@ import 'package:ui/src/engine/vector_math.dart';
 
 import '../common/spy.dart';
 import '../common/test_initialization.dart';
+
+@JS('InputEvent')
+@staticInterop
+class MockDomInputEvent extends DomUIEvent {
+}
+
+extension MockDomInputEventExtension on MockDomInputEvent {
+  @JS('inputType')
+  external JSString get _inputType;
+  String get inputType => _inputType;
+}
 
 /// The `keyCode` of the "Enter" key.
 const int _kReturnKeyCode = 13;
@@ -1745,6 +1757,142 @@ Future<void> testMain() async {
                 'deltaEnd': -1,
                 'selectionBase': 2,
                 'selectionExtent': 5,
+                'composingBase': -1,
+                'composingExtent': -1
+              }
+            ],
+          }
+        ],
+      );
+      spy.messages.clear();
+
+      hideKeyboard();
+    });
+
+    test('Supports deletion at inverted selection', () {
+      final MethodCall setClient = MethodCall(
+          'TextInput.setClient', <dynamic>[123, createFlutterConfig('text', enableDeltaModel: true)]);
+      sendFrameworkMessage(codec.encodeMethodCall(setClient));
+
+      const MethodCall setEditingState =
+      MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': 'Hello world',
+        'selectionBase': 9,
+        'selectionExtent': 3,
+      });
+      sendFrameworkMessage(codec.encodeMethodCall(setEditingState));
+
+      const MethodCall show = MethodCall('TextInput.show');
+      sendFrameworkMessage(codec.encodeMethodCall(show));
+
+      final DomHTMLInputElement input = textEditing!.strategy.domElement! as
+          DomHTMLInputElement;
+
+      final Object jsInputEvent = js_util.getProperty<Object>(domWindow, 'InputEvent');
+      final List<dynamic> eventArgs = <dynamic>[
+        'beforeinput',
+        js_util.jsify(<String, dynamic>{
+          'inputType': 'delete',
+        }),
+      ];
+      final MockDomInputEvent testEvent = js_util.callConstructor<MockDomInputEvent>(
+        jsInputEvent,
+        eventArgs,
+      );
+      input.dispatchEvent(testEvent);
+
+      EditingState editingState = EditingState(
+        text: 'Helld',
+        baseOffset: 3,
+        extentOffset: 3,
+      );
+      editingState.applyToDomElement(input);
+      input.dispatchEvent(createDomEvent('Event', 'input'));
+
+      expect(spy.messages, hasLength(1));
+      expect(spy.messages[0].channel, 'flutter/textinput');
+      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingStateWithDeltas');
+      expect(
+        spy.messages[0].methodArguments,
+        <dynamic>[
+          123, // Client ID
+          <String, dynamic>{
+            'deltas': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'oldText': 'Hello world',
+                'deltaText': '',
+                'deltaStart': 3,
+                'deltaEnd': 9,
+                'selectionBase': 3,
+                'selectionExtent': 3,
+                'composingBase': -1,
+                'composingExtent': -1
+              }
+            ],
+          }
+        ],
+      );
+      spy.messages.clear();
+
+      hideKeyboard();
+    });
+
+    test('Supports new line at inverted selection', () {
+      final MethodCall setClient = MethodCall(
+          'TextInput.setClient', <dynamic>[123, createFlutterConfig('text', enableDeltaModel: true)]);
+      sendFrameworkMessage(codec.encodeMethodCall(setClient));
+
+      const MethodCall setEditingState =
+      MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': 'Hello world',
+        'selectionBase': 9,
+        'selectionExtent': 3,
+      });
+      sendFrameworkMessage(codec.encodeMethodCall(setEditingState));
+
+      const MethodCall show = MethodCall('TextInput.show');
+      sendFrameworkMessage(codec.encodeMethodCall(show));
+
+      final DomHTMLInputElement input = textEditing!.strategy.domElement! as
+          DomHTMLInputElement;
+
+      final Object jsInputEvent = js_util.getProperty<Object>(domWindow, 'InputEvent');
+      final List<dynamic> eventArgs = <dynamic>[
+        'beforeinput',
+        js_util.jsify(<String, dynamic>{
+          'inputType': 'insertLineBreak',
+        }),
+      ];
+      final MockDomInputEvent testEvent = js_util.callConstructor<MockDomInputEvent>(
+        jsInputEvent,
+        eventArgs,
+      );
+      input.dispatchEvent(testEvent);
+
+      EditingState editingState = EditingState(
+        text: 'Hel\nld',
+        baseOffset: 3,
+        extentOffset: 3,
+      );
+      editingState.applyToDomElement(input);
+      input.dispatchEvent(createDomEvent('Event', 'input'));
+
+      expect(spy.messages, hasLength(1));
+      expect(spy.messages[0].channel, 'flutter/textinput');
+      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingStateWithDeltas');
+      expect(
+        spy.messages[0].methodArguments,
+        <dynamic>[
+          123, // Client ID
+          <String, dynamic>{
+            'deltas': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'oldText': 'Hello world',
+                'deltaText': '\n',
+                'deltaStart': 3,
+                'deltaEnd': 9,
+                'selectionBase': 3,
+                'selectionExtent': 3,
                 'composingBase': -1,
                 'composingExtent': -1
               }

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -1868,7 +1868,7 @@ Future<void> testMain() async {
               <String, dynamic>{
                 'oldText': 'Hello world',
                 'deltaText': '\n',
-                'deltaStart': 9,
+                'deltaStart': 3,
                 'deltaEnd': 9,
                 'selectionBase': 3,
                 'selectionExtent': 3,

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -23,17 +23,6 @@ import 'package:ui/src/engine/vector_math.dart';
 import '../common/spy.dart';
 import '../common/test_initialization.dart';
 
-@JS('InputEvent')
-@staticInterop
-class MockDomInputEvent extends DomUIEvent {
-}
-
-extension MockDomInputEventExtension on MockDomInputEvent {
-  @JS('inputType')
-  external JSString get _inputType;
-  String get inputType => _inputType;
-}
-
 /// The `keyCode` of the "Enter" key.
 const int _kReturnKeyCode = 13;
 
@@ -1788,20 +1777,15 @@ Future<void> testMain() async {
       final DomHTMLInputElement input = textEditing!.strategy.domElement! as
           DomHTMLInputElement;
 
-      final Object jsInputEvent = js_util.getProperty<Object>(domWindow, 'InputEvent');
-      final List<dynamic> eventArgs = <dynamic>[
+      final DomInputEvent testEvent = createDomInputEvent(
         'beforeinput',
-        js_util.jsify(<String, dynamic>{
-          'inputType': 'delete',
-        }),
-      ];
-      final MockDomInputEvent testEvent = js_util.callConstructor<MockDomInputEvent>(
-        jsInputEvent,
-        eventArgs,
+        <Object?, Object?>{
+          'inputType': 'deleteContentBackward',
+        },
       );
       input.dispatchEvent(testEvent);
 
-      EditingState editingState = EditingState(
+      final EditingState editingState = EditingState(
         text: 'Helld',
         baseOffset: 3,
         extentOffset: 3,
@@ -1856,20 +1840,15 @@ Future<void> testMain() async {
       final DomHTMLInputElement input = textEditing!.strategy.domElement! as
           DomHTMLInputElement;
 
-      final Object jsInputEvent = js_util.getProperty<Object>(domWindow, 'InputEvent');
-      final List<dynamic> eventArgs = <dynamic>[
+      final DomInputEvent testEvent = createDomInputEvent(
         'beforeinput',
-        js_util.jsify(<String, dynamic>{
+        <Object?, Object?>{
           'inputType': 'insertLineBreak',
-        }),
-      ];
-      final MockDomInputEvent testEvent = js_util.callConstructor<MockDomInputEvent>(
-        jsInputEvent,
-        eventArgs,
+        },
       );
       input.dispatchEvent(testEvent);
 
-      EditingState editingState = EditingState(
+      final EditingState editingState = EditingState(
         text: 'Hel\nld',
         baseOffset: 3,
         extentOffset: 3,
@@ -1889,7 +1868,7 @@ Future<void> testMain() async {
               <String, dynamic>{
                 'oldText': 'Hello world',
                 'deltaText': '\n',
-                'deltaStart': 3,
+                'deltaStart': 9,
                 'deltaEnd': 9,
                 'selectionBase': 3,
                 'selectionExtent': 3,


### PR DESCRIPTION
Fixes issue where the delta range would be calculated wrong when the selection is inverted.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.