### PR TITLE
Use decal TileMode in blur image_filter_test.dart

### DIFF
--- a/testing/dart/image_filter_test.dart
+++ b/testing/dart/image_filter_test.dart
@@ -176,7 +176,7 @@ void main() {
   test('ImageFilter - blur', () async {
     final Paint paint = Paint()
       ..color = green
-      ..imageFilter = makeBlur(1.0, 1.0);
+      ..imageFilter = makeBlur(1.0, 1.0, TileMode.decal);
 
     final Uint32List bytes = await getBytesForPaint(paint);
     checkBytes(bytes, greenCenterBlurred, greenSideBlurred, greenCornerBlurred);


### PR DESCRIPTION
The expected color values appear to match the output of Skia's raster backend's blur. Historically, that doesn't support any tile mode other than decal, so while the `makeBlur()` function defaulted to clamp tiling, the output was decal and thus showed the blur fading to transparent.

The test draws a 1x1 green rectangle in the center of a 3x3 image. Clamp tiling would actually cause the output of the blur to just copy the central green color to the remaining 8 pixels. This is the output of Skia's GPU blur. I am working to land changes in Skia that make the raster backend handle all tile modes, which then has it match the existing GPU blur's behavior of a constant output for clamp tiling in this test (so it then fails).

Decal tiling appears to be more useful for this test case anyways because it creates per-pixel variations that can be validated against.

This is needed to land Skia-side fixes for skbug.com/40039877 and skbug.com/40039025

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
