### PR TITLE
[Impeller] Added recycled command buffers.

### DIFF
--- a/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -14,6 +14,10 @@
 
 namespace impeller {
 
+// This number comes from observing the recycled_buffers_ size while running
+// Wonderous and seeing it cap out at 7.
+static constexpr size_t kMaxRecycledBufferSize = 10;
+
 using CommandPoolMap = std::map<uint64_t, std::shared_ptr<CommandPoolVK>>;
 FML_THREAD_LOCAL fml::ThreadLocalUniquePtr<CommandPoolMap> tls_command_pool;
 
@@ -91,15 +95,22 @@ bool CommandPoolVK::IsValid() const {
 }
 
 void CommandPoolVK::Reset() {
-  Lock lock(buffers_to_collect_mutex_);
-  graphics_pool_.reset();
+  {
+    Lock lock(buffers_to_collect_mutex_);
+    graphics_pool_.reset();
 
-  // When the command pool is destroyed, all of its command buffers are freed.
-  // Handles allocated from that pool are now invalid and must be discarded.
-  for (vk::UniqueCommandBuffer& buffer : buffers_to_collect_) {
+    // When the command pool is destroyed, all of its command buffers are freed.
+    // Handles allocated from that pool are now invalid and must be discarded.
+    for (vk::UniqueCommandBuffer& buffer : buffers_to_collect_) {
+      buffer.release();
+    }
+    buffers_to_collect_.clear();
+  }
+
+  for (vk::UniqueCommandBuffer& buffer : recycled_buffers_) {
     buffer.release();
   }
-  buffers_to_collect_.clear();
+  recycled_buffers_.clear();
 
   is_valid_ = false;
 }
@@ -113,13 +124,18 @@ vk::UniqueCommandBuffer CommandPoolVK::CreateGraphicsCommandBuffer() {
   if (!strong_device) {
     return {};
   }
-  if (std::this_thread::get_id() != owner_id_) {
-    return {};
-  }
+  FML_DCHECK(std::this_thread::get_id() == owner_id_);
   {
     Lock lock(buffers_to_collect_mutex_);
     GarbageCollectBuffersIfAble();
   }
+
+  if (!recycled_buffers_.empty()) {
+    vk::UniqueCommandBuffer result = std::move(recycled_buffers_.back());
+    recycled_buffers_.pop_back();
+    return result;
+  }
+
   vk::CommandBufferAllocateInfo alloc_info;
   alloc_info.commandPool = graphics_pool_.get();
   alloc_info.commandBufferCount = 1u;
@@ -147,6 +163,14 @@ void CommandPoolVK::CollectGraphicsCommandBuffer(
 void CommandPoolVK::GarbageCollectBuffersIfAble() {
   if (std::this_thread::get_id() != owner_id_) {
     return;
+  }
+  for (auto& buffer : buffers_to_collect_) {
+    if (recycled_buffers_.size() >= kMaxRecycledBufferSize) {
+      // Don't grow boundlessly.
+      break;
+    }
+    buffer->reset();
+    recycled_buffers_.emplace_back(std::move(buffer));
   }
   buffers_to_collect_.clear();
 }

--- a/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -14,10 +14,6 @@
 
 namespace impeller {
 
-// This number comes from observing the recycled_buffers_ size while running
-// Wonderous and seeing it cap out at 7.
-static constexpr size_t kMaxRecycledBufferSize = 10;
-
 using CommandPoolMap = std::map<uint64_t, std::shared_ptr<CommandPoolVK>>;
 FML_THREAD_LOCAL fml::ThreadLocalUniquePtr<CommandPoolMap> tls_command_pool;
 
@@ -164,14 +160,12 @@ void CommandPoolVK::GarbageCollectBuffersIfAble() {
   if (std::this_thread::get_id() != owner_id_) {
     return;
   }
+
   for (auto& buffer : buffers_to_collect_) {
-    if (recycled_buffers_.size() >= kMaxRecycledBufferSize) {
-      // Don't grow boundlessly.
-      break;
-    }
     buffer->reset();
     recycled_buffers_.emplace_back(std::move(buffer));
   }
+
   buffers_to_collect_.clear();
 }
 

--- a/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -44,6 +44,7 @@ class CommandPoolVK {
   Mutex buffers_to_collect_mutex_;
   std::vector<vk::UniqueCommandBuffer> buffers_to_collect_
       IPLR_GUARDED_BY(buffers_to_collect_mutex_);
+  std::vector<vk::UniqueCommandBuffer> recycled_buffers_;
   bool is_valid_ = false;
 
   explicit CommandPoolVK(const ContextVK* context);


### PR DESCRIPTION
Recycles command buffers instead of deleting them when they are done being used.

@jonahwilliams profiled the Gallery on the Pixel 7 pro and saw that sometimes `RenderPassVK::OnEncodeCommands` takes a long time in https://github.com/flutter/flutter/issues/132690.  After adding adding more tracing it was found that the culprit was deleting the CommandBuffers on the raster thread.  This PR removes the deletion of the CommandBuffers and instead resets and recycles them.

![unnamed](https://github.com/flutter/engine/assets/30870216/2136dda0-6747-43a7-9a94-a0223c55b704)

> where GARBO2 is
> ```c++
> void CommandPoolVK::GarbageCollectBuffersIfAble() {
>   TRACE_EVENT0("impeller", "CommandPoolVK::GARBO2");
>    if (std::this_thread::get_id() != owner_id_) {    
>      return;  
>    }
>    buffers_to_collect_.clear();
> }
> ```

This approach matches the guidances from ["Vulkan Best Practice for Mobile Developers"](https://arm-software.github.io/vulkan_best_practice_for_mobile_developers/samples/performance/command_buffer_usage/command_buffer_usage_tutorial.html) where it is preferable to recycle command buffers than delete them.  Also, the recommendation is that if you are not reusing command buffers that you should periodically reset the pool, which we weren't doing.

issue: https://github.com/flutter/flutter/issues/132690


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
