### PR TITLE
Enable private field promotion

### DIFF
--- a/ci/pubspec.yaml
+++ b/ci/pubspec.yaml
@@ -5,7 +5,7 @@
 name: ci_scripts
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/pkg, //third_party/dart/pkg, or

--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -18,7 +18,7 @@ homepage: https://flutter.dev
 # relative to this directory into //third_party/dart
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   args: any

--- a/impeller/golden_tests_harvester/pubspec.yaml
+++ b/impeller/golden_tests_harvester/pubspec.yaml
@@ -5,7 +5,7 @@
 name: golden_tests_harvester
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/dart/pkg, //third_party/dart/third_party/pkg, or

--- a/impeller/tessellator/dart/pubspec.yaml
+++ b/impeller/tessellator/dart/pubspec.yaml
@@ -8,4 +8,4 @@ publish_to: none
 homepage: https://github.com/flutter/impeller/tree/main/tessellator/dart
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/lib/gpu/pubspec.yaml
+++ b/lib/gpu/pubspec.yaml
@@ -7,7 +7,7 @@ description: A framework for writing Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   sky_engine:

--- a/lib/snapshot/pubspec.yaml
+++ b/lib/snapshot/pubspec.yaml
@@ -5,4 +5,4 @@
 # This file is needed by Fuchsia's dart_library template.
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -1004,7 +1004,7 @@ class BrowserManager {
           final String pathToTest = p.dirname(path);
 
           final String mapPath = p.join(
-            _sourceMapDirectory!.path,
+            _sourceMapDirectory.path,
             pathToTest,
             sourceMapFileName
           );

--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -406,8 +406,7 @@ class ImageFilterEngineLayer extends ContainerLayer
     prerollContext.mutatorsStack.pushTransform(transform);
     final ui.Rect childPaintBounds =
         prerollChildren(prerollContext, childMatrix);
-    (_filter as CkManagedSkImageFilterConvertible)
-        .imageFilter((SkImageFilter filter) {
+    _filter.imageFilter((SkImageFilter filter) {
       paintBounds =
           rectFromSkIRect(filter.getOutputBounds(toSkRect(childPaintBounds)));
     });

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 # Keep the SDK version range in sync with pubspecs under web_sdk
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   js: 0.6.4

--- a/lib/web_ui/test/common/fake_asset_manager.dart
+++ b/lib/web_ui/test/common/fake_asset_manager.dart
@@ -81,7 +81,7 @@ class FakeAssetScope {
       return fetcher();
     }
     if (_parent != null) {
-      return _parent!.getAssetData(assetKey);
+      return _parent.getAssetData(assetKey);
     }
     return null;
   }

--- a/shell/platform/fuchsia/dart-pkg/fuchsia/pubspec.yaml
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/pubspec.yaml
@@ -3,4 +3,4 @@
 # found in the LICENSE file.
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/shell/platform/fuchsia/dart-pkg/zircon/pubspec.yaml
+++ b/shell/platform/fuchsia/dart-pkg/zircon/pubspec.yaml
@@ -5,7 +5,7 @@
 name: zircon
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 
 # Uncomment block for local testing

--- a/shell/platform/fuchsia/dart-pkg/zircon_ffi/pubspec.yaml
+++ b/shell/platform/fuchsia/dart-pkg/zircon_ffi/pubspec.yaml
@@ -1,7 +1,7 @@
 name: zircon_ffi
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   ffi: ^1.0.0

--- a/shell/platform/fuchsia/dart_runner/embedder/pubspec.yaml
+++ b/shell/platform/fuchsia/dart_runner/embedder/pubspec.yaml
@@ -6,5 +6,5 @@
 # template in BUILD.gn.
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 

--- a/shell/platform/fuchsia/dart_runner/vmservice/pubspec.yaml
+++ b/shell/platform/fuchsia/dart_runner/vmservice/pubspec.yaml
@@ -3,5 +3,5 @@
 # found in the LICENSE file.
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 

--- a/shell/platform/fuchsia/flutter/kernel/pubspec.yaml
+++ b/shell/platform/fuchsia/flutter/kernel/pubspec.yaml
@@ -3,4 +3,4 @@
 # found in the LICENSE file.
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/child-view/pubspec.yaml
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/child-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: child_view2
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/pubspec.yaml
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: parent-view2
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/pubspec.yaml
+++ b/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: mouse-input-view
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/pubspec.yaml
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: text-input-view
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/pubspec.yaml
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: embedding-flutter-view
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/pubspec.yaml
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: touch-input-view
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/shell/platform/fuchsia/runtime/dart/profiler_symbols/pubspec.yaml
+++ b/shell/platform/fuchsia/runtime/dart/profiler_symbols/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: profiler_symbols
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 version: 0
 description: Extracts a minimal symbols table for the Dart VM profiler
 author: Dart Team <misc@dartlang.org>

--- a/shell/vmservice/pubspec.yaml
+++ b/shell/vmservice/pubspec.yaml
@@ -5,4 +5,4 @@
 name: vmservice_snapshot
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/sky/packages/sky_engine/pubspec.yaml
+++ b/sky/packages/sky_engine/pubspec.yaml
@@ -5,4 +5,4 @@ description: Dart SDK extensions for dart:ui
 homepage: http://flutter.io
 # sky_engine requires sdk_ext support in the analyzer which was added in 1.11.x
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'

--- a/testing/android_background_image/pubspec.yaml
+++ b/testing/android_background_image/pubspec.yaml
@@ -5,7 +5,7 @@
 name: android_background_image
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/dart/pkg, //third_party/dart/third_party/pkg, or

--- a/testing/benchmark/pubspec.yaml
+++ b/testing/benchmark/pubspec.yaml
@@ -5,7 +5,7 @@
 name: flutter_engine_benchmark
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/pkg, //third_party/dart/pkg, or

--- a/testing/dart/pubspec.yaml
+++ b/testing/dart/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: none
 # relative to this directory into //third_party/dart
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   litetest: any

--- a/testing/litetest/pubspec.yaml
+++ b/testing/litetest/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: none
 # relative to this directory into //third_party/dart
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   async_helper: any

--- a/testing/scenario_app/pubspec.yaml
+++ b/testing/scenario_app/pubspec.yaml
@@ -5,7 +5,7 @@
 name: scenario_app
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/dart/pkg, //third_party/dart/third_party/pkg, or

--- a/testing/skia_gold_client/pubspec.yaml
+++ b/testing/skia_gold_client/pubspec.yaml
@@ -5,7 +5,7 @@
 name: skia_gold_client
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/dart/pkg, //third_party/dart/third_party/pkg, or

--- a/testing/smoke_test_failure/pubspec.yaml
+++ b/testing/smoke_test_failure/pubspec.yaml
@@ -5,7 +5,7 @@
 name: smoke_test_failure
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/dart/pkg or //third_party/dart/third_party/pkg.

--- a/testing/symbols/pubspec.yaml
+++ b/testing/symbols/pubspec.yaml
@@ -5,7 +5,7 @@
 name: verify_exported
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/pkg, //third_party/dart/pkg, or

--- a/third_party/web_locale_keymap/pubspec.yaml
+++ b/third_party/web_locale_keymap/pubspec.yaml
@@ -3,7 +3,7 @@ name: web_locale_keymap
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dev_dependencies:
   test: ^1.21.7

--- a/third_party/web_test_fonts/pubspec.yaml
+++ b/third_party/web_test_fonts/pubspec.yaml
@@ -3,7 +3,7 @@ name: web_test_fonts
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dev_dependencies:
   args: any

--- a/third_party/web_unicode/pubspec.yaml
+++ b/third_party/web_unicode/pubspec.yaml
@@ -3,7 +3,7 @@ name: web_unicode
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dev_dependencies:
   args: any

--- a/tools/android_lint/pubspec.yaml
+++ b/tools/android_lint/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: android_lint
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party.pkg, //third_party/dart/pkg, or

--- a/tools/api_check/pubspec.yaml
+++ b/tools/api_check/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: none
 # relative to this directory into //third_party/dart
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/pkg, //third_party/dart/pkg, or

--- a/tools/build_bucket_golden_scraper/pubspec.yaml
+++ b/tools/build_bucket_golden_scraper/pubspec.yaml
@@ -5,7 +5,7 @@
 name: build_bucket_golden_scraper
 publish_to: none
 environment:
-  sdk: ^3.0.0
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/pkg, //third_party/dart/pkg, or

--- a/tools/clang_tidy/pubspec.yaml
+++ b/tools/clang_tidy/pubspec.yaml
@@ -5,7 +5,7 @@
 name: clang_tidy
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/pkg, //third_party/dart/pkg, or

--- a/tools/const_finder/pubspec.yaml
+++ b/tools/const_finder/pubspec.yaml
@@ -6,7 +6,7 @@ name: const_finder
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/dart/pkg or //third_party/dart/third_party/pkg.

--- a/tools/gen_web_locale_keymap/pubspec.yaml
+++ b/tools/gen_web_locale_keymap/pubspec.yaml
@@ -2,7 +2,7 @@ name: gen_web_keyboard_keymap
 description: Generates keyboard layouts for Web from external sources.
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   args: any

--- a/tools/githooks/pubspec.yaml
+++ b/tools/githooks/pubspec.yaml
@@ -5,7 +5,7 @@
 name: githooks
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party.pkg, //third_party/dart/pkg, or

--- a/tools/licenses/pubspec.yaml
+++ b/tools/licenses/pubspec.yaml
@@ -5,7 +5,7 @@
 name: licenses
 publish_to: none
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided
 # in //third_party.pkg, //third_party/dart/pkg, or

--- a/tools/path_ops/dart/pubspec.yaml
+++ b/tools/path_ops/dart/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: none
 homepage: https://github.com/flutter/engine/tree/main/tools/path_ops
 
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dev_dependencies:
   litetest: any

--- a/tools/pkg/engine_build_configs/pubspec.yaml
+++ b/tools/pkg/engine_build_configs/pubspec.yaml
@@ -5,7 +5,7 @@
 name: engine_build_configs
 publish_to: none
 environment:
-  sdk: '>=3.1.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/pkg, //third_party/dart/pkg, or

--- a/tools/pkg/engine_repo_tools/pubspec.yaml
+++ b/tools/pkg/engine_repo_tools/pubspec.yaml
@@ -5,7 +5,7 @@
 name: engine_repo_tools
 publish_to: none
 environment:
-  sdk: ^3.0.0
+  sdk: '>=3.2.0-0 <4.0.0'
 
 # Do not add any dependencies that require more than what is provided in
 # //third_party/pkg, //third_party/dart/pkg, or

--- a/web_sdk/pubspec.yaml
+++ b/web_sdk/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_sdk_tests
 
 # Keep the SDK version range in sync with lib/web_ui/pubspec.yaml
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   args: 2.3.1

--- a/web_sdk/web_engine_tester/pubspec.yaml
+++ b/web_sdk/web_engine_tester/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_engine_tester
 
 # Keep the SDK version range in sync with lib/web_ui/pubspec.yaml
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   js: 0.6.4

--- a/web_sdk/web_test_utils/pubspec.yaml
+++ b/web_sdk/web_test_utils/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_test_utils
 
 # Keep the SDK version range in sync with lib/web_ui/pubspec.yaml
 environment:
-  sdk: '>=3.0.0-0 <4.0.0'
+  sdk: '>=3.2.0-0 <4.0.0'
 
 dependencies:
   collection: 1.17.0


### PR DESCRIPTION
New feature in upcoming Dart 3.2. See https://github.com/dart-lang/language/issues/2020. Feature is enabled by bumping the min SDK version to 3.2.

Part of https://github.com/flutter/flutter/issues/134476.