### PR TITLE
Migrate VK calls of GrBackend*

### DIFF
--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -13,6 +13,7 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #include "vulkan/vulkan_core.h"
 
 namespace flutter {
@@ -115,10 +116,8 @@ sk_sp<SkSurface> GPUSurfaceVulkan::CreateSurfaceFromVulkanImage(
       .fSampleCount = 1,
       .fLevelCount = 1,
   };
-  GrBackendTexture backend_texture(size.width(),   //
-                                   size.height(),  //
-                                   image_info      //
-  );
+  auto backend_texture =
+      GrBackendTextures::MakeVk(size.width(), size.height(), image_info);
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -94,6 +94,10 @@ extern const intptr_t kPlatformStrongDillSize;
 #endif  // IMPELLER_SUPPORTS_RENDERING
 #endif  // SHELL_ENABLE_METAL
 
+#ifdef SHELL_ENABLE_VULKAN
+#include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
+#endif  // SHELL_ENABLE_VULKAN
+
 const int32_t kFlutterSemanticsNodeIdBatchEnd = -1;
 const int32_t kFlutterSemanticsCustomActionIdBatchEnd = -1;
 
@@ -1105,10 +1109,8 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
       .fSampleCount = 1,
       .fLevelCount = 1,
   };
-  GrBackendTexture backend_texture(config.size.width,   //
-                                   config.size.height,  //
-                                   image_info           //
-  );
+  auto backend_texture = GrBackendTextures::MakeVk(
+      config.size.width, config.size.height, image_info);
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -21,6 +21,10 @@
 #include <memory>
 #include <utility>
 
+#ifdef SHELL_ENABLE_VULKAN
+#include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
+#endif  // SHELL_ENABLE_VULKAN
+
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
 
@@ -329,8 +333,8 @@ bool EmbedderTestBackingStoreProducer::CreateVulkanImage(
       .fSampleCount = 1,
       .fLevelCount = 1,
   };
-  GrBackendTexture backend_texture(surface_size.width(), surface_size.height(),
-                                   image_info);
+  auto backend_texture = GrBackendTextures::MakeVk(
+      surface_size.width(), surface_size.height(), image_info);
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 

--- a/testing/test_vulkan_surface.cc
+++ b/testing/test_vulkan_surface.cc
@@ -13,6 +13,7 @@
 #include "third_party/skia/include/core/SkSurfaceProps.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 
 namespace flutter {
@@ -43,10 +44,8 @@ std::unique_ptr<TestVulkanSurface> TestVulkanSurface::Create(
       .fSampleCount = 1,
       .fLevelCount = 1,
   };
-  GrBackendTexture backend_texture(surface_size.width(),   //
-                                   surface_size.height(),  //
-                                   image_info              //
-  );
+  auto backend_texture = GrBackendTextures::MakeVk(
+      surface_size.width(), surface_size.height(), image_info);
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -11,6 +11,7 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 
 #include "vulkan_backbuffer.h"
@@ -242,8 +243,8 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(
   image_info.fLevelCount = 1;
 
   // TODO(chinmaygarde): Setup the stencil buffer and the sampleCnt.
-  GrBackendRenderTarget backend_render_target(size.fWidth, size.fHeight,
-                                              image_info);
+  auto backend_render_target =
+      GrBackendRenderTargets::MakeVk(size.fWidth, size.fHeight, image_info);
   SkSurfaceProps props(0, kUnknown_SkPixelGeometry);
 
   return SkSurfaces::WrapBackendRenderTarget(
@@ -483,7 +484,8 @@ VulkanSwapchain::AcquireResult VulkanSwapchain::AcquireSurface() {
     FML_DLOG(INFO) << "Could not get backend render target.";
     return error;
   }
-  backendRT.setVkImageLayout(destination_image_layout);
+  GrBackendRenderTargets::SetVkImageLayout(&backendRT,
+                                           destination_image_layout);
 
   current_image_index_ = next_image_index;
 


### PR DESCRIPTION
In https://skia-review.googlesource.com/c/skia/+/742797 Skia refactored GrBackend* to not require #ifdefs. This changes
callsites in Flutter to use static functions instead of methods that were conditionally compiled on those classes.

There should be no functional change.