### PR TITLE
Revert "Remove deprecated MOCK_METHODx calls"

### DIFF
--- a/flow/stopwatch_unittests.cc
+++ b/flow/stopwatch_unittests.cc
@@ -13,7 +13,7 @@ namespace testing {
 
 class MockRefreshRateUpdater : public Stopwatch::RefreshRateUpdater {
  public:
-  MOCK_METHOD(fml::Milliseconds, GetFrameBudget, (), (const, override));
+  MOCK_CONST_METHOD0(GetFrameBudget, fml::Milliseconds());
 };
 
 TEST(Instrumentation, GetDefaultFrameBudgetTest) {

--- a/impeller/aiks/testing/context_mock.h
+++ b/impeller/aiks/testing/context_mock.h
@@ -21,19 +21,15 @@ class CommandBufferMock : public CommandBuffer {
   CommandBufferMock(std::weak_ptr<const Context> context)
       : CommandBuffer(context) {}
 
-  MOCK_METHOD(bool, IsValid, (), (const, override));
+  MOCK_CONST_METHOD0(IsValid, bool());
 
-  MOCK_METHOD(void, SetLabel, (const std::string& label), (const, override));
+  MOCK_CONST_METHOD1(SetLabel, void(const std::string& label));
 
-  MOCK_METHOD(bool,
-              SubmitCommandsAsync,
-              (std::shared_ptr<RenderPass> render_pass),
-              (override));
+  MOCK_METHOD1(SubmitCommandsAsync,
+               bool(std::shared_ptr<RenderPass> render_pass));
 
-  MOCK_METHOD(std::shared_ptr<RenderPass>,
-              OnCreateRenderPass,
-              (RenderTarget render_target),
-              (override));
+  MOCK_METHOD1(OnCreateRenderPass,
+               std::shared_ptr<RenderPass>(RenderTarget render_target));
 
   static std::shared_ptr<RenderPass> ForwardOnCreateRenderPass(
       CommandBuffer* command_buffer,
@@ -41,30 +37,24 @@ class CommandBufferMock : public CommandBuffer {
     return command_buffer->OnCreateRenderPass(render_target);
   }
 
-  MOCK_METHOD(std::shared_ptr<BlitPass>, OnCreateBlitPass, (), (override));
+  MOCK_METHOD0(OnCreateBlitPass, std::shared_ptr<BlitPass>());
   static std::shared_ptr<BlitPass> ForwardOnCreateBlitPass(
       CommandBuffer* command_buffer) {
     return command_buffer->OnCreateBlitPass();
   }
 
-  MOCK_METHOD(bool,
-              OnSubmitCommands,
-              (CompletionCallback callback),
-              (override));
+  MOCK_METHOD1(OnSubmitCommands, bool(CompletionCallback callback));
   static bool ForwardOnSubmitCommands(CommandBuffer* command_buffer,
                                       CompletionCallback callback) {
     return command_buffer->OnSubmitCommands(callback);
   }
 
-  MOCK_METHOD(void, OnWaitUntilScheduled, (), (override));
+  MOCK_METHOD0(OnWaitUntilScheduled, void());
   static void ForwardOnWaitUntilScheduled(CommandBuffer* command_buffer) {
     return command_buffer->OnWaitUntilScheduled();
   }
 
-  MOCK_METHOD(std::shared_ptr<ComputePass>,
-              OnCreateComputePass,
-              (),
-              (override));
+  MOCK_METHOD0(OnCreateComputePass, std::shared_ptr<ComputePass>());
   static std::shared_ptr<ComputePass> ForwardOnCreateComputePass(
       CommandBuffer* command_buffer) {
     return command_buffer->OnCreateComputePass();
@@ -73,48 +63,28 @@ class CommandBufferMock : public CommandBuffer {
 
 class ContextMock : public Context {
  public:
-  MOCK_METHOD(std::string, DescribeGpuModel, (), (const, override));
+  MOCK_CONST_METHOD0(DescribeGpuModel, std::string());
 
-  MOCK_METHOD(Context::BackendType, GetBackendType, (), (const, override));
+  MOCK_CONST_METHOD0(GetBackendType, Context::BackendType());
 
-  MOCK_METHOD(bool, IsValid, (), (const, override));
+  MOCK_CONST_METHOD0(IsValid, bool());
 
-  MOCK_METHOD(const std::shared_ptr<const Capabilities>&,
-              GetCapabilities,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetCapabilities,
+                     const std::shared_ptr<const Capabilities>&());
 
-  MOCK_METHOD(bool,
-              UpdateOffscreenLayerPixelFormat,
-              (PixelFormat format),
-              (override));
+  MOCK_METHOD1(UpdateOffscreenLayerPixelFormat, bool(PixelFormat format));
 
-  MOCK_METHOD(std::shared_ptr<Allocator>,
-              GetResourceAllocator,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetResourceAllocator, std::shared_ptr<Allocator>());
 
-  MOCK_METHOD(std::shared_ptr<ShaderLibrary>,
-              GetShaderLibrary,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetShaderLibrary, std::shared_ptr<ShaderLibrary>());
 
-  MOCK_METHOD(std::shared_ptr<SamplerLibrary>,
-              GetSamplerLibrary,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetSamplerLibrary, std::shared_ptr<SamplerLibrary>());
 
-  MOCK_METHOD(std::shared_ptr<PipelineLibrary>,
-              GetPipelineLibrary,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetPipelineLibrary, std::shared_ptr<PipelineLibrary>());
 
-  MOCK_METHOD(std::shared_ptr<CommandBuffer>,
-              CreateCommandBuffer,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(CreateCommandBuffer, std::shared_ptr<CommandBuffer>());
 
-  MOCK_METHOD(void, Shutdown, (), (override));
+  MOCK_METHOD0(Shutdown, void());
 };
 
 }  // namespace testing

--- a/impeller/renderer/testing/mocks.h
+++ b/impeller/renderer/testing/mocks.h
@@ -17,151 +17,111 @@ namespace testing {
 class MockDeviceBuffer : public DeviceBuffer {
  public:
   MockDeviceBuffer(const DeviceBufferDescriptor& desc) : DeviceBuffer(desc) {}
+  MOCK_METHOD3(CopyHostBuffer,
+               bool(const uint8_t* source, Range source_range, size_t offset));
 
-  MOCK_METHOD(bool, SetLabel, (const std::string& label), (override));
+  MOCK_METHOD1(SetLabel, bool(const std::string& label));
 
-  MOCK_METHOD(bool,
-              SetLabel,
-              (const std::string& label, Range range),
-              (override));
+  MOCK_METHOD2(SetLabel, bool(const std::string& label, Range range));
 
-  MOCK_METHOD(uint8_t*, OnGetContents, (), (const, override));
+  MOCK_CONST_METHOD0(OnGetContents, uint8_t*());
 
-  MOCK_METHOD(bool,
-              OnCopyHostBuffer,
-              (const uint8_t* source, Range source_range, size_t offset),
-              (override));
+  MOCK_METHOD3(OnCopyHostBuffer,
+               bool(const uint8_t* source, Range source_range, size_t offset));
 };
 
 class MockAllocator : public Allocator {
  public:
-  MOCK_METHOD(ISize, GetMaxTextureSizeSupported, (), (const, override));
-  MOCK_METHOD(std::shared_ptr<DeviceBuffer>,
-              OnCreateBuffer,
-              (const DeviceBufferDescriptor& desc),
-              (override));
-  MOCK_METHOD(std::shared_ptr<Texture>,
-              OnCreateTexture,
-              (const TextureDescriptor& desc),
-              (override));
+  MOCK_CONST_METHOD0(GetMaxTextureSizeSupported, ISize());
+  MOCK_METHOD1(
+      OnCreateBuffer,
+      std::shared_ptr<DeviceBuffer>(const DeviceBufferDescriptor& desc));
+  MOCK_METHOD1(OnCreateTexture,
+               std::shared_ptr<Texture>(const TextureDescriptor& desc));
 };
 
 class MockBlitPass : public BlitPass {
  public:
-  MOCK_METHOD(bool, IsValid, (), (const, override));
-  MOCK_METHOD(bool,
-              EncodeCommands,
-              (const std::shared_ptr<Allocator>& transients_allocator),
-              (const, override));
-  MOCK_METHOD(void, OnSetLabel, (std::string label), (override));
+  MOCK_CONST_METHOD0(IsValid, bool());
+  MOCK_CONST_METHOD1(
+      EncodeCommands,
+      bool(const std::shared_ptr<Allocator>& transients_allocator));
+  MOCK_METHOD1(OnSetLabel, void(std::string label));
 
-  MOCK_METHOD(bool,
-              OnCopyTextureToTextureCommand,
-              (std::shared_ptr<Texture> source,
-               std::shared_ptr<Texture> destination,
-               IRect source_region,
-               IPoint destination_origin,
-               std::string label),
-              (override));
+  MOCK_METHOD5(OnCopyTextureToTextureCommand,
+               bool(std::shared_ptr<Texture> source,
+                    std::shared_ptr<Texture> destination,
+                    IRect source_region,
+                    IPoint destination_origin,
+                    std::string label));
 
-  MOCK_METHOD(bool,
-              OnCopyTextureToBufferCommand,
-              (std::shared_ptr<Texture> source,
-               std::shared_ptr<DeviceBuffer> destination,
-               IRect source_region,
-               size_t destination_offset,
-               std::string label),
-              (override));
-  MOCK_METHOD(bool,
-              OnCopyBufferToTextureCommand,
-              (BufferView source,
-               std::shared_ptr<Texture> destination,
-               IPoint destination_origin,
-               std::string label),
-              (override));
-  MOCK_METHOD(bool,
-              OnGenerateMipmapCommand,
-              (std::shared_ptr<Texture> texture, std::string label),
-              (override));
+  MOCK_METHOD5(OnCopyTextureToBufferCommand,
+               bool(std::shared_ptr<Texture> source,
+                    std::shared_ptr<DeviceBuffer> destination,
+                    IRect source_region,
+                    size_t destination_offset,
+                    std::string label));
+  MOCK_METHOD4(OnCopyBufferToTextureCommand,
+               bool(BufferView source,
+                    std::shared_ptr<Texture> destination,
+                    IPoint destination_origin,
+                    std::string label));
+  MOCK_METHOD2(OnGenerateMipmapCommand,
+               bool(std::shared_ptr<Texture> texture, std::string label));
 };
 
 class MockCommandBuffer : public CommandBuffer {
  public:
   MockCommandBuffer(std::weak_ptr<const Context> context)
       : CommandBuffer(context) {}
-  MOCK_METHOD(bool, IsValid, (), (const, override));
-  MOCK_METHOD(void, SetLabel, (const std::string& label), (const, override));
-  MOCK_METHOD(std::shared_ptr<BlitPass>, OnCreateBlitPass, (), (override));
-  MOCK_METHOD(bool,
-              OnSubmitCommands,
-              (CompletionCallback callback),
-              (override));
-  MOCK_METHOD(void, OnWaitUntilScheduled, (), (override));
-  MOCK_METHOD(std::shared_ptr<ComputePass>,
-              OnCreateComputePass,
-              (),
-              (override));
-  MOCK_METHOD(std::shared_ptr<RenderPass>,
-              OnCreateRenderPass,
-              (RenderTarget render_target),
-              (override));
+  MOCK_CONST_METHOD0(IsValid, bool());
+  MOCK_CONST_METHOD1(SetLabel, void(const std::string& label));
+  MOCK_METHOD0(OnCreateBlitPass, std::shared_ptr<BlitPass>());
+  MOCK_METHOD1(OnSubmitCommands, bool(CompletionCallback callback));
+  MOCK_METHOD0(OnWaitUntilScheduled, void());
+  MOCK_METHOD0(OnCreateComputePass, std::shared_ptr<ComputePass>());
+  MOCK_METHOD1(OnCreateRenderPass,
+               std::shared_ptr<RenderPass>(RenderTarget render_target));
 };
 
 class MockImpellerContext : public Context {
  public:
-  MOCK_METHOD(Context::BackendType, GetBackendType, (), (const, override));
+  MOCK_CONST_METHOD0(GetBackendType, Context::BackendType());
 
-  MOCK_METHOD(std::string, DescribeGpuModel, (), (const, override));
+  MOCK_CONST_METHOD0(DescribeGpuModel, std::string());
 
-  MOCK_METHOD(bool, IsValid, (), (const, override));
+  MOCK_CONST_METHOD0(IsValid, bool());
 
-  MOCK_METHOD(void, Shutdown, (), (override));
+  MOCK_METHOD0(Shutdown, void());
 
-  MOCK_METHOD(std::shared_ptr<Allocator>,
-              GetResourceAllocator,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetResourceAllocator, std::shared_ptr<Allocator>());
 
-  MOCK_METHOD(std::shared_ptr<ShaderLibrary>,
-              GetShaderLibrary,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetShaderLibrary, std::shared_ptr<ShaderLibrary>());
 
-  MOCK_METHOD(std::shared_ptr<SamplerLibrary>,
-              GetSamplerLibrary,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetSamplerLibrary, std::shared_ptr<SamplerLibrary>());
 
-  MOCK_METHOD(std::shared_ptr<PipelineLibrary>,
-              GetPipelineLibrary,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetPipelineLibrary, std::shared_ptr<PipelineLibrary>());
 
-  MOCK_METHOD(std::shared_ptr<CommandBuffer>,
-              CreateCommandBuffer,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(CreateCommandBuffer, std::shared_ptr<CommandBuffer>());
 
-  MOCK_METHOD(const std::shared_ptr<const Capabilities>&,
-              GetCapabilities,
-              (),
-              (const, override));
+  MOCK_CONST_METHOD0(GetCapabilities,
+                     const std::shared_ptr<const Capabilities>&());
 };
 
 class MockTexture : public Texture {
  public:
   MockTexture(const TextureDescriptor& desc) : Texture(desc) {}
-  MOCK_METHOD(void, SetLabel, (std::string_view label), (override));
-  MOCK_METHOD(bool, IsValid, (), (const, override));
-  MOCK_METHOD(ISize, GetSize, (), (const, override));
-  MOCK_METHOD(bool,
-              OnSetContents,
-              (const uint8_t* contents, size_t length, size_t slice),
-              (override));
-  MOCK_METHOD(bool,
-              OnSetContents,
-              (std::shared_ptr<const fml::Mapping> mapping, size_t slice),
-              (override));
+  MOCK_METHOD1(SetLabel, void(std::string_view label));
+  MOCK_METHOD3(SetContents,
+               bool(const uint8_t* contents, size_t length, size_t slice));
+  MOCK_METHOD2(SetContents,
+               bool(std::shared_ptr<const fml::Mapping> mapping, size_t slice));
+  MOCK_CONST_METHOD0(IsValid, bool());
+  MOCK_CONST_METHOD0(GetSize, ISize());
+  MOCK_METHOD3(OnSetContents,
+               bool(const uint8_t* contents, size_t length, size_t slice));
+  MOCK_METHOD2(OnSetContents,
+               bool(std::shared_ptr<const fml::Mapping> mapping, size_t slice));
 };
 
 }  // namespace testing

--- a/lib/ui/painting/image_encoding_unittests.cc
+++ b/lib/ui/painting/image_encoding_unittests.cc
@@ -31,16 +31,13 @@ fml::AutoResetWaitableEvent message_latch;
 
 class MockDlImage : public DlImage {
  public:
-  MOCK_METHOD(sk_sp<SkImage>, skia_image, (), (const, override));
-  MOCK_METHOD(std::shared_ptr<impeller::Texture>,
-              impeller_texture,
-              (),
-              (const, override));
-  MOCK_METHOD(bool, isOpaque, (), (const, override));
-  MOCK_METHOD(bool, isTextureBacked, (), (const, override));
-  MOCK_METHOD(bool, isUIThreadSafe, (), (const, override));
-  MOCK_METHOD(SkISize, dimensions, (), (const, override));
-  MOCK_METHOD(size_t, GetApproximateByteSize, (), (const, override));
+  MOCK_CONST_METHOD0(skia_image, sk_sp<SkImage>());
+  MOCK_CONST_METHOD0(impeller_texture, std::shared_ptr<impeller::Texture>());
+  MOCK_CONST_METHOD0(isOpaque, bool());
+  MOCK_CONST_METHOD0(isTextureBacked, bool());
+  MOCK_CONST_METHOD0(isUIThreadSafe, bool());
+  MOCK_CONST_METHOD0(dimensions, SkISize());
+  MOCK_CONST_METHOD0(GetApproximateByteSize, size_t());
 };
 
 }  // namespace
@@ -60,8 +57,8 @@ class MockSyncSwitch {
     std::function<void()> false_handler = [] {};
   };
 
-  MOCK_METHOD(void, Execute, (const Handlers& handlers), (const));
-  MOCK_METHOD(void, SetSwitch, (bool value));
+  MOCK_CONST_METHOD1(Execute, void(const Handlers& handlers));
+  MOCK_METHOD1(SetSwitch, void(bool value));
 };
 
 TEST_F(ShellTest, EncodeImageGivesExternalTypedData) {

--- a/shell/common/animator_unittests.cc
+++ b/shell/common/animator_unittests.cc
@@ -25,24 +25,18 @@ namespace testing {
 
 class FakeAnimatorDelegate : public Animator::Delegate {
  public:
-  MOCK_METHOD(void,
-              OnAnimatorBeginFrame,
-              (fml::TimePoint frame_target_time, uint64_t frame_number),
-              (override));
+  MOCK_METHOD2(OnAnimatorBeginFrame,
+               void(fml::TimePoint frame_target_time, uint64_t frame_number));
 
   void OnAnimatorNotifyIdle(fml::TimeDelta deadline) override {
     notify_idle_called_ = true;
   }
 
-  MOCK_METHOD(void,
-              OnAnimatorUpdateLatestFrameTargetTime,
-              (fml::TimePoint frame_target_time),
-              (override));
+  MOCK_METHOD1(OnAnimatorUpdateLatestFrameTargetTime,
+               void(fml::TimePoint frame_target_time));
 
-  MOCK_METHOD(void,
-              OnAnimatorDraw,
-              (std::shared_ptr<LayerTreePipeline> pipeline),
-              (override));
+  MOCK_METHOD1(OnAnimatorDraw,
+               void(std::shared_ptr<LayerTreePipeline> pipeline));
 
   void OnAnimatorDrawLastLayerTree(
       std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder) override {}

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -15,88 +15,64 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
+///\note Deprecated MOCK_METHOD macros used until this issue is resolved:
+// https://github.com/google/googletest/issues/2490
+
 namespace flutter {
 
 namespace {
 
 class MockDelegate : public Engine::Delegate {
  public:
-  MOCK_METHOD(void,
-              OnEngineUpdateSemantics,
-              (SemanticsNodeUpdates, CustomAccessibilityActionUpdates),
-              (override));
-  MOCK_METHOD(void,
-              OnEngineHandlePlatformMessage,
-              (std::unique_ptr<PlatformMessage>),
-              (override));
-  MOCK_METHOD(void, OnPreEngineRestart, (), (override));
-  MOCK_METHOD(void, OnRootIsolateCreated, (), (override));
-  MOCK_METHOD(void,
-              UpdateIsolateDescription,
-              (const std::string, int64_t),
-              (override));
-  MOCK_METHOD(void, SetNeedsReportTimings, (bool), (override));
-  MOCK_METHOD(std::unique_ptr<std::vector<std::string>>,
-              ComputePlatformResolvedLocale,
-              (const std::vector<std::string>&),
-              (override));
-  MOCK_METHOD(void, RequestDartDeferredLibrary, (intptr_t), (override));
-  MOCK_METHOD(fml::TimePoint, GetCurrentTimePoint, (), (override));
-  MOCK_METHOD(const std::shared_ptr<PlatformMessageHandler>&,
-              GetPlatformMessageHandler,
-              (),
-              (const, override));
-  MOCK_METHOD(void, OnEngineChannelUpdate, (std::string, bool), (override));
-  MOCK_METHOD(double,
-              GetScaledFontSize,
-              (double font_size, int configuration_id),
-              (const, override));
+  MOCK_METHOD2(OnEngineUpdateSemantics,
+               void(SemanticsNodeUpdates, CustomAccessibilityActionUpdates));
+  MOCK_METHOD1(OnEngineHandlePlatformMessage,
+               void(std::unique_ptr<PlatformMessage>));
+  MOCK_METHOD0(OnPreEngineRestart, void());
+  MOCK_METHOD0(OnRootIsolateCreated, void());
+  MOCK_METHOD2(UpdateIsolateDescription, void(const std::string, int64_t));
+  MOCK_METHOD1(SetNeedsReportTimings, void(bool));
+  MOCK_METHOD1(ComputePlatformResolvedLocale,
+               std::unique_ptr<std::vector<std::string>>(
+                   const std::vector<std::string>&));
+  MOCK_METHOD1(RequestDartDeferredLibrary, void(intptr_t));
+  MOCK_METHOD0(GetCurrentTimePoint, fml::TimePoint());
+  MOCK_CONST_METHOD0(GetPlatformMessageHandler,
+                     const std::shared_ptr<PlatformMessageHandler>&());
+  MOCK_METHOD2(OnEngineChannelUpdate, void(std::string, bool));
+  MOCK_CONST_METHOD2(GetScaledFontSize,
+                     double(double font_size, int configuration_id));
 };
 
 class MockResponse : public PlatformMessageResponse {
  public:
-  MOCK_METHOD(void, Complete, (std::unique_ptr<fml::Mapping> data), (override));
-  MOCK_METHOD(void, CompleteEmpty, (), (override));
+  MOCK_METHOD1(Complete, void(std::unique_ptr<fml::Mapping> data));
+  MOCK_METHOD0(CompleteEmpty, void());
 };
 
 class MockRuntimeDelegate : public RuntimeDelegate {
  public:
-  MOCK_METHOD(std::string, DefaultRouteName, (), (override));
-  MOCK_METHOD(void, ScheduleFrame, (bool), (override));
-  MOCK_METHOD(void,
-              Render,
-              (std::unique_ptr<flutter::LayerTree>, float),
-              (override));
-  MOCK_METHOD(void,
-              UpdateSemantics,
-              (SemanticsNodeUpdates, CustomAccessibilityActionUpdates),
-              (override));
-  MOCK_METHOD(void,
-              HandlePlatformMessage,
-              (std::unique_ptr<PlatformMessage>),
-              (override));
-  MOCK_METHOD(FontCollection&, GetFontCollection, (), (override));
-  MOCK_METHOD(std::shared_ptr<AssetManager>, GetAssetManager, (), (override));
-  MOCK_METHOD(void, OnRootIsolateCreated, (), (override));
-  MOCK_METHOD(void,
-              UpdateIsolateDescription,
-              (const std::string, int64_t),
-              (override));
-  MOCK_METHOD(void, SetNeedsReportTimings, (bool), (override));
-  MOCK_METHOD(std::unique_ptr<std::vector<std::string>>,
-              ComputePlatformResolvedLocale,
-              (const std::vector<std::string>&),
-              (override));
-  MOCK_METHOD(void, RequestDartDeferredLibrary, (intptr_t), (override));
-  MOCK_METHOD(std::weak_ptr<PlatformMessageHandler>,
-              GetPlatformMessageHandler,
-              (),
-              (const, override));
-  MOCK_METHOD(void, SendChannelUpdate, (std::string, bool), (override));
-  MOCK_METHOD(double,
-              GetScaledFontSize,
-              (double font_size, int configuration_id),
-              (const, override));
+  MOCK_METHOD0(ImplicitViewEnabled, bool());
+  MOCK_METHOD0(DefaultRouteName, std::string());
+  MOCK_METHOD1(ScheduleFrame, void(bool));
+  MOCK_METHOD2(Render, void(std::unique_ptr<flutter::LayerTree>, float));
+  MOCK_METHOD2(UpdateSemantics,
+               void(SemanticsNodeUpdates, CustomAccessibilityActionUpdates));
+  MOCK_METHOD1(HandlePlatformMessage, void(std::unique_ptr<PlatformMessage>));
+  MOCK_METHOD0(GetFontCollection, FontCollection&());
+  MOCK_METHOD0(GetAssetManager, std::shared_ptr<AssetManager>());
+  MOCK_METHOD0(OnRootIsolateCreated, void());
+  MOCK_METHOD2(UpdateIsolateDescription, void(const std::string, int64_t));
+  MOCK_METHOD1(SetNeedsReportTimings, void(bool));
+  MOCK_METHOD1(ComputePlatformResolvedLocale,
+               std::unique_ptr<std::vector<std::string>>(
+                   const std::vector<std::string>&));
+  MOCK_METHOD1(RequestDartDeferredLibrary, void(intptr_t));
+  MOCK_CONST_METHOD0(GetPlatformMessageHandler,
+                     std::weak_ptr<PlatformMessageHandler>());
+  MOCK_METHOD2(SendChannelUpdate, void(std::string, bool));
+  MOCK_CONST_METHOD2(GetScaledFontSize,
+                     double(double font_size, int configuration_id));
 };
 
 class MockRuntimeController : public RuntimeController {
@@ -104,17 +80,12 @@ class MockRuntimeController : public RuntimeController {
   MockRuntimeController(RuntimeDelegate& client,
                         const TaskRunners& p_task_runners)
       : RuntimeController(client, p_task_runners) {}
-  MOCK_METHOD(bool, IsRootIsolateRunning, (), (override));
-  MOCK_METHOD(bool,
-              DispatchPlatformMessage,
-              (std::unique_ptr<PlatformMessage>),
-              (override));
-  MOCK_METHOD(void,
-              LoadDartDeferredLibraryError,
-              (intptr_t, const std::string, bool),
-              (override));
-  MOCK_METHOD(DartVM*, GetDartVM, (), (const, override));
-  MOCK_METHOD(bool, NotifyIdle, (fml::TimeDelta), (override));
+  MOCK_METHOD0(IsRootIsolateRunning, bool());
+  MOCK_METHOD1(DispatchPlatformMessage, bool(std::unique_ptr<PlatformMessage>));
+  MOCK_METHOD3(LoadDartDeferredLibraryError,
+               void(intptr_t, const std::string, bool));
+  MOCK_CONST_METHOD0(GetDartVM, DartVM*());
+  MOCK_METHOD1(NotifyIdle, bool(fml::TimeDelta));
 };
 
 std::unique_ptr<PlatformMessage> MakePlatformMessage(

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -34,77 +34,56 @@ constexpr float kDevicePixelRatio = 2.0f;
 
 class MockDelegate : public Rasterizer::Delegate {
  public:
-  MOCK_METHOD(void,
-              OnFrameRasterized,
-              (const FrameTiming& frame_timing),
-              (override));
-  MOCK_METHOD(fml::Milliseconds, GetFrameBudget, (), (override));
-  MOCK_METHOD(fml::TimePoint, GetLatestFrameTargetTime, (), (const, override));
-  MOCK_METHOD(const TaskRunners&, GetTaskRunners, (), (const, override));
-  MOCK_METHOD(const fml::RefPtr<fml::RasterThreadMerger>,
-              GetParentRasterThreadMerger,
-              (),
-              (const, override));
-  MOCK_METHOD(std::shared_ptr<const fml::SyncSwitch>,
-              GetIsGpuDisabledSyncSwitch,
-              (),
-              (const, override));
-  MOCK_METHOD(const Settings&, GetSettings, (), (const, override));
-  MOCK_METHOD(bool,
-              ShouldDiscardLayerTree,
-              (int64_t, const flutter::LayerTree&),
-              (override));
+  MOCK_METHOD1(OnFrameRasterized, void(const FrameTiming& frame_timing));
+  MOCK_METHOD0(GetFrameBudget, fml::Milliseconds());
+  MOCK_CONST_METHOD0(GetLatestFrameTargetTime, fml::TimePoint());
+  MOCK_CONST_METHOD0(GetTaskRunners, const TaskRunners&());
+  MOCK_CONST_METHOD0(GetParentRasterThreadMerger,
+                     const fml::RefPtr<fml::RasterThreadMerger>());
+  MOCK_CONST_METHOD0(GetIsGpuDisabledSyncSwitch,
+                     std::shared_ptr<const fml::SyncSwitch>());
+  MOCK_CONST_METHOD0(GetSettings, const Settings&());
+  MOCK_METHOD2(ShouldDiscardLayerTree,
+               bool(int64_t, const flutter::LayerTree&));
 };
 
 class MockSurface : public Surface {
  public:
-  MOCK_METHOD(bool, IsValid, (), (override));
-  MOCK_METHOD(std::unique_ptr<SurfaceFrame>,
-              AcquireFrame,
-              (const SkISize& size),
-              (override));
-  MOCK_METHOD(SkMatrix, GetRootTransformation, (), (const, override));
-  MOCK_METHOD(GrDirectContext*, GetContext, (), (override));
-  MOCK_METHOD(std::unique_ptr<GLContextResult>,
-              MakeRenderContextCurrent,
-              (),
-              (override));
-  MOCK_METHOD(bool, ClearRenderContext, (), (override));
-  MOCK_METHOD(bool, AllowsDrawingWhenGpuDisabled, (), (const, override));
+  MOCK_METHOD0(IsValid, bool());
+  MOCK_METHOD1(AcquireFrame,
+               std::unique_ptr<SurfaceFrame>(const SkISize& size));
+  MOCK_CONST_METHOD0(GetRootTransformation, SkMatrix());
+  MOCK_METHOD0(GetContext, GrDirectContext*());
+  MOCK_METHOD0(GetExternalViewEmbedder, ExternalViewEmbedder*());
+  MOCK_METHOD0(MakeRenderContextCurrent, std::unique_ptr<GLContextResult>());
+  MOCK_METHOD0(ClearRenderContext, bool());
+  MOCK_CONST_METHOD0(AllowsDrawingWhenGpuDisabled, bool());
 };
 
 class MockExternalViewEmbedder : public ExternalViewEmbedder {
  public:
-  MOCK_METHOD(DlCanvas*, GetRootCanvas, (), (override));
-  MOCK_METHOD(void, CancelFrame, (), (override));
-  MOCK_METHOD(void,
-              BeginFrame,
-              (SkISize frame_size,
-               GrDirectContext* context,
-               double device_pixel_ratio,
-               fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger),
-              (override));
-  MOCK_METHOD(void,
-              PrerollCompositeEmbeddedView,
-              (int64_t view_id, std::unique_ptr<EmbeddedViewParams> params),
-              (override));
-  MOCK_METHOD(PostPrerollResult,
-              PostPrerollAction,
-              (fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger),
-              (override));
-  MOCK_METHOD(DlCanvas*, CompositeEmbeddedView, (int64_t view_id), (override));
-  MOCK_METHOD(void,
-              SubmitFrame,
-              (GrDirectContext * context,
-               const std::shared_ptr<impeller::AiksContext>& aiks_context,
-               std::unique_ptr<SurfaceFrame> frame),
-              (override));
-  MOCK_METHOD(void,
-              EndFrame,
-              (bool should_resubmit_frame,
-               fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger),
-              (override));
-  MOCK_METHOD(bool, SupportsDynamicThreadMerging, (), (override));
+  MOCK_METHOD0(GetRootCanvas, DlCanvas*());
+  MOCK_METHOD0(CancelFrame, void());
+  MOCK_METHOD4(BeginFrame,
+               void(SkISize frame_size,
+                    GrDirectContext* context,
+                    double device_pixel_ratio,
+                    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger));
+  MOCK_METHOD2(PrerollCompositeEmbeddedView,
+               void(int64_t view_id,
+                    std::unique_ptr<EmbeddedViewParams> params));
+  MOCK_METHOD1(PostPrerollAction,
+               PostPrerollResult(
+                   fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger));
+  MOCK_METHOD1(CompositeEmbeddedView, DlCanvas*(int64_t view_id));
+  MOCK_METHOD3(SubmitFrame,
+               void(GrDirectContext* context,
+                    const std::shared_ptr<impeller::AiksContext>& aiks_context,
+                    std::unique_ptr<SurfaceFrame> frame));
+  MOCK_METHOD2(EndFrame,
+               void(bool should_resubmit_frame,
+                    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger));
+  MOCK_METHOD0(SupportsDynamicThreadMerging, bool());
 };
 }  // namespace
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -67,110 +67,75 @@ using ::testing::Return;
 
 namespace {
 class MockPlatformViewDelegate : public PlatformView::Delegate {
-  MOCK_METHOD(void,
-              OnPlatformViewCreated,
-              (std::unique_ptr<Surface> surface),
-              (override));
+  MOCK_METHOD1(OnPlatformViewCreated, void(std::unique_ptr<Surface> surface));
 
-  MOCK_METHOD(void, OnPlatformViewDestroyed, (), (override));
+  MOCK_METHOD0(OnPlatformViewDestroyed, void());
 
-  MOCK_METHOD(void, OnPlatformViewScheduleFrame, (), (override));
+  MOCK_METHOD0(OnPlatformViewScheduleFrame, void());
 
-  MOCK_METHOD(void,
-              OnPlatformViewSetNextFrameCallback,
-              (const fml::closure& closure),
-              (override));
+  MOCK_METHOD1(OnPlatformViewSetNextFrameCallback,
+               void(const fml::closure& closure));
 
-  MOCK_METHOD(void,
-              OnPlatformViewSetViewportMetrics,
-              (int64_t view_id, const ViewportMetrics& metrics),
-              (override));
+  MOCK_METHOD2(OnPlatformViewSetViewportMetrics,
+               void(int64_t view_id, const ViewportMetrics& metrics));
 
-  MOCK_METHOD(void,
-              OnPlatformViewDispatchPlatformMessage,
-              (std::unique_ptr<PlatformMessage> message),
-              (override));
+  MOCK_METHOD1(OnPlatformViewDispatchPlatformMessage,
+               void(std::unique_ptr<PlatformMessage> message));
 
-  MOCK_METHOD(void,
-              OnPlatformViewDispatchPointerDataPacket,
-              (std::unique_ptr<PointerDataPacket> packet),
-              (override));
+  MOCK_METHOD1(OnPlatformViewDispatchPointerDataPacket,
+               void(std::unique_ptr<PointerDataPacket> packet));
 
-  MOCK_METHOD(void,
-              OnPlatformViewDispatchSemanticsAction,
-              (int32_t id, SemanticsAction action, fml::MallocMapping args),
-              (override));
+  MOCK_METHOD3(OnPlatformViewDispatchSemanticsAction,
+               void(int32_t id,
+                    SemanticsAction action,
+                    fml::MallocMapping args));
 
-  MOCK_METHOD(void,
-              OnPlatformViewSetSemanticsEnabled,
-              (bool enabled),
-              (override));
+  MOCK_METHOD1(OnPlatformViewSetSemanticsEnabled, void(bool enabled));
 
-  MOCK_METHOD(void,
-              OnPlatformViewSetAccessibilityFeatures,
-              (int32_t flags),
-              (override));
+  MOCK_METHOD1(OnPlatformViewSetAccessibilityFeatures, void(int32_t flags));
 
-  MOCK_METHOD(void,
-              OnPlatformViewRegisterTexture,
-              (std::shared_ptr<Texture> texture),
-              (override));
+  MOCK_METHOD1(OnPlatformViewRegisterTexture,
+               void(std::shared_ptr<Texture> texture));
 
-  MOCK_METHOD(void,
-              OnPlatformViewUnregisterTexture,
-              (int64_t texture_id),
-              (override));
+  MOCK_METHOD1(OnPlatformViewUnregisterTexture, void(int64_t texture_id));
 
-  MOCK_METHOD(void,
-              OnPlatformViewMarkTextureFrameAvailable,
-              (int64_t texture_id),
-              (override));
+  MOCK_METHOD1(OnPlatformViewMarkTextureFrameAvailable,
+               void(int64_t texture_id));
 
   MOCK_METHOD(const Settings&,
               OnPlatformViewGetSettings,
               (),
               (const, override));
 
-  MOCK_METHOD(void,
-              LoadDartDeferredLibrary,
-              (intptr_t loading_unit_id,
-               std::unique_ptr<const fml::Mapping> snapshot_data,
-               std::unique_ptr<const fml::Mapping> snapshot_instructions),
-              (override));
+  MOCK_METHOD3(LoadDartDeferredLibrary,
+               void(intptr_t loading_unit_id,
+                    std::unique_ptr<const fml::Mapping> snapshot_data,
+                    std::unique_ptr<const fml::Mapping> snapshot_instructions));
 
-  MOCK_METHOD(void,
-              LoadDartDeferredLibraryError,
-              (intptr_t loading_unit_id,
-               const std::string error_message,
-               bool transient),
-              (override));
+  MOCK_METHOD3(LoadDartDeferredLibraryError,
+               void(intptr_t loading_unit_id,
+                    const std::string error_message,
+                    bool transient));
 
-  MOCK_METHOD(void,
-              UpdateAssetResolverByType,
-              (std::unique_ptr<AssetResolver> updated_asset_resolver,
-               AssetResolver::AssetResolverType type),
-              (override));
+  MOCK_METHOD2(UpdateAssetResolverByType,
+               void(std::unique_ptr<AssetResolver> updated_asset_resolver,
+                    AssetResolver::AssetResolverType type));
 };
 
 class MockSurface : public Surface {
  public:
-  MOCK_METHOD(bool, IsValid, (), (override));
+  MOCK_METHOD0(IsValid, bool());
 
-  MOCK_METHOD(std::unique_ptr<SurfaceFrame>,
-              AcquireFrame,
-              (const SkISize& size),
-              (override));
+  MOCK_METHOD1(AcquireFrame,
+               std::unique_ptr<SurfaceFrame>(const SkISize& size));
 
-  MOCK_METHOD(SkMatrix, GetRootTransformation, (), (const, override));
+  MOCK_CONST_METHOD0(GetRootTransformation, SkMatrix());
 
-  MOCK_METHOD(GrDirectContext*, GetContext, (), (override));
+  MOCK_METHOD0(GetContext, GrDirectContext*());
 
-  MOCK_METHOD(std::unique_ptr<GLContextResult>,
-              MakeRenderContextCurrent,
-              (),
-              (override));
+  MOCK_METHOD0(MakeRenderContextCurrent, std::unique_ptr<GLContextResult>());
 
-  MOCK_METHOD(bool, ClearRenderContext, (), (override));
+  MOCK_METHOD0(ClearRenderContext, bool());
 };
 
 class MockPlatformView : public PlatformView {
@@ -178,38 +143,27 @@ class MockPlatformView : public PlatformView {
   MockPlatformView(MockPlatformViewDelegate& delegate,
                    const TaskRunners& task_runners)
       : PlatformView(delegate, task_runners) {}
-  MOCK_METHOD(std::unique_ptr<Surface>, CreateRenderingSurface, (), (override));
-  MOCK_METHOD(std::shared_ptr<PlatformMessageHandler>,
-              GetPlatformMessageHandler,
-              (),
-              (const, override));
+  MOCK_METHOD0(CreateRenderingSurface, std::unique_ptr<Surface>());
+  MOCK_CONST_METHOD0(GetPlatformMessageHandler,
+                     std::shared_ptr<PlatformMessageHandler>());
 };
 
 class TestPlatformView : public PlatformView {
  public:
   TestPlatformView(Shell& shell, const TaskRunners& task_runners)
       : PlatformView(shell, task_runners) {}
-  MOCK_METHOD(std::unique_ptr<Surface>, CreateRenderingSurface, (), (override));
+  MOCK_METHOD0(CreateRenderingSurface, std::unique_ptr<Surface>());
 };
 
 class MockPlatformMessageHandler : public PlatformMessageHandler {
  public:
-  MOCK_METHOD(void,
-              HandlePlatformMessage,
-              (std::unique_ptr<PlatformMessage> message),
-              (override));
-  MOCK_METHOD(bool,
-              DoesHandlePlatformMessageOnPlatformThread,
-              (),
-              (const, override));
-  MOCK_METHOD(void,
-              InvokePlatformMessageResponseCallback,
-              (int response_id, std::unique_ptr<fml::Mapping> mapping),
-              (override));
-  MOCK_METHOD(void,
-              InvokePlatformMessageEmptyResponseCallback,
-              (int response_id),
-              (override));
+  MOCK_METHOD1(HandlePlatformMessage,
+               void(std::unique_ptr<PlatformMessage> message));
+  MOCK_CONST_METHOD0(DoesHandlePlatformMessageOnPlatformThread, bool());
+  MOCK_METHOD2(InvokePlatformMessageResponseCallback,
+               void(int response_id, std::unique_ptr<fml::Mapping> mapping));
+  MOCK_METHOD1(InvokePlatformMessageEmptyResponseCallback,
+               void(int response_id));
 };
 
 class MockPlatformMessageResponse : public PlatformMessageResponse {
@@ -217,8 +171,8 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
   static fml::RefPtr<MockPlatformMessageResponse> Create() {
     return fml::AdoptRef(new MockPlatformMessageResponse());
   }
-  MOCK_METHOD(void, Complete, (std::unique_ptr<fml::Mapping> data), (override));
-  MOCK_METHOD(void, CompleteEmpty, (), (override));
+  MOCK_METHOD1(Complete, void(std::unique_ptr<fml::Mapping> data));
+  MOCK_METHOD0(CompleteEmpty, void());
 };
 }  // namespace
 

--- a/shell/platform/android/android_context_gl_impeller_unittests.cc
+++ b/shell/platform/android/android_context_gl_impeller_unittests.cc
@@ -18,11 +18,8 @@ using ::impeller::egl::ConfigDescriptor;
 namespace {
 class MockDisplay : public impeller::egl::Display {
  public:
-  MOCK_METHOD(bool, IsValid, (), (const, override));
-  MOCK_METHOD(std::unique_ptr<Config>,
-              ChooseConfig,
-              (ConfigDescriptor),
-              (const, override));
+  MOCK_CONST_METHOD0(IsValid, bool());
+  MOCK_CONST_METHOD1(ChooseConfig, std::unique_ptr<Config>(ConfigDescriptor));
 };
 }  // namespace
 

--- a/shell/platform/android/android_shell_holder_unittests.cc
+++ b/shell/platform/android/android_shell_holder_unittests.cc
@@ -9,95 +9,59 @@ namespace testing {
 namespace {
 class MockPlatformViewAndroidJNI : public PlatformViewAndroidJNI {
  public:
-  MOCK_METHOD(void,
-              FlutterViewHandlePlatformMessage,
-              (std::unique_ptr<flutter::PlatformMessage> message,
-               int responseId),
-              (override));
-  MOCK_METHOD(void,
-              FlutterViewHandlePlatformMessageResponse,
-              (int responseId, std::unique_ptr<fml::Mapping> data),
-              (override));
-  MOCK_METHOD(void,
-              FlutterViewUpdateSemantics,
-              (std::vector<uint8_t> buffer,
-               std::vector<std::string> strings,
-               std::vector<std::vector<uint8_t>> string_attribute_args),
-              (override));
-  MOCK_METHOD(void,
-              FlutterViewUpdateCustomAccessibilityActions,
-              (std::vector<uint8_t> actions_buffer,
-               std::vector<std::string> strings),
-              (override));
-  MOCK_METHOD(void, FlutterViewOnFirstFrame, (), (override));
-  MOCK_METHOD(void, FlutterViewOnPreEngineRestart, (), (override));
-  MOCK_METHOD(void,
-              SurfaceTextureAttachToGLContext,
-              (JavaLocalRef surface_texture, int textureId),
-              (override));
-  MOCK_METHOD(void,
-              SurfaceTextureUpdateTexImage,
-              (JavaLocalRef surface_texture),
-              (override));
-  MOCK_METHOD(void,
-              SurfaceTextureGetTransformMatrix,
-              (JavaLocalRef surface_texture, SkMatrix& transform),
-              (override));
-  MOCK_METHOD(void,
-              SurfaceTextureDetachFromGLContext,
-              (JavaLocalRef surface_texture),
-              (override));
-  MOCK_METHOD(JavaLocalRef,
-              ImageTextureEntryAcquireLatestImage,
-              (JavaLocalRef image_texture_entry),
-              (override));
-  MOCK_METHOD(JavaLocalRef,
-              ImageGetHardwareBuffer,
-              (JavaLocalRef image),
-              (override));
-  MOCK_METHOD(void, ImageClose, (JavaLocalRef image), (override));
-  MOCK_METHOD(void,
-              HardwareBufferClose,
-              (JavaLocalRef hardware_buffer),
-              (override));
-  MOCK_METHOD(void,
-              FlutterViewOnDisplayPlatformView,
-              (int view_id,
-               int x,
-               int y,
-               int width,
-               int height,
-               int viewWidth,
-               int viewHeight,
-               MutatorsStack mutators_stack),
-              (override));
-  MOCK_METHOD(void,
-              FlutterViewDisplayOverlaySurface,
-              (int surface_id, int x, int y, int width, int height),
-              (override));
-  MOCK_METHOD(void, FlutterViewBeginFrame, (), (override));
-  MOCK_METHOD(void, FlutterViewEndFrame, (), (override));
-  MOCK_METHOD(std::unique_ptr<PlatformViewAndroidJNI::OverlayMetadata>,
-              FlutterViewCreateOverlaySurface,
-              (),
-              (override));
-  MOCK_METHOD(void, FlutterViewDestroyOverlaySurfaces, (), (override));
-  MOCK_METHOD(std::unique_ptr<std::vector<std::string>>,
-              FlutterViewComputePlatformResolvedLocale,
-              (std::vector<std::string> supported_locales_data),
-              (override));
-  MOCK_METHOD(double, GetDisplayRefreshRate, (), (override));
-  MOCK_METHOD(double, GetDisplayWidth, (), (override));
-  MOCK_METHOD(double, GetDisplayHeight, (), (override));
-  MOCK_METHOD(double, GetDisplayDensity, (), (override));
-  MOCK_METHOD(bool,
-              RequestDartDeferredLibrary,
-              (int loading_unit_id),
-              (override));
-  MOCK_METHOD(double,
-              FlutterViewGetScaledFontSize,
-              (double font_size, int configuration_id),
-              (const, override));
+  MOCK_METHOD2(FlutterViewHandlePlatformMessage,
+               void(std::unique_ptr<flutter::PlatformMessage> message,
+                    int responseId));
+  MOCK_METHOD2(FlutterViewHandlePlatformMessageResponse,
+               void(int responseId, std::unique_ptr<fml::Mapping> data));
+  MOCK_METHOD3(FlutterViewUpdateSemantics,
+               void(std::vector<uint8_t> buffer,
+                    std::vector<std::string> strings,
+                    std::vector<std::vector<uint8_t>> string_attribute_args));
+  MOCK_METHOD2(FlutterViewUpdateCustomAccessibilityActions,
+               void(std::vector<uint8_t> actions_buffer,
+                    std::vector<std::string> strings));
+  MOCK_METHOD0(FlutterViewOnFirstFrame, void());
+  MOCK_METHOD0(FlutterViewOnPreEngineRestart, void());
+  MOCK_METHOD2(SurfaceTextureAttachToGLContext,
+               void(JavaLocalRef surface_texture, int textureId));
+  MOCK_METHOD1(SurfaceTextureUpdateTexImage,
+               void(JavaLocalRef surface_texture));
+  MOCK_METHOD2(SurfaceTextureGetTransformMatrix,
+               void(JavaLocalRef surface_texture, SkMatrix& transform));
+  MOCK_METHOD1(SurfaceTextureDetachFromGLContext,
+               void(JavaLocalRef surface_texture));
+  MOCK_METHOD1(ImageTextureEntryAcquireLatestImage,
+               JavaLocalRef(JavaLocalRef image_texture_entry));
+  MOCK_METHOD1(ImageGetHardwareBuffer, JavaLocalRef(JavaLocalRef image));
+  MOCK_METHOD1(ImageClose, void(JavaLocalRef image));
+  MOCK_METHOD1(HardwareBufferClose, void(JavaLocalRef hardware_buffer));
+  MOCK_METHOD8(FlutterViewOnDisplayPlatformView,
+               void(int view_id,
+                    int x,
+                    int y,
+                    int width,
+                    int height,
+                    int viewWidth,
+                    int viewHeight,
+                    MutatorsStack mutators_stack));
+  MOCK_METHOD5(FlutterViewDisplayOverlaySurface,
+               void(int surface_id, int x, int y, int width, int height));
+  MOCK_METHOD0(FlutterViewBeginFrame, void());
+  MOCK_METHOD0(FlutterViewEndFrame, void());
+  MOCK_METHOD0(FlutterViewCreateOverlaySurface,
+               std::unique_ptr<PlatformViewAndroidJNI::OverlayMetadata>());
+  MOCK_METHOD0(FlutterViewDestroyOverlaySurfaces, void());
+  MOCK_METHOD1(FlutterViewComputePlatformResolvedLocale,
+               std::unique_ptr<std::vector<std::string>>(
+                   std::vector<std::string> supported_locales_data));
+  MOCK_METHOD0(GetDisplayRefreshRate, double());
+  MOCK_METHOD0(GetDisplayWidth, double());
+  MOCK_METHOD0(GetDisplayHeight, double());
+  MOCK_METHOD0(GetDisplayDensity, double());
+  MOCK_METHOD1(RequestDartDeferredLibrary, bool(int loading_unit_id));
+  MOCK_CONST_METHOD2(FlutterViewGetScaledFontSize,
+                     double(double font_size, int configuration_id));
 };
 
 class MockPlatformMessageResponse : public PlatformMessageResponse {
@@ -105,8 +69,8 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
   static fml::RefPtr<MockPlatformMessageResponse> Create() {
     return fml::AdoptRef(new MockPlatformMessageResponse());
   }
-  MOCK_METHOD(void, Complete, (std::unique_ptr<fml::Mapping> data), (override));
-  MOCK_METHOD(void, CompleteEmpty, (), (override));
+  MOCK_METHOD1(Complete, void(std::unique_ptr<fml::Mapping> data));
+  MOCK_METHOD0(CompleteEmpty, void());
 };
 }  // namespace
 

--- a/shell/platform/android/apk_asset_provider_unittests.cc
+++ b/shell/platform/android/apk_asset_provider_unittests.cc
@@ -6,10 +6,9 @@ namespace flutter {
 namespace testing {
 class MockAPKAssetProviderImpl : public APKAssetProviderInternal {
  public:
-  MOCK_METHOD(std::unique_ptr<fml::Mapping>,
-              GetAsMapping,
-              (const std::string& asset_name),
-              (const, override));
+  MOCK_CONST_METHOD1(
+      GetAsMapping,
+      std::unique_ptr<fml::Mapping>(const std::string& asset_name));
 };
 
 TEST(APKAssetProvider, Clone) {

--- a/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
+++ b/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
@@ -17,14 +17,11 @@ namespace {
 
 class MockStandardCodecSerializer : public StandardCodecSerializer {
  public:
-  MOCK_METHOD(void,
-              WriteValue,
-              (const EncodableValue& value, ByteStreamWriter* stream),
-              (const, override));
-  MOCK_METHOD(EncodableValue,
-              ReadValueOfType,
-              (uint8_t type, ByteStreamReader* stream),
-              (const, override));
+  MOCK_CONST_METHOD2(WriteValue,
+                     void(const EncodableValue& value,
+                          ByteStreamWriter* stream));
+  MOCK_CONST_METHOD2(ReadValueOfType,
+                     EncodableValue(uint8_t type, ByteStreamReader* stream));
 };
 }  // namespace
 

--- a/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -16,79 +16,46 @@ namespace flutter {
 namespace testing {
 namespace {
 class MockDelegate : public PlatformView::Delegate {
-  MOCK_METHOD(void,
-              OnPlatformViewCreated,
-              (std::unique_ptr<Surface>),
-              (override));
-  MOCK_METHOD(void, OnPlatformViewDestroyed, (), (override));
-  MOCK_METHOD(void, OnPlatformViewScheduleFrame, (), (override));
-  MOCK_METHOD(void,
-              OnPlatformViewSetNextFrameCallback,
-              (const fml::closure& closure),
-              (override));
-  MOCK_METHOD(void,
-              OnPlatformViewSetViewportMetrics,
-              (int64_t view_id, const ViewportMetrics& metrics),
-              (override));
-  MOCK_METHOD(void,
-              OnPlatformViewDispatchPlatformMessage,
-              (std::unique_ptr<PlatformMessage> message),
-              (override));
-  MOCK_METHOD(void,
-              OnPlatformViewDispatchPointerDataPacket,
-              (std::unique_ptr<PointerDataPacket> packet),
-              (override));
-  MOCK_METHOD(void,
-              OnPlatformViewDispatchSemanticsAction,
-              (int32_t id, SemanticsAction action, fml::MallocMapping args),
-              (override));
-  MOCK_METHOD(void,
-              OnPlatformViewSetSemanticsEnabled,
-              (bool enabled),
-              (override));
-  MOCK_METHOD(void,
-              OnPlatformViewSetAccessibilityFeatures,
-              (int32_t flags),
-              (override));
-  MOCK_METHOD(void,
-              OnPlatformViewRegisterTexture,
-              (std::shared_ptr<Texture> texture),
-              (override));
-  MOCK_METHOD(void,
-              OnPlatformViewUnregisterTexture,
-              (int64_t texture_id),
-              (override));
-  MOCK_METHOD(void,
-              OnPlatformViewMarkTextureFrameAvailable,
-              (int64_t texture_id),
-              (override));
-  MOCK_METHOD(void,
-              LoadDartDeferredLibrary,
-              (intptr_t loading_unit_id,
-               std::unique_ptr<const fml::Mapping> snapshot_data,
-               std::unique_ptr<const fml::Mapping> snapshot_instructions),
-              (override));
-  MOCK_METHOD(void,
-              LoadDartDeferredLibraryError,
-              (intptr_t loading_unit_id,
-               const std::string error_message,
-               bool transient),
-              (override));
-  MOCK_METHOD(void,
-              UpdateAssetResolverByType,
-              (std::unique_ptr<AssetResolver> updated_asset_resolver,
-               AssetResolver::AssetResolverType type),
-              (override));
-  MOCK_METHOD(const Settings&,
-              OnPlatformViewGetSettings,
-              (),
-              (const, override));
+  MOCK_METHOD1(OnPlatformViewCreated, void(std::unique_ptr<Surface>));
+  MOCK_METHOD0(OnPlatformViewDestroyed, void());
+  MOCK_METHOD0(OnPlatformViewScheduleFrame, void());
+  MOCK_METHOD1(OnPlatformViewSetNextFrameCallback,
+               void(const fml::closure& closure));
+  MOCK_METHOD2(OnPlatformViewSetViewportMetrics,
+               void(int64_t view_id, const ViewportMetrics& metrics));
+  MOCK_METHOD1(OnPlatformViewDispatchPlatformMessage,
+               void(std::unique_ptr<PlatformMessage> message));
+  MOCK_METHOD1(OnPlatformViewDispatchPointerDataPacket,
+               void(std::unique_ptr<PointerDataPacket> packet));
+  MOCK_METHOD3(OnPlatformViewDispatchSemanticsAction,
+               void(int32_t id,
+                    SemanticsAction action,
+                    fml::MallocMapping args));
+  MOCK_METHOD1(OnPlatformViewSetSemanticsEnabled, void(bool enabled));
+  MOCK_METHOD1(OnPlatformViewSetAccessibilityFeatures, void(int32_t flags));
+  MOCK_METHOD1(OnPlatformViewRegisterTexture,
+               void(std::shared_ptr<Texture> texture));
+  MOCK_METHOD1(OnPlatformViewUnregisterTexture, void(int64_t texture_id));
+  MOCK_METHOD1(OnPlatformViewMarkTextureFrameAvailable,
+               void(int64_t texture_id));
+  MOCK_METHOD3(LoadDartDeferredLibrary,
+               void(intptr_t loading_unit_id,
+                    std::unique_ptr<const fml::Mapping> snapshot_data,
+                    std::unique_ptr<const fml::Mapping> snapshot_instructions));
+  MOCK_METHOD3(LoadDartDeferredLibraryError,
+               void(intptr_t loading_unit_id,
+                    const std::string error_message,
+                    bool transient));
+  MOCK_METHOD2(UpdateAssetResolverByType,
+               void(std::unique_ptr<AssetResolver> updated_asset_resolver,
+                    AssetResolver::AssetResolverType type));
+  MOCK_CONST_METHOD0(OnPlatformViewGetSettings, const Settings&());
 };
 
 class MockResponse : public PlatformMessageResponse {
  public:
-  MOCK_METHOD(void, Complete, (std::unique_ptr<fml::Mapping> data), (override));
-  MOCK_METHOD(void, CompleteEmpty, (), (override));
+  MOCK_METHOD1(Complete, void(std::unique_ptr<fml::Mapping> data));
+  MOCK_METHOD0(CompleteEmpty, void());
 };
 }  // namespace
 

--- a/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -176,8 +176,8 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
 
 class MockResponse : public flutter::PlatformMessageResponse {
  public:
-  MOCK_METHOD(void, Complete, (std::unique_ptr<fml::Mapping> data), (override));
-  MOCK_METHOD(void, CompleteEmpty, (), (override));
+  MOCK_METHOD1(Complete, void(std::unique_ptr<fml::Mapping> data));
+  MOCK_METHOD0(CompleteEmpty, void());
 };
 
 class TestPlatformMessageResponse : public flutter::PlatformMessageResponse {

--- a/shell/platform/linux/testing/mock_binary_messenger.h
+++ b/shell/platform/linux/testing/mock_binary_messenger.h
@@ -22,47 +22,41 @@ class MockBinaryMessenger {
 
   operator FlBinaryMessenger*();
 
-  MOCK_METHOD(void,
-              fl_binary_messenger_set_message_handler_on_channel,
-              (FlBinaryMessenger * messenger,
-               const gchar* channel,
-               FlBinaryMessengerMessageHandler handler,
-               gpointer user_data,
-               GDestroyNotify destroy_notify));
+  MOCK_METHOD5(fl_binary_messenger_set_message_handler_on_channel,
+               void(FlBinaryMessenger* messenger,
+                    const gchar* channel,
+                    FlBinaryMessengerMessageHandler handler,
+                    gpointer user_data,
+                    GDestroyNotify destroy_notify));
 
-  MOCK_METHOD(gboolean,
-              fl_binary_messenger_send_response,
-              (FlBinaryMessenger * messenger,
-               FlBinaryMessengerResponseHandle* response_handle,
-               GBytes* response,
-               GError** error));
+  MOCK_METHOD4(fl_binary_messenger_send_response,
+               gboolean(FlBinaryMessenger* messenger,
+                        FlBinaryMessengerResponseHandle* response_handle,
+                        GBytes* response,
+                        GError** error));
 
-  MOCK_METHOD(void,
-              fl_binary_messenger_send_on_channel,
-              (FlBinaryMessenger * messenger,
-               const gchar* channel,
-               GBytes* message,
-               GCancellable* cancellable,
-               GAsyncReadyCallback callback,
-               gpointer user_data));
+  MOCK_METHOD6(fl_binary_messenger_send_on_channel,
+               void(FlBinaryMessenger* messenger,
+                    const gchar* channel,
+                    GBytes* message,
+                    GCancellable* cancellable,
+                    GAsyncReadyCallback callback,
+                    gpointer user_data));
 
-  MOCK_METHOD(GBytes*,
-              fl_binary_messenger_send_on_channel_finish,
-              (FlBinaryMessenger * messenger,
-               GAsyncResult* result,
-               GError** error));
+  MOCK_METHOD3(fl_binary_messenger_send_on_channel_finish,
+               GBytes*(FlBinaryMessenger* messenger,
+                       GAsyncResult* result,
+                       GError** error));
 
-  MOCK_METHOD(void,
-              fl_binary_messenger_resize_channel,
-              (FlBinaryMessenger * messenger,
-               const gchar* channel,
-               int64_t new_size));
+  MOCK_METHOD3(fl_binary_messenger_resize_channel,
+               void(FlBinaryMessenger* messenger,
+                    const gchar* channel,
+                    int64_t new_size));
 
-  MOCK_METHOD(void,
-              fl_binary_messenger_set_allow_channel_overflow,
-              (FlBinaryMessenger * messenger,
-               const gchar* channel,
-               bool allowed));
+  MOCK_METHOD3(fl_binary_messenger_set_allow_channel_overflow,
+               void(FlBinaryMessenger* messenger,
+                    const gchar* channel,
+                    bool allowed));
 
   bool HasMessageHandler(const gchar* channel) const;
 

--- a/shell/platform/linux/testing/mock_im_context.h
+++ b/shell/platform/linux/testing/mock_im_context.h
@@ -18,34 +18,31 @@ class MockIMContext {
 
   operator GtkIMContext*();
 
-  MOCK_METHOD(void,
-              gtk_im_context_set_client_window,
-              (GtkIMContext * context, GdkWindow* window));
-  MOCK_METHOD(void,
-              gtk_im_context_get_preedit_string,
-              (GtkIMContext * context,
-               gchar** str,
-               PangoAttrList** attrs,
-               gint* cursor_pos));
-  MOCK_METHOD(gboolean,
-              gtk_im_context_filter_keypress,
-              (GtkIMContext * context, GdkEventKey* event));
-  MOCK_METHOD(gboolean, gtk_im_context_focus_in, (GtkIMContext * context));
-  MOCK_METHOD(void, gtk_im_context_focus_out, (GtkIMContext * context));
-  MOCK_METHOD(void, gtk_im_context_reset, (GtkIMContext * context));
-  MOCK_METHOD(void,
-              gtk_im_context_set_cursor_location,
-              (GtkIMContext * context, GdkRectangle* area));
-  MOCK_METHOD(void,
-              gtk_im_context_set_use_preedit,
-              (GtkIMContext * context, gboolean use_preedit));
-  MOCK_METHOD(
-      void,
-      gtk_im_context_set_surrounding,
-      (GtkIMContext * context, const gchar* text, gint len, gint cursor_index));
-  MOCK_METHOD(gboolean,
-              gtk_im_context_get_surrounding,
-              (GtkIMContext * context, gchar** text, gint* cursor_index));
+  MOCK_METHOD2(gtk_im_context_set_client_window,
+               void(GtkIMContext* context, GdkWindow* window));
+  MOCK_METHOD4(gtk_im_context_get_preedit_string,
+               void(GtkIMContext* context,
+                    gchar** str,
+                    PangoAttrList** attrs,
+                    gint* cursor_pos));
+  MOCK_METHOD2(gtk_im_context_filter_keypress,
+               gboolean(GtkIMContext* context, GdkEventKey* event));
+  MOCK_METHOD1(gtk_im_context_focus_in, gboolean(GtkIMContext* context));
+  MOCK_METHOD1(gtk_im_context_focus_out, void(GtkIMContext* context));
+  MOCK_METHOD1(gtk_im_context_reset, void(GtkIMContext* context));
+  MOCK_METHOD2(gtk_im_context_set_cursor_location,
+               void(GtkIMContext* context, GdkRectangle* area));
+  MOCK_METHOD2(gtk_im_context_set_use_preedit,
+               void(GtkIMContext* context, gboolean use_preedit));
+  MOCK_METHOD4(gtk_im_context_set_surrounding,
+               void(GtkIMContext* context,
+                    const gchar* text,
+                    gint len,
+                    gint cursor_index));
+  MOCK_METHOD3(gtk_im_context_get_surrounding,
+               gboolean(GtkIMContext* context,
+                        gchar** text,
+                        gint* cursor_index));
 
  private:
   GtkIMContext* instance_ = nullptr;

--- a/shell/platform/linux/testing/mock_settings.h
+++ b/shell/platform/linux/testing/mock_settings.h
@@ -20,21 +20,18 @@ class MockSettings {
 
   operator FlSettings*();
 
-  MOCK_METHOD(FlClockFormat,
-              fl_settings_get_clock_format,
-              (FlSettings * settings));
+  MOCK_METHOD1(fl_settings_get_clock_format,
+               FlClockFormat(FlSettings* settings));
 
-  MOCK_METHOD(FlColorScheme,
-              fl_settings_get_color_scheme,
-              (FlSettings * settings));
+  MOCK_METHOD1(fl_settings_get_color_scheme,
+               FlColorScheme(FlSettings* settings));
 
-  MOCK_METHOD(bool, fl_settings_get_enable_animations, (FlSettings * settings));
+  MOCK_METHOD1(fl_settings_get_enable_animations, bool(FlSettings* settings));
 
-  MOCK_METHOD(bool, fl_settings_get_high_contrast, (FlSettings * settings));
+  MOCK_METHOD1(fl_settings_get_high_contrast, bool(FlSettings* settings));
 
-  MOCK_METHOD(gdouble,
-              fl_settings_get_text_scaling_factor,
-              (FlSettings * settings));
+  MOCK_METHOD1(fl_settings_get_text_scaling_factor,
+               gdouble(FlSettings* settings));
 
  private:
   FlSettings* instance_ = nullptr;

--- a/shell/platform/linux/testing/mock_signal_handler.h
+++ b/shell/platform/linux/testing/mock_signal_handler.h
@@ -50,7 +50,7 @@ class MockSignalHandler : public SignalHandler {
   MockSignalHandler(gpointer instance, const gchar* name)
       : SignalHandler(instance, name, G_CALLBACK(OnSignal)) {}
 
-  MOCK_METHOD(void, Handler, ());
+  MOCK_METHOD0(Handler, void());
 
  private:
   static void OnSignal(MockSignalHandler* mock) { mock->Handler(); }
@@ -63,7 +63,7 @@ class MockSignalHandler1 : public SignalHandler {
   MockSignalHandler1(gpointer instance, const gchar* name)
       : SignalHandler(instance, name, G_CALLBACK(OnSignal1)) {}
 
-  MOCK_METHOD(void, Handler1, (A1 a1));
+  MOCK_METHOD1(Handler1, void(A1 a1));
 
  private:
   static void OnSignal1(MockSignalHandler1* mock, A1 a1) { mock->Handler1(a1); }
@@ -76,7 +76,7 @@ class MockSignalHandler2 : public SignalHandler {
   MockSignalHandler2(gpointer instance, const gchar* name)
       : SignalHandler(instance, name, G_CALLBACK(OnSignal2)) {}
 
-  MOCK_METHOD(void, Handler2, (A1 a1, A2 a2));
+  MOCK_METHOD2(Handler2, void(A1 a1, A2 a2));
 
  private:
   static void OnSignal2(MockSignalHandler2* mock, A1 a1, A2 a2) {

--- a/shell/platform/linux/testing/mock_text_input_view_delegate.h
+++ b/shell/platform/linux/testing/mock_text_input_view_delegate.h
@@ -22,13 +22,12 @@ class MockTextInputViewDelegate {
 
   operator FlTextInputViewDelegate*();
 
-  MOCK_METHOD(void,
-              fl_text_input_view_delegate_translate_coordinates,
-              (FlTextInputViewDelegate * delegate,
-               gint view_x,
-               gint view_y,
-               gint* window_x,
-               gint* window_y));
+  MOCK_METHOD5(fl_text_input_view_delegate_translate_coordinates,
+               void(FlTextInputViewDelegate* delegate,
+                    gint view_x,
+                    gint view_y,
+                    gint* window_x,
+                    gint* window_y));
 
  private:
   FlTextInputViewDelegate* instance_ = nullptr;

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -44,40 +44,29 @@ class MockFlutterWindow : public FlutterWindow {
     return HandleMessage(message, wparam, lparam);
   }
 
-  MOCK_METHOD(void, OnDpiScale, (unsigned int), (override));
-  MOCK_METHOD(void, OnResize, (unsigned int, unsigned int), (override));
-  MOCK_METHOD(void,
-              OnPointerMove,
-              (double, double, FlutterPointerDeviceKind, int32_t, int),
-              (override));
-  MOCK_METHOD(void,
-              OnPointerDown,
-              (double, double, FlutterPointerDeviceKind, int32_t, UINT),
-              (override));
-  MOCK_METHOD(void,
-              OnPointerUp,
-              (double, double, FlutterPointerDeviceKind, int32_t, UINT),
-              (override));
-  MOCK_METHOD(void,
-              OnPointerLeave,
-              (double, double, FlutterPointerDeviceKind, int32_t),
-              (override));
-  MOCK_METHOD(void, OnSetCursor, (), (override));
-  MOCK_METHOD(float, GetScrollOffsetMultiplier, (), (override));
-  MOCK_METHOD(bool, GetHighContrastEnabled, (), (override));
-  MOCK_METHOD(float, GetDpiScale, (), (override));
-  MOCK_METHOD(bool, IsVisible, (), (override));
-  MOCK_METHOD(void, UpdateCursorRect, (const Rect&), (override));
-  MOCK_METHOD(void, OnResetImeComposing, (), (override));
-  MOCK_METHOD(UINT, Win32DispatchMessage, (UINT, WPARAM, LPARAM), (override));
-  MOCK_METHOD(BOOL, Win32PeekMessage, (LPMSG, UINT, UINT, UINT), (override));
-  MOCK_METHOD(uint32_t, Win32MapVkToChar, (uint32_t), (override));
-  MOCK_METHOD(HWND, GetPlatformWindow, (), (override));
-  MOCK_METHOD(ui::AXFragmentRootDelegateWin*,
-              GetAxFragmentRootDelegate,
-              (),
-              (override));
-  MOCK_METHOD(void, OnWindowStateEvent, (WindowStateEvent), (override));
+  MOCK_METHOD1(OnDpiScale, void(unsigned int));
+  MOCK_METHOD2(OnResize, void(unsigned int, unsigned int));
+  MOCK_METHOD4(OnPointerMove,
+               void(double, double, FlutterPointerDeviceKind, int32_t));
+  MOCK_METHOD5(OnPointerDown,
+               void(double, double, FlutterPointerDeviceKind, int32_t, UINT));
+  MOCK_METHOD5(OnPointerUp,
+               void(double, double, FlutterPointerDeviceKind, int32_t, UINT));
+  MOCK_METHOD4(OnPointerLeave,
+               void(double, double, FlutterPointerDeviceKind, int32_t));
+  MOCK_METHOD0(OnSetCursor, void());
+  MOCK_METHOD0(GetScrollOffsetMultiplier, float());
+  MOCK_METHOD0(GetHighContrastEnabled, bool());
+  MOCK_METHOD0(GetDpiScale, float());
+  MOCK_METHOD0(IsVisible, bool());
+  MOCK_METHOD1(UpdateCursorRect, void(const Rect&));
+  MOCK_METHOD0(OnResetImeComposing, void());
+  MOCK_METHOD3(Win32DispatchMessage, UINT(UINT, WPARAM, LPARAM));
+  MOCK_METHOD4(Win32PeekMessage, BOOL(LPMSG, UINT, UINT, UINT));
+  MOCK_METHOD1(Win32MapVkToChar, uint32_t(uint32_t));
+  MOCK_METHOD0(GetPlatformWindow, HWND());
+  MOCK_METHOD0(GetAxFragmentRootDelegate, ui::AXFragmentRootDelegateWin*());
+  MOCK_METHOD1(OnWindowStateEvent, void(WindowStateEvent));
 
  protected:
   // |KeyboardManager::WindowDelegate|
@@ -99,10 +88,8 @@ class MockFlutterWindowsView : public FlutterWindowsView {
       : FlutterWindowsView(std::move(window_binding)) {}
   ~MockFlutterWindowsView() {}
 
-  MOCK_METHOD(void,
-              NotifyWinEventWrapper,
-              (ui::AXPlatformNodeWin*, ax::mojom::Event),
-              (override));
+  MOCK_METHOD2(NotifyWinEventWrapper,
+               void(ui::AXPlatformNodeWin*, ax::mojom::Event));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsView);

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -606,11 +606,9 @@ class MockFlutterWindowsView : public FlutterWindowsView {
       : FlutterWindowsView(std::move(wbh)) {}
   ~MockFlutterWindowsView() {}
 
-  MOCK_METHOD(void,
-              NotifyWinEventWrapper,
-              (ui::AXPlatformNodeWin*, ax::mojom::Event),
-              (override));
-  MOCK_METHOD(PlatformWindow, GetPlatformWindow, (), (const, override));
+  MOCK_METHOD2(NotifyWinEventWrapper,
+               void(ui::AXPlatformNodeWin*, ax::mojom::Event));
+  MOCK_METHOD0(GetPlatformWindow, HWND());
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsView);
@@ -664,14 +662,14 @@ class MockWindowsLifecycleManager : public WindowsLifecycleManager {
       : WindowsLifecycleManager(engine) {}
   virtual ~MockWindowsLifecycleManager() {}
 
-  MOCK_METHOD(
-      void,
-      Quit,
-      (std::optional<HWND>, std::optional<WPARAM>, std::optional<LPARAM>, UINT),
-      (override));
-  MOCK_METHOD(void, DispatchMessage, (HWND, UINT, WPARAM, LPARAM), (override));
-  MOCK_METHOD(bool, IsLastWindowOfProcess, (), (override));
-  MOCK_METHOD(void, SetLifecycleState, (AppLifecycleState), (override));
+  MOCK_METHOD4(Quit,
+               void(std::optional<HWND>,
+                    std::optional<WPARAM>,
+                    std::optional<LPARAM>,
+                    UINT));
+  MOCK_METHOD4(DispatchMessage, void(HWND, UINT, WPARAM, LPARAM));
+  MOCK_METHOD0(IsLastWindowOfProcess, bool(void));
+  MOCK_METHOD1(SetLifecycleState, void(AppLifecycleState));
 
   void BeginProcessingLifecycle() override {
     WindowsLifecycleManager::BeginProcessingLifecycle();

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -59,7 +59,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   WindowsRenderTarget* GetRenderTarget() const;
 
   // Return the currently configured PlatformWindow.
-  virtual PlatformWindow GetPlatformWindow() const;
+  PlatformWindow GetPlatformWindow() const;
 
   // Returns the engine backing this view.
   FlutterWindowsEngine* GetEngine();

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -110,8 +110,8 @@ class MockFlutterWindowsEngine : public FlutterWindowsEngine {
  public:
   MockFlutterWindowsEngine() : FlutterWindowsEngine(GetTestProject()) {}
 
-  MOCK_METHOD(bool, Stop, (), (override));
-  MOCK_METHOD(bool, PostRasterThreadTask, (fml::closure), (override));
+  MOCK_METHOD0(Stop, bool());
+  MOCK_METHOD(bool, PostRasterThreadTask, (fml::closure));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsEngine);
@@ -121,17 +121,11 @@ class MockAngleSurfaceManager : public AngleSurfaceManager {
  public:
   MockAngleSurfaceManager() : AngleSurfaceManager(false) {}
 
-  MOCK_METHOD(bool,
-              CreateSurface,
-              (WindowsRenderTarget*, EGLint, EGLint, bool),
-              (override));
-  MOCK_METHOD(void,
-              ResizeSurface,
-              (WindowsRenderTarget*, EGLint, EGLint, bool),
-              (override));
-  MOCK_METHOD(void, DestroySurface, (), (override));
+  MOCK_METHOD4(CreateSurface, bool(WindowsRenderTarget*, EGLint, EGLint, bool));
+  MOCK_METHOD4(ResizeSurface, void(WindowsRenderTarget*, EGLint, EGLint, bool));
+  MOCK_METHOD0(DestroySurface, void());
 
-  MOCK_METHOD(void, SetVSyncEnabled, (bool), (override));
+  MOCK_METHOD1(SetVSyncEnabled, void(bool));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockAngleSurfaceManager);

--- a/shell/platform/windows/platform_handler_unittests.cc
+++ b/shell/platform/windows/platform_handler_unittests.cc
@@ -70,33 +70,23 @@ class MockPlatformHandler : public PlatformHandler {
 
   virtual ~MockPlatformHandler() = default;
 
-  MOCK_METHOD(void,
-              GetPlainText,
-              (std::unique_ptr<MethodResult<rapidjson::Document>>,
-               std::string_view key),
-              (override));
-  MOCK_METHOD(void,
-              GetHasStrings,
-              (std::unique_ptr<MethodResult<rapidjson::Document>>),
-              (override));
-  MOCK_METHOD(void,
-              SetPlainText,
-              (const std::string&,
-               std::unique_ptr<MethodResult<rapidjson::Document>>),
-              (override));
-  MOCK_METHOD(void,
-              SystemSoundPlay,
-              (const std::string&,
-               std::unique_ptr<MethodResult<rapidjson::Document>>),
-              (override));
+  MOCK_METHOD2(GetPlainText,
+               void(std::unique_ptr<MethodResult<rapidjson::Document>>,
+                    std::string_view key));
+  MOCK_METHOD1(GetHasStrings,
+               void(std::unique_ptr<MethodResult<rapidjson::Document>>));
+  MOCK_METHOD2(SetPlainText,
+               void(const std::string&,
+                    std::unique_ptr<MethodResult<rapidjson::Document>>));
+  MOCK_METHOD2(SystemSoundPlay,
+               void(const std::string&,
+                    std::unique_ptr<MethodResult<rapidjson::Document>>));
 
-  MOCK_METHOD(void,
-              QuitApplication,
-              (std::optional<HWND> hwnd,
-               std::optional<WPARAM> wparam,
-               std::optional<LPARAM> lparam,
-               UINT exit_code),
-              (override));
+  MOCK_METHOD4(QuitApplication,
+               void(std::optional<HWND> hwnd,
+                    std::optional<WPARAM> wparam,
+                    std::optional<LPARAM> lparam,
+                    UINT exit_code));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockPlatformHandler);

--- a/shell/platform/windows/settings_plugin_unittests.cc
+++ b/shell/platform/windows/settings_plugin_unittests.cc
@@ -26,12 +26,12 @@ class MockSettingsPlugin : public SettingsPlugin {
   bool is_high_contrast() { return is_high_contrast_; }
 
   // |SettingsPlugin|
-  MOCK_METHOD(bool, GetAlwaysUse24HourFormat, (), (override));
-  MOCK_METHOD(float, GetTextScaleFactor, (), (override));
-  MOCK_METHOD(PlatformBrightness, GetPreferredBrightness, (), (override));
+  MOCK_METHOD0(GetAlwaysUse24HourFormat, bool());
+  MOCK_METHOD0(GetTextScaleFactor, float());
+  MOCK_METHOD0(GetPreferredBrightness, PlatformBrightness());
 
-  MOCK_METHOD(void, WatchPreferredBrightnessChanged, (), (override));
-  MOCK_METHOD(void, WatchTextScaleFactorChanged, (), (override));
+  MOCK_METHOD0(WatchPreferredBrightnessChanged, void());
+  MOCK_METHOD0(WatchTextScaleFactorChanged, void());
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockSettingsPlugin);

--- a/shell/platform/windows/testing/mock_direct_manipulation.h
+++ b/shell/platform/windows/testing/mock_direct_manipulation.h
@@ -19,7 +19,7 @@ class MockDirectManipulationOwner : public DirectManipulationOwner {
       : DirectManipulationOwner(window){};
   virtual ~MockDirectManipulationOwner() = default;
 
-  MOCK_METHOD(void, SetContact, (UINT contact_id), (override));
+  MOCK_METHOD1(SetContact, void(UINT contact_id));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockDirectManipulationOwner);

--- a/shell/platform/windows/testing/mock_text_input_manager.h
+++ b/shell/platform/windows/testing/mock_text_input_manager.h
@@ -21,15 +21,9 @@ class MockTextInputManager : public TextInputManager {
   MockTextInputManager();
   virtual ~MockTextInputManager();
 
-  MOCK_METHOD(std::optional<std::u16string>,
-              GetComposingString,
-              (),
-              (const, override));
-  MOCK_METHOD(std::optional<std::u16string>,
-              GetResultString,
-              (),
-              (const, override));
-  MOCK_METHOD(long, GetComposingCursorPosition, (), (const, override));
+  MOCK_CONST_METHOD0(GetComposingString, std::optional<std::u16string>());
+  MOCK_CONST_METHOD0(GetResultString, std::optional<std::u16string>());
+  MOCK_CONST_METHOD0(GetComposingCursorPosition, long());
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockTextInputManager);

--- a/shell/platform/windows/testing/mock_window.h
+++ b/shell/platform/windows/testing/mock_window.h
@@ -35,59 +35,38 @@ class MockWindow : public Window {
 
   void InjectMessageList(int count, const Win32Message* messages);
 
-  MOCK_METHOD(void, OnDpiScale, (unsigned int), (override));
-  MOCK_METHOD(void, OnResize, (unsigned int, unsigned int), (override));
-  MOCK_METHOD(void, OnPaint, (), (override));
-  MOCK_METHOD(void,
-              OnPointerMove,
-              (double, double, FlutterPointerDeviceKind, int32_t, int),
-              (override));
-  MOCK_METHOD(void,
-              OnPointerDown,
-              (double, double, FlutterPointerDeviceKind, int32_t, UINT),
-              (override));
-  MOCK_METHOD(void,
-              OnPointerUp,
-              (double, double, FlutterPointerDeviceKind, int32_t, UINT),
-              (override));
-  MOCK_METHOD(void,
-              OnPointerLeave,
-              (double, double, FlutterPointerDeviceKind, int32_t),
-              (override));
-  MOCK_METHOD(void, OnSetCursor, (), (override));
-  MOCK_METHOD(void, OnText, (const std::u16string&), (override));
-  MOCK_METHOD(void,
-              OnKey,
-              (int, int, int, char32_t, bool, bool, KeyEventCallback),
-              (override));
-  MOCK_METHOD(void, OnUpdateSemanticsEnabled, (bool), (override));
-  MOCK_METHOD(gfx::NativeViewAccessible,
-              GetNativeViewAccessible,
-              (),
-              (override));
-  MOCK_METHOD(void,
-              OnScroll,
-              (double, double, FlutterPointerDeviceKind, int32_t),
-              (override));
-  MOCK_METHOD(void, OnComposeBegin, (), (override));
-  MOCK_METHOD(void, OnComposeCommit, (), (override));
-  MOCK_METHOD(void, OnComposeEnd, (), (override));
-  MOCK_METHOD(void, OnComposeChange, (const std::u16string&, int), (override));
-  MOCK_METHOD(void,
-              OnImeComposition,
-              (UINT const, WPARAM const, LPARAM const),
-              (override));
+  MOCK_METHOD1(OnDpiScale, void(unsigned int));
+  MOCK_METHOD2(OnResize, void(unsigned int, unsigned int));
+  MOCK_METHOD0(OnPaint, void());
+  MOCK_METHOD5(OnPointerMove,
+               void(double, double, FlutterPointerDeviceKind, int32_t, int));
+  MOCK_METHOD5(OnPointerDown,
+               void(double, double, FlutterPointerDeviceKind, int32_t, UINT));
+  MOCK_METHOD5(OnPointerUp,
+               void(double, double, FlutterPointerDeviceKind, int32_t, UINT));
+  MOCK_METHOD4(OnPointerLeave,
+               void(double, double, FlutterPointerDeviceKind, int32_t));
+  MOCK_METHOD0(OnSetCursor, void());
+  MOCK_METHOD1(OnText, void(const std::u16string&));
+  MOCK_METHOD7(OnKey,
+               void(int, int, int, char32_t, bool, bool, KeyEventCallback));
+  MOCK_METHOD1(OnUpdateSemanticsEnabled, void(bool));
+  MOCK_METHOD0(GetNativeViewAccessible, gfx::NativeViewAccessible());
+  MOCK_METHOD4(OnScroll,
+               void(double, double, FlutterPointerDeviceKind, int32_t));
+  MOCK_METHOD0(OnComposeBegin, void());
+  MOCK_METHOD0(OnComposeCommit, void());
+  MOCK_METHOD0(OnComposeEnd, void());
+  MOCK_METHOD2(OnComposeChange, void(const std::u16string&, int));
+  MOCK_METHOD3(OnImeComposition, void(UINT const, WPARAM const, LPARAM const));
 
-  MOCK_METHOD(void, OnThemeChange, (), (override));
+  MOCK_METHOD0(OnThemeChange, void());
 
-  MOCK_METHOD(ui::AXFragmentRootDelegateWin*,
-              GetAxFragmentRootDelegate,
-              (),
-              (override));
+  MOCK_METHOD0(GetAxFragmentRootDelegate, ui::AXFragmentRootDelegateWin*());
 
-  MOCK_METHOD(LRESULT, OnGetObject, (UINT, WPARAM, LPARAM), (override));
+  MOCK_METHOD3(OnGetObject, LRESULT(UINT, WPARAM, LPARAM));
 
-  MOCK_METHOD(void, OnWindowStateEvent, (WindowStateEvent), (override));
+  MOCK_METHOD1(OnWindowStateEvent, void(WindowStateEvent));
 
   void CallOnImeComposition(UINT const message,
                             WPARAM const wparam,

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -19,29 +19,24 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MockWindowBindingHandler();
   virtual ~MockWindowBindingHandler();
 
-  MOCK_METHOD(void, SetView, (WindowBindingHandlerDelegate * view), (override));
-  MOCK_METHOD(WindowsRenderTarget, GetRenderTarget, (), (override));
-  MOCK_METHOD(PlatformWindow, GetPlatformWindow, (), (override));
-  MOCK_METHOD(float, GetDpiScale, (), (override));
-  MOCK_METHOD(bool, IsVisible, (), (override));
-  MOCK_METHOD(void, OnWindowResized, (), (override));
-  MOCK_METHOD(PhysicalWindowBounds, GetPhysicalWindowBounds, (), (override));
-  MOCK_METHOD(void,
-              UpdateFlutterCursor,
-              (const std::string& cursor_name),
-              (override));
-  MOCK_METHOD(void, SetFlutterCursor, (HCURSOR cursor_name), (override));
-  MOCK_METHOD(void, OnCursorRectUpdated, (const Rect& rect), (override));
-  MOCK_METHOD(void, OnResetImeComposing, (), (override));
-  MOCK_METHOD(bool,
-              OnBitmapSurfaceUpdated,
-              (const void* allocation, size_t row_bytes, size_t height),
-              (override));
-  MOCK_METHOD(PointerLocation, GetPrimaryPointerLocation, (), (override));
-  MOCK_METHOD(void, SendInitialAccessibilityFeatures, (), (override));
-  MOCK_METHOD(AlertPlatformNodeDelegate*, GetAlertDelegate, (), (override));
-  MOCK_METHOD(ui::AXPlatformNodeWin*, GetAlert, (), (override));
-  MOCK_METHOD(bool, NeedsVSync, (), (override));
+  MOCK_METHOD1(SetView, void(WindowBindingHandlerDelegate* view));
+  MOCK_METHOD0(GetRenderTarget, WindowsRenderTarget());
+  MOCK_METHOD0(GetPlatformWindow, PlatformWindow());
+  MOCK_METHOD0(GetDpiScale, float());
+  MOCK_METHOD0(IsVisible, bool());
+  MOCK_METHOD0(OnWindowResized, void());
+  MOCK_METHOD0(GetPhysicalWindowBounds, PhysicalWindowBounds());
+  MOCK_METHOD1(UpdateFlutterCursor, void(const std::string& cursor_name));
+  MOCK_METHOD1(SetFlutterCursor, void(HCURSOR cursor_name));
+  MOCK_METHOD1(OnCursorRectUpdated, void(const Rect& rect));
+  MOCK_METHOD0(OnResetImeComposing, void());
+  MOCK_METHOD3(OnBitmapSurfaceUpdated,
+               bool(const void* allocation, size_t row_bytes, size_t height));
+  MOCK_METHOD0(GetPrimaryPointerLocation, PointerLocation());
+  MOCK_METHOD0(SendInitialAccessibilityFeatures, void());
+  MOCK_METHOD0(GetAlertDelegate, AlertPlatformNodeDelegate*());
+  MOCK_METHOD0(GetAlert, ui::AXPlatformNodeWin*());
+  MOCK_METHOD0(NeedsVSync, bool());
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowBindingHandler);

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -16,66 +16,52 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
  public:
   MockWindowBindingHandlerDelegate() {}
 
-  MOCK_METHOD(void, OnWindowSizeChanged, (size_t, size_t), (override));
-  MOCK_METHOD(void, OnWindowRepaint, (), (override));
-  MOCK_METHOD(void,
-              OnPointerMove,
-              (double, double, FlutterPointerDeviceKind, int32_t, int),
-              (override));
-  MOCK_METHOD(void,
-              OnPointerDown,
-              (double,
-               double,
-               FlutterPointerDeviceKind,
-               int32_t,
-               FlutterPointerMouseButtons),
-              (override));
-  MOCK_METHOD(void,
-              OnPointerUp,
-              (double,
-               double,
-               FlutterPointerDeviceKind,
-               int32_t,
-               FlutterPointerMouseButtons),
-              (override));
-  MOCK_METHOD(void,
-              OnPointerLeave,
-              (double, double, FlutterPointerDeviceKind, int32_t),
-              (override));
-  MOCK_METHOD(void, OnPointerPanZoomStart, (int32_t), (override));
-  MOCK_METHOD(void,
-              OnPointerPanZoomUpdate,
-              (int32_t, double, double, double, double),
-              (override));
-  MOCK_METHOD(void, OnPointerPanZoomEnd, (int32_t), (override));
-  MOCK_METHOD(void, OnText, (const std::u16string&), (override));
-  MOCK_METHOD(void,
-              OnKey,
-              (int, int, int, char32_t, bool, bool, KeyEventCallback),
-              (override));
-  MOCK_METHOD(void, OnComposeBegin, (), (override));
-  MOCK_METHOD(void, OnComposeCommit, (), (override));
-  MOCK_METHOD(void, OnComposeEnd, (), (override));
-  MOCK_METHOD(void, OnComposeChange, (const std::u16string&, int), (override));
-  MOCK_METHOD(void, OnUpdateSemanticsEnabled, (bool), (override));
-  MOCK_METHOD(gfx::NativeViewAccessible,
-              GetNativeViewAccessible,
-              (),
-              (override));
-  MOCK_METHOD(
-      void,
-      OnScroll,
-      (double, double, double, double, int, FlutterPointerDeviceKind, int32_t),
-      (override));
-  MOCK_METHOD(void, OnScrollInertiaCancel, (int32_t), (override));
-  MOCK_METHOD(void, UpdateHighContrastEnabled, (bool enabled), (override));
+  MOCK_METHOD2(OnWindowSizeChanged, void(size_t, size_t));
+  MOCK_METHOD0(OnWindowRepaint, void());
+  MOCK_METHOD5(OnPointerMove,
+               void(double, double, FlutterPointerDeviceKind, int32_t, int));
+  MOCK_METHOD5(OnPointerDown,
+               void(double,
+                    double,
+                    FlutterPointerDeviceKind,
+                    int32_t,
+                    FlutterPointerMouseButtons));
+  MOCK_METHOD5(OnPointerUp,
+               void(double,
+                    double,
+                    FlutterPointerDeviceKind,
+                    int32_t,
+                    FlutterPointerMouseButtons));
+  MOCK_METHOD4(OnPointerLeave,
+               void(double, double, FlutterPointerDeviceKind, int32_t));
+  MOCK_METHOD1(OnPointerPanZoomStart, void(int32_t));
+  MOCK_METHOD5(OnPointerPanZoomUpdate,
+               void(int32_t, double, double, double, double));
+  MOCK_METHOD1(OnPointerPanZoomEnd, void(int32_t));
+  MOCK_METHOD1(OnText, void(const std::u16string&));
+  MOCK_METHOD7(OnKey,
+               void(int, int, int, char32_t, bool, bool, KeyEventCallback));
+  MOCK_METHOD0(OnComposeBegin, void());
+  MOCK_METHOD0(OnComposeCommit, void());
+  MOCK_METHOD0(OnComposeEnd, void());
+  MOCK_METHOD2(OnComposeChange, void(const std::u16string&, int));
+  MOCK_METHOD1(OnUpdateSemanticsEnabled, void(bool));
+  MOCK_METHOD0(GetNativeViewAccessible, gfx::NativeViewAccessible());
+  MOCK_METHOD7(OnScroll,
+               void(double,
+                    double,
+                    double,
+                    double,
+                    int,
+                    FlutterPointerDeviceKind,
+                    int32_t));
+  MOCK_METHOD1(OnScrollInertiaCancel, void(int32_t));
+  MOCK_METHOD0(OnPlatformBrightnessChanged, void());
+  MOCK_METHOD1(UpdateHighContrastEnabled, void(bool enabled));
 
-  MOCK_METHOD(ui::AXFragmentRootDelegateWin*,
-              GetAxFragmentRootDelegate,
-              (),
-              (override));
+  MOCK_METHOD0(GetAxFragmentRootDelegate, ui::AXFragmentRootDelegateWin*());
 
-  MOCK_METHOD(void, OnWindowStateEvent, (HWND, WindowStateEvent), (override));
+  MOCK_METHOD2(OnWindowStateEvent, void(HWND, WindowStateEvent));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowBindingHandlerDelegate);

--- a/shell/platform/windows/testing/mock_windows_proc_table.h
+++ b/shell/platform/windows/testing/mock_windows_proc_table.h
@@ -18,15 +18,11 @@ class MockWindowsProcTable : public WindowsProcTable {
   MockWindowsProcTable() = default;
   virtual ~MockWindowsProcTable() = default;
 
-  MOCK_METHOD(BOOL,
-              GetPointerType,
-              (UINT32 pointer_id, POINTER_INPUT_TYPE* pointer_type),
-              (override));
+  MOCK_METHOD2(GetPointerType,
+               BOOL(UINT32 pointer_id, POINTER_INPUT_TYPE* pointer_type));
 
-  MOCK_METHOD(LRESULT,
-              GetThreadPreferredUILanguages,
-              (DWORD, PULONG, PZZWSTR, PULONG),
-              (const, override));
+  MOCK_CONST_METHOD4(GetThreadPreferredUILanguages,
+                     LRESULT(DWORD, PULONG, PZZWSTR, PULONG));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowsProcTable);

--- a/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/shell/platform/windows/text_input_plugin_unittest.cc
@@ -100,8 +100,8 @@ class MockTextInputPluginDelegate : public TextInputPluginDelegate {
   MockTextInputPluginDelegate() {}
   virtual ~MockTextInputPluginDelegate() = default;
 
-  MOCK_METHOD(void, OnCursorRectUpdated, (const Rect&), (override));
-  MOCK_METHOD(void, OnResetImeComposing, (), (override));
+  MOCK_METHOD1(OnCursorRectUpdated, void(const Rect&));
+  MOCK_METHOD0(OnResetImeComposing, void());
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockTextInputPluginDelegate);

--- a/shell/profiling/sampling_profiler_unittest.cc
+++ b/shell/profiling/sampling_profiler_unittest.cc
@@ -18,17 +18,13 @@ class MockTaskRunner : public fml::TaskRunner {
   inline static RefPtr<MockTaskRunner> Create() {
     return AdoptRef(new MockTaskRunner());
   }
-  MOCK_METHOD(void, PostTask, (const fml::closure& task), (override));
-  MOCK_METHOD(void,
-              PostTaskForTime,
-              (const fml::closure& task, fml::TimePoint target_time),
-              (override));
-  MOCK_METHOD(void,
-              PostDelayedTask,
-              (const fml::closure& task, fml::TimeDelta delay),
-              (override));
-  MOCK_METHOD(bool, RunsTasksOnCurrentThread, (), (override));
-  MOCK_METHOD(TaskQueueId, GetTaskQueueId, (), (override));
+  MOCK_METHOD1(PostTask, void(const fml::closure& task));
+  MOCK_METHOD2(PostTaskForTime,
+               void(const fml::closure& task, fml::TimePoint target_time));
+  MOCK_METHOD2(PostDelayedTask,
+               void(const fml::closure& task, fml::TimeDelta delay));
+  MOCK_METHOD0(RunsTasksOnCurrentThread, bool());
+  MOCK_METHOD0(GetTaskQueueId, TaskQueueId());
 
  private:
   MockTaskRunner() : TaskRunner(fml::RefPtr<MessageLoopImpl>()) {}


### PR DESCRIPTION
Reverts flutter/engine#45307 due to internal breakage. b/298953971