### PR TITLE
Revert "[Impeller] add trace events for VkRenderPass and VkFrameBuffe…

### DIFF
--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -89,7 +89,6 @@ static vk::AttachmentDescription CreateAttachmentDescription(
 SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
     const ContextVK& context,
     const std::shared_ptr<CommandBufferVK>& command_buffer) const {
-  TRACE_EVENT0("impeller", "RenderPassVK::CreateVKRenderPass");
   std::vector<vk::AttachmentDescription> attachments;
 
   std::vector<vk::AttachmentReference> color_refs;
@@ -223,7 +222,6 @@ static std::vector<vk::ClearValue> GetVKClearValues(
 SharedHandleVK<vk::Framebuffer> RenderPassVK::CreateVKFramebuffer(
     const ContextVK& context,
     const vk::RenderPass& pass) const {
-  TRACE_EVENT0("impeller", "RenderPassVK::CreateVKFramebuffer");
   vk::FramebufferCreateInfo fb_info;
 
   fb_info.renderPass = pass;


### PR DESCRIPTION
…r creation. (#44837)"

This reverts commit ca4ea82258a661f81aa3dec9c6e668c686f0e820.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

These trace events aren't super useful, since we've tracked down the issues as either 1) phone is overloaded due to image decoding at large size or 2) https://github.com/flutter/flutter/issues/133198