### PR TITLE
Revert "Reland "Build iOS unittest target in unopt builds" (#44356)""

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -149,10 +149,6 @@ group("unittests") {
         [ "//flutter/shell/platform/android:flutter_shell_native_unittests" ]
   }
 
-  if (is_ios) {
-    public_deps += [ "//flutter/shell/platform/darwin/ios:ios_test_flutter" ]
-  }
-
   # Compile all unittests targets if enabled.
   if (enable_unittests) {
     public_deps += [

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -270,7 +270,7 @@ source_set("ios_test_flutter_mrc") {
 
 shared_library("ios_test_flutter") {
   testonly = true
-  visibility = [ "*" ]
+  visibility = [ ":*" ]
   cflags = [
     "-fvisibility=default",
     "-F$platform_frameworks_path",


### PR DESCRIPTION
Reverts flutter/engine#44821

clang-tidy failures https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20Production%20Engine%20Drone/137227/overview