### PR TITLE
Reduce unnecessary Dart_TimelineGetMicros call

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -123,14 +123,17 @@ void Animator::BeginFrame(
           if (!self) {
             return;
           }
-          auto now = fml::TimeDelta::FromMicroseconds(Dart_TimelineGetMicros());
           // If there's a frame scheduled, bail.
           // If there's no frame scheduled, but we're not yet past the last
           // vsync deadline, bail.
-          if (!self->frame_scheduled_ && now > self->dart_frame_deadline_) {
-            TRACE_EVENT0("flutter", "BeginFrame idle callback");
-            self->delegate_.OnAnimatorNotifyIdle(
-                now + fml::TimeDelta::FromMilliseconds(100));
+          if (!self->frame_scheduled_) {
+            auto now =
+                fml::TimeDelta::FromMicroseconds(Dart_TimelineGetMicros());
+            if (now > self->dart_frame_deadline_) {
+              TRACE_EVENT0("flutter", "BeginFrame idle callback");
+              self->delegate_.OnAnimatorNotifyIdle(
+                  now + fml::TimeDelta::FromMilliseconds(100));
+            }
           }
         },
         kNotifyIdleTaskWaitTime);


### PR DESCRIPTION
Minor changes that reduce unnecessary Dart_TimelineGetMicros calls.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
