### PR TITLE
[web] Set default test timeout to 5 minutes

### DIFF
--- a/lib/web_ui/dev/steps/run_suite_step.dart
+++ b/lib/web_ui/dev/steps/run_suite_step.dart
@@ -85,9 +85,7 @@ class RunSuiteStep implements PipelineStep {
       '--precompiled=$bundleBuildPath',
       '--configuration=$configurationFilePath',
       if (AnsiColors.shouldEscape) '--color' else '--no-color',
-
-      // TODO(jacksongardner): Set the default timeout to five minutes when
-      // https://github.com/dart-lang/test/issues/2006 is fixed.
+      '--timeout=5m',
       '--',
       ..._collectTestPaths(),
     ];


### PR DESCRIPTION
The underlying issue preventing us from setting the default timeout has been closed, so we should be okay to change the default timeout to 5 minutes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
