### PR TITLE
Roll clang with fix for ABI change

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -39,7 +39,7 @@ vars = {
   # The list of revisions for these tools comes from Fuchsia, here:
   # https://fuchsia.googlesource.com/integration/+/HEAD/toolchain
   # If there are problems with the toolchain, contact fuchsia-toolchain@.
-  'clang_version': 'git_revision:6d667d4b261e81f325756fdfd5bb43b3b3d2451d',
+  'clang_version': 'git_revision:020d2fb7711d70e296f19d83565f8d93d2cfda71',
 
   # The goma version and the clang version can be tightly coupled. If goma
   # stops working on a clang roll, this may need to be updated using the value

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2582,6 +2582,7 @@ ORIGIN: ../../../flutter/shell/platform/common/text_editing_delta.h + ../../../f
 ORIGIN: ../../../flutter/shell/platform/common/text_input_model.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/common/text_input_model.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/common/text_range.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/common/availability_version_check.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/buffer_conversions.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/buffer_conversions.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/common/command_line.h + ../../../flutter/LICENSE
@@ -5336,6 +5337,7 @@ FILE: ../../../flutter/shell/platform/common/text_editing_delta.h
 FILE: ../../../flutter/shell/platform/common/text_input_model.cc
 FILE: ../../../flutter/shell/platform/common/text_input_model.h
 FILE: ../../../flutter/shell/platform/common/text_range.h
+FILE: ../../../flutter/shell/platform/darwin/common/availability_version_check.cc
 FILE: ../../../flutter/shell/platform/darwin/common/buffer_conversions.h
 FILE: ../../../flutter/shell/platform/darwin/common/buffer_conversions.mm
 FILE: ../../../flutter/shell/platform/darwin/common/command_line.h

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -13,6 +13,7 @@ source_set("common") {
   cflags_objcc = flutter_cflags_objcc
 
   sources = [
+    "availability_version_check.cc",
     "buffer_conversions.h",
     "buffer_conversions.mm",
     "command_line.h",

--- a/shell/platform/darwin/common/availability_version_check.cc
+++ b/shell/platform/darwin/common/availability_version_check.cc
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <dispatch/dispatch.h>
+#include <dlfcn.h>
+#include <cstdint>
+
+#include "flutter/fml/logging.h"
+
+// See context in https://github.com/flutter/flutter/issues/132130 and
+// https://github.com/flutter/engine/pull/44711.
+
+// TODO(zanderso): Remove this after Clang 18 rolls into Xcode.
+// https://github.com/flutter/flutter/issues/133203
+
+namespace {
+
+typedef uint32_t dyld_platform_t;
+
+typedef struct {
+  dyld_platform_t platform;
+  uint32_t version;
+} dyld_build_version_t;
+
+typedef bool (*AvailabilityVersionCheckFn)(uint32_t count,
+                                           dyld_build_version_t versions[]);
+
+AvailabilityVersionCheckFn AvailabilityVersionCheck;
+
+dispatch_once_t DispatchOnceCounter;
+
+void InitializeAvailabilityCheck(void* unused) {
+  if (AvailabilityVersionCheck) {
+    return;
+  }
+  AvailabilityVersionCheck = reinterpret_cast<AvailabilityVersionCheckFn>(
+      dlsym(RTLD_DEFAULT, "_availability_version_check"));
+  FML_CHECK(AvailabilityVersionCheck);
+}
+
+extern "C" bool _availability_version_check(uint32_t count,
+                                            dyld_build_version_t versions[]) {
+  dispatch_once_f(&DispatchOnceCounter, NULL, InitializeAvailabilityCheck);
+  return AvailabilityVersionCheck(count, versions);
+}
+
+}  // namespace

--- a/shell/platform/darwin/macos/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterAppDelegateTest.mm
@@ -46,7 +46,9 @@ TEST(FlutterAppDelegateTest, ReceivesOpenURLs) {
       [[AppDelegateTestFlutterAppLifecycleDelegate alloc] init];
   [appDelegate addApplicationLifecycleDelegate:delegate];
 
-  NSArray<NSURL*>* URLs = @[ [NSURL URLWithString:@"https://flutter.dev"] ];
+  NSURL* URL = [NSURL URLWithString:@"https://flutter.dev"];
+  EXPECT_NE(URL, nil);
+  NSArray<NSURL*>* URLs = @[ URL ];
   [appDelegate application:NSApplication.sharedApplication openURLs:URLs];
 
   EXPECT_EQ([delegate receivedURLs], URLs);
@@ -61,7 +63,9 @@ TEST(FlutterAppDelegateTest, OperURLsStopsAfterHandled) {
   [appDelegate addApplicationLifecycleDelegate:firstDelegate];
   [appDelegate addApplicationLifecycleDelegate:secondDelegate];
 
-  NSArray<NSURL*>* URLs = @[ [NSURL URLWithString:@"https://flutter.dev"] ];
+  NSURL* URL = [NSURL URLWithString:@"https://flutter.dev"];
+  EXPECT_NE(URL, nil);
+  NSArray<NSURL*>* URLs = @[ URL ];
   [appDelegate application:NSApplication.sharedApplication openURLs:URLs];
 
   EXPECT_EQ([firstDelegate receivedURLs], URLs);


### PR DESCRIPTION
In the change here https://github.com/llvm/llvm-project/commit/b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0, an intentional ABI breaking change was introduced to the clang runtime library for macOS and iOS. That change caused a symbol requiring dynamic linkage to be exposed that triggers iOS App Store checks for usage of private API.

This PR resolves that issue by rolling clang forward and introducing a definition of `_availability_version_check`. The declaration with weak linkage in the clang runtime library [here](https://github.com/llvm/llvm-project/blob/b653a2823fe4b4c9c6d85cfe119f31d8e70c2fa0/compiler-rt/lib/builtins/os_version_check.c#L89) will then be resolved against the definition introduced in this PR. Since the declaration in the clang runtime library will now be resolved by static linking, the Flutter dylib will no longer require it to be dynamically linked, and will therefore not trigger the App Store check for using private API.

The definition of `_availability_version_check` is implemented using the `dlsym` strategy used by the old version of clang [here](https://github.com/llvm/llvm-project/blob/f9ac5575675e4117c2e097a71ad0f02cab92aa97/compiler-rt/lib/builtins/os_version_check.c#L97).

Fixes https://github.com/flutter/flutter/issues/132130