### PR TITLE
Remove explicit mac cpu dimensions

### DIFF
--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -15,7 +15,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -54,7 +54,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -94,7 +94,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -134,7 +134,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -173,7 +173,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -213,7 +213,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -14,8 +14,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -53,8 +52,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -93,8 +91,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -133,8 +130,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -172,8 +168,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -212,8 +207,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -474,6 +474,12 @@
             "dependencies": [
                 "host_release"
             ],
+            "test_dependencies": [
+                {
+                    "dependency": "goldctl",
+                    "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"
+                }
+            ],
             "tasks": [
                 {
                     "language": "python3",

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -15,7 +15,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -63,7 +64,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -107,7 +109,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=arm64"
             ],
             "dependencies": [
                 {
@@ -162,7 +165,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+		"cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -209,7 +212,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+		"cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -253,7 +256,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+		"cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -47,21 +47,7 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "14e300c"
                 }
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_debug",
-                    "parameters": [
-                        "--variant",
-                        "host_debug",
-                        "--type",
-                        "dart,engine",
-                        "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                }
-            ]
+            }
         },
         {
             "archives": [
@@ -469,6 +455,37 @@
             "source": "out/release/snapshot/gen_snapshot.zip",
             "destination": "darwin-x64-release/gen_snapshot.zip",
             "realm": "production"
+        }
+    ],
+    "tests": [
+        {
+            "name": "Mac Host Tests for host_debug",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=x86"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug"
+            ],
+            "tasks": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--type",
+                        "dart,engine",
+                        "--engine-capture-core-dump"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                }
+            ]
         }
     ]
 }

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -15,9 +15,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86",
-                "mac_model=Macmini8,1"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -79,9 +77,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86",
-                "mac_model=Macmini8,1"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -139,9 +135,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86",
-                "mac_model=Macmini8,1"
+                "os=Mac-12"
             ],
             "dependencies": [
                 {

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -158,20 +158,7 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "14e300c"
                 }
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Impeller-golden, dart and engine tests for host_release",
-                    "parameters": [
-                        "--variant",
-                        "host_release",
-                        "--type",
-                        "dart,engine,impeller-golden"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                }
-            ]
+            }
         },
         {
             "archives": [
@@ -482,6 +469,34 @@
                         "--type",
                         "dart,engine",
                         "--engine-capture-core-dump"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                }
+            ]
+        },
+        {
+            "name": "Mac Impeller-golden, dart and engine tests for host_release",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=x86"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_release"
+            ],
+            "tasks": [
+                {
+                    "language": "python3",
+                    "name": "Impeller-golden, dart and engine tests for host_release",
+                    "parameters": [
+                        "--variant",
+                        "host_release",
+                        "--type",
+                        "dart,engine,impeller-golden"
                     ],
                     "script": "flutter/testing/run_tests.py"
                 }

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -90,21 +90,7 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "14e300c"
                 }
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_profile",
-                    "parameters": [
-                        "--variant",
-                        "host_profile",
-                        "--type",
-                        "dart,engine",
-                        "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                }
-            ]
+            }
         },
         {
             "archives": [
@@ -497,6 +483,35 @@
                         "host_release",
                         "--type",
                         "dart,engine,impeller-golden"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                }
+            ]
+        },
+        {
+            "name": "Mac Host Tests for host_profile",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=x86"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_profile"
+            ],
+            "tasks": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_profile",
+                    "parameters": [
+                        "--variant",
+                        "host_profile",
+                        "--type",
+                        "dart,engine",
+                        "--engine-capture-core-dump"
                     ],
                     "script": "flutter/testing/run_tests.py"
                 }

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -15,8 +15,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -64,8 +63,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -109,8 +107,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "dependencies": [
                 {
@@ -164,8 +161,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -211,8 +207,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -255,8 +250,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -3,7 +3,6 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [
@@ -26,7 +25,6 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [
@@ -50,7 +48,6 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [
@@ -74,7 +71,6 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [
@@ -99,7 +95,6 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -3,8 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",
@@ -26,8 +25,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",
@@ -50,8 +48,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",
@@ -74,8 +71,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",
@@ -99,8 +95,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-		"cpu=arm64"
+                "os=Mac-12"
             ],
             "gn": [
                 "--ios",

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -3,7 +3,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=arm64"
             ],
             "gn": [
                 "--ios",
@@ -25,7 +26,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=arm64"
             ],
             "gn": [
                 "--ios",
@@ -48,7 +50,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=arm64"
             ],
             "gn": [
                 "--ios",
@@ -71,7 +74,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=arm64"
             ],
             "gn": [
                 "--ios",
@@ -95,7 +99,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=arm64"
             ],
             "gn": [
                 "--ios",

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -103,7 +103,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=arm64"
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -11,9 +11,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86",
-                "mac_model=Macmini8,1"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -292,6 +292,15 @@
             "contexts": [
                 "osx_sdk"
             ],
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "runtime_versions": [
+                        "ios-16-4_14e300c",
+                        "ios-16-2_14c18"
+                    ],
+                    "sdk_version": "14e300c"
+                }
+            },
             "tasks": [
                 {
                     "language": "python3",

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -75,30 +75,7 @@
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
                 ]
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Tests for ios_debug_sim",
-                    "parameters": [
-                        "--variant",
-                        "ios_debug_sim",
-                        "--type",
-                        "objc",
-                        "--engine-capture-core-dump",
-                        "--ios-variant",
-                        "ios_debug_sim"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                },
-                {
-                    "name": "Scenario App Integration Tests",
-                    "parameters": [
-                        "ios_debug_sim"
-                    ],
-                    "script": "flutter/testing/scenario_app/run_ios_tests.sh"
-                }
-            ]
+            }
         },
         {
             "archives": [
@@ -181,30 +158,7 @@
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
                 ]
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Tests for ios_debug_sim_arm64",
-                    "parameters": [
-                        "--variant",
-                        "ios_debug_sim_arm64",
-                        "--type",
-                        "objc",
-                        "--engine-capture-core-dump",
-                        "--ios-variant",
-                        "ios_debug_sim_arm64"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                },
-                {
-                    "name": "Scenario App Integration Tests",
-                    "parameters": [
-                        "ios_debug_sim_arm64"
-                    ],
-                    "script": "flutter/testing/scenario_app/run_ios_tests.sh"
-                }
-            ]
+            }
         },
         {
             "archives": [
@@ -250,7 +204,129 @@
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
                 ]
+            }
+        }
+    ],
+    "tests": [
+        {
+            "name": "Mac Host Tests for host_debug_unopt",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
             },
+            "dependencies": [
+                "host_debug_unopt"
+            ],
+            "tasks": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_debug_unopt",
+                    "parameters": [
+                        "--variant",
+                        "host_debug_unopt",
+                        "--type",
+                        "dart,engine",
+                        "--engine-capture-core-dump"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                }
+            ]
+        },
+        {
+            "name": "Mac Tests for ios_debug_sim",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "ios_debug_sim"
+            ],
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Tests for ios_debug_sim",
+                    "parameters": [
+                        "--variant",
+                        "ios_debug_sim",
+                        "--type",
+                        "objc",
+                        "--engine-capture-core-dump",
+                        "--ios-variant",
+                        "ios_debug_sim"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                },
+                {
+                    "name": "Scenario App Integration Tests",
+                    "parameters": [
+                        "ios_debug_sim"
+                    ],
+                    "script": "flutter/testing/scenario_app/run_ios_tests.sh"
+                }
+            ]
+        },
+        {
+            "name": "Mac Tests for ios_debug_sim_arm64",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "ios_debug_sim_arm64"
+            ],
+            "tasks": [
+                {
+                    "language": "python3",
+                    "name": "Tests for ios_debug_sim_arm64",
+                    "parameters": [
+                        "--variant",
+                        "ios_debug_sim_arm64",
+                        "--type",
+                        "objc",
+                        "--engine-capture-core-dump",
+                        "--ios-variant",
+                        "ios_debug_sim_arm64"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                },
+                {
+                    "name": "Scenario App Integration Tests",
+                    "parameters": [
+                        "ios_debug_sim_arm64"
+                    ],
+                    "script": "flutter/testing/scenario_app/run_ios_tests.sh"
+                }
+            ]
+        },
+        {
+            "name": "Mac Tests for ios_debug_sim_arm64_extension_safe",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "ios_debug_sim_arm64_extension_safe"
+            ],
             "tests": [
                 {
                     "language": "python3",
@@ -272,37 +348,6 @@
                         "ios_debug_sim_arm64_extension_safe"
                     ],
                     "script": "flutter/testing/scenario_app/run_ios_tests.sh"
-                }
-            ]
-        }
-    ],
-    "tests": [
-        {
-            "name": "Mac Host Tests for host_debug_unopt",
-            "recipe": "engine_v2/tester_engine",
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "dependencies": [
-                "host_debug"
-            ],
-            "tasks": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_debug_unopt",
-                    "parameters": [
-                        "--variant",
-                        "host_debug_unopt",
-                        "--type",
-                        "dart,engine",
-                        "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
                 }
             ]
         }

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -1,14 +1,6 @@
 {
     "builds": [
         {
-            "archives": [
-                {
-                    "base_path": "out/host_debug_unopt/zip_archives/",
-                    "type": "gcs",
-                    "include_paths": [],
-                    "name": "host_debug_unopt"
-                }
-            ],
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
@@ -36,14 +28,6 @@
             }
         },
         {
-            "archives": [
-                {
-                    "base_path": "out/ios_debug_sim/zip_archives/",
-                    "type": "gcs",
-                    "include_paths": [],
-                    "name": "ios_debug_sim"
-                }
-            ],
             "properties": {
                 "$flutter/osx_sdk": {
                     "runtime_versions": [
@@ -56,7 +40,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=arm64"
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -78,14 +62,6 @@
             }
         },
         {
-            "archives": [
-                {
-                    "base_path": "out/host_debug_unopt_arm64/zip_archives/",
-                    "type": "gcs",
-                    "include_paths": [],
-                    "name": "host_debug_unopt_arm64"
-                }
-            ],
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
@@ -106,8 +82,7 @@
             ],
             "name": "host_debug_unopt_arm64",
             "ninja": {
-                "config": "host_debug_unopt_arm64",
-                "targets": []
+                "config": "host_debug_unopt_arm64"
             },
             "properties": {
                 "$flutter/osx_sdk": {
@@ -116,14 +91,6 @@
             }
         },
         {
-            "archives": [
-                {
-                    "base_path": "out/ios_debug_sim_arm64/zip_archives/",
-                    "type": "gcs",
-                    "include_paths": [],
-                    "name": "ios_debug_sim_arm64"
-                }
-            ],
             "properties": {
                 "$flutter/osx_sdk": {
                     "runtime_versions": [
@@ -161,14 +128,6 @@
             }
         },
         {
-            "archives": [
-                {
-                    "base_path": "out/ios_debug_sim_arm64_extension_safe/zip_archives/",
-                    "type": "gcs",
-                    "include_paths": [],
-                    "name": "ios_debug_sim_arm64_extension_safe"
-                }
-            ],
             "properties": {
                 "$flutter/osx_sdk": {
                     "runtime_versions": [

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -281,7 +281,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=arm64"
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -281,13 +281,16 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
             },
             "dependencies": [
                 "ios_debug_sim_arm64"
+            ],
+            "contexts": [
+                "osx_sdk"
             ],
             "tasks": [
                 {

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -281,7 +281,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -11,7 +11,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+		"cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -69,7 +70,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-                "cpu=x86"
+		"cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -3,8 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -39,8 +38,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -64,8 +62,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -102,8 +99,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -139,8 +135,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -172,8 +167,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -201,8 +195,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -239,8 +232,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -289,8 +281,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=arm64"
+                "os=Mac-12"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -12,7 +12,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-		"cpu=arm64"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -33,21 +33,7 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "14e300c"
                 }
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_debug_unopt",
-                    "parameters": [
-                        "--variant",
-                        "host_debug_unopt",
-                        "--type",
-                        "dart,engine",
-                        "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                }
-            ]
+            }
         },
         {
             "archives": [
@@ -70,7 +56,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-		"cpu=arm64"
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -119,8 +105,7 @@
                 {
                     "base_path": "out/host_debug_unopt_arm64/zip_archives/",
                     "type": "gcs",
-                    "include_paths": [
-                    ],
+                    "include_paths": [],
                     "name": "host_debug_unopt_arm64"
                 }
             ],
@@ -133,20 +118,19 @@
                 "download_android_deps": false
             },
             "gn": [
-               "--runtime-mode",
-               "debug",
-               "--unoptimized",
-               "--no-lto",
-               "--prebuilt-dart-sdk",
-               "--force-mac-arm64",
-               "--mac-cpu",
-               "arm64"
+                "--runtime-mode",
+                "debug",
+                "--unoptimized",
+                "--no-lto",
+                "--prebuilt-dart-sdk",
+                "--force-mac-arm64",
+                "--mac-cpu",
+                "arm64"
             ],
             "name": "host_debug_unopt_arm64",
             "ninja": {
                 "config": "host_debug_unopt_arm64",
-                "targets": [
-                ]
+                "targets": []
             },
             "properties": {
                 "$flutter/osx_sdk": {
@@ -159,8 +143,7 @@
                 {
                     "base_path": "out/ios_debug_sim_arm64/zip_archives/",
                     "type": "gcs",
-                    "include_paths": [
-                    ],
+                    "include_paths": [],
                     "name": "ios_debug_sim_arm64"
                 }
             ],
@@ -221,7 +204,6 @@
                     ],
                     "script": "flutter/testing/scenario_app/run_ios_tests.sh"
                 }
-
             ]
         },
         {
@@ -229,8 +211,7 @@
                 {
                     "base_path": "out/ios_debug_sim_arm64_extension_safe/zip_archives/",
                     "type": "gcs",
-                    "include_paths": [
-                    ],
+                    "include_paths": [],
                     "name": "ios_debug_sim_arm64_extension_safe"
                 }
             ],
@@ -292,7 +273,37 @@
                     ],
                     "script": "flutter/testing/scenario_app/run_ios_tests.sh"
                 }
-
+            ]
+        }
+    ],
+    "tests": [
+        {
+            "name": "Mac Host Tests for host_debug_unopt",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=x86"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "dependencies": [
+                "host_debug"
+            ],
+            "tasks": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_debug_unopt",
+                    "parameters": [
+                        "--variant",
+                        "host_debug_unopt",
+                        "--type",
+                        "dart,engine",
+                        "--engine-capture-core-dump"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                }
             ]
         }
     ]


### PR DESCRIPTION
Running builds and tests on x64 machines is causing long queue times even when there is plenty of arm64 machines. This PR is removing most of the cpu pinned dimensions and it is separating some of the test to global tests to allow to select x64 machines only for the tests part. 