### PR TITLE
[Impeller] Remove unused HasThreadingRestrictions capability.

### DIFF
--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -62,7 +62,6 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
   {
     device_capabilities_ =
         CapabilitiesBuilder()
-            .SetHasThreadingRestrictions(true)
             .SetSupportsOffscreenMSAA(false)
             .SetSupportsSSBO(false)
             .SetSupportsBufferToTextureBlits(false)

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -52,7 +52,6 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
     id<MTLDevice> device,
     PixelFormat color_format) {
   return CapabilitiesBuilder()
-      .SetHasThreadingRestrictions(false)
       .SetSupportsOffscreenMSAA(true)
       .SetSupportsSSBO(true)
       .SetSupportsBufferToTextureBlits(true)

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -397,11 +397,6 @@ bool CapabilitiesVK::SetPhysicalDevice(const vk::PhysicalDevice& device) {
 }
 
 // |Capabilities|
-bool CapabilitiesVK::HasThreadingRestrictions() const {
-  return false;
-}
-
-// |Capabilities|
 bool CapabilitiesVK::SupportsOffscreenMSAA() const {
   return true;
 }

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -58,9 +58,6 @@ class CapabilitiesVK final : public Capabilities,
   void SetOffscreenFormat(PixelFormat pixel_format) const;
 
   // |Capabilities|
-  bool HasThreadingRestrictions() const override;
-
-  // |Capabilities|
   bool SupportsOffscreenMSAA() const override;
 
   // |Capabilities|

--- a/impeller/renderer/capabilities.cc
+++ b/impeller/renderer/capabilities.cc
@@ -16,11 +16,6 @@ class StandardCapabilities final : public Capabilities {
   ~StandardCapabilities() override = default;
 
   // |Capabilities|
-  bool HasThreadingRestrictions() const override {
-    return has_threading_restrictions_;
-  }
-
-  // |Capabilities|
   bool SupportsOffscreenMSAA() const override {
     return supports_offscreen_msaa_;
   }
@@ -81,8 +76,7 @@ class StandardCapabilities final : public Capabilities {
   }
 
  private:
-  StandardCapabilities(bool has_threading_restrictions,
-                       bool supports_offscreen_msaa,
+  StandardCapabilities(bool supports_offscreen_msaa,
                        bool supports_ssbo,
                        bool supports_buffer_to_texture_blits,
                        bool supports_texture_to_texture_blits,
@@ -95,8 +89,7 @@ class StandardCapabilities final : public Capabilities {
                        bool supports_memoryless_textures,
                        PixelFormat default_color_format,
                        PixelFormat default_stencil_format)
-      : has_threading_restrictions_(has_threading_restrictions),
-        supports_offscreen_msaa_(supports_offscreen_msaa),
+      : supports_offscreen_msaa_(supports_offscreen_msaa),
         supports_ssbo_(supports_ssbo),
         supports_buffer_to_texture_blits_(supports_buffer_to_texture_blits),
         supports_texture_to_texture_blits_(supports_texture_to_texture_blits),
@@ -113,7 +106,6 @@ class StandardCapabilities final : public Capabilities {
 
   friend class CapabilitiesBuilder;
 
-  bool has_threading_restrictions_ = false;
   bool supports_offscreen_msaa_ = false;
   bool supports_ssbo_ = false;
   bool supports_buffer_to_texture_blits_ = false;
@@ -134,12 +126,6 @@ class StandardCapabilities final : public Capabilities {
 CapabilitiesBuilder::CapabilitiesBuilder() = default;
 
 CapabilitiesBuilder::~CapabilitiesBuilder() = default;
-
-CapabilitiesBuilder& CapabilitiesBuilder::SetHasThreadingRestrictions(
-    bool value) {
-  has_threading_restrictions_ = value;
-  return *this;
-}
 
 CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsOffscreenMSAA(bool value) {
   supports_offscreen_msaa_ = value;
@@ -217,7 +203,6 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsMemorylessTextures(
 
 std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
   return std::unique_ptr<StandardCapabilities>(new StandardCapabilities(  //
-      has_threading_restrictions_,                                        //
       supports_offscreen_msaa_,                                           //
       supports_ssbo_,                                                     //
       supports_buffer_to_texture_blits_,                                  //

--- a/impeller/renderer/capabilities.h
+++ b/impeller/renderer/capabilities.h
@@ -15,8 +15,6 @@ class Capabilities {
  public:
   virtual ~Capabilities();
 
-  virtual bool HasThreadingRestrictions() const = 0;
-
   virtual bool SupportsOffscreenMSAA() const = 0;
 
   virtual bool SupportsSSBO() const = 0;
@@ -55,8 +53,6 @@ class CapabilitiesBuilder {
 
   ~CapabilitiesBuilder();
 
-  CapabilitiesBuilder& SetHasThreadingRestrictions(bool value);
-
   CapabilitiesBuilder& SetSupportsOffscreenMSAA(bool value);
 
   CapabilitiesBuilder& SetSupportsSSBO(bool value);
@@ -86,7 +82,6 @@ class CapabilitiesBuilder {
   std::unique_ptr<Capabilities> Build();
 
  private:
-  bool has_threading_restrictions_ = false;
   bool supports_offscreen_msaa_ = false;
   bool supports_ssbo_ = false;
   bool supports_buffer_to_texture_blits_ = false;

--- a/impeller/renderer/capabilities_unittests.cc
+++ b/impeller/renderer/capabilities_unittests.cc
@@ -18,7 +18,6 @@ namespace testing {
     ASSERT_EQ(opposite->name(), !default_value);                             \
   }
 
-CAPABILITY_TEST(HasThreadingRestrictions, false);
 CAPABILITY_TEST(SupportsOffscreenMSAA, false);
 CAPABILITY_TEST(SupportsSSBO, false);
 CAPABILITY_TEST(SupportsBufferToTextureBlits, false);


### PR DESCRIPTION
Noticed this while working through documenting all of the capabilities. I guess we don't need this one anymore?