### PR TITLE
[Impeller] its not safe to presentWithTransaction from a background thread.

### DIFF
--- a/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
@@ -58,8 +58,11 @@ GPUCAMetalLayerHandle IOSSurfaceMetalImpeller::GetCAMetalLayer(const SkISize& fr
 
   // When there are platform views in the scene, the drawable needs to be presented in the same
   // transaction as the one created for platform views. When the drawable are being presented from
-  // the raster thread, participate with the implicit CA transaction.
-  layer.presentsWithTransaction = YES;
+  // the raster thread, we may not be able to use a transaction as it will dirty the UIViews being
+  // presented. If there is a non-Flutter UIView active, such as in add2app or a
+  // presentViewController page transition, then this will cause CoreAnimation assertion errors and
+  // exit the app.
+  layer.presentsWithTransaction = [[NSThread currentThread] isMainThread];
 
   return layer;
 }


### PR DESCRIPTION
Sad Trombone. Because Flutter runs from a background thread, if we touch a CATransaction while there is a main thread transaction occuring then we'll trigger a framework error.

Fixes https://github.com/flutter/flutter/issues/133147
