### PR TITLE
Revert "Conditionally enable HardwareBuffer backed platform views (#44744)"

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -968,12 +968,11 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
 
   private static PlatformViewRenderTarget makePlatformViewRenderTarget(
       TextureRegistry textureRegistry) {
-    if (Build.VERSION.SDK_INT >= 29) {
-      // Prefer ImageReader-based backend on versions >= 29.
+    // TODO(johnmccutchan): Enable ImageReaderPlatformViewRenderTarget for public use.
+    if (false) {
       final TextureRegistry.ImageTextureEntry textureEntry = textureRegistry.createImageTexture();
       return new ImageReaderPlatformViewRenderTarget(textureEntry);
     }
-    // Fallback to SurfaceTexture support on old phones.
     final TextureRegistry.SurfaceTextureEntry textureEntry = textureRegistry.createSurfaceTexture();
     return new SurfaceTexturePlatformViewRenderTarget(textureEntry);
   }


### PR DESCRIPTION
This reverts commit 12cafaeb9e3113149e5d9fdfd136ee7cca9e91b2.

The https://github.com/flutter/flutter/tree/master/dev/integration_tests/abstract_method_smoke_test test was not rendering the platform view with that change.
