### PR TITLE
[Impeller] Flutter GPU: Add HostBuffer.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1728,12 +1728,12 @@ ORIGIN: ../../../flutter/lib/gpu/context.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/context.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/export.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/export.h + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/lib/gpu/lib/gpu.dart + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/lib/gpu/lib/src/context.dart + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/lib/gpu/lib/src/host_buffer.dart + ../../../flutter/LICENSE
-ORIGIN: ../../../flutter/lib/gpu/lib/src/smoketest.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/host_buffer.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/host_buffer.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/lib/gpu.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/lib/src/buffer.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/lib/src/context.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/lib/src/smoketest.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/smoketest.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/smoketest.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/io/dart_io.cc + ../../../flutter/LICENSE
@@ -4459,12 +4459,12 @@ FILE: ../../../flutter/lib/gpu/context.cc
 FILE: ../../../flutter/lib/gpu/context.h
 FILE: ../../../flutter/lib/gpu/export.cc
 FILE: ../../../flutter/lib/gpu/export.h
-FILE: ../../../flutter/lib/gpu/lib/gpu.dart
-FILE: ../../../flutter/lib/gpu/lib/src/context.dart
-FILE: ../../../flutter/lib/gpu/lib/src/host_buffer.dart
-FILE: ../../../flutter/lib/gpu/lib/src/smoketest.dart
 FILE: ../../../flutter/lib/gpu/host_buffer.cc
 FILE: ../../../flutter/lib/gpu/host_buffer.h
+FILE: ../../../flutter/lib/gpu/lib/gpu.dart
+FILE: ../../../flutter/lib/gpu/lib/src/buffer.dart
+FILE: ../../../flutter/lib/gpu/lib/src/context.dart
+FILE: ../../../flutter/lib/gpu/lib/src/smoketest.dart
 FILE: ../../../flutter/lib/gpu/smoketest.cc
 FILE: ../../../flutter/lib/gpu/smoketest.h
 FILE: ../../../flutter/lib/io/dart_io.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1730,7 +1730,10 @@ ORIGIN: ../../../flutter/lib/gpu/export.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/export.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/lib/gpu.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/lib/src/context.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/lib/src/host_buffer.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/lib/src/smoketest.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/host_buffer.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/gpu/host_buffer.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/smoketest.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/gpu/smoketest.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/io/dart_io.cc + ../../../flutter/LICENSE
@@ -4458,7 +4461,10 @@ FILE: ../../../flutter/lib/gpu/export.cc
 FILE: ../../../flutter/lib/gpu/export.h
 FILE: ../../../flutter/lib/gpu/lib/gpu.dart
 FILE: ../../../flutter/lib/gpu/lib/src/context.dart
+FILE: ../../../flutter/lib/gpu/lib/src/host_buffer.dart
 FILE: ../../../flutter/lib/gpu/lib/src/smoketest.dart
+FILE: ../../../flutter/lib/gpu/host_buffer.cc
+FILE: ../../../flutter/lib/gpu/host_buffer.h
 FILE: ../../../flutter/lib/gpu/smoketest.cc
 FILE: ../../../flutter/lib/gpu/smoketest.h
 FILE: ../../../flutter/lib/io/dart_io.cc

--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -21,15 +21,15 @@ void instantiateDefaultContext() {
 
 @pragma('vm:entry-point')
 void canEmplaceHostBuffer() {
-  final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
+  final gpu.HostBuffer hostBuffer = gpu.HostBuffer();
 
-  final gpu.BufferView view0 = hostBuffer.emplaceBytes(
-      bytes: Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData());
+  final gpu.BufferView view0 = hostBuffer
+      .emplace(Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData());
   assert(view0.offsetInBytes == 0);
   assert(view0.lengthInBytes == 4);
 
-  final gpu.BufferView view1 = hostBuffer.emplaceBytes(
-      bytes: Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData());
+  final gpu.BufferView view1 = hostBuffer
+      .emplace(Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData());
   assert(view1.offsetInBytes >= 4);
   assert(view1.lengthInBytes == 4);
 }

--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 import '../../lib/gpu/lib/gpu.dart' as gpu;
 
@@ -16,4 +17,19 @@ void sayHi() {
 void instantiateDefaultContext() {
   // ignore: unused_local_variable
   final gpu.GpuContext context = gpu.gpuContext;
+}
+
+@pragma('vm:entry-point')
+void canEmplaceHostBuffer() {
+  final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
+
+  final gpu.BufferView view0 = hostBuffer.emplaceBytes(
+      bytes: Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData());
+  assert(view0.offsetInBytes == 0);
+  assert(view0.lengthInBytes == 4);
+
+  final gpu.BufferView view1 = hostBuffer.emplaceBytes(
+      bytes: Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData());
+  assert(view1.offsetInBytes >= 4);
+  assert(view1.lengthInBytes == 4);
 }

--- a/impeller/renderer/renderer_dart_unittests.cc
+++ b/impeller/renderer/renderer_dart_unittests.cc
@@ -111,5 +111,19 @@ TEST_P(RendererDartTest, CanInstantiateFlutterGPUContext) {
   ASSERT_TRUE(result);
 }
 
+TEST_P(RendererDartTest, CanEmplaceHostBuffer) {
+  auto isolate = GetIsolate();
+  bool result = isolate->RunInIsolateScope([]() -> bool {
+    if (tonic::CheckAndHandleError(
+            ::Dart_Invoke(Dart_RootLibrary(),
+                          tonic::ToDart("canEmplaceHostBuffer"), 0, nullptr))) {
+      return false;
+    }
+    return true;
+  });
+
+  ASSERT_TRUE(result);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/lib/gpu/BUILD.gn
+++ b/lib/gpu/BUILD.gn
@@ -36,6 +36,8 @@ source_set("gpu") {
       "context.h",
       "export.cc",
       "export.h",
+      "host_buffer.cc",
+      "host_buffer.h",
       "smoketest.cc",
       "smoketest.h",
     ]

--- a/lib/gpu/context.cc
+++ b/lib/gpu/context.cc
@@ -15,20 +15,24 @@ namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(gpu, Context);
 
-std::shared_ptr<impeller::Context> Context::override_context_;
+std::shared_ptr<impeller::Context> Context::default_context_;
 
 void Context::SetOverrideContext(std::shared_ptr<impeller::Context> context) {
-  override_context_ = std::move(context);
+  default_context_ = std::move(context);
 }
 
-std::shared_ptr<impeller::Context> Context::GetOverrideContext() {
-  return override_context_;
+std::shared_ptr<impeller::Context> Context::GetDefaultContext() {
+  return default_context_;
 }
 
 Context::Context(std::shared_ptr<impeller::Context> context)
     : context_(std::move(context)) {}
 
 Context::~Context() = default;
+
+std::shared_ptr<impeller::Context> Context::GetContext() {
+  return context_;
+}
 
 }  // namespace flutter
 
@@ -40,7 +44,7 @@ Dart_Handle InternalFlutterGpu_Context_InitializeDefault(Dart_Handle wrapper) {
   auto dart_state = flutter::UIDartState::Current();
 
   std::shared_ptr<impeller::Context> impeller_context =
-      flutter::Context::GetOverrideContext();
+      flutter::Context::GetDefaultContext();
 
   if (!impeller_context) {
     if (!dart_state->IsImpellerEnabled()) {

--- a/lib/gpu/context.h
+++ b/lib/gpu/context.h
@@ -18,18 +18,19 @@ class Context : public RefCountedDartWrappable<Context> {
  public:
   static void SetOverrideContext(std::shared_ptr<impeller::Context> context);
 
-  static std::shared_ptr<impeller::Context> GetOverrideContext();
+  static std::shared_ptr<impeller::Context> GetDefaultContext();
 
   explicit Context(std::shared_ptr<impeller::Context> context);
   ~Context() override;
 
- protected:
+  std::shared_ptr<impeller::Context> GetContext();
+
+ private:
   /// An Impeller context that takes precedent over the IO state context when
   /// set. This is used to inject the context when running with the Impeller
   /// playground, which doesn't instantiate an Engine instance.
-  static std::shared_ptr<impeller::Context> override_context_;
+  static std::shared_ptr<impeller::Context> default_context_;
 
- private:
   std::shared_ptr<impeller::Context> context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Context);

--- a/lib/gpu/host_buffer.cc
+++ b/lib/gpu/host_buffer.cc
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/gpu/host_buffer.h"
+
+#include "impeller/core/host_buffer.h"
+#include "impeller/core/platform.h"
+#include "third_party/tonic/typed_data/dart_byte_data.h"
+
+namespace flutter {
+
+IMPLEMENT_WRAPPERTYPEINFO(gpu, HostBuffer);
+
+HostBuffer::HostBuffer() : host_buffer_(impeller::HostBuffer::Create()) {}
+
+HostBuffer::~HostBuffer() = default;
+
+size_t HostBuffer::EmplaceBytes(const tonic::DartByteData& byte_data) {
+  auto view =
+      host_buffer_->Emplace(byte_data.data(), byte_data.length_in_bytes(),
+                            impeller::DefaultUniformAlignment());
+  return view.range.offset;
+}
+
+}  // namespace flutter
+
+//----------------------------------------------------------------------------
+/// Exports
+///
+
+void InternalFlutterGpu_HostBuffer_Initialize(Dart_Handle wrapper) {
+  auto res = fml::MakeRefCounted<flutter::HostBuffer>();
+  res->AssociateWithDartWrapper(wrapper);
+}
+
+size_t InternalFlutterGpu_HostBuffer_EmplaceBytes(flutter::HostBuffer* wrapper,
+                                                  Dart_Handle byte_data) {
+  return wrapper->EmplaceBytes(tonic::DartByteData(byte_data));
+}

--- a/lib/gpu/host_buffer.h
+++ b/lib/gpu/host_buffer.h
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "flutter/lib/gpu/export.h"
+#include "flutter/lib/ui/dart_wrapper.h"
+#include "impeller/core/host_buffer.h"
+#include "third_party/tonic/typed_data/dart_byte_data.h"
+
+namespace flutter {
+
+class HostBuffer : public RefCountedDartWrappable<HostBuffer> {
+  DEFINE_WRAPPERTYPEINFO();
+  FML_FRIEND_MAKE_REF_COUNTED(HostBuffer);
+
+ public:
+  explicit HostBuffer();
+
+  ~HostBuffer() override;
+
+  size_t EmplaceBytes(const tonic::DartByteData& byte_data);
+
+ private:
+  std::shared_ptr<impeller::HostBuffer> host_buffer_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(HostBuffer);
+};
+
+}  // namespace flutter
+
+//----------------------------------------------------------------------------
+/// Exports
+///
+
+extern "C" {
+
+FLUTTER_GPU_EXPORT
+extern void InternalFlutterGpu_HostBuffer_Initialize(Dart_Handle wrapper);
+
+FLUTTER_GPU_EXPORT
+extern size_t InternalFlutterGpu_HostBuffer_EmplaceBytes(
+    flutter::HostBuffer* wrapper,
+    Dart_Handle byte_data);
+
+}  // extern "C"

--- a/lib/gpu/lib/gpu.dart
+++ b/lib/gpu/lib/gpu.dart
@@ -11,5 +11,7 @@
 ///  * [Flutter GPU Wiki page](https://github.com/flutter/flutter/wiki/Flutter-GPU).
 library flutter_gpu;
 
-export 'src/context.dart';
 export 'src/smoketest.dart';
+
+export 'src/context.dart';
+export 'src/buffer.dart';

--- a/lib/gpu/lib/src/buffer.dart
+++ b/lib/gpu/lib/src/buffer.dart
@@ -32,11 +32,10 @@ class BufferView {
 /// This is useful for efficiently chunking sparse data uploads, especially
 /// ephemeral uniform data that needs to change from frame to frame.
 ///
-/// Note: Different platforms have different data alignment requirements for
-///       accessing device buffer data. The [HostBuffer] takes these
-///       requirements into account and automatically inserts padding between
-///       emplaced data if necessary.
-class HostBuffer extends NativeFieldWrapperClass1 {
+/// Different platforms have different data alignment requirements for accessing
+/// device buffer data. The [HostBuffer] takes these requirements into account
+/// and automatically inserts padding between emplaced data if necessary.
+base class HostBuffer extends NativeFieldWrapperClass1 {
   /// Creates a new HostBuffer.
   HostBuffer() {
     _initialize();

--- a/lib/gpu/lib/src/buffer.dart
+++ b/lib/gpu/lib/src/buffer.dart
@@ -8,30 +8,31 @@ import 'dart:typed_data';
 
 import 'context.dart';
 
-/// A buffer data range.
+/// A reference to a byte range within a GPU-resident [Buffer].
 class BufferView {
   /// The buffer of this view.
   final Buffer buffer;
+
   /// The start of the view, in bytes starting from the beginning of the
   /// [buffer].
   final int offsetInBytes;
+
   /// The end of the view
   final int lengthInBytes;
 
   /// Create a new view into a buffer on the GPU.
-  const BufferView(
-      {required this.buffer,
-      required this.offsetInBytes,
-      required this.lengthInBytes});
+  const BufferView(this.buffer,
+      {required this.offsetInBytes, required this.lengthInBytes});
 }
 
 /// A buffer that can be referenced by commands on the GPU.
 mixin Buffer {}
 
-/// [HostBuffer] is a [Buffer] which is allocated on the host and lazily
-/// uploaded to the GPU. A [HostBuffer] can be safely mutated or extended at
-/// any time on the host, and will be automatically re-uploaded to the GPU
-/// the next time a GPU operation needs to access it.
+/// [HostBuffer] is a [Buffer] which is allocated on the host (native CPU
+/// resident memory) and lazily uploaded to the GPU. A [HostBuffer] can be
+/// safely mutated or extended at any time on the host, and will be
+/// automatically re-uploaded to the GPU the next time a GPU operation needs to
+/// access it.
 ///
 /// This is useful for efficiently chunking sparse data uploads, especially
 /// ephemeral uniform data that needs to change from frame to frame.
@@ -54,17 +55,16 @@ class HostBuffer extends NativeFieldWrapperClass1 with Buffer {
   /// Append byte data to the end of the [HostBuffer] and produce a [BufferView]
   /// that references the new data in the buffer.
   ///
-  /// This method automatically inserts padding in-between emplaced data if
-  /// necessary to abide by platform-specific uniform alignment requirements.
+  /// This method automatically inserts padding in-between emplace calls in the
+  /// buffer if necessary to abide by platform-specific uniform alignment
+  /// requirements.
   ///
   /// The updated buffer will be uploaded to the GPU if the returned
   /// [BufferView] is used by a rendering command.
-  BufferView emplaceBytes({required ByteData bytes}) {
+  BufferView emplace(ByteData bytes) {
     int resultOffset = _emplaceBytes(bytes);
-    return BufferView(
-        buffer: this,
-        offsetInBytes: resultOffset,
-        lengthInBytes: bytes.lengthInBytes);
+    return BufferView(this,
+        offsetInBytes: resultOffset, lengthInBytes: bytes.lengthInBytes);
   }
 
   @Native<Uint64 Function(Pointer<Void>, Handle)>(

--- a/lib/gpu/lib/src/buffer.dart
+++ b/lib/gpu/lib/src/buffer.dart
@@ -1,0 +1,73 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi';
+import 'dart:nativewrappers';
+import 'dart:typed_data';
+
+import 'context.dart';
+
+/// A buffer data range.
+class BufferView {
+  /// The buffer of this view.
+  final Buffer buffer;
+  /// The start of the view, in bytes starting from the beginning of the
+  /// [buffer].
+  final int offsetInBytes;
+  /// The end of the view
+  final int lengthInBytes;
+
+  /// Create a new view into a buffer on the GPU.
+  const BufferView(
+      {required this.buffer,
+      required this.offsetInBytes,
+      required this.lengthInBytes});
+}
+
+/// A buffer that can be referenced by commands on the GPU.
+mixin Buffer {}
+
+/// [HostBuffer] is a [Buffer] which is allocated on the host and lazily
+/// uploaded to the GPU. A [HostBuffer] can be safely mutated or extended at
+/// any time on the host, and will be automatically re-uploaded to the GPU
+/// the next time a GPU operation needs to access it.
+///
+/// This is useful for efficiently chunking sparse data uploads, especially
+/// ephemeral uniform data that needs to change from frame to frame.
+///
+/// Note: Different platforms have different data alignment requirements for
+///       accessing device buffer data. The [HostBuffer] takes these
+///       requirements into account and automatically inserts padding between
+///       emplaced data if necessary.
+class HostBuffer extends NativeFieldWrapperClass1 with Buffer {
+  /// Creates a new HostBuffer.
+  HostBuffer() {
+    _initialize();
+  }
+
+  /// Wrap with native counterpart.
+  @Native<Void Function(Handle)>(
+      symbol: 'InternalFlutterGpu_HostBuffer_Initialize')
+  external void _initialize();
+
+  /// Append byte data to the end of the [HostBuffer] and produce a [BufferView]
+  /// that references the new data in the buffer.
+  ///
+  /// This method automatically inserts padding in-between emplaced data if
+  /// necessary to abide by platform-specific uniform alignment requirements.
+  ///
+  /// The updated buffer will be uploaded to the GPU if the returned
+  /// [BufferView] is used by a rendering command.
+  BufferView emplaceBytes({required ByteData bytes}) {
+    int resultOffset = _emplaceBytes(bytes);
+    return BufferView(
+        buffer: this,
+        offsetInBytes: resultOffset,
+        lengthInBytes: bytes.lengthInBytes);
+  }
+
+  @Native<Uint64 Function(Pointer<Void>, Handle)>(
+      symbol: 'InternalFlutterGpu_HostBuffer_EmplaceBytes')
+  external int _emplaceBytes(ByteData bytes);
+}

--- a/lib/gpu/lib/src/buffer.dart
+++ b/lib/gpu/lib/src/buffer.dart
@@ -6,27 +6,22 @@ import 'dart:ffi';
 import 'dart:nativewrappers';
 import 'dart:typed_data';
 
-import 'context.dart';
-
 /// A reference to a byte range within a GPU-resident [Buffer].
 class BufferView {
   /// The buffer of this view.
-  final Buffer buffer;
+  final HostBuffer buffer;
 
   /// The start of the view, in bytes starting from the beginning of the
   /// [buffer].
   final int offsetInBytes;
 
-  /// The end of the view
+  /// The length of the view.
   final int lengthInBytes;
 
   /// Create a new view into a buffer on the GPU.
   const BufferView(this.buffer,
       {required this.offsetInBytes, required this.lengthInBytes});
 }
-
-/// A buffer that can be referenced by commands on the GPU.
-mixin Buffer {}
 
 /// [HostBuffer] is a [Buffer] which is allocated on the host (native CPU
 /// resident memory) and lazily uploaded to the GPU. A [HostBuffer] can be
@@ -41,7 +36,7 @@ mixin Buffer {}
 ///       accessing device buffer data. The [HostBuffer] takes these
 ///       requirements into account and automatically inserts padding between
 ///       emplaced data if necessary.
-class HostBuffer extends NativeFieldWrapperClass1 with Buffer {
+class HostBuffer extends NativeFieldWrapperClass1 {
   /// Creates a new HostBuffer.
   HostBuffer() {
     _initialize();

--- a/lib/gpu/lib/src/context.dart
+++ b/lib/gpu/lib/src/context.dart
@@ -5,8 +5,6 @@
 import 'dart:ffi';
 import 'dart:nativewrappers';
 
-import 'buffer.dart';
-
 /// A handle to a graphics context. Used to create and manage GPU resources.
 ///
 /// To obtain the default graphics context, use [getContext].

--- a/lib/gpu/lib/src/context.dart
+++ b/lib/gpu/lib/src/context.dart
@@ -24,12 +24,6 @@ class GpuContext extends NativeFieldWrapperClass1 {
   @Native<Handle Function(Handle)>(
       symbol: 'InternalFlutterGpu_Context_InitializeDefault')
   external String? _initializeDefault();
-
-  /// Create a new [HostBuffer] that can be used for staging and transferring
-  /// data from the host to the GPU.
-  HostBuffer createHostBuffer() {
-    return HostBuffer();
-  }
 }
 
 /// The default graphics context.

--- a/lib/gpu/lib/src/context.dart
+++ b/lib/gpu/lib/src/context.dart
@@ -5,6 +5,8 @@
 import 'dart:ffi';
 import 'dart:nativewrappers';
 
+import 'buffer.dart';
+
 /// A handle to a graphics context. Used to create and manage GPU resources.
 ///
 /// To obtain the default graphics context, use [getContext].
@@ -22,6 +24,12 @@ class GpuContext extends NativeFieldWrapperClass1 {
   @Native<Handle Function(Handle)>(
       symbol: 'InternalFlutterGpu_Context_InitializeDefault')
   external String? _initializeDefault();
+
+  /// Create a new [HostBuffer] that can be used for staging and transferring
+  /// data from the host to the GPU.
+  HostBuffer createHostBuffer() {
+    return HostBuffer();
+  }
 }
 
 /// The default graphics context.


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/132516.

Add `impeller::HostBuffer` wrapper to Flutter GPU.
* Allows for lazy batch uploads of sparse host data to the GPU.
* Handles platform alignment requirements.
* API returns buffer view handles that will be fed to commands.