### PR TITLE
Don't run clang_tidy --lint-all in presubmit

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -210,6 +210,7 @@ targets:
 
   - name: Linux linux_clang_tidy
     recipe: engine_v2/engine_v2
+    presubmit: false
     timeout: 120
     properties:
       config_name: linux_clang_tidy
@@ -227,7 +228,6 @@ targets:
       - "**.vert"
 
   - name: Linux linux_clang_tidy_presubmit
-    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 120
     properties:
@@ -361,6 +361,7 @@ targets:
 
   - name: Mac mac_clang_tidy
     recipe: engine_v2/engine_v2
+    presubmit: false
     timeout: 120
     properties:
       config_name: mac_clang_tidy
@@ -380,7 +381,6 @@ targets:
       - "**.mm"
 
   - name: Mac mac_clang_tidy_presubmit
-    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 120
     properties:

--- a/ci/builders/mac_clang_tidy_presubmit.json
+++ b/ci/builders/mac_clang_tidy_presubmit.json
@@ -101,7 +101,6 @@
                     "parameters": [
                         "--variant",
                         "ios_debug_sim",
-                        "--lint-all",
                         "--shard-id=1",
                         "--shard-variants=host_debug"
                     ],


### PR DESCRIPTION
Instead, this PR runs clang_tidy only on files that have been changed.

Related https://github.com/flutter/flutter/issues/105068