### PR TITLE
[fuchsia] Restructure Flatland vsync loop (#45531)

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -354,8 +354,6 @@ void Engine::Initialize(
        view_protocols = std::move(view_protocols),
        request = parent_viewport_watcher.NewRequest(),
        view_ref_pair = std::move(view_ref_pair),
-       max_frames_in_flight = product_config.get_max_frames_in_flight(),
-       vsync_offset = product_config.get_vsync_offset(),
        software_rendering = product_config.software_rendering()]() mutable {
         if (software_rendering) {
           surface_producer_ = std::make_shared<SoftwareSurfaceProducer>();
@@ -365,8 +363,7 @@ void Engine::Initialize(
 
         flatland_connection_ = std::make_shared<FlatlandConnection>(
             thread_label_, std::move(flatland),
-            std::move(session_error_callback), [](auto) {},
-            max_frames_in_flight, vsync_offset);
+            std::move(session_error_callback), [](auto) {});
 
         fuchsia::ui::views::ViewIdentityOnCreation view_identity = {
             .view_ref = std::move(view_ref_pair.second),

--- a/shell/platform/fuchsia/flutter/flatland_connection.cc
+++ b/shell/platform/fuchsia/flutter/flatland_connection.cc
@@ -13,11 +13,10 @@ namespace flutter_runner {
 
 namespace {
 
-fml::TimePoint GetNextPresentationTime(fml::TimePoint now,
-                                       fml::TimePoint next_presentation_time) {
-  return now > next_presentation_time
-             ? now + flutter_runner::kDefaultFlatlandPresentationInterval
-             : next_presentation_time;
+// Helper function for traces.
+double DeltaFromNowInNanoseconds(const fml::TimePoint& now,
+                                 const fml::TimePoint& time) {
+  return (time - now).ToNanoseconds();
 }
 
 }  // namespace
@@ -26,9 +25,7 @@ FlatlandConnection::FlatlandConnection(
     std::string debug_label,
     fuchsia::ui::composition::FlatlandHandle flatland,
     fml::closure error_callback,
-    on_frame_presented_event on_frame_presented_callback,
-    uint64_t max_frames_in_flight,
-    fml::TimeDelta vsync_offset)
+    on_frame_presented_event on_frame_presented_callback)
     : flatland_(flatland.Bind()),
       error_callback_(error_callback),
       on_frame_presented_callback_(std::move(on_frame_presented_callback)) {
@@ -49,11 +46,9 @@ FlatlandConnection::~FlatlandConnection() = default;
 
 // This method is called from the raster thread.
 void FlatlandConnection::Present() {
-  if (!threadsafe_state_.first_present_called_) {
-    std::scoped_lock<std::mutex> lock(threadsafe_state_.mutex_);
-    threadsafe_state_.first_present_called_ = true;
-  }
-  if (present_credits_ > 0) {
+  TRACE_DURATION("flutter", "FlatlandConnection::Present");
+  std::scoped_lock<std::mutex> lock(threadsafe_state_.mutex_);
+  if (threadsafe_state_.present_credits_ > 0) {
     DoPresent();
   } else {
     present_waiting_for_credit_ = true;
@@ -66,14 +61,15 @@ void FlatlandConnection::DoPresent() {
   TRACE_FLOW_BEGIN("gfx", "Flatland::Present", next_present_trace_id_);
   ++next_present_trace_id_;
 
-  FML_CHECK(present_credits_ > 0);
-  --present_credits_;
+  FML_CHECK(threadsafe_state_.present_credits_ > 0);
+  --threadsafe_state_.present_credits_;
 
   fuchsia::ui::composition::PresentArgs present_args;
   present_args.set_requested_presentation_time(0);
   present_args.set_acquire_fences(std::move(acquire_fences_));
   present_args.set_release_fences(std::move(previous_present_release_fences_));
-  present_args.set_unsquashable(false);
+  // Frame rate over latency.
+  present_args.set_unsquashable(true);
   flatland_->Present(std::move(present_args));
 
   // In Flatland, release fences apply to the content of the previous present.
@@ -86,38 +82,44 @@ void FlatlandConnection::DoPresent() {
 
 // This method is called from the UI thread.
 void FlatlandConnection::AwaitVsync(FireCallbackCallback callback) {
-  std::scoped_lock<std::mutex> lock(threadsafe_state_.mutex_);
-  const fml::TimePoint now = fml::TimePoint::Now();
+  TRACE_DURATION("flutter", "FlatlandConnection::AwaitVsync");
 
-  // Immediately fire callbacks until the first Present. We might receive
-  // multiple requests for AwaitVsync() until the first Present, which relies on
-  // receiving size on PlatformView::OnGetLayout() at an uncertain time.
-  if (!threadsafe_state_.first_present_called_) {
-    callback(now, now + kDefaultFlatlandPresentationInterval);
+  std::scoped_lock<std::mutex> lock(threadsafe_state_.mutex_);
+  threadsafe_state_.pending_fire_callback_ = nullptr;
+  const auto now = fml::TimePoint::Now();
+
+  // Initial case.
+  if (MaybeRunInitialVsyncCallback(now, callback))
+    return;
+
+  // Throttle case.
+  if (threadsafe_state_.present_credits_ == 0) {
+    threadsafe_state_.pending_fire_callback_ = callback;
     return;
   }
 
-  threadsafe_state_.fire_callback_ = callback;
-
-  // Immediately fire callback if OnNextFrameBegin() is already called.
-  if (threadsafe_state_.on_next_frame_pending_) {
-    threadsafe_state_.fire_callback_(
-        now, GetNextPresentationTime(
-                 now, threadsafe_state_.next_presentation_time_));
-    threadsafe_state_.fire_callback_ = nullptr;
-    threadsafe_state_.on_next_frame_pending_ = false;
-  }
+  // Regular case.
+  RunVsyncCallback(now, callback);
 }
 
 // This method is called from the UI thread.
 void FlatlandConnection::AwaitVsyncForSecondaryCallback(
     FireCallbackCallback callback) {
-  const fml::TimePoint now = fml::TimePoint::Now();
+  TRACE_DURATION("flutter",
+                 "FlatlandConnection::AwaitVsyncForSecondaryCallback");
+
   std::scoped_lock<std::mutex> lock(threadsafe_state_.mutex_);
-  callback(now, GetNextPresentationTime(
-                    now, threadsafe_state_.next_presentation_time_));
+  const auto now = fml::TimePoint::Now();
+
+  // Initial case.
+  if (MaybeRunInitialVsyncCallback(now, callback))
+    return;
+
+  // Regular case.
+  RunVsyncCallback(now, callback);
 }
 
+// This method is called from the raster thread.
 void FlatlandConnection::OnError(
     fuchsia::ui::composition::FlatlandError error) {
   FML_LOG(ERROR) << "Flatland error: " << static_cast<int>(error);
@@ -127,30 +129,62 @@ void FlatlandConnection::OnError(
 // This method is called from the raster thread.
 void FlatlandConnection::OnNextFrameBegin(
     fuchsia::ui::composition::OnNextFrameBeginValues values) {
-  present_credits_ += values.additional_present_credits();
+  // Collect now before locking because this is an important timing information
+  // from Scenic.
+  const auto now = fml::TimePoint::Now();
 
-  if (present_waiting_for_credit_ && present_credits_ > 0) {
+  std::scoped_lock<std::mutex> lock(threadsafe_state_.mutex_);
+  threadsafe_state_.first_feedback_received_ = true;
+  threadsafe_state_.present_credits_ += values.additional_present_credits();
+  TRACE_DURATION("flutter", "FlatlandConnection::OnNextFrameBegin",
+                 "present_credits", threadsafe_state_.present_credits_);
+
+  if (present_waiting_for_credit_ && threadsafe_state_.present_credits_ > 0) {
     DoPresent();
     present_waiting_for_credit_ = false;
   }
 
-  if (present_credits_ > 0) {
-    FML_CHECK(values.has_future_presentation_infos() &&
-              !values.future_presentation_infos().empty());
-    const auto next_presentation_time =
-        fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromNanoseconds(
-            values.future_presentation_infos().front().presentation_time()));
+  // Update vsync_interval_ by calculating the difference between the first two
+  // presentation times. Flatland always returns >1 presentation_infos, so this
+  // check is to guard against any changes to this assumption.
+  if (values.has_future_presentation_infos() &&
+      values.future_presentation_infos().size() > 1) {
+    threadsafe_state_.vsync_interval_ = fml::TimeDelta::FromNanoseconds(
+        values.future_presentation_infos().at(1).presentation_time() -
+        values.future_presentation_infos().at(0).presentation_time());
+  } else {
+    FML_LOG(WARNING)
+        << "Flatland didn't send enough future_presentation_infos to update "
+           "vsync interval.";
+  }
 
-    std::scoped_lock<std::mutex> lock(threadsafe_state_.mutex_);
-    if (threadsafe_state_.fire_callback_) {
-      threadsafe_state_.fire_callback_(
-          /*frame_start=*/fml::TimePoint::Now(),
-          /*frame_target=*/next_presentation_time);
-      threadsafe_state_.fire_callback_ = nullptr;
-    } else {
-      threadsafe_state_.on_next_frame_pending_ = true;
-    }
-    threadsafe_state_.next_presentation_time_ = next_presentation_time;
+  // Update next_presentation_times_.
+  std::queue<fml::TimePoint> new_times;
+  for (const auto& info : values.future_presentation_infos()) {
+    new_times.emplace(fml::TimePoint::FromEpochDelta(
+        fml::TimeDelta::FromNanoseconds(info.presentation_time())));
+  }
+  threadsafe_state_.next_presentation_times_.swap(new_times);
+
+  // Update vsync_offset_.
+  // We use modulo here because Flatland may point to the following vsync if
+  // OnNextFrameBegin() is called after the current frame's latch point.
+  auto vsync_offset =
+      (fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromNanoseconds(
+           values.future_presentation_infos().front().presentation_time())) -
+       now) %
+      threadsafe_state_.vsync_interval_;
+  // Thread contention may result in OnNextFrameBegin() being called after the
+  // presentation time. Ignore these outliers.
+  if (vsync_offset > fml::TimeDelta::Zero()) {
+    threadsafe_state_.vsync_offset_ = vsync_offset;
+  }
+
+  // Throttle case.
+  if (threadsafe_state_.pending_fire_callback_ &&
+      threadsafe_state_.present_credits_ > 0) {
+    RunVsyncCallback(now, threadsafe_state_.pending_fire_callback_);
+    threadsafe_state_.pending_fire_callback_ = nullptr;
   }
 }
 
@@ -158,6 +192,68 @@ void FlatlandConnection::OnNextFrameBegin(
 void FlatlandConnection::OnFramePresented(
     fuchsia::scenic::scheduling::FramePresentedInfo info) {
   on_frame_presented_callback_(std::move(info));
+}
+
+// Parses and updates next_presentation_times_.
+fml::TimePoint FlatlandConnection::GetNextPresentationTime(
+    const fml::TimePoint& now) {
+  const fml::TimePoint& cutoff =
+      now > threadsafe_state_.last_presentation_time_
+          ? now
+          : threadsafe_state_.last_presentation_time_;
+
+  // Remove presentation times that may have been passed. This may happen after
+  // a long draw call.
+  while (!threadsafe_state_.next_presentation_times_.empty() &&
+         threadsafe_state_.next_presentation_times_.front() <= cutoff) {
+    threadsafe_state_.next_presentation_times_.pop();
+  }
+
+  // Calculate a presentation time based on
+  // |threadsafe_state_.last_presentation_time_| that is later than cutoff using
+  // |vsync_interval| increments if we don't have any future presentation times
+  // left.
+  if (threadsafe_state_.next_presentation_times_.empty()) {
+    auto result = threadsafe_state_.last_presentation_time_;
+    while (result <= cutoff) {
+      result = result + threadsafe_state_.vsync_interval_;
+    }
+    return result;
+  }
+
+  // Return the next presentation time in the queue for the regular case.
+  const auto result = threadsafe_state_.next_presentation_times_.front();
+  threadsafe_state_.next_presentation_times_.pop();
+  return result;
+}
+
+// This method is called from the UI thread.
+bool FlatlandConnection::MaybeRunInitialVsyncCallback(
+    const fml::TimePoint& now,
+    FireCallbackCallback& callback) {
+  if (!threadsafe_state_.first_feedback_received_) {
+    TRACE_DURATION("flutter",
+                   "FlatlandConnection::MaybeRunInitialVsyncCallback");
+    const auto frame_end = now + kInitialFlatlandVsyncOffset;
+    threadsafe_state_.last_presentation_time_ = frame_end;
+    callback(now, frame_end);
+    return true;
+  }
+  return false;
+}
+
+// This method may be called from the raster or UI thread, but it is safe
+// because VsyncWaiter posts the vsync callback on UI thread.
+void FlatlandConnection::RunVsyncCallback(const fml::TimePoint& now,
+                                          FireCallbackCallback& callback) {
+  const auto& frame_end = GetNextPresentationTime(now);
+  const auto& frame_start = frame_end - threadsafe_state_.vsync_offset_;
+  threadsafe_state_.last_presentation_time_ = frame_end;
+  TRACE_DURATION("flutter", "FlatlandConnection::RunVsyncCallback",
+                 "frame_start_delta",
+                 DeltaFromNowInNanoseconds(now, frame_start), "frame_end_delta",
+                 DeltaFromNowInNanoseconds(now, frame_end));
+  callback(frame_start, frame_end);
 }
 
 // This method is called from the raster thread.

--- a/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
+++ b/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
@@ -23,18 +23,6 @@ FlutterRunnerProductConfiguration::FlutterRunnerProductConfiguration(
   }
 
   // Parse out all values we're expecting.
-  if (document.HasMember("vsync_offset_in_us")) {
-    auto& val = document["vsync_offset_in_us"];
-    if (val.IsInt()) {
-      vsync_offset_ = fml::TimeDelta::FromMicroseconds(val.GetInt());
-    }
-  }
-  if (document.HasMember("max_frames_in_flight")) {
-    auto& val = document["max_frames_in_flight"];
-    if (val.IsInt()) {
-      max_frames_in_flight_ = val.GetInt();
-    }
-  }
   if (document.HasMember("intercept_all_input")) {
     auto& val = document["intercept_all_input"];
     if (val.IsBool()) {

--- a/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h
+++ b/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h
@@ -7,8 +7,6 @@
 
 #include <string>
 
-#include "flutter/fml/time/time_delta.h"
-
 namespace flutter_runner {
 
 class FlutterRunnerProductConfiguration {
@@ -16,8 +14,6 @@ class FlutterRunnerProductConfiguration {
   FlutterRunnerProductConfiguration() {}
   explicit FlutterRunnerProductConfiguration(std::string json_string);
 
-  fml::TimeDelta get_vsync_offset() { return vsync_offset_; }
-  uint64_t get_max_frames_in_flight() { return max_frames_in_flight_; }
   bool get_intercept_all_input() { return intercept_all_input_; }
   bool software_rendering() { return software_rendering_; }
   bool enable_shader_warmup() { return enable_shader_warmup_; }
@@ -26,8 +22,6 @@ class FlutterRunnerProductConfiguration {
   }
 
  private:
-  fml::TimeDelta vsync_offset_ = fml::TimeDelta::Zero();
-  uint64_t max_frames_in_flight_ = 3;
   bool intercept_all_input_ = false;
   bool software_rendering_ = false;
   bool enable_shader_warmup_ = false;

--- a/shell/platform/fuchsia/flutter/tests/external_view_embedder_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/external_view_embedder_unittests.cc
@@ -414,12 +414,9 @@ class ExternalViewEmbedderTest : public ::testing::Test {
 
     const auto test_name =
         ::testing::UnitTest::GetInstance()->current_test_info()->name();
-    const auto max_frames_in_flight = 1;
-    const auto vsync_offset = fml::TimeDelta::Zero();
     return std::make_shared<FlatlandConnection>(
         std::move(test_name), std::move(flatland),
-        /*error_callback=*/[] { FAIL(); }, /*ofpe_callback=*/[](auto...) {},
-        max_frames_in_flight, vsync_offset);
+        /*error_callback=*/[] { FAIL(); }, /*ofpe_callback=*/[](auto...) {});
   }
 
   // Primary loop and subloop for the FakeFlatland instance to process its

--- a/shell/platform/fuchsia/flutter/tests/flutter_runner_product_configuration_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flutter_runner_product_configuration_unittests.cc
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include "flutter/fml/time/time_delta.h"
 #include "flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h"
 
 using namespace flutter_runner;
@@ -13,79 +12,24 @@ namespace flutter_runner_test {
 
 class FlutterRunnerProductConfigurationTest : public testing::Test {};
 
-TEST_F(FlutterRunnerProductConfigurationTest, ValidVsyncOffset) {
-  const std::string json_string = "{ \"vsync_offset_in_us\" : 9000 } ";
-  const fml::TimeDelta expected_offset = fml::TimeDelta::FromMicroseconds(9000);
-
-  FlutterRunnerProductConfiguration product_config =
-      FlutterRunnerProductConfiguration(json_string);
-  EXPECT_EQ(product_config.get_vsync_offset(), expected_offset);
-}
-
 TEST_F(FlutterRunnerProductConfigurationTest, InvalidJsonString) {
   const std::string json_string = "{ \"invalid json string\" }}} ";
-  const fml::TimeDelta expected_offset = fml::TimeDelta::FromMicroseconds(0);
+  const uint64_t expected_intercept_all_input = false;
 
   FlutterRunnerProductConfiguration product_config =
       FlutterRunnerProductConfiguration(json_string);
-  EXPECT_EQ(product_config.get_vsync_offset(), expected_offset);
+  EXPECT_EQ(expected_intercept_all_input,
+            product_config.get_intercept_all_input());
 }
 
 TEST_F(FlutterRunnerProductConfigurationTest, EmptyJsonString) {
   const std::string json_string = "";
-  const fml::TimeDelta expected_offset = fml::TimeDelta::FromMicroseconds(0);
+  const uint64_t expected_intercept_all_input = false;
 
   FlutterRunnerProductConfiguration product_config =
       FlutterRunnerProductConfiguration(json_string);
-  EXPECT_EQ(product_config.get_vsync_offset(), expected_offset);
-}
-
-TEST_F(FlutterRunnerProductConfigurationTest, EmptyVsyncOffset) {
-  const std::string json_string = "{ \"vsync_offset_in_us\" : } ";
-  const fml::TimeDelta expected_offset = fml::TimeDelta::FromMicroseconds(0);
-
-  FlutterRunnerProductConfiguration product_config =
-      FlutterRunnerProductConfiguration(json_string);
-  EXPECT_EQ(product_config.get_vsync_offset(), expected_offset);
-}
-
-TEST_F(FlutterRunnerProductConfigurationTest, NegativeVsyncOffset) {
-  const std::string json_string = "{ \"vsync_offset_in_us\" : -15410 } ";
-  const fml::TimeDelta expected_offset =
-      fml::TimeDelta::FromMicroseconds(-15410);
-
-  FlutterRunnerProductConfiguration product_config =
-      FlutterRunnerProductConfiguration(json_string);
-  EXPECT_EQ(product_config.get_vsync_offset(), expected_offset);
-}
-
-TEST_F(FlutterRunnerProductConfigurationTest, NonIntegerVsyncOffset) {
-  const std::string json_string = "{ \"vsync_offset_in_us\" : 3.14159 } ";
-  const fml::TimeDelta expected_offset = fml::TimeDelta::FromMicroseconds(0);
-
-  FlutterRunnerProductConfiguration product_config =
-      FlutterRunnerProductConfiguration(json_string);
-  EXPECT_EQ(product_config.get_vsync_offset(), expected_offset);
-}
-
-TEST_F(FlutterRunnerProductConfigurationTest, ValidMaxFramesInFlight) {
-  const std::string json_string = "{ \"max_frames_in_flight\" : 5 } ";
-  const uint64_t expected_max_frames_in_flight = 5;
-
-  FlutterRunnerProductConfiguration product_config =
-      FlutterRunnerProductConfiguration(json_string);
-  EXPECT_EQ(product_config.get_max_frames_in_flight(),
-            expected_max_frames_in_flight);
-}
-
-TEST_F(FlutterRunnerProductConfigurationTest, MissingMaxFramesInFlight) {
-  const std::string json_string = "{ \"max_frames_in_flight\" :  } ";
-  const uint64_t minimum_reasonable_max_frames_in_flight = 1;
-
-  FlutterRunnerProductConfiguration product_config =
-      FlutterRunnerProductConfiguration(json_string);
-  EXPECT_GE(product_config.get_max_frames_in_flight(),
-            minimum_reasonable_max_frames_in_flight);
+  EXPECT_EQ(expected_intercept_all_input,
+            product_config.get_intercept_all_input());
 }
 
 TEST_F(FlutterRunnerProductConfigurationTest, ValidInterceptAllInput) {


### PR DESCRIPTION
This CL restructures Flatland vsync loop to fire for each vsync instead of each OnNextFrameBegin. As shown in the traces attached to the bug, the current implementation of firing callbacks on each OnNextFrameBegin causes skips when Flutter has longer draw calls. By scheduling frames in between, we are increasing the chance of sending one before the latch point. OnNextFrameBegin is now used to keep track of present credits and future presentation times as well as when to start frame, replacing the need for max_frames_in_flight and vsync_offset fields.

Bug: b/296272449
(cherry picked from commit 633ba427c498d9a5d096ac4979ecaa83ace4deaa)