### PR TITLE
[Impeller] use public Skia API to look up glyph emoji/colr status

### DIFF
--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -55,7 +55,7 @@ void VisualizeStopWatch(DlCanvas* canvas,
     DlPaint paint(0xFF888888);
 #ifdef IMPELLER_SUPPORTS_RENDERING
     if (impeller_enabled) {
-      canvas->DrawTextFrame(impeller::MakeTextFrameFromTextBlobSkia(text),
+      canvas->DrawTextFrame(impeller::MakeTextFrameFromTextBlobSkia(text, false),
                             x + label_x, y + height + label_y, paint);
     }
 #endif  // IMPELLER_SUPPORTS_RENDERING

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -55,8 +55,9 @@ void VisualizeStopWatch(DlCanvas* canvas,
     DlPaint paint(0xFF888888);
 #ifdef IMPELLER_SUPPORTS_RENDERING
     if (impeller_enabled) {
-      canvas->DrawTextFrame(impeller::MakeTextFrameFromTextBlobSkia(text, false),
-                            x + label_x, y + height + label_y, paint);
+      canvas->DrawTextFrame(
+          impeller::MakeTextFrameFromTextBlobSkia(text, false), x + label_x,
+          y + height + label_y, paint);
     }
 #endif  // IMPELLER_SUPPORTS_RENDERING
     canvas->DrawTextBlob(text, x + label_x, y + height + label_y, paint);

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1277,7 +1277,7 @@ bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
   }
 
   // Create the Impeller text frame and draw it at the designated baseline.
-  auto frame = MakeTextFrameFromTextBlobSkia(blob);
+  auto frame = MakeTextFrameFromTextBlobSkiaTestOnly(blob);
 
   Paint text_paint;
   text_paint.color = Color::Yellow().WithAlpha(options.alpha);
@@ -1466,7 +1466,7 @@ TEST_P(AiksTest, CanRenderTextOutsideBoundaries) {
     {
       auto blob = SkTextBlob::MakeFromString(t.text, sk_font);
       ASSERT_NE(blob, nullptr);
-      auto frame = MakeTextFrameFromTextBlobSkia(blob);
+      auto frame = MakeTextFrameFromTextBlobSkiaTestOnly(blob);
       canvas.DrawTextFrame(frame, Point(), text_paint);
     }
     canvas.Restore();
@@ -3089,7 +3089,7 @@ TEST_P(AiksTest, TextForegroundShaderWithTransform) {
 
   auto blob = SkTextBlob::MakeFromString("Hello", sk_font);
   ASSERT_NE(blob, nullptr);
-  auto frame = MakeTextFrameFromTextBlobSkia(blob);
+  auto frame = MakeTextFrameFromTextBlobSkiaTestOnly(blob);
   canvas.DrawTextFrame(frame, Point(), text_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2174,7 +2174,7 @@ TEST_P(EntityTest, InheritOpacityTest) {
   SkFont font;
   font.setSize(30);
   auto blob = SkTextBlob::MakeFromString("A", font);
-  auto frame = MakeTextFrameFromTextBlobSkia(blob);
+  auto frame = MakeTextFrameFromTextBlobSkiaTestOnly(blob);
   auto lazy_glyph_atlas =
       std::make_shared<LazyGlyphAtlas>(TypographerContextSkia::Make());
   lazy_glyph_atlas->AddTextFrame(*frame, 1.0f);

--- a/impeller/typographer/backends/skia/text_frame_skia.h
+++ b/impeller/typographer/backends/skia/text_frame_skia.h
@@ -9,7 +9,17 @@
 
 namespace impeller {
 
+/// @brief Create an Impeller text frame from a Skia text blob.
+///
+///  has_color_font controls whether or not the glyphs can be cached in the
+///  alpha atlas or the full color atlas.
 std::shared_ptr<impeller::TextFrame> MakeTextFrameFromTextBlobSkia(
+    const sk_sp<SkTextBlob>& blob,
+    bool has_color_font);
+
+/// @brief Testonly version of `MakeTextFrameFromTextBlobSkia` that looks up whether
+/// or not the font has bitmap glyphs at runtime.
+std::shared_ptr<impeller::TextFrame> MakeTextFrameFromTextBlobSkiaTestOnly(
     const sk_sp<SkTextBlob>& blob);
 
 }  // namespace impeller

--- a/impeller/typographer/backends/skia/text_frame_skia.h
+++ b/impeller/typographer/backends/skia/text_frame_skia.h
@@ -17,8 +17,8 @@ std::shared_ptr<impeller::TextFrame> MakeTextFrameFromTextBlobSkia(
     const sk_sp<SkTextBlob>& blob,
     bool has_color_font);
 
-/// @brief Testonly version of `MakeTextFrameFromTextBlobSkia` that looks up whether
-/// or not the font has bitmap glyphs at runtime.
+/// @brief Testonly version of `MakeTextFrameFromTextBlobSkia` that looks up
+/// whether or not the font has bitmap glyphs at runtime.
 std::shared_ptr<impeller::TextFrame> MakeTextFrameFromTextBlobSkiaTestOnly(
     const sk_sp<SkTextBlob>& blob);
 

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -40,7 +40,7 @@ TEST_P(TypographerTest, CanConvertTextBlob) {
   auto blob = SkTextBlob::MakeFromString(
       "the quick brown fox jumped over the lazy dog.", font);
   ASSERT_TRUE(blob);
-  auto frame = MakeTextFrameFromTextBlobSkia(blob);
+  auto frame = MakeTextFrameFromTextBlobSkiaTestOnly(blob);
   ASSERT_EQ(frame->GetRunCount(), 1u);
   for (const auto& run : frame->GetRuns()) {
     ASSERT_TRUE(run.IsValid());
@@ -62,7 +62,7 @@ TEST_P(TypographerTest, CanCreateGlyphAtlas) {
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
       *GetContext(), context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
-      atlas_context, *MakeTextFrameFromTextBlobSkia(blob));
+      atlas_context, *MakeTextFrameFromTextBlobSkiaTestOnly(blob));
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
   ASSERT_EQ(atlas->GetType(), GlyphAtlas::Type::kAlphaBitmap);
@@ -113,7 +113,7 @@ TEST_P(TypographerTest, LazyAtlasTracksColor) {
 
   auto blob = SkTextBlob::MakeFromString("hello", sk_font);
   ASSERT_TRUE(blob);
-  auto frame = MakeTextFrameFromTextBlobSkia(blob);
+  auto frame = MakeTextFrameFromTextBlobSkiaTestOnly(blob);
 
   ASSERT_FALSE(frame->GetAtlasType() == GlyphAtlas::Type::kColorBitmap);
 
@@ -121,7 +121,7 @@ TEST_P(TypographerTest, LazyAtlasTracksColor) {
 
   lazy_atlas.AddTextFrame(*frame, 1.0f);
 
-  frame = MakeTextFrameFromTextBlobSkia(
+  frame = MakeTextFrameFromTextBlobSkiaTestOnly(
       SkTextBlob::MakeFromString("😀 ", emoji_font));
 
   ASSERT_TRUE(frame->GetAtlasType() == GlyphAtlas::Type::kColorBitmap);
@@ -147,7 +147,7 @@ TEST_P(TypographerTest, GlyphAtlasWithOddUniqueGlyphSize) {
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
       *GetContext(), context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
-      atlas_context, *MakeTextFrameFromTextBlobSkia(blob));
+      atlas_context, *MakeTextFrameFromTextBlobSkiaTestOnly(blob));
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
 
@@ -164,7 +164,7 @@ TEST_P(TypographerTest, GlyphAtlasIsRecycledIfUnchanged) {
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
       *GetContext(), context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
-      atlas_context, *MakeTextFrameFromTextBlobSkia(blob));
+      atlas_context, *MakeTextFrameFromTextBlobSkiaTestOnly(blob));
   ASSERT_NE(atlas, nullptr);
   ASSERT_NE(atlas->GetTexture(), nullptr);
   ASSERT_EQ(atlas, atlas_context->GetGlyphAtlas());
@@ -173,7 +173,7 @@ TEST_P(TypographerTest, GlyphAtlasIsRecycledIfUnchanged) {
 
   auto next_atlas = CreateGlyphAtlas(
       *GetContext(), context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
-      atlas_context, *MakeTextFrameFromTextBlobSkia(blob));
+      atlas_context, *MakeTextFrameFromTextBlobSkiaTestOnly(blob));
   ASSERT_EQ(atlas, next_atlas);
   ASSERT_EQ(atlas_context->GetGlyphAtlas(), atlas);
 }
@@ -196,7 +196,7 @@ TEST_P(TypographerTest, GlyphAtlasWithLotsOfdUniqueGlyphSize) {
   FontGlyphMap font_glyph_map;
   size_t size_count = 8;
   for (size_t index = 0; index < size_count; index += 1) {
-    MakeTextFrameFromTextBlobSkia(blob)->CollectUniqueFontGlyphPairs(
+    MakeTextFrameFromTextBlobSkiaTestOnly(blob)->CollectUniqueFontGlyphPairs(
         font_glyph_map, 0.6 * index);
   };
   auto atlas =
@@ -231,7 +231,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledIfUnchanged) {
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
       *GetContext(), context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
-      atlas_context, *MakeTextFrameFromTextBlobSkia(blob));
+      atlas_context, *MakeTextFrameFromTextBlobSkiaTestOnly(blob));
   auto old_packer = atlas_context->GetRectPacker();
 
   ASSERT_NE(atlas, nullptr);
@@ -245,7 +245,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledIfUnchanged) {
   auto blob2 = SkTextBlob::MakeFromString("spooky 2", sk_font);
   auto next_atlas = CreateGlyphAtlas(
       *GetContext(), context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
-      atlas_context, *MakeTextFrameFromTextBlobSkia(blob2));
+      atlas_context, *MakeTextFrameFromTextBlobSkiaTestOnly(blob2));
   ASSERT_EQ(atlas, next_atlas);
   auto* second_texture = next_atlas->GetTexture().get();
 
@@ -264,7 +264,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
       *GetContext(), context.get(), GlyphAtlas::Type::kAlphaBitmap, 1.0f,
-      atlas_context, *MakeTextFrameFromTextBlobSkia(blob));
+      atlas_context, *MakeTextFrameFromTextBlobSkiaTestOnly(blob));
   auto old_packer = atlas_context->GetRectPacker();
 
   ASSERT_NE(atlas, nullptr);
@@ -279,7 +279,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
   auto blob2 = SkTextBlob::MakeFromString("spooky 1", sk_font);
   auto next_atlas = CreateGlyphAtlas(
       *GetContext(), context.get(), GlyphAtlas::Type::kColorBitmap, 1.0f,
-      atlas_context, *MakeTextFrameFromTextBlobSkia(blob2));
+      atlas_context, *MakeTextFrameFromTextBlobSkiaTestOnly(blob2));
   ASSERT_NE(atlas, next_atlas);
   auto* second_texture = next_atlas->GetTexture().get();
 
@@ -296,11 +296,11 @@ TEST_P(TypographerTest, MaybeHasOverlapping) {
   SkFont sk_font(typeface, 0.5f);
 
   auto frame =
-      MakeTextFrameFromTextBlobSkia(SkTextBlob::MakeFromString("1", sk_font));
+      MakeTextFrameFromTextBlobSkiaTestOnly(SkTextBlob::MakeFromString("1", sk_font));
   // Single character has no overlapping
   ASSERT_FALSE(frame->MaybeHasOverlapping());
 
-  auto frame_2 = MakeTextFrameFromTextBlobSkia(
+  auto frame_2 = MakeTextFrameFromTextBlobSkiaTestOnly(
       SkTextBlob::MakeFromString("123456789", sk_font));
   ASSERT_FALSE(frame_2->MaybeHasOverlapping());
 }

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -295,8 +295,8 @@ TEST_P(TypographerTest, MaybeHasOverlapping) {
       font_mgr->matchFamilyStyle("Arial", SkFontStyle::Normal());
   SkFont sk_font(typeface, 0.5f);
 
-  auto frame =
-      MakeTextFrameFromTextBlobSkiaTestOnly(SkTextBlob::MakeFromString("1", sk_font));
+  auto frame = MakeTextFrameFromTextBlobSkiaTestOnly(
+      SkTextBlob::MakeFromString("1", sk_font));
   // Single character has no overlapping
   ASSERT_FALSE(frame->MaybeHasOverlapping());
 

--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -334,7 +334,8 @@ void ParagraphSkia::Layout(double width) {
 }
 
 bool ParagraphSkia::Paint(DisplayListBuilder* builder, double x, double y) {
-  DisplayListParagraphPainter painter(builder, paragraph_, dl_paints_, impeller_enabled_);
+  DisplayListParagraphPainter painter(builder, paragraph_, dl_paints_,
+                                      impeller_enabled_);
   paragraph_->paint(&painter, x, y);
   return true;
 }

--- a/third_party/txt/src/skia/paragraph_skia.h
+++ b/third_party/txt/src/skia/paragraph_skia.h
@@ -72,7 +72,7 @@ class ParagraphSkia : public Paragraph {
  private:
   TextStyle SkiaToTxt(const skia::textlayout::TextStyle& skia);
 
-  std::unique_ptr<skia::textlayout::Paragraph> paragraph_;
+  std::shared_ptr<skia::textlayout::Paragraph> paragraph_;
   std::vector<flutter::DlPaint> dl_paints_;
   std::optional<std::vector<LineMetrics>> line_metrics_;
   std::vector<TextStyle> line_metrics_styles_;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/112005

Now that the text frames are constructed closer to where the SkParagraph is, we can use the public API for lookup up emoji/colr font status.

I moved the old functionality into a "test only" method that we can use for now to look up this data in testing. Not sure what we should do there long term.
