### PR TITLE
[cp][ios][ios17]fix auto correction highlight on top left corner on iOS 17 (again)

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -2289,18 +2289,32 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 }
 
 - (void)setEditableSizeAndTransform:(NSDictionary*)dictionary {
-  [_activeView setEditableTransform:dictionary[@"transform"]];
+  NSArray* transform = dictionary[@"transform"];
+  [_activeView setEditableTransform:transform];
+  const int leftIndex = 12;
+  const int topIndex = 13;
   if ([_activeView isScribbleAvailable]) {
     // This is necessary to set up where the scribble interactable element will be.
-    int leftIndex = 12;
-    int topIndex = 13;
     _inputHider.frame =
-        CGRectMake([dictionary[@"transform"][leftIndex] intValue],
-                   [dictionary[@"transform"][topIndex] intValue], [dictionary[@"width"] intValue],
-                   [dictionary[@"height"] intValue]);
+        CGRectMake([transform[leftIndex] intValue], [transform[topIndex] intValue],
+                   [dictionary[@"width"] intValue], [dictionary[@"height"] intValue]);
     _activeView.frame =
         CGRectMake(0, 0, [dictionary[@"width"] intValue], [dictionary[@"height"] intValue]);
     _activeView.tintColor = [UIColor clearColor];
+  } else {
+    // TODO(hellohuanlin): Also need to handle iOS 16 case, where the auto-correction highlight does
+    // not match the size of text.
+    // See https://github.com/flutter/flutter/issues/131695
+    if (@available(iOS 17, *)) {
+      // Move auto-correction highlight to overlap with the actual text.
+      // This is to fix an issue where the system auto-correction highlight is displayed at
+      // the top left corner of the screen on iOS 17+.
+      // This problem also happens on iOS 16, but the size of highlight does not match the text.
+      // See https://github.com/flutter/flutter/issues/131695
+      // TODO(hellohuanlin): Investigate if we can use non-zero size.
+      _inputHider.frame =
+          CGRectMake([transform[leftIndex] intValue], [transform[topIndex] intValue], 0, 0);
+    }
   }
 }
 
@@ -2328,7 +2342,22 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                                          ? NSWritingDirectionLeftToRight
                                                          : NSWritingDirectionRightToLeft]];
   }
+
+  BOOL shouldNotifyTextChange = NO;
+  if (@available(iOS 17, *)) {
+    // Force UIKit to query the selectionRects again on iOS 17+
+    // This is to fix a bug on iOS 17+ where UIKit queries the outdated selectionRects after
+    // entering a character, resulting in auto-correction highlight region missing the last
+    // character.
+    shouldNotifyTextChange = YES;
+  }
+  if (shouldNotifyTextChange) {
+    [_activeView.inputDelegate textWillChange:_activeView];
+  }
   _activeView.selectionRects = rectsAsRect;
+  if (shouldNotifyTextChange) {
+    [_activeView.inputDelegate textDidChange:_activeView];
+  }
 }
 
 - (void)startLiveTextInput {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -60,6 +60,7 @@ FLUTTER_ASSERT_ARC
 
 @interface FlutterTextInputPlugin ()
 @property(nonatomic, assign) FlutterTextInputView* activeView;
+@property(nonatomic, readonly) UIView* inputHider;
 @property(nonatomic, readonly)
     NSMutableDictionary<NSString*, FlutterTextInputView*>* autofillContext;
 
@@ -398,6 +399,72 @@ FLUTTER_ASSERT_ARC
     [inputView firstRectForRange:[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)]];
     // showAutocorrectionPromptRectForStart fires in response to firstRectForRange.
     XCTAssertEqual(callCount, 3);
+  }
+}
+
+- (void)testInputHiderOverlapWithTextWhenScribbleIsDisabledAfterIOS17AndDoesNotOverlapBeforeIOS17 {
+  FlutterTextInputPlugin* myInputPlugin =
+      [[FlutterTextInputPlugin alloc] initWithDelegate:OCMClassMock([FlutterEngine class])];
+
+  FlutterMethodCall* setClientCall =
+      [FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                        arguments:@[ @(123), self.mutableTemplateCopy ]];
+  [myInputPlugin handleMethodCall:setClientCall
+                           result:^(id _Nullable result){
+                           }];
+
+  FlutterTextInputView* mockInputView = OCMPartialMock(myInputPlugin.activeView);
+  OCMStub([mockInputView isScribbleAvailable]).andReturn(NO);
+
+  // yOffset = 200.
+  NSArray* yOffsetMatrix = @[ @1, @0, @0, @0, @0, @1, @0, @0, @0, @0, @1, @0, @0, @200, @0, @1 ];
+
+  FlutterMethodCall* setPlatformViewClientCall =
+      [FlutterMethodCall methodCallWithMethodName:@"TextInput.setEditableSizeAndTransform"
+                                        arguments:@{@"transform" : yOffsetMatrix}];
+  [myInputPlugin handleMethodCall:setPlatformViewClientCall
+                           result:^(id _Nullable result){
+                           }];
+
+  if (@available(iOS 17, *)) {
+    XCTAssert(CGRectEqualToRect(myInputPlugin.inputHider.frame, CGRectMake(0, 200, 0, 0)),
+              @"The input hider should overlap with the text on and after iOS 17");
+
+  } else {
+    XCTAssert(CGRectEqualToRect(myInputPlugin.inputHider.frame, CGRectZero),
+              @"The input hider should be on the origin of screen on and before iOS 16.");
+  }
+}
+
+- (void)testSetSelectionRectsNotifiesTextChangeAfterIOS17AndDoesNotNotifyBeforeIOS17 {
+  FlutterTextInputPlugin* myInputPlugin =
+      [[FlutterTextInputPlugin alloc] initWithDelegate:OCMClassMock([FlutterEngine class])];
+
+  FlutterMethodCall* setClientCall =
+      [FlutterMethodCall methodCallWithMethodName:@"TextInput.setClient"
+                                        arguments:@[ @(123), self.mutableTemplateCopy ]];
+  [myInputPlugin handleMethodCall:setClientCall
+                           result:^(id _Nullable result){
+                           }];
+
+  id mockInputDelegate = OCMProtocolMock(@protocol(UITextInputDelegate));
+  myInputPlugin.activeView.inputDelegate = mockInputDelegate;
+
+  NSArray<NSNumber*>* selectionRect = [NSArray arrayWithObjects:@0, @0, @100, @100, @0, @1, nil];
+  NSArray* selectionRects = [NSArray arrayWithObjects:selectionRect, nil];
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"Scribble.setSelectionRects"
+                                        arguments:selectionRects];
+  [myInputPlugin handleMethodCall:methodCall
+                           result:^(id _Nullable result){
+                           }];
+
+  if (@available(iOS 17.0, *)) {
+    OCMVerify([mockInputDelegate textWillChange:myInputPlugin.activeView]);
+    OCMVerify([mockInputDelegate textDidChange:myInputPlugin.activeView]);
+  } else {
+    OCMVerify(never(), [mockInputDelegate textWillChange:myInputPlugin.activeView]);
+    OCMVerify(never(), [mockInputDelegate textDidChange:myInputPlugin.activeView]);
   }
 }
 


### PR DESCRIPTION
CP for https://github.com/flutter/engine/pull/44779

Tested the stable branch with the fix on iPhone and iPad, with hardware and software keyboards, and with and without IME languages, iOS 16 and iOS 17

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/131622
Fixes https://github.com/flutter/flutter/issues/131695
Fixes https://github.com/flutter/flutter/issues/130818

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
