### PR TITLE
FlutterFragment predictive back

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -521,6 +521,7 @@ public class FlutterFragmentActivity extends FragmentActivity
             ? TransparencyMode.opaque
             : TransparencyMode.transparent;
     final boolean shouldDelayFirstAndroidViewDraw = renderMode == RenderMode.surface;
+    final boolean shouldAutomaticallyHandleOnBackPressed = Build.VERSION.SDK_INT >= 33;
 
     if (getCachedEngineId() != null) {
       Log.v(
@@ -545,8 +546,7 @@ public class FlutterFragmentActivity extends FragmentActivity
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
           .destroyEngineWithFragment(shouldDestroyEngineWithHost())
           .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
-          // TODO(justinmc): Unsure whether this is relevant to predictive back.
-          // .shouldAutomaticallyHandleOnBackPressed(Build.VERSION.SDK_INT >= 33)
+          .shouldAutomaticallyHandleOnBackPressed(shouldAutomaticallyHandleOnBackPressed)
           .build();
     } else {
       Log.v(
@@ -583,6 +583,7 @@ public class FlutterFragmentActivity extends FragmentActivity
             .transparencyMode(transparencyMode)
             .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
             .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
+            .shouldAutomaticallyHandleOnBackPressed(shouldAutomaticallyHandleOnBackPressed)
             .build();
       }
 
@@ -598,6 +599,7 @@ public class FlutterFragmentActivity extends FragmentActivity
           .transparencyMode(transparencyMode)
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
           .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
+          .shouldAutomaticallyHandleOnBackPressed(shouldAutomaticallyHandleOnBackPressed)
           .build();
     }
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -545,6 +545,8 @@ public class FlutterFragmentActivity extends FragmentActivity
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
           .destroyEngineWithFragment(shouldDestroyEngineWithHost())
           .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
+          // TODO(justinmc): Unsure whether this is relevant to predictive back.
+          // .shouldAutomaticallyHandleOnBackPressed(Build.VERSION.SDK_INT >= 33)
           .build();
     } else {
       Log.v(


### PR DESCRIPTION
Following up on https://github.com/flutter/engine/pull/39208 and https://github.com/flutter/engine/pull/42789, which added predictive back support for FlutterActivity.

My test app for this is: https://github.com/justinmc/flutter-add-to-app

I tried this both with the Flutter app as the main activity, and with it as a secondary activity after an initial Android route. Predictive back worked in both cases.

Related: https://github.com/flutter/flutter/issues/109558, and my comment https://github.com/flutter/flutter/issues/109558#issuecomment-1683099477.

b/242216228