### PR TITLE
[iOS] Don't call App lifecycle resumed when device is locked

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1035,10 +1035,15 @@ static void SendFakeTouchEvent(UIScreen* screen,
   if (_viewportMetrics.physical_width) {
     [self surfaceUpdated:YES];
   }
-  [self goToApplicationLifecycle:@"AppLifecycleState.resumed"];
+  [self performSelector:@selector(goToApplicationLifecycle:)
+             withObject:@"AppLifecycleState.resumed"
+             afterDelay:0.0f];
 }
 
 - (void)appOrSceneWillResignActive {
+  [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                           selector:@selector(goToApplicationLifecycle:)
+                                             object:@"AppLifecycleState.resumed"];
   [self goToApplicationLifecycle:@"AppLifecycleState.inactive"];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -1858,8 +1858,15 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 #endif
   XCTAssertFalse(flutterViewController.isKeyboardInOrTransitioningFromBackground);
   OCMVerify([mockVC surfaceUpdated:YES]);
-  OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.resumed"]);
-  [flutterViewController deregisterNotifications];
+  XCTestExpectation* timeoutApplicationLifeCycle =
+      [self expectationWithDescription:@"timeoutApplicationLifeCycle"];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(), ^{
+                   [timeoutApplicationLifeCycle fulfill];
+                   OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.resumed"]);
+                   [flutterViewController deregisterNotifications];
+                 });
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 
 - (void)testLifeCycleNotificationWillResignActive {
@@ -1973,6 +1980,35 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 #endif
   OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.inactive"]);
   [flutterViewController deregisterNotifications];
+}
+
+- (void)testLifeCycleNotificationCancelledInvalidResumed {
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine runWithEntrypoint:nil];
+  FlutterViewController* flutterViewController =
+      [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  NSNotification* applicationDidBecomeActiveNotification =
+      [NSNotification notificationWithName:UIApplicationDidBecomeActiveNotification
+                                    object:nil
+                                  userInfo:nil];
+  NSNotification* applicationWillResignActiveNotification =
+      [NSNotification notificationWithName:UIApplicationWillResignActiveNotification
+                                    object:nil
+                                  userInfo:nil];
+  id mockVC = OCMPartialMock(flutterViewController);
+  [[NSNotificationCenter defaultCenter] postNotification:applicationDidBecomeActiveNotification];
+  [[NSNotificationCenter defaultCenter] postNotification:applicationWillResignActiveNotification];
+  OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.inactive"]);
+
+  XCTestExpectation* timeoutApplicationLifeCycle =
+      [self expectationWithDescription:@"timeoutApplicationLifeCycle"];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(), ^{
+                   OCMReject([mockVC goToApplicationLifecycle:@"AppLifecycleState.resumed"]);
+                   [timeoutApplicationLifeCycle fulfill];
+                   [flutterViewController deregisterNotifications];
+                 });
+  [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -1998,7 +1998,10 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   id mockVC = OCMPartialMock(flutterViewController);
   [[NSNotificationCenter defaultCenter] postNotification:applicationDidBecomeActiveNotification];
   [[NSNotificationCenter defaultCenter] postNotification:applicationWillResignActiveNotification];
+#if APPLICATION_EXTENSION_API_ONLY
+#else
   OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.inactive"]);
+#endif
 
   XCTestExpectation* timeoutApplicationLifeCycle =
       [self expectationWithDescription:@"timeoutApplicationLifeCycle"];


### PR DESCRIPTION
Fixed https://github.com/flutter/flutter/issues/130055.
We can cancel the `resumed` life cycle notification if we received `inactive` notification in the same runloop.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
