### PR TITLE
Flush pending graphics commands when the unref queue is drained on the IO thread

### DIFF
--- a/flow/skia_gpu_object.h
+++ b/flow/skia_gpu_object.h
@@ -128,6 +128,8 @@ class UnrefQueue : public fml::RefCountedThreadSafe<UnrefQueue<T>> {
       if (!skia_objects.empty()) {
         context->performDeferredCleanup(std::chrono::milliseconds(0));
       }
+
+      context->flushAndSubmit(true);
     }
   }
 

--- a/flow/skia_gpu_object_unittests.cc
+++ b/flow/skia_gpu_object_unittests.cc
@@ -43,6 +43,7 @@ class TestResourceContext : public TestSkObject {
   ~TestResourceContext() = default;
   void performDeferredCleanup(std::chrono::milliseconds msNotUsed) {}
   void deleteBackendTexture(const GrBackendTexture& texture) {}
+  void flushAndSubmit(bool syncCpu) {}
 };
 
 class SkiaGpuObjectTest : public ThreadTest {


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/131524