### PR TITLE
[Impeller] Fix swapchain recreation for non-polling cases.

### DIFF
--- a/impeller/renderer/backend/vulkan/surface_context_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.cc
@@ -69,13 +69,14 @@ bool SurfaceContextVK::SetWindowSurface(vk::UniqueSurfaceKHR surface) {
 std::unique_ptr<Surface> SurfaceContextVK::AcquireNextSurface() {
   TRACE_EVENT0("impeller", __FUNCTION__);
   auto surface = swapchain_ ? swapchain_->AcquireNextDrawable() : nullptr;
-  auto pipeline_library = parent_->GetPipelineLibrary();
-  if (surface && pipeline_library) {
+  if (!surface) {
+    return nullptr;
+  }
+  if (auto pipeline_library = parent_->GetPipelineLibrary()) {
     impeller::PipelineLibraryVK::Cast(*pipeline_library)
         .DidAcquireSurfaceFrame();
   }
-  auto allocator = parent_->GetResourceAllocator();
-  if (allocator) {
+  if (auto allocator = parent_->GetResourceAllocator()) {
     allocator->DidAcquireSurfaceFrame();
   }
   return surface;


### PR DESCRIPTION
Earlier, there was no recovery from vk::Result::eSuboptimalKHR. This made the playground be stuck with a swapchain image size of 1x1 with suboptimal error code on acquisition indefinitely.

Towards fixing the playgrounds. There are still some validation errors.