### PR TITLE
Remove @pragma('vm:entry-point') annotations on members that aren't accessed from C++

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -574,7 +574,6 @@ abstract class SceneBuilder {
 
 base class _NativeSceneBuilder extends NativeFieldWrapperClass1 implements SceneBuilder {
   /// Creates an empty [SceneBuilder] object.
-  @pragma('vm:entry-point')
   _NativeSceneBuilder() {
     _constructor();
   }

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -632,7 +632,6 @@ class Rect {
   ///
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltrb.png#gh-light-mode-only)
   /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/rect_from_ltrb_dark.png#gh-dark-mode-only)
-  @pragma('vm:entry-point')
   const Rect.fromLTRB(this.left, this.top, this.right, this.bottom);
 
   /// Construct a rectangle from its left and top edges, its width, and its

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -99,7 +99,6 @@ class Color {
   /// For example, to get a fully opaque orange, you would use `const
   /// Color(0xFFFF9000)` (`FF` for the alpha, `FF` for the red, `90` for the
   /// green, and `00` for the blue).
-  @pragma('vm:entry-point')
   const Color(int value) : value = value & 0xFFFFFFFF;
 
   /// Construct a color from the lower 8 bits of four integers.
@@ -2098,7 +2097,6 @@ abstract class Codec {
   void dispose();
 }
 
-@pragma('vm:entry-point')
 base class _NativeCodec extends NativeFieldWrapperClass1 implements Codec {
   //
   // This class is created by the engine, and should not be instantiated
@@ -2106,7 +2104,6 @@ base class _NativeCodec extends NativeFieldWrapperClass1 implements Codec {
   //
   // To obtain an instance of the [Codec] interface, see
   // [instantiateImageCodec].
-  @pragma('vm:entry-point')
   _NativeCodec._();
 
   int? _cachedFrameCount;
@@ -2574,11 +2571,9 @@ abstract class EngineLayer {
   void dispose();
 }
 
-@pragma('vm:entry-point')
 base class _NativeEngineLayer extends NativeFieldWrapperClass1 implements EngineLayer {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
-  @pragma('vm:entry-point')
   _NativeEngineLayer._();
 
   @override
@@ -2889,10 +2884,8 @@ abstract class Path {
   PathMetrics computeMetrics({bool forceClosed = false});
 }
 
-@pragma('vm:entry-point')
 base class _NativePath extends NativeFieldWrapperClass1 implements Path {
   /// Create a new empty [Path] object.
-  @pragma('vm:entry-point')
   _NativePath() { _constructor(); }
 
   /// Avoids creating a new native backing for the path for methods that will
@@ -5766,7 +5759,6 @@ abstract class Canvas {
 }
 
 base class _NativeCanvas extends NativeFieldWrapperClass1 implements Canvas {
-  @pragma('vm:entry-point')
   _NativeCanvas(PictureRecorder recorder, [ Rect? cullRect ])  {
     if (recorder.isRecording) {
       throw ArgumentError('"recorder" must not already be associated with another Canvas.');
@@ -6305,13 +6297,11 @@ abstract class Picture {
   int get approximateBytesUsed;
 }
 
-@pragma('vm:entry-point')
 base class _NativePicture extends NativeFieldWrapperClass1 implements Picture {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
   ///
   /// To create a [Picture], use a [PictureRecorder].
-  @pragma('vm:entry-point')
   _NativePicture._();
 
   @override
@@ -6410,7 +6400,6 @@ abstract class PictureRecorder {
 }
 
 base class _NativePictureRecorder extends NativeFieldWrapperClass1 implements PictureRecorder {
-  @pragma('vm:entry-point')
   _NativePictureRecorder() { _constructor(); }
 
   @Native<Void Function(Handle)>(symbol: 'PictureRecorder::Create')

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -848,9 +848,7 @@ abstract class SemanticsUpdateBuilder {
   SemanticsUpdate build();
 }
 
-@pragma('vm:entry-point')
 base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1 implements SemanticsUpdateBuilder {
-  @pragma('vm:entry-point')
   _NativeSemanticsUpdateBuilder() { _constructor(); }
 
   @Native<Void Function(Handle)>(symbol: 'SemanticsUpdateBuilder::Create')
@@ -1039,13 +1037,11 @@ abstract class SemanticsUpdate {
   void dispose();
 }
 
-@pragma('vm:entry-point')
 base class _NativeSemanticsUpdate extends NativeFieldWrapperClass1 implements SemanticsUpdate {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
   ///
   /// To create a SemanticsUpdate object, use a [SemanticsUpdateBuilder].
-  @pragma('vm:entry-point')
   _NativeSemanticsUpdate._();
 
   @override

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2314,7 +2314,6 @@ enum TextDirection {
 /// A rectangle enclosing a run of text.
 ///
 /// This is similar to [Rect] but includes an inherent [TextDirection].
-@pragma('vm:entry-point')
 class TextBox {
   /// Creates an object that describes a box containing text.
   const TextBox.fromLTRBD(
@@ -3004,13 +3003,11 @@ abstract class Paragraph {
   bool get debugDisposed;
 }
 
-@pragma('vm:entry-point')
 base class _NativeParagraph extends NativeFieldWrapperClass1 implements Paragraph {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
   ///
   /// To create a [Paragraph] object, use a [ParagraphBuilder].
-  @pragma('vm:entry-point')
   _NativeParagraph._();
 
   bool _needsLayout = true;
@@ -3322,7 +3319,6 @@ abstract class ParagraphBuilder {
 }
 
 base class _NativeParagraphBuilder extends NativeFieldWrapperClass1 implements ParagraphBuilder {
-  @pragma('vm:entry-point')
   _NativeParagraphBuilder(ParagraphStyle style)
     : _defaultLeadingDistribution = style._leadingDistribution {
       List<String>? strutFontFamilies;


### PR DESCRIPTION
The `@pragma('vm:entry-point')` annotation serves as an annotation telling our AOT compiler that the member is needed and cannot be tree-shaken because it may be accessed from the outside (i.e. C++).

There are seemingly entry-point annotations on members that aren't actually used from C++.
=> We remove the annotation from those members in this CL.