### PR TITLE
Nullability check for platform views

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -775,9 +775,14 @@ void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
     int64_t platform_view_id = composition_order_[i];
     std::vector<std::shared_ptr<FlutterPlatformViewLayer>> layers = layer_map[platform_view_id];
     UIView* platform_view_root = root_views_[platform_view_id].get();
-    [desired_platform_subviews addObject:platform_view_root];
+    
+    if (platform_view_root != nil) {
+      [desired_platform_subviews addObject:platform_view_root];
+    }
     for (const std::shared_ptr<FlutterPlatformViewLayer>& layer : layers) {
-      [desired_platform_subviews addObject:layer->overlay_view_wrapper];
+      if (layer->overlay_view_wrapper != nil) {
+        [desired_platform_subviews addObject:layer->overlay_view_wrapper];
+      }
     }
     active_composition_order_.push_back(platform_view_id);
   }


### PR DESCRIPTION
Environment:
iOS 15/16
any iPhone
flutter 3.10.6 (the same issue i see in 3.13.x codebase, but other dependencies(like get_it) are not compatible to 3.13.x yet)

The PR is needed to fix crash in FlutterPlatformViews.mm.

I have a multimedia application with several platform views. Where one of them is VideoPlayer(AvPlayer)
For iOS there are AVPlayer and MPVolumeView wrapped in widgets.
The application has a complex UI and crashes inside the engine during the player content switching.(At that moment we hide and show same PlatformView)

Crash is on FlutterPlatformViews.mm line 773
There is an attempt to add null object
[desired_platform_subviews addObject:platform_view_root];

In my opinion it's caused because there is no any nullability check for platform_view_root before adding to the array.
And i think the same potential issue can be on line 775

In the 3.3.10 engine there was a different logic in the BringLayersIntoView without additional NSMutableArray

Related issue https://github.com/flutter/flutter/issues/134106
