### PR TITLE
[web] De-singletonize MouseCursor for multi-view

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -743,6 +743,7 @@ extension DomCSSStyleDeclarationExtension on DomCSSStyleDeclaration {
   set alignContent(String value) => setProperty('align-content', value);
   set textAlign(String value) => setProperty('text-align', value);
   set font(String value) => setProperty('font', value);
+  set cursor(String value) => setProperty('cursor', value);
   String get width => getPropertyValue('width');
   String get height => getPropertyValue('height');
   String get position => getPropertyValue('position');
@@ -807,6 +808,7 @@ extension DomCSSStyleDeclarationExtension on DomCSSStyleDeclaration {
   String get alignContent => getPropertyValue('align-content');
   String get textAlign => getPropertyValue('text-align');
   String get font => getPropertyValue('font');
+  String get cursor => getPropertyValue('cursor');
 
   @JS('getPropertyValue')
   external JSString _getPropertyValue(JSString property);

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -226,7 +226,6 @@ Future<void> initializeEngineUi() async {
   _initializationState = DebugEngineInitializationState.initializingUi;
 
   RawKeyboard.initialize(onMacOs: operatingSystem == OperatingSystem.macOs);
-  MouseCursor.initialize();
   ensureFlutterViewEmbedderInitialized();
   _initializationState = DebugEngineInitializationState.initialized;
 }

--- a/lib/web_ui/lib/src/engine/mouse_cursor.dart
+++ b/lib/web_ui/lib/src/engine/mouse_cursor.dart
@@ -2,23 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'embedder.dart';
-import 'util.dart';
+import 'dom.dart';
+import 'window.dart';
 
-/// Provides mouse cursor bindings, such as the `flutter/mousecursor` channel.
+/// Controls the mouse cursor in the given [view].
 class MouseCursor {
-  MouseCursor._();
+  MouseCursor(this.view);
 
-  /// Initializes the [MouseCursor] singleton.
-  ///
-  /// Use the [instance] getter to get the singleton after calling this method.
-  static void initialize() {
-    _instance ??= MouseCursor._();
-  }
-
-  /// The [MouseCursor] singleton.
-  static MouseCursor? get instance => _instance;
-  static MouseCursor? _instance;
+  final EngineFlutterView view;
 
   // Map from Flutter's kind values to CSS's cursor values.
   //
@@ -61,15 +52,12 @@ class MouseCursor {
     'zoomIn': 'zoom-in',
     'zoomOut': 'zoom-out',
   };
+
   static String _mapKindToCssValue(String? kind) {
     return _kindToCssValueMap[kind] ?? 'default';
   }
 
   void activateSystemCursor(String? kind) {
-    setElementStyle(
-      flutterViewEmbedder.flutterViewElement,
-      'cursor',
-      _mapKindToCssValue(kind),
-    );
+    view.rootElement.style.cursor = _mapKindToCssValue(kind);
   }
 }

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -171,7 +171,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// * [PlatformDisptacher.views] for a list of all [FlutterView]s provided
   ///   by the platform.
   @override
-  ui.FlutterView? get implicitView => viewData[kImplicitViewId];
+  EngineFlutterWindow? get implicitView => viewData[kImplicitViewId] as EngineFlutterWindow?;
 
   /// A callback that is invoked whenever the platform's [devicePixelRatio],
   /// [physicalSize], [padding], [viewInsets], or [systemGestureInsets]
@@ -505,10 +505,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
             // TODO(a-wallen): As multi-window support expands, the pop call
             // will need to include the view ID. Right now only one view is
             // supported.
-            (viewData[kImplicitViewId]! as EngineFlutterWindow)
-                .browserHistory
-                .exit()
-                .then((_) {
+            implicitView!.browserHistory.exit().then((_) {
               replyToPlatformMessage(
                   callback, codec.encodeSuccessEnvelope(true));
             });
@@ -585,7 +582,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         final Map<dynamic, dynamic> arguments = decoded.arguments as Map<dynamic, dynamic>;
         switch (decoded.method) {
           case 'activateSystemCursor':
-            MouseCursor.instance!.activateSystemCursor(arguments.tryString('kind'));
+            implicitView!.mouseCursor.activateSystemCursor(arguments.tryString('kind'));
         }
         return;
 
@@ -618,9 +615,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         // TODO(a-wallen): As multi-window support expands, the navigation call
         // will need to include the view ID. Right now only one view is
         // supported.
-        (viewData[kImplicitViewId]! as EngineFlutterWindow)
-            .handleNavigationMessage(data)
-            .then((bool handled) {
+        implicitView!.handleNavigationMessage(data).then((bool handled) {
           if (handled) {
             const MethodCodec codec = JSONMethodCodec();
             replyToPlatformMessage(callback, codec.encodeSuccessEnvelope(true));
@@ -1231,8 +1226,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   ///    requests from the embedder.
   @override
   String get defaultRouteName {
-    return _defaultRouteName ??=
-        (viewData[kImplicitViewId]! as EngineFlutterWindow).browserHistory.currentPath;
+    return _defaultRouteName ??= implicitView!.browserHistory.currentPath;
   }
 
   /// Lazily initialized when the `defaultRouteName` getter is invoked.

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -16,6 +16,8 @@ import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 import '../engine.dart' show DimensionsProvider, registerHotRestartListener, renderer;
 import 'display.dart';
 import 'dom.dart';
+import 'embedder.dart';
+import 'mouse_cursor.dart';
 import 'navigation/history.dart';
 import 'platform_dispatcher.dart';
 import 'services.dart';
@@ -29,8 +31,17 @@ const bool debugPrintPlatformMessages = false;
 /// The view ID for the implicit flutter view provided by the platform.
 const int kImplicitViewId = 0;
 
+/// Represents all views in the Flutter Web Engine.
+///
+/// In addition to everything defined in [ui.FlutterView], this class adds
+/// a few web-specific properties.
+abstract class EngineFlutterView extends ui.FlutterView {
+  MouseCursor get mouseCursor;
+  DomElement get rootElement;
+}
+
 /// The Web implementation of [ui.SingletonFlutterWindow].
-class EngineFlutterWindow extends ui.SingletonFlutterWindow {
+class EngineFlutterWindow extends ui.SingletonFlutterWindow implements EngineFlutterView {
   EngineFlutterWindow(this.viewId, this.platformDispatcher) {
     platformDispatcher.viewData[viewId] = this;
     platformDispatcher.windowConfigurations[viewId] = const ViewConfiguration();
@@ -52,6 +63,12 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
 
   @override
   final EnginePlatformDispatcher platformDispatcher;
+
+  @override
+  late final MouseCursor mouseCursor = MouseCursor(this);
+
+  @override
+  DomElement get rootElement => flutterViewEmbedder.flutterViewElement;
 
   /// Handles the browser history integration to allow users to use the back
   /// button, etc.

--- a/lib/web_ui/test/canvaskit/initialization/services_vs_ui_test.dart
+++ b/lib/web_ui/test/canvaskit/initialization/services_vs_ui_test.dart
@@ -17,7 +17,6 @@ void testMain() {
 
     expect(findGlassPane(), isNull);
     expect(RawKeyboard.instance, isNull);
-    expect(MouseCursor.instance, isNull);
     expect(KeyboardBinding.instance, isNull);
     expect(PointerBinding.instance, isNull);
 
@@ -28,7 +27,6 @@ void testMain() {
 
     expect(findGlassPane(), isNull);
     expect(RawKeyboard.instance, isNull);
-    expect(MouseCursor.instance, isNull);
     expect(KeyboardBinding.instance, isNull);
     expect(PointerBinding.instance, isNull);
 
@@ -36,7 +34,6 @@ void testMain() {
     await initializeEngineUi();
     expect(findGlassPane(), isNotNull);
     expect(RawKeyboard.instance, isNotNull);
-    expect(MouseCursor.instance, isNotNull);
     expect(KeyboardBinding.instance, isNotNull);
     expect(PointerBinding.instance, isNotNull);
   });

--- a/lib/web_ui/test/engine/mouse_cursor_test.dart
+++ b/lib/web_ui/test/engine/mouse_cursor_test.dart
@@ -1,0 +1,99 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('$MouseCursor', () {
+    test('sets correct `cursor` style on root element', () {
+      final DomElement rootViewElement = createDomElement('div');
+      final MockFlutterView view = MockFlutterView()
+        ..rootElement = rootViewElement;
+      final MouseCursor mouseCursor = MouseCursor(view);
+
+      mouseCursor.activateSystemCursor('alias');
+      expect(rootViewElement.style.cursor, 'alias');
+
+      mouseCursor.activateSystemCursor('move');
+      expect(rootViewElement.style.cursor, 'move');
+
+      mouseCursor.activateSystemCursor('precise');
+      expect(rootViewElement.style.cursor, 'crosshair');
+
+      mouseCursor.activateSystemCursor('resizeDownRight');
+      expect(rootViewElement.style.cursor, 'se-resize');
+    });
+
+    test('handles unknown cursor type', () {
+      final DomElement rootViewElement = createDomElement('div');
+      final MockFlutterView view = MockFlutterView()
+        ..rootElement = rootViewElement;
+      final MouseCursor mouseCursor = MouseCursor(view);
+
+      mouseCursor.activateSystemCursor('unknown');
+      expect(rootViewElement.style.cursor, 'default');
+    });
+  });
+}
+
+class MockFlutterView implements EngineFlutterView {
+  @override
+  late DomElement rootElement;
+
+  @override
+  double get devicePixelRatio => throw UnimplementedError();
+
+  @override
+  ui.Display get display => throw UnimplementedError();
+
+  @override
+  List<ui.DisplayFeature> get displayFeatures => throw UnimplementedError();
+
+  @override
+  ui.GestureSettings get gestureSettings => throw UnimplementedError();
+
+  @override
+  MouseCursor get mouseCursor => throw UnimplementedError();
+
+  @override
+  ViewPadding get padding => throw UnimplementedError();
+
+  @override
+  ui.Rect get physicalGeometry => throw UnimplementedError();
+
+  @override
+  ui.Size get physicalSize => throw UnimplementedError();
+
+  @override
+  ui.PlatformDispatcher get platformDispatcher => throw UnimplementedError();
+
+  @override
+  void render(ui.Scene scene) {
+    throw UnimplementedError();
+  }
+
+  @override
+  ViewPadding get systemGestureInsets => throw UnimplementedError();
+
+  @override
+  void updateSemantics(ui.SemanticsUpdate update) {
+    throw UnimplementedError();
+  }
+
+  @override
+  int get viewId => throw UnimplementedError();
+
+  @override
+  ViewPadding get viewInsets => throw UnimplementedError();
+
+  @override
+  ViewPadding get viewPadding => throw UnimplementedError();
+}


### PR DESCRIPTION
`MouseCursor` is a singleton that works by accessing `flutterViewEmbedder` directly. After this PR, `MouseCursor` becomes a non-singleton that takes a `FlutterView` and controls the mouse cursor for said view.