### PR TITLE
Stop using deprecated GrBackendRenderTarget constructor

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -409,7 +409,7 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrDirectContext> context,
   image_info.fSampleCount = 1;
   image_info.fLevelCount = image_create_info.mipLevels;
 
-  GrBackendRenderTarget sk_render_target(size.width(), size.height(), 0,
+  GrBackendRenderTarget sk_render_target(size.width(), size.height(),
                                          image_info);
 
   SkSurfaceProps sk_surface_props(0, kUnknown_SkPixelGeometry);

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -242,7 +242,7 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(
   image_info.fLevelCount = 1;
 
   // TODO(chinmaygarde): Setup the stencil buffer and the sampleCnt.
-  GrBackendRenderTarget backend_render_target(size.fWidth, size.fHeight, 0,
+  GrBackendRenderTarget backend_render_target(size.fWidth, size.fHeight,
                                               image_info);
   SkSurfaceProps props(0, kUnknown_SkPixelGeometry);
 


### PR DESCRIPTION
Sample count is part of GrVkImageInfo (and was already being set in both places).