### PR TITLE
Implement 2 suggested Clang Tidy fixes we don't look for yet.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -362,7 +362,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
   RenderTarget subpass_target;
   if (context->GetCapabilities()->SupportsOffscreenMSAA() && msaa_enabled) {
     subpass_target = RenderTarget::CreateOffscreenMSAA(
-        *context, *GetRenderTargetCache().get(), texture_size,
+        *context, *GetRenderTargetCache(), texture_size,
         SPrintF("%s Offscreen", label.c_str()),
         RenderTarget::kDefaultColorAttachmentConfigMSAA  //
 #ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.
@@ -372,7 +372,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
     );
   } else {
     subpass_target = RenderTarget::CreateOffscreen(
-        *context, *GetRenderTargetCache().get(), texture_size,
+        *context, *GetRenderTargetCache(), texture_size,
         SPrintF("%s Offscreen", label.c_str()),
         RenderTarget::kDefaultColorAttachmentConfig  //
 #ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.

--- a/impeller/entity/contents/scene_contents.cc
+++ b/impeller/entity/contents/scene_contents.cc
@@ -45,10 +45,10 @@ bool SceneContents::Render(const ContentContext& renderer,
   }
 
   RenderTarget subpass_target = RenderTarget::CreateOffscreenMSAA(
-      *renderer.GetContext(),                  // context
-      *renderer.GetRenderTargetCache().get(),  // allocator
-      ISize(coverage.value().size),            // size
-      "SceneContents",                         // label
+      *renderer.GetContext(),            // context
+      *renderer.GetRenderTargetCache(),  // allocator
+      ISize(coverage.value().size),      // size
+      "SceneContents",                   // label
       RenderTarget::AttachmentConfigMSAA{
           .storage_mode = StorageMode::kDeviceTransient,
           .resolve_storage_mode = StorageMode::kDevicePrivate,

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -209,10 +209,10 @@ static EntityPassTarget CreateRenderTarget(ContentContext& renderer,
   RenderTarget target;
   if (context->GetCapabilities()->SupportsOffscreenMSAA()) {
     target = RenderTarget::CreateOffscreenMSAA(
-        *context,                                // context
-        *renderer.GetRenderTargetCache().get(),  // allocator
-        size,                                    // size
-        "EntityPass",                            // label
+        *context,                          // context
+        *renderer.GetRenderTargetCache(),  // allocator
+        size,                              // size
+        "EntityPass",                      // label
         RenderTarget::AttachmentConfigMSAA{
             .storage_mode = StorageMode::kDeviceTransient,
             .resolve_storage_mode = StorageMode::kDevicePrivate,
@@ -223,10 +223,10 @@ static EntityPassTarget CreateRenderTarget(ContentContext& renderer,
     );
   } else {
     target = RenderTarget::CreateOffscreen(
-        *context,                                // context
-        *renderer.GetRenderTargetCache().get(),  // allocator
-        size,                                    // size
-        "EntityPass",                            // label
+        *context,                          // context
+        *renderer.GetRenderTargetCache(),  // allocator
+        size,                              // size
+        "EntityPass",                      // label
         RenderTarget::AttachmentConfig{
             .storage_mode = StorageMode::kDevicePrivate,
             .load_action = LoadAction::kDontCare,
@@ -386,7 +386,7 @@ bool EntityPass::Render(ContentContext& renderer,
   // provided by the caller.
   else {
     root_render_target.SetupStencilAttachment(
-        *renderer.GetContext(), *renderer.GetRenderTargetCache().get(),
+        *renderer.GetContext(), *renderer.GetRenderTargetCache(),
         color0.texture->GetSize(),
         renderer.GetContext()->GetCapabilities()->SupportsOffscreenMSAA(),
         "ImpellerOnscreen",

--- a/impeller/entity/render_target_cache.cc
+++ b/impeller/entity/render_target_cache.cc
@@ -19,7 +19,7 @@ void RenderTargetCache::Start() {
 void RenderTargetCache::End() {
   std::vector<TextureData> retain;
 
-  for (auto td : texture_data_) {
+  for (const auto& td : texture_data_) {
     if (td.used_this_frame) {
       retain.push_back(td);
     }


### PR DESCRIPTION
I haven't investigated if there are more occurrences or if it's worth enforcing turning the check on generally.

(They were flagged on the Google roll, ironically)

---

[`readability-redundant-smartptr-get`](https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-smartptr-get.html)

> Find and remove redundant calls to smart pointer’s `.get()` method

[`performance-for-range-copy`](https://clang.llvm.org/extra/clang-tidy/checks/performance/for-range-copy.html)

> Finds C++11 for ranges where the loop variable is copied in each iteration but it would suffice to obtain it by reference.
