### PR TITLE
[Impeller] Only enable captures in debug builds.

### DIFF
--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -11,10 +11,11 @@ config("impeller_public_config") {
   defines = []
 
   if (impeller_debug) {
-    defines += [
-      "IMPELLER_DEBUG=1",
-      "IMPELLER_ENABLE_CAPTURE=1",
-    ]
+    defines += [ "IMPELLER_DEBUG=1" ]
+  }
+
+  if (impeller_capture) {
+    defines += [ "IMPELLER_ENABLE_CAPTURE=1" ]
   }
 
   if (impeller_supports_rendering) {

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -11,6 +11,9 @@ declare_args() {
   impeller_debug =
       flutter_runtime_mode == "debug" || flutter_runtime_mode == "profile"
 
+  # Whether the runtime capture/playback system is enabled.
+  impeller_capture = flutter_runtime_mode == "debug"
+
   # Whether the Metal backend is enabled.
   impeller_enable_metal = (is_mac || is_ios) && target_os != "fuchsia"
 


### PR DESCRIPTION
Disable Impeller captures on profile builds.

So that we can verify it doesn't have any overhead when build-time disabled in the benchmarks: https://github.com/flutter/flutter/issues/133440