### PR TITLE
Adds new builders for partial clang-tidy checks.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -226,6 +226,25 @@ targets:
       - "**.frag"
       - "**.vert"
 
+  - name: Linux linux_clang_tidy_presubmit
+    bringup: true
+    recipe: engine_v2/engine_v2
+    timeout: 120
+    properties:
+      config_name: linux_clang_tidy_presubmit
+    runIf:
+      - DEPS
+      - .ci.yaml
+      - tools/clang_tidy/**
+      - ci/builders/**
+      - ci/clang_tidy.sh
+      - "**.h"
+      - "**.c"
+      - "**.cc"
+      - "**.fbs"
+      - "**.frag"
+      - "**.vert"
+
   - name: Linux linux_arm_host_engine
     recipe: engine_v2/engine_v2
     timeout: 120
@@ -345,6 +364,27 @@ targets:
     timeout: 120
     properties:
       config_name: mac_clang_tidy
+    runIf:
+      - DEPS
+      - .ci.yaml
+      - tools/clang_tidy/**
+      - ci/builders/**
+      - ci/clang_tidy.sh
+      - "**.h"
+      - "**.c"
+      - "**.cc"
+      - "**.fbs"
+      - "**.frag"
+      - "**.vert"
+      - "**.m"
+      - "**.mm"
+
+  - name: Mac mac_clang_tidy_presubmit
+    bringup: true
+    recipe: engine_v2/engine_v2
+    timeout: 120
+    properties:
+      config_name: mac_clang_tidy_presubmit
     runIf:
       - DEPS
       - .ci.yaml

--- a/ci/builders/linux_clang_tidy_presubmit.json
+++ b/ci/builders/linux_clang_tidy_presubmit.json
@@ -1,0 +1,95 @@
+{
+    "builds": [
+        {
+            "name": "android_debug_arm64",
+            "archives": [],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gn": [
+                "--android",
+                "--android-cpu",
+                "arm64",
+                "--no-lto"
+            ],
+            "ninja": {
+                "config": "android_debug_arm64"
+            }
+        },
+        {
+            "name": "host_debug",
+            "archives": [],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gn": [
+                "--runtime-mode",
+                "debug",
+                "--prebuilt-dart-sdk",
+                "--no-lto"
+            ],
+            "ninja": {
+                "config": "host_debug"
+            }
+        }
+    ],
+    "tests": [
+        {
+            "name": "test: lint host_debug",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cores=32"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug",
+                "android_debug_arm64"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--shard-id=0",
+                        "--shard-variants=android_debug_arm64"
+                    ],
+                    "max_attempts": 1,
+                    "script": "flutter/ci/clang_tidy.sh"
+                }
+            ]
+        },
+        {
+            "name": "test: lint android_debug_arm64",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "cores=32"
+            ],
+            "dependencies": [
+                "host_debug",
+                "android_debug_arm64"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint android_debug_arm64",
+                    "parameters": [
+                        "--variant",
+                        "android_debug_arm64",
+                        "--shard-id=1",
+                        "--shard-variants=host_debug"
+                    ],
+                    "max_attempts": 1,
+                    "script": "flutter/ci/clang_tidy.sh"
+                }
+            ]
+        }
+    ]
+}

--- a/ci/builders/mac_clang_tidy_presubmit.json
+++ b/ci/builders/mac_clang_tidy_presubmit.json
@@ -1,0 +1,114 @@
+{
+    "builds": [
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--runtime-mode",
+                "debug",
+                "--prebuilt-dart-sdk",
+                "--no-lto",
+                "--force-mac-arm64"
+            ],
+            "name": "host_debug",
+            "ninja": {
+                "config": "host_debug"
+            }
+        },
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--ios",
+                "--runtime-mode",
+                "debug",
+                "--simulator",
+                "--no-lto",
+                "--force-mac-arm64"
+            ],
+            "name": "ios_debug_sim",
+            "ninja": {
+                "config": "ios_debug_sim"
+            }
+        }
+    ],
+    "tests": [
+        {
+            "name": "test: lint host_debug",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug",
+                "ios_debug_sim"
+            ],
+            "contexts": [
+                "osx_sdk"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--shard-id=0",
+                        "--shard-variants=ios_debug_sim"
+                    ],
+                    "max_attempts": 1,
+                    "script": "flutter/ci/clang_tidy.sh"
+                }
+            ]
+        },
+        {
+            "name": "test: lint ios_debug_sim",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug",
+                "ios_debug_sim"
+            ],
+            "contexts": [
+                "osx_sdk"
+            ],
+            "tasks": [
+                {
+                    "name": "test: lint ios_debug_sim",
+                    "parameters": [
+                        "--variant",
+                        "ios_debug_sim",
+                        "--lint-all",
+                        "--shard-id=1",
+                        "--shard-variants=host_debug"
+                    ],
+                    "max_attempts": 1,
+                    "script": "flutter/ci/clang_tidy.sh"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is the first in a sequence of PRs which will lint only changed files on presubmit. The process is the following:
1. Add new `bringup: true` builders that lint only changed files. `bringup: true` builders don't run in presubmit, and since after landing this no files will be detected as changed, these builders will not do anything yet.
1. Remove `bringup: true`. This will allow the new builders to run in presubmit.
1. Ask the team to monitor the new checks on PRs to make sure they are doing the right thing.
1. When we're reasonably sure that the checks are doing the right thing, add `presubmit: false` to `mac_clang_tidy` and `linux_clang_tidy` so that we no longer needlessly lint all files in presubmit.

Related https://github.com/flutter/flutter/issues/105068