### PR TITLE
Add missing GrVkTypes include

### DIFF
--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -15,6 +15,7 @@
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
 #include "third_party/skia/include/gpu/gl/GrGLTypes.h"
+#include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 
 #include <cstdlib>
 #include <memory>


### PR DESCRIPTION
IWYU fix for an incoming Skia change. This header is needed for GrVkImageInfo.