### PR TITLE
Pipe VMA asserts to FML.

### DIFF
--- a/flutter_vma/BUILD.gn
+++ b/flutter_vma/BUILD.gn
@@ -15,6 +15,7 @@ source_set("flutter_vma") {
   }
 
   public_deps = [
+    "//flutter/fml",
     "//third_party/vulkan-deps/vulkan-headers/src:vulkan_headers",
     "//third_party/vulkan_memory_allocator",
   ]

--- a/flutter_vma/flutter_vma.cc
+++ b/flutter_vma/flutter_vma.cc
@@ -31,4 +31,11 @@ void VMADebugPrint(const char* message, ...) {
 }
 #endif
 
+#include "flutter/fml/logging.h"
+
+#define VMA_ASSERT(expr) \
+  FML_DCHECK((expr)) << "Vulkan Memory Allocator Failure!"
+#define VMA_HEAVY_ASSERT(expr) \
+  FML_DCHECK((expr)) << "Vulkan Memory Allocator Failure!"
+
 #include "flutter/flutter_vma/flutter_vma.h"


### PR DESCRIPTION
These are still only enabled in unopt modes (we can tweak this later). Asserts sometimes may not get piped to the loggers Flutter engine developers usually use. This now brings assertions back in the control of the engine.