### PR TITLE
[Impeller] If validations are enabled but not found, still create the VK context.

### DIFF
--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -100,7 +100,7 @@ class CapabilitiesVK final : public Capabilities,
   PixelFormat GetDefaultDepthStencilFormat() const override;
 
  private:
-  const bool enable_validations_;
+  bool validations_enabled_ = false;
   std::map<std::string, std::set<std::string>> exts_;
   std::set<OptionalDeviceExtensionVK> optional_device_extensions_;
   mutable PixelFormat default_color_format_ = PixelFormat::kUnknown;

--- a/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -83,5 +83,13 @@ TEST(ContextVKTest, DeletePipelineLibraryAfterContext) {
                         "vkDestroyDevice") != functions->end());
 }
 
+TEST(ContextVKTest, CanCreateContextInAbsenceOfValidationLayers) {
+  // The mocked methods don't report the presence of a validation layer but we
+  // explicitly ask for validation. Context creation should continue anyway.
+  auto context = CreateMockVulkanContext(
+      [](auto& settings) { settings.enable_validation = true; });
+  ASSERT_NE(context, nullptr);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -490,10 +490,14 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
 
 }  // namespace
 
-std::shared_ptr<ContextVK> CreateMockVulkanContext(void) {
-  ContextVK::Settings settings;
+std::shared_ptr<ContextVK> CreateMockVulkanContext(
+    const std::function<void(ContextVK::Settings&)>& settings_callback) {
   auto message_loop = fml::ConcurrentMessageLoop::Create();
+  ContextVK::Settings settings;
   settings.proc_address_callback = GetMockVulkanProcAddress;
+  if (settings_callback) {
+    settings_callback(settings);
+  }
   return ContextVK::Create(std::move(settings));
 }
 

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -15,7 +16,18 @@ namespace testing {
 std::shared_ptr<std::vector<std::string>> GetMockVulkanFunctions(
     VkDevice device);
 
-std::shared_ptr<ContextVK> CreateMockVulkanContext(void);
+//------------------------------------------------------------------------------
+/// @brief      Create a Vulkan context with Vulkan functions mocked. The caller
+///             is given a chance to tinker on the settings right before a
+///             context is created.
+///
+/// @param[in]  settings_callback  The settings callback
+///
+/// @return     A context if one can be created.
+///
+std::shared_ptr<ContextVK> CreateMockVulkanContext(
+    const std::function<void(ContextVK::Settings&)>& settings_callback =
+        nullptr);
 
 }  // namespace testing
 }  // namespace impeller

--- a/shell/platform/android/android_context_vulkan_impeller.cc
+++ b/shell/platform/android/android_context_vulkan_impeller.cc
@@ -38,14 +38,17 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
   settings.cache_directory = fml::paths::GetCachesDirectory();
   settings.enable_validation = enable_vulkan_validation;
 
-  if (settings.enable_validation) {
+  auto context = impeller::ContextVK::Create(std::move(settings));
+
+  if (context && impeller::CapabilitiesVK::Cast(*context->GetCapabilities())
+                     .AreValidationsEnabled()) {
     FML_LOG(ERROR) << "Using the Impeller rendering backend (Vulkan with "
                       "Validation Layers).";
   } else {
     FML_LOG(ERROR) << "Using the Impeller rendering backend (Vulkan).";
   }
 
-  return impeller::ContextVK::Create(std::move(settings));
+  return context;
 }
 
 AndroidContextVulkanImpeller::AndroidContextVulkanImpeller(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/131714
