### PR TITLE
[Impeller] fix performance overlay early release.

### DIFF
--- a/flow/stopwatch_dl.cc
+++ b/flow/stopwatch_dl.cc
@@ -102,7 +102,11 @@ void DlStopwatchVisualizer::Visualize(DlCanvas* canvas,
 
   // Actually draw.
   // Note we use kSrcOver, because some of the colors above have opacity < 1.0.
-  canvas->DrawVertices(painter.IntoVertices(), DlBlendMode::kSrcOver, paint);
+  // The Canvas does not actually hold onto a strong reference to the DlVertices
+  // object, so it needs to be cached on the painter to avoid being deleted
+  // while the backend is trying to read data from it.
+  dl_vertices_ = painter.IntoVertices();
+  canvas->DrawVertices(dl_vertices_, DlBlendMode::kSrcOver, paint);
 }
 
 void DlVertexPainter::DrawRect(const SkRect& rect, const DlColor& color) {

--- a/flow/stopwatch_dl.cc
+++ b/flow/stopwatch_dl.cc
@@ -105,6 +105,7 @@ void DlStopwatchVisualizer::Visualize(DlCanvas* canvas,
   // The Canvas does not actually hold onto a strong reference to the DlVertices
   // object, so it needs to be cached on the painter to avoid being deleted
   // while the backend is trying to read data from it.
+  // See: https://github.com/flutter/flutter/issues/133797
   dl_vertices_ = painter.IntoVertices();
   canvas->DrawVertices(dl_vertices_, DlBlendMode::kSrcOver, paint);
 }

--- a/flow/stopwatch_dl.h
+++ b/flow/stopwatch_dl.h
@@ -24,6 +24,11 @@ class DlStopwatchVisualizer : public StopwatchVisualizer {
 
   void Visualize(DlCanvas* canvas, const SkRect& rect) const override;
 
+  // Visible for testing.
+  const std::shared_ptr<DlVertices> GetLastVertices() const {
+    return dl_vertices_;
+  }
+
  private:
   mutable std::shared_ptr<DlVertices> dl_vertices_;
 };

--- a/flow/stopwatch_dl.h
+++ b/flow/stopwatch_dl.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_FLOW_STOPWATCH_DL_H_
 #define FLUTTER_FLOW_STOPWATCH_DL_H_
 
+#include "display_list/dl_vertices.h"
 #include "flow/stopwatch.h"
 
 namespace flutter {
@@ -22,6 +23,9 @@ class DlStopwatchVisualizer : public StopwatchVisualizer {
       : StopwatchVisualizer(stopwatch) {}
 
   void Visualize(DlCanvas* canvas, const SkRect& rect) const override;
+
+ private:
+  mutable std::shared_ptr<DlVertices> dl_vertices_;
 };
 
 /// @brief Provides canvas-like painting methods that actually build vertices.

--- a/flow/stopwatch_dl_unittests.cc
+++ b/flow/stopwatch_dl_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/flow/stopwatch_dl.h"
 #include "gtest/gtest.h"
+#include "testing/mock_canvas.h"
 
 namespace flutter {
 namespace testing {
@@ -18,7 +19,7 @@ static SkRect MakeRectFromVertices(SkPoint vertices[6]) {
   return SkRect::MakeLTRB(left, top, right, bottom);
 }
 
-TEST(DlVertexPainter, DrawRectIntoVertices) {
+TEST(DlVertexPainterTest, DrawRectIntoVertices) {
   auto painter = DlVertexPainter();
 
   // Paint a red rectangle.
@@ -67,6 +68,19 @@ TEST(DlVertexPainter, DrawRectIntoVertices) {
   EXPECT_EQ(colors[9], DlColor::kBlue());
   EXPECT_EQ(colors[10], DlColor::kBlue());
   EXPECT_EQ(colors[11], DlColor::kBlue());
+}
+
+TEST(DlVertexPainterTest, HoldsLastPaintedVertices) {
+  auto stopwatch = std::make_shared<FixedRefreshRateStopwatch>();
+  auto visualizer = std::make_shared<DlStopwatchVisualizer>(*stopwatch.get());
+
+  EXPECT_EQ(visualizer->GetLastVertices(), nullptr);
+
+  MockCanvas mock_canvas;
+
+  visualizer->Visualize(&mock_canvas, SkRect::MakeLTRB(0, 0, 100, 100));
+
+  EXPECT_NE(visualizer->GetLastVertices(), nullptr);
 }
 
 }  // namespace testing

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -296,8 +296,10 @@ void MockCanvas::DrawImageNine(const sk_sp<DlImage>& image,
   FML_DCHECK(false);
 }
 
-void MockCanvas::DrawVertices(const DlVertices*, DlBlendMode, const DlPaint&) {
-  FML_DCHECK(false);
+void MockCanvas::DrawVertices(const DlVertices*,
+                              DlBlendMode mode,
+                              const DlPaint& paint) {
+  draw_calls_.emplace_back(DrawVerticesData{.mode = mode, .paint = paint});
 }
 
 void MockCanvas::DrawAtlas(const sk_sp<DlImage>&,
@@ -520,6 +522,16 @@ bool operator==(const MockCanvas::ClipPathData& a,
 std::ostream& operator<<(std::ostream& os,
                          const MockCanvas::ClipPathData& data) {
   return os << data.path << " " << data.clip_op << " " << data.style;
+}
+
+bool operator==(const MockCanvas::DrawVerticesData& a,
+                const MockCanvas::DrawVerticesData& b) {
+  return a.mode == b.mode && a.paint == b.paint;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const MockCanvas::DrawVerticesData& data) {
+  return os << "DrawVertices: ";
 }
 
 std::ostream& operator<<(std::ostream& os,

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -130,6 +130,11 @@ class MockCanvas final : public DlCanvas {
     DlPaint paint;
   };
 
+  struct DrawVerticesData {
+    DlBlendMode mode;
+    DlPaint paint;
+  };
+
   // Discriminated union of all the different |DrawCall| types.  It is roughly
   // equivalent to the different methods in |SkCanvas|' public API.
   using DrawCallData = std::variant<SaveData,
@@ -147,7 +152,8 @@ class MockCanvas final : public DlCanvas {
                                     ClipRectData,
                                     ClipRRectData,
                                     ClipPathData,
-                                    DrawPaintData>;
+                                    DrawPaintData,
+                                    DrawVerticesData>;
 
   // A single call made against this canvas.
   struct DrawCall {


### PR DESCRIPTION
Canvas apparently doesn't hold a strong reference to the DLVertices, so it can be destructed before/while Impeller is reading data from it.
