### PR TITLE
[skwasm] encode PNGs using browser APIs

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -1430,6 +1430,7 @@ class DomImageBitmap {}
 extension DomImageBitmapExtension on DomImageBitmap {
   external JSNumber get width;
   external JSNumber get height;
+  external void close();
 }
 
 @JS()
@@ -2263,6 +2264,10 @@ extension DomURLExtension on DomURL {
 @staticInterop
 class DomBlob {
   external factory DomBlob(JSArray parts);
+}
+
+extension DomBlobExtension on DomBlob {
+  external JSPromise arrayBuffer();
 }
 
 DomBlob createDomBlob(List<Object?> parts) =>

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -72,6 +72,11 @@ class SkwasmImage extends SkwasmObjectWrapper<RawImage> implements ui.Image {
       context.transferFromImageBitmap(bitmap);
       final DomBlob blob = await offscreenCanvas.convertToBlob();
       final JSArrayBuffer arrayBuffer = (await blob.arrayBuffer().toDart)! as JSArrayBuffer;
+
+      // Zero out the contents of the canvas so that resources can be reclaimed
+      // by the browser.
+      offscreenCanvas.width = 0;
+      offscreenCanvas.height = 0;
       return ByteData.view(arrayBuffer.toDart);
     } else {
       return (renderer as SkwasmRenderer).surface.rasterizeImage(this, format);

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ffi';
+import 'dart:js_interop';
 import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart';
@@ -55,8 +56,26 @@ class SkwasmImage extends SkwasmObjectWrapper<RawImage> implements ui.Image {
 
   @override
   Future<ByteData?> toByteData(
-      {ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) {
-    return (renderer as SkwasmRenderer).surface.rasterizeImage(this, format);
+      {ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
+    if (format == ui.ImageByteFormat.png) {
+      final ui.PictureRecorder recorder = ui.PictureRecorder();
+      final ui.Canvas canvas = ui.Canvas(recorder);
+      canvas.drawImage(this, ui.Offset.zero, ui.Paint());
+      final DomImageBitmap bitmap =
+        await (renderer as SkwasmRenderer).surface.renderPicture(
+          recorder.endRecording() as SkwasmPicture,
+        );
+      final DomOffscreenCanvas offscreenCanvas =
+        createDomOffscreenCanvas(bitmap.width.toDartInt, bitmap.height.toDartInt);
+      final DomCanvasRenderingContextBitmapRenderer context =
+        offscreenCanvas.getContext('bitmaprenderer')! as DomCanvasRenderingContextBitmapRenderer;
+      context.transferFromImageBitmap(bitmap);
+      final DomBlob blob = await offscreenCanvas.convertToBlob();
+      final JSArrayBuffer arrayBuffer = (await blob.arrayBuffer().toDart)! as JSArrayBuffer;
+      return ByteData.view(arrayBuffer.toDart);
+    } else {
+      return (renderer as SkwasmRenderer).surface.rasterizeImage(this, format);
+    }
   }
 
   @override

--- a/third_party/canvaskit/BUILD.gn
+++ b/third_party/canvaskit/BUILD.gn
@@ -81,6 +81,10 @@ wasm_toolchain("skwasm") {
     skia_use_libpng_decode = false
     skia_use_libwebp_decode = false
 
+    # We use OffscreenCanvas to produce PNG data instead of skia
+    skia_use_no_png_encode = true
+    skia_use_libpng_encode = false
+
     # skwasm is multithreaded
     wasm_use_pthreads = true
     wasm_prioritize_size = true


### PR DESCRIPTION
This allows us to remove libpng from skia entirely, which saves us about 25kb brotli compressed.

Note, this should not change any functionality. The existing functionality is covered by the unit tests here: https://github.com/flutter/engine/blame/bd2132a0814f6df95471e97f7d5efaca515506bd/lib/web_ui/test/ui/image_golden_test.dart#L197-L197