### PR TITLE
[Impeller] Gaussian blur: Remove lingering BlurStyle vertex data/uniforms.

### DIFF
--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur.glsl
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur.glsl
@@ -41,7 +41,6 @@ f16vec4 Sample(f16sampler2D tex, vec2 coords) {
 }
 
 in vec2 v_texture_coords;
-in vec2 v_src_texture_coords;
 
 out f16vec4 frag_color;
 

--- a/impeller/entity/shaders/gaussian_blur/gaussian_blur.vert
+++ b/impeller/entity/shaders/gaussian_blur/gaussian_blur.vert
@@ -8,21 +8,16 @@
 uniform FrameInfo {
   mat4 mvp;
   float texture_sampler_y_coord_scale;
-  float alpha_mask_sampler_y_coord_scale;
 }
 frame_info;
 
 in vec2 vertices;
 in vec2 texture_coords;
-in vec2 src_texture_coords;
 
 out vec2 v_texture_coords;
-out vec2 v_src_texture_coords;
 
 void main() {
   gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
   v_texture_coords =
       IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);
-  v_src_texture_coords = IPRemapCoords(
-      src_texture_coords, frame_info.alpha_mask_sampler_y_coord_scale);
 }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -3449,11 +3449,11 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.03125,
-              0.03125,
+              0.015625,
+              0.015625,
+              0.015625,
               0.0,
-              4.0,
+              3.0,
               0.0
             ],
             "pipelines": [
@@ -3468,29 +3468,29 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.03125,
-              0.03125,
+              0.015625,
+              0.015625,
+              0.015625,
               0.0,
-              4.0,
+              3.0,
               0.0
             ],
             "total_bound_pipelines": [
               "load_store"
             ],
             "total_cycles": [
-              0.03125,
-              0.03125,
-              0.03125,
+              0.015625,
+              0.015625,
+              0.015625,
               0.0,
-              4.0,
+              3.0,
               0.0
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 22,
-          "work_registers_used": 10
+          "work_registers_used": 8
         }
       }
     }
@@ -7028,11 +7028,11 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.03125,
-              0.03125,
+              0.015625,
+              0.015625,
+              0.015625,
               0.0,
-              4.0,
+              3.0,
               0.0
             ],
             "pipelines": [
@@ -7047,29 +7047,29 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.03125,
-              0.03125,
-              0.03125,
+              0.015625,
+              0.015625,
+              0.015625,
               0.0,
-              4.0,
+              3.0,
               0.0
             ],
             "total_bound_pipelines": [
               "load_store"
             ],
             "total_cycles": [
-              0.03125,
-              0.03125,
-              0.03125,
+              0.015625,
+              0.015625,
+              0.015625,
               0.0,
-              4.0,
+              3.0,
               0.0
             ]
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 10,
-          "work_registers_used": 10
+          "work_registers_used": 8
         }
       }
     },
@@ -7086,8 +7086,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              3.299999952316284,
-              7.0,
+              2.9700000286102295,
+              5.0,
               0.0
             ],
             "pipelines": [
@@ -7099,22 +7099,22 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              3.299999952316284,
-              7.0,
+              2.9700000286102295,
+              5.0,
               0.0
             ],
             "total_bound_pipelines": [
               "load_store"
             ],
             "total_cycles": [
-              3.3333332538604736,
-              7.0,
+              3.0,
+              5.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
           "uniform_registers_used": 6,
-          "work_registers_used": 3
+          "work_registers_used": 2
         }
       }
     }


### PR DESCRIPTION
Follow-up for https://github.com/flutter/engine/pull/45520.

Missed a few things... These were getting defaulted thanks to impeller's header gen but don't have any purpose now that we've removed the old blur style impl.