### PR TITLE
Remove some of our hacks around JSPromise now that we have better APIs.

### DIFF
--- a/lib/web_ui/lib/src/engine/app_bootstrap.dart
+++ b/lib/web_ui/lib/src/engine/app_bootstrap.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:js/js_util.dart' show allowInterop;
+import 'dart:js_interop';
 
 import 'configuration.dart';
 import 'js_interop/js_loader.dart';
@@ -40,33 +40,26 @@ class AppBootstrap {
       // This is a convenience method that lets the programmer call "autoStart"
       // from JavaScript immediately after the main.dart.js has loaded.
       // Returns a promise that resolves to the Flutter app that was started.
-      autoStart: allowInterop(() => futureToPromise(() async {
+      autoStart: (() => futureToPromise(() async {
         await autoStart();
         // Return the App that was just started
-        return _prepareFlutterApp();
-      }())),
+        return _prepareFlutterApp() as JSAny;
+      }())).toJS,
       // Calls [_initEngine], and returns a JS Promise that resolves to an
       // app runner object.
-      initializeEngine: allowInterop(([JsFlutterConfiguration? configuration]) => futureToPromise(() async {
+      initializeEngine: (([JsFlutterConfiguration? configuration]) => futureToPromise(() async {
         await _initializeEngine(configuration);
-        return _prepareAppRunner();
-      }()))
+        return _prepareAppRunner() as JSAny;
+      }())).toJS
     );
   }
 
   /// Creates an appRunner that runs our encapsulated runApp function.
   FlutterAppRunner _prepareAppRunner() {
-    return FlutterAppRunner(runApp: allowInterop(([RunAppFnParameters? params]) {
-      // `params` coming from JS may be used to configure the run app method.
-      return Promise<FlutterApp>(allowInterop((
-        PromiseResolver<FlutterApp> resolve,
-        PromiseRejecter _,
-      ) async {
-        await _runApp();
-        // Return the App that was just started
-        resolve.resolve(_prepareFlutterApp());
-      }));
-    }));
+    return FlutterAppRunner(runApp: (([RunAppFnParameters? params]) => futureToPromise(() async {
+      await _runApp();
+      return _prepareFlutterApp() as JSAny;
+    }())).toJS);
   }
 
   /// Represents the App that was just started, and its JS API.

--- a/lib/web_ui/lib/src/engine/app_bootstrap.dart
+++ b/lib/web_ui/lib/src/engine/app_bootstrap.dart
@@ -2,11 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
-
 import 'configuration.dart';
 import 'js_interop/js_loader.dart';
-import 'js_interop/js_promise.dart';
 
 /// The type of a function that initializes an engine (in Dart).
 typedef InitEngineFn = Future<void> Function([JsFlutterConfiguration? params]);
@@ -40,26 +37,26 @@ class AppBootstrap {
       // This is a convenience method that lets the programmer call "autoStart"
       // from JavaScript immediately after the main.dart.js has loaded.
       // Returns a promise that resolves to the Flutter app that was started.
-      autoStart: (() => futureToPromise(() async {
+      autoStart: () async {
         await autoStart();
         // Return the App that was just started
-        return _prepareFlutterApp() as JSAny;
-      }())).toJS,
+        return _prepareFlutterApp();
+      },
       // Calls [_initEngine], and returns a JS Promise that resolves to an
       // app runner object.
-      initializeEngine: (([JsFlutterConfiguration? configuration]) => futureToPromise(() async {
+      initializeEngine: ([JsFlutterConfiguration? configuration]) async {
         await _initializeEngine(configuration);
-        return _prepareAppRunner() as JSAny;
-      }())).toJS
+        return _prepareAppRunner();
+      }
     );
   }
 
   /// Creates an appRunner that runs our encapsulated runApp function.
   FlutterAppRunner _prepareAppRunner() {
-    return FlutterAppRunner(runApp: (([RunAppFnParameters? params]) => futureToPromise(() async {
+    return FlutterAppRunner(runApp: ([RunAppFnParameters? params]) async {
       await _runApp();
-      return _prepareFlutterApp() as JSAny;
-    }())).toJS);
+      return _prepareFlutterApp();
+    });
   }
 
   /// Represents the App that was just started, and its JS API.

--- a/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
@@ -142,7 +142,7 @@ Future<ByteBuffer> readVideoFramePixelsUnmodified(VideoFrame videoFrame) async {
   // In dart2wasm, Uint8List is not the same as a JS Uint8Array. So we
   // explicitly construct the JS object here.
   final JSUint8Array destination = createUint8ArrayFromLength(size);
-  final JsPromise copyPromise = videoFrame.copyTo(destination);
+  final JSPromise copyPromise = videoFrame.copyTo(destination);
   await promiseToFuture<void>(copyPromise);
 
   // In dart2wasm, `toDart` incurs a copy here. On JS backends, this is a

--- a/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
@@ -9,9 +9,6 @@ import 'dart:js_interop';
 
 import 'package:js/js_util.dart' as js_util;
 
-import '../configuration.dart';
-import 'js_promise.dart';
-
 @JS()
 @staticInterop
 class FlutterJS {}
@@ -45,21 +42,10 @@ extension FlutterLoaderExtension on FlutterLoader {
 @staticInterop
 abstract class FlutterEngineInitializer{
   external factory FlutterEngineInitializer({
-    required InitializeEngineFn initializeEngine,
-    required ImmediateRunAppFn autoStart,
+    required JSFunction initializeEngine,
+    required JSFunction autoStart,
   });
 }
-
-/// Typedef for the function that initializes the flutter engine.
-///
-/// [JsFlutterConfiguration] comes from `../configuration.dart`. It is the same
-/// object that can be used to configure flutter "inline", through the
-/// (to be deprecated) `window.flutterConfiguration` object.
-typedef InitializeEngineFn = Promise<FlutterAppRunner> Function([JsFlutterConfiguration?]);
-
-/// Typedef for the `autoStart` function that can be called straight from an engine initializer instance.
-/// (Similar to [RunAppFn], but taking no specific "runApp" parameters).
-typedef ImmediateRunAppFn = Promise<FlutterApp> Function();
 
 // FlutterAppRunner
 
@@ -71,7 +57,7 @@ typedef ImmediateRunAppFn = Promise<FlutterApp> Function();
 abstract class FlutterAppRunner {
   /// Runs a flutter app
   external factory FlutterAppRunner({
-    required RunAppFn runApp, // Returns an App
+    required JSFunction runApp, // Returns an App
   });
 }
 
@@ -82,9 +68,6 @@ abstract class FlutterAppRunner {
 @staticInterop
 abstract class RunAppFnParameters {
 }
-
-/// Typedef for the function that runs the flutter app main entrypoint.
-typedef RunAppFn = Promise<FlutterApp> Function([RunAppFnParameters?]);
 
 // FlutterApp
 

--- a/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
@@ -75,7 +75,7 @@ abstract class FlutterEngineInitializer{
 @staticInterop
 abstract class FlutterAppRunner extends JSObject {
   factory FlutterAppRunner({required RunAppFn runApp,}) => FlutterAppRunner._(
-    runApp: ((RunAppFnParameters args) => runApp(args)).toJS
+    runApp: ((RunAppFnParameters args) => futureToPromise(runApp(args))).toJS
   );
 
   /// Runs a flutter app
@@ -90,6 +90,7 @@ abstract class FlutterAppRunner extends JSObject {
 @anonymous
 @staticInterop
 abstract class RunAppFnParameters {
+  external factory RunAppFnParameters();
 }
 
 /// Typedef for the function that runs the flutter app main entrypoint.

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -196,20 +196,6 @@ bool get _defaultBrowserSupportsImageDecoder =>
 // enable it explicitly.
 bool get _isBrowserImageDecoderStable => browserEngine == BrowserEngine.blink;
 
-/// The signature of the function passed to the constructor of JavaScript `Promise`.
-typedef JsPromiseCallback = void Function(void Function(Object? value) resolve, void Function(Object? error) reject);
-
-/// Corresponds to JavaScript's `Promise`.
-///
-/// This type doesn't need any members. Instead, it should be first converted
-/// to Dart's [Future] using [promiseToFuture] then interacted with through the
-/// [Future] API.
-@JS('window.Promise')
-@staticInterop
-class JsPromise {
-  external factory JsPromise(JsPromiseCallback callback);
-}
-
 /// Corresponds to the browser's `ImageDecoder` type.
 ///
 /// See also:
@@ -228,7 +214,7 @@ extension ImageDecoderExtension on ImageDecoder {
   external JSBoolean get _complete;
   bool get complete => _complete.toDart;
 
-  external JsPromise decode(DecodeOptions options);
+  external JSPromise decode(DecodeOptions options);
   external JSVoid close();
 }
 
@@ -302,8 +288,8 @@ extension VideoFrameExtension on VideoFrame {
   double allocationSize() => _allocationSize().toDartDouble;
 
   @JS('copyTo')
-  external JsPromise _copyTo(JSAny destination);
-  JsPromise copyTo(Object destination) => _copyTo(destination.toJSAnyShallow);
+  external JSPromise _copyTo(JSAny destination);
+  JSPromise copyTo(Object destination) => _copyTo(destination.toJSAnyShallow);
 
   @JS('format')
   external JSString? get _format;
@@ -344,7 +330,7 @@ extension VideoFrameExtension on VideoFrame {
 class ImageTrackList {}
 
 extension ImageTrackListExtension on ImageTrackList {
-  external JsPromise get ready;
+  external JSPromise get ready;
   external ImageTrack? get selectedTrack;
 }
 

--- a/lib/web_ui/test/engine/app_bootstrap_test.dart
+++ b/lib/web_ui/test/engine/app_bootstrap_test.dart
@@ -88,9 +88,17 @@ void testMain() {
 
     final FlutterEngineInitializer engineInitializer = bootstrap.prepareEngineInitializer();
 
-    final Object appInitializer = await promiseToFuture<Object>(callMethod<Object>(engineInitializer, 'initializeEngine', <Object?>[]));
-    final Object maybeApp = await promiseToFuture<Object>(callMethod<Object>(appInitializer, 'runApp', <Object?>[]));
-
+    final Object appInitializer = await promiseToFuture<Object>(callMethod<Object>(
+      engineInitializer,
+      'initializeEngine',
+      <Object?>[]
+    ));
+    expect(appInitializer, isA<FlutterAppRunner>());
+    final Object maybeApp = await promiseToFuture<Object>(callMethod<Object>(
+      appInitializer,
+      'runApp',
+      <Object?>[RunAppFnParameters()]
+    ));
     expect(maybeApp, isA<FlutterApp>());
     expect(initCalled, 1, reason: 'initEngine should have been called.');
     expect(runCalled, 2, reason: 'runApp should have been called.');

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:js_interop';
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
@@ -331,19 +332,18 @@ Future<void> testMain() async {
     // The `orientation` property cannot be overridden, so this test overrides the entire `screen`.
     js_util.setProperty(domWindow, 'screen', js_util.jsify(<Object?, Object?>{
       'orientation': <Object?, Object?>{
-        'lock': allowInterop((String lockType) {
+        'lock': (String lockType) {
           lockCalls.add(lockType);
-          return Promise<Object?>(allowInterop((PromiseResolver<Object?> resolve, PromiseRejecter reject) {
-            if (!simulateError) {
-              resolve.resolve(null);
-            } else {
-              reject.reject('Simulating error');
+          return futureToPromise(() async {
+            if (simulateError) {
+              throw Error();
             }
-          }));
-        }),
-        'unlock': allowInterop(() {
+            return 0.toJS;
+          }());
+        }.toJS,
+        'unlock': () {
           unlockCount += 1;
-        }),
+        }.toJS,
       },
     }));
 


### PR DESCRIPTION
Our JSPromise hackery is causing some issues with the new dart roll. We should just use the `JSPromise` and `JSFunction` support to simplify this. Note that I still have to do *some* hackery to construct `JSPromise` objects and to invoke `JSFunction` objects, and eventually we'll probably be able to simplify this even more once those APIs are baked into `dart:js_interop`