### PR TITLE
Use safer GrDirectContext APIs

### DIFF
--- a/display_list/benchmarking/dl_benchmarks.cc
+++ b/display_list/benchmarking/dl_benchmarks.cc
@@ -14,6 +14,7 @@
 #include "third_party/skia/include/core/SkTextBlob.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/GrRecordingContext.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
 
 namespace flutter {
 namespace testing {
@@ -47,7 +48,7 @@ static void FlushSubmitCpuSync(const sk_sp<SkSurface>& surface) {
   }
   if (GrDirectContext* dContext =
           GrAsDirectContext(surface->recordingContext())) {
-    dContext->flushAndSubmit(surface, /*syncCpu=*/true);
+    dContext->flushAndSubmit(surface.get(), GrSyncCpu::kYes);
   }
 }
 

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -25,6 +25,7 @@
 #include "third_party/skia/include/effects/SkImageFilters.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/GrRecordingContext.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
 
 namespace flutter {
 namespace testing {
@@ -501,7 +502,7 @@ class RenderEnvironment {
 
     if (GrDirectContext* dContext =
             GrAsDirectContext(surface->recordingContext())) {
-      dContext->flushAndSubmit(surface, /*syncCpu=*/true);
+      dContext->flushAndSubmit(surface.get(), GrSyncCpu::kYes);
     }
     return std::make_unique<RenderResult>(surface);
   }
@@ -4203,7 +4204,8 @@ class DisplayListNopTest : public DisplayListCanvas {
       if (GrDirectContext* direct_context = GrAsDirectContext(
               result_surface->sk_surface()->recordingContext())) {
         direct_context->flushAndSubmit();
-        direct_context->flushAndSubmit(result_surface->sk_surface(), true);
+        direct_context->flushAndSubmit(result_surface->sk_surface().get(),
+                                       GrSyncCpu::kYes);
       }
       auto result_pixels =
           std::make_unique<RenderResult>(result_surface->sk_surface());
@@ -4264,7 +4266,8 @@ class DisplayListNopTest : public DisplayListCanvas {
       if (GrDirectContext* direct_context = GrAsDirectContext(
               result_surface->sk_surface()->recordingContext())) {
         direct_context->flushAndSubmit();
-        direct_context->flushAndSubmit(result_surface->sk_surface(), true);
+        direct_context->flushAndSubmit(result_surface->sk_surface().get(),
+                                       GrSyncCpu::kYes);
       }
       auto result_pixels =
           std::make_unique<RenderResult>(result_surface->sk_surface());

--- a/flow/skia_gpu_object.h
+++ b/flow/skia_gpu_object.h
@@ -15,6 +15,7 @@
 #include "third_party/skia/include/core/SkRefCnt.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
 
 namespace flutter {
 
@@ -129,7 +130,7 @@ class UnrefQueue : public fml::RefCountedThreadSafe<UnrefQueue<T>> {
         context->performDeferredCleanup(std::chrono::milliseconds(0));
       }
 
-      context->flushAndSubmit(true);
+      context->flushAndSubmit(GrSyncCpu::kYes);
     }
   }
 

--- a/flow/skia_gpu_object_unittests.cc
+++ b/flow/skia_gpu_object_unittests.cc
@@ -13,6 +13,7 @@
 #include "flutter/testing/thread_test.h"
 #include "gtest/gtest.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
 
 namespace flutter {
 namespace testing {
@@ -43,7 +44,7 @@ class TestResourceContext : public TestSkObject {
   ~TestResourceContext() = default;
   void performDeferredCleanup(std::chrono::milliseconds msNotUsed) {}
   void deleteBackendTexture(const GrBackendTexture& texture) {}
-  void flushAndSubmit(bool syncCpu) {}
+  void flushAndSubmit(GrSyncCpu sync) {}
 };
 
 class SkiaGpuObjectTest : public ThreadTest {

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -29,6 +29,7 @@
 #include "third_party/skia/include/encode/SkPngEncoder.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 #include "third_party/skia/include/utils/SkBase64.h"
 
@@ -111,7 +112,7 @@ void Rasterizer::Teardown() {
     if (context_switch->GetResult()) {
       compositor_context_->OnGrContextDestroyed();
       if (auto* context = surface_->GetContext()) {
-        context->purgeUnlockedResources(/*scratchResourcesOnly=*/false);
+        context->purgeUnlockedResources(GrPurgeResourceOptions::kAllResources);
       }
     }
     surface_.reset();

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -17,6 +17,7 @@
 
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 
 #include "gmock/gmock.h"
@@ -1014,7 +1015,7 @@ TEST(RasterizerTest, TeardownFreesResourceCache) {
 
   SkPaint paint;
   sk_surface->getCanvas()->drawPaint(paint);
-  context->flushAndSubmit(true);
+  context->flushAndSubmit(GrSyncCpu::kYes);
 
   EXPECT_EQ(context->getResourceCachePurgeableBytes(), 0ul);
 

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -27,6 +27,7 @@
 #include "flutter/shell/common/thread_host.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSerialProcs.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
 #include "third_party/skia/include/ports/SkFontMgr_fuchsia.h"
 
 #include "../runtime/dart/utils/files.h"
@@ -944,7 +945,8 @@ void Engine::WarmupSkps(
             };
 
             surface_producer->gr_context()->flush(flush_info);
-            surface_producer->gr_context()->submit(synchronous);
+            surface_producer->gr_context()->submit(
+                synchronous ? GrSyncCpu::kYes : GrSyncCpu::kNo);
           }
         } else {
           if (i == count - 1) {


### PR DESCRIPTION
In http://review.skia.org/750403 and http://review.skia.org/751523, Skia modified some `GrDirectContext` APIs to make them less error-prone in response to https://crbug.com/1475906. This updates Flutter to call those modified APIs.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
