### PR TITLE
[Impeller] Reorganize the glyph atlas to improve efficiency when looking up runs of glyphs in the same font

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -166,13 +166,17 @@ bool TextContents::Render(const ContentContext& renderer,
           const Font& font = run.GetFont();
           Scalar rounded_scale = TextFrame::RoundScaledFontSize(
               scale_, font.GetMetrics().point_size);
+          const FontGlyphAtlas* font_atlas =
+              atlas->GetFontGlyphAtlas(font, rounded_scale);
+          if (!font_atlas) {
+            VALIDATION_LOG << "Could not find font in the atlas.";
+            continue;
+          }
 
           for (const TextRun::GlyphPosition& glyph_position :
                run.GetGlyphPositions()) {
-            FontGlyphPair font_glyph_pair{font, glyph_position.glyph,
-                                          rounded_scale};
             std::optional<Rect> maybe_atlas_glyph_bounds =
-                atlas->FindFontGlyphBounds(font_glyph_pair);
+                font_atlas->FindGlyphBounds(glyph_position.glyph);
             if (!maybe_atlas_glyph_bounds.has_value()) {
               VALIDATION_LOG << "Could not find glyph position in the atlas.";
               continue;

--- a/impeller/typographer/backends/skia/typographer_context_skia.h
+++ b/impeller/typographer/backends/skia/typographer_context_skia.h
@@ -25,7 +25,7 @@ class TypographerContextSkia : public TypographerContext {
       Context& context,
       GlyphAtlas::Type type,
       std::shared_ptr<GlyphAtlasContext> atlas_context,
-      const FontGlyphPair::Set& font_glyph_pairs) const override;
+      const FontGlyphMap& font_glyph_map) const override;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(TypographerContextSkia);

--- a/impeller/typographer/backends/stb/typographer_context_stb.h
+++ b/impeller/typographer/backends/stb/typographer_context_stb.h
@@ -27,7 +27,7 @@ class TypographerContextSTB : public TypographerContext {
       Context& context,
       GlyphAtlas::Type type,
       std::shared_ptr<GlyphAtlasContext> atlas_context,
-      const FontGlyphPair::Set& font_glyph_pairs) const override;
+      const FontGlyphMap& font_glyph_map) const override;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(TypographerContextSTB);

--- a/impeller/typographer/glyph.h
+++ b/impeller/typographer/glyph.h
@@ -48,7 +48,9 @@ static_assert(sizeof(Glyph) == 20);
 template <>
 struct std::hash<impeller::Glyph> {
   constexpr std::size_t operator()(const impeller::Glyph& g) const {
-    return fml::HashCombine(g.index, g.type);
+    static_assert(sizeof(g.index) == 2);
+    static_assert(sizeof(g.type) == 1);
+    return (static_cast<size_t>(g.type) << 16) | g.index;
   }
 };
 

--- a/impeller/typographer/glyph_atlas.cc
+++ b/impeller/typographer/glyph_atlas.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/typographer/glyph_atlas.h"
 
+#include <numeric>
 #include <utility>
 
 namespace impeller {
@@ -59,37 +60,60 @@ void GlyphAtlas::SetTexture(std::shared_ptr<Texture> texture) {
 
 void GlyphAtlas::AddTypefaceGlyphPosition(const FontGlyphPair& pair,
                                           Rect rect) {
-  positions_[pair] = rect;
+  font_atlas_map_[pair.scaled_font].positions_[pair.glyph] = rect;
 }
 
 std::optional<Rect> GlyphAtlas::FindFontGlyphBounds(
     const FontGlyphPair& pair) const {
-  const auto& found = positions_.find(pair);
-  if (found == positions_.end()) {
+  const auto& found = font_atlas_map_.find(pair.scaled_font);
+  if (found == font_atlas_map_.end()) {
     return std::nullopt;
   }
-  return found->second;
+  return found->second.FindGlyphBounds(pair.glyph);
+}
+
+const FontGlyphAtlas* GlyphAtlas::GetFontGlyphAtlas(const Font& font,
+                                                    Scalar scale) const {
+  const auto& found = font_atlas_map_.find({font, scale});
+  if (found == font_atlas_map_.end()) {
+    return nullptr;
+  }
+  return &found->second;
 }
 
 size_t GlyphAtlas::GetGlyphCount() const {
-  return positions_.size();
+  return std::accumulate(font_atlas_map_.begin(), font_atlas_map_.end(), 0,
+                         [](const int a, const auto& b) {
+                           return a + b.second.positions_.size();
+                         });
 }
 
 size_t GlyphAtlas::IterateGlyphs(
-    const std::function<bool(const FontGlyphPair& pair, const Rect& rect)>&
-        iterator) const {
+    const std::function<bool(const ScaledFont& scaled_font,
+                             const Glyph& glyph,
+                             const Rect& rect)>& iterator) const {
   if (!iterator) {
     return 0u;
   }
 
   size_t count = 0u;
-  for (const auto& position : positions_) {
-    count++;
-    if (!iterator(position.first, position.second)) {
-      return count;
+  for (const auto& font_value : font_atlas_map_) {
+    for (const auto& glyph_value : font_value.second.positions_) {
+      count++;
+      if (!iterator(font_value.first, glyph_value.first, glyph_value.second)) {
+        return count;
+      }
     }
   }
   return count;
+}
+
+std::optional<Rect> FontGlyphAtlas::FindGlyphBounds(const Glyph& glyph) const {
+  const auto& found = positions_.find(glyph);
+  if (found == positions_.end()) {
+    return std::nullopt;
+  }
+  return found->second;
 }
 
 }  // namespace impeller

--- a/impeller/typographer/lazy_glyph_atlas.cc
+++ b/impeller/typographer/lazy_glyph_atlas.cc
@@ -26,15 +26,15 @@ LazyGlyphAtlas::~LazyGlyphAtlas() = default;
 void LazyGlyphAtlas::AddTextFrame(const TextFrame& frame, Scalar scale) {
   FML_DCHECK(atlas_map_.empty());
   if (frame.GetAtlasType() == GlyphAtlas::Type::kAlphaBitmap) {
-    frame.CollectUniqueFontGlyphPairs(alpha_set_, scale);
+    frame.CollectUniqueFontGlyphPairs(alpha_glyph_map_, scale);
   } else {
-    frame.CollectUniqueFontGlyphPairs(color_set_, scale);
+    frame.CollectUniqueFontGlyphPairs(color_glyph_map_, scale);
   }
 }
 
 void LazyGlyphAtlas::ResetTextFrames() {
-  alpha_set_.clear();
-  color_set_.clear();
+  alpha_glyph_map_.clear();
+  color_glyph_map_.clear();
   atlas_map_.clear();
 }
 
@@ -59,11 +59,12 @@ std::shared_ptr<GlyphAtlas> LazyGlyphAtlas::CreateOrGetGlyphAtlas(
     return nullptr;
   }
 
-  auto& set = type == GlyphAtlas::Type::kAlphaBitmap ? alpha_set_ : color_set_;
+  auto& glyph_map = type == GlyphAtlas::Type::kAlphaBitmap ? alpha_glyph_map_
+                                                           : color_glyph_map_;
   auto atlas_context =
       type == GlyphAtlas::Type::kAlphaBitmap ? alpha_context_ : color_context_;
-  auto atlas =
-      typographer_context_->CreateGlyphAtlas(context, type, atlas_context, set);
+  auto atlas = typographer_context_->CreateGlyphAtlas(context, type,
+                                                      atlas_context, glyph_map);
   if (!atlas || !atlas->IsValid()) {
     VALIDATION_LOG << "Could not create valid atlas.";
     return nullptr;

--- a/impeller/typographer/lazy_glyph_atlas.h
+++ b/impeller/typographer/lazy_glyph_atlas.h
@@ -32,8 +32,8 @@ class LazyGlyphAtlas {
  private:
   std::shared_ptr<TypographerContext> typographer_context_;
 
-  FontGlyphPair::Set alpha_set_;
-  FontGlyphPair::Set color_set_;
+  FontGlyphMap alpha_glyph_map_;
+  FontGlyphMap color_glyph_map_;
   std::shared_ptr<GlyphAtlasContext> alpha_context_;
   std::shared_ptr<GlyphAtlasContext> color_context_;
   mutable std::unordered_map<GlyphAtlas::Type, std::shared_ptr<GlyphAtlas>>

--- a/impeller/typographer/text_frame.cc
+++ b/impeller/typographer/text_frame.cc
@@ -67,12 +67,13 @@ Scalar TextFrame::RoundScaledFontSize(Scalar scale, Scalar point_size) {
   return std::round(scale * 100) / 100;
 }
 
-void TextFrame::CollectUniqueFontGlyphPairs(FontGlyphPair::Set& set,
+void TextFrame::CollectUniqueFontGlyphPairs(FontGlyphMap& glyph_map,
                                             Scalar scale) const {
   for (const TextRun& run : GetRuns()) {
     const Font& font = run.GetFont();
     auto rounded_scale =
         RoundScaledFontSize(scale, font.GetMetrics().point_size);
+    auto& set = glyph_map[{font, rounded_scale}];
     for (const TextRun::GlyphPosition& glyph_position :
          run.GetGlyphPositions()) {
 #if false
@@ -82,7 +83,7 @@ if (rounded_scale != scale) {
   FML_LOG(ERROR) << glyph_position.glyph.bounds.size * delta;
 }
 #endif
-      set.insert({font, glyph_position.glyph, rounded_scale});
+      set.insert(glyph_position.glyph);
     }
   }
 }

--- a/impeller/typographer/text_frame.h
+++ b/impeller/typographer/text_frame.h
@@ -24,7 +24,7 @@ class TextFrame {
 
   ~TextFrame();
 
-  void CollectUniqueFontGlyphPairs(FontGlyphPair::Set& set, Scalar scale) const;
+  void CollectUniqueFontGlyphPairs(FontGlyphMap& glyph_map, Scalar scale) const;
 
   static Scalar RoundScaledFontSize(Scalar scale, Scalar point_size);
 

--- a/impeller/typographer/typographer_context.h
+++ b/impeller/typographer/typographer_context.h
@@ -36,7 +36,7 @@ class TypographerContext {
       Context& context,
       GlyphAtlas::Type type,
       std::shared_ptr<GlyphAtlasContext> atlas_context,
-      const FontGlyphPair::Set& font_glyph_pairs) const = 0;
+      const FontGlyphMap& font_glyph_map) const = 0;
 
  protected:
   //----------------------------------------------------------------------------


### PR DESCRIPTION
The atlas will now store a separate map of glyph positions for each font/scale pair.  This avoids the cost of repeated hashing and copying of font objects for each glyph in a text run.

See https://github.com/flutter/flutter/issues/133201
