### PR TITLE
Passthrough stderr results of clang_tidy when --enable-check-profile.

### DIFF
--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -359,6 +359,12 @@ class ClangTidy {
         _logWithTimestamp('Still running: $sortedJobs');
       }
       if (job.result.exitCode == 0) {
+        if (options.enableCheckProfile) {
+          // stderr is lazily evaluated, so force it to be evaluated here.
+          final String stderr = job.result.stderr;
+          _errSink.writeln('Results of --enable-check-profile for ${job.name}:');
+          _errSink.writeln(stderr);
+        }
         continue;
       }
       _errSink.writeln('❌ Failures for ${job.name}:');


### PR DESCRIPTION
Required to actually see the results of the profile :)