### PR TITLE
Do not decode PNG images into a wide gamut color space

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -176,8 +176,10 @@ DecompressResult ImageDecoderImpeller::DecompressTexture(
   ///
 
   const auto base_image_info = descriptor->image_info();
-  const bool is_wide_gamut =
-      supports_wide_gamut ? IsWideGamut(base_image_info.colorSpace()) : false;
+  const bool is_wide_gamut = supports_wide_gamut
+                                 ? IsWideGamut(base_image_info.colorSpace()) &&
+                                       descriptor->is_wide_gamut_compatible()
+                                 : false;
   SkAlphaType alpha_type =
       ChooseCompatibleAlphaType(base_image_info.alphaType());
   SkImageInfo image_info;

--- a/lib/ui/painting/image_descriptor.cc
+++ b/lib/ui/painting/image_descriptor.cc
@@ -28,14 +28,16 @@ ImageDescriptor::ImageDescriptor(sk_sp<SkData> buffer,
     : buffer_(std::move(buffer)),
       generator_(nullptr),
       image_info_(image_info),
-      row_bytes_(row_bytes) {}
+      row_bytes_(row_bytes),
+      wide_gamut_compatible_(true) {}
 
 ImageDescriptor::ImageDescriptor(sk_sp<SkData> buffer,
                                  std::shared_ptr<ImageGenerator> generator)
     : buffer_(std::move(buffer)),
       generator_(std::move(generator)),
       image_info_(CreateImageInfo()),
-      row_bytes_(std::nullopt) {}
+      row_bytes_(std::nullopt),
+      wide_gamut_compatible_(generator_->IsWideGamutCompatible()) {}
 
 Dart_Handle ImageDescriptor::initEncoded(Dart_Handle descriptor_handle,
                                          ImmutableBuffer* immutable_buffer,

--- a/lib/ui/painting/image_descriptor.h
+++ b/lib/ui/painting/image_descriptor.h
@@ -93,6 +93,10 @@ class ImageDescriptor : public RefCountedDartWrappable<ImageDescriptor> {
   ///         not.
   bool is_compressed() const { return !!generator_; }
 
+  /// @brief  Whether this image's generator can decode the image into a wide
+  ///         gamut color space.
+  bool is_wide_gamut_compatible() const { return wide_gamut_compatible_; }
+
   /// @brief  The orientation corrected image info for this image.
   const SkImageInfo& image_info() const { return image_info_; }
 
@@ -127,6 +131,7 @@ class ImageDescriptor : public RefCountedDartWrappable<ImageDescriptor> {
   std::shared_ptr<ImageGenerator> generator_;
   const SkImageInfo image_info_;
   std::optional<size_t> row_bytes_;
+  const bool wide_gamut_compatible_;
 
   const SkImageInfo CreateImageInfo() const;
 

--- a/lib/ui/painting/image_generator.cc
+++ b/lib/ui/painting/image_generator.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "flutter/fml/logging.h"
+#include "third_party/skia/include/codec/SkEncodedImageFormat.h"
 #include "third_party/skia/include/codec/SkEncodedOrigin.h"
 #include "third_party/skia/include/codec/SkPixmapUtils.h"
 #include "third_party/skia/include/core/SkBitmap.h"
@@ -139,6 +140,12 @@ SkISize BuiltinSkiaCodecImageGenerator::GetScaledDimensions(
     std::swap(size.fWidth, size.fHeight);
   }
   return size;
+}
+
+bool BuiltinSkiaCodecImageGenerator::IsWideGamutCompatible() {
+  // Skia's PNG codec may be unable to decode some images (such as
+  // palette-based images) into a wide gamut color space.
+  return codec_->getEncodedFormat() != SkEncodedImageFormat::kPNG;
 }
 
 bool BuiltinSkiaCodecImageGenerator::GetPixels(

--- a/lib/ui/painting/image_generator.h
+++ b/lib/ui/painting/image_generator.h
@@ -101,6 +101,10 @@ class ImageGenerator {
   /// @see        `GetPixels`
   virtual SkISize GetScaledDimensions(float scale) = 0;
 
+  /// @brief      Returns whether the generator is able to decode this image
+  ///             into a wide gamut color space.
+  virtual bool IsWideGamutCompatible() { return true; }
+
   /// @brief      Decode the image into a given buffer. This method is currently
   ///             always used for sub-pixel image decoding. For full-sized still
   ///             images, `GetImage` is always attempted first.
@@ -203,6 +207,9 @@ class BuiltinSkiaCodecImageGenerator : public ImageGenerator {
 
   // |ImageGenerator|
   SkISize GetScaledDimensions(float desired_scale) override;
+
+  // |ImageGenerator|
+  virtual bool IsWideGamutCompatible() override;
 
   // |ImageGenerator|
   bool GetPixels(


### PR DESCRIPTION
Skia's PNG codec does not support wide gamut output formats for some images (such as palette-based images)

See https://github.com/flutter/flutter/issues/133013
