### PR TITLE
Turn on the `skia_enable_optimize_size` flag to save a bit of binary size

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -731,6 +731,7 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['skia_canvaskit_enable_paragraph'] = True
   gn_args['skia_canvaskit_enable_webgl'] = True
   gn_args['skia_canvaskit_enable_webgpu'] = False
+  gn_args['skia_enable_optimize_size'] = True
   gn_args['skia_canvaskit_profile_build'] = args.runtime_mode == 'profile'
   gn_args['flutter_prebuilt_dart_sdk'] = True
 


### PR DESCRIPTION
This flag removes some code from CanvasKit to reduce size by a little bit. I went ahead and did a run of the benchmarks (https://github.com/flutter/flutter/pull/133208) to see if it negatively affected anything, and there was no difference beyond noise between the current benchmark numbers and the benchmarks with this flag enabled.

The size differences are as follows:
Before the change:
```
total 30616
drwxr-xr-x  11 jacksongardner  primarygroup      352 Aug 23 14:33 .
drwxr-xr-x   7 jacksongardner  primarygroup      224 Aug 10 18:14 ..
-rw-r--r--@  1 jacksongardner  primarygroup     6148 May 12 17:41 .DS_Store
-rw-r--r--   2 jacksongardner  primarygroup    94899 Aug 23 14:23 canvaskit.js
-rwxr-xr-x   2 jacksongardner  primarygroup  6631693 Aug 23 14:23 canvaskit.wasm
-rwxr-xr-x   1 jacksongardner  primarygroup  2102151 Aug 23 14:23 canvaskit.wasm.br
drwxr-xr-x   5 jacksongardner  primarygroup      160 Aug 23 14:33 chromium
-rw-r--r--   2 jacksongardner  primarygroup   161478 Aug 23 14:28 skwasm.js
-rwxr-xr-x   2 jacksongardner  primarygroup  3296038 Aug 23 14:28 skwasm.wasm
-rwxr-xr-x   1 jacksongardner  primarygroup  1101502 Aug 23 14:28 skwasm.wasm.br
-rw-r--r--   2 jacksongardner  primarygroup     3095 Aug 23 14:28 skwasm.worker.js

./chromium:
total 15520
drwxr-xr-x   5 jacksongardner  primarygroup      160 Aug 23 14:33 .
drwxr-xr-x  11 jacksongardner  primarygroup      352 Aug 23 14:33 ..
-rw-r--r--   2 jacksongardner  primarygroup    94545 Aug 23 14:25 canvaskit.js
-rwxr-xr-x   2 jacksongardner  primarygroup  5223378 Aug 23 14:25 canvaskit.wasm
-rwxr-xr-x   1 jacksongardner  primarygroup  1492433 Aug 23 14:25 canvaskit.wasm.br
```

After the change:
```
total 28568
drwxr-xr-x  11 jacksongardner  primarygroup      352 Aug 23 14:42 .
drwxr-xr-x   7 jacksongardner  primarygroup      224 Aug 10 18:14 ..
-rw-r--r--@  1 jacksongardner  primarygroup     6148 May 12 17:41 .DS_Store
-rw-r--r--   2 jacksongardner  primarygroup    94899 Aug 23 14:37 canvaskit.js
-rwxr-xr-x   2 jacksongardner  primarygroup  6401703 Aug 23 14:37 canvaskit.wasm
-rwxr-xr-x   1 jacksongardner  primarygroup  2038390 Aug 23 14:37 canvaskit.wasm.br
drwxr-xr-x   5 jacksongardner  primarygroup      160 Aug 23 14:42 chromium
-rw-r--r--   2 jacksongardner  primarygroup   161478 Aug 23 14:41 skwasm.js
-rwxr-xr-x   2 jacksongardner  primarygroup  3143431 Aug 23 14:41 skwasm.wasm
-rwxr-xr-x   1 jacksongardner  primarygroup  1050854 Aug 23 14:41 skwasm.wasm.br
-rw-r--r--   2 jacksongardner  primarygroup     3095 Aug 23 14:41 skwasm.worker.js

./chromium:
total 15392
drwxr-xr-x   5 jacksongardner  primarygroup      160 Aug 23 14:42 .
drwxr-xr-x  11 jacksongardner  primarygroup      352 Aug 23 14:42 ..
-rw-r--r--   2 jacksongardner  primarygroup    94545 Aug 23 14:39 canvaskit.js
-rwxr-xr-x   2 jacksongardner  primarygroup  4993586 Aug 23 14:39 canvaskit.wasm
-rwxr-xr-x   1 jacksongardner  primarygroup  1427979 Aug 23 14:39 canvaskit.wasm.br
```

The brotli-compressed wasm modules save about 50-70kb each with this flag.