### PR TITLE
Eliminate android test log spam

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -68,6 +68,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Before
   public void setup() {
     FlutterInjector.reset();
@@ -406,6 +407,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void itGivesHostAnOpportunityToConfigureFlutterTextureView() {
     // ---- Test setup ----

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -66,6 +66,8 @@ public class FlutterActivityAndFragmentDelegateTest {
   private FlutterEngine mockFlutterEngine;
   private FlutterActivityAndFragmentDelegate.Host mockHost;
 
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity
   @Before
   public void setup() {
     FlutterInjector.reset();
@@ -402,6 +404,8 @@ public class FlutterActivityAndFragmentDelegateTest {
     verify(mockHost, times(1)).onFlutterSurfaceViewCreated(isNotNull());
   }
 
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity
   @Test
   public void itGivesHostAnOpportunityToConfigureFlutterTextureView() {
     // ---- Test setup ----

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -207,6 +207,8 @@ public class FlutterAndroidComponentTest {
     verify(delegate, never()).detachFromFlutterEngine();
   }
 
+  @SuppressWarnings("deprecation")
+  // Robolectric.buildActivity
   @Test
   public void twoOverlappingFlutterActivitiesDoNotCrosstalk() {
     // ---- Test setup ----
@@ -265,6 +267,9 @@ public class FlutterAndroidComponentTest {
       return ApplicationProvider.getApplicationContext();
     }
 
+
+    @SuppressWarnings("deprecation")
+    // Robolectric.setupActivity
     @Nullable
     @Override
     public Activity getActivity() {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -207,8 +207,6 @@ public class FlutterAndroidComponentTest {
     verify(delegate, never()).detachFromFlutterEngine();
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.buildActivity
   @Test
   public void twoOverlappingFlutterActivitiesDoNotCrosstalk() {
     // ---- Test setup ----
@@ -269,6 +267,7 @@ public class FlutterAndroidComponentTest {
 
     @SuppressWarnings("deprecation")
     // Robolectric.setupActivity
+    // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
     @Nullable
     @Override
     public Activity getActivity() {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -267,7 +267,6 @@ public class FlutterAndroidComponentTest {
       return ApplicationProvider.getApplicationContext();
     }
 
-
     @SuppressWarnings("deprecation")
     // Robolectric.setupActivity
     @Nullable

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -285,6 +285,7 @@ public class FlutterFragmentTest {
 
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void itDelegatesOnBackPressedAutomaticallyWhenEnabled() {
     // We need to mock FlutterJNI to avoid triggering native code.
@@ -321,6 +322,7 @@ public class FlutterFragmentTest {
 
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void itHandlesPopSystemNavigationAutomaticallyWhenEnabled() {
     // We need to mock FlutterJNI to avoid triggering native code.

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -283,6 +283,8 @@ public class FlutterFragmentTest {
     assertEquals(fragment.getExclusiveAppComponent(), delegate);
   }
 
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity
   @Test
   public void itDelegatesOnBackPressedAutomaticallyWhenEnabled() {
     // We need to mock FlutterJNI to avoid triggering native code.
@@ -317,6 +319,8 @@ public class FlutterFragmentTest {
     verify(mockDelegate, times(1)).onBackPressed();
   }
 
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity
   @Test
   public void itHandlesPopSystemNavigationAutomaticallyWhenEnabled() {
     // We need to mock FlutterJNI to avoid triggering native code.

--- a/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import junit.framework.Assert;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -489,25 +488,25 @@ public class KeyboardManagerTest {
   @Test
   public void basicCombingCharactersTest() {
     final KeyboardManager.CharacterCombiner combiner = new KeyboardManager.CharacterCombiner();
-    Assert.assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
-    Assert.assertEquals('A', (int) combiner.applyCombiningCharacterToBaseCharacter('A'));
-    Assert.assertEquals('B', (int) combiner.applyCombiningCharacterToBaseCharacter('B'));
-    Assert.assertEquals('B', (int) combiner.applyCombiningCharacterToBaseCharacter('B'));
-    Assert.assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
-    Assert.assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
+    assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
+    assertEquals('B', (int) combiner.applyCombiningCharacterToBaseCharacter('B'));
+    assertEquals('B', (int) combiner.applyCombiningCharacterToBaseCharacter('B'));
+    assertEquals('A', (int) combiner.applyCombiningCharacterToBaseCharacter('A'));
+    assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
+    assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
 
-    Assert.assertEquals('`', (int) combiner.applyCombiningCharacterToBaseCharacter(DEAD_KEY));
-    Assert.assertEquals('`', (int) combiner.applyCombiningCharacterToBaseCharacter(DEAD_KEY));
-    Assert.assertEquals('À', (int) combiner.applyCombiningCharacterToBaseCharacter('A'));
+    assertEquals('`', (int) combiner.applyCombiningCharacterToBaseCharacter(DEAD_KEY));
+    assertEquals('`', (int) combiner.applyCombiningCharacterToBaseCharacter(DEAD_KEY));
+    assertEquals('À', (int) combiner.applyCombiningCharacterToBaseCharacter('A'));
 
-    Assert.assertEquals('`', (int) combiner.applyCombiningCharacterToBaseCharacter(DEAD_KEY));
-    Assert.assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
+    assertEquals('`', (int) combiner.applyCombiningCharacterToBaseCharacter(DEAD_KEY));
+    assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
     // The 0 input should remove the combining state.
-    Assert.assertEquals('A', (int) combiner.applyCombiningCharacterToBaseCharacter('A'));
+    assertEquals('A', (int) combiner.applyCombiningCharacterToBaseCharacter('A'));
 
-    Assert.assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
-    Assert.assertEquals('`', (int) combiner.applyCombiningCharacterToBaseCharacter(DEAD_KEY));
-    Assert.assertEquals('À', (int) combiner.applyCombiningCharacterToBaseCharacter('A'));
+    assertEquals(0, (int) combiner.applyCombiningCharacterToBaseCharacter(0));
+    assertEquals('`', (int) combiner.applyCombiningCharacterToBaseCharacter(DEAD_KEY));
+    assertEquals('À', (int) combiner.applyCombiningCharacterToBaseCharacter('A'));
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/SplashShadowResources.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/SplashShadowResources.java
@@ -15,6 +15,8 @@ import org.robolectric.shadows.ShadowResources;
 import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
+@SuppressWarnings("deprecation")
+// getDrawableInt
 @Implements(Resources.class)
 public class SplashShadowResources extends ShadowResources {
   @RealObject private Resources resources;

--- a/shell/platform/android/test/io/flutter/embedding/android/SplashShadowResources.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/SplashShadowResources.java
@@ -10,7 +10,6 @@ import androidx.annotation.Nullable;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowResources;
 import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
@@ -23,6 +22,7 @@ public class SplashShadowResources extends ShadowResources {
 
   public static final int SPLASH_DRAWABLE_ID = 191919;
   public static final int THEMED_SPLASH_DRAWABLE_ID = 212121;
+
   @ForType(Resources.class)
   interface ResourcesReflector {
     @Direct

--- a/shell/platform/android/test/io/flutter/embedding/android/SplashShadowResources.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/SplashShadowResources.java
@@ -1,5 +1,7 @@
 package io.flutter.embedding.android;
 
+import static org.robolectric.util.reflector.Reflector.reflector;
+
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
@@ -10,6 +12,8 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowResources;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(Resources.class)
 public class SplashShadowResources extends ShadowResources {
@@ -17,13 +21,21 @@ public class SplashShadowResources extends ShadowResources {
 
   public static final int SPLASH_DRAWABLE_ID = 191919;
   public static final int THEMED_SPLASH_DRAWABLE_ID = 212121;
+  @ForType(Resources.class)
+  interface ResourcesReflector {
+    @Direct
+    Drawable getDrawable(int id, Resources.Theme theme);
+
+    @Direct
+    Drawable getDrawable(int id);
+  }
 
   @Implementation
   protected Drawable getDrawable(int id) {
     if (id == SPLASH_DRAWABLE_ID) {
       return new ColorDrawable(Color.BLUE);
     }
-    return Shadow.directlyOn(resources, Resources.class).getDrawable(id);
+    return reflector(Resources.class, resources).getDrawable(id);
   }
 
   @Implementation
@@ -37,6 +49,6 @@ public class SplashShadowResources extends ShadowResources {
       }
       return new ColorDrawable(Color.GRAY);
     }
-    return Shadow.directlyOn(resources, Resources.class).getDrawable(id, theme);
+    return reflector(Resources.class, resources).getDrawable(id, theme);
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupCacheTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupCacheTest.java
@@ -7,13 +7,13 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import androidx.test.core.app.ApplicationProvider;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.loader.FlutterLoader;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -75,8 +75,8 @@ public class FlutterEngineGroupCacheTest {
   @Test
   public void itRemovesAllFlutterEngineGroups() {
     // --- Test Setup ---
-    FlutterEngineGroup flutterEngineGroup1 = new FlutterEngineGroup(RuntimeEnvironment.application);
-    FlutterEngineGroup flutterEngineGroup2 = new FlutterEngineGroup(RuntimeEnvironment.application);
+    FlutterEngineGroup flutterEngineGroup1 = new FlutterEngineGroup(ApplicationProvider.getApplicationContext());
+    FlutterEngineGroup flutterEngineGroup2 = new FlutterEngineGroup(ApplicationProvider.getApplicationContext());
     FlutterEngineGroupCache cache = new FlutterEngineGroupCache();
 
     // --- Execute Test ---

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupCacheTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineGroupCacheTest.java
@@ -75,8 +75,10 @@ public class FlutterEngineGroupCacheTest {
   @Test
   public void itRemovesAllFlutterEngineGroups() {
     // --- Test Setup ---
-    FlutterEngineGroup flutterEngineGroup1 = new FlutterEngineGroup(ApplicationProvider.getApplicationContext());
-    FlutterEngineGroup flutterEngineGroup2 = new FlutterEngineGroup(ApplicationProvider.getApplicationContext());
+    FlutterEngineGroup flutterEngineGroup1 =
+        new FlutterEngineGroup(ApplicationProvider.getApplicationContext());
+    FlutterEngineGroup flutterEngineGroup2 =
+        new FlutterEngineGroup(ApplicationProvider.getApplicationContext());
     FlutterEngineGroupCache cache = new FlutterEngineGroupCache();
 
     // --- Execute Test ---

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -82,6 +82,7 @@ public class PlayStoreDeferredComponentManagerTest {
       loadDartLibrary(loadingUnitId, componentName);
     }
   }
+
   @SuppressWarnings("deprecation")
   // getApplicationInfo
   private Context createSpyContext(Bundle metadata) throws NameNotFoundException {

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -82,7 +82,8 @@ public class PlayStoreDeferredComponentManagerTest {
       loadDartLibrary(loadingUnitId, componentName);
     }
   }
-
+  @SuppressWarnings("deprecation")
+  // getApplicationInfo
   private Context createSpyContext(Bundle metadata) throws NameNotFoundException {
     Context spyContext = spy(ApplicationProvider.getApplicationContext());
     doReturn(spyContext).when(spyContext).createPackageContext(any(), anyInt());

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
@@ -48,6 +48,8 @@ public class ApplicationInfoLoaderTest {
     assertNull(info.nativeLibraryDir);
   }
 
+  @SuppressWarnings("deprecation")
+  // getApplicationInfo
   private Context generateMockContext(Bundle metadata, String networkPolicyXml) throws Exception {
     Context context = mock(Context.class);
     PackageManager packageManager = mock(PackageManager.class);

--- a/shell/platform/android/test/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistryTest.java
@@ -49,7 +49,8 @@ public class ShimPluginRegistryTest {
     ShimPluginRegistry registryUnderTest = new ShimPluginRegistry(mockFlutterEngine);
     // Fully qualifed name because imports can not have deprecation supression.
     // This is the consumption side of the old plugins.
-    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest = registryUnderTest.registrarFor("test");
+    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest =
+        registryUnderTest.registrarFor("test");
 
     ArgumentCaptor<FlutterPlugin> shimAggregateCaptor =
         ArgumentCaptor.forClass(FlutterPlugin.class);
@@ -73,8 +74,10 @@ public class ShimPluginRegistryTest {
   public void itSuppliesMultipleOldPlugins() {
     ShimPluginRegistry registryUnderTest = new ShimPluginRegistry(mockFlutterEngine);
     // Fully qualifed name because imports can not have deprecation supression.
-    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest1 = registryUnderTest.registrarFor("test1");
-    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest2 = registryUnderTest.registrarFor("test2");
+    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest1 =
+        registryUnderTest.registrarFor("test1");
+    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest2 =
+        registryUnderTest.registrarFor("test2");
 
     ArgumentCaptor<FlutterPlugin> shimAggregateCaptor =
         ArgumentCaptor.forClass(FlutterPlugin.class);
@@ -96,7 +99,8 @@ public class ShimPluginRegistryTest {
   @Test
   public void itCanOnlySupplyActivityBindingWhenUpstreamActivityIsAttached() {
     ShimPluginRegistry registryUnderTest = new ShimPluginRegistry(mockFlutterEngine);
-    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest = registryUnderTest.registrarFor("test");
+    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest =
+        registryUnderTest.registrarFor("test");
 
     ArgumentCaptor<FlutterPlugin> shimAggregateCaptor =
         ArgumentCaptor.forClass(FlutterPlugin.class);

--- a/shell/platform/android/test/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistryTest.java
@@ -15,7 +15,6 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
 import io.flutter.embedding.engine.plugins.PluginRegistry;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,11 +42,14 @@ public class ShimPluginRegistryTest {
     when(mockActivityPluginBinding.getActivity()).thenReturn(mockActivity);
   }
 
+  @SuppressWarnings("deprecation")
+  // Test is intentionally verifying deprecated behavior.
   @Test
   public void itSuppliesOldAPIsViaTheNewFlutterPluginBinding() {
     ShimPluginRegistry registryUnderTest = new ShimPluginRegistry(mockFlutterEngine);
+    // Fully qualifed name because imports can not have deprecation supression.
     // This is the consumption side of the old plugins.
-    Registrar registrarUnderTest = registryUnderTest.registrarFor("test");
+    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest = registryUnderTest.registrarFor("test");
 
     ArgumentCaptor<FlutterPlugin> shimAggregateCaptor =
         ArgumentCaptor.forClass(FlutterPlugin.class);
@@ -65,11 +67,14 @@ public class ShimPluginRegistryTest {
     verify(mockFlutterPluginBinding).getApplicationContext();
   }
 
+  @SuppressWarnings("deprecation")
+  // Test is intentionally verifying deprecated behavior.
   @Test
   public void itSuppliesMultipleOldPlugins() {
     ShimPluginRegistry registryUnderTest = new ShimPluginRegistry(mockFlutterEngine);
-    Registrar registrarUnderTest1 = registryUnderTest.registrarFor("test1");
-    Registrar registrarUnderTest2 = registryUnderTest.registrarFor("test2");
+    // Fully qualifed name because imports can not have deprecation supression.
+    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest1 = registryUnderTest.registrarFor("test1");
+    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest2 = registryUnderTest.registrarFor("test2");
 
     ArgumentCaptor<FlutterPlugin> shimAggregateCaptor =
         ArgumentCaptor.forClass(FlutterPlugin.class);
@@ -86,10 +91,12 @@ public class ShimPluginRegistryTest {
     verify(mockFlutterPluginBinding, times(2)).getApplicationContext();
   }
 
+  @SuppressWarnings("deprecation")
+  // Test is intentionally verifying deprecated behavior.
   @Test
   public void itCanOnlySupplyActivityBindingWhenUpstreamActivityIsAttached() {
     ShimPluginRegistry registryUnderTest = new ShimPluginRegistry(mockFlutterEngine);
-    Registrar registrarUnderTest = registryUnderTest.registrarFor("test");
+    io.flutter.plugin.common.PluginRegistry.Registrar registrarUnderTest = registryUnderTest.registrarFor("test");
 
     ArgumentCaptor<FlutterPlugin> shimAggregateCaptor =
         ArgumentCaptor.forClass(FlutterPlugin.class);

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyboardChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyboardChannelTest.java
@@ -32,6 +32,8 @@ public class KeyboardChannelTest {
     return reply;
   }
 
+  @SuppressWarnings("deprecation")
+  // setMessageHandler is deprecated.
   @Test
   public void respondsToGetKeyboardStateChannelMessage() {
     ArgumentCaptor<BinaryMessenger.BinaryMessageHandler> binaryMessageHandlerCaptor =

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/SettingsChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/SettingsChannelTest.java
@@ -23,6 +23,8 @@ public class SettingsChannelTest {
   @Test
   @TargetApi(33)
   @Config(sdk = 33)
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   public void setDisplayMetricsDoesNothingOnAPILevel33() {
     final DartExecutor executor = mock(DartExecutor.class);
     executor.onAttachedToJNI();

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -135,6 +135,8 @@ public class InputConnectionAdaptorTest {
     assertEquals(editable.length(), Selection.getSelectionEnd(editable));
   }
 
+  @SuppressWarnings("deprecation")
+  // ClipboardManager.hasText is deprecated.
   @Test
   public void testPerformContextMenuAction_cut() {
     ClipboardManager clipboardManager = ctx.getSystemService(ClipboardManager.class);
@@ -152,6 +154,8 @@ public class InputConnectionAdaptorTest {
     assertFalse(editable.toString().contains(textToBeCut));
   }
 
+  @SuppressWarnings("deprecation")
+  // ClipboardManager.hasText is deprecated.
   @Test
   public void testPerformContextMenuAction_copy() {
     ClipboardManager clipboardManager = ctx.getSystemService(ClipboardManager.class);
@@ -171,6 +175,8 @@ public class InputConnectionAdaptorTest {
         clipboardManager.getPrimaryClip().getItemAt(0).getText());
   }
 
+  @SuppressWarnings("deprecation")
+  // ClipboardManager.setText is deprecated.
   @Test
   public void testPerformContextMenuAction_paste() {
     ClipboardManager clipboardManager = ctx.getSystemService(ClipboardManager.class);

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -185,6 +185,8 @@ public class InputConnectionAdaptorTest {
     assertTrue(editable.toString().startsWith(textToBePasted));
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testCommitContent() throws JSONException {
     View testView = new View(ctx);
@@ -244,6 +246,8 @@ public class InputConnectionAdaptorTest {
         });
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testPerformPrivateCommand_dataIsNull() throws JSONException {
     View testView = new View(ctx);
@@ -273,6 +277,8 @@ public class InputConnectionAdaptorTest {
         new String[] {"0", "{\"action\":\"actionCommand\"}"});
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testPerformPrivateCommand_dataIsByteArray() throws JSONException {
     View testView = new View(ctx);
@@ -308,6 +314,8 @@ public class InputConnectionAdaptorTest {
         });
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testPerformPrivateCommand_dataIsByte() throws JSONException {
     View testView = new View(ctx);
@@ -341,6 +349,8 @@ public class InputConnectionAdaptorTest {
         new String[] {"0", "{\"data\":{\"keyboard_layout\":3},\"action\":\"actionCommand\"}"});
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testPerformPrivateCommand_dataIsCharArray() throws JSONException {
     View testView = new View(ctx);
@@ -377,6 +387,8 @@ public class InputConnectionAdaptorTest {
         });
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testPerformPrivateCommand_dataIsChar() throws JSONException {
     View testView = new View(ctx);
@@ -410,6 +422,8 @@ public class InputConnectionAdaptorTest {
         new String[] {"0", "{\"data\":{\"keyboard_layout\":\"a\"},\"action\":\"actionCommand\"}"});
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testPerformPrivateCommand_dataIsCharSequenceArray() throws JSONException {
     View testView = new View(ctx);
@@ -447,6 +461,8 @@ public class InputConnectionAdaptorTest {
         });
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testPerformPrivateCommand_dataIsCharSequence() throws JSONException {
     View testView = new View(ctx);
@@ -482,6 +498,8 @@ public class InputConnectionAdaptorTest {
         });
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testPerformPrivateCommand_dataIsFloat() throws JSONException {
     View testView = new View(ctx);
@@ -515,6 +533,8 @@ public class InputConnectionAdaptorTest {
         new String[] {"0", "{\"data\":{\"keyboard_layout\":0.5},\"action\":\"actionCommand\"}"});
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void testPerformPrivateCommand_dataIsFloatArray() throws JSONException {
     View testView = new View(ctx);

--- a/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/SpellCheckPluginTest.java
@@ -44,6 +44,8 @@ public class SpellCheckPluginTest {
         (ByteBuffer) encodedMethodCall.flip(), mock(BinaryMessenger.BinaryReply.class));
   }
 
+  @SuppressWarnings("deprecation")
+  // setMessageHandler is deprecated.
   @Test
   public void respondsToSpellCheckChannelMessage() {
     ArgumentCaptor<BinaryMessenger.BinaryMessageHandler> binaryMessageHandlerCaptor =

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1449,15 +1449,12 @@ public class TextInputPluginTest {
 
   @Config(minSdk = Build.VERSION_CODES.O)
   @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity.
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void autofill_onProvideVirtualViewStructure() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       return;
     }
-    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
-    FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView testView = getTestView();
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1542,8 +1539,6 @@ public class TextInputPluginTest {
   }
 
   @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity.
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Config(minSdk = Build.VERSION_CODES.O)
   @Test
   public void autofill_onProvideVirtualViewStructure_singular_textfield() {
@@ -1551,7 +1546,7 @@ public class TextInputPluginTest {
       return;
     }
     // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
-    FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView testView = getTestView();
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1597,9 +1592,6 @@ public class TextInputPluginTest {
   }
 
   @Config(minSdk = Build.VERSION_CODES.O)
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity.
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void autofill_testLifeCycle() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1607,7 +1599,7 @@ public class TextInputPluginTest {
     }
 
     TestAfm testAfm = Shadow.extract(ctx.getSystemService(AutofillManager.class));
-    FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView testView = getTestView();
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1736,8 +1728,6 @@ public class TextInputPluginTest {
 
   @Config(minSdk = Build.VERSION_CODES.O)
   @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity.
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void autofill_testAutofillUpdatesTheFramework() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1745,7 +1735,7 @@ public class TextInputPluginTest {
     }
 
     TestAfm testAfm = Shadow.extract(ctx.getSystemService(AutofillManager.class));
-    FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView testView = getTestView();
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1884,9 +1874,6 @@ public class TextInputPluginTest {
   }
 
   @Config(minSdk = Build.VERSION_CODES.O)
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity.
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void autofill_testSetTextIpnutClientUpdatesSideFields() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1894,7 +1881,7 @@ public class TextInputPluginTest {
     }
 
     TestAfm testAfm = Shadow.extract(ctx.getSystemService(AutofillManager.class));
-    FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView testView = getTestView();
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1965,6 +1952,12 @@ public class TextInputPluginTest {
     assertEquals("Unfocused fields need love like everything does", testAfm.changeString);
   }
   // -------- End: Autofill Tests -------
+
+  @SuppressWarnings("deprecation")
+  private FlutterView getTestView() {
+    // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
+    return new FlutterView(Robolectric.setupActivity(Activity.class));
+  }
 
   @SuppressWarnings("deprecation")
   // setMessageHandler is deprecated.
@@ -2063,11 +2056,10 @@ public class TextInputPluginTest {
   @TargetApi(30)
   @Config(sdk = 30)
   @SuppressWarnings("deprecation")
-  // getWindowSystemUiVisibility, SYSTEM_UI_FLAG_LAYOUT_STABLE, Robolectric.setupActivity.
+  // getWindowSystemUiVisibility, SYSTEM_UI_FLAG_LAYOUT_STABLE.
   // flutter#133074 tracks migration work.
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   public void ime_windowInsetsSync_notLaidOutBehindNavigation_excludesNavigationBars() {
-    FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
+    FlutterView testView = spy(getTestView());
     when(testView.getWindowSystemUiVisibility()).thenReturn(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
 
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
@@ -2143,11 +2135,10 @@ public class TextInputPluginTest {
   @TargetApi(30)
   @Config(sdk = 30)
   @SuppressWarnings("deprecation")
-  // getWindowSystemUiVisibility, Robolectric.setupActivity.
+  // getWindowSystemUiVisibility
   // flutter#133074 tracks migration work.
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   public void ime_windowInsetsSync_laidOutBehindNavigation_includesNavigationBars() {
-    FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
+    FlutterView testView = spy(getTestView());
     when(testView.getWindowSystemUiVisibility())
         .thenReturn(
             View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
@@ -2225,11 +2216,10 @@ public class TextInputPluginTest {
   @TargetApi(30)
   @Config(sdk = 30)
   @SuppressWarnings("deprecation")
-  // getWindowSystemUiVisibility, SYSTEM_UI_FLAG_LAYOUT_STABLE, Robolectric.setupActivity.
+  // getWindowSystemUiVisibility, SYSTEM_UI_FLAG_LAYOUT_STABLE
   // flutter#133074 tracks migration work.
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   public void lastWindowInsets_updatedOnSecondOnProgressCall() {
-    FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
+    FlutterView testView = spy(getTestView());
     when(testView.getWindowSystemUiVisibility()).thenReturn(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
 
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -43,7 +43,6 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
-import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.android.FlutterView;

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1448,15 +1448,16 @@ public class TextInputPluginTest {
     verify(children[0]).setHint("placeholder");
   }
 
+  @Config(minSdk = Build.VERSION_CODES.O)
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity.
   @Test
   public void autofill_onProvideVirtualViewStructure() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       return;
     }
-    try(ActivityScenario<Activity> scenario = ActivityScenario.launch(Activity.class)) {
-        scenario.onActivity(activity -> {
-
-    FlutterView testView = new FlutterView(activity);
+    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
+    FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1538,17 +1539,17 @@ public class TextInputPluginTest {
     verify(children[1]).setAutofillHints(aryEq(new String[] {"HINT2", "EXTRA"}));
     verify(children[1]).setDimens(anyInt(), anyInt(), anyInt(), anyInt(), gt(0), gt(0));
     verify(children[1], times(0)).setHint(any());
-
-        });
-       }
   }
 
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity.
+  @Config(minSdk = Build.VERSION_CODES.O)
   @Test
   public void autofill_onProvideVirtualViewStructure_singular_textfield() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       return;
     }
-
+    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
     FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
@@ -1594,6 +1595,9 @@ public class TextInputPluginTest {
     verify(children[0]).setDimens(anyInt(), anyInt(), anyInt(), anyInt(), gt(0), gt(0));
   }
 
+  @Config(minSdk = Build.VERSION_CODES.O)
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity.
   @Test
   public void autofill_testLifeCycle() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1728,6 +1732,9 @@ public class TextInputPluginTest {
     assertEquals("1".hashCode(), testAfm.exitId);
   }
 
+  @Config(minSdk = Build.VERSION_CODES.O)
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity.
   @Test
   public void autofill_testAutofillUpdatesTheFramework() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1824,6 +1831,7 @@ public class TextInputPluginTest {
     assertEquals(editState.text, "unfocused field");
   }
 
+  @Config(minSdk = Build.VERSION_CODES.O)
   @Test
   public void autofill_doesNotCrashAfterClearClientCall() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1872,6 +1880,9 @@ public class TextInputPluginTest {
         .updateEditingState(anyInt(), any(), anyInt(), anyInt(), anyInt(), anyInt());
   }
 
+  @Config(minSdk = Build.VERSION_CODES.O)
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity.
   @Test
   public void autofill_testSetTextIpnutClientUpdatesSideFields() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -2048,7 +2059,7 @@ public class TextInputPluginTest {
   @TargetApi(30)
   @Config(sdk = 30)
   @SuppressWarnings("deprecation")
-  // getWindowSystemUiVisibility and SYSTEM_UI_FLAG_LAYOUT_STABLE are deprecated
+  // getWindowSystemUiVisibility, SYSTEM_UI_FLAG_LAYOUT_STABLE, Robolectric.setupActivity.
   // flutter#133074 tracks migration work.
   public void ime_windowInsetsSync_notLaidOutBehindNavigation_excludesNavigationBars() {
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
@@ -2127,7 +2138,8 @@ public class TextInputPluginTest {
   @TargetApi(30)
   @Config(sdk = 30)
   @SuppressWarnings("deprecation")
-  // getWindowSystemUiVisibility is deprecated flutter#133074 tracks migration work.
+  // getWindowSystemUiVisibility, Robolectric.setupActivity.
+  // flutter#133074 tracks migration work.
   public void ime_windowInsetsSync_laidOutBehindNavigation_includesNavigationBars() {
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
     when(testView.getWindowSystemUiVisibility())
@@ -2207,7 +2219,7 @@ public class TextInputPluginTest {
   @TargetApi(30)
   @Config(sdk = 30)
   @SuppressWarnings("deprecation")
-  // getWindowSystemUiVisibility and SYSTEM_UI_FLAG_LAYOUT_STABLE are deprecated
+  // getWindowSystemUiVisibility, SYSTEM_UI_FLAG_LAYOUT_STABLE, Robolectric.setupActivity.
   // flutter#133074 tracks migration work.
   public void lastWindowInsets_updatedOnSecondOnProgressCall() {
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -43,6 +43,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.android.FlutterView;
@@ -118,6 +119,8 @@ public class TextInputPluginTest {
         (ByteBuffer) encodedMethodCall.flip(), mock(BinaryMessenger.BinaryReply.class));
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void textInputPlugin_RequestsReattachOnCreation() throws JSONException {
     // Initialize a general TextInputPlugin.
@@ -992,6 +995,7 @@ public class TextInputPluginTest {
   // need the restart.
   // Update: many other keyboards need this too:
   // https://github.com/flutter/flutter/issues/78827
+  @SuppressWarnings("deprecation") // InputMethodSubtype
   @Test
   public void setTextInputEditingState_restartsIMEOnlyWhenFrameworkChangesComposingRegion() {
     // Initialize a TextInputPlugin that needs to be always restarted.
@@ -1136,6 +1140,8 @@ public class TextInputPluginTest {
     verify(textInputChannel, times(1)).setTextInputMethodHandler(isNull());
   }
 
+  @SuppressWarnings("deprecation")
+  // DartExecutor.send is deprecated.
   @Test
   public void inputConnection_createsActionFromEnter() throws JSONException {
     TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
@@ -1192,6 +1198,7 @@ public class TextInputPluginTest {
         new String[] {"0", "TextInputAction.done"});
   }
 
+  @SuppressWarnings("deprecation") // InputMethodSubtype
   @Test
   public void inputConnection_finishComposingTextUpdatesIMM() throws JSONException {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
@@ -1446,8 +1453,10 @@ public class TextInputPluginTest {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
       return;
     }
+    try(ActivityScenario<Activity> scenario = ActivityScenario.launch(Activity.class)) {
+        scenario.onActivity(activity -> {
 
-    FlutterView testView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView testView = new FlutterView(activity);
     TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
     TextInputPlugin textInputPlugin =
         new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
@@ -1529,6 +1538,9 @@ public class TextInputPluginTest {
     verify(children[1]).setAutofillHints(aryEq(new String[] {"HINT2", "EXTRA"}));
     verify(children[1]).setDimens(anyInt(), anyInt(), anyInt(), anyInt(), gt(0), gt(0));
     verify(children[1], times(0)).setHint(any());
+
+        });
+       }
   }
 
   @Test
@@ -1939,6 +1951,8 @@ public class TextInputPluginTest {
   }
   // -------- End: Autofill Tests -------
 
+  @SuppressWarnings("deprecation")
+  // setMessageHandler is deprecated.
   @Test
   public void respondsToInputChannelMessages() {
     ArgumentCaptor<BinaryMessenger.BinaryMessageHandler> binaryMessageHandlerCaptor =
@@ -1966,6 +1980,8 @@ public class TextInputPluginTest {
     verify(mockHandler, times(1)).finishAutofillContext(false);
   }
 
+  @SuppressWarnings("deprecation")
+  // setMessageHandler is deprecated.
   @Test
   public void sendAppPrivateCommand_dataIsEmpty() throws JSONException {
     ArgumentCaptor<BinaryMessenger.BinaryMessageHandler> binaryMessageHandlerCaptor =
@@ -1995,6 +2011,8 @@ public class TextInputPluginTest {
         .sendAppPrivateCommand(any(View.class), eq("actionCommand"), eq(null));
   }
 
+  @SuppressWarnings("deprecation")
+  // setMessageHandler is deprecated.
   @Test
   public void sendAppPrivateCommand_hasData() throws JSONException {
     ArgumentCaptor<BinaryMessenger.BinaryMessageHandler> binaryMessageHandlerCaptor =
@@ -2029,6 +2047,9 @@ public class TextInputPluginTest {
   @Test
   @TargetApi(30)
   @Config(sdk = 30)
+  @SuppressWarnings("deprecation")
+  // getWindowSystemUiVisibility and SYSTEM_UI_FLAG_LAYOUT_STABLE are deprecated
+  // flutter#133074 tracks migration work.
   public void ime_windowInsetsSync_notLaidOutBehindNavigation_excludesNavigationBars() {
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
     when(testView.getWindowSystemUiVisibility()).thenReturn(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
@@ -2105,6 +2126,8 @@ public class TextInputPluginTest {
   @Test
   @TargetApi(30)
   @Config(sdk = 30)
+  @SuppressWarnings("deprecation")
+  // getWindowSystemUiVisibility is deprecated flutter#133074 tracks migration work.
   public void ime_windowInsetsSync_laidOutBehindNavigation_includesNavigationBars() {
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
     when(testView.getWindowSystemUiVisibility())
@@ -2183,6 +2206,9 @@ public class TextInputPluginTest {
   @Test
   @TargetApi(30)
   @Config(sdk = 30)
+  @SuppressWarnings("deprecation")
+  // getWindowSystemUiVisibility and SYSTEM_UI_FLAG_LAYOUT_STABLE are deprecated
+  // flutter#133074 tracks migration work.
   public void lastWindowInsets_updatedOnSecondOnProgressCall() {
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
     when(testView.getWindowSystemUiVisibility()).thenReturn(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1450,6 +1450,7 @@ public class TextInputPluginTest {
   @Config(minSdk = Build.VERSION_CODES.O)
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void autofill_onProvideVirtualViewStructure() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1542,6 +1543,7 @@ public class TextInputPluginTest {
 
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Config(minSdk = Build.VERSION_CODES.O)
   @Test
   public void autofill_onProvideVirtualViewStructure_singular_textfield() {
@@ -1597,6 +1599,7 @@ public class TextInputPluginTest {
   @Config(minSdk = Build.VERSION_CODES.O)
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void autofill_testLifeCycle() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1734,6 +1737,7 @@ public class TextInputPluginTest {
   @Config(minSdk = Build.VERSION_CODES.O)
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void autofill_testAutofillUpdatesTheFramework() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1882,6 +1886,7 @@ public class TextInputPluginTest {
   @Config(minSdk = Build.VERSION_CODES.O)
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void autofill_testSetTextIpnutClientUpdatesSideFields() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -2060,6 +2065,7 @@ public class TextInputPluginTest {
   @SuppressWarnings("deprecation")
   // getWindowSystemUiVisibility, SYSTEM_UI_FLAG_LAYOUT_STABLE, Robolectric.setupActivity.
   // flutter#133074 tracks migration work.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   public void ime_windowInsetsSync_notLaidOutBehindNavigation_excludesNavigationBars() {
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
     when(testView.getWindowSystemUiVisibility()).thenReturn(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
@@ -2139,6 +2145,7 @@ public class TextInputPluginTest {
   @SuppressWarnings("deprecation")
   // getWindowSystemUiVisibility, Robolectric.setupActivity.
   // flutter#133074 tracks migration work.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   public void ime_windowInsetsSync_laidOutBehindNavigation_includesNavigationBars() {
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
     when(testView.getWindowSystemUiVisibility())
@@ -2220,6 +2227,7 @@ public class TextInputPluginTest {
   @SuppressWarnings("deprecation")
   // getWindowSystemUiVisibility, SYSTEM_UI_FLAG_LAYOUT_STABLE, Robolectric.setupActivity.
   // flutter#133074 tracks migration work.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   public void lastWindowInsets_updatedOnSecondOnProgressCall() {
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
     when(testView.getWindowSystemUiVisibility()).thenReturn(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);

--- a/shell/platform/android/test/io/flutter/plugin/mouse/MouseCursorPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/mouse/MouseCursorPluginTest.java
@@ -33,6 +33,7 @@ public class MouseCursorPluginTest {
 
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void mouseCursorPlugin_SetsSystemCursorOnRequest() throws JSONException {
     // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736

--- a/shell/platform/android/test/io/flutter/plugin/mouse/MouseCursorPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/mouse/MouseCursorPluginTest.java
@@ -25,12 +25,17 @@ import org.robolectric.annotation.Config;
 
 @Config(
     manifest = Config.NONE,
+    minSdk = 24,
     shadows = {})
 @RunWith(AndroidJUnit4.class)
 @TargetApi(24)
 public class MouseCursorPluginTest {
+
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity.
   @Test
   public void mouseCursorPlugin_SetsSystemCursorOnRequest() throws JSONException {
+    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
     // Initialize a general MouseCursorPlugin.
     FlutterView testView = spy(new FlutterView(Robolectric.setupActivity(Activity.class)));
     MouseCursorChannel mouseCursorChannel = new MouseCursorChannel(mock(DartExecutor.class));

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -527,7 +527,6 @@ public class PlatformPluginTest {
     verify(mockActivity, never()).finish();
   }
 
-
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity.
   @Test

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -94,6 +94,8 @@ public class PlatformPluginTest {
     assertNull(platformPlugin.mPlatformMessageHandler.getClipboardData(clipboardFormat));
   }
 
+  @SuppressWarnings("deprecation")
+  // ClipboardManager.getText
   @Config(sdk = 28)
   @Test
   public void platformPlugin_hasStrings() {
@@ -315,6 +317,8 @@ public class PlatformPluginTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
+  // SYSTEM_UI_FLAG_*, setSystemUiVisibility
   @Config(sdk = 29)
   @Test
   public void setSystemUiMode() {
@@ -371,8 +375,11 @@ public class PlatformPluginTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
+  // Robolectric.buildActivity.
   @Test
   public void setSystemUiModeListener_overlaysAreHidden() {
+    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
     ActivityController<Activity> controller = Robolectric.buildActivity(Activity.class);
     controller.setup();
     Activity fakeActivity = controller.get();
@@ -400,8 +407,11 @@ public class PlatformPluginTest {
     verify(fakePlatformChannel).systemChromeChanged(false);
   }
 
+  @SuppressWarnings("deprecation")
+  // Robolectric.buildActivity.
   @Test
   public void setSystemUiModeListener_overlaysAreVisible() {
+    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
     ActivityController<Activity> controller = Robolectric.buildActivity(Activity.class);
     controller.setup();
     Activity fakeActivity = controller.get();
@@ -426,6 +436,8 @@ public class PlatformPluginTest {
     verify(fakePlatformChannel).systemChromeChanged(true);
   }
 
+  @SuppressWarnings("deprecation")
+  // SYSTEM_UI_FLAG_*, setSystemUiVisibility
   @Config(sdk = 28)
   @Test
   public void doNotEnableEdgeToEdgeOnOlderSdk() {
@@ -446,6 +458,8 @@ public class PlatformPluginTest {
                 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
   }
 
+  @SuppressWarnings("deprecation")
+  // FLAG_TRANSLUCENT_STATUS, FLAG_TRANSLUCENT_NAVIGATION
   @Config(sdk = 29)
   @Test
   public void verifyWindowFlagsSetToStyleOverlays() {
@@ -513,8 +527,12 @@ public class PlatformPluginTest {
     verify(mockActivity, never()).finish();
   }
 
+
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity.
   @Test
   public void popSystemNavigatorFlutterFragment() {
+    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
     FragmentActivity activity = spy(Robolectric.setupActivity(FragmentActivity.class));
     final AtomicBoolean onBackPressedCalled = new AtomicBoolean(false);
     OnBackPressedCallback backCallback =
@@ -539,8 +557,11 @@ public class PlatformPluginTest {
     assertTrue(onBackPressedCalled.get());
   }
 
+  @SuppressWarnings("deprecation")
+  // Robolectric.setupActivity.
   @Test
   public void doesNotDoAnythingByDefaultIfFragmentPopSystemNavigatorOverridden() {
+    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
     FragmentActivity activity = spy(Robolectric.setupActivity(FragmentActivity.class));
     PlatformChannel mockPlatformChannel = mock(PlatformChannel.class);
     PlatformPluginDelegate mockPlatformPluginDelegate = mock(PlatformPluginDelegate.class);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -376,10 +376,9 @@ public class PlatformPluginTest {
   }
 
   @SuppressWarnings("deprecation")
-  // Robolectric.buildActivity.
+  // SYSTEM_UI_FLAG_FULLSCREEN
   @Test
   public void setSystemUiModeListener_overlaysAreHidden() {
-    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
     ActivityController<Activity> controller = Robolectric.buildActivity(Activity.class);
     controller.setup();
     Activity fakeActivity = controller.get();
@@ -408,10 +407,9 @@ public class PlatformPluginTest {
   }
 
   @SuppressWarnings("deprecation")
-  // Robolectric.buildActivity.
+  // dispatchSystemUiVisibilityChanged
   @Test
   public void setSystemUiModeListener_overlaysAreVisible() {
-    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
     ActivityController<Activity> controller = Robolectric.buildActivity(Activity.class);
     controller.setup();
     Activity fakeActivity = controller.get();
@@ -529,6 +527,7 @@ public class PlatformPluginTest {
 
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void popSystemNavigatorFlutterFragment() {
     // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
@@ -558,9 +557,9 @@ public class PlatformPluginTest {
 
   @SuppressWarnings("deprecation")
   // Robolectric.setupActivity.
+  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void doesNotDoAnythingByDefaultIfFragmentPopSystemNavigatorOverridden() {
-    // Migrate to ActivityScenario by following https://github.com/robolectric/robolectric/pull/4736
     FragmentActivity activity = spy(Robolectric.setupActivity(FragmentActivity.class));
     PlatformChannel mockPlatformChannel = mock(PlatformChannel.class);
     PlatformPluginDelegate mockPlatformPluginDelegate = mock(PlatformPluginDelegate.class);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -2,8 +2,6 @@ package io.flutter.plugin.platform;
 
 import static android.os.Looper.getMainLooper;
 import static io.flutter.embedding.engine.systemchannels.PlatformViewsChannel.PlatformViewTouch;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -28,7 +28,6 @@ import io.flutter.embedding.android.FlutterImageView;
 import io.flutter.embedding.android.FlutterSurfaceView;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.MotionEventTracker;
-import io.flutter.embedding.android.RenderMode;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.FlutterOverlaySurface;

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -25,6 +25,7 @@ import android.widget.FrameLayout.LayoutParams;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.android.FlutterImageView;
+import io.flutter.embedding.android.FlutterSurfaceView;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.MotionEventTracker;
 import io.flutter.embedding.android.RenderMode;
@@ -1521,7 +1522,7 @@ public class PlatformViewsControllerTest {
       FlutterJNI jni, PlatformViewsController platformViewsController) {
     final Context context = ApplicationProvider.getApplicationContext();
     final FlutterView flutterView =
-        new FlutterView(context, RenderMode.surface) {
+        new FlutterView(context, new FlutterSurfaceView(context)) {
           @Override
           public FlutterImageView createImageView() {
             final FlutterImageView view = mock(FlutterImageView.class);

--- a/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -3,7 +3,7 @@ package io.flutter.plugin.platform;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.R;
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;

--- a/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -13,10 +13,10 @@ import android.content.Context;
 import android.hardware.display.DisplayManager;
 import android.view.Display;
 import android.view.inputmethod.InputMethodManager;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -38,7 +38,7 @@ public class SingleViewPresentationTest {
     // system service instead of the spy's and fails.
 
     // Create an SVP under test with a Context that returns a local IMM mock.
-    Context context = spy(RuntimeEnvironment.application);
+    Context context = spy(ApplicationProvider.getApplicationContext());
     InputMethodManager expected = mock(InputMethodManager.class);
     when(context.getSystemService(Context.INPUT_METHOD_SERVICE)).thenReturn(expected);
     DisplayManager dm = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
@@ -60,7 +60,7 @@ public class SingleViewPresentationTest {
     // The IMM should also persist across display contexts created from the base context.
 
     // Create an SVP under test with a Context that returns a local IMM mock.
-    Context context = spy(RuntimeEnvironment.application);
+    Context context = spy(ApplicationProvider.getApplicationContext());
     InputMethodManager expected = mock(InputMethodManager.class);
     when(context.getSystemService(Context.INPUT_METHOD_SERVICE)).thenReturn(expected);
     Display display =

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -81,7 +81,8 @@ public class AccessibilityBridgeTest {
     assertEquals(nodeInfo.getText(), null);
   }
 
-  @TargetApi(26)
+  @Config(sdk = 28)
+  @TargetApi(28)
   @Test
   public void itDescribesTextFieldsWithTextAndHint() {
     AccessibilityBridge accessibilityBridge = setUpBridge();
@@ -322,6 +323,7 @@ public class AccessibilityBridgeTest {
     verify(mockNodeInfo2, times(1)).setTraversalAfter(eq(mockRootView), eq(1));
   }
 
+  @Config(sdk = 24)
   @TargetApi(24)
   @Test
   public void itSetsRootViewNotImportantForAccessibility() {
@@ -350,6 +352,7 @@ public class AccessibilityBridgeTest {
     verify(mockNodeInfo, times(1)).setImportantForAccessibility(eq(false));
   }
 
+  @Config(sdk = 24)
   @TargetApi(24)
   @Test
   public void itSetsNodeImportantForAccessibilityIfItHasContent() {
@@ -380,6 +383,7 @@ public class AccessibilityBridgeTest {
     verify(mockNodeInfo, times(1)).setImportantForAccessibility(eq(true));
   }
 
+  @Config(sdk = 24)
   @TargetApi(24)
   @Test
   public void itSetsNodeImportantForAccessibilityIfItHasActions() {
@@ -410,6 +414,7 @@ public class AccessibilityBridgeTest {
     verify(mockNodeInfo, times(1)).setImportantForAccessibility(eq(true));
   }
 
+  @Config(sdk = 24)
   @TargetApi(24)
   @Test
   public void itSetsNodeUnImportantForAccessibilityIfItIsEmpty() {
@@ -449,6 +454,9 @@ public class AccessibilityBridgeTest {
     verify(mockNodeInfo1, times(1)).setImportantForAccessibility(eq(false));
   }
 
+  @SuppressWarnings("deprecation")
+  // getSystemWindowInset* methods deprecated.
+  @Config(sdk = 28)
   @TargetApi(28)
   @Test
   public void itSetCutoutInsetBasedonLayoutModeNever() {
@@ -498,6 +506,9 @@ public class AccessibilityBridgeTest {
             new Rect(left + expectedInsetLeft, top, right + expectedInsetLeft, bottom));
   }
 
+  @SuppressWarnings("deprecation")
+  // getSystemWindowInset* methods deprecated.
+  @Config(sdk = 28)
   @TargetApi(28)
   @Test
   public void itSetCutoutInsetBasedonLayoutModeDefault() {
@@ -547,6 +558,9 @@ public class AccessibilityBridgeTest {
             new Rect(left + expectedInsetLeft, top, right + expectedInsetLeft, bottom));
   }
 
+  @SuppressWarnings("deprecation")
+  // getSystemWindowInset* methods deprecated.
+  @Config(sdk = 28)
   @TargetApi(28)
   @Test
   public void itSetCutoutInsetBasedonLayoutModeShortEdges() {
@@ -595,6 +609,10 @@ public class AccessibilityBridgeTest {
     verify(mockNodeInfo, times(1)).setBoundsInScreen(new Rect(left, top, right, bottom));
   }
 
+  @SuppressWarnings("deprecation")
+  // getSystemWindowInset* methods deprecated.
+  // fluter#133074 tracks post deprecation work.
+  @Config(sdk = 30)
   @TargetApi(30)
   @Test
   public void itSetCutoutInsetBasedonLayoutModeAlways() {
@@ -840,6 +858,7 @@ public class AccessibilityBridgeTest {
     verify(mockRootView, times(1)).setAccessibilityPaneTitle(eq("new_node2"));
   }
 
+  @Config(sdk = 21)
   @TargetApi(21)
   @Test
   public void itCanPerformSetText() {
@@ -879,6 +898,7 @@ public class AccessibilityBridgeTest {
         .dispatchSemanticsAction(1, AccessibilityBridge.Action.SET_TEXT, expectedText);
   }
 
+  @Config(sdk = 21)
   @TargetApi(21)
   @Test
   public void itCanPredictSetText() {
@@ -918,6 +938,7 @@ public class AccessibilityBridgeTest {
     assertEquals(nodeInfo.getText().toString(), expectedText);
   }
 
+  @Config(sdk = 21)
   @TargetApi(21)
   @Test
   public void itBuildsAttributedString() {
@@ -984,6 +1005,7 @@ public class AccessibilityBridgeTest {
     assertEquals(actual.getSpanEnd(spellOutSpan), 9);
   }
 
+  @Config(sdk = 21)
   @TargetApi(21)
   @Test
   public void itSetsTextCorrectly() {
@@ -1043,6 +1065,7 @@ public class AccessibilityBridgeTest {
     assertEquals(objectSpans.length, 0);
   }
 
+  @Config(sdk = 28)
   @TargetApi(28)
   @Test
   public void itSetsTooltipCorrectly() {
@@ -1080,6 +1103,7 @@ public class AccessibilityBridgeTest {
     assertEquals(actual.toString(), root.tooltip);
   }
 
+  @Config(sdk = 21)
   @TargetApi(21)
   @Test
   public void itCanCreateAccessibilityNodeInfoWithSetText() {
@@ -1255,6 +1279,7 @@ public class AccessibilityBridgeTest {
     assertTrue(node2Info.isFocusable());
   }
 
+  @Config(sdk = 31)
   @TargetApi(31)
   @Test
   public void itSetsBoldTextFlagCorrectly() {

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -18,11 +18,10 @@ apply plugin: "com.android.library"
 rootProject.buildDir = project.property("build_dir")
 
 // Shows warnings for usage of deprecated API usages.
-// TODO(camsim99): Make deprecation warnings fatal and remove limit when all
-// 434 (at the time of this comment) deprecations are fixed.
+// TODO(reidbaker): Expand linter coverage https://github.com/flutter/flutter/issues/133154
 gradle.projectsEvaluated {
   tasks.withType(JavaCompile) {
-      options.compilerArgs << "-Xlint:deprecation" << "-Werror" << "-Xmaxwarns" << "434"
+      options.compilerArgs << "-Xlint:deprecation" << "-Werror"
   }
 }
 

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -22,7 +22,7 @@ rootProject.buildDir = project.property("build_dir")
 // 434 (at the time of this comment) deprecations are fixed.
 gradle.projectsEvaluated {
   tasks.withType(JavaCompile) {
-      options.compilerArgs << "-Xlint:deprecation" << "-Xmaxwarns" << "434"
+      options.compilerArgs << "-Xlint:deprecation" << "-Werror" << "-Xmaxwarns" << "434"
   }
 }
 


### PR DESCRIPTION
Set gradle to treat warnings as errors and suppress or fix all warnings in engine android tests. 

Fixes flutter/flutter#133070

After doing this work I was disappointed to realized that the only lint turned on was deprecration but this is still a step in the right direction. 

- Remove usages of deprecated junit.framework and replace with org.junit in KeyboardManagerTest, PlatformViewsControllerTest and SinglePresentationViewTest
- Annotate deprecated usages of Registrar
- Suppress warnings for getSystemWindowInsets and ensure roboletric config consistant with targetApi lint annotation, bump itDescribesTextFieldsWithTextAndHint to 28 because test actually fails on api 26
- Suppress warnings for DartExecutor.send
- Suppress warnings for ClipboardManager.set/hasText
- Suppress warnings for getWindowSystemUiVisibility, setMessageHandler, DartExecutor.send, InputMethodSubtype, and proof of concept migration from Roboletric.setupActivity
- Suppress deprecation warnings, set minsdk on tests that were checking for sdk version
- Suppress deprecation warnings in SpellCheckPluginTest
- Suppress deprecation warnings in MouseCursorPluginTest, set minsdk config to match target api
- Stop calling RuntimeEnvrionment.application and insted a call ApplicationProvider.getApplicationContext() in SingleViewPresentationTest
- Start calling FlutterView(Context, FlutterSurfaceView)
- Suppress deprecation warnings in PlatformPluginTest, getText, Robolectric.setup/buildActivity, system ui flags
- Suppress deprecation warnings in PlayStoreDeferredComponentManagerTest
- Suppress deprecation warnings in KeyboardChannelTest
- Suppress deprecation warnings in SettingsChannelTest
- Suppress deprecation warnings in ApplicationInfoLoaderTest
- Stop calling RuntimeEnvrionment.application and insted a call ApplicationProvider.getApplicationContext() in FlutterEngineGroupCacheTest
- Suppress deprecation warnings in FlutterAndroidComponentTest
- Suppress deprecation warnings in FlutterFragmentTest, more robolectric setup activity calls
- Suppress deprecation warnings in FlutterActivityAndFragmentDelegateTest
- Shadow.directlyOn is incompatible with java 17+, refactor to use reflectors and direct following https://github.com/robolectric/robolectric/pull/6598/files as an example Unsure if SplashShadowResources is used anywhere
- Enable warnings as errors
- Formatting


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
