### PR TITLE
[Windows] Update vsync on raster thread

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -343,6 +343,13 @@ void AngleSurfaceManager::SetVSyncEnabled(bool enabled) {
     LogEglError("Unable to update the swap interval");
     return;
   }
+
+  if (eglMakeCurrent(egl_display_, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                     EGL_NO_CONTEXT) != EGL_TRUE) {
+    LogEglError(
+        "Unable to release the context after updating the swap interval");
+    return;
+  }
 }
 
 bool AngleSurfaceManager::GetDevice(ID3D11Device** device) {

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -199,7 +199,7 @@ class FlutterWindowsEngine {
   bool MarkExternalTextureFrameAvailable(int64_t texture_id);
 
   // Posts the given callback onto the raster thread.
-  bool PostRasterThreadTask(fml::closure callback);
+  virtual bool PostRasterThreadTask(fml::closure callback);
 
   // Invoke on the embedder's vsync callback to schedule a frame.
   void OnVsync(intptr_t baton);

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -669,7 +669,12 @@ void FlutterWindowsView::UpdateSemanticsEnabled(bool enabled) {
 
 void FlutterWindowsView::OnDwmCompositionChanged() {
   if (engine_->surface_manager()) {
-    engine_->surface_manager()->SetVSyncEnabled(binding_handler_->NeedsVSync());
+    // Update the surface with the new composition state.
+    // Switch to the raster thread as this requires making the context current.
+    auto needs_vsync = binding_handler_->NeedsVSync();
+    engine_->PostRasterThreadTask([this, needs_vsync]() {
+      engine_->surface_manager()->SetVSyncEnabled(needs_vsync);
+    });
   }
 }
 

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -111,7 +111,7 @@ class MockFlutterWindowsEngine : public FlutterWindowsEngine {
   MockFlutterWindowsEngine() : FlutterWindowsEngine(GetTestProject()) {}
 
   MOCK_METHOD0(Stop, bool());
-  MOCK_METHOD(PostRasterThreadTask, bool(fml::closure));
+  MOCK_METHOD(bool, PostRasterThreadTask, (fml::closure));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsEngine);

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -111,6 +111,7 @@ class MockFlutterWindowsEngine : public FlutterWindowsEngine {
   MockFlutterWindowsEngine() : FlutterWindowsEngine(GetTestProject()) {}
 
   MOCK_METHOD0(Stop, bool());
+  MOCK_METHOD1(PostRasterThreadTask, bool(fml::closure));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsEngine);
@@ -1279,6 +1280,13 @@ TEST(FlutterWindowsViewTest, UpdatesVSyncOnDwmUpdates) {
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   std::unique_ptr<MockAngleSurfaceManager> surface_manager =
       std::make_unique<MockAngleSurfaceManager>();
+
+  EXPECT_CALL(*engine.get(), PostRasterThreadTask)
+      .Times(2)
+      .WillRepeatedly([](fml::closure callback) {
+        callback();
+        return true;
+      });
 
   EXPECT_CALL(*window_binding_handler.get(), NeedsVSync)
       .WillOnce(Return(true))

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -111,7 +111,7 @@ class MockFlutterWindowsEngine : public FlutterWindowsEngine {
   MockFlutterWindowsEngine() : FlutterWindowsEngine(GetTestProject()) {}
 
   MOCK_METHOD0(Stop, bool());
-  MOCK_METHOD1(PostRasterThreadTask, bool(fml::closure));
+  MOCK_METHOD(PostRasterThreadTask, bool(fml::closure));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsEngine);


### PR DESCRIPTION
## Background

If the Windows system compositor is enabled, the Windows embedder disables the swap interval so that presenting to a surface does not block until the v-blank. If the Windows system compositor is disabled (which is possible on Windows 7), the Windows embedder enables swap interval to prevent screen tearing.

Updating the swap interval requires making the GL surface current, which we currently do on the platform thread. However, the raster thread also needs the GL surface for rendering. Our current version of ANGLE allows making a GL surface current on multiple threads. However, the latest version of ANGLE errors if a GL context is made current on multiple threads. This is causing the ANGLE roll to fail ([example](https://ci.chromium.org/ui/p/flutter/builders/try/Windows%20Engine%20Drone/203788/overview)).

## Solution

There's two fixes:

1. The GL context is released once the swap interval is updated. This allows the platform thread to set the initial swap interval at start up, before the raster thread is started. This fixes the ANGLE roll.
3. When the system compositor changes, the Windows embedder now switches to the raster thread before updating the swap interval. This ensures that the GL surface is only made current on the raster thread once the raster thread has started. I updated unit tests to cover this scenario and tested this manually on a Windows 7 machine.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
