### PR TITLE
[Impeller] Fixes stroke path geometry that can draw outside of path if the path ends at sharp turn.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1206,6 +1206,22 @@ TEST_P(AiksTest, CanRenderRoundedRectWithNonUniformRadii) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanRenderStrokePathThatEndsAtSharpTurn) {
+  Canvas canvas;
+
+  Paint paint;
+  paint.color = Color::Red();
+  paint.style = Paint::Style::kStroke;
+  paint.stroke_width = 200;
+
+  Rect rect = {100, 100, 200, 200};
+  PathBuilder builder;
+  builder.AddArc(rect, Degrees(0), Degrees(90), false);
+
+  canvas.DrawPath(builder.TakePath(), paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, CanRenderDifferencePaths) {
   Canvas canvas;
 
@@ -1943,6 +1959,22 @@ TEST_P(AiksTest, DrawRectStrokesRenderCorrectly) {
   paint.color = Color::Red();
   paint.style = Paint::Style::kStroke;
   paint.stroke_width = 10;
+
+  canvas.Translate({100, 100});
+  canvas.DrawPath(
+      PathBuilder{}.AddRect(Rect::MakeSize(Size{100, 100})).TakePath(),
+      {paint});
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, DrawRectStrokesWithBevelJoinRenderCorrectly) {
+  Canvas canvas;
+  Paint paint;
+  paint.color = Color::Red();
+  paint.style = Paint::Style::kStroke;
+  paint.stroke_width = 10;
+  paint.stroke_join = Join::kBevel;
 
   canvas.Translate({100, 100});
   canvas.DrawPath(

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1222,6 +1222,21 @@ TEST_P(AiksTest, CanRenderStrokePathThatEndsAtSharpTurn) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanRenderStrokePathWithCubicLine) {
+  Canvas canvas;
+
+  Paint paint;
+  paint.color = Color::Red();
+  paint.style = Paint::Style::kStroke;
+  paint.stroke_width = 20;
+
+  PathBuilder builder;
+  builder.AddCubicCurve({0, 200}, {50, 400}, {350, 0}, {400, 200});
+
+  canvas.DrawPath(builder.TakePath(), paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, CanRenderDifferencePaths) {
   Canvas canvas;
 

--- a/impeller/core/formats.h
+++ b/impeller/core/formats.h
@@ -325,11 +325,33 @@ enum class IndexType {
   kNone,
 };
 
+/// Decides how backend draws pixels based on input vertices.
 enum class PrimitiveType {
+  /// Draws a triage for each separate set of three vertices.
+  ///
+  /// Vertices [A, B, C, D, E, F] will produce triages
+  /// [ABC, DEF].
   kTriangle,
+
+  /// Draws a triage for every adjacent three vertices.
+  ///
+  /// Vertices [A, B, C, D, E, F] will produce triages
+  /// [ABC, BCD, CDE, DEF].
   kTriangleStrip,
+
+  /// Draws a line for each separate set of two vertices.
+  ///
+  /// Vertices [A, B, C] will produce discontinued line
+  /// [AB, BC].
   kLine,
+
+  /// Draws a continuous line that connect every input vertices
+  ///
+  /// Vertices [A, B, C] will produce one continuous line
+  /// [ABC].
   kLineStrip,
+
+  /// Draws a point at each input vertices.
   kPoint,
   // Triangle fans are implementation dependent and need extra extensions
   // checks. Hence, they are not supported here.

--- a/impeller/core/formats.h
+++ b/impeller/core/formats.h
@@ -351,7 +351,7 @@ enum class PrimitiveType {
   /// [ABC].
   kLineStrip,
 
-  /// Draws a point at each input vertices.
+  /// Draws a point at each input vertex.
   kPoint,
   // Triangle fans are implementation dependent and need extra extensions
   // checks. Hence, they are not supported here.

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -356,7 +356,7 @@ StrokePathGeometry::CreateSolidStrokeVertices(
     if (!contour.is_closed) {
       auto cap_offset =
           Vector2(-contour.end_direction.y, contour.end_direction.x) *
-          stroke_width * 0.5; // Clockwise normal
+          stroke_width * 0.5;  // Clockwise normal
       cap_proc(vtx_builder, polyline.points[contour_end_point_i - 1],
                cap_offset, scale, false);
     } else {

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -309,7 +309,9 @@ StrokePathGeometry::CreateSolidStrokeVertices(
     // Generate contour geometry.
     for (size_t point_i = contour_start_point_i + 1;
          point_i < contour_end_point_i; point_i++) {
-      if ((contour_section + 1 >= contour.sections.size()) && contour.sections[contour_section + 1].section_start_index <= point_i) {
+      if ((contour_section + 1 >= contour.sections.size()) &&
+          contour.sections[contour_section + 1].section_start_index <=
+              point_i) {
         // The point_i has entered the next section in this contour.
         contour_section += 1;
       }
@@ -322,8 +324,8 @@ StrokePathGeometry::CreateSolidStrokeVertices(
       // Curve sections don't require the two end points of the rect assuming
       // the angles between of a continous two points are close enough.
       //
-      // This also prevents overdraw the line rect if the contour ends at a sharp
-      // curve with thick stroke width.
+      // This also prevents overdraw the line rect if the contour ends at a
+      // sharp curve with thick stroke width.
       if (!contour.sections[contour_section].is_curve) {
         vtx.position = polyline.points[point_i] + offset;
         vtx_builder.AppendVertex(vtx);

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -331,6 +331,16 @@ StrokePathGeometry::CreateSolidStrokeVertices(
         vtx_builder.AppendVertex(vtx);
         vtx.position = polyline.points[point_i] - offset;
         vtx_builder.AppendVertex(vtx);
+      } else if (point_i == contour_end_point_i - 1) {
+        // If this is a curve and is the end of the contour, two end points
+        // need to be drawn with the contour end_direction.
+        auto end_offset =
+          Vector2(-contour.end_direction.y, contour.end_direction.x) *
+          stroke_width * 0.5;
+        vtx.position = polyline.points[contour_end_point_i - 1] + end_offset;
+        vtx_builder.AppendVertex(vtx);
+        vtx.position = polyline.points[contour_end_point_i - 1] - end_offset;
+        vtx_builder.AppendVertex(vtx);
       }
 
       if (point_i < contour_end_point_i - 1) {
@@ -343,10 +353,10 @@ StrokePathGeometry::CreateSolidStrokeVertices(
     }
 
     // Generate end cap or join.
-    if (!polyline.contours[contour_i].is_closed) {
+    if (!contour.is_closed) {
       auto cap_offset =
-          Vector2(-contour.end_direction.y, contour.end_direction.x) *
-          stroke_width * 0.5;  // Clockwise normal
+        Vector2(-contour.end_direction.y, contour.end_direction.x) *
+        stroke_width * 0.5;
       cap_proc(vtx_builder, polyline.points[contour_end_point_i - 1],
                cap_offset, scale, false);
     } else {

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -335,8 +335,8 @@ StrokePathGeometry::CreateSolidStrokeVertices(
         // If this is a curve and is the end of the contour, two end points
         // need to be drawn with the contour end_direction.
         auto end_offset =
-          Vector2(-contour.end_direction.y, contour.end_direction.x) *
-          stroke_width * 0.5;
+            Vector2(-contour.end_direction.y, contour.end_direction.x) *
+            stroke_width * 0.5;
         vtx.position = polyline.points[contour_end_point_i - 1] + end_offset;
         vtx_builder.AppendVertex(vtx);
         vtx.position = polyline.points[contour_end_point_i - 1] - end_offset;
@@ -355,8 +355,8 @@ StrokePathGeometry::CreateSolidStrokeVertices(
     // Generate end cap or join.
     if (!contour.is_closed) {
       auto cap_offset =
-        Vector2(-contour.end_direction.y, contour.end_direction.x) *
-        stroke_width * 0.5;
+          Vector2(-contour.end_direction.y, contour.end_direction.x) *
+          stroke_width * 0.5;
       cap_proc(vtx_builder, polyline.points[contour_end_point_i - 1],
                cap_offset, scale, false);
     } else {

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -356,7 +356,7 @@ StrokePathGeometry::CreateSolidStrokeVertices(
     if (!contour.is_closed) {
       auto cap_offset =
           Vector2(-contour.end_direction.y, contour.end_direction.x) *
-          stroke_width * 0.5;
+          stroke_width * 0.5; // Clockwise normal
       cap_proc(vtx_builder, polyline.points[contour_end_point_i - 1],
                cap_offset, scale, false);
     } else {

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -321,10 +321,10 @@ StrokePathGeometry::CreateSolidStrokeVertices(
       vtx.position = polyline.points[point_i - 1] - offset;
       vtx_builder.AppendVertex(vtx);
 
-      // Curve sections don't require the two end points of the rect assuming
-      // the angles between of a continous two points are close enough.
+      // Curve sections don't require the two end points of the line rects
+      // assuming the angles between of a continous two points are close enough.
       //
-      // This also prevents overdraw the line rect if the contour ends at a
+      // This also prevents overdrawing the line rect if the contour ends at a
       // sharp curve with thick stroke width.
       if (!contour.sections[contour_section].is_curve) {
         vtx.position = polyline.points[point_i] + offset;

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -367,24 +367,24 @@ Path::Polyline Path::CreatePolyline(Scalar scale) const {
     switch (component.type) {
       case ComponentType::kLinear:
         sections.push_back({
-          .section_start_index = polyline.points.size(),
-          .is_curve = false,
+            .section_start_index = polyline.points.size(),
+            .is_curve = false,
         });
         collect_points(linears_[component.index].CreatePolyline());
         previous_path_component_index = component_i;
         break;
       case ComponentType::kQuadratic:
         sections.push_back({
-          .section_start_index = polyline.points.size(),
-          .is_curve = true,
+            .section_start_index = polyline.points.size(),
+            .is_curve = true,
         });
         collect_points(quads_[component.index].CreatePolyline(scale));
         previous_path_component_index = component_i;
         break;
       case ComponentType::kCubic:
         sections.push_back({
-          .section_start_index = polyline.points.size(),
-          .is_curve = true,
+            .section_start_index = polyline.points.size(),
+            .is_curve = true,
         });
         collect_points(cubics_[component.index].CreatePolyline(scale));
         previous_path_component_index = component_i;

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -324,9 +324,10 @@ Path::Polyline Path::CreatePolyline(Scalar scale) const {
         return Vector2(0, -1);
       };
 
+  std::vector<PolylineContour::Section> sections;
   std::optional<size_t> previous_path_component_index;
   auto end_contour = [&polyline, &previous_path_component_index,
-                      &get_path_component]() {
+                      &get_path_component, &sections]() {
     // Whenever a contour has ended, extract the exact end direction from the
     // last component.
     if (polyline.contours.empty()) {
@@ -339,6 +340,8 @@ Path::Polyline Path::CreatePolyline(Scalar scale) const {
 
     auto& contour = polyline.contours.back();
     contour.end_direction = Vector2(0, 1);
+    contour.sections = sections;
+    sections.clear();
 
     size_t previous_index = previous_path_component_index.value();
     while (!std::holds_alternative<std::monostate>(
@@ -363,14 +366,26 @@ Path::Polyline Path::CreatePolyline(Scalar scale) const {
     const auto& component = components_[component_i];
     switch (component.type) {
       case ComponentType::kLinear:
+        sections.push_back({
+          .section_start_index = polyline.points.size(),
+          .is_curve = false,
+        });
         collect_points(linears_[component.index].CreatePolyline());
         previous_path_component_index = component_i;
         break;
       case ComponentType::kQuadratic:
+        sections.push_back({
+          .section_start_index = polyline.points.size(),
+          .is_curve = true,
+        });
         collect_points(quads_[component.index].CreatePolyline(scale));
         previous_path_component_index = component_i;
         break;
       case ComponentType::kCubic:
+        sections.push_back({
+          .section_start_index = polyline.points.size(),
+          .is_curve = true,
+        });
         collect_points(cubics_[component.index].CreatePolyline(scale));
         previous_path_component_index = component_i;
         break;
@@ -386,13 +401,14 @@ Path::Polyline Path::CreatePolyline(Scalar scale) const {
         const auto& contour = contours_[component.index];
         polyline.contours.push_back({.start_index = polyline.points.size(),
                                      .is_closed = contour.is_closed,
-                                     .start_direction = start_direction});
+                                     .start_direction = start_direction,
+                                     .sections = sections});
         previous_contour_point = std::nullopt;
         collect_points({contour.destination});
         break;
     }
-    end_contour();
   }
+  end_contour();
   return polyline;
 }
 

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -81,7 +81,7 @@ class Path {
     /// The direction of the contour's end cap.
     Vector2 end_direction;
 
-    /// Distinct sections in thie contour.
+    /// Distinct sections in this contour.
     ///
     /// If this contour is generated from multiple path components, each
     /// component forms a section.

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -61,11 +61,11 @@ class Path {
   };
 
   struct PolylineContour {
-    struct Section {
-      size_t section_start_index;
-      /// Denotes whether this section is a curve.
+    struct Component {
+      size_t component_start_index;
+      /// Denotes whether this component is a curve.
       ///
-      /// This is set to true when this section is generated from
+      /// This is set to true when this component is generated from
       /// QuadraticComponent or CubicPathComponent.
       bool is_curve;
     };
@@ -81,11 +81,11 @@ class Path {
     /// The direction of the contour's end cap.
     Vector2 end_direction;
 
-    /// Distinct sections in this contour.
+    /// Distinct components in this contour.
     ///
     /// If this contour is generated from multiple path components, each
-    /// component forms a section.
-    std::vector<Section> sections;
+    /// path component forms a component in this vector.
+    std::vector<Component> components;
   };
 
   /// One or more contours represented as a series of points and indices in

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -61,8 +61,18 @@ class Path {
   };
 
   struct PolylineContour {
+    struct Section {
+      size_t section_start_index;
+      /// Denotes whether this section is a curve.
+      ///
+      /// This is set to true when this section is generated from QuadraticComponent
+      /// or CubicPathComponent.
+      bool is_curve;
+
+    };
     /// Index that denotes the first point of this contour.
     size_t start_index;
+
     /// Denotes whether the last point of this contour is connected to the first
     /// point of this contour or not.
     bool is_closed;
@@ -71,6 +81,12 @@ class Path {
     Vector2 start_direction;
     /// The direction of the contour's end cap.
     Vector2 end_direction;
+
+    /// Distinct sections in thie contour.
+    ///
+    /// If this contour is generated from multiple path components, each
+    /// component forms a section.
+    std::vector<Section> sections;
   };
 
   /// One or more contours represented as a series of points and indices in

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -65,10 +65,9 @@ class Path {
       size_t section_start_index;
       /// Denotes whether this section is a curve.
       ///
-      /// This is set to true when this section is generated from QuadraticComponent
-      /// or CubicPathComponent.
+      /// This is set to true when this section is generated from
+      /// QuadraticComponent or CubicPathComponent.
       bool is_curve;
-
     };
     /// Index that denotes the first point of this contour.
     size_t start_index;

--- a/impeller/geometry/path_component.h
+++ b/impeller/geometry/path_component.h
@@ -47,9 +47,13 @@ struct LinearPathComponent {
   std::optional<Vector2> GetEndDirection() const;
 };
 
+// A component represet a Quadratic Bézier curve.
 struct QuadraticPathComponent {
+  // Start point.
   Point p1;
+  // Control point.
   Point cp;
+  // End point.
   Point p2;
 
   QuadraticPathComponent() {}
@@ -87,10 +91,15 @@ struct QuadraticPathComponent {
   std::optional<Vector2> GetEndDirection() const;
 };
 
+// A component represet a Cubic Bézier curve.
 struct CubicPathComponent {
+  // Start point.
   Point p1;
+  // The first control point.
   Point cp1;
+  // The second control point.
   Point cp2;
+  // End point.
   Point p2;
 
   CubicPathComponent() {}

--- a/impeller/geometry/path_component.h
+++ b/impeller/geometry/path_component.h
@@ -47,7 +47,7 @@ struct LinearPathComponent {
   std::optional<Vector2> GetEndDirection() const;
 };
 
-// A component represets a Quadratic Bézier curve.
+// A component that represets a Quadratic Bézier curve.
 struct QuadraticPathComponent {
   // Start point.
   Point p1;
@@ -91,7 +91,7 @@ struct QuadraticPathComponent {
   std::optional<Vector2> GetEndDirection() const;
 };
 
-// A component represets a Cubic Bézier curve.
+// A component that represets a Cubic Bézier curve.
 struct CubicPathComponent {
   // Start point.
   Point p1;

--- a/impeller/geometry/path_component.h
+++ b/impeller/geometry/path_component.h
@@ -47,7 +47,7 @@ struct LinearPathComponent {
   std::optional<Vector2> GetEndDirection() const;
 };
 
-// A component represet a Quadratic Bézier curve.
+// A component represets a Quadratic Bézier curve.
 struct QuadraticPathComponent {
   // Start point.
   Point p1;
@@ -91,7 +91,7 @@ struct QuadraticPathComponent {
   std::optional<Vector2> GetEndDirection() const;
 };
 
-// A component represet a Cubic Bézier curve.
+// A component represets a Cubic Bézier curve.
 struct CubicPathComponent {
   // Start point.
   Point p1;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/133032

The issue is that when we draw a line we always try to draw a complete rectangle from point 1 to point2 before drawing the join and the next line
![Untitled drawing (7)](https://github.com/flutter/engine/assets/47866232/c51aa4a8-bd8e-4764-9941-4e2968b4fb8e)

This becomes a problem if there is a sharp turn
![Untitled drawing (6)](https://github.com/flutter/engine/assets/47866232/2b743792-52b7-402d-b2e8-f08ed47c0943)


![Untitled drawing (5)](https://github.com/flutter/engine/assets/47866232/794a75c9-5e87-4548-a264-7dd9cf088ae7)


Notice there will be a slight over drawing at the bottom.

The solution then is to not draw the rect first before drawing the join. It will be the join's responsibility to draw the complete the rect from the line start to the join.

This should also save a lot of repeatedly drawing during the join
![rect](https://github.com/flutter/engine/assets/47866232/24802df6-69b5-4543-8d09-fcfbff4cedbb)


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
