### PR TITLE
Include GrVkTypes where necessary

### DIFF
--- a/testing/test_vulkan_surface.cc
+++ b/testing/test_vulkan_surface.cc
@@ -13,6 +13,7 @@
 #include "third_party/skia/include/core/SkSurfaceProps.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 
 namespace flutter {
 namespace testing {


### PR DESCRIPTION
IWYU fix to be able to use GrVkImageInfo. An incoming Skia change will otherwise fail to compile here.