### PR TITLE
Add more tests for CompositionAwareMixin

### DIFF
--- a/lib/web_ui/test/engine/composition_test.dart
+++ b/lib/web_ui/test/engine/composition_test.dart
@@ -106,14 +106,81 @@ Future<void> testMain() async {
     });
 
     group('determine composition state', () {
-      test('should return new composition state - compositing middle of text', () {
-        const int baseOffset = 100;
+      test('should return editing state if extentOffset is null', () {
+        final EditingState editingState = EditingState(text: 'Test');
+
+        final _MockWithCompositionAwareMixin mockWithCompositionAwareMixin =
+            _MockWithCompositionAwareMixin();
+        mockWithCompositionAwareMixin.composingText = 'Test';
+
+        expect(
+            mockWithCompositionAwareMixin
+                .determineCompositionState(editingState),
+            editingState);
+      });
+
+      test('should return editing state if composingText is null', () {
+        final EditingState editingState = EditingState(
+          text: 'Test',
+          baseOffset: 0,
+          extentOffset: 4,
+        );
+
+        final _MockWithCompositionAwareMixin mockWithCompositionAwareMixin =
+            _MockWithCompositionAwareMixin();
+
+        expect(
+            mockWithCompositionAwareMixin
+                .determineCompositionState(editingState),
+            editingState);
+      });
+
+      test('should return editing state if text is null', () {
+        final EditingState editingState = EditingState(
+          baseOffset: 0,
+          extentOffset: 0,
+        );
+
+        final _MockWithCompositionAwareMixin mockWithCompositionAwareMixin =
+            _MockWithCompositionAwareMixin();
+        mockWithCompositionAwareMixin.composingText = 'Test';
+
+        expect(
+            mockWithCompositionAwareMixin
+                .determineCompositionState(editingState),
+            editingState);
+      });
+
+      test(
+          'should return editing state if extentOffset is smaller than composingText length',
+          () {
         const String composingText = 'composeMe';
 
         final EditingState editingState = EditingState(
-          extentOffset: baseOffset,
-          text: 'testing',
+          text: 'Test',
+          baseOffset: 0,
+          extentOffset: 4,
+        );
+
+        final _MockWithCompositionAwareMixin mockWithCompositionAwareMixin =
+            _MockWithCompositionAwareMixin();
+        mockWithCompositionAwareMixin.composingText = composingText;
+
+        expect(
+            mockWithCompositionAwareMixin
+                .determineCompositionState(editingState),
+            editingState);
+      });
+
+      test('should return new composition state - compositing middle of text',
+          () {
+        const int baseOffset = 7;
+        const String composingText = 'Test';
+
+        final EditingState editingState = EditingState(
+          text: 'Testing',
           baseOffset: baseOffset,
+          extentOffset: baseOffset,
         );
 
         final _MockWithCompositionAwareMixin mockWithCompositionAwareMixin =
@@ -123,13 +190,17 @@ Future<void> testMain() async {
         const int expectedComposingBase = baseOffset - composingText.length;
 
         expect(
-            mockWithCompositionAwareMixin.determineCompositionState(editingState),
+            mockWithCompositionAwareMixin
+                .determineCompositionState(editingState),
             editingState.copyWith(
                 composingBaseOffset: expectedComposingBase,
-                composingExtentOffset: expectedComposingBase + composingText.length));
+                composingExtentOffset:
+                    expectedComposingBase + composingText.length));
       });
 
-      test('should return new composition state - compositing from beginning of text', () {
+      test(
+          'should return new composition state - compositing from beginning of text',
+          () {
         const String composingText = '今日は';
 
         final EditingState editingState = EditingState(

--- a/lib/web_ui/test/engine/composition_test.dart
+++ b/lib/web_ui/test/engine/composition_test.dart
@@ -114,9 +114,9 @@ Future<void> testMain() async {
         mockWithCompositionAwareMixin.composingText = 'Test';
 
         expect(
-            mockWithCompositionAwareMixin
-                .determineCompositionState(editingState),
-            editingState);
+          mockWithCompositionAwareMixin.determineCompositionState(editingState),
+          editingState,
+        );
       });
 
       test('should return editing state if composingText is null', () {
@@ -130,9 +130,9 @@ Future<void> testMain() async {
             _MockWithCompositionAwareMixin();
 
         expect(
-            mockWithCompositionAwareMixin
-                .determineCompositionState(editingState),
-            editingState);
+          mockWithCompositionAwareMixin.determineCompositionState(editingState),
+          editingState,
+        );
       });
 
       test('should return editing state if text is null', () {
@@ -146,9 +146,9 @@ Future<void> testMain() async {
         mockWithCompositionAwareMixin.composingText = 'Test';
 
         expect(
-            mockWithCompositionAwareMixin
-                .determineCompositionState(editingState),
-            editingState);
+          mockWithCompositionAwareMixin.determineCompositionState(editingState),
+          editingState,
+        );
       });
 
       test(
@@ -167,9 +167,9 @@ Future<void> testMain() async {
         mockWithCompositionAwareMixin.composingText = composingText;
 
         expect(
-            mockWithCompositionAwareMixin
-                .determineCompositionState(editingState),
-            editingState);
+          mockWithCompositionAwareMixin.determineCompositionState(editingState),
+          editingState,
+        );
       });
 
       test('should return new composition state - compositing middle of text',
@@ -190,12 +190,12 @@ Future<void> testMain() async {
         const int expectedComposingBase = baseOffset - composingText.length;
 
         expect(
-            mockWithCompositionAwareMixin
-                .determineCompositionState(editingState),
-            editingState.copyWith(
-                composingBaseOffset: expectedComposingBase,
-                composingExtentOffset:
-                    expectedComposingBase + composingText.length));
+          mockWithCompositionAwareMixin.determineCompositionState(editingState),
+          editingState.copyWith(
+            composingBaseOffset: expectedComposingBase,
+            composingExtentOffset: expectedComposingBase + composingText.length,
+          ),
+        );
       });
 
       test(


### PR DESCRIPTION
Adds missing tests for `CompositionAwareMixin`. Check https://github.com/flutter/engine/pull/44139#discussion_r1288733128 and https://github.com/flutter/engine/pull/44139#discussion_r1288009016

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
