### PR TITLE
[Impeller] Remove sync switch

### DIFF
--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -209,31 +209,22 @@ bool CommandBufferMTL::SubmitCommandsAsync(
           [render_command_encoder endEncoding];
           return;
         }
-        auto is_gpu_disabled_sync_switch =
-            ContextMTL::Cast(*context).GetIsGpuDisabledSyncSwitch();
-        is_gpu_disabled_sync_switch->Execute(
-            fml::SyncSwitch::Handlers()
-                .SetIfFalse([&render_pass, &render_command_encoder, &buffer,
-                             &context] {
-                  auto mtl_render_pass =
-                      static_cast<RenderPassMTL*>(render_pass.get());
-                  if (!mtl_render_pass->label_.empty()) {
-                    [render_command_encoder
-                        setLabel:@(mtl_render_pass->label_.c_str())];
-                  }
 
-                  auto result = mtl_render_pass->EncodeCommands(
-                      context->GetResourceAllocator(), render_command_encoder);
-                  [render_command_encoder endEncoding];
-                  if (result) {
-                    [buffer commit];
-                  } else {
-                    VALIDATION_LOG << "Failed to encode command buffer";
-                  }
-                })
-                .SetIfTrue([&render_command_encoder] {
-                  [render_command_encoder endEncoding];
-                }));
+        auto mtl_render_pass =
+            static_cast<RenderPassMTL*>(render_pass.get());
+        if (!mtl_render_pass->label_.empty()) {
+          [render_command_encoder
+              setLabel:@(mtl_render_pass->label_.c_str())];
+        }
+
+        auto result = mtl_render_pass->EncodeCommands(
+            context->GetResourceAllocator(), render_command_encoder);
+        [render_command_encoder endEncoding];
+        if (result) {
+          [buffer commit];
+        } else {
+          VALIDATION_LOG << "Failed to encode command buffer";
+        }
       });
   worker_task_runner->PostTask(task);
   return true;

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -210,11 +210,9 @@ bool CommandBufferMTL::SubmitCommandsAsync(
           return;
         }
 
-        auto mtl_render_pass =
-            static_cast<RenderPassMTL*>(render_pass.get());
+        auto mtl_render_pass = static_cast<RenderPassMTL*>(render_pass.get());
         if (!mtl_render_pass->label_.empty()) {
-          [render_command_encoder
-              setLabel:@(mtl_render_pass->label_.c_str())];
+          [render_command_encoder setLabel:@(mtl_render_pass->label_.c_str())];
         }
 
         auto result = mtl_render_pass->EncodeCommands(


### PR DESCRIPTION
Adding back the waitUntilScheduled introduced a regression with this sync switch behavior. Because we block on all previous cmd buffer submission, if the sync switch fires partially through the raster thread workload, then some of our cmd buffers won't be submitted and waitUntilScheduled won't terminate.

But since we added back the waitUntilScheduled, we don't actually need these guards, as this ensures that the raster thread doesn't finish until all worker threads have finished.
