### PR TITLE
[iOS ] Fix errors in unittest and scenario tests running against iOS 17 simulators (details in the description)

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenTestManager.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenTestManager.m
@@ -76,7 +76,7 @@ NSDictionary* launchArgsMap;
 - (void)checkGoldenForTest:(XCTestCase*)test {
   XCUIScreenshot* screenshot = [[XCUIScreen mainScreen] screenshot];
   if (!_goldenImage.image) {
-    XCTAttachment* attachment = [XCTAttachment attachmentWithScreenshot:screenshot.image];
+    XCTAttachment* attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
     attachment.name = [_goldenImage.goldenName stringByAppendingString:@"_new.png"];
     attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
     [test addAttachment:attachment];

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/LocalizationInitializationTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/LocalizationInitializationTest.m
@@ -26,10 +26,17 @@ FLUTTER_ASSERT_ARC
   NSTimeInterval timeout = 10.0;
 
   // The locales received by dart:ui are exposed onBeginFrame via semantics label.
-  // There should only be one locale, since the default iOS app only has en_US as
-  // the locale. The list should consist of just the en locale.
+  // There should only be one locale. The list should consist of the default
+  // locale provided by the iOS app.
+  NSArray<NSString*>* preferredLocales = [NSLocale preferredLanguages];
+  XCTAssertEqual(preferredLocales.count, 1);
+  // Dart connects the locale parts with `_` while iOS connects them with `-`.
+  // Converts to dart format before comparing.
+  NSString* localeDart = [preferredLocales.firstObject stringByReplacingOccurrencesOfString:@"-"
+                                                                                 withString:@"_"];
+  NSString* expectedIdentifier = [NSString stringWithFormat:@"[%@]", localeDart];
   XCUIElement* textInputSemanticsObject =
-      [self.application.textFields matchingIdentifier:@"[en]"].element;
+      [self.application.textFields matchingIdentifier:expectedIdentifier].element;
   XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:timeout]);
 
   [textInputSemanticsObject tap];


### PR DESCRIPTION
1. New Mac version seems to have updated the locale data, to match the mac change, we can dynamically read the data when testing instead of hard coding.

2. "we are sending a UIImage type as parameter to `XCTAttachment attachmentWithScreenshot:`, which takes a `XCUIScreenshot` as parameter, this is not supposed to pass in old iOS versions." In this PR we updated the parameter to use the `XCUIScreenshot` type.

Fixes https://github.com/flutter/flutter/issues/133783

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
