### PR TITLE
ios: remove shared_application and support app extension build

### DIFF
--- a/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.h
@@ -30,17 +30,17 @@ NSBundle* FLTFrameworkBundleInternal(NSString* flutterFrameworkBundleID, NSURL* 
 // `+[NSBundle bundleWithIdentifier:]`.
 NSBundle* FLTFrameworkBundleWithIdentifier(NSString* flutterFrameworkBundleID);
 
-// Find the bundle of the application.
+// Finds the bundle of the application.
 //
-// This returns [NSBundle mainBundle] if the current running process is the application.
+// Returns [NSBundle mainBundle] if the current running process is the application.
 NSBundle* FLTGetApplicationBundle();
 
-// Find the Flutter asset directory from `bundle`.
+// Finds the Flutter asset directory from `bundle`.
 //
 // The raw path can be set by the application via info.plist's `FLTAssetsPath` key.
 // If the key is not set, `flutter_assets` is used as the raw path value.
 //
-// If no valid asset is found under the raw path, return nil.
+// If no valid asset is found under the raw path, returns nil.
 NSURL* FLTAssetsURLFromBundle(NSBundle* bundle);
 
 NS_ASSUME_NONNULL_END

--- a/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.h
@@ -9,12 +9,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// Finds a bundle with the named `bundleID` within `searchURL`.
+// Finds a bundle with the named `flutterFrameworkBundleID` within `searchURL`.
 //
 // Returns `nil` if the bundle cannot be found or if errors are encountered.
-NSBundle* FLTFrameworkBundleInternal(NSString* bundleID, NSURL* searchURL);
+NSBundle* FLTFrameworkBundleInternal(NSString* flutterFrameworkBundleID, NSURL* searchURL);
 
-// Finds a bundle with the named `bundleID`.
+// Finds a bundle with the named `flutterFrameworkBundleID`.
 //
 // `+[NSBundle bundleWithIdentifier:]` is slow, and can take in the order of
 // tens of milliseconds in a minimal flutter app, and closer to 100 milliseconds
@@ -28,11 +28,20 @@ NSBundle* FLTFrameworkBundleInternal(NSString* bundleID, NSURL* searchURL);
 // frameworks used by this file are placed. If the desired bundle cannot be
 // found here, the implementation falls back to
 // `+[NSBundle bundleWithIdentifier:]`.
-NSBundle* FLTFrameworkBundleWithIdentifier(NSString* bundleID);
+NSBundle* FLTFrameworkBundleWithIdentifier(NSString* flutterFrameworkBundleID);
 
+// Find the bundle of the application.
+//
+// This returns [NSBundle mainBundle] if the current running process is the application.
 NSBundle* FLTGetApplicationBundle();
 
-NSURL* FLTAssetsFromBundle(NSBundle* bundle);
+// Find the Flutter asset directory from `bundle`.
+//
+// The raw path can be set by the application via info.plist's `FLTAssetsPath` key.
+// If the key is not set, `flutter_assets` is used as the raw path value.
+//
+// If no valid asset is found under the raw path, return nil.
+NSURL* FLTAssetsURLFromBundle(NSBundle* bundle);
 
 NS_ASSUME_NONNULL_END
 

--- a/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.h
@@ -30,6 +30,10 @@ NSBundle* FLTFrameworkBundleInternal(NSString* bundleID, NSURL* searchURL);
 // `+[NSBundle bundleWithIdentifier:]`.
 NSBundle* FLTFrameworkBundleWithIdentifier(NSString* bundleID);
 
+NSBundle* FLTGetApplicationBundle();
+
+NSURL* FLTAssetsFromBundle(NSBundle* bundle);
+
 NS_ASSUME_NONNULL_END
 
 #endif  // SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_SOURCE_FLUTTERNSBUNDLEUTILS_H_

--- a/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.mm
@@ -8,7 +8,7 @@
 
 FLUTTER_ASSERT_ARC
 
-NSBundle* FLTFrameworkBundleInternal(NSString* bundleID, NSURL* searchURL) {
+NSBundle* FLTFrameworkBundleInternal(NSString* flutterFrameworkBundleID, NSURL* searchURL) {
   NSDirectoryEnumerator<NSURL*>* frameworkEnumerator = [NSFileManager.defaultManager
                  enumeratorAtURL:searchURL
       includingPropertiesForKeys:nil
@@ -18,9 +18,9 @@ NSBundle* FLTFrameworkBundleInternal(NSString* bundleID, NSURL* searchURL) {
                     errorHandler:nil];
 
   for (NSURL* candidate in frameworkEnumerator) {
-    NSBundle* bundle = [NSBundle bundleWithURL:candidate];
-    if ([bundle.bundleIdentifier isEqualToString:bundleID]) {
-      return bundle;
+    NSBundle* flutterFrameworkBundle = [NSBundle bundleWithURL:candidate];
+    if ([flutterFrameworkBundle.bundleIdentifier isEqualToString:flutterFrameworkBundleID]) {
+      return flutterFrameworkBundle;
     }
   }
   return nil;
@@ -28,7 +28,7 @@ NSBundle* FLTFrameworkBundleInternal(NSString* bundleID, NSURL* searchURL) {
 
 NSBundle* FLTGetApplicationBundle() {
   NSBundle* mainBundle = [NSBundle mainBundle];
-  // App extension bundle is in Runner.app/PlugIns/Extension.appex.
+  // App extension bundle is in <AppName>.app/PlugIns/Extension.appex.
   if ([mainBundle.bundleURL.pathExtension isEqualToString:@"appex"]) {
     // Up two levels.
     return [NSBundle bundleWithURL:mainBundle.bundleURL.URLByDeletingLastPathComponent
@@ -37,24 +37,24 @@ NSBundle* FLTGetApplicationBundle() {
   return mainBundle;
 }
 
-NSBundle* FLTFrameworkBundleWithIdentifier(NSString* flutterBundleID) {
+NSBundle* FLTFrameworkBundleWithIdentifier(NSString* flutterFrameworkBundleID) {
   NSBundle* appBundle = FLTGetApplicationBundle();
-  NSBundle* bundle = FLTFrameworkBundleInternal(flutterBundleID, appBundle.privateFrameworksURL);
-  if (bundle == nil) {
+  NSBundle* flutterFrameworkBundle =
+      FLTFrameworkBundleInternal(flutterFrameworkBundleID, appBundle.privateFrameworksURL);
+  if (flutterFrameworkBundle == nil) {
     // Fallback to slow implementation.
-    bundle = [NSBundle bundleWithIdentifier:flutterBundleID];
+    flutterFrameworkBundle = [NSBundle bundleWithIdentifier:flutterFrameworkBundleID];
   }
-  if (bundle == nil) {
-    bundle = [NSBundle mainBundle];
+  if (flutterFrameworkBundle == nil) {
+    flutterFrameworkBundle = [NSBundle mainBundle];
   }
-  return bundle;
+  return flutterFrameworkBundle;
 }
 
-NSURL* FLTAssetsFromBundle(NSBundle* bundle) {
+NSURL* FLTAssetsURLFromBundle(NSBundle* bundle) {
   NSString* assetsPathFromInfoPlist = [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
-  NSString* flutterAssetsName =
-      assetsPathFromInfoPlist != nil ? assetsPathFromInfoPlist : @"flutter_assets";
-  NSURL* assets = [bundle URLForResource:flutterAssetsName withExtension:nil];
+  NSString* flutterAssetsPath = assetsPathFromInfoPlist ?: @"flutter_assets";
+  NSURL* assets = [bundle URLForResource:flutterAssetsPath withExtension:nil];
 
   if ([assets checkResourceIsReachableAndReturnError:NULL]) {
     return assets;

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -336,6 +336,10 @@ shared_library("create_flutter_framework_dylib") {
 
   ldflags = [ "-Wl,-install_name,@rpath/Flutter.framework/Flutter" ]
 
+  if (darwin_extension_safe) {
+    ldflags += [ "-fapplication-extension" ]
+  }
+
   public = _flutter_framework_headers
 
   deps = [
@@ -426,7 +430,10 @@ copy("copy_license") {
 shared_library("copy_and_verify_framework_module") {
   framework_search_path = rebase_path("$root_out_dir")
   visibility = [ ":*" ]
-  cflags_objc = [ "-F$framework_search_path" ]
+  cflags_objc = [
+    "-F$framework_search_path",
+    "-fapplication-extension",
+  ]
 
   sources = [ "framework/Source/FlutterUmbrellaImport.m" ]
   deps = [
@@ -434,6 +441,17 @@ shared_library("copy_and_verify_framework_module") {
     ":copy_framework_info_plist",
     ":copy_framework_module_map",
   ]
+
+  if (darwin_extension_safe) {
+    ldflags = [
+      "-F$framework_search_path",
+      "-fapplication-extension",
+      "-Xlinker",
+      "-fatal_warnings",
+    ]
+    deps += [ ":copy_dylib" ]
+    frameworks = [ "Flutter.framework" ]
+  }
 }
 
 group("universal_flutter_framework") {

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -353,7 +353,8 @@ typedef enum {
  *
  * @param delegate The receiving object, such as the plugin's main class.
  */
-- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate;
+- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in plugins used in app extensions");
 
 /**
  * Returns the file name for the given asset.

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -41,15 +41,12 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   // 3. Settings from the NSBundle with the default bundle ID.
   // 4. Settings from the main NSBundle and default values.
 
-  NSBundle* mainBundle = [NSBundle mainBundle];
+  NSBundle* mainBundle = FLTGetApplicationBundle();
   NSBundle* engineBundle = [NSBundle bundleForClass:[FlutterViewController class]];
 
   bool hasExplicitBundle = bundle != nil;
   if (bundle == nil) {
     bundle = FLTFrameworkBundleWithIdentifier([FlutterDartProject defaultBundleIdentifier]);
-  }
-  if (bundle == nil) {
-    bundle = mainBundle;
   }
 
   auto settings = flutter::SettingsFromCommandLine(command_line);
@@ -122,29 +119,24 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
 
   // Checks to see if the flutter assets directory is already present.
   if (settings.assets_path.empty()) {
-    NSString* assetsName = [FlutterDartProject flutterAssetsName:bundle];
-    NSString* assetsPath = [bundle pathForResource:assetsName ofType:@""];
+    NSURL* assetsURL = FLTAssetsFromBundle(bundle);
 
-    if (assetsPath.length == 0) {
-      assetsPath = [mainBundle pathForResource:assetsName ofType:@""];
-    }
-
-    if (assetsPath.length == 0) {
-      NSLog(@"Failed to find assets path for \"%@\"", assetsName);
+    if (!assetsURL) {
+      NSLog(@"Failed to find assets path for 1\"%@\"", bundle);
     } else {
-      settings.assets_path = assetsPath.UTF8String;
+      settings.assets_path = assetsURL.path.UTF8String;
 
       // Check if there is an application kernel snapshot in the assets directory we could
       // potentially use.  Looking for the snapshot makes sense only if we have a VM that can use
       // it.
       if (!flutter::DartVM::IsRunningPrecompiledCode()) {
         NSURL* applicationKernelSnapshotURL =
-            [NSURL URLWithString:@(kApplicationKernelSnapshotFileName)
-                   relativeToURL:[NSURL fileURLWithPath:assetsPath]];
-        if ([[NSFileManager defaultManager] fileExistsAtPath:applicationKernelSnapshotURL.path]) {
+            [assetsURL URLByAppendingPathComponent:@(kApplicationKernelSnapshotFileName)];
+        NSError* error;
+        if ([applicationKernelSnapshotURL checkResourceIsReachableAndReturnError:&error]) {
           settings.application_kernel_asset = applicationKernelSnapshotURL.path.UTF8String;
         } else {
-          NSLog(@"Failed to find snapshot: %@", applicationKernelSnapshotURL.path);
+          NSLog(@"Failed to find snapshot at %@: %@", applicationKernelSnapshotURL.path, error);
         }
       }
     }
@@ -339,9 +331,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   if (bundle == nil) {
     bundle = FLTFrameworkBundleWithIdentifier([FlutterDartProject defaultBundleIdentifier]);
   }
-  if (bundle == nil) {
-    bundle = [NSBundle mainBundle];
-  }
+
   NSString* flutterAssetsName = [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
   if (flutterAssetsName == nil) {
     flutterAssetsName = @"Frameworks/App.framework/flutter_assets";

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -119,7 +119,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
 
   // Checks to see if the flutter assets directory is already present.
   if (settings.assets_path.empty()) {
-    NSURL* assetsURL = FLTAssetsFromBundle(bundle);
+    NSURL* assetsURL = FLTAssetsURLFromBundle(bundle);
 
     if (!assetsURL) {
       NSLog(@"Failed to find assets path for 1\"%@\"", bundle);

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -73,6 +73,20 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotNil(found);
 }
 
+- (void)testFLTGetApplicationBundleWhenCurrentTargetIsNotExtension {
+  NSBundle* bundle = FLTGetApplicationBundle();
+  XCTAssertEqual(bundle, [NSBundle mainBundle]);
+}
+
+- (void)testFLTGetApplicationBundleWhenCurrentTargetIsExtension {
+  id mockMainBundle = OCMPartialMock([NSBundle mainBundle]);
+  NSURL *url = [[NSBundle mainBundle].bundleURL URLByAppendingPathComponent:@"foo/ext.appex"];
+  OCMStub([mockMainBundle bundleURL]).andReturn(url);
+  NSBundle* bundle = FLTGetApplicationBundle();
+  [mockMainBundle stopMocking];
+  XCTAssertEqualObjects(bundle.bundleURL, [NSBundle mainBundle].bundleURL);
+}
+
 - (void)testDisableImpellerSettingIsCorrectlyParsed {
   id mockMainBundle = OCMPartialMock([NSBundle mainBundle]);
   OCMStub([mockMainBundle objectForInfoDictionaryKey:@"FLTEnableImpeller"]).andReturn(@"NO");

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -80,7 +80,7 @@ FLUTTER_ASSERT_ARC
 
 - (void)testFLTGetApplicationBundleWhenCurrentTargetIsExtension {
   id mockMainBundle = OCMPartialMock([NSBundle mainBundle]);
-  NSURL *url = [[NSBundle mainBundle].bundleURL URLByAppendingPathComponent:@"foo/ext.appex"];
+  NSURL* url = [[NSBundle mainBundle].bundleURL URLByAppendingPathComponent:@"foo/ext.appex"];
   OCMStub([mockMainBundle bundleURL]).andReturn(url);
   NSBundle* bundle = FLTGetApplicationBundle();
   [mockMainBundle stopMocking];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -1516,7 +1516,8 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   }];
 }
 
-- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate {
+- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in plugins used in app extensions") {
   id<UIApplicationDelegate> appDelegate = [[UIApplication sharedApplication] delegate];
   if ([appDelegate conformsToProtocol:@protocol(FlutterAppLifeCycleProvider)]) {
     id<FlutterAppLifeCycleProvider> lifeCycleProvider =

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -17,10 +17,14 @@ namespace {
 
 constexpr char kTextPlainFormat[] = "text/plain";
 const UInt32 kKeyPressClickSoundId = 1306;
+
+#if APPLICATION_EXTENSION_API_ONLY
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 const NSString* searchURLPrefix = @"x-web-search://?";
 #pragma GCC diagnostic pop
+#endif
+
 }  // namespace
 
 namespace flutter {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -17,8 +17,10 @@ namespace {
 
 constexpr char kTextPlainFormat[] = "text/plain";
 const UInt32 kKeyPressClickSoundId = 1306;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 const NSString* searchURLPrefix = @"x-web-search://?";
-
+#pragma GCC diagnostic pop
 }  // namespace
 
 namespace flutter {
@@ -36,6 +38,24 @@ const char* const kOverlayStyleUpdateNotificationKey =
 }  // namespace flutter
 
 using namespace flutter;
+
+static void SetStatusBarHiddenForSharedApplication(BOOL hidden) {
+#if APPLICATION_EXTENSION_API_ONLY
+  [UIApplication sharedApplication].statusBarHidden = hidden;
+#else
+  FML_LOG(WARNING) << "Application based status bar styling is not available in app extension.";
+#endif
+}
+
+static void SetStatusBarStyleForSharedApplication(UIStatusBarStyle style) {
+#if APPLICATION_EXTENSION_API_ONLY
+  // Note: -[UIApplication setStatusBarStyle] is deprecated in iOS9
+  // in favor of delegating to the view controller.
+  [[UIApplication sharedApplication] setStatusBarStyle:style];
+#else
+  FML_LOG(WARNING) << "Application based status bar styling is not available in app extension.";
+#endif
+}
 
 @interface FlutterPlatformPlugin ()
 
@@ -141,6 +161,9 @@ using namespace flutter;
 }
 
 - (void)searchWeb:(NSString*)searchTerm {
+#if APPLICATION_EXTENSION_API_ONLY
+  FML_LOG(WARNING) << "SearchWeb.invoke is not availabe in app extension.";
+#else
   NSString* escapedText = [searchTerm
       stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet
                                                              URLHostAllowedCharacterSet]];
@@ -149,6 +172,7 @@ using namespace flutter;
   [[UIApplication sharedApplication] openURL:[NSURL URLWithString:searchURL]
                                      options:@{}
                            completionHandler:nil];
+#endif
 }
 
 - (void)playSystemSound:(NSString*)soundType {
@@ -231,7 +255,7 @@ using namespace flutter;
     // We opt out of view controller based status bar visibility since we want
     // to be able to modify this on the fly. The key used is
     // UIViewControllerBasedStatusBarAppearance.
-    [UIApplication sharedApplication].statusBarHidden = statusBarShouldBeHidden;
+    SetStatusBarHiddenForSharedApplication(statusBarShouldBeHidden);
   }
 }
 
@@ -246,7 +270,7 @@ using namespace flutter;
     // We opt out of view controller based status bar visibility since we want
     // to be able to modify this on the fly. The key used is
     // UIViewControllerBasedStatusBarAppearance.
-    [UIApplication sharedApplication].statusBarHidden = !edgeToEdge;
+    SetStatusBarHiddenForSharedApplication(!edgeToEdge);
   }
   [[NSNotificationCenter defaultCenter]
       postNotificationName:edgeToEdge ? FlutterViewControllerShowHomeIndicator
@@ -284,9 +308,7 @@ using namespace flutter;
                       object:nil
                     userInfo:@{@(kOverlayStyleUpdateNotificationKey) : @(statusBarStyle)}];
   } else {
-    // Note: -[UIApplication setStatusBarStyle] is deprecated in iOS9
-    // in favor of delegating to the view controller.
-    [[UIApplication sharedApplication] setStatusBarStyle:statusBarStyle];
+    SetStatusBarStyleForSharedApplication(statusBarStyle);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -18,11 +18,8 @@ namespace {
 constexpr char kTextPlainFormat[] = "text/plain";
 const UInt32 kKeyPressClickSoundId = 1306;
 
-#if APPLICATION_EXTENSION_API_ONLY
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
+#if not APPLICATION_EXTENSION_API_ONLY
 const NSString* searchURLPrefix = @"x-web-search://?";
-#pragma GCC diagnostic pop
 #endif
 
 }  // namespace

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -30,7 +30,6 @@
 
 @implementation FlutterPlatformPluginTest
 - (void)testSearchWebInvokedWithEscapedTerm {
-
   id mockApplication = OCMClassMock([UIApplication class]);
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -30,6 +30,7 @@
 
 @implementation FlutterPlatformPluginTest
 - (void)testSearchWebInvokedWithEscapedTerm {
+
   id mockApplication = OCMClassMock([UIApplication class]);
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 
@@ -50,9 +51,11 @@
 
   FlutterResult result = ^(id result) {
     OCMVerify([mockPlugin searchWeb:@"Testing Word!"]);
+#if not APPLICATION_EXTENSION_API_ONLY
     OCMVerify([mockApplication openURL:[NSURL URLWithString:@"x-web-search://?Testing%20Word!"]
                                options:@{}
                      completionHandler:nil]);
+#endif
     [invokeExpectation fulfill];
   };
 
@@ -82,9 +85,11 @@
 
   FlutterResult result = ^(id result) {
     OCMVerify([mockPlugin searchWeb:@"Test"]);
+#if not APPLICATION_EXTENSION_API_ONLY
     OCMVerify([mockApplication openURL:[NSURL URLWithString:@"x-web-search://?Test"]
                                options:@{}
                      completionHandler:nil]);
+#endif
     [invokeExpectation fulfill];
   };
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -17,11 +17,16 @@ static const SEL kSelectorsHandledByPlugins[] = {
     @selector(application:performFetchWithCompletionHandler:)};
 
 @interface FlutterPluginAppLifeCycleDelegate ()
-- (void)handleDidEnterBackground:(NSNotification*)notification;
-- (void)handleWillEnterForeground:(NSNotification*)notification;
-- (void)handleWillResignActive:(NSNotification*)notification;
-- (void)handleDidBecomeActive:(NSNotification*)notification;
-- (void)handleWillTerminate:(NSNotification*)notification;
+- (void)handleDidEnterBackground:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions");
+- (void)handleWillEnterForeground:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions");
+- (void)handleWillResignActive:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions");
+- (void)handleDidBecomeActive:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions");
+- (void)handleWillTerminate:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions");
 @end
 
 @implementation FlutterPluginAppLifeCycleDelegate {
@@ -46,6 +51,7 @@ static const SEL kSelectorsHandledByPlugins[] = {
     _notificationUnsubscribers = [[NSMutableArray alloc] init];
     std::string cachePath = fml::paths::JoinPaths({getenv("HOME"), kCallbackCacheSubDir});
     [FlutterCallbackCache setCachePath:[NSString stringWithUTF8String:cachePath.c_str()]];
+#if not APPLICATION_EXTENSION_API_ONLY
     [self addObserverFor:UIApplicationDidEnterBackgroundNotification
                 selector:@selector(handleDidEnterBackground:)];
     [self addObserverFor:UIApplicationWillEnterForegroundNotification
@@ -56,6 +62,7 @@ static const SEL kSelectorsHandledByPlugins[] = {
                 selector:@selector(handleDidBecomeActive:)];
     [self addObserverFor:UIApplicationWillTerminateNotification
                 selector:@selector(handleWillTerminate:)];
+#endif
     _delegates = [[NSPointerArray weakObjectsPointerArray] retain];
     _debugBackgroundTask = UIBackgroundTaskInvalid;
   }
@@ -134,7 +141,8 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
   return YES;
 }
 
-- (void)handleDidEnterBackground:(NSNotification*)notification {
+- (void)handleDidEnterBackground:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions") {
   UIApplication* application = [UIApplication sharedApplication];
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   // The following keeps the Flutter session alive when the device screen locks
@@ -166,7 +174,8 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
   }
 }
 
-- (void)handleWillEnterForeground:(NSNotification*)notification {
+- (void)handleWillEnterForeground:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions") {
   UIApplication* application = [UIApplication sharedApplication];
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   if (_debugBackgroundTask != UIBackgroundTaskInvalid) {
@@ -184,7 +193,8 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
   }
 }
 
-- (void)handleWillResignActive:(NSNotification*)notification {
+- (void)handleWillResignActive:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions") {
   UIApplication* application = [UIApplication sharedApplication];
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
     if (!delegate) {
@@ -196,7 +206,8 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
   }
 }
 
-- (void)handleDidBecomeActive:(NSNotification*)notification {
+- (void)handleDidBecomeActive:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions") {
   UIApplication* application = [UIApplication sharedApplication];
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
     if (!delegate) {
@@ -208,7 +219,8 @@ static BOOL IsPowerOfTwo(NSUInteger x) {
   }
 }
 
-- (void)handleWillTerminate:(NSNotification*)notification {
+- (void)handleWillTerminate:(NSNotification*)notification
+    NS_EXTENSION_UNAVAILABLE_IOS("Disallowed in app extensions") {
   UIApplication* application = [UIApplication sharedApplication];
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
     if (!delegate) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm
@@ -20,6 +20,7 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotNil(delegate);
 }
 
+#if not APPLICATION_EXTENSION_API_ONLY
 - (void)testDidEnterBackground {
   XCTNSNotificationExpectation* expectation = [[XCTNSNotificationExpectation alloc]
       initWithName:UIApplicationDidEnterBackgroundNotification];
@@ -88,5 +89,6 @@ FLUTTER_ASSERT_ARC
   [self waitForExpectations:@[ expectation ] timeout:5.0];
   OCMVerify([plugin applicationWillTerminate:[UIApplication sharedApplication]]);
 }
+#endif
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1968,7 +1968,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 #endif
       [self requestGeometryUpdateForWindowScenes:scenes];
     } else {
-      UIInterfaceOrientationMask currentInterfaceOrientation;
+      UIInterfaceOrientationMask currentInterfaceOrientation = 0;
       if (@available(iOS 13.0, *)) {
         UIWindowScene* windowScene = [self flutterWindowSceneIfViewLoaded];
         if (!windowScene) {
@@ -1978,7 +1978,13 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
         }
         currentInterfaceOrientation = 1 << windowScene.interfaceOrientation;
       } else {
+#if APPLICATION_EXTENSION_API_ONLY
+        FML_LOG(ERROR) << "Applicatioin based status bar orentiation update is not supported in "
+                          "app extension. Orientation: "
+                       << currentInterfaceOrientation;
+#else
         currentInterfaceOrientation = 1 << [[UIApplication sharedApplication] statusBarOrientation];
+#endif
       }
       if (!(_orientationPreferences & currentInterfaceOrientation)) {
         [UIViewController attemptRotationToDeviceOrientation];
@@ -2103,6 +2109,10 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (CGFloat)textScaleFactor {
+#if APPLICATION_EXTENSION_API_ONLY
+  FML_LOG(WARNING) << "Dynamic content size update is not supported in app extension.";
+  return 1.0;
+#else
   UIContentSizeCategory category = [UIApplication sharedApplication].preferredContentSizeCategory;
   // The delta is computed by approximating Apple's typography guidelines:
   // https://developer.apple.com/ios/human-interface-guidelines/visual-design/typography/
@@ -2153,6 +2163,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   } else {
     return 1.0;
   }
+#endif
 }
 
 - (BOOL)isAlwaysUse24HourFormat {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1979,7 +1979,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
         currentInterfaceOrientation = 1 << windowScene.interfaceOrientation;
       } else {
 #if APPLICATION_EXTENSION_API_ONLY
-        FML_LOG(ERROR) << "Applicatioin based status bar orentiation update is not supported in "
+        FML_LOG(ERROR) << "Application based status bar orentiation update is not supported in "
                           "app extension. Orientation: "
                        << currentInterfaceOrientation;
 #else


### PR DESCRIPTION
This PR turns on the flag to support engine to build app extension. 
When building for app extension, the usage of sharedApplication API is removed.

fixes https://github.com/flutter/flutter/issues/124286 and https://github.com/flutter/flutter/issues/124289

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
