### PR TITLE
[ios][ios17]fix auto correction highlight on top left corner

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -2462,7 +2462,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
         CGRectMake(0, 0, [dictionary[@"width"] intValue], [dictionary[@"height"] intValue]);
     _activeView.tintColor = [UIColor clearColor];
   } else {
-    // TODO: Also need to handle iOS 16 case, where the auto-correction highlight does
+    // TODO(hellohuanlin): Also need to handle iOS 16 case, where the auto-correction highlight does
     // not match the size of text.
     // See https://github.com/flutter/flutter/issues/131695
     if (@available(iOS 17, *)) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -2469,7 +2469,9 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
       // Move auto-correction highlight to overlap with the actual text.
       // This is to fix an issue where the system auto-correction highlight is displayed at
       // the top left corner of the screen on iOS 17+.
+      // This problem also happens on iOS 16, but the size of highlight does not match the text.
       // See https://github.com/flutter/flutter/issues/131695
+      // TODO(hellohuanlin): Investigate if we can use non-zero size.
       _inputHider.frame =
           CGRectMake([transform[leftIndex] intValue], [transform[topIndex] intValue], 0, 0);
     }


### PR DESCRIPTION
Fix native auto-correction highlight region on top left corner. 


This PR uses the system auto-correction highlight on iOS 17, which was disabled by https://github.com/flutter/engine/pull/44354

<img width="479" alt="Screenshot 2023-08-16 at 1 19 39 PM" src="https://github.com/flutter/engine/assets/41930132/a5a1dda7-ba21-462e-a65c-1afeecf7559f">

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/131622
Fixes https://github.com/flutter/flutter/issues/131695
Fixes https://github.com/flutter/flutter/issues/130818

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
