### PR TITLE
[web] support manual loading of manifest fonts

### DIFF
--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -312,6 +312,19 @@ class FlutterConfiguration {
   /// The font used to render color emojis is large (~24MB). This configuration
   /// gives developers the ability to decide for their app.
   bool get useColorEmoji => _configuration?.useColorEmoji ?? false;
+
+  /// Whether to load fonts from the font manifest prior to calling the app's
+  /// `main` function.
+  ///
+  /// If set to true, manifest fonts will load as part of engine initialization,
+  /// delaying the invocation of `main`, if necessary.
+  ///
+  /// If set to false, engine initialization does not include manifest fonts.
+  /// Instead, the developer can load manifest fonts using the
+  /// `loadManifestFonts` function from `dart:ui_web`.
+  ///
+  /// Defaults to true.
+  bool get loadManifestFontsBeforeAppMain => _configuration?.loadManifestFontsBeforeAppMain ?? true;
 }
 
 @JS('window.flutterConfiguration')
@@ -320,7 +333,22 @@ external JsFlutterConfiguration? get _jsConfiguration;
 /// The JS bindings for the object that's set as `window.flutterConfiguration`.
 @JS()
 @staticInterop
-class JsFlutterConfiguration {}
+@anonymous
+class JsFlutterConfiguration {
+  external factory JsFlutterConfiguration({
+    JSString? assetBase,
+    JSString? canvasKitBaseUrl,
+    JSString? canvasKitVariant,
+    JSBoolean? canvasKitForceCpuOnly,
+    JSNumber? canvasKitMaximumSurfaces,
+    JSBoolean? debugShowSemanticsNodes,
+    DomElement? hostElement,
+    JSString? nonce,
+    JSString? renderer,
+    JSBoolean? useColorEmoji,
+    JSBoolean? loadManifestFontsBeforeAppMain,
+  });
+}
 
 extension JsFlutterConfigurationExtension on JsFlutterConfiguration {
   @JS('assetBase')
@@ -360,6 +388,10 @@ extension JsFlutterConfigurationExtension on JsFlutterConfiguration {
   @JS('useColorEmoji')
   external JSBoolean? get _useColorEmoji;
   bool? get useColorEmoji => _useColorEmoji?.toDart;
+
+  @JS('loadManifestFontsBeforeAppMain')
+  external JSBoolean? get _loadManifestFontsBeforeAppMain;
+  bool? get loadManifestFontsBeforeAppMain => _loadManifestFontsBeforeAppMain?.toDart;
 }
 
 /// A JavaScript entrypoint that allows developer to set rendering backend

--- a/lib/web_ui/lib/src/engine/font_change_util.dart
+++ b/lib/web_ui/lib/src/engine/font_change_util.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:typed_data';
 
 import 'dom.dart';
@@ -18,7 +17,11 @@ final ByteData? _fontChangeMessage =
 // This flag ensures we properly schedule a single call to framework.
 bool _fontChangeScheduled = false;
 
-FutureOr<void> sendFontChangeMessage() async {
+/// Notifies the framework that fonts have changed.
+///
+/// The framework is expected to rerender the UI using the new fonts, relaying
+/// out text if necessary.
+void sendFontChangeMessage() {
   if (!_fontChangeScheduled) {
     _fontChangeScheduled = true;
     // Batch updates into next animationframe.

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -199,7 +199,11 @@ Future<void> initializeEngineServices({
   _setAssetManager(assetManager);
 
   Future<void> initializeRendererCallback () async => renderer.initialize();
-  await Future.wait<void>(<Future<void>>[initializeRendererCallback(), _downloadAssetFonts()]);
+  await Future.wait<void>(<Future<void>>[
+    initializeRendererCallback(),
+    if (configuration.loadManifestFontsBeforeAppMain)
+      downloadAssetFonts(),
+  ]);
   _initializationState = DebugEngineInitializationState.initializedServices;
 }
 
@@ -242,7 +246,7 @@ void _setAssetManager(ui_web.AssetManager assetManager) {
   _assetManager = assetManager;
 }
 
-Future<void> _downloadAssetFonts() async {
+Future<void> downloadAssetFonts() async {
   renderer.fontCollection.clear();
 
   if (ui_web.debugEmulateFlutterTesterEnvironment) {

--- a/lib/web_ui/lib/ui_web/src/ui_web/initialization.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/initialization.dart
@@ -55,3 +55,22 @@ Future<void> bootstrapEngine({
     loader.didCreateEngineInitializer(bootstrap.prepareEngineInitializer());
   }
 }
+
+/// Loads manifest fonts.
+///
+/// By default manifest fonts are loaded automatically as part of engine
+/// initialization. However, that may delay the invocation of the app's `main`
+/// function. If the app needs to start doing useful work before the fonts are
+/// fully loaded, such as render UI without text (e.g. a loading indicator), or
+/// perform non-UI work (e.g. make early HTTP calls), then the configuration
+/// option `loadManifestFontsBeforeAppMain` can be set to `false`. This will
+/// make the engine skip font loading. Instead, the app can call this function
+/// directly when appropriate.
+///
+/// Beware that attempting to render text before fonts are loaded may lead to
+/// improper text rendering. It is expected that the developer has enough
+/// control over the app's code to ensure the correct loading sequence.
+Future<void> loadManifestFonts() async {
+  await downloadAssetFonts();
+  sendFontChangeMessage();
+}

--- a/lib/web_ui/test/canvaskit/initialization/load_manifest_fonts_manually_test.dart
+++ b/lib/web_ui/test/canvaskit/initialization/load_manifest_fonts_manually_test.dart
@@ -1,0 +1,94 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+import 'package:web_engine_tester/golden_tester.dart';
+
+@JS('window.flutterConfiguration')
+external set _jsConfiguration(JsFlutterConfiguration? configuration);
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  test('fonts can be loaded manually', () async {
+    _jsConfiguration = null;
+
+    // Fully initialize engine services and UI without manifest fonts. Test that
+    // the engine can still render everything, albeit without text.
+    await initializeEngineServices(jsConfiguration: JsFlutterConfiguration(
+      loadManifestFontsBeforeAppMain: false.toJS,
+      canvasKitBaseUrl: '/canvaskit/'.toJS,
+    ));
+    await initializeEngineUi();
+
+    String? messageChannel;
+    Object? messageData;
+
+    EnginePlatformDispatcher.instance.onPlatformMessage = (String name, ByteData? data, ui.PlatformMessageResponseCallback? callback) {
+      messageChannel = name;
+      messageData = const JSONMessageCodec().decodeMessage(data);
+    };
+
+    await _testTextRendering('canvaskit_text_without_fonts');
+    expect(messageChannel, isNull);
+    expect(messageData, isNull);
+
+    // Load fonts manually. Test that text is now rendered fully.
+    await ui_web.loadManifestFonts();
+
+    // The notification message is sent in the next frame so there's only one
+    // notification for a batch of fonts, so wait for 2 frames before checking
+    // for the message.
+    final Completer<void> waitForFontMessage = Completer<void>();
+    domWindow.requestAnimationFrame((_) {
+      domWindow.requestAnimationFrame((_) {
+        waitForFontMessage.complete();
+      });
+    });
+    await waitForFontMessage.future;
+
+    expect(messageChannel, 'flutter/system');
+    expect(messageData, <String, dynamic>{'type': 'fontsChange'});
+    await _testTextRendering('canvaskit_text_with_fonts');
+  });
+}
+
+Future<void> _testTextRendering(String testName) async {
+  final CkPicture picture;
+  {
+    final CkPictureRecorder recorder = CkPictureRecorder();
+    final CkCanvas canvas = recorder.beginRecording(ui.Rect.largest);
+    final CkParagraphBuilder builder = CkParagraphBuilder(CkParagraphStyle());
+    builder.addText('Hello');
+    final CkParagraph paragraph = builder.build();
+    paragraph.layout(const ui.ParagraphConstraints(width: 1000));
+    canvas.drawRect(
+      ui.Rect.fromLTWH(0, 0, paragraph.width, paragraph.height).inflate(10),
+      CkPaint()..color = const ui.Color(0xFF00FF00)
+    );
+    canvas.drawParagraph(paragraph, ui.Offset.zero);
+    picture = recorder.endRecording();
+  }
+
+  {
+    final LayerSceneBuilder builder = LayerSceneBuilder();
+    builder.pushOffset(0, 0);
+    builder.addPicture(ui.Offset.zero, picture);
+    final LayerTree layerTree = builder.build().layerTree;
+    CanvasKitRenderer.instance.rasterizer.draw(layerTree);
+
+    await matchGoldenFile('$testName.png',
+        region: const ui.Rect.fromLTRB(0, 0, 50, 30));
+  }
+}


### PR DESCRIPTION
Add support for manual loading of manifest fonts (i.e. those specified in `pubspec.yaml`):

- Add a new option `loadManifestFontsBeforeAppMain` in the configuration object (defaults to `true`). If not specified or set to true, font loading works like it does today: manifest fonts are loaded prior to calling the `main()` function. If set to `false`, the engine does not load manifest fonts automatically, but does allow rendering UI. Attempting to render text without fonts will result in blank space in place of the text.
- Add a new function `loadManifestFonts`, which can be called explicitly to load manifest fonts. After this function completes successfully, text can be rendered using manifest fonts.

Fixes https://github.com/flutter/flutter/issues/134594