### PR TITLE
Cull the RTree bounds when they are forwarded in DrawDisplayList

### DIFF
--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -1225,7 +1225,7 @@ void DisplayListBuilder::DrawDisplayList(const sk_sp<DisplayList> display_list,
       auto rtree = display_list->rtree();
       if (rtree) {
         std::list<SkRect> rects =
-            rtree->searchAndConsolidateRects(bounds, false);
+            rtree->searchAndConsolidateRects(GetLocalClipBounds(), false);
         accumulated = false;
         for (const SkRect& rect : rects) {
           // TODO (https://github.com/flutter/flutter/issues/114919): Attributes


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/133437

With this fix, the [benchmarks](https://github.com/flutter/flutter/pull/133434) for pictures with huge bounds become runnable under more conditions. Currently those benchmarks only run on platforms where we don't run into this issue. The performance on those platforms/conditions will not change much, but with this fix we can run them on Impeller and add a variant that has a platform view on the display.