### PR TITLE
[Impeller] Disable Impeller on Fuchsia

### DIFF
--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -12,13 +12,15 @@ declare_args() {
       flutter_runtime_mode == "debug" || flutter_runtime_mode == "profile"
 
   # Whether the Metal backend is enabled.
-  impeller_enable_metal = is_mac || is_ios
+  impeller_enable_metal = (is_mac || is_ios) && target_os != "fuchsia"
 
   # Whether the OpenGLES backend is enabled.
-  impeller_enable_opengles = is_linux || is_win || is_android
+  impeller_enable_opengles =
+      (is_linux || is_win || is_android) && target_os != "fuchsia"
 
   # Whether the Vulkan backend is enabled.
-  impeller_enable_vulkan = is_linux || is_win || is_android
+  impeller_enable_vulkan =
+      (is_linux || is_win || is_android) && target_os != "fuchsia"
 
   # Whether to use a prebuilt impellerc.
   # If this is the empty string, impellerc will be built.


### PR DESCRIPTION
In some build variations, `is_mac` or `is_linux` is true, but `target_os == "fuchsia"`.

We should explicitly disable Impeller in those variants.

Fixes https://github.com/flutter/flutter/issues/132793
