### PR TITLE
Add an API in `ui_web` to create a `ui.Image` from an `ImageBitmap`

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -219,14 +219,31 @@ extension CanvasKitExtension on CanvasKit {
   ) => _MakeImage(info, pixels.toJS, bytesPerRow.toJS);
 
   @JS('MakeLazyImageFromTextureSource')
-  external SkImage? _MakeLazyImageFromTextureSource(
+  external SkImage? _MakeLazyImageFromTextureSource1(
     JSAny src,
     SkPartialImageInfo info,
   );
-  SkImage? MakeLazyImageFromTextureSource(
+
+  @JS('MakeLazyImageFromTextureSource')
+  external SkImage? _MakeLazyImageFromTextureSource2(
+    JSAny src,
+    JSNumber zeroSecondArgument,
+    JSBoolean srcIsPremultiplied,
+  );
+
+  SkImage? MakeLazyImageFromTextureSourceWithInfo(
     Object src,
     SkPartialImageInfo info,
-  ) => _MakeLazyImageFromTextureSource(src.toJSAnyShallow, info);
+  ) => _MakeLazyImageFromTextureSource1(src.toJSAnyShallow, info);
+
+  SkImage? MakeLazyImageFromImageBitmap(
+    DomImageBitmap imageBitmap,
+    bool hasPremultipliedAlpha,
+  ) => _MakeLazyImageFromTextureSource2(
+    imageBitmap as JSAny,
+    0.toJS,
+    hasPremultipliedAlpha.toJS,
+  );
 }
 
 @JS('window.CanvasKitInit')

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -219,13 +219,13 @@ extension CanvasKitExtension on CanvasKit {
   ) => _MakeImage(info, pixels.toJS, bytesPerRow.toJS);
 
   @JS('MakeLazyImageFromTextureSource')
-  external SkImage? _MakeLazyImageFromTextureSource1(
+  external SkImage? _MakeLazyImageFromTextureSource2(
     JSAny src,
     SkPartialImageInfo info,
   );
 
   @JS('MakeLazyImageFromTextureSource')
-  external SkImage? _MakeLazyImageFromTextureSource2(
+  external SkImage? _MakeLazyImageFromTextureSource3(
     JSAny src,
     JSNumber zeroSecondArgument,
     JSBoolean srcIsPremultiplied,
@@ -234,12 +234,12 @@ extension CanvasKitExtension on CanvasKit {
   SkImage? MakeLazyImageFromTextureSourceWithInfo(
     Object src,
     SkPartialImageInfo info,
-  ) => _MakeLazyImageFromTextureSource1(src.toJSAnyShallow, info);
+  ) => _MakeLazyImageFromTextureSource2(src.toJSAnyShallow, info);
 
   SkImage? MakeLazyImageFromImageBitmap(
     DomImageBitmap imageBitmap,
     bool hasPremultipliedAlpha,
-  ) => _MakeLazyImageFromTextureSource2(
+  ) => _MakeLazyImageFromTextureSource3(
     imageBitmap as JSAny,
     0.toJS,
     hasPremultipliedAlpha.toJS,

--- a/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
@@ -60,7 +60,7 @@ class CkBrowserImageDecoder extends BrowserImageDecoder {
 
   @override
   ui.Image generateImageFromVideoFrame(VideoFrame frame) {
-    final SkImage? skImage = canvasKit.MakeLazyImageFromTextureSource(
+    final SkImage? skImage = canvasKit.MakeLazyImageFromTextureSourceWithInfo(
       frame,
       SkPartialImageInfo(
         alphaType: canvasKit.AlphaType.Premul,

--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -213,6 +213,18 @@ class CanvasKitRenderer implements Renderer {
   }) => skiaInstantiateWebImageCodec(uri.toString(), chunkCallback);
 
   @override
+  ui.Image createImageFromImageBitmap(DomImageBitmap imageBitmap) {
+    final SkImage? skImage = canvasKit.MakeLazyImageFromImageBitmap(
+      imageBitmap,
+      true
+    );
+    if (skImage == null) {
+      throw Exception('Failed to convert image bitmap to an SkImage.');
+    }
+    return CkImage(skImage);
+  }
+
+  @override
   void decodeImageFromPixels(
     Uint8List pixels,
     int width,

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -1433,6 +1433,33 @@ extension DomImageBitmapExtension on DomImageBitmap {
   external void close();
 }
 
+
+@JS('createImageBitmap')
+external JSPromise _createImageBitmap1(
+  JSAny source,
+);
+@JS('createImageBitmap')
+external JSPromise _createImageBitmap2(
+  JSAny source,
+  JSNumber x,
+  JSNumber y,
+  JSNumber width,
+  JSNumber height,
+);
+JSPromise createImageBitmap(JSAny source, [({int x, int y, int width, int height})? bounds]) {
+  if (bounds != null) {
+    return _createImageBitmap2(
+      source,
+      bounds.x.toJS,
+      bounds.y.toJS,
+      bounds.width.toJS,
+      bounds.height.toJS
+    );
+  } else {
+    return _createImageBitmap1(source);
+  }
+}
+
 @JS()
 @staticInterop
 class DomCanvasPattern {}
@@ -2264,14 +2291,24 @@ extension DomURLExtension on DomURL {
 @staticInterop
 class DomBlob {
   external factory DomBlob(JSArray parts);
+
+  external factory DomBlob.withOptions(JSArray parts, JSAny options);
 }
 
 extension DomBlobExtension on DomBlob {
   external JSPromise arrayBuffer();
 }
 
-DomBlob createDomBlob(List<Object?> parts) =>
-    DomBlob(parts.toJSAnyShallow as JSArray);
+DomBlob createDomBlob(List<Object?> parts, [Map<String, dynamic>? options]) {
+  if (options == null) {
+    return DomBlob(parts.toJSAnyShallow as JSArray);
+  } else {
+    return DomBlob.withOptions(
+      parts.toJSAnyShallow as JSArray,
+      options.toJSAnyDeep
+    );
+  }
+}
 
 typedef DomMutationCallback = void Function(
     JSArray mutation, DomMutationObserver observer);

--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -6,16 +6,10 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_stub.dart' if (dart.library.ffi) 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
-
-import 'browser_detection.dart';
-import 'canvaskit/renderer.dart';
-import 'configuration.dart';
-import 'embedder.dart';
-import 'fonts.dart';
-import 'html/renderer.dart';
 
 final Renderer _renderer = Renderer._internal();
 Renderer get renderer => _renderer;
@@ -133,6 +127,8 @@ abstract class Renderer {
     Uri uri, {
     ui_web.ImageCodecChunkCallback? chunkCallback,
   });
+
+  FutureOr<ui.Image> createImageFromImageBitmap(DomImageBitmap imageSource);
 
   void decodeImageFromPixels(
     Uint8List pixels,

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -1003,6 +1003,12 @@ class OffScreenCanvas {
         : canvasElement!.getContext('2d');
   }
 
+  DomCanvasRenderingContextBitmapRenderer? getBitmapRendererContext() {
+    return (offScreenCanvas != null
+        ? offScreenCanvas!.getContext('bitmaprenderer')
+        : canvasElement!.getContext('bitmaprenderer')) as DomCanvasRenderingContextBitmapRenderer?;
+  }
+
   /// Feature detection for transferToImageBitmap on OffscreenCanvas.
   bool get transferToImageBitmapSupported =>
       js_util.hasProperty(offScreenCanvas!, 'transferToImageBitmap');

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/codecs.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/codecs.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:js_interop';
+
 import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
@@ -18,8 +20,8 @@ class SkwasmImageDecoder extends BrowserImageDecoder {
     final int width = frame.codedWidth.toInt();
     final int height = frame.codedHeight.toInt();
     final SkwasmSurface surface = (renderer as SkwasmRenderer).surface;
-    return SkwasmImage(imageCreateFromVideoFrame(
-      frame,
+    return SkwasmImage(imageCreateFromTextureSource(
+      frame as JSAny,
       width,
       height,
       surface.handle,

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_image.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_image.dart
@@ -8,7 +8,6 @@ library skwasm_impl;
 import 'dart:ffi';
 import 'dart:js_interop';
 
-import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 
 final class RawImage extends Opaque {}
@@ -47,9 +46,9 @@ external ImageHandle imageCreateFromPixels(
 //   Int,
 //   Int,
 //   SurfaceHandle,
-// )>(symbol: 'image_createFromVideoFrame', isLeaf: true)
-// external ImageHandle imageCreateFromVideoFrame(
-//   JSAny videoFrame,
+// )>(symbol: 'image_createFromTextureSource', isLeaf: true)
+// external ImageHandle imageCreateFromTextureSource(
+//   JSAny textureSource,
 //   int width,
 //   int height,
 //   SurfaceHandle handle,
@@ -59,21 +58,21 @@ external ImageHandle imageCreateFromPixels(
 // annotations currently. For now, we can use JS interop to expose this function
 // instead.
 extension SkwasmImageExtension on SkwasmInstance {
-  @JS('wasmExports.image_createFromVideoFrame')
-  external JSNumber imageCreateFromVideoFrame(
-    VideoFrame frame,
+  @JS('wasmExports.image_createFromTextureSource')
+  external JSNumber imageCreateFromTextureSource(
+    JSAny textureSource,
     JSNumber width,
     JSNumber height,
     JSNumber surfaceHandle,
   );
 }
-ImageHandle imageCreateFromVideoFrame(
-  VideoFrame frame,
+ImageHandle imageCreateFromTextureSource(
+  JSAny frame,
   int width,
   int height,
   SurfaceHandle handle
 ) => ImageHandle.fromAddress(
-  skwasmInstance.imageCreateFromVideoFrame(
+  skwasmInstance.imageCreateFromTextureSource(
     frame,
     width.toJS,
     height.toJS,

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -448,6 +448,16 @@ class SkwasmRenderer implements Renderer {
     baseline: baseline,
     lineNumber: lineNumber
   );
+
+  @override
+  ui.Image createImageFromImageBitmap(DomImageBitmap imageSource) {
+    return SkwasmImage(imageCreateFromTextureSource(
+      imageSource as JSAny,
+      imageSource.width.toDartInt,
+      imageSource.height.toDartInt,
+      surface.handle,
+    ));
+  }
 }
 
 class SkwasmPictureRenderer implements PictureRenderer {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
@@ -189,4 +189,9 @@ class SkwasmRenderer implements Renderer {
     required double baseline,
     required int lineNumber
   }) => throw UnimplementedError('Skwasm not implemented on this platform.');
+
+  @override
+  ui.Image createImageFromImageBitmap(DomImageBitmap imageSource) {
+    throw UnimplementedError('Skwasm not implemented on this platform.');
+  }
 }

--- a/lib/web_ui/lib/ui_web/src/ui_web/images.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/images.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:js_interop';
+
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
@@ -23,5 +26,20 @@ Future<ui.Codec> createImageCodecFromUrl(
   return renderer.instantiateImageCodecFromUrl(
     uri,
     chunkCallback: chunkCallback,
+  );
+}
+
+/// Creates a [ui.Image] from an ImageBitmap object.
+/// The contents of the ImageBitmap must have a premultiplied alpha.
+/// The engine will take ownership of the ImageBitmap object and consume its
+/// contents.
+///
+/// See https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap
+FutureOr<ui.Image> createImageFromImageBitmap(JSAny imageSource) {
+  if (!domInstanceOfString(imageSource, 'ImageBitmap')) {
+    throw Exception('Image source $imageSource is not an ImageBitmap!');
+  }
+  return renderer.createImageFromImageBitmap(
+    imageSource as DomImageBitmap,
   );
 }

--- a/lib/web_ui/lib/ui_web/src/ui_web/images.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/images.dart
@@ -30,6 +30,7 @@ Future<ui.Codec> createImageCodecFromUrl(
 }
 
 /// Creates a [ui.Image] from an ImageBitmap object.
+///
 /// The contents of the ImageBitmap must have a premultiplied alpha.
 /// The engine will take ownership of the ImageBitmap object and consume its
 /// contents.
@@ -37,7 +38,7 @@ Future<ui.Codec> createImageCodecFromUrl(
 /// See https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap
 FutureOr<ui.Image> createImageFromImageBitmap(JSAny imageSource) {
   if (!domInstanceOfString(imageSource, 'ImageBitmap')) {
-    throw Exception('Image source $imageSource is not an ImageBitmap!');
+    throw ArgumentError('Image source $imageSource is not an ImageBitmap.', 'imageSource');
   }
   return renderer.createImageFromImageBitmap(
     imageSource as DomImageBitmap,

--- a/lib/web_ui/skwasm/library_skwasm_support.js
+++ b/lib/web_ui/skwasm/library_skwasm_support.js
@@ -82,13 +82,13 @@ mergeInto(LibraryManager.library, {
         imageBitmap,
       });
     };
-    _skwasm_createGlTextureFromVideoFrame = function(videoFrame, width, height) {
+    _skwasm_createGlTextureFromTextureSource = function(textureSource, width, height) {
       const glCtx = GL.currentContext.GLctx;
       const newTexture = glCtx.createTexture();
       glCtx.bindTexture(glCtx.TEXTURE_2D, newTexture);
       glCtx.pixelStorei(glCtx.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
       
-      glCtx.texImage2D(glCtx.TEXTURE_2D, 0, glCtx.RGBA, width, height, 0, glCtx.RGBA, glCtx.UNSIGNED_BYTE, videoFrame);
+      glCtx.texImage2D(glCtx.TEXTURE_2D, 0, glCtx.RGBA, width, height, 0, glCtx.RGBA, glCtx.UNSIGNED_BYTE, textureSource);
 
       glCtx.pixelStorei(glCtx.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
       glCtx.bindTexture(glCtx.TEXTURE_2D, null);
@@ -118,7 +118,7 @@ mergeInto(LibraryManager.library, {
   skwasm_resizeCanvas__deps: ['$skwasm_support_setup'],
   skwasm_captureImageBitmap: function () {},
   skwasm_captureImageBitmap__deps: ['$skwasm_support_setup'],
-  skwasm_createGlTextureFromVideoFrame: function () {},
-  skwasm_createGlTextureFromVideoFrame__deps: ['$skwasm_support_setup'],
+  skwasm_createGlTextureFromTextureSource: function () {},
+  skwasm_createGlTextureFromTextureSource__deps: ['$skwasm_support_setup'],
 });
   

--- a/lib/web_ui/skwasm/skwasm_support.h
+++ b/lib/web_ui/skwasm/skwasm_support.h
@@ -26,8 +26,8 @@ extern void skwasm_captureImageBitmap(Skwasm::Surface* surfaceHandle,
                                       uint32_t bitmapId,
                                       int width,
                                       int height);
-extern unsigned int skwasm_createGlTextureFromVideoFrame(
-    SkwasmObject videoFrame,
+extern unsigned int skwasm_createGlTextureFromTextureSource(
+    SkwasmObject textureSource,
     int width,
     int height);
 }

--- a/lib/web_ui/skwasm/surface.cpp
+++ b/lib/web_ui/skwasm/surface.cpp
@@ -60,10 +60,10 @@ uint32_t Surface::rasterizeImage(SkImage* image, ImageByteFormat format) {
   return callbackId;
 }
 
-std::unique_ptr<VideoFrameWrapper> Surface::createVideoFrameWrapper(
-    SkwasmObject videoFrame) {
-  return std::unique_ptr<VideoFrameWrapper>(
-      new VideoFrameWrapper(_thread, videoFrame));
+std::unique_ptr<TextureSourceWrapper> Surface::createTextureSourceWrapper(
+    SkwasmObject textureSource) {
+  return std::unique_ptr<TextureSourceWrapper>(
+      new TextureSourceWrapper(_thread, textureSource));
 }
 
 // Main thread only

--- a/lib/web_ui/skwasm/surface.h
+++ b/lib/web_ui/skwasm/surface.h
@@ -33,18 +33,18 @@ enum class ImageByteFormat {
   png,
 };
 
-class VideoFrameWrapper {
+class TextureSourceWrapper {
  public:
-  VideoFrameWrapper(unsigned long threadId, SkwasmObject videoFrame)
+  TextureSourceWrapper(unsigned long threadId, SkwasmObject textureSource)
       : _rasterThreadId(threadId) {
-    skwasm_setAssociatedObjectOnThread(_rasterThreadId, this, videoFrame);
+    skwasm_setAssociatedObjectOnThread(_rasterThreadId, this, textureSource);
   }
 
-  ~VideoFrameWrapper() {
+  ~TextureSourceWrapper() {
     skwasm_disposeAssociatedObjectOnThread(_rasterThreadId, this);
   }
 
-  SkwasmObject getVideoFrame() { return skwasm_getAssociatedObject(this); }
+  SkwasmObject getTextureSource() { return skwasm_getAssociatedObject(this); }
 
  private:
   unsigned long _rasterThreadId;
@@ -67,8 +67,8 @@ class Surface {
   void onRenderComplete(uint32_t callbackId, SkwasmObject imageBitmap);
 
   // Any thread
-  std::unique_ptr<VideoFrameWrapper> createVideoFrameWrapper(
-      SkwasmObject videoFrame);
+  std::unique_ptr<TextureSourceWrapper> createTextureSourceWrapper(
+      SkwasmObject textureSource);
 
  private:
   void _runWorker();

--- a/lib/web_ui/test/engine/scene_view_test.dart
+++ b/lib/web_ui/test/engine/scene_view_test.dart
@@ -14,15 +14,6 @@ import 'package:ui/ui_web/src/ui_web.dart';
 
 import 'scene_builder_utils.dart';
 
-@JS('createImageBitmap')
-external JSPromise createImageBitmap(
-  JSAny source,
-  JSNumber x,
-  JSNumber y,
-  JSNumber width,
-  JSNumber height
-);
-
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
@@ -37,10 +28,7 @@ class StubPictureRenderer implements PictureRenderer {
     final ui.Rect cullRect = picture.cullRect;
     final DomImageBitmap bitmap = (await createImageBitmap(
       scratchCanvasElement as JSAny,
-      0.toJS,
-      0.toJS,
-      cullRect.width.toJS,
-      cullRect.height.toJS
+      (x: 0, y: 0, width: cullRect.width.toInt(), height: cullRect.height.toInt())
     ).toDart)! as DomImageBitmap;
     return bitmap;
   }

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:js_interop';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -292,6 +293,30 @@ Future<void> testMain() async {
 
     final ui.FrameInfo info = await codec.getNextFrame();
     return info.image;
+  });
+
+  emitImageTests('svg_image_bitmap', () async {
+    final DomBlob svgBlob = createDomBlob(<String>[
+'''
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="150">
+  <path d="M25,75  A50,50 0 1,0 125 75 L75,25 Z" stroke="blue" stroke-width="10" fill="red"></path>
+</svg>
+'''
+    ], <String, String>{'type': 'image/svg+xml'});
+    final String url = domWindow.URL.createObjectURL(svgBlob);
+    final DomHTMLImageElement image = createDomHTMLImageElement();
+    final Completer<void> completer = Completer<void>();
+    late final DomEventListener loadListener;
+    loadListener = createDomEventListener((DomEvent event) {
+      completer.complete();
+      image.removeEventListener('load', loadListener);
+    });
+    image.addEventListener('load', loadListener);
+    image.src = url;
+    await completer.future;
+
+    final DomImageBitmap bitmap = (await createImageBitmap(image as JSAny).toDart)! as DomImageBitmap;
+    return renderer.createImageFromImageBitmap(bitmap);
   });
 
   emitImageTests('codec_list_resized', () async {

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -242,21 +242,25 @@ Future<void> testMain() async {
     return data;
   }
 
-  emitImageTests('decodeImageFromPixels_unscaled', () {
-    final Uint8List pixels = generatePixelData(150, 150, (double x, double y) {
-      final double r = sqrt(x * x + y * y);
-      final double theta = atan2(x, y);
-      return ui.Color.fromRGBO(
-        (255 * (sin(r * 10.0) + 1.0) / 2.0).round(),
-        (255 * (sin(theta * 10.0) + 1.0) / 2.0).round(),
-        0,
-        1,
-      );
+  // This API doesn't work in headless Firefox due to requiring WebGL
+  // See https://github.com/flutter/flutter/issues/109265
+  if (!isFirefox) {
+    emitImageTests('decodeImageFromPixels_unscaled', () {
+      final Uint8List pixels = generatePixelData(150, 150, (double x, double y) {
+        final double r = sqrt(x * x + y * y);
+        final double theta = atan2(x, y);
+        return ui.Color.fromRGBO(
+          (255 * (sin(r * 10.0) + 1.0) / 2.0).round(),
+          (255 * (sin(theta * 10.0) + 1.0) / 2.0).round(),
+          0,
+          1,
+        );
+      });
+      final Completer<ui.Image> completer = Completer<ui.Image>();
+      ui.decodeImageFromPixels(pixels, 150, 150, ui.PixelFormat.rgba8888, completer.complete);
+      return completer.future;
     });
-    final Completer<ui.Image> completer = Completer<ui.Image>();
-    ui.decodeImageFromPixels(pixels, 150, 150, ui.PixelFormat.rgba8888, completer.complete);
-    return completer.future;
-  });
+  }
 
   // https://github.com/flutter/flutter/issues/126603
   if (!isHtml) {


### PR DESCRIPTION
This API will help with situations in which the user has a browser resource that they want to transform into a `ui.Image` and render directly into the layer tree. Most browser resources can be converted to an `ImageBitmap` via the `createImageBitmap` API.