### PR TITLE
[Impeller] Fix clip management for DrawPicture.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3060,6 +3060,26 @@ TEST_P(AiksTest, DrawPictureWithText) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, DrawPictureClipped) {
+  Canvas subcanvas;
+  subcanvas.ClipRRect(Rect::MakeLTRB(100, 100, 400, 400), 15);
+  subcanvas.DrawPaint({.color = Color::Red()});
+  auto picture = subcanvas.EndRecordingAsPicture();
+
+  Canvas canvas;
+  canvas.DrawPaint({.color = Color::CornflowerBlue()});
+
+  // Draw a red RRect via DrawPicture.
+  canvas.DrawPicture(picture);
+
+  // Draw over the picture with a larger green rectangle, completely covering it
+  // up.
+  canvas.ClipRRect(Rect::MakeLTRB(100, 100, 400, 400).Expand(20), 15);
+  canvas.DrawPaint({.color = Color::Green()});
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, MatrixSaveLayerFilter) {
   Canvas canvas;
   canvas.DrawPaint({.color = Color::Black()});

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -881,6 +881,22 @@ bool EntityPass::OnRender(
   return true;
 }
 
+void EntityPass::IterateAllElements(
+    const std::function<bool(Element&)>& iterator) {
+  if (!iterator) {
+    return;
+  }
+
+  for (auto& element : elements_) {
+    if (!iterator(element)) {
+      return;
+    }
+    if (auto subpass = std::get_if<std::unique_ptr<EntityPass>>(&element)) {
+      subpass->get()->IterateAllElements(iterator);
+    }
+  }
+}
+
 void EntityPass::IterateAllEntities(
     const std::function<bool(Entity&)>& iterator) {
   if (!iterator) {
@@ -973,6 +989,10 @@ void EntityPass::SetTransformation(Matrix xformation) {
 
 void EntityPass::SetStencilDepth(size_t stencil_depth) {
   stencil_depth_ = stencil_depth;
+}
+
+size_t EntityPass::GetStencilDepth() {
+  return stencil_depth_;
 }
 
 void EntityPass::SetBlendMode(BlendMode blend_mode) {

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -88,6 +88,12 @@ class EntityPass {
   bool Render(ContentContext& renderer,
               const RenderTarget& render_target) const;
 
+  /// @brief  Iterate all elements (entities and subpasses) in this pass,
+  ///         recursively including elements of child passes. The iteration
+  ///         order is depth-first. Whenever a subpass elements is encountered,
+  ///         it's included in the stream before its children.
+  void IterateAllElements(const std::function<bool(Element&)>& iterator);
+
   /// @brief  Iterate all entities in this pass, recursively including entities
   ///         of child passes. The iteration order is depth-first.
   void IterateAllEntities(const std::function<bool(Entity&)>& iterator);
@@ -110,6 +116,8 @@ class EntityPass {
   void SetTransformation(Matrix xformation);
 
   void SetStencilDepth(size_t stencil_depth);
+
+  size_t GetStencilDepth();
 
   void SetBlendMode(BlendMode blend_mode);
 


### PR DESCRIPTION
Solves two problems:
1. Fix the debug crash by restoring the clip after the `EntityPass` merge. I initially surrounded the merge with a `Save` and `Restore`, which was a mistake and is a no-op in this situation. This should have no excess impact on performance, since we ignore clips in `EntityPass` when we detect that they won't do anything.
2. Picture subpasses weren't getting their stencil depth adjusted during the merge, which can result in subpass entities potentially receiving a clip depth that's too high.

Before:

```
[ RUN      ] Play/AiksTest.DrawPictureClipped/Metal
2023-08-17 19:23:34.204 impeller_unittests[83313:21896481] Metal API Validation Enabled
2023-08-17 19:23:34.204 impeller_unittests[83313:21896481] Metal GPU Validation Enabled
[FATAL:flutter/impeller/entity/entity_pass.cc(689)] Check failed: stencil_coverage_stack.back().stencil_depth == stencil_coverage_stack.size() - 1.
[1]    83313 abort      ../out/host_debug_unopt/impeller_unittests --timeout=0  --enable_playground
```

After:

<img width="1136" alt="Screenshot 2023-08-17 at 7 41 31 PM" src="https://github.com/flutter/engine/assets/919017/6f05c9c5-ab91-4bc4-8959-e8b15f8ae3b6">
