### PR TITLE
Reland: Enforce the rule of calling FlutterView.Render (#45300)

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -308,6 +308,21 @@ class PlatformDispatcher {
     _invoke(onMetricsChanged, _onMetricsChangedZone);
   }
 
+  // [FlutterView]s for which [FlutterView.render] has already been called
+  // during the current [onBeginFrame]/[onDrawFrame] callback sequence.
+  //
+  // The field is null outside the scope of those callbacks indicating that
+  // calls to [FlutterView.render] must be ignored. Furthermore, if a given
+  // [FlutterView] is already present in this set when its [FlutterView.render]
+  // is called again, that call must be ignored as a duplicate.
+  //
+  // Between [onBeginFrame] and [onDrawFrame] the properties value is
+  // temporarily stored in `_renderedViewsBetweenCallbacks` so that it survives
+  // the gap between the two callbacks.
+  Set<FlutterView>? _renderedViews;
+  // Temporary storage of the `_renderedViews` value between `_beginFrame` and
+  // `_drawFrame`.
+  Set<FlutterView>? _renderedViewsBetweenCallbacks;
 
   /// A callback invoked when any view begins a frame.
   ///
@@ -329,11 +344,20 @@ class PlatformDispatcher {
 
   // Called from the engine, via hooks.dart
   void _beginFrame(int microseconds) {
+    assert(_renderedViews == null);
+    assert(_renderedViewsBetweenCallbacks == null);
+
+    _renderedViews = <FlutterView>{};
     _invoke1<Duration>(
       onBeginFrame,
       _onBeginFrameZone,
       Duration(microseconds: microseconds),
     );
+    _renderedViewsBetweenCallbacks = _renderedViews;
+    _renderedViews = null;
+
+    assert(_renderedViews == null);
+    assert(_renderedViewsBetweenCallbacks != null);
   }
 
   /// A callback that is invoked for each frame after [onBeginFrame] has
@@ -351,7 +375,16 @@ class PlatformDispatcher {
 
   // Called from the engine, via hooks.dart
   void _drawFrame() {
+    assert(_renderedViews == null);
+    assert(_renderedViewsBetweenCallbacks != null);
+
+    _renderedViews = _renderedViewsBetweenCallbacks;
+    _renderedViewsBetweenCallbacks = null;
     _invoke(onDrawFrame, _onDrawFrameZone);
+    _renderedViews = null;
+
+    assert(_renderedViews == null);
+    assert(_renderedViewsBetweenCallbacks == null);
   }
 
   /// A callback that is invoked when pointer data is available.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -353,7 +353,14 @@ class FlutterView {
   ///   scheduling of frames.
   /// * [RendererBinding], the Flutter framework class which manages layout and
   ///   painting.
-  void render(Scene scene) => _render(scene as _NativeScene);
+  void render(Scene scene) {
+    if (platformDispatcher._renderedViews?.add(this) != true) {
+      // Duplicated calls or calls outside of onBeginFrame/onDrawFrame
+      // (indicated by _renderedViews being null) are ignored, as documented.
+      return;
+    }
+    _render(scene as _NativeScene);
+  }
 
   @Native<Void Function(Pointer<Void>)>(symbol: 'PlatformConfigurationNativeApi::Render')
   external static void _render(_NativeScene scene);

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -327,14 +327,21 @@ class FlutterView {
 
   /// Updates the view's rendering on the GPU with the newly provided [Scene].
   ///
-  /// This function must be called within the scope of the
-  /// [PlatformDispatcher.onBeginFrame] or [PlatformDispatcher.onDrawFrame]
-  /// callbacks being invoked.
+  /// ## Requirement for calling this method
   ///
-  /// If this function is called a second time during a single
-  /// [PlatformDispatcher.onBeginFrame]/[PlatformDispatcher.onDrawFrame]
-  /// callback sequence or called outside the scope of those callbacks, the call
-  /// will be ignored.
+  /// This method must be called within the synchronous scope of the
+  /// [PlatformDispatcher.onBeginFrame] or [PlatformDispatcher.onDrawFrame]
+  /// callbacks. Calls out of this scope will be ignored. To use this method,
+  /// create a callback that calls this method instead, and assign it to either
+  /// of the fields above; then schedule a frame, which is done typically with
+  /// [PlatformDispatcher.scheduleFrame]. Also, make sure the callback does not
+  /// have `await` before the `FlutterWindow.render` call.
+  ///
+  /// Additionally, this method can only be called once for each view during a
+  /// single [PlatformDispatcher.onBeginFrame]/[PlatformDispatcher.onDrawFrame]
+  /// callback sequence. Duplicate calls will be ignored in production.
+  ///
+  /// ## How to record a scene
   ///
   /// To record graphical operations, first create a [PictureRecorder], then
   /// construct a [Canvas], passing that [PictureRecorder] to its constructor.

--- a/lib/ui/window/platform_configuration_unittests.cc
+++ b/lib/ui/window/platform_configuration_unittests.cc
@@ -15,9 +15,170 @@
 #include "flutter/shell/common/shell_test.h"
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/testing/testing.h"
+#include "gmock/gmock.h"
 
 namespace flutter {
+
+namespace {
+
+static constexpr int64_t kImplicitViewId = 0;
+
+static void PostSync(const fml::RefPtr<fml::TaskRunner>& task_runner,
+                     const fml::closure& task) {
+  fml::AutoResetWaitableEvent latch;
+  fml::TaskRunner::RunNowOrPostTask(task_runner, [&latch, &task] {
+    task();
+    latch.Signal();
+  });
+  latch.Wait();
+}
+
+class MockRuntimeDelegate : public RuntimeDelegate {
+ public:
+  MOCK_METHOD(std::string, DefaultRouteName, (), (override));
+  MOCK_METHOD(void, ScheduleFrame, (bool), (override));
+  MOCK_METHOD(void,
+              Render,
+              (std::unique_ptr<flutter::LayerTree>, float),
+              (override));
+  MOCK_METHOD(void,
+              UpdateSemantics,
+              (SemanticsNodeUpdates, CustomAccessibilityActionUpdates),
+              (override));
+  MOCK_METHOD(void,
+              HandlePlatformMessage,
+              (std::unique_ptr<PlatformMessage>),
+              (override));
+  MOCK_METHOD(FontCollection&, GetFontCollection, (), (override));
+  MOCK_METHOD(std::shared_ptr<AssetManager>, GetAssetManager, (), (override));
+  MOCK_METHOD(void, OnRootIsolateCreated, (), (override));
+  MOCK_METHOD(void,
+              UpdateIsolateDescription,
+              (const std::string, int64_t),
+              (override));
+  MOCK_METHOD(void, SetNeedsReportTimings, (bool), (override));
+  MOCK_METHOD(std::unique_ptr<std::vector<std::string>>,
+              ComputePlatformResolvedLocale,
+              (const std::vector<std::string>&),
+              (override));
+  MOCK_METHOD(void, RequestDartDeferredLibrary, (intptr_t), (override));
+  MOCK_METHOD(std::weak_ptr<PlatformMessageHandler>,
+              GetPlatformMessageHandler,
+              (),
+              (const, override));
+  MOCK_METHOD(void, SendChannelUpdate, (std::string, bool), (override));
+  MOCK_METHOD(double,
+              GetScaledFontSize,
+              (double font_size, int configuration_id),
+              (const, override));
+};
+
+class MockPlatformMessageHandler : public PlatformMessageHandler {
+ public:
+  MOCK_METHOD(void,
+              HandlePlatformMessage,
+              (std::unique_ptr<PlatformMessage> message),
+              (override));
+  MOCK_METHOD(bool,
+              DoesHandlePlatformMessageOnPlatformThread,
+              (),
+              (const, override));
+  MOCK_METHOD(void,
+              InvokePlatformMessageResponseCallback,
+              (int response_id, std::unique_ptr<fml::Mapping> mapping),
+              (override));
+  MOCK_METHOD(void,
+              InvokePlatformMessageEmptyResponseCallback,
+              (int response_id),
+              (override));
+};
+
+// A class that can launch a RuntimeController with the specified
+// RuntimeDelegate.
+//
+// To use this class, contruct this class with Create, call LaunchRootIsolate,
+// and use the controller with ControllerTaskSync().
+class RuntimeControllerContext {
+ public:
+  using ControllerCallback = std::function<void(RuntimeController&)>;
+
+  [[nodiscard]] static std::unique_ptr<RuntimeControllerContext> Create(
+      Settings settings,                //
+      const TaskRunners& task_runners,  //
+      RuntimeDelegate& client) {
+    auto [vm, isolate_snapshot] = Shell::InferVmInitDataFromSettings(settings);
+    FML_CHECK(vm) << "Must be able to initialize the VM.";
+    // Construct the class with `new` because `make_unique` has no access to the
+    // private constructor.
+    RuntimeControllerContext* raw_pointer = new RuntimeControllerContext(
+        settings, task_runners, client, std::move(vm), isolate_snapshot);
+    return std::unique_ptr<RuntimeControllerContext>(raw_pointer);
+  }
+
+  ~RuntimeControllerContext() {
+    PostSync(task_runners_.GetUITaskRunner(),
+             [&]() { runtime_controller_.reset(); });
+  }
+
+  // Launch the root isolate. The post_launch callback will be executed in the
+  // same UI task, which can be used to create initial views.
+  void LaunchRootIsolate(RunConfiguration& configuration,
+                         ControllerCallback post_launch) {
+    PostSync(task_runners_.GetUITaskRunner(), [&]() {
+      bool launch_success = runtime_controller_->LaunchRootIsolate(
+          settings_,                                  //
+          []() {},                                    //
+          configuration.GetEntrypoint(),              //
+          configuration.GetEntrypointLibrary(),       //
+          configuration.GetEntrypointArgs(),          //
+          configuration.TakeIsolateConfiguration());  //
+      ASSERT_TRUE(launch_success);
+      post_launch(*runtime_controller_);
+    });
+  }
+
+  // Run a task that operates the RuntimeController on the UI thread, and wait
+  // for the task to end.
+  void ControllerTaskSync(ControllerCallback task) {
+    ASSERT_TRUE(runtime_controller_);
+    ASSERT_TRUE(task);
+    PostSync(task_runners_.GetUITaskRunner(),
+             [&]() { task(*runtime_controller_); });
+  }
+
+ private:
+  RuntimeControllerContext(const Settings& settings,
+                           const TaskRunners& task_runners,
+                           RuntimeDelegate& client,
+                           DartVMRef vm,
+                           fml::RefPtr<const DartSnapshot> isolate_snapshot)
+      : settings_(settings),
+        task_runners_(task_runners),
+        isolate_snapshot_(std::move(isolate_snapshot)),
+        vm_(std::move(vm)),
+        runtime_controller_(std::make_unique<RuntimeController>(
+            client,
+            &vm_,
+            std::move(isolate_snapshot_),
+            settings.idle_notification_callback,  // idle notification callback
+            flutter::PlatformData(),              // platform data
+            settings.isolate_create_callback,     // isolate create callback
+            settings.isolate_shutdown_callback,   // isolate shutdown callback
+            settings.persistent_isolate_data,     // persistent isolate data
+            UIDartState::Context{task_runners})) {}
+
+  Settings settings_;
+  TaskRunners task_runners_;
+  fml::RefPtr<const DartSnapshot> isolate_snapshot_;
+  DartVMRef vm_;
+  std::unique_ptr<RuntimeController> runtime_controller_;
+};
+}  // namespace
+
 namespace testing {
+
+using ::testing::_;
+using ::testing::Return;
 
 class PlatformConfigurationTest : public ShellTest {};
 
@@ -330,6 +491,85 @@ TEST_F(PlatformConfigurationTest, SetDartPerformanceMode) {
 
   message_latch->Wait();
   DestroyShell(std::move(shell), task_runners);
+}
+
+TEST_F(PlatformConfigurationTest, OutOfScopeRenderCallsAreIgnored) {
+  Settings settings = CreateSettingsForFixture();
+  TaskRunners task_runners = GetTaskRunnersForFixture();
+
+  MockRuntimeDelegate client;
+  auto platform_message_handler =
+      std::make_shared<MockPlatformMessageHandler>();
+  EXPECT_CALL(client, GetPlatformMessageHandler)
+      .WillOnce(Return(platform_message_handler));
+  // Render should not be called.
+  EXPECT_CALL(client, Render).Times(0);
+
+  auto message_latch = std::make_shared<fml::AutoResetWaitableEvent>();
+  auto finish = [message_latch](Dart_NativeArguments args) {
+    message_latch->Signal();
+  };
+  AddNativeCallback("Finish", CREATE_NATIVE_ENTRY(finish));
+
+  auto runtime_controller_context =
+      RuntimeControllerContext::Create(settings, task_runners, client);
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("incorrectImmediateRender");
+  runtime_controller_context->LaunchRootIsolate(
+      configuration, [](RuntimeController& runtime_controller) {
+        runtime_controller.AddView(
+            kImplicitViewId,
+            ViewportMetrics(
+                /*pixel_ratio=*/1.0, /*width=*/20, /*height=*/20,
+                /*touch_slop=*/2, /*display_id=*/0));
+      });
+
+  // Wait for the Dart main function to end.
+  message_latch->Wait();
+}
+
+TEST_F(PlatformConfigurationTest, DuplicateRenderCallsAreIgnored) {
+  Settings settings = CreateSettingsForFixture();
+  TaskRunners task_runners = GetTaskRunnersForFixture();
+
+  MockRuntimeDelegate client;
+  auto platform_message_handler =
+      std::make_shared<MockPlatformMessageHandler>();
+  EXPECT_CALL(client, GetPlatformMessageHandler)
+      .WillOnce(Return(platform_message_handler));
+  // Render should only be called once, because the second call is ignored.
+  EXPECT_CALL(client, Render).Times(1);
+
+  auto message_latch = std::make_shared<fml::AutoResetWaitableEvent>();
+  auto finish = [message_latch](Dart_NativeArguments args) {
+    message_latch->Signal();
+  };
+  AddNativeCallback("Finish", CREATE_NATIVE_ENTRY(finish));
+
+  auto runtime_controller_context =
+      RuntimeControllerContext::Create(settings, task_runners, client);
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("incorrectDoubleRender");
+  runtime_controller_context->LaunchRootIsolate(
+      configuration, [](RuntimeController& runtime_controller) {
+        runtime_controller.AddView(
+            kImplicitViewId,
+            ViewportMetrics(
+                /*pixel_ratio=*/1.0, /*width=*/20, /*height=*/20,
+                /*touch_slop=*/2, /*display_id=*/0));
+      });
+
+  // Wait for the Dart main function to end.
+  message_latch->Wait();
+
+  runtime_controller_context->ControllerTaskSync(
+      [](RuntimeController& runtime_controller) {
+        // This BeginFrame calls PlatformDispatcher's handleBeginFrame and
+        // handleDrawFrame synchronously. Therefore don't wait after it.
+        runtime_controller.BeginFrame(fml::TimePoint::Now(), 0);
+      });
 }
 
 }  // namespace testing

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -438,6 +438,16 @@ class Shell final : public PlatformView::Delegate,
   const std::shared_ptr<fml::ConcurrentTaskRunner>
   GetConcurrentWorkerTaskRunner() const;
 
+  // Infer the VM ref and the isolate snapshot based on the settings.
+  //
+  // If the VM is already running, the settings are ignored, but the returned
+  // isolate snapshot always prioritize what is specified by the settings, and
+  // falls back to the one VM was launched with.
+  //
+  // This function is what Shell::Create uses to infer snapshot settings.
+  static std::pair<DartVMRef, fml::RefPtr<const DartSnapshot>>
+  InferVmInitDataFromSettings(Settings& settings);
+
  private:
   using ServiceProtocolHandler =
       std::function<bool(const ServiceProtocol::Handler::ServiceProtocolMap&,

--- a/testing/dart/platform_view_test.dart
+++ b/testing/dart/platform_view_test.dart
@@ -10,10 +10,13 @@ void main() {
   test('PlatformView layers do not emit errors from tester', () async {
     final SceneBuilder builder = SceneBuilder();
     builder.addPlatformView(1);
-    final Scene scene = builder.build();
 
-    PlatformDispatcher.instance.implicitView!.render(scene);
-    scene.dispose();
+    PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+      final Scene scene = builder.build();
+      PlatformDispatcher.instance.implicitView!.render(scene);
+      scene.dispose();
+    };
+    PlatformDispatcher.instance.scheduleFrame();
     // Test harness asserts that this does not emit an error from the shell logs.
   });
 }


### PR DESCRIPTION
This PR relands #45300 which was reverted in https://github.com/flutter/engine/pull/45525 due to hanging on a windows startup test. The culprit test still calls `FlutterView.render` in the illegal way, which is ignored, causing no frame being ever produced. This has been fixed in https://github.com/flutter/flutter/pull/134245. I've also searched through the framework repo for `render(` to ensure there are no other cases.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
