### PR TITLE
Increase maximum length of function names from 30 to 60.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -158,10 +158,10 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression which should only match correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
+function-rgx=[a-z_][a-z0-9_]{2,60}$
 
 # Regular expression which should only match correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=[a-z_][a-z0-9_]{2,60}$
 
 # Regular expression which should only match correct instance attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$


### PR DESCRIPTION
Unblocks https://github.com/flutter/engine/pull/45243, which adds the function:

```py
def `gather_build_bucket_golden_scraper_tests`():
```