### PR TITLE
Fix: On the Web, cannot support multiline inputting when registering customized TextInputControl

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -112,7 +112,7 @@ class NoTextInputType extends EngineInputType {
 /// For [NoTextInputType] (mapped to [TextInputType.none] with
 /// [isMultiline] = false), it creates an <input> element with the
 /// inputmode="none" attribute.
-class MultilineNoTextInputType extends EngineInputType {
+class MultilineNoTextInputType extends MultilineInputType {
   const MultilineNoTextInputType();
 
   @override

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -14,7 +14,7 @@ import '../dom.dart';
 abstract class EngineInputType {
   const EngineInputType();
 
-  static EngineInputType fromName(String name, {bool isDecimal = false}) {
+  static EngineInputType fromName(String name, {bool isDecimal = false, bool forceMultiline = false}) {
     switch (name) {
       case 'TextInputType.number':
         return isDecimal ? decimal : number;
@@ -27,7 +27,7 @@ abstract class EngineInputType {
       case 'TextInputType.multiline':
         return multiline;
       case 'TextInputType.none':
-        return none;
+        return forceMultiline ? multilineNone : none;
       case 'TextInputType.text':
       default:
         return text;
@@ -36,6 +36,9 @@ abstract class EngineInputType {
 
   /// No text input.
   static const NoTextInputType none = NoTextInputType();
+
+  /// Multi-line no text input.
+  static const MultilineNoTextInputType multilineNone = MultilineNoTextInputType();
 
   /// Single-line text input type.
   static const TextInputType text = TextInputType();
@@ -92,6 +95,14 @@ class NoTextInputType extends EngineInputType {
 
   @override
   String get inputmodeAttribute => 'none';
+}
+
+/// Multi-line no text input.
+class MultilineNoTextInputType extends EngineInputType {
+  const MultilineNoTextInputType();
+
+  @override
+  String? get inputmodeAttribute => 'none';
 
   @override
   DomHTMLElement createDomElement() => createDomHTMLTextAreaElement();

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -92,6 +92,9 @@ class NoTextInputType extends EngineInputType {
 
   @override
   String get inputmodeAttribute => 'none';
+
+  @override
+  DomHTMLElement createDomElement() => createDomHTMLTextAreaElement();
 }
 
 /// Single-line text input type.

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -97,6 +97,7 @@ class NoTextInputType extends EngineInputType {
   String get inputmodeAttribute => 'none';
 }
 
+/// See: https://github.com/flutter/flutter/issues/125875
 /// Multi-line no text input from system virtual keyboard.
 ///
 /// Use this for inputting multiple lines with a customized keyboard.
@@ -104,12 +105,12 @@ class NoTextInputType extends EngineInputType {
 /// When Flutter uses a custom virtual keyboard, it sends [TextInputType.none]
 /// with a [forceMultiline] flag to block the system virtual keyboard.
 ///
-/// For [MultilineNoTextInputType] (mapped to [TextInputType.none] with 
-/// [forceMultiline] = true), it creates a <textarea> element with the 
+/// For [MultilineNoTextInputType] (mapped to [TextInputType.none] with
+/// [forceMultiline] = true), it creates a <textarea> element with the
 /// inputmode="none" attribute.
 ///
-/// For [NoTextInputType] (mapped to [TextInputType.none] with 
-/// [forceMultiline] = false), it creates an <input> element with the 
+/// For [NoTextInputType] (mapped to [TextInputType.none] with
+/// [forceMultiline] = false), it creates an <input> element with the
 /// inputmode="none" attribute.
 class MultilineNoTextInputType extends EngineInputType {
   const MultilineNoTextInputType();

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -14,7 +14,7 @@ import '../dom.dart';
 abstract class EngineInputType {
   const EngineInputType();
 
-  static EngineInputType fromName(String name, {bool isDecimal = false, bool isMultiline= false}) {
+  static EngineInputType fromName(String name, {bool isDecimal = false, bool isMultiline = false}) {
     switch (name) {
       case 'TextInputType.number':
         return isDecimal ? decimal : number;

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -14,7 +14,7 @@ import '../dom.dart';
 abstract class EngineInputType {
   const EngineInputType();
 
-  static EngineInputType fromName(String name, {bool isDecimal = false, bool forceMultiline = false}) {
+  static EngineInputType fromName(String name, {bool isDecimal = false, bool isMultiline= false}) {
     switch (name) {
       case 'TextInputType.number':
         return isDecimal ? decimal : number;
@@ -27,7 +27,7 @@ abstract class EngineInputType {
       case 'TextInputType.multiline':
         return multiline;
       case 'TextInputType.none':
-        return forceMultiline ? multilineNone : none;
+        return isMultiline ? multilineNone : none;
       case 'TextInputType.text':
       default:
         return text;
@@ -103,14 +103,14 @@ class NoTextInputType extends EngineInputType {
 /// Use this for inputting multiple lines with a customized keyboard.
 ///
 /// When Flutter uses a custom virtual keyboard, it sends [TextInputType.none]
-/// with a [forceMultiline] flag to block the system virtual keyboard.
+/// with a [isMultiline] flag to block the system virtual keyboard.
 ///
 /// For [MultilineNoTextInputType] (mapped to [TextInputType.none] with
-/// [forceMultiline] = true), it creates a <textarea> element with the
+/// [isMultiline] = true), it creates a <textarea> element with the
 /// inputmode="none" attribute.
 ///
 /// For [NoTextInputType] (mapped to [TextInputType.none] with
-/// [forceMultiline] = false), it creates an <input> element with the
+/// [isMultiline] = false), it creates an <input> element with the
 /// inputmode="none" attribute.
 class MultilineNoTextInputType extends EngineInputType {
   const MultilineNoTextInputType();

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -97,7 +97,20 @@ class NoTextInputType extends EngineInputType {
   String get inputmodeAttribute => 'none';
 }
 
-/// Multi-line no text input.
+/// Multi-line no text input from system virtual keyboard.
+///
+/// Use this for inputting multiple lines with a customized keyboard.
+///
+/// When Flutter uses a custom virtual keyboard, it sends [TextInputType.none]
+/// with a [forceMultiline] flag to block the system virtual keyboard.
+///
+/// For [MultilineNoTextInputType] (mapped to [TextInputType.none] with 
+/// [forceMultiline] = true), it creates a <textarea> element with the 
+/// inputmode="none" attribute.
+///
+/// For [NoTextInputType] (mapped to [TextInputType.none] with 
+/// [forceMultiline] = false), it creates an <input> element with the 
+/// inputmode="none" attribute.
 class MultilineNoTextInputType extends EngineInputType {
   const MultilineNoTextInputType();
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -961,7 +961,7 @@ class InputConfiguration {
       : inputType = EngineInputType.fromName(
           flutterInputConfiguration.readJson('inputType').readString('name'),
           isDecimal: flutterInputConfiguration.readJson('inputType').tryBool('decimal') ?? false,
-          forceMultiline: flutterInputConfiguration.readJson('inputType').tryBool('forceMultiline') ?? false,
+          isMultiline: flutterInputConfiguration.readJson('inputType').tryBool('isMultiline') ?? false,
         ),
         inputAction =
             flutterInputConfiguration.tryString('inputAction') ?? 'TextInputAction.done',

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1462,7 +1462,7 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
       if (event.keyCode == _kReturnKeyCode) {
         onAction!(inputConfiguration.inputAction);
         // Prevent the browser from inserting a new line when it's not a multiline input.
-        if (inputConfiguration.inputType is! MultilineInputType) {
+        if (inputConfiguration.inputType is! MultilineInputType && inputConfiguration.inputType is! NoTextInputType) {
           event.preventDefault();
         }
       }

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1281,7 +1281,7 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
       activeDomElement.setAttribute('type', 'password');
     }
 
-    if (config.inputType == EngineInputType.none) {
+    if (config.inputType == EngineInputType.none || config.inputType == EngineInputType.multilineNone) {
       activeDomElement.setAttribute('inputmode', 'none');
     }
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1281,7 +1281,7 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
       activeDomElement.setAttribute('type', 'password');
     }
 
-    if (config.inputType == EngineInputType.none || config.inputType == EngineInputType.multilineNone) {
+    if (config.inputType.inputmodeAttribute == 'none') {
       activeDomElement.setAttribute('inputmode', 'none');
     }
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -961,6 +961,7 @@ class InputConfiguration {
       : inputType = EngineInputType.fromName(
           flutterInputConfiguration.readJson('inputType').readString('name'),
           isDecimal: flutterInputConfiguration.readJson('inputType').tryBool('decimal') ?? false,
+          forceMultiline: flutterInputConfiguration.readJson('inputType').tryBool('forceMultiline') ?? false,
         ),
         inputAction =
             flutterInputConfiguration.tryString('inputAction') ?? 'TextInputAction.done',
@@ -1462,7 +1463,7 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
       if (event.keyCode == _kReturnKeyCode) {
         onAction!(inputConfiguration.inputAction);
         // Prevent the browser from inserting a new line when it's not a multiline input.
-        if (inputConfiguration.inputType is! MultilineInputType && inputConfiguration.inputType is! NoTextInputType) {
+        if (inputConfiguration.inputType is! MultilineInputType && inputConfiguration.inputType is! MultilineNoTextInputType) {
           event.preventDefault();
         }
       }

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1463,7 +1463,7 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
       if (event.keyCode == _kReturnKeyCode) {
         onAction!(inputConfiguration.inputAction);
         // Prevent the browser from inserting a new line when it's not a multiline input.
-        if (inputConfiguration.inputType is! MultilineInputType && inputConfiguration.inputType is! MultilineNoTextInputType) {
+        if (inputConfiguration.inputType is! MultilineInputType) {
           event.preventDefault();
         }
       }

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -441,6 +441,31 @@ Future<void> testMain() async {
       expect(event.defaultPrevented, isFalse);
     });
 
+    test('Triggers input action in multiline-none mode', () {
+      final InputConfiguration config = InputConfiguration(
+        inputType: EngineInputType.multilineNone,
+      );
+      editingStrategy!.enable(
+        config,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+
+      // No input action so far.
+      expect(lastInputAction, isNull);
+
+      final DomKeyboardEvent event = dispatchKeyboardEvent(
+        editingStrategy!.domElement!,
+        'keydown',
+        keyCode: _kReturnKeyCode,
+      );
+
+      // Input action is triggered!
+      expect(lastInputAction, 'TextInputAction.done');
+      // And default behavior of keyboard event shouldn't have been prevented.
+      expect(event.defaultPrevented, isFalse);
+    });
+
     test('Triggers input action and prevent new line key event for single line field', () {
       // Regression test for https://github.com/flutter/flutter/issues/113559
       final InputConfiguration config = InputConfiguration();


### PR DESCRIPTION
For [flutter/flutter/125875](https://github.com/flutter/flutter/issues/125875)

When registering customized TextInputControl, the _PlatformTextInputControl sends inputType = TextInputType.none to the engine. After receiving TextInputType.none, the engine on the Web will create a `<input>` element instead of  `<textarea>`. So there is no way to input \n(multiline).

This is my solution. I tested in Android Chrome, iOS Safari, and macOS Chrome. It works for me. But I'm not sure about other use cases. I pleasure, If someone gives me suggestions.
