### PR TITLE
Render only during callback scopes

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -341,7 +341,7 @@ class PlatformDispatcher {
     assert(_renderedViews == null);
     assert(_renderedViewsBetweenCallbacks == null);
 
-    _renderedViews = Set<FlutterView>();
+    _renderedViews = <FlutterView>{};
     _invoke1<Duration>(
       onBeginFrame,
       _onBeginFrameZone,

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -315,7 +315,13 @@ class PlatformDispatcher {
   // calls to [FlutterView.render] must be ignored. Furthermore, if a given
   // [FlutterView] is already present in this set when its [FlutterView.render]
   // is called again, that call must be ignored as a duplicate.
+  //
+  // Between [onBeginFrame] and [onDrawFrame] the properties value is
+  // temporarily stored in `_renderedViewsBetweenCallbacks` so that it survives
+  // the gap between the two callbacks.
   Set<FlutterView>? _renderedViews;
+  // Temporary storage of the `_renderedViews` value between `_beginFrame` and
+  // `_drawFrame`.
   Set<FlutterView>? _renderedViewsBetweenCallbacks;
 
   /// A callback invoked when any view begins a frame.

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -308,6 +308,15 @@ class PlatformDispatcher {
     _invoke(onMetricsChanged, _onMetricsChangedZone);
   }
 
+  // [FlutterView]s for which [FlutterView.render] has already been called
+  // during the current [onBeginFrame]/[onDrawFrame] callback sequence.
+  //
+  // The field is null outside the scope of those callbacks indicating that
+  // calls to [FlutterView.render] must be ignored. Furthermore, if a given
+  // [FlutterView] is already present in this set when its [FlutterView.render]
+  // is called again, that call must be ignored as a duplicate.
+  Set<FlutterView>? _renderedViews;
+  Set<FlutterView>? _renderedViewsBetweenCallbacks;
 
   /// A callback invoked when any view begins a frame.
   ///
@@ -329,11 +338,20 @@ class PlatformDispatcher {
 
   // Called from the engine, via hooks.dart
   void _beginFrame(int microseconds) {
+    assert(_renderedViews == null);
+    assert(_renderedViewsBetweenCallbacks == null);
+
+    _renderedViews = Set<FlutterView>();
     _invoke1<Duration>(
       onBeginFrame,
       _onBeginFrameZone,
       Duration(microseconds: microseconds),
     );
+    _renderedViewsBetweenCallbacks = _renderedViews;
+    _renderedViews = null;
+
+    assert(_renderedViews == null);
+    assert(_renderedViewsBetweenCallbacks != null);
   }
 
   /// A callback that is invoked for each frame after [onBeginFrame] has
@@ -351,7 +369,16 @@ class PlatformDispatcher {
 
   // Called from the engine, via hooks.dart
   void _drawFrame() {
+    assert(_renderedViews == null);
+    assert(_renderedViewsBetweenCallbacks != null);
+
+    _renderedViews = _renderedViewsBetweenCallbacks;
+    _renderedViewsBetweenCallbacks = null;
     _invoke(onDrawFrame, _onDrawFrameZone);
+    _renderedViews = null;
+
+    assert(_renderedViews == null);
+    assert(_renderedViewsBetweenCallbacks == null);
   }
 
   /// A callback that is invoked when pointer data is available.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -353,7 +353,14 @@ class FlutterView {
   ///   scheduling of frames.
   /// * [RendererBinding], the Flutter framework class which manages layout and
   ///   painting.
-  void render(Scene scene) => _render(scene as _NativeScene);
+  void render(Scene scene) {
+    if (platformDispatcher._renderedViews?.add(this) != true) {
+      // Duplicated calls or calls outside of onBeginFrame/onDrawFrame
+      // (indicated by _renderedViews being null) are ignored, as documented.
+      return;
+    }
+    _render(scene as _NativeScene);
+  }
 
   @Native<Void Function(Pointer<Void>)>(symbol: 'PlatformConfigurationNativeApi::Render')
   external static void _render(_NativeScene scene);


### PR DESCRIPTION
Enforces documented behavior in preparation for multi view rendering. Quoting from https://master-api.flutter.dev/flutter/dart-ui/FlutterView/render.html:

> This function must be called within the scope of the [PlatformDispatcher.onBeginFrame](https://master-api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onBeginFrame.html) or [PlatformDispatcher.onDrawFrame](https://master-api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onDrawFrame.html) callbacks being invoked.
>
> If this function is called a second time during a single [PlatformDispatcher.onBeginFrame](https://master-api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onBeginFrame.html)/[PlatformDispatcher.onDrawFrame](https://master-api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onDrawFrame.html) callback sequence or called outside the scope of those callbacks, the call will be ignored.

Fixes https://github.com/flutter/flutter/issues/125326.

This change is passing a TGP in g3: tap/OCL:558891137:BASE:558891211:1692660347578:e108b061