### PR TITLE
[Impeller] Fix thread leak in ResourceManagerVK.

### DIFF
--- a/impeller/renderer/backend/vulkan/resource_manager_vk.h
+++ b/impeller/renderer/backend/vulkan/resource_manager_vk.h
@@ -78,7 +78,7 @@ class ResourceManagerVK final
   std::mutex reclaimables_mutex_;
   std::condition_variable reclaimables_cv_;
   Reclaimables reclaimables_;
-  bool should_exit_ = false;
+  bool should_exit_;
   // This should be initialized last since it references the other instance
   // variables.
   std::thread waiter_;

--- a/impeller/renderer/backend/vulkan/resource_manager_vk.h
+++ b/impeller/renderer/backend/vulkan/resource_manager_vk.h
@@ -78,7 +78,7 @@ class ResourceManagerVK final
   std::mutex reclaimables_mutex_;
   std::condition_variable reclaimables_cv_;
   Reclaimables reclaimables_;
-  bool should_exit_;
+  bool should_exit_ = false;
   // This should be initialized last since it references the other instance
   // variables.
   std::thread waiter_;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/134482.

I wish I knew how to create the thread in `::Create()`, but given the constructor is private I feel less bad about reverting part of https://github.com/flutter/engine/pull/45474. Added a test that consistently fails before this PR and passes after.

(Unblocks https://github.com/flutter/flutter/issues/133198)