### PR TITLE
Add callback to Embedder API to respond to new channel listeners, and use for Windows lifecycle

### DIFF
--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -380,6 +380,7 @@ class ChannelBuffers {
     assert(!name.contains('\u0000'), 'Channel names must not contain U+0000 NULL characters.');
     final _Channel channel = _channels.putIfAbsent(name, () => _Channel());
     channel.setListener(callback);
+    channelListenedTo(name, true);
   }
 
   /// Clears the listener for the specified channel.
@@ -392,8 +393,14 @@ class ChannelBuffers {
     final _Channel? channel = _channels[name];
     if (channel != null) {
       channel.clearListener();
+      channelListenedTo(name, false);
     }
   }
+
+  @Native<Void Function(Handle, Bool)>(symbol: 'PlatformConfigurationNativeApi::PlatformChannelListenedTo')
+  external static void _channelListenedTo(String name, bool listening);
+
+  void channelListenedTo(String name, bool listening) => _channelListenedTo(name, listening);
 
   /// Deprecated. Migrate to [setListener] instead.
   ///

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -110,6 +110,7 @@ typedef CanvasPath Path;
   V(PlatformConfigurationNativeApi::GetRootIsolateToken, 0)           \
   V(PlatformConfigurationNativeApi::RegisterBackgroundIsolate, 1)     \
   V(PlatformConfigurationNativeApi::SendPortPlatformMessage, 4)       \
+  V(PlatformConfigurationNativeApi::PlatformChannelListenedTo, 1)     \
   V(DartRuntimeHooks::Logger_PrintDebugString, 1)                     \
   V(DartRuntimeHooks::Logger_PrintString, 1)                          \
   V(DartRuntimeHooks::ScheduleMicrotask, 1)                           \

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -110,7 +110,7 @@ typedef CanvasPath Path;
   V(PlatformConfigurationNativeApi::GetRootIsolateToken, 0)           \
   V(PlatformConfigurationNativeApi::RegisterBackgroundIsolate, 1)     \
   V(PlatformConfigurationNativeApi::SendPortPlatformMessage, 4)       \
-  V(PlatformConfigurationNativeApi::PlatformChannelListenedTo, 1)     \
+  V(PlatformConfigurationNativeApi::PlatformChannelListenedTo, 2)     \
   V(DartRuntimeHooks::Logger_PrintDebugString, 1)                     \
   V(DartRuntimeHooks::Logger_PrintString, 1)                          \
   V(DartRuntimeHooks::ScheduleMicrotask, 1)                           \

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -539,4 +539,9 @@ void PlatformConfigurationNativeApi::RegisterBackgroundIsolate(
   dart_state->SetPlatformMessageHandler(weak_platform_message_handler);
 }
 
+void PlatformConfigurationNativeApi::PlatformChannelListenedTo(const std::string& name) {
+  // TODO implement this function
+  FML_LOG(ERROR) << "Listening to platform channel named " << name;
+}
+
 }  // namespace flutter

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -540,8 +540,7 @@ void PlatformConfigurationNativeApi::RegisterBackgroundIsolate(
 }
 
 void PlatformConfigurationNativeApi::PlatformChannelListenedTo(const std::string& name, bool listening) {
-  // TODO implement this function
-  FML_LOG(ERROR) << "Listening to platform channel named " << name;
+  UIDartState::Current()->platform_configuration()->client()->ChannelListenedTo(name, listening);
 }
 
 }  // namespace flutter

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -539,7 +539,7 @@ void PlatformConfigurationNativeApi::RegisterBackgroundIsolate(
   dart_state->SetPlatformMessageHandler(weak_platform_message_handler);
 }
 
-void PlatformConfigurationNativeApi::PlatformChannelListenedTo(const std::string& name) {
+void PlatformConfigurationNativeApi::PlatformChannelListenedTo(const std::string& name, bool listening) {
   // TODO implement this function
   FML_LOG(ERROR) << "Listening to platform channel named " << name;
 }

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -539,8 +539,11 @@ void PlatformConfigurationNativeApi::RegisterBackgroundIsolate(
   dart_state->SetPlatformMessageHandler(weak_platform_message_handler);
 }
 
-void PlatformConfigurationNativeApi::PlatformChannelListenedTo(const std::string& name, bool listening) {
-  UIDartState::Current()->platform_configuration()->client()->ChannelListenedTo(name, listening);
+void PlatformConfigurationNativeApi::PlatformChannelListenedTo(
+    const std::string& name,
+    bool listening) {
+  UIDartState::Current()->platform_configuration()->client()->ChannelListenedTo(
+      name, listening);
 }
 
 }  // namespace flutter

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -217,6 +217,15 @@ class PlatformConfigurationClient {
   ///
   virtual void RequestDartDeferredLibrary(intptr_t loading_unit_id) = 0;
 
+  //--------------------------------------------------------------------------
+  /// @brief      Invoked when a listener is registered on a platform channel.
+  ///
+  /// @param[in]  name             The name of the platform channel to which a
+  ///                              listener has been registered or cleared.
+  /// 
+  /// @param[in]  listening        Whether the listener has been set (true) or
+  ///                              cleared (false).
+  ///
   virtual void ChannelListenedTo(const std::string& name, bool listening) = 0;
 
  protected:

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -222,7 +222,7 @@ class PlatformConfigurationClient {
   ///
   /// @param[in]  name             The name of the platform channel to which a
   ///                              listener has been registered or cleared.
-  /// 
+  ///
   /// @param[in]  listening        Whether the listener has been set (true) or
   ///                              cleared (false).
   ///
@@ -532,7 +532,8 @@ class PlatformConfigurationNativeApi {
   static void RespondToPlatformMessage(int response_id,
                                        const tonic::DartByteData& data);
 
-  static void PlatformChannelListenedTo(const std::string& name, bool listening);
+  static void PlatformChannelListenedTo(const std::string& name,
+                                        bool listening);
 
   //--------------------------------------------------------------------------
   /// @brief      Requests the Dart VM to adjusts the GC heuristics based on

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -521,7 +521,7 @@ class PlatformConfigurationNativeApi {
   static void RespondToPlatformMessage(int response_id,
                                        const tonic::DartByteData& data);
 
-  static void PlatformChannelListenedTo(const std::string& name);
+  static void PlatformChannelListenedTo(const std::string& name, bool listening);
 
   //--------------------------------------------------------------------------
   /// @brief      Requests the Dart VM to adjusts the GC heuristics based on

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -521,6 +521,8 @@ class PlatformConfigurationNativeApi {
   static void RespondToPlatformMessage(int response_id,
                                        const tonic::DartByteData& data);
 
+  static void PlatformChannelListenedTo(const std::string& name);
+
   //--------------------------------------------------------------------------
   /// @brief      Requests the Dart VM to adjusts the GC heuristics based on
   ///             the requested `performance_mode`. Returns the old performance

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -217,6 +217,8 @@ class PlatformConfigurationClient {
   ///
   virtual void RequestDartDeferredLibrary(intptr_t loading_unit_id) = 0;
 
+  virtual void ChannelListenedTo(const std::string& name, bool listening) = 0;
+
  protected:
   virtual ~PlatformConfigurationClient();
 };

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -388,6 +388,11 @@ RuntimeController::ComputePlatformResolvedLocale(
   return client_.ComputePlatformResolvedLocale(supported_locale_data);
 }
 
+// |PlatformConfigurationClient|
+void RuntimeController::ChannelListenedTo(const std::string& name, bool listening) {
+  client_.ChannelListenedTo(name, listening);
+}
+
 Dart_Port RuntimeController::GetMainPort() {
   std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   return root_isolate ? root_isolate->main_port() : ILLEGAL_PORT;

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -389,7 +389,8 @@ RuntimeController::ComputePlatformResolvedLocale(
 }
 
 // |PlatformConfigurationClient|
-void RuntimeController::ChannelListenedTo(const std::string& name, bool listening) {
+void RuntimeController::ChannelListenedTo(const std::string& name,
+                                          bool listening) {
   client_.ChannelListenedTo(name, listening);
 }
 

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -656,6 +656,9 @@ class RuntimeController : public PlatformConfigurationClient {
   std::unique_ptr<std::vector<std::string>> ComputePlatformResolvedLocale(
       const std::vector<std::string>& supported_locale_data) override;
 
+  // |PlatformConfigurationClient|
+  void ChannelListenedTo(const std::string& name, bool listening) override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(RuntimeController);
 };
 

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -56,6 +56,8 @@ class RuntimeDelegate {
   virtual std::weak_ptr<PlatformMessageHandler> GetPlatformMessageHandler()
       const = 0;
 
+  virtual void ChannelListenedTo(const std::string& name, bool listening) = 0;
+
  protected:
   virtual ~RuntimeDelegate();
 };

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -565,6 +565,10 @@ std::weak_ptr<PlatformMessageHandler> Engine::GetPlatformMessageHandler()
   return delegate_.GetPlatformMessageHandler();
 }
 
+void Engine::ChannelListenedTo(const std::string& name, bool listening) {
+  delegate_.OnEngineChannelListenedTo(name, listening);
+}
+
 void Engine::LoadDartDeferredLibrary(
     intptr_t loading_unit_id,
     std::unique_ptr<const fml::Mapping> snapshot_data,

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -294,7 +294,15 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
     virtual const std::shared_ptr<PlatformMessageHandler>&
     GetPlatformMessageHandler() const = 0;
 
-    //----------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    /// @brief      Invoked when a listener is registered on a platform channel.
+    ///
+    /// @param[in]  name             The name of the platform channel to which a
+    ///                              listener has been registered or cleared.
+    /// 
+    /// @param[in]  listening        Whether the listener has been set (true) or
+    ///                              cleared (false).
+    ///
     virtual void OnEngineChannelListenedTo(const std::string& name, bool listening) = 0;
   };
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -293,6 +293,9 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
     ///        Flutter to the host platform (and its responses).
     virtual const std::shared_ptr<PlatformMessageHandler>&
     GetPlatformMessageHandler() const = 0;
+
+    //----------------------------------------------------------------------------
+    virtual void OnEngineChannelListenedTo(const std::string& name, bool listening) = 0;
   };
 
   //----------------------------------------------------------------------------
@@ -932,6 +935,9 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   // |RuntimeDelegate|
   std::weak_ptr<PlatformMessageHandler> GetPlatformMessageHandler()
       const override;
+
+  // |RuntimeDelegate|
+  void ChannelListenedTo(const std::string& name, bool listening) override;
 
   void SetNeedsReportTimings(bool value) override;
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -299,11 +299,12 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
     ///
     /// @param[in]  name             The name of the platform channel to which a
     ///                              listener has been registered or cleared.
-    /// 
+    ///
     /// @param[in]  listening        Whether the listener has been set (true) or
     ///                              cleared (false).
     ///
-    virtual void OnEngineChannelListenedTo(const std::string& name, bool listening) = 0;
+    virtual void OnEngineChannelListenedTo(const std::string& name,
+                                           bool listening) = 0;
   };
 
   //----------------------------------------------------------------------------

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -40,6 +40,7 @@ class MockDelegate : public Engine::Delegate {
   MOCK_METHOD0(GetCurrentTimePoint, fml::TimePoint());
   MOCK_CONST_METHOD0(GetPlatformMessageHandler,
                      const std::shared_ptr<PlatformMessageHandler>&());
+  MOCK_METHOD2(OnEngineChannelListenedTo, void(const std::string&, bool));
 };
 
 class MockResponse : public PlatformMessageResponse {
@@ -68,6 +69,7 @@ class MockRuntimeDelegate : public RuntimeDelegate {
   MOCK_METHOD1(RequestDartDeferredLibrary, void(intptr_t));
   MOCK_CONST_METHOD0(GetPlatformMessageHandler,
                      std::weak_ptr<PlatformMessageHandler>());
+  MOCK_METHOD2(ChannelListenedTo, void(const std::string&, bool));
 };
 
 class MockRuntimeController : public RuntimeController {

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -114,6 +114,8 @@ void PlatformView::UpdateSemantics(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     CustomAccessibilityActionUpdates actions) {}
 
+void PlatformView::ChannelListenedTo(const std::string& name, bool listening) {}
+
 void PlatformView::HandlePlatformMessage(
     std::unique_ptr<PlatformMessage> message) {
   if (auto response = message->response()) {

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -466,6 +466,9 @@ class PlatformView {
                                CustomAccessibilityActionUpdates actions);
 
   //----------------------------------------------------------------------------
+  virtual void ChannelListenedTo(const std::string& name, bool listening);
+
+  //----------------------------------------------------------------------------
   /// @brief      Used by embedders to specify the updated viewport metrics for
   ///             a view. In response to this call, on the raster thread, the
   ///             rasterizer may need to be reconfigured to the updated viewport

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1332,6 +1332,11 @@ void Shell::OnEngineHandlePlatformMessage(
   }
 }
 
+void Shell::OnEngineChannelListenedTo(const std::string& name, bool listening) {
+  FML_LOG(ERROR) << "Shell received indication of listening to " << name;
+  // TODO forward to platform view
+}
+
 void Shell::HandleEngineSkiaMessage(std::unique_ptr<PlatformMessage> message) {
   const auto& data = message->data();
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1333,8 +1333,15 @@ void Shell::OnEngineHandlePlatformMessage(
 }
 
 void Shell::OnEngineChannelListenedTo(const std::string& name, bool listening) {
-  FML_LOG(ERROR) << "Shell received indication of listening to " << name;
-  // TODO forward to platform view
+  FML_DCHECK(is_set_up_);
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
+
+  task_runners_.GetPlatformTaskRunner()->PostTask(
+      [view = platform_view_->GetWeakPtr(), name, listening] {
+        if (view) {
+          view->ChannelListenedTo(name, listening);
+        }
+      });
 }
 
 void Shell::HandleEngineSkiaMessage(std::unique_ptr<PlatformMessage> message) {

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -649,6 +649,9 @@ class Shell final : public PlatformView::Delegate,
   // |Engine::Delegate|
   fml::TimePoint GetCurrentTimePoint() override;
 
+  // |Engine::Delegate|
+  void OnEngineChannelListenedTo(const std::string& name, bool listening) override;
+
   // |Rasterizer::Delegate|
   void OnFrameRasterized(const FrameTiming&) override;
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -650,7 +650,8 @@ class Shell final : public PlatformView::Delegate,
   fml::TimePoint GetCurrentTimePoint() override;
 
   // |Engine::Delegate|
-  void OnEngineChannelListenedTo(const std::string& name, bool listening) override;
+  void OnEngineChannelListenedTo(const std::string& name,
+                                 bool listening) override;
 
   // |Rasterizer::Delegate|
   void OnFrameRasterized(const FrameTiming&) override;

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1881,9 +1881,12 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
                                       user_data]() { return ptr(user_data); };
   }
 
-  flutter::PlatformViewEmbedder::ChannelListenedToCallback channel_listened_to_callback = nullptr;
+  flutter::PlatformViewEmbedder::ChannelListenedToCallback
+      channel_listened_to_callback = nullptr;
   if (SAFE_ACCESS(args, channel_listened_to_callback, nullptr) != nullptr) {
-    channel_listened_to_callback = [ptr = args->channel_listened_to_callback, user_data](const std::string& name, bool listening) {
+    channel_listened_to_callback = [ptr = args->channel_listened_to_callback,
+                                    user_data](const std::string& name,
+                                               bool listening) {
       size_t name_len = name.size();
       ptr(name.data(), name_len, listening, user_data);
     };

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1881,6 +1881,14 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
                                       user_data]() { return ptr(user_data); };
   }
 
+  flutter::PlatformViewEmbedder::ChannelListenedToCallback channel_listened_to_callback = nullptr;
+  if (SAFE_ACCESS(args, channel_listened_to_callback, nullptr) != nullptr) {
+    channel_listened_to_callback = [ptr = args->channel_listened_to_callback, user_data](const std::string& name, bool listening) {
+      size_t name_len = name.size();
+      ptr(name.data(), name_len, listening, user_data);
+    };
+  }
+
   auto external_view_embedder_result = InferExternalViewEmbedderFromArgs(
       SAFE_ACCESS(args, compositor, nullptr), settings.enable_impeller);
   if (external_view_embedder_result.second) {
@@ -1895,6 +1903,7 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
           vsync_callback,                             //
           compute_platform_resolved_locale_callback,  //
           on_pre_engine_restart_callback,             //
+          channel_listened_to_callback,               //
       };
 
   auto on_create_platform_view = InferPlatformViewCreationCallback(

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1327,10 +1327,10 @@ typedef void (*FlutterUpdateSemanticsCallback2)(
     void* /* user data*/);
 
 typedef void (*FlutterChannelListenedToCallback)(
-  const char* data /* name */,
-  size_t data_len /* name.size */,
-  bool /* listening */,
-  void* /* user data */);
+    const char* data /* name */,
+    size_t data_len /* name.size */,
+    bool /* listening */,
+    void* /* user data */);
 
 typedef struct _FlutterTaskRunner* FlutterTaskRunner;
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1326,6 +1326,12 @@ typedef void (*FlutterUpdateSemanticsCallback2)(
     const FlutterSemanticsUpdate2* /* semantics update */,
     void* /* user data*/);
 
+typedef void (*FlutterChannelListenedToCallback)(
+  const char* data /* name */,
+  size_t data_len /* name.size */,
+  bool /* listening */,
+  void* /* user data */);
+
 typedef struct _FlutterTaskRunner* FlutterTaskRunner;
 
 typedef struct {
@@ -2118,6 +2124,10 @@ typedef struct {
   /// and `update_semantics_callback2` may be provided; the others must be set
   /// to null.
   FlutterUpdateSemanticsCallback2 update_semantics_callback2;
+
+  /// The callback invoked by the engine in response to a channel listener
+  /// being registered on the framework side.
+  FlutterChannelListenedToCallback channel_listened_to_callback;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -200,7 +200,8 @@ void PlatformViewEmbedder::OnPreEngineRestart() const {
 }
 
 // |PlatformView|
-void PlatformViewEmbedder::ChannelListenedTo(const std::string& name, bool listening) {
+void PlatformViewEmbedder::ChannelListenedTo(const std::string& name,
+                                             bool listening) {
   if (platform_dispatch_table_.on_channel_listened_to != nullptr) {
     platform_dispatch_table_.on_channel_listened_to(name, listening);
   }

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -199,6 +199,13 @@ void PlatformViewEmbedder::OnPreEngineRestart() const {
   }
 }
 
+// |PlatformView|
+void PlatformViewEmbedder::ChannelListenedTo(const std::string& name, bool listening) {
+  if (platform_dispatch_table_.on_channel_listened_to != nullptr) {
+    platform_dispatch_table_.on_channel_listened_to(name, listening);
+  }
+}
+
 std::shared_ptr<PlatformMessageHandler>
 PlatformViewEmbedder::GetPlatformMessageHandler() const {
   return platform_message_handler_;

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -41,6 +41,7 @@ class PlatformViewEmbedder final : public PlatformView {
       std::function<std::unique_ptr<std::vector<std::string>>(
           const std::vector<std::string>& supported_locale_data)>;
   using OnPreEngineRestartCallback = std::function<void()>;
+  using ChannelListenedToCallback = std::function<void(const std::string&, bool)>;
 
   struct PlatformDispatchTable {
     UpdateSemanticsCallback update_semantics_callback;  // optional
@@ -50,6 +51,7 @@ class PlatformViewEmbedder final : public PlatformView {
     ComputePlatformResolvedLocaleCallback
         compute_platform_resolved_locale_callback;
     OnPreEngineRestartCallback on_pre_engine_restart_callback;  // optional
+    ChannelListenedToCallback on_channel_listened_to; // optional
   };
 
   // Create a platform view that sets up a software rasterizer.
@@ -133,6 +135,9 @@ class PlatformViewEmbedder final : public PlatformView {
   // |PlatformView|
   std::unique_ptr<std::vector<std::string>> ComputePlatformResolvedLocales(
       const std::vector<std::string>& supported_locale_data) override;
+
+  // |PlatformView|
+  void ChannelListenedTo(const std::string& name, bool listening) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewEmbedder);
 };

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -41,7 +41,8 @@ class PlatformViewEmbedder final : public PlatformView {
       std::function<std::unique_ptr<std::vector<std::string>>(
           const std::vector<std::string>& supported_locale_data)>;
   using OnPreEngineRestartCallback = std::function<void()>;
-  using ChannelListenedToCallback = std::function<void(const std::string&, bool)>;
+  using ChannelListenedToCallback =
+      std::function<void(const std::string&, bool)>;
 
   struct PlatformDispatchTable {
     UpdateSemanticsCallback update_semantics_callback;  // optional
@@ -51,7 +52,7 @@ class PlatformViewEmbedder final : public PlatformView {
     ComputePlatformResolvedLocaleCallback
         compute_platform_resolved_locale_callback;
     OnPreEngineRestartCallback on_pre_engine_restart_callback;  // optional
-    ChannelListenedToCallback on_channel_listened_to; // optional
+    ChannelListenedToCallback on_channel_listened_to;           // optional
   };
 
   // Create a platform view that sets up a software rasterizer.

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -376,7 +376,7 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
   args.channel_listened_to_callback = [](const char* name, size_t name_len, bool listening, void* user_data) {
     auto host = static_cast<FlutterWindowsEngine*>(user_data);
     std::string channel_name(name, name + name_len);
-    FML_LOG(ERROR) << "Engine receives notification for " << channel_name;
+    host->OnChannelListenedTo(channel_name, listening);
   };
 
   args.custom_task_runners = &custom_task_runners;
@@ -822,6 +822,14 @@ std::optional<LRESULT> FlutterWindowsEngine::ProcessExternalWindowMessage(
                                                      lparam);
   }
   return std::nullopt;
+}
+
+void FlutterWindowsEngine::OnChannelListenedTo(const std::string& name, bool listening) {
+  if (name.compare("flutter/platform") == 0) {
+    lifecycle_manager_->BeginProcessingExit();
+  } else if (name.compare("flutter/lifecycle") == 0) {
+    lifecycle_manager_->BeginProcessingLifecycle();
+  }
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -797,16 +797,6 @@ void FlutterWindowsEngine::OnDwmCompositionChanged() {
   view_->OnDwmCompositionChanged();
 }
 
-// TODO(yaakovschectman): This enables the flutter/lifecycle channel
-// once the System.initializationComplete message is received on
-// the flutter/system channel. This is a short-term workaround to
-// ensure the framework is initialized and ready to accept lifecycle
-// messages. This cross-channel dependency should be removed.
-// See: https://github.com/flutter/flutter/issues/132514
-void FlutterWindowsEngine::OnApplicationLifecycleEnabled() {
-  lifecycle_manager_->BeginProcessingLifecycle();
-}
-
 void FlutterWindowsEngine::OnWindowStateEvent(HWND hwnd,
                                               WindowStateEvent event) {
   lifecycle_manager_->OnWindowStateEvent(hwnd, event);

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -373,7 +373,8 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
       host->root_isolate_create_callback_();
     }
   };
-  args.channel_listened_to_callback = [](const char* name, size_t name_len, bool listening, void* user_data) {
+  args.channel_listened_to_callback = [](const char* name, size_t name_len,
+                                         bool listening, void* user_data) {
     auto host = static_cast<FlutterWindowsEngine*>(user_data);
     std::string channel_name(name, name + name_len);
     host->OnChannelListenedTo(channel_name, listening);
@@ -814,7 +815,8 @@ std::optional<LRESULT> FlutterWindowsEngine::ProcessExternalWindowMessage(
   return std::nullopt;
 }
 
-void FlutterWindowsEngine::OnChannelListenedTo(const std::string& name, bool listening) {
+void FlutterWindowsEngine::OnChannelListenedTo(const std::string& name,
+                                               bool listening) {
   if (name.compare("flutter/platform") == 0) {
     lifecycle_manager_->BeginProcessingExit();
   } else if (name.compare("flutter/lifecycle") == 0) {

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -373,6 +373,11 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
       host->root_isolate_create_callback_();
     }
   };
+  args.channel_listened_to_callback = [](const char* name, size_t name_len, bool listening, void* user_data) {
+    auto host = static_cast<FlutterWindowsEngine*>(user_data);
+    std::string channel_name(name, name + name_len);
+    FML_LOG(ERROR) << "Engine receives notification for " << channel_name;
+  };
 
   args.custom_task_runners = &custom_task_runners;
 

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -297,6 +297,8 @@ class FlutterWindowsEngine {
   // created. This is typically caused by a hot restart (Shift-R in CLI.)
   void OnPreEngineRestart();
 
+  // Invoked by the engine when a listener is set or cleared on a platform
+  // channel.
   virtual void OnChannelListenedTo(const std::string& name, bool listening);
 
  private:

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -258,10 +258,6 @@ class FlutterWindowsEngine {
   // Called when a WM_DWMCOMPOSITIONCHANGED message is received.
   void OnDwmCompositionChanged();
 
-  // Called in response to the framework registering a ServiceBindings.
-  // Registers the top level handler for the WM_CLOSE window message.
-  void OnApplicationLifecycleEnabled();
-
   // Called when a Window receives an event that may alter the application
   // lifecycle state.
   void OnWindowStateEvent(HWND hwnd, WindowStateEvent event);

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -301,6 +301,8 @@ class FlutterWindowsEngine {
   // created. This is typically caused by a hot restart (Shift-R in CLI.)
   void OnPreEngineRestart();
 
+  virtual void OnChannelListenedTo(const std::string& name, bool listening);
+
  private:
   // Allows swapping out embedder_api_ calls in tests.
   friend class EngineModifier;

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -1128,14 +1128,14 @@ TEST_F(FlutterWindowsEngineTest, ChannelListenedTo) {
 
   static bool listened_to = false;
   modifier.embedder_api().Run = MOCK_ENGINE_PROC(
-      Run, ([old_run](
-                size_t version, const FlutterRendererConfig* config,
-                const FlutterProjectArgs* args, void* user_data,
-                FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
+      Run, ([old_run](size_t version, const FlutterRendererConfig* config,
+                      const FlutterProjectArgs* args, void* user_data,
+                      FLUTTER_API_SYMBOL(FlutterEngine) * engine_out) {
         FlutterProjectArgs new_args = *args;
-        new_args.channel_listened_to_callback = [](const char* name, size_t len, bool listening, void* user_data) {
-          listened_to = true;
-        };
+        new_args.channel_listened_to_callback =
+            [](const char* name, size_t len, bool listening, void* user_data) {
+              listened_to = true;
+            };
         return old_run(version, config, &new_args, user_data, engine_out);
       }));
   engine->Run();

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -703,7 +703,6 @@ TEST_F(FlutterWindowsEngineTest, TestExit) {
   ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([]() { return true; });
   EXPECT_CALL(*handler, Quit).Times(1);
   modifier.SetLifecycleManager(std::move(handler));
-  // engine->OnApplicationLifecycleEnabled();
 
   engine->lifecycle_manager()->BeginProcessingExit();
 
@@ -742,7 +741,6 @@ TEST_F(FlutterWindowsEngineTest, TestExitCancel) {
   ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([]() { return true; });
   EXPECT_CALL(*handler, Quit).Times(0);
   modifier.SetLifecycleManager(std::move(handler));
-  // engine->OnApplicationLifecycleEnabled();
   engine->lifecycle_manager()->BeginProcessingExit();
 
   auto binary_messenger =
@@ -804,7 +802,6 @@ TEST_F(FlutterWindowsEngineTest, TestExitSecondCloseMessage) {
                 hwnd, msg, wparam, lparam);
           });
   modifier.SetLifecycleManager(std::move(handler));
-  // engine->OnApplicationLifecycleEnabled();
   engine->lifecycle_manager()->BeginProcessingExit();
 
   engine->Run();
@@ -856,7 +853,6 @@ TEST_F(FlutterWindowsEngineTest, TestExitCloseMultiWindow) {
   // Quit should not be called when there is more than one window.
   EXPECT_CALL(*handler, Quit).Times(0);
   modifier.SetLifecycleManager(std::move(handler));
-  // engine->OnApplicationLifecycleEnabled();
   engine->lifecycle_manager()->BeginProcessingExit();
 
   engine->Run();
@@ -905,7 +901,6 @@ TEST_F(FlutterWindowsEngineTest, EnableApplicationLifecycle) {
   });
   EXPECT_CALL(*handler, IsLastWindowOfProcess).Times(1);
   modifier.SetLifecycleManager(std::move(handler));
-  //engine->OnApplicationLifecycleEnabled();
   engine->lifecycle_manager()->BeginProcessingExit();
 
   engine->window_proc_delegate_manager()->OnTopLevelWindowProc(0, WM_CLOSE, 0,
@@ -1060,7 +1055,6 @@ TEST_F(FlutterWindowsEngineTest, EnableLifecycleState) {
   EXPECT_FALSE(finished);
 
   // Test that we can set the state afterwards.
-  // engine->OnApplicationLifecycleEnabled();
 
   engine->lifecycle_manager()->BeginProcessingLifecycle();
   view.OnWindowStateEvent(hwnd, WindowStateEvent::kShow);

--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -498,7 +498,7 @@ void PlatformHandler::HandleMethodCall(
 
     SystemSoundPlay(sound_type.GetString(), std::move(result));
   } else if (method.compare(kInitializationCompleteMethod) == 0) {
-    engine_->OnApplicationLifecycleEnabled();
+    // Deprecated but should not cause an error.
     result->Success();
   } else {
     result->NotImplemented();

--- a/shell/platform/windows/windows_lifecycle_manager.cc
+++ b/shell/platform/windows/windows_lifecycle_manager.cc
@@ -49,7 +49,7 @@ bool WindowsLifecycleManager::WindowProc(HWND hwnd,
     // is, we re-dispatch a new WM_CLOSE message. In order to allow the new
     // message to reach other delegates, we ignore it here.
     case WM_CLOSE: {
-      if (!process_lifecycle_) {
+      if (!process_exit_) {
         return false;
       }
       auto key = std::make_tuple(hwnd, wpar, lpar);
@@ -181,6 +181,10 @@ bool WindowsLifecycleManager::IsLastWindowOfProcess() {
 
 void WindowsLifecycleManager::BeginProcessingLifecycle() {
   process_lifecycle_ = true;
+}
+
+void WindowsLifecycleManager::BeginProcessingExit() {
+  process_exit_ = true;
 }
 
 // TODO(schectman): Wait until the platform channel is registered to send

--- a/shell/platform/windows/windows_lifecycle_manager.h
+++ b/shell/platform/windows/windows_lifecycle_manager.h
@@ -52,9 +52,11 @@ class WindowsLifecycleManager {
   // update the application lifecycle.
   bool WindowProc(HWND hwnd, UINT msg, WPARAM w, LPARAM l, LRESULT* result);
 
-  // Signal to start consuming WM_CLOSE messages and sending lifecycle state
-  // update messages.
+  // Signal to start  sending lifecycle state update messages.
   virtual void BeginProcessingLifecycle();
+
+  // Signal to start consuming WM_CLOSE messages.
+  virtual void BeginProcessingExit();
 
   // Update the app lifecycle state in response to a change in window state.
   // When the app lifecycle state actually changes, this sends a platform
@@ -102,6 +104,7 @@ class WindowsLifecycleManager {
   std::map<std::tuple<HWND, WPARAM, LPARAM>, int> sent_close_messages_;
 
   bool process_lifecycle_ = false;
+  bool process_exit_ = false;
 
   std::set<HWND> visible_windows_;
 


### PR DESCRIPTION
Supplant the temporary solution https://github.com/flutter/engine/pull/44238 with a more elegant solution with am embedder API callback. The windows engine provides a callback that enables graceful exit and app lifecycle when the platform and lifecycle channels are listened to, respectively.

https://github.com/flutter/flutter/issues/131616

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
