### PR TITLE
[Impeller] Don't place vertex buffer bindings in the Binding map.

### DIFF
--- a/impeller/core/buffer_view.h
+++ b/impeller/core/buffer_view.h
@@ -15,7 +15,7 @@ struct BufferView {
   uint8_t* contents;
   Range range;
 
-  constexpr operator bool() const { return static_cast<bool>(buffer); }
+  constexpr explicit operator bool() const { return static_cast<bool>(buffer); }
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -177,12 +177,6 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
                                            Allocator& transients_allocator,
                                            const BufferResource& buffer) const {
   const auto* metadata = buffer.GetMetadata();
-  if (metadata == nullptr) {
-    // Vertex buffer bindings don't have metadata as those definitions are
-    // already handled by vertex attrib pointers. Keep going.
-    return true;
-  }
-
   auto device_buffer =
       buffer.resource.buffer->GetDeviceBuffer(transients_allocator);
   if (!device_buffer) {

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -409,7 +409,8 @@ bool RenderPassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
                                   const Bindings& bindings,
                                   ShaderStage stage) -> bool {
     if (stage == ShaderStage::kVertex) {
-      if (!Bind(pass_bindings, *allocator, stage, VertexDescriptor::kReservedVertexBufferIndex,
+      if (!Bind(pass_bindings, *allocator, stage,
+                VertexDescriptor::kReservedVertexBufferIndex,
                 bindings.vertex_buffer.view.resource)) {
         return false;
       }

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -18,6 +18,7 @@
 #include "impeller/renderer/backend/metal/pipeline_mtl.h"
 #include "impeller/renderer/backend/metal/sampler_mtl.h"
 #include "impeller/renderer/backend/metal/texture_mtl.h"
+#include "impeller/renderer/vertex_descriptor.h"
 
 namespace impeller {
 
@@ -407,6 +408,12 @@ bool RenderPassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
   auto bind_stage_resources = [&allocator, &pass_bindings](
                                   const Bindings& bindings,
                                   ShaderStage stage) -> bool {
+    if (stage == ShaderStage::kVertex) {
+      if (!Bind(pass_bindings, *allocator, stage, VertexDescriptor::kReservedVertexBufferIndex,
+                bindings.vertex_buffer.view.resource)) {
+        return false;
+      }
+    }
     for (const auto& buffer : bindings.buffers) {
       if (!Bind(pass_bindings, *allocator, stage, buffer.first,
                 buffer.second.view.resource)) {

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -382,11 +382,6 @@ static bool AllocateAndBindDescriptorSets(const ContextVK& context,
         return false;
       }
 
-      // Reserved index used for per-vertex data.
-      if (buffer_index == VertexDescriptor::kReservedVertexBufferIndex) {
-        continue;
-      }
-
       if (!encoder.Track(device_buffer)) {
         return false;
       }

--- a/impeller/renderer/command.cc
+++ b/impeller/renderer/command.cc
@@ -18,7 +18,7 @@ bool Command::BindVertices(const VertexBuffer& buffer) {
     return false;
   }
 
-  vertex_bindings.buffers[VertexDescriptor::kReservedVertexBufferIndex] =
+  vertex_bindings.vertex_buffer =
       BufferAndUniformSlot{.slot = {}, .view = {nullptr, buffer.vertex_buffer}};
   index_buffer = buffer.index_buffer;
   vertex_count = buffer.vertex_count;
@@ -27,12 +27,7 @@ bool Command::BindVertices(const VertexBuffer& buffer) {
 }
 
 BufferView Command::GetVertexBuffer() const {
-  auto found = vertex_bindings.buffers.find(
-      VertexDescriptor::kReservedVertexBufferIndex);
-  if (found != vertex_bindings.buffers.end()) {
-    return found->second.view.resource;
-  }
-  return {};
+  return vertex_bindings.vertex_buffer.view.resource;
 }
 
 bool Command::BindResource(ShaderStage stage,
@@ -55,6 +50,7 @@ bool Command::DoBindResource(ShaderStage stage,
                              const ShaderUniformSlot& slot,
                              const T metadata,
                              const BufferView& view) {
+  FML_DCHECK(slot.ext_res_0 != VertexDescriptor::kReservedVertexBufferIndex);
   if (!view) {
     return false;
   }

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -77,6 +77,8 @@ struct BufferAndUniformSlot {
 struct Bindings {
   std::map<size_t, TextureAndSampler> sampled_images;
   std::map<size_t, BufferAndUniformSlot> buffers;
+  // This is only valid for vertex bindings.
+  BufferAndUniformSlot vertex_buffer;
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
The metal backend is the only backend that doesn't treat binding the vertex buffer specially. For the GLES and Vulkan backend, we can instead pull it out of the cmd map entirely.

This will make it easier to partially inline the map into the bindings object.

https://github.com/flutter/flutter/issues/133199