### PR TITLE
[Impeller] Fix mask blurs and the Gaussian blur coverage hint.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3273,5 +3273,40 @@ TEST_P(AiksTest, PipelineBlendSingleParameter) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, ClippedBlurFilterRendersCorrectlyInteractive) {
+  auto callback = [&](AiksContext& renderer, RenderTarget& render_target) {
+    auto point = IMPELLER_PLAYGROUND_POINT(Point(400, 400), 20, Color::Green());
+
+    Canvas canvas;
+    canvas.Translate(point - Point(400, 400));
+    Paint paint;
+    paint.mask_blur_descriptor = Paint::MaskBlurDescriptor{
+        .style = FilterContents::BlurStyle::kNormal,
+        .sigma = Radius{120 * 3},
+    };
+    paint.color = Color::Red();
+    PathBuilder builder{};
+    builder.AddRect(Rect::MakeLTRB(0, 0, 800, 800));
+    canvas.DrawPath(builder.TakePath(), paint);
+    return renderer.Render(canvas.EndRecordingAsPicture(), render_target);
+  };
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
+}
+
+TEST_P(AiksTest, ClippedBlurFilterRendersCorrectly) {
+  Canvas canvas;
+  canvas.Translate(Point(0, -400));
+  Paint paint;
+  paint.mask_blur_descriptor = Paint::MaskBlurDescriptor{
+      .style = FilterContents::BlurStyle::kNormal,
+      .sigma = Radius{120 * 3},
+  };
+  paint.color = Color::Red();
+  PathBuilder builder{};
+  builder.AddRect(Rect::MakeLTRB(0, 0, 800, 800));
+  canvas.DrawPath(builder.TakePath(), paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -492,7 +492,7 @@ void Canvas::DrawImageRect(const std::shared_ptr<Image>& image,
   Entity entity;
   entity.SetBlendMode(paint.blend_mode);
   entity.SetStencilDepth(GetStencilDepth());
-  entity.SetContents(paint.WithFilters(contents, false));
+  entity.SetContents(paint.WithFilters(contents));
   entity.SetTransformation(GetCurrentTransformation());
 
   GetCurrentPass().AddEntity(entity);
@@ -561,8 +561,14 @@ void Canvas::DrawTextFrame(const TextFrame& text_frame,
     color_text_contents->SetColorSourceContents(
         paint.color_source.GetContents(paint));
 
-    entity.SetContents(
-        paint.WithFilters(std::move(color_text_contents), false));
+    // TODO(bdero): This mask blur application is a hack. It will always wind up
+    //              doing a gaussian blur that affects the color source itself
+    //              instead of just the mask. The color filter text support
+    //              needs to be reworked in order to interact correctly with
+    //              mask filters.
+    //              https://github.com/flutter/flutter/issues/133297
+    entity.SetContents(paint.WithFilters(
+        paint.WithMaskBlur(std::move(color_text_contents), true)));
 
     GetCurrentPass().AddEntity(entity);
     return;
@@ -573,7 +579,14 @@ void Canvas::DrawTextFrame(const TextFrame& text_frame,
   entity.SetTransformation(GetCurrentTransformation() *
                            Matrix::MakeTranslation(position));
 
-  entity.SetContents(paint.WithFilters(std::move(text_contents), true));
+  // TODO(bdero): This mask blur application is a hack. It will always wind up
+  //              doing a gaussian blur that affects the color source itself
+  //              instead of just the mask. The color filter text support
+  //              needs to be reworked in order to interact correctly with
+  //              mask filters.
+  //              https://github.com/flutter/flutter/issues/133297
+  entity.SetContents(
+      paint.WithFilters(paint.WithMaskBlur(std::move(text_contents), true)));
 
   GetCurrentPass().AddEntity(entity);
 }
@@ -682,7 +695,7 @@ void Canvas::DrawAtlas(const std::shared_ptr<Image>& atlas,
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());
   entity.SetBlendMode(paint.blend_mode);
-  entity.SetContents(paint.WithFilters(contents, false));
+  entity.SetContents(paint.WithFilters(contents));
 
   GetCurrentPass().AddEntity(entity);
 }

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -42,7 +42,8 @@ struct Paint {
     Sigma sigma;
 
     std::shared_ptr<FilterContents> CreateMaskBlur(
-        std::shared_ptr<ColorSourceContents> color_source_contents) const;
+        std::shared_ptr<ColorSourceContents> color_source_contents,
+        const std::shared_ptr<ColorFilter>& color_filter) const;
 
     std::shared_ptr<FilterContents> CreateMaskBlur(
         const FilterInput::Ref& input,
@@ -67,18 +68,10 @@ struct Paint {
 
   /// @brief      Wrap this paint's configured filters to the given contents.
   /// @param[in]  input           The contents to wrap with paint's filters.
-  /// @param[in]  is_solid_color  Affects mask blurring behavior. If false, use
-  ///                             the image border for mask blurring. If true,
-  ///                             do a Gaussian blur to achieve the mask
-  ///                             blurring effect for arbitrary paths. If unset,
-  ///                             use the current paint configuration to infer
-  ///                             the result.
   /// @return     The filter-wrapped contents. If there are no filters that need
   ///             to be wrapped for the current paint configuration, the
   ///             original contents is returned.
-  std::shared_ptr<Contents> WithFilters(
-      std::shared_ptr<Contents> input,
-      std::optional<bool> is_solid_color = std::nullopt) const;
+  std::shared_ptr<Contents> WithFilters(std::shared_ptr<Contents> input) const;
 
   /// @brief      Wrap this paint's configured filters to the given contents of
   ///             subpass target.
@@ -101,10 +94,10 @@ struct Paint {
   /// @brief   Whether this paint has a color filter that can apply opacity
   bool HasColorFilter() const;
 
- private:
   std::shared_ptr<Contents> WithMaskBlur(std::shared_ptr<Contents> input,
                                          bool is_solid_color) const;
 
+ private:
   std::shared_ptr<Contents> WithImageFilter(std::shared_ptr<Contents> input,
                                             const Matrix& effect_transform,
                                             bool is_subpass) const;

--- a/impeller/entity/contents/color_source_contents.cc
+++ b/impeller/entity/contents/color_source_contents.cc
@@ -38,6 +38,10 @@ const Matrix& ColorSourceContents::GetInverseEffectTransform() const {
   return inverse_matrix_;
 }
 
+bool ColorSourceContents::IsSolidColor() const {
+  return false;
+}
+
 std::optional<Rect> ColorSourceContents::GetCoverage(
     const Entity& entity) const {
   return geometry_->GetCoverage(entity.GetTransformation());

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -90,6 +90,8 @@ class ColorSourceContents : public Contents {
   ///
   Scalar GetOpacityFactor() const;
 
+  virtual bool IsSolidColor() const;
+
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -24,6 +24,10 @@ Color SolidColorContents::GetColor() const {
   return color_.WithAlpha(color_.alpha * GetOpacityFactor());
 }
 
+bool SolidColorContents::IsSolidColor() const {
+  return true;
+}
+
 bool SolidColorContents::IsOpaque() const {
   return GetColor().IsOpaque();
 }

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -34,6 +34,9 @@ class SolidColorContents final : public ColorSourceContents {
 
   Color GetColor() const;
 
+  // |ColorSourceContents|
+  bool IsSolidColor() const override;
+
   // |Contents|
   bool IsOpaque() const override;
 

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -30,6 +30,9 @@ static const std::vector<std::string> kSkipTests = {
     "impeller_Play_AiksTest_CanRenderRadialGradientManyColors_Vulkan",
     "impeller_Play_AiksTest_CanRenderBackdropBlurInteractive_Metal",
     "impeller_Play_AiksTest_CanRenderBackdropBlurInteractive_Vulkan",
+    "impeller_Play_AiksTest_ClippedBlurFilterRendersCorrectlyInteractive_Metal",
+    "impeller_Play_AiksTest_ClippedBlurFilterRendersCorrectlyInteractive_"
+    "Vulkan",
     "impeller_Play_AiksTest_TextFrameSubpixelAlignment_Metal",
     "impeller_Play_AiksTest_TextFrameSubpixelAlignment_Vulkan",
     "impeller_Play_AiksTest_ColorWheel_Metal",


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/132936.

* In some cases, mask blurs were getting applied twice.
* Coverage hint clipping was too aggressive on the second pass of the gaussian blur.
* Rework the mask blur applicator to support gracefully falling back to GPU-based color filters when necessary.

This fix requires us to cherry-pick: https://github.com/flutter/engine/pull/43519
Going a revert-based route to fix all of these problems would also be pretty complex.

I've been testing this against 3.13 and still need to cross reference the other issues. I haven't rigorously tested this against HEAD yet.

https://github.com/flutter/engine/assets/919017/9ee5e856-af7a-42b9-b135-ea268c2ba53f