### PR TITLE
Revert "Remove some of our hacks around JSPromise now that we have better APIs."

### DIFF
--- a/lib/web_ui/lib/src/engine/app_bootstrap.dart
+++ b/lib/web_ui/lib/src/engine/app_bootstrap.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:js/js_util.dart' show allowInterop;
+
 import 'configuration.dart';
 import 'js_interop/js_loader.dart';
+import 'js_interop/js_promise.dart';
 
 /// The type of a function that initializes an engine (in Dart).
 typedef InitEngineFn = Future<void> Function([JsFlutterConfiguration? params]);
@@ -37,26 +40,33 @@ class AppBootstrap {
       // This is a convenience method that lets the programmer call "autoStart"
       // from JavaScript immediately after the main.dart.js has loaded.
       // Returns a promise that resolves to the Flutter app that was started.
-      autoStart: () async {
+      autoStart: allowInterop(() => futureToPromise(() async {
         await autoStart();
         // Return the App that was just started
         return _prepareFlutterApp();
-      },
+      }())),
       // Calls [_initEngine], and returns a JS Promise that resolves to an
       // app runner object.
-      initializeEngine: ([JsFlutterConfiguration? configuration]) async {
+      initializeEngine: allowInterop(([JsFlutterConfiguration? configuration]) => futureToPromise(() async {
         await _initializeEngine(configuration);
         return _prepareAppRunner();
-      }
+      }()))
     );
   }
 
   /// Creates an appRunner that runs our encapsulated runApp function.
   FlutterAppRunner _prepareAppRunner() {
-    return FlutterAppRunner(runApp: ([RunAppFnParameters? params]) async {
-      await _runApp();
-      return _prepareFlutterApp();
-    });
+    return FlutterAppRunner(runApp: allowInterop(([RunAppFnParameters? params]) {
+      // `params` coming from JS may be used to configure the run app method.
+      return Promise<FlutterApp>(allowInterop((
+        PromiseResolver<FlutterApp> resolve,
+        PromiseRejecter _,
+      ) async {
+        await _runApp();
+        // Return the App that was just started
+        resolve.resolve(_prepareFlutterApp());
+      }));
+    }));
   }
 
   /// Represents the App that was just started, and its JS API.

--- a/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_web_codecs.dart
@@ -142,7 +142,7 @@ Future<ByteBuffer> readVideoFramePixelsUnmodified(VideoFrame videoFrame) async {
   // In dart2wasm, Uint8List is not the same as a JS Uint8Array. So we
   // explicitly construct the JS object here.
   final JSUint8Array destination = createUint8ArrayFromLength(size);
-  final JSPromise copyPromise = videoFrame.copyTo(destination);
+  final JsPromise copyPromise = videoFrame.copyTo(destination);
   await promiseToFuture<void>(copyPromise);
 
   // In dart2wasm, `toDart` incurs a copy here. On JS backends, this is a

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -196,6 +196,20 @@ bool get _defaultBrowserSupportsImageDecoder =>
 // enable it explicitly.
 bool get _isBrowserImageDecoderStable => browserEngine == BrowserEngine.blink;
 
+/// The signature of the function passed to the constructor of JavaScript `Promise`.
+typedef JsPromiseCallback = void Function(void Function(Object? value) resolve, void Function(Object? error) reject);
+
+/// Corresponds to JavaScript's `Promise`.
+///
+/// This type doesn't need any members. Instead, it should be first converted
+/// to Dart's [Future] using [promiseToFuture] then interacted with through the
+/// [Future] API.
+@JS('window.Promise')
+@staticInterop
+class JsPromise {
+  external factory JsPromise(JsPromiseCallback callback);
+}
+
 /// Corresponds to the browser's `ImageDecoder` type.
 ///
 /// See also:
@@ -214,7 +228,7 @@ extension ImageDecoderExtension on ImageDecoder {
   external JSBoolean get _complete;
   bool get complete => _complete.toDart;
 
-  external JSPromise decode(DecodeOptions options);
+  external JsPromise decode(DecodeOptions options);
   external JSVoid close();
 }
 
@@ -288,8 +302,8 @@ extension VideoFrameExtension on VideoFrame {
   double allocationSize() => _allocationSize().toDartDouble;
 
   @JS('copyTo')
-  external JSPromise _copyTo(JSAny destination);
-  JSPromise copyTo(Object destination) => _copyTo(destination.toJSAnyShallow);
+  external JsPromise _copyTo(JSAny destination);
+  JsPromise copyTo(Object destination) => _copyTo(destination.toJSAnyShallow);
 
   @JS('format')
   external JSString? get _format;
@@ -330,7 +344,7 @@ extension VideoFrameExtension on VideoFrame {
 class ImageTrackList {}
 
 extension ImageTrackListExtension on ImageTrackList {
-  external JSPromise get ready;
+  external JsPromise get ready;
   external ImageTrack? get selectedTrack;
 }
 

--- a/lib/web_ui/test/engine/app_bootstrap_test.dart
+++ b/lib/web_ui/test/engine/app_bootstrap_test.dart
@@ -88,17 +88,9 @@ void testMain() {
 
     final FlutterEngineInitializer engineInitializer = bootstrap.prepareEngineInitializer();
 
-    final Object appInitializer = await promiseToFuture<Object>(callMethod<Object>(
-      engineInitializer,
-      'initializeEngine',
-      <Object?>[]
-    ));
-    expect(appInitializer, isA<FlutterAppRunner>());
-    final Object maybeApp = await promiseToFuture<Object>(callMethod<Object>(
-      appInitializer,
-      'runApp',
-      <Object?>[RunAppFnParameters()]
-    ));
+    final Object appInitializer = await promiseToFuture<Object>(callMethod<Object>(engineInitializer, 'initializeEngine', <Object?>[]));
+    final Object maybeApp = await promiseToFuture<Object>(callMethod<Object>(appInitializer, 'runApp', <Object?>[]));
+
     expect(maybeApp, isA<FlutterApp>());
     expect(initCalled, 1, reason: 'initEngine should have been called.');
     expect(runCalled, 2, reason: 'runApp should have been called.');

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:js_interop';
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
@@ -332,18 +331,19 @@ Future<void> testMain() async {
     // The `orientation` property cannot be overridden, so this test overrides the entire `screen`.
     js_util.setProperty(domWindow, 'screen', js_util.jsify(<Object?, Object?>{
       'orientation': <Object?, Object?>{
-        'lock': (String lockType) {
+        'lock': allowInterop((String lockType) {
           lockCalls.add(lockType);
-          return futureToPromise(() async {
-            if (simulateError) {
-              throw Error();
+          return Promise<Object?>(allowInterop((PromiseResolver<Object?> resolve, PromiseRejecter reject) {
+            if (!simulateError) {
+              resolve.resolve(null);
+            } else {
+              reject.reject('Simulating error');
             }
-            return 0.toJS;
-          }());
-        }.toJS,
-        'unlock': () {
+          }));
+        }),
+        'unlock': allowInterop(() {
           unlockCount += 1;
-        }.toJS,
+        }),
       },
     }));
 


### PR DESCRIPTION
Reverts flutter/engine#45591

This is somehow causing some issues with the hot reload tests and blocking engine -> framework rolls. See https://github.com/flutter/flutter/pull/134455