### PR TITLE
Revert "Turn on the `skia_enable_optimize_size` flag to save a bit of binary size"

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -731,7 +731,6 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['skia_canvaskit_enable_paragraph'] = True
   gn_args['skia_canvaskit_enable_webgl'] = True
   gn_args['skia_canvaskit_enable_webgpu'] = False
-  gn_args['skia_enable_optimize_size'] = True
   gn_args['skia_canvaskit_profile_build'] = args.runtime_mode == 'profile'
   gn_args['flutter_prebuilt_dart_sdk'] = True
 


### PR DESCRIPTION
Reverts flutter/engine#45029

It appears this is causing a regression in the length of time some of our integration tests are taking, causing them to take twice as long, which is causing timeouts in CI. We should revert while we investigate.