### PR TITLE
[Impeller] Removed copies of Font in GlyphAtlas.

### DIFF
--- a/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -152,8 +152,10 @@ static ISize OptimumAtlasSizeForFontGlyphPairs(
   return ISize{0, 0};
 }
 
+namespace {
+template <typename T>
 static void DrawGlyph(SkCanvas* canvas,
-                      const FontGlyphPair& font_glyph,
+                      const T& font_glyph,
                       const Rect& location,
                       bool has_color) {
   const auto& metrics = font_glyph.font.GetMetrics();
@@ -184,6 +186,7 @@ static void DrawGlyph(SkCanvas* canvas,
       glyph_paint                                        // paint
   );
 }
+}  // namespace
 
 static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
                               const std::shared_ptr<SkBitmap>& bitmap,
@@ -243,7 +246,7 @@ static std::shared_ptr<SkBitmap> CreateAtlasBitmap(const GlyphAtlas& atlas,
 
   bool has_color = atlas.GetType() == GlyphAtlas::Type::kColorBitmap;
 
-  atlas.IterateGlyphs([canvas, has_color](const FontGlyphPair& font_glyph,
+  atlas.IterateGlyphs([canvas, has_color](const FontRefGlyphPair& font_glyph,
                                           const Rect& location) -> bool {
     DrawGlyph(canvas, font_glyph, location, has_color);
     return true;

--- a/impeller/typographer/backends/stb/typographer_context_stb.cc
+++ b/impeller/typographer/backends/stb/typographer_context_stb.cc
@@ -195,10 +195,12 @@ static ISize OptimumAtlasSizeForFontGlyphPairs(
   return ISize{0, 0};
 }
 
-static void DrawGlyph(BitmapSTB* bitmap,
-                      const FontGlyphPair& font_glyph,
-                      const Rect& location,
-                      bool has_color) {
+namespace {
+template <typename T>
+void DrawGlyph(BitmapSTB* bitmap,
+               const T& font_glyph,
+               const Rect& location,
+               bool has_color) {
   const auto& metrics = font_glyph.font.GetMetrics();
 
   const impeller::Font& font = font_glyph.font;
@@ -269,6 +271,7 @@ static void DrawGlyph(BitmapSTB* bitmap,
     stbtt_FreeBitmap(glyph_pixels, nullptr);
   }
 }
+}  // namespace
 
 static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
                               const std::shared_ptr<BitmapSTB>& bitmap,
@@ -302,7 +305,7 @@ static std::shared_ptr<BitmapSTB> CreateAtlasBitmap(const GlyphAtlas& atlas,
 
   bool has_color = atlas.GetType() == GlyphAtlas::Type::kColorBitmap;
 
-  atlas.IterateGlyphs([&bitmap, has_color](const FontGlyphPair& font_glyph,
+  atlas.IterateGlyphs([&bitmap, has_color](const FontRefGlyphPair& font_glyph,
                                            const Rect& location) -> bool {
     DrawGlyph(bitmap.get(), font_glyph, location, has_color);
     return true;

--- a/impeller/typographer/font.h
+++ b/impeller/typographer/font.h
@@ -44,7 +44,7 @@ class Font : public Comparable<Font> {
 
   Font(std::shared_ptr<Typeface> typeface, Metrics metrics);
 
-  ~Font();
+  virtual ~Font();
 
   bool IsValid() const;
 

--- a/impeller/typographer/font_glyph_pair.h
+++ b/impeller/typographer/font_glyph_pair.h
@@ -19,18 +19,20 @@ namespace impeller {
 /// @brief      A font along with a glyph in that font rendered at a particular
 ///             scale. Used in glyph atlases as keys.
 ///
-struct FontGlyphPair {
+template <typename FontType>
+struct FontGlyphPairPrototype {
   struct Hash;
   struct Equal;
+  struct Less;
 
-  using Set = std::unordered_set<FontGlyphPair, Hash, Equal>;
+  using Set = std::unordered_set<FontGlyphPairPrototype<FontType>, Hash, Equal>;
 
-  Font font;
+  FontType font;
   Glyph glyph;
   Scalar scale;
 
   struct Hash {
-    std::size_t operator()(const FontGlyphPair& p) const {
+    std::size_t operator()(const FontGlyphPairPrototype<FontType>& p) const {
       static_assert(sizeof(p.glyph.index) == 2);
       static_assert(sizeof(p.glyph.type) == 1);
       size_t index = p.glyph.index;
@@ -48,11 +50,15 @@ struct FontGlyphPair {
     }
   };
   struct Equal {
-    bool operator()(const FontGlyphPair& lhs, const FontGlyphPair& rhs) const {
+    bool operator()(const FontGlyphPairPrototype<FontType>& lhs,
+                    const FontGlyphPairPrototype<FontType>& rhs) const {
       return lhs.font.IsEqual(rhs.font) && lhs.glyph.index == rhs.glyph.index &&
              lhs.glyph.type == rhs.glyph.type && lhs.scale == rhs.scale;
     }
   };
 };
+
+using FontGlyphPair = FontGlyphPairPrototype<Font>;
+using FontRefGlyphPair = FontGlyphPairPrototype<const Font&>;
 
 }  // namespace impeller

--- a/impeller/typographer/glyph_atlas.cc
+++ b/impeller/typographer/glyph_atlas.cc
@@ -59,12 +59,25 @@ void GlyphAtlas::SetTexture(std::shared_ptr<Texture> texture) {
 
 void GlyphAtlas::AddTypefaceGlyphPosition(const FontGlyphPair& pair,
                                           Rect rect) {
-  positions_[pair] = rect;
+  auto [it, did_insert] = fonts_.insert(pair.font);
+  positions_[FontRefGlyphPair{
+      .font = *it,          //
+      .glyph = pair.glyph,  //
+      .scale = pair.scale   //
+  }] = rect;
 }
 
 std::optional<Rect> GlyphAtlas::FindFontGlyphBounds(
     const FontGlyphPair& pair) const {
-  const auto& found = positions_.find(pair);
+  auto font_it = fonts_.find(pair.font);
+  if (font_it == fonts_.end()) {
+    return std::nullopt;
+  }
+  const auto& found = positions_.find(FontRefGlyphPair{
+      .font = *font_it,     //
+      .glyph = pair.glyph,  //
+      .scale = pair.scale   //
+  });
   if (found == positions_.end()) {
     return std::nullopt;
   }
@@ -76,7 +89,7 @@ size_t GlyphAtlas::GetGlyphCount() const {
 }
 
 size_t GlyphAtlas::IterateGlyphs(
-    const std::function<bool(const FontGlyphPair& pair, const Rect& rect)>&
+    const std::function<bool(const FontRefGlyphPair& pair, const Rect& rect)>&
         iterator) const {
   if (!iterator) {
     return 0u;

--- a/impeller/typographer/glyph_atlas.h
+++ b/impeller/typographer/glyph_atlas.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <set>
 #include <unordered_map>
 
 #include "flutter/fml/macros.h"
@@ -97,7 +98,7 @@ class GlyphAtlas {
   /// @return     The number of glyphs iterated over.
   ///
   size_t IterateGlyphs(
-      const std::function<bool(const FontGlyphPair& pair, const Rect& rect)>&
+      const std::function<bool(const FontRefGlyphPair& pair, const Rect& rect)>&
           iterator) const;
 
   //----------------------------------------------------------------------------
@@ -113,11 +114,20 @@ class GlyphAtlas {
  private:
   const Type type_;
   std::shared_ptr<Texture> texture_;
+  struct FontHash {
+    std::size_t operator()(const Font& font) const { return font.GetHash(); }
+  };
+  struct FontEqual {
+    bool operator()(const Font& lhs, const Font& rhs) const {
+      return lhs.IsEqual(rhs);
+    }
+  };
+  std::unordered_set<Font, FontHash, FontEqual> fonts_;
 
-  std::unordered_map<FontGlyphPair,
+  std::unordered_map<FontRefGlyphPair,
                      Rect,
-                     FontGlyphPair::Hash,
-                     FontGlyphPair::Equal>
+                     FontRefGlyphPair::Hash,
+                     FontRefGlyphPair::Equal>
       positions_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(GlyphAtlas);

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -71,8 +71,9 @@ TEST_P(TypographerTest, CanCreateGlyphAtlas) {
   std::optional<FontGlyphPair> first_pair;
   Rect first_rect;
   atlas->IterateGlyphs(
-      [&](const FontGlyphPair& pair, const Rect& rect) -> bool {
-        first_pair = pair;
+      [&](const FontRefGlyphPair& pair, const Rect& rect) -> bool {
+        first_pair = FontGlyphPair{
+            .font = pair.font, .glyph = pair.glyph, .scale = pair.scale};
         first_rect = rect;
         return false;
       });
@@ -202,7 +203,7 @@ TEST_P(TypographerTest, GlyphAtlasWithLotsOfdUniqueGlyphSize) {
 
   std::set<uint16_t> unique_glyphs;
   std::vector<uint16_t> total_glyphs;
-  atlas->IterateGlyphs([&](const FontGlyphPair& pair, const Rect& rect) {
+  atlas->IterateGlyphs([&](const FontRefGlyphPair& pair, const Rect& rect) {
     unique_glyphs.insert(pair.glyph.index);
     total_glyphs.push_back(pair.glyph.index);
     return true;


### PR DESCRIPTION
issue https://github.com/flutter/flutter/issues/132164

This resolves the issue, but I don't think it's going to pan out since it requires 2 different hash lookups.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
