### PR TITLE
[impeller] premultiply vertices colors.

### DIFF
--- a/impeller/display_list/dl_unittests.cc
+++ b/impeller/display_list/dl_unittests.cc
@@ -1500,6 +1500,29 @@ TEST_P(DisplayListTest, DrawVerticesSolidColorTrianglesWithIndices) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(DisplayListTest, DrawVerticesPremultipliesColors) {
+  std::vector<SkPoint> positions = {
+      SkPoint::Make(100, 300), SkPoint::Make(200, 100), SkPoint::Make(300, 300),
+      SkPoint::Make(200, 500)};
+  auto color = flutter::DlColor::kBlue().withAlpha(0x99);
+  std::vector<uint16_t> indices = {0, 1, 2, 0, 2, 3};
+  std::vector<flutter::DlColor> colors = {color, color, color, color};
+
+  auto vertices = flutter::DlVertices::Make(
+      flutter::DlVertexMode::kTriangles, 6, positions.data(),
+      /*texture_coorindates=*/nullptr, colors.data(), 6, indices.data());
+
+  flutter::DisplayListBuilder builder;
+  flutter::DlPaint paint;
+  paint.setBlendMode(flutter::DlBlendMode::kSrcOver);
+  paint.setColor(flutter::DlColor::kRed());
+
+  builder.DrawRect(SkRect::MakeLTRB(0, 0, 400, 400), paint);
+  builder.DrawVertices(vertices, flutter::DlBlendMode::kDst, paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 TEST_P(DisplayListTest, DrawShapes) {
   flutter::DisplayListBuilder builder;
   std::vector<flutter::DlStrokeJoin> joins = {

--- a/impeller/display_list/dl_vertices_geometry.cc
+++ b/impeller/display_list/dl_vertices_geometry.cc
@@ -46,7 +46,8 @@ std::shared_ptr<impeller::VerticesGeometry> MakeVertices(
   if (vertices->colors()) {
     colors.reserve(vertices->vertex_count());
     for (auto i = 0; i < vertices->vertex_count(); i++) {
-      colors.push_back(skia_conversions::ToColor(vertices->colors()[i]));
+      colors.push_back(
+          skia_conversions::ToColor(vertices->colors()[i]).Premultiply());
     }
   }
   std::vector<Point> texture_coordinates;


### PR DESCRIPTION
Lost this after the transition.

### After

![image](https://github.com/flutter/engine/assets/8975114/cec40045-581a-4bc4-8470-fbc201a0773b)


### Before

![image](https://github.com/flutter/engine/assets/8975114/23229175-54db-4aac-8605-cfe8568be436)
