### PR TITLE
[Impeller] unconditionally present with transaction.

### DIFF
--- a/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
@@ -64,7 +64,7 @@ GPUCAMetalLayerHandle IOSSurfaceMetalImpeller::GetCAMetalLayer(const SkISize& fr
   // When there are platform views in the scene, the drawable needs to be presented in the same
   // transaction as the one created for platform views. When the drawable are being presented from
   // the raster thread, there is no such transaction.
-  layer.presentsWithTransaction = [[NSThread currentThread] isMainThread];
+  layer.presentsWithTransaction = YES;
 
   return layer;
 }


### PR DESCRIPTION
Testing the potential fix for iOS scheduling issues.
