### PR TITLE
Add dart2wasm dependency to flutter_frontend_server

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -53,6 +53,8 @@ dependency_overrides:
     path: ../../third_party/dart/pkg/dart_internal
   dart2js_info:
     path: ../../third_party/dart/pkg/dart2js_info
+  dart2wasm:
+    path: ../../third_party/dart/pkg/dart2wasm
   dev_compiler:
     path: ../../third_party/dart/pkg/dev_compiler
   expect:
@@ -113,5 +115,7 @@ dependency_overrides:
     path: ../../third_party/dart/pkg/vm_service
   vm_snapshot_analysis:
     path: ../../third_party/dart/pkg/vm_snapshot_analysis
+  wasm_builder:
+    path: ../../pkg/wasm_builder
   yaml:
     path: ../../third_party/dart/third_party/pkg/yaml

--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -116,6 +116,6 @@ dependency_overrides:
   vm_snapshot_analysis:
     path: ../../third_party/dart/pkg/vm_snapshot_analysis
   wasm_builder:
-    path: ../../pkg/wasm_builder
+    path: ../../third_party/dart/pkg/wasm_builder
   yaml:
     path: ../../third_party/dart/third_party/pkg/yaml


### PR DESCRIPTION
The change
https://dart-review.googlesource.com/c/sdk/+/323000 added a dependency on dart2wasm to the frontend_server package.

Flutter engine has all dependencies in its source checkout, and paths to their locations hardcoded in the dependency_ovedrrides of flutter_frontend_server's pubspec.yaml.

Add the dart2wasm package location to pubspec.yaml. Add the transitive dependency wasm_builder package lcoation to pubspec.yaml.