### PR TITLE
Roll clang to 576b184d6e3b633f51b908b61ebd281d2ecbf66f

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -39,7 +39,7 @@ vars = {
   # The list of revisions for these tools comes from Fuchsia, here:
   # https://fuchsia.googlesource.com/integration/+/HEAD/toolchain
   # If there are problems with the toolchain, contact fuchsia-toolchain@.
-  'clang_version': 'git_revision:020d2fb7711d70e296f19d83565f8d93d2cfda71',
+  'clang_version': 'git_revision:576b184d6e3b633f51b908b61ebd281d2ecbf66f',
 
   # The goma version and the clang version can be tightly coupled. If goma
   # stops working on a clang roll, this may need to be updated using the value
@@ -261,7 +261,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e6f6fba04e50ea8e4c385ae2b63b7cc4133800de',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '9bbdc3ffac00cab766dd381c3272fea195f51c7c',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Also rolls buildroot to pick up flags to silence new warnings.