### PR TITLE
Ignore unguarded-availability for unit test

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -227,6 +227,11 @@ source_set("ios_test_flutter_mrc") {
     "-F$platform_frameworks_path",
     "-mios-simulator-version-min=$ios_testing_deployment_target",
   ]
+
+  # An XCode15-beta has a bug where iOS 17 API usage is not guarded.
+  # This bug results engine build failure since the engine treats warnings as errors.
+  # The `-Wno-unguarded-availability-new` can be removed when the XCode bug is fixed.
+  # See details in https://github.com/flutter/flutter/issues/128958.
   cflags_objcc = [ "-Wno-unguarded-availability-new" ]
   sources = [
     "framework/Source/FlutterEnginePlatformViewTest.mm",
@@ -272,6 +277,11 @@ shared_library("ios_test_flutter") {
     "-fobjc-arc",
     "-mios-simulator-version-min=$ios_testing_deployment_target",
   ]
+
+  # An XCode15-beta has a bug where iOS 17 API usage is not guarded.
+  # This bug results engine build failure since the engine treats warnings as errors.
+  # The `-Wno-unguarded-availability-new` can be removed when the XCode bug is fixed.
+  # See details in https://github.com/flutter/flutter/issues/128958.
   cflags_objcc = [ "-Wno-unguarded-availability-new" ]
   ldflags = [
     "-F$platform_frameworks_path",

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -227,6 +227,9 @@ source_set("ios_test_flutter_mrc") {
     "-F$platform_frameworks_path",
     "-mios-simulator-version-min=$ios_testing_deployment_target",
   ]
+  cflags_objcc = [
+    "-Wno-unguarded-availability-new",
+  ]
   sources = [
     "framework/Source/FlutterEnginePlatformViewTest.mm",
     "framework/Source/FlutterEngineTest_mrc.mm",
@@ -270,6 +273,9 @@ shared_library("ios_test_flutter") {
     "-F$platform_frameworks_path",
     "-fobjc-arc",
     "-mios-simulator-version-min=$ios_testing_deployment_target",
+  ]
+  cflags_objcc = [
+    "-Wno-unguarded-availability-new",
   ]
   ldflags = [
     "-F$platform_frameworks_path",

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -228,7 +228,7 @@ source_set("ios_test_flutter_mrc") {
     "-mios-simulator-version-min=$ios_testing_deployment_target",
   ]
 
-  # An XCode15-beta has a bug where iOS 17 API usage is not guarded.
+  # XCode 15 beta has a bug where iOS 17 API usage is not guarded.
   # This bug results engine build failure since the engine treats warnings as errors.
   # The `-Wno-unguarded-availability-new` can be removed when the XCode bug is fixed.
   # See details in https://github.com/flutter/flutter/issues/128958.
@@ -278,7 +278,7 @@ shared_library("ios_test_flutter") {
     "-mios-simulator-version-min=$ios_testing_deployment_target",
   ]
 
-  # An XCode15-beta has a bug where iOS 17 API usage is not guarded.
+  # XCode 15 beta has a bug where iOS 17 API usage is not guarded.
   # This bug results engine build failure since the engine treats warnings as errors.
   # The `-Wno-unguarded-availability-new` can be removed when the XCode bug is fixed.
   # See details in https://github.com/flutter/flutter/issues/128958.

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -227,9 +227,7 @@ source_set("ios_test_flutter_mrc") {
     "-F$platform_frameworks_path",
     "-mios-simulator-version-min=$ios_testing_deployment_target",
   ]
-  cflags_objcc = [
-    "-Wno-unguarded-availability-new",
-  ]
+  cflags_objcc = [ "-Wno-unguarded-availability-new" ]
   sources = [
     "framework/Source/FlutterEnginePlatformViewTest.mm",
     "framework/Source/FlutterEngineTest_mrc.mm",
@@ -274,9 +272,7 @@ shared_library("ios_test_flutter") {
     "-fobjc-arc",
     "-mios-simulator-version-min=$ios_testing_deployment_target",
   ]
-  cflags_objcc = [
-    "-Wno-unguarded-availability-new",
-  ]
+  cflags_objcc = [ "-Wno-unguarded-availability-new" ]
   ldflags = [
     "-F$platform_frameworks_path",
     "-Wl,-install_name,@rpath/Frameworks/libios_test_flutter.dylib",


### PR DESCRIPTION
Ignore ungarded-availability for unit test

fixes https://github.com/flutter/flutter/issues/128958

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
