### PR TITLE
[macOS] Link __availability_version_check

### DIFF
--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -13,12 +13,37 @@ source_set("common") {
   cflags_objcc = flutter_cflags_objcc
 
   sources = [
-    "availability_version_check.cc",
     "buffer_conversions.h",
     "buffer_conversions.mm",
     "command_line.h",
     "command_line.mm",
   ]
+
+  deps = [
+    ":availability_version_check",
+    "//flutter/fml",
+  ]
+
+  public_configs = [ "//flutter:config" ]
+}
+
+# Provides an implementation for _availability_version_check.
+#
+# This is required due to an upstream compiler builtin (runtime) change
+# that marked this function as weakly-linked via __attribute__((weak import))
+# As such, no linking failure occurs when the function is unavailable at
+# link time. Since the symbol is no longer linked in, App Store review blocks
+# publishing due to relying on a private symbol. Instead we link in our own
+# implementation, which provides the exact implementation used in clang prior
+# to the upstream change.
+#
+# See: Upstream clang change: https://reviews.llvm.org/D150397
+# See: https://github.com/flutter/flutter/issues/133777
+source_set("availability_version_check") {
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
+
+  sources = [ "availability_version_check.cc" ]
 
   deps = [ "//flutter/fml" ]
 

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -121,6 +121,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/common:common_cpp_enums",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_switches",
+    "//flutter/shell/platform/darwin/common:availability_version_check",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/darwin/graphics:graphics",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",


### PR DESCRIPTION
Links in an implementation of _availability_version_check on macOS.                
This is required due to an upstream compiler builtin (runtime) change              
that marked this function as weakly-linked via `__attribute__((weak import))`   
As such, no linking failure occurs when the function is unavailable at             
link time.                                                                         
                                                                                   
By providing an implementation, the linker picks up our implementation,            
which looks up symbol in question at runtime (via dlsym) on the first              
invocation, caches it for later invocations, then invokes it. This is,             
in fact, precisely what the original clang builtin implementation did.             
                                                                                   
Upstream clang change: https://reviews.llvm.org/D150397                            
                                                                                   
Issue: https://github.com/flutter/flutter/issues/133777 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
