### PR TITLE
Revert "Fix global tests doing nothing."

### DIFF
--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -14,7 +14,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -52,7 +53,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -91,7 +93,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -130,7 +133,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -168,7 +172,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -207,7 +212,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -15,7 +15,9 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86",
+                "mac_model=Macmini8,1"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -47,7 +49,21 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "14e300c"
                 }
-            }
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_debug",
+                    "parameters": [
+                        "--variant",
+                        "host_debug",
+                        "--type",
+                        "dart,engine",
+                        "--engine-capture-core-dump"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                }
+            ]
         },
         {
             "archives": [
@@ -63,7 +79,9 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86",
+                "mac_model=Macmini8,1"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -90,7 +108,21 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "14e300c"
                 }
-            }
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_profile",
+                    "parameters": [
+                        "--variant",
+                        "host_profile",
+                        "--type",
+                        "dart,engine",
+                        "--engine-capture-core-dump"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                }
+            ]
         },
         {
             "archives": [
@@ -107,7 +139,9 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86",
+                "mac_model=Macmini8,1"
             ],
             "dependencies": [
                 {
@@ -144,7 +178,20 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "14e300c"
                 }
-            }
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Impeller-golden, dart and engine tests for host_release",
+                    "parameters": [
+                        "--variant",
+                        "host_release",
+                        "--type",
+                        "dart,engine,impeller-golden"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                }
+            ]
         },
         {
             "archives": [
@@ -161,7 +208,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -207,7 +255,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -250,7 +299,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -425,100 +475,6 @@
             "source": "out/release/snapshot/gen_snapshot.zip",
             "destination": "darwin-x64-release/gen_snapshot.zip",
             "realm": "production"
-        }
-    ],
-    "tests": [
-        {
-            "name": "Mac Host Tests for host_debug",
-            "recipe": "engine_v2/tester_engine",
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "dependencies": [
-                "host_debug"
-            ],
-            "tasks": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_debug",
-                    "parameters": [
-                        "--variant",
-                        "host_debug",
-                        "--type",
-                        "dart,engine",
-                        "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                }
-            ]
-        },
-        {
-            "name": "Mac Impeller-golden, dart and engine tests for host_release",
-            "recipe": "engine_v2/tester_engine",
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "dependencies": [
-                "host_release"
-            ],
-            "test_dependencies": [
-                {
-                    "dependency": "goldctl",
-                    "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"
-                }
-            ],
-            "tasks": [
-                {
-                    "language": "python3",
-                    "name": "Impeller-golden, dart and engine tests for host_release",
-                    "parameters": [
-                        "--variant",
-                        "host_release",
-                        "--type",
-                        "dart,engine,impeller-golden"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                }
-            ]
-        },
-        {
-            "name": "Mac Host Tests for host_profile",
-            "recipe": "engine_v2/tester_engine",
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "dependencies": [
-                "host_profile"
-            ],
-            "tasks": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_profile",
-                    "parameters": [
-                        "--variant",
-                        "host_profile",
-                        "--type",
-                        "dart,engine",
-                        "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                }
-            ]
         }
     ]
 }

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -3,6 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
+                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [
@@ -25,6 +26,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
+                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [
@@ -48,6 +50,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
+                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [
@@ -71,6 +74,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
+                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [
@@ -95,6 +99,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
+                "mac_model=Macmini8,1",
                 "os=Mac-12"
             ],
             "gn": [

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -1,9 +1,19 @@
 {
     "builds": [
         {
+            "archives": [
+                {
+                    "base_path": "out/host_debug_unopt/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [],
+                    "name": "host_debug_unopt"
+                }
+            ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86",
+                "mac_model=Macmini8,1"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -25,9 +35,31 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "14e300c"
                 }
-            }
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for host_debug_unopt",
+                    "parameters": [
+                        "--variant",
+                        "host_debug_unopt",
+                        "--type",
+                        "dart,engine",
+                        "--engine-capture-core-dump"
+                    ],
+                    "script": "flutter/testing/run_tests.py"
+                }
+            ]
         },
         {
+            "archives": [
+                {
+                    "base_path": "out/ios_debug_sim/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [],
+                    "name": "ios_debug_sim"
+                }
+            ],
             "properties": {
                 "$flutter/osx_sdk": {
                     "runtime_versions": [
@@ -40,7 +72,7 @@
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
-		"cpu=x86"
+                "cpu=x86"
             ],
             "gclient_variables": {
                 "download_android_deps": false
@@ -59,166 +91,8 @@
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
                 ]
-            }
-        },
-        {
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
             },
-            "gn": [
-                "--runtime-mode",
-                "debug",
-                "--unoptimized",
-                "--no-lto",
-                "--prebuilt-dart-sdk",
-                "--force-mac-arm64",
-                "--mac-cpu",
-                "arm64"
-            ],
-            "name": "host_debug_unopt_arm64",
-            "ninja": {
-                "config": "host_debug_unopt_arm64"
-            },
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "sdk_version": "14e300c"
-                }
-            }
-        },
-        {
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "runtime_versions": [
-                        "ios-16-4_14e300c",
-                        "ios-16-2_14c18"
-                    ],
-                    "sdk_version": "14e300c"
-                }
-            },
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "gn": [
-                "--ios",
-                "--runtime-mode",
-                "debug",
-                "--simulator",
-                "--no-lto",
-                "--force-mac-arm64",
-                "--simulator-cpu",
-                "arm64"
-            ],
-            "name": "ios_debug_sim_arm64",
-            "ninja": {
-                "config": "ios_debug_sim_arm64",
-                "targets": [
-                    "flutter/testing/scenario_app",
-                    "flutter/shell/platform/darwin/ios:ios_test_flutter"
-                ]
-            }
-        },
-        {
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "runtime_versions": [
-                        "ios-16-4_14e300c",
-                        "ios-16-2_14c18"
-                    ],
-                    "sdk_version": "14e300c"
-                }
-            },
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "gn": [
-                "--ios",
-                "--runtime-mode",
-                "debug",
-                "--simulator",
-                "--no-lto",
-                "--force-mac-arm64",
-                "--simulator-cpu",
-                "arm64",
-                "--darwin-extension-safe"
-            ],
-            "name": "ios_debug_sim_arm64_extension_safe",
-            "ninja": {
-                "config": "ios_debug_sim_arm64_extension_safe",
-                "targets": [
-                    "flutter/testing/scenario_app",
-                    "flutter/shell/platform/darwin/ios:ios_test_flutter"
-                ]
-            }
-        }
-    ],
-    "tests": [
-        {
-            "name": "Mac Host Tests for host_debug_unopt",
-            "recipe": "engine_v2/tester_engine",
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "dependencies": [
-                "host_debug_unopt"
-            ],
-            "tasks": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for host_debug_unopt",
-                    "parameters": [
-                        "--variant",
-                        "host_debug_unopt",
-                        "--type",
-                        "dart,engine",
-                        "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
-                }
-            ]
-        },
-        {
-            "name": "Mac Tests for ios_debug_sim",
-            "recipe": "engine_v2/tester_engine",
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12",
-		"cpu=x86"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "dependencies": [
-                "ios_debug_sim"
-            ],
-            "contexts": [
-                "osx_sdk"
-            ],
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "runtime_versions": [
-                        "ios-16-4_14e300c",
-                        "ios-16-2_14c18"
-                    ],
-                    "sdk_version": "14e300c"
-                }
-            },
-            "tasks": [
+            "tests": [
                 {
                     "language": "python3",
                     "name": "Tests for ios_debug_sim",
@@ -243,8 +117,15 @@
             ]
         },
         {
-            "name": "Mac Tests for ios_debug_sim_arm64",
-            "recipe": "engine_v2/tester_engine",
+            "archives": [
+                {
+                    "base_path": "out/host_debug_unopt_arm64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                    ],
+                    "name": "host_debug_unopt_arm64"
+                }
+            ],
             "drone_dimensions": [
                 "device_type=none",
                 "os=Mac-12",
@@ -253,11 +134,37 @@
             "gclient_variables": {
                 "download_android_deps": false
             },
-            "dependencies": [
-                "ios_debug_sim_arm64"
+            "gn": [
+               "--runtime-mode",
+               "debug",
+               "--unoptimized",
+               "--no-lto",
+               "--prebuilt-dart-sdk",
+               "--force-mac-arm64",
+               "--mac-cpu",
+               "arm64"
             ],
-            "contexts": [
-                "osx_sdk"
+            "name": "host_debug_unopt_arm64",
+            "ninja": {
+                "config": "host_debug_unopt_arm64",
+                "targets": [
+                ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "14e300c"
+                }
+            }
+        },
+        {
+            "archives": [
+                {
+                    "base_path": "out/ios_debug_sim_arm64/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                    ],
+                    "name": "ios_debug_sim_arm64"
+                }
             ],
             "properties": {
                 "$flutter/osx_sdk": {
@@ -268,7 +175,33 @@
                     "sdk_version": "14e300c"
                 }
             },
-            "tasks": [
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--ios",
+                "--runtime-mode",
+                "debug",
+                "--simulator",
+                "--no-lto",
+                "--force-mac-arm64",
+                "--simulator-cpu",
+                "arm64"
+            ],
+            "name": "ios_debug_sim_arm64",
+            "ninja": {
+                "config": "ios_debug_sim_arm64",
+                "targets": [
+                    "flutter/testing/scenario_app",
+                    "flutter/shell/platform/darwin/ios:ios_test_flutter"
+                ]
+            },
+            "tests": [
                 {
                     "language": "python3",
                     "name": "Tests for ios_debug_sim_arm64",
@@ -290,23 +223,18 @@
                     ],
                     "script": "flutter/testing/scenario_app/run_ios_tests.sh"
                 }
+
             ]
         },
         {
-            "name": "Mac Tests for ios_debug_sim_arm64_extension_safe",
-            "recipe": "engine_v2/tester_engine",
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-12"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "dependencies": [
-                "ios_debug_sim_arm64_extension_safe"
-            ],
-            "contexts": [
-                "osx_sdk"
+            "archives": [
+                {
+                    "base_path": "out/ios_debug_sim_arm64_extension_safe/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                    ],
+                    "name": "ios_debug_sim_arm64_extension_safe"
+                }
             ],
             "properties": {
                 "$flutter/osx_sdk": {
@@ -317,7 +245,34 @@
                     "sdk_version": "14e300c"
                 }
             },
-            "tasks": [
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-12",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false
+            },
+            "gn": [
+                "--ios",
+                "--runtime-mode",
+                "debug",
+                "--simulator",
+                "--no-lto",
+                "--force-mac-arm64",
+                "--simulator-cpu",
+                "arm64",
+                "--darwin-extension-safe"
+            ],
+            "name": "ios_debug_sim_arm64_extension_safe",
+            "ninja": {
+                "config": "ios_debug_sim_arm64_extension_safe",
+                "targets": [
+                    "flutter/testing/scenario_app",
+                    "flutter/shell/platform/darwin/ios:ios_test_flutter"
+                ]
+            },
+            "tests": [
                 {
                     "language": "python3",
                     "name": "Tests for ios_debug_sim_arm64_extension_safe",
@@ -339,6 +294,7 @@
                     ],
                     "script": "flutter/testing/scenario_app/run_ios_tests.sh"
                 }
+
             ]
         }
     ]


### PR DESCRIPTION
Reverts flutter/engine#45097

Many failures on CI like:
```
ld: warning: ignoring file ../../../../out/ios_debug_sim_arm64_extension_safe/libocmock_shared.dylib, building for iOS Simulator-x86_64 but attempting to link with file built for iOS Simulator-arm64
ld: warning: ignoring file ../../../../out/ios_debug_sim_arm64_extension_safe/libios_test_flutter.dylib, building for iOS Simulator-x86_64 but attempting to link with file built for iOS Simulator-arm64
```

https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20Production%20Engine%20Drone/131188/overview

Not sure if there are also other tests failing in different ways.