### PR TITLE
Fix damage calculation when not providing populate_existing_damage for gl embedder

### DIFF
--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -27,8 +27,6 @@ struct GLFrameInfo {
 struct GLFBOInfo {
   // The frame buffer's ID.
   uint32_t fbo_id;
-  // This boolean flags whether the returned FBO supports partial repaint.
-  const bool partial_repaint_enabled;
   // The frame buffer's existing damage (i.e. damage since it was last used).
   const std::optional<SkIRect> existing_damage;
 };

--- a/shell/platform/android/android_surface_gl_skia.cc
+++ b/shell/platform/android/android_surface_gl_skia.cc
@@ -166,7 +166,6 @@ GLFBOInfo AndroidSurfaceGLSkia::GLContextFBO(GLFrameInfo frame_info) const {
   // The default window bound framebuffer on Android.
   return GLFBOInfo{
       .fbo_id = 0,
-      .partial_repaint_enabled = onscreen_surface_->SupportsPartialRepaint(),
       .existing_damage = onscreen_surface_->InitialDamage(),
   };
 }

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -1298,3 +1298,25 @@ void channel_listener_response() async {
   });
   signalNativeTest();
 }
+
+@pragma('vm:entry-point')
+void render_gradient_retained() {
+  OffsetEngineLayer? offsetLayer; // Retain the offset layer.
+  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+    Size size = Size(800.0, 600.0);
+
+    SceneBuilder builder = SceneBuilder();
+
+    offsetLayer = builder.pushOffset(0.0, 0.0, oldLayer: offsetLayer);
+
+    // display_list_layer will comparing the display_list
+    // no need to retain the picture
+    builder.addPicture(
+        Offset(0.0, 0.0), CreateGradientBox(size)); // gradient - flutter
+
+    builder.pop();
+
+    PlatformDispatcher.instance.views.first.render(builder.build());
+  };
+  PlatformDispatcher.instance.scheduleFrame();
+}


### PR DESCRIPTION
# Description

This PR fixes the `gl_populate_existing_damage` in embedder.cc, which currently returns an empty rectangle when a full repaint is needed. This leads to the `frame_damage` being considered empty in rasterizer.cc, causing incorrect partial repaint within Flutter when `gl_populate_existing_damage` is not provided by the embedder.


# Related Issue

https://github.com/flutter/flutter/issues/119601

# Tests

Add a new test. Also fixes damage calculation related tests in EmbedderTest by

* Use a new Dart embedder fixture entry point `render_gradient_retained` which retains the old layer to make sure layer tree diff happens.
* Add `latch.Wait()` after `SetGLPresentCallback` to make sure assertions have been executed.
* Make `existing_damage_rects` static since it should be valid after `populate_existing_damage` returns.



