### PR TITLE
Update comment const_finder.dart

### DIFF
--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -174,8 +174,7 @@ class _ConstVisitor extends RecursiveVisitor<void> {
 
 /// A kernel AST visitor that finds const references.
 class ConstFinder {
-  /// Creates a new ConstFinder class.  All arguments are required and must not
-  /// be null.
+  /// Creates a new ConstFinder class.
   ///
   /// The `kernelFilePath` is the path to a dill (kernel) file to process.
   ConstFinder({


### PR DESCRIPTION
The arguments no longer seem to be all required and non-null. Updated the doc comment to reflect this.