### PR TITLE
[macOS,iOS] Expose channel buffers 'resize' and 'overflow' control co…

### DIFF
--- a/shell/platform/darwin/common/framework/Headers/FlutterChannels.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterChannels.h
@@ -143,8 +143,45 @@ FLUTTER_DARWIN_EXPORT
  * Adjusts the number of messages that will get buffered when sending messages to
  * channels that aren't fully set up yet.  For example, the engine isn't running
  * yet or the channel's message handler isn't set up on the Dart side yet.
+ *
+ * @param name The channel name.
+ * @param messenger The binary messenger.
+ * @param newSize The new size of the buffer.
+ */
++ (void)resizeChannelWithName:(NSString*)name
+              binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger
+                      newSize:(NSInteger)newSize;
+
+/**
+ * Adjusts the number of messages that will get buffered when sending messages to
+ * channels that aren't fully set up yet.  For example, the engine isn't running
+ * yet or the channel's message handler isn't set up on the Dart side yet.
+ *
+ * @param newSize The new size of the buffer.
  */
 - (void)resizeChannelBuffer:(NSInteger)newSize;
+
+/**
+ * Toggles whether the channel should show warning messages when discarding messages
+ * due to overflow.
+ *
+ * @param name The channel name.
+ * @param messenger The binary messenger.
+ * @param allowed When true, the channel is expected to overflow and warning messages
+ *                will not be shown.
+ */
++ (void)setAllowOverflowChannelWithName:(NSString*)name
+                        binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger
+                                allowed:(BOOL)allowed;
+
+/**
+ * Toggles whether the channel should show warning messages when discarding messages
+ * due to overflow.
+ *
+ * @param allowed When true, the channel is expected to overflow and warning messages
+ *                will not be shown.
+ */
+- (void)setAllowOverflow:(BOOL)allowed;
 
 @end
 

--- a/shell/platform/darwin/common/framework/Headers/FlutterChannels.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterChannels.h
@@ -146,42 +146,42 @@ FLUTTER_DARWIN_EXPORT
  *
  * @param name The channel name.
  * @param messenger The binary messenger.
- * @param newSize The new size of the buffer.
+ * @param newSize The number of messages that will get buffered.
  */
 + (void)resizeChannelWithName:(NSString*)name
               binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger
-                      newSize:(NSInteger)newSize;
+                         size:(NSInteger)newSize;
 
 /**
  * Adjusts the number of messages that will get buffered when sending messages to
  * channels that aren't fully set up yet.  For example, the engine isn't running
  * yet or the channel's message handler isn't set up on the Dart side yet.
  *
- * @param newSize The new size of the buffer.
+ * @param newSize The number of messages that will get buffered.
  */
 - (void)resizeChannelBuffer:(NSInteger)newSize;
 
 /**
- * Toggles whether the channel should show warning messages when discarding messages
+ * Defines whether the channel should show warning messages when discarding messages
  * due to overflow.
  *
+ * @param allowed When true, the channel is expected to overflow and warning messages
+ *                will not be shown.
  * @param name The channel name.
  * @param messenger The binary messenger.
- * @param allowed When true, the channel is expected to overflow and warning messages
- *                will not be shown.
  */
-+ (void)setAllowOverflowChannelWithName:(NSString*)name
-                        binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger
-                                allowed:(BOOL)allowed;
++ (void)setWarnsOnOverflow:(BOOL)allowed
+        forChannelWithName:(NSString*)name
+           binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
 
 /**
- * Toggles whether the channel should show warning messages when discarding messages
+ * Defines whether the channel should show warning messages when discarding messages
  * due to overflow.
  *
  * @param allowed When true, the channel is expected to overflow and warning messages
  *                will not be shown.
  */
-- (void)setAllowOverflow:(BOOL)allowed;
+- (void)setWarnsOnOverflow:(BOOL)allowed;
 
 @end
 

--- a/shell/platform/darwin/common/framework/Headers/FlutterChannels.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterChannels.h
@@ -165,12 +165,12 @@ FLUTTER_DARWIN_EXPORT
  * Defines whether the channel should show warning messages when discarding messages
  * due to overflow.
  *
- * @param allowed When true, the channel is expected to overflow and warning messages
- *                will not be shown.
+ * @param warns When false, the channel is expected to overflow and warning messages
+ *              will not be shown.
  * @param name The channel name.
  * @param messenger The binary messenger.
  */
-+ (void)setWarnsOnOverflow:(BOOL)allowed
++ (void)setWarnsOnOverflow:(BOOL)warns
         forChannelWithName:(NSString*)name
            binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
 
@@ -178,10 +178,10 @@ FLUTTER_DARWIN_EXPORT
  * Defines whether the channel should show warning messages when discarding messages
  * due to overflow.
  *
- * @param allowed When true, the channel is expected to overflow and warning messages
- *                will not be shown.
+ * @param warns When false, the channel is expected to overflow and warning messages
+ *              will not be shown.
  */
-- (void)setWarnsOnOverflow:(BOOL)allowed;
+- (void)setWarnsOnOverflow:(BOOL)warns;
 
 @end
 

--- a/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
@@ -16,7 +16,10 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
                                 NSString* channel,
                                 NSInteger newSize) {
   NSCAssert(newSize >= 0, @"Channel buffer size must be non-negative");
-  NSArray* args = @[ channel, @(newSize) ];
+  // Cast newSize to int because the deserialization logic handles only 32 bits values,
+  // see
+  // https://github.com/flutter/engine/blob/93e8901490e78c7ba7e319cce4470d9c6478c6dc/lib/ui/channel_buffers.dart#L495.
+  NSArray* args = @[ channel, @((int)newSize) ];
   FlutterMethodCall* resizeMethodCall = [FlutterMethodCall methodCallWithMethodName:kResizeMethod
                                                                           arguments:args];
   NSObject<FlutterMethodCodec>* codec = [FlutterStandardMethodCodec sharedInstance];

--- a/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
@@ -19,7 +19,7 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
   // Cast newSize to int because the deserialization logic handles only 32 bits values,
   // see
   // https://github.com/flutter/engine/blob/93e8901490e78c7ba7e319cce4470d9c6478c6dc/lib/ui/channel_buffers.dart#L495.
-  NSArray* args = @[ channel, @((int)newSize) ];
+  NSArray* args = @[ channel, @(static_cast<int>(newSize)) ];
   FlutterMethodCall* resizeMethodCall = [FlutterMethodCall methodCallWithMethodName:kResizeMethod
                                                                           arguments:args];
   NSObject<FlutterMethodCodec>* codec = [FlutterStandardMethodCodec sharedInstance];
@@ -33,15 +33,15 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
  *
  * @param binaryMessenger The binary messenger.
  * @param channel The channel name.
- * @param allowed When true, the channel is expected to overflow and warning messages
- *                will not be shown.
+ * @param warns When false, the channel is expected to overflow and warning messages
+ *              will not be shown.
  */
 static void SetWarnsOnOverflow(NSObject<FlutterBinaryMessenger>* binaryMessenger,
                                NSString* channel,
-                               BOOL allowed) {
-  NSArray* args = @[ channel, @(allowed) ];
+                               BOOL warns) {
   FlutterMethodCall* overflowMethodCall =
-      [FlutterMethodCall methodCallWithMethodName:kOverflowMethod arguments:args];
+      [FlutterMethodCall methodCallWithMethodName:kOverflowMethod
+                                        arguments:@[ channel, @(!warns) ]];
   NSObject<FlutterMethodCodec>* codec = [FlutterStandardMethodCodec sharedInstance];
   NSData* message = [codec encodeMethodCall:overflowMethodCall];
   [binaryMessenger sendOnChannel:kFlutterChannelBuffersChannel message:message];
@@ -153,14 +153,14 @@ static FlutterBinaryMessengerConnection SetMessageHandler(
   ResizeChannelBuffer(_messenger, _name, newSize);
 }
 
-+ (void)setWarnsOnOverflow:(BOOL)allowed
++ (void)setWarnsOnOverflow:(BOOL)warns
         forChannelWithName:(NSString*)name
            binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger {
-  SetWarnsOnOverflow(messenger, name, allowed);
+  SetWarnsOnOverflow(messenger, name, warns);
 }
 
-- (void)setWarnsOnOverflow:(BOOL)allowed {
-  SetWarnsOnOverflow(_messenger, _name, allowed);
+- (void)setWarnsOnOverflow:(BOOL)warns {
+  SetWarnsOnOverflow(_messenger, _name, warns);
 }
 
 @end

--- a/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
@@ -188,7 +188,7 @@ FLUTTER_ASSERT_ARC
   NSData* expectedMessage = [NSData dataWithBytes:bytes length:sizeof(bytes)];
 
   OCMExpect([binaryMessenger sendOnChannel:@"dev.flutter/channel-buffers" message:expectedMessage]);
-  [channel setWarnsOnOverflow:YES];
+  [channel setWarnsOnOverflow:NO];
   OCMVerifyAll(binaryMessenger);
   [binaryMessenger stopMocking];
 }

--- a/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
@@ -147,7 +147,7 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testResize {
-  NSString* channelName = @"foo";
+  NSString* channelName = @"flutter/test";
   id binaryMessenger = OCMStrictProtocolMock(@protocol(FlutterBinaryMessenger));
   id codec = OCMProtocolMock(@protocol(FlutterMethodCodec));
   FlutterBasicMessageChannel* channel =
@@ -156,11 +156,39 @@ FLUTTER_ASSERT_ARC
                                                  codec:codec];
   XCTAssertNotNil(channel);
 
-  NSString* expectedMessageString =
-      [NSString stringWithFormat:@"resize\r%@\r%@", channelName, @100];
-  NSData* expectedMessage = [expectedMessageString dataUsingEncoding:NSUTF8StringEncoding];
+  // The expected content was created from the following Dart code:
+  //   MethodCall call = MethodCall('resize', ['flutter/test',3]);
+  //   StandardMethodCodec().encodeMethodCall(call).buffer.asUint8List();
+  const unsigned char bytes[] = {7,   6,   114, 101, 115, 105, 122, 101, 12,  2,
+                                 7,   12,  102, 108, 117, 116, 116, 101, 114, 47,
+                                 116, 101, 115, 116, 3,   3,   0,   0,   0};
+  NSData* expectedMessage = [NSData dataWithBytes:bytes length:sizeof(bytes)];
+
   OCMExpect([binaryMessenger sendOnChannel:@"dev.flutter/channel-buffers" message:expectedMessage]);
-  [channel resizeChannelBuffer:100];
+  [channel resizeChannelBuffer:3];
+  OCMVerifyAll(binaryMessenger);
+  [binaryMessenger stopMocking];
+}
+
+- (bool)testetAllowChannelOverflow {
+  NSString* channelName = @"flutter/test";
+  id binaryMessenger = OCMStrictProtocolMock(@protocol(FlutterBinaryMessenger));
+  id codec = OCMProtocolMock(@protocol(FlutterMethodCodec));
+  FlutterBasicMessageChannel* channel =
+      [[FlutterBasicMessageChannel alloc] initWithName:channelName
+                                       binaryMessenger:binaryMessenger
+                                                 codec:codec];
+  XCTAssertNotNil(channel);
+
+  // The expected content was created from the following Dart code:
+  //   MethodCall call = MethodCall('overflow',['flutter/test', true]);
+  //   StandardMethodCodec().encodeMethodCall(call).buffer.asUint8List();
+  const unsigned char bytes[] = {7,   8,   111, 118, 101, 114, 102, 108, 111, 119, 12,  2,   7, 12,
+                                 102, 108, 117, 116, 116, 101, 114, 47,  116, 101, 115, 116, 1};
+  NSData* expectedMessage = [NSData dataWithBytes:bytes length:sizeof(bytes)];
+
+  OCMExpect([binaryMessenger sendOnChannel:@"dev.flutter/channel-buffers" message:expectedMessage]);
+  [channel setAllowOverflow:YES];
   OCMVerifyAll(binaryMessenger);
   [binaryMessenger stopMocking];
 }

--- a/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
@@ -170,7 +170,7 @@ FLUTTER_ASSERT_ARC
   [binaryMessenger stopMocking];
 }
 
-- (bool)testetAllowChannelOverflow {
+- (bool)testSetWarnsOnOverflow {
   NSString* channelName = @"flutter/test";
   id binaryMessenger = OCMStrictProtocolMock(@protocol(FlutterBinaryMessenger));
   id codec = OCMProtocolMock(@protocol(FlutterMethodCodec));
@@ -188,7 +188,7 @@ FLUTTER_ASSERT_ARC
   NSData* expectedMessage = [NSData dataWithBytes:bytes length:sizeof(bytes)];
 
   OCMExpect([binaryMessenger sendOnChannel:@"dev.flutter/channel-buffers" message:expectedMessage]);
-  [channel setAllowOverflow:YES];
+  [channel setWarnsOnOverflow:YES];
   OCMVerifyAll(binaryMessenger);
   [binaryMessenger stopMocking];
 }


### PR DESCRIPTION
## Description

This PR update the helper function that invokes the control channel 'resize' command (previous implementation relied on a deprecated format). It also adds a similar helper function for the 'overflow' commands exposed by the control channel.

See:

https://github.com/flutter/engine/blob/93e8901490e78c7ba7e319cce4470d9c6478c6dc/lib/ui/channel_buffers.dart#L302-L309

## Related Issue

iOS and macOS implementation for https://github.com/flutter/flutter/issues/132386

Similar implementations:
- Android: https://github.com/flutter/engine/pull/44434
- Linux: https://github.com/flutter/engine/pull/44636

## Tests

Adds two tests.