### PR TITLE
[cp] Revert "Lazily allocate RasterCacheItems only when caching is enabled…

### DIFF
--- a/flow/layers/clip_rect_layer_unittests.cc
+++ b/flow/layers/clip_rect_layer_unittests.cc
@@ -499,69 +499,28 @@ TEST_F(ClipRectLayerTest, LayerCached) {
 
   use_mock_raster_cache();
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
 
-  layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
-  LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
-
-  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
-            RasterCacheItem::CacheState::kNone);
+  const auto* clip_cache_item = layer->raster_cache_item();
 
   layer->Preroll(preroll_context());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
+
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
-            RasterCacheItem::CacheState::kNone);
+  EXPECT_EQ(clip_cache_item->cache_state(), RasterCacheItem::CacheState::kNone);
+
+  layer->Preroll(preroll_context());
+  LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
+  EXPECT_EQ(clip_cache_item->cache_state(), RasterCacheItem::CacheState::kNone);
 
   layer->Preroll(preroll_context());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(clip_cache_item->cache_state(),
             RasterCacheItem::CacheState::kCurrent);
   DlPaint paint;
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_TRUE(raster_cache()->Draw(clip_cache_item->GetId().value(),
                                    cache_canvas, &paint));
-}
-
-TEST_F(ClipRectLayerTest, NullRasterCacheResetsRasterCacheItem) {
-  auto path1 = SkPath().addRect({10, 10, 30, 30});
-  auto mock1 = MockLayer::MakeOpacityCompatible(path1);
-  SkRect clip_rect = SkRect::MakeWH(500, 500);
-  auto layer =
-      std::make_shared<ClipRectLayer>(clip_rect, Clip::antiAliasWithSaveLayer);
-  layer->Add(mock1);
-
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  layer->Preroll(preroll_context());
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  use_mock_raster_cache();
-
-  int limit = RasterCacheUtil::kMinimumRendersBeforeCachingFilterLayer;
-  for (int i = 1; i < limit; i++) {
-    layer->Preroll(preroll_context());
-    ASSERT_NE(layer->raster_cache_item(), nullptr);
-    ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-              RasterCacheItem::kNone);
-    ASSERT_FALSE(
-        layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-  }
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-            RasterCacheItem::kCurrent);
-  ASSERT_TRUE(
-      layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-
-  use_null_raster_cache();
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(), RasterCacheItem::kNone);
 }
 
 TEST_F(ClipRectLayerTest, EmptyClipDoesNotCullPlatformView) {

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -512,70 +512,27 @@ TEST_F(ClipRRectLayerTest, LayerCached) {
 
   use_mock_raster_cache();
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
 
-  layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
-  LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
-
-  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
-            RasterCacheItem::CacheState::kNone);
+  const auto* clip_cache_item = layer->raster_cache_item();
 
   layer->Preroll(preroll_context());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
+
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
-            RasterCacheItem::CacheState::kNone);
+  EXPECT_EQ(clip_cache_item->cache_state(), RasterCacheItem::CacheState::kNone);
+
+  layer->Preroll(preroll_context());
+  LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
+  EXPECT_EQ(clip_cache_item->cache_state(), RasterCacheItem::CacheState::kNone);
 
   layer->Preroll(preroll_context());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(clip_cache_item->cache_state(),
             RasterCacheItem::CacheState::kCurrent);
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_TRUE(raster_cache()->Draw(clip_cache_item->GetId().value(),
                                    cache_canvas, &paint));
-}
-
-TEST_F(ClipRRectLayerTest, NullRasterCacheResetsRasterCacheItem) {
-  auto path1 = SkPath().addRect({10, 10, 30, 30});
-  DlPaint paint = DlPaint();
-  auto mock1 = MockLayer::MakeOpacityCompatible(path1);
-  SkRect clip_rect = SkRect::MakeWH(500, 500);
-  SkRRect clip_rrect = SkRRect::MakeRectXY(clip_rect, 20, 20);
-  auto layer = std::make_shared<ClipRRectLayer>(clip_rrect,
-                                                Clip::antiAliasWithSaveLayer);
-  layer->Add(mock1);
-
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  layer->Preroll(preroll_context());
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  use_mock_raster_cache();
-
-  int limit = RasterCacheUtil::kMinimumRendersBeforeCachingFilterLayer;
-  for (int i = 1; i < limit; i++) {
-    layer->Preroll(preroll_context());
-    ASSERT_NE(layer->raster_cache_item(), nullptr);
-    ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-              RasterCacheItem::kNone);
-    ASSERT_FALSE(
-        layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-  }
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-            RasterCacheItem::kCurrent);
-  ASSERT_TRUE(
-      layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-
-  use_null_raster_cache();
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(), RasterCacheItem::kNone);
 }
 
 TEST_F(ClipRRectLayerTest, NoSaveLayerShouldNotCache) {
@@ -594,23 +551,24 @@ TEST_F(ClipRRectLayerTest, NoSaveLayerShouldNotCache) {
 
   use_mock_raster_cache();
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+
+  const auto* clip_cache_item = layer->raster_cache_item();
 
   layer->Preroll(preroll_context());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  EXPECT_EQ(clip_cache_item->cache_state(), RasterCacheItem::CacheState::kNone);
 
   layer->Preroll(preroll_context());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  EXPECT_EQ(clip_cache_item->cache_state(), RasterCacheItem::CacheState::kNone);
 
   layer->Preroll(preroll_context());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  EXPECT_EQ(clip_cache_item->cache_state(), RasterCacheItem::CacheState::kNone);
 }
 
 TEST_F(ClipRRectLayerTest, EmptyClipDoesNotCullPlatformView) {

--- a/flow/layers/clip_shape_layer.h
+++ b/flow/layers/clip_shape_layer.h
@@ -48,7 +48,9 @@ class ClipShapeLayer : public CacheableContainerLayer {
     // We can use the raster_cache for children only when the use_save_layer is
     // true so if use_save_layer is false we pass the layer_raster_item is
     // nullptr which mean we don't do raster cache logic.
-    AutoCache cache(*this, context, uses_save_layer);
+    AutoCache cache =
+        AutoCache(uses_save_layer ? layer_raster_cache_item_.get() : nullptr,
+                  context, context->state_stack.transform_3x3());
 
     Layer::AutoPrerollSaveLayerState save =
         Layer::AutoPrerollSaveLayerState::Create(

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -39,7 +39,8 @@ void ColorFilterLayer::Diff(DiffContext* context, const Layer* old_layer) {
 void ColorFilterLayer::Preroll(PrerollContext* context) {
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
-  AutoCache cache(*this, context);
+  AutoCache cache = AutoCache(layer_raster_cache_item_.get(), context,
+                              context->state_stack.transform_3x3());
 
   ContainerLayer::Preroll(context);
 

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -271,25 +271,27 @@ TEST_F(ColorFilterLayerTest, CacheChild) {
   other_canvas.Transform(other_transform);
 
   use_mock_raster_cache();
+  const auto* cacheable_color_filter_item = layer->raster_cache_item();
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  EXPECT_EQ(cacheable_color_filter_item->cache_state(),
+            RasterCacheItem::CacheState::kNone);
+  EXPECT_FALSE(cacheable_color_filter_item->GetId().has_value());
 
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_color_filter_item->cache_state(),
             RasterCacheItem::CacheState::kChildren);
   EXPECT_EQ(
-      layer->raster_cache_item()->GetId().value(),
+      cacheable_color_filter_item->GetId().value(),
       RasterCacheKeyID(RasterCacheKeyID::LayerChildrenIds(layer.get()).value(),
                        RasterCacheKeyType::kLayerChildren));
-  EXPECT_FALSE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
-                                    other_canvas, &paint));
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_FALSE(raster_cache()->Draw(
+      cacheable_color_filter_item->GetId().value(), other_canvas, &paint));
+  EXPECT_TRUE(raster_cache()->Draw(cacheable_color_filter_item->GetId().value(),
                                    cache_canvas, &paint));
 }
 
@@ -315,63 +317,28 @@ TEST_F(ColorFilterLayerTest, CacheChildren) {
   use_mock_raster_cache();
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  const auto* cacheable_color_filter_item = layer->raster_cache_item();
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
+
+  EXPECT_EQ(cacheable_color_filter_item->cache_state(),
+            RasterCacheItem::CacheState::kNone);
+  EXPECT_FALSE(cacheable_color_filter_item->GetId().has_value());
 
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_color_filter_item->cache_state(),
             RasterCacheItem::CacheState::kChildren);
   EXPECT_EQ(
-      layer->raster_cache_item()->GetId().value(),
+      cacheable_color_filter_item->GetId().value(),
       RasterCacheKeyID(RasterCacheKeyID::LayerChildrenIds(layer.get()).value(),
                        RasterCacheKeyType::kLayerChildren));
-  EXPECT_FALSE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
-                                    other_canvas, &paint));
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_FALSE(raster_cache()->Draw(
+      cacheable_color_filter_item->GetId().value(), other_canvas, &paint));
+  EXPECT_TRUE(raster_cache()->Draw(cacheable_color_filter_item->GetId().value(),
                                    cache_canvas, &paint));
-}
-
-TEST_F(ColorFilterLayerTest, NullRasterCacheResetsRasterCacheItem) {
-  auto layer_filter = DlSrgbToLinearGammaColorFilter::instance;
-  const SkPath child_path = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
-  DlPaint paint = DlPaint();
-  auto mock_layer = std::make_shared<MockLayer>(child_path);
-  auto layer = std::make_shared<ColorFilterLayer>(layer_filter);
-  layer->Add(mock_layer);
-
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  layer->Preroll(preroll_context());
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  use_mock_raster_cache();
-
-  int limit = RasterCacheUtil::kMinimumRendersBeforeCachingFilterLayer;
-  for (int i = 1; i < limit; i++) {
-    layer->Preroll(preroll_context());
-    ASSERT_NE(layer->raster_cache_item(), nullptr);
-    ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-              RasterCacheItem::kChildren);
-    ASSERT_TRUE(
-        layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-  }
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-            RasterCacheItem::kCurrent);
-  ASSERT_TRUE(
-      layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-
-  use_null_raster_cache();
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(), RasterCacheItem::kNone);
 }
 
 TEST_F(ColorFilterLayerTest, CacheColorFilterLayerSelf) {
@@ -395,28 +362,25 @@ TEST_F(ColorFilterLayerTest, CacheColorFilterLayerSelf) {
 
   use_mock_raster_cache();
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  const auto* cacheable_color_filter_item = layer->raster_cache_item();
 
   // frame 1.
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
   layer->Paint(paint_context());
   // frame 2.
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
   // ColorFilterLayer default cache children.
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_color_filter_item->cache_state(),
             RasterCacheItem::CacheState::kChildren);
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_TRUE(raster_cache()->Draw(cacheable_color_filter_item->GetId().value(),
                                    cache_canvas, &paint));
-  EXPECT_FALSE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
-                                    other_canvas, &paint));
+  EXPECT_FALSE(raster_cache()->Draw(
+      cacheable_color_filter_item->GetId().value(), other_canvas, &paint));
   layer->Paint(paint_context());
 
   // frame 3.
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
   layer->Paint(paint_context());
 
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
@@ -425,14 +389,14 @@ TEST_F(ColorFilterLayerTest, CacheColorFilterLayerSelf) {
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)2);
 
   // ColorFilterLayer default cache itself.
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_color_filter_item->cache_state(),
             RasterCacheItem::CacheState::kCurrent);
-  EXPECT_EQ(layer->raster_cache_item()->GetId(),
+  EXPECT_EQ(cacheable_color_filter_item->GetId(),
             RasterCacheKeyID(layer->unique_id(), RasterCacheKeyType::kLayer));
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_TRUE(raster_cache()->Draw(cacheable_color_filter_item->GetId().value(),
                                    cache_canvas, &paint));
-  EXPECT_FALSE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
-                                    other_canvas, &paint));
+  EXPECT_FALSE(raster_cache()->Draw(
+      cacheable_color_filter_item->GetId().value(), other_canvas, &paint));
 }
 
 TEST_F(ColorFilterLayerTest, OpacityInheritance) {

--- a/flow/layers/display_list_layer.h
+++ b/flow/layers/display_list_layer.h
@@ -8,14 +8,13 @@
 #include <memory>
 
 #include "flutter/display_list/display_list.h"
-#include "flutter/flow/layers/cacheable_layer.h"
 #include "flutter/flow/layers/display_list_raster_cache_item.h"
 #include "flutter/flow/layers/layer.h"
 #include "flutter/flow/raster_cache_item.h"
 
 namespace flutter {
 
-class DisplayListLayer : public Layer, public CacheableLayer {
+class DisplayListLayer : public Layer {
  public:
   static constexpr size_t kMaxBytesToCompare = 10000;
 
@@ -48,18 +47,12 @@ class DisplayListLayer : public Layer, public CacheableLayer {
   }
 
  private:
-  RasterCacheItem* realize_raster_cache_item() override;
-  void disable_raster_cache_item() override;
   std::unique_ptr<DisplayListRasterCacheItem> display_list_raster_cache_item_;
-
-  friend class AutoCache;
 
   SkPoint offset_;
   SkRect bounds_;
 
   sk_sp<DisplayList> display_list_;
-  bool is_complex_;
-  bool will_change_;
 
   static bool Compare(DiffContext::Statistics& statistics,
                       const DisplayListLayer* l1,

--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -56,7 +56,8 @@ void ImageFilterLayer::Preroll(PrerollContext* context) {
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
 
-  AutoCache cache(*this, context);
+  AutoCache cache = AutoCache(layer_raster_cache_item_.get(), context,
+                              context->state_stack.transform_3x3());
 
   SkRect child_bounds = SkRect::MakeEmpty();
 
@@ -86,9 +87,13 @@ void ImageFilterLayer::Preroll(PrerollContext* context) {
 
   // CacheChildren only when the transformed_filter_ doesn't equal null.
   // So in here we reset the LayerRasterCacheItem cache state.
+  layer_raster_cache_item_->MarkNotCacheChildren();
+
   transformed_filter_ =
       filter_->makeWithLocalMatrix(context->state_stack.transform_3x3());
-  MarkCanCacheChildren(transformed_filter_ != nullptr);
+  if (transformed_filter_) {
+    layer_raster_cache_item_->MarkCacheChildren();
+  }
 }
 
 void ImageFilterLayer::Paint(PaintContext& context) const {

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -367,26 +367,27 @@ TEST_F(ImageFilterLayerTest, CacheChild) {
   DlPaint paint;
 
   use_mock_raster_cache();
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  const auto* cacheable_image_filter_item = layer->raster_cache_item();
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(cacheable_items().size(), 0u);
+  // ImageFilterLayer default cache itself.
+  EXPECT_EQ(cacheable_image_filter_item->cache_state(),
+            RasterCacheItem::CacheState::kNone);
+  EXPECT_FALSE(cacheable_image_filter_item->Draw(paint_context(), &paint));
 
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
-  EXPECT_EQ(cacheable_items().size(), 1u);
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
   // The layer_cache_item's strategy is Children, mean we will must cache
   // his children
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_image_filter_item->cache_state(),
             RasterCacheItem::CacheState::kChildren);
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_TRUE(raster_cache()->Draw(cacheable_image_filter_item->GetId().value(),
                                    cache_canvas, &paint));
-  EXPECT_FALSE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
-                                    other_canvas, &paint));
+  EXPECT_FALSE(raster_cache()->Draw(
+      cacheable_image_filter_item->GetId().value(), other_canvas, &paint));
 }
 
 TEST_F(ImageFilterLayerTest, CacheChildren) {
@@ -412,27 +413,30 @@ TEST_F(ImageFilterLayerTest, CacheChildren) {
 
   use_mock_raster_cache();
 
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  const auto* cacheable_image_filter_item = layer->raster_cache_item();
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
+
+  // ImageFilterLayer default cache itself.
+  EXPECT_EQ(cacheable_image_filter_item->cache_state(),
+            RasterCacheItem::CacheState::kNone);
+  EXPECT_FALSE(cacheable_image_filter_item->Draw(paint_context(), &paint));
 
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
 
   // The layer_cache_item's strategy is Children, mean we will must cache his
   // children
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_image_filter_item->cache_state(),
             RasterCacheItem::CacheState::kChildren);
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_TRUE(raster_cache()->Draw(cacheable_image_filter_item->GetId().value(),
                                    cache_canvas, &paint));
-  EXPECT_FALSE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
-                                    other_canvas, &paint));
+  EXPECT_FALSE(raster_cache()->Draw(
+      cacheable_image_filter_item->GetId().value(), other_canvas, &paint));
 
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
 
   SkRect children_bounds = child_path1.getBounds();
   children_bounds.join(child_path2.getBounds());
@@ -455,52 +459,13 @@ TEST_F(ImageFilterLayerTest, CacheChildren) {
       expected_builder.Transform(snapped_matrix);
       DlPaint dl_paint;
       dl_paint.setImageFilter(transformed_filter.get());
-      raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+      raster_cache()->Draw(cacheable_image_filter_item->GetId().value(),
                            expected_builder, &dl_paint);
     }
     expected_builder.Restore();
   }
   expected_builder.Restore();
   EXPECT_TRUE(DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
-}
-
-TEST_F(ImageFilterLayerTest, NullRasterCacheResetsRasterCacheItem) {
-  auto dl_image_filter = std::make_shared<DlMatrixImageFilter>(
-      SkMatrix(), DlImageSampling::kMipmapLinear);
-  const SkPath child_path = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
-  auto mock_layer = std::make_shared<MockLayer>(child_path);
-  auto layer = std::make_shared<ImageFilterLayer>(dl_image_filter);
-  layer->Add(mock_layer);
-
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  layer->Preroll(preroll_context());
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  use_mock_raster_cache();
-
-  int limit = RasterCacheUtil::kMinimumRendersBeforeCachingFilterLayer;
-  for (int i = 1; i < limit; i++) {
-    layer->Preroll(preroll_context());
-    ASSERT_NE(layer->raster_cache_item(), nullptr);
-    ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-              RasterCacheItem::kChildren);
-    ASSERT_TRUE(
-        layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-  }
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-            RasterCacheItem::kCurrent);
-  ASSERT_TRUE(
-      layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-
-  use_null_raster_cache();
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(), RasterCacheItem::kNone);
 }
 
 TEST_F(ImageFilterLayerTest, CacheImageFilterLayerSelf) {
@@ -530,10 +495,9 @@ TEST_F(ImageFilterLayerTest, CacheImageFilterLayerSelf) {
 
   use_mock_raster_cache();
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  const auto* cacheable_image_filter_item = layer->raster_cache_item();
   // frame 1.
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
 
   layer->Paint(display_list_paint_context());
   {
@@ -573,14 +537,14 @@ TEST_F(ImageFilterLayerTest, CacheImageFilterLayerSelf) {
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)2);
 
   // ImageFilterLayer default cache itself.
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_image_filter_item->cache_state(),
             RasterCacheItem::CacheState::kCurrent);
-  EXPECT_EQ(layer->raster_cache_item()->GetId(),
+  EXPECT_EQ(cacheable_image_filter_item->GetId(),
             RasterCacheKeyID(layer->unique_id(), RasterCacheKeyType::kLayer));
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_TRUE(raster_cache()->Draw(cacheable_image_filter_item->GetId().value(),
                                    cache_canvas, &paint));
-  EXPECT_FALSE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
-                                    other_canvas, &paint));
+  EXPECT_FALSE(raster_cache()->Draw(
+      cacheable_image_filter_item->GetId().value(), other_canvas, &paint));
 
   layer->Preroll(preroll_context());
 
@@ -592,7 +556,7 @@ TEST_F(ImageFilterLayerTest, CacheImageFilterLayerSelf) {
       expected_builder.Save();
       {
         EXPECT_TRUE(
-            raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+            raster_cache()->Draw(cacheable_image_filter_item->GetId().value(),
                                  expected_builder, nullptr));
       }
       expected_builder.Restore();

--- a/flow/layers/layer_raster_cache_item.h
+++ b/flow/layers/layer_raster_cache_item.h
@@ -45,9 +45,9 @@ class LayerRasterCacheItem : public RasterCacheItem {
   bool TryToPrepareRasterCache(const PaintContext& context,
                                bool parent_cached = false) const override;
 
-  void MarkCanCacheChildren(bool can_cache_children) {
-    can_cache_children_ = can_cache_children;
-  }
+  void MarkCacheChildren() { can_cache_children_ = true; }
+
+  void MarkNotCacheChildren() { can_cache_children_ = false; }
 
   bool IsCacheChildren() const { return cache_state_ == CacheState::kChildren; }
 

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -42,7 +42,8 @@ void OpacityLayer::Preroll(PrerollContext* context) {
   mutator.translate(offset_);
   mutator.applyOpacity(SkRect(), DlColor::toOpacity(alpha_));
 
-  AutoCache auto_cache(*this, context);
+  AutoCache auto_cache = AutoCache(layer_raster_cache_item_.get(), context,
+                                   context->state_stack.transform_3x3());
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
 
@@ -77,7 +78,7 @@ void OpacityLayer::Paint(PaintContext& context) const {
 
   mutator.applyOpacity(child_paint_bounds(), opacity());
 
-  if (context.raster_cache && !children_can_accept_opacity()) {
+  if (!children_can_accept_opacity()) {
     DlPaint paint;
     if (layer_raster_cache_item_->Draw(context,
                                        context.state_stack.fill(paint))) {

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -103,24 +103,29 @@ TEST_F(OpacityLayerTest, CacheChild) {
   use_mock_raster_cache();
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+
+  const auto* cacheable_opacity_item = layer->raster_cache_item();
+
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
+  EXPECT_EQ(cacheable_opacity_item->cache_state(),
+            RasterCacheItem::CacheState::kNone);
+  EXPECT_FALSE(cacheable_opacity_item->GetId().has_value());
 
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
 
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_opacity_item->cache_state(),
             RasterCacheItem::CacheState::kChildren);
   EXPECT_EQ(
-      layer->raster_cache_item()->GetId().value(),
+      cacheable_opacity_item->GetId().value(),
       RasterCacheKeyID(RasterCacheKeyID::LayerChildrenIds(layer.get()).value(),
                        RasterCacheKeyType::kLayerChildren));
-  EXPECT_FALSE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_FALSE(raster_cache()->Draw(cacheable_opacity_item->GetId().value(),
                                     other_canvas, &paint));
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_TRUE(raster_cache()->Draw(cacheable_opacity_item->GetId().value(),
                                    cache_canvas, &paint));
 }
 
@@ -147,59 +152,30 @@ TEST_F(OpacityLayerTest, CacheChildren) {
   use_mock_raster_cache();
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+
+  const auto* cacheable_opacity_item = layer->raster_cache_item();
+
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
+  EXPECT_EQ(cacheable_opacity_item->cache_state(),
+            RasterCacheItem::CacheState::kNone);
+  EXPECT_FALSE(cacheable_opacity_item->GetId().has_value());
 
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
 
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_opacity_item->cache_state(),
             RasterCacheItem::CacheState::kChildren);
   EXPECT_EQ(
-      layer->raster_cache_item()->GetId().value(),
+      cacheable_opacity_item->GetId().value(),
       RasterCacheKeyID(RasterCacheKeyID::LayerChildrenIds(layer.get()).value(),
                        RasterCacheKeyType::kLayerChildren));
-  EXPECT_FALSE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_FALSE(raster_cache()->Draw(cacheable_opacity_item->GetId().value(),
                                     other_canvas, &paint));
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
+  EXPECT_TRUE(raster_cache()->Draw(cacheable_opacity_item->GetId().value(),
                                    cache_canvas, &paint));
-}
-
-TEST_F(OpacityLayerTest, NullRasterCacheResetsRasterCacheItem) {
-  const SkAlpha alpha_half = 255 / 2;
-  const SkPath child_path = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
-  auto mock_layer = std::make_shared<MockLayer>(child_path);
-  mock_layer->set_fake_opacity_compatible(false);
-  auto layer =
-      std::make_shared<OpacityLayer>(alpha_half, SkPoint::Make(0.0f, 0.0f));
-  layer->Add(mock_layer);
-
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  layer->Preroll(preroll_context());
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  use_mock_raster_cache();
-
-  // OpacityLayer will never cache itself, only its children
-  int limit = 10 * RasterCacheUtil::kMinimumRendersBeforeCachingFilterLayer;
-  for (int i = 1; i < limit; i++) {
-    layer->Preroll(preroll_context());
-    ASSERT_NE(layer->raster_cache_item(), nullptr);
-    ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-              RasterCacheItem::kChildren);
-    ASSERT_TRUE(
-        layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-  }
-
-  use_null_raster_cache();
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(), RasterCacheItem::kNone);
 }
 
 TEST_F(OpacityLayerTest, ShouldNotCacheChildren) {
@@ -214,20 +190,24 @@ TEST_F(OpacityLayerTest, ShouldNotCacheChildren) {
   use_mock_raster_cache();
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(opacity_layer->raster_cache_item(), nullptr);
+
+  const auto* cacheable_opacity_item = opacity_layer->raster_cache_item();
+
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
+  EXPECT_EQ(cacheable_opacity_item->cache_state(),
+            RasterCacheItem::CacheState::kNone);
+  EXPECT_FALSE(cacheable_opacity_item->GetId().has_value());
 
   opacity_layer->Preroll(preroll_context());
-  EXPECT_NE(opacity_layer->raster_cache_item(), nullptr);
 
   EXPECT_EQ(context->renderable_state_flags,
             LayerStateStack::kCallerCanApplyOpacity);
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(opacity_layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_opacity_item->cache_state(),
             RasterCacheItem::CacheState::kNone);
-  EXPECT_FALSE(
-      opacity_layer->raster_cache_item()->Draw(paint_context(), &paint));
+  EXPECT_FALSE(cacheable_opacity_item->Draw(paint_context(), &paint));
 }
 
 TEST_F(OpacityLayerTest, FullyOpaque) {

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -37,7 +37,8 @@ void ShaderMaskLayer::Diff(DiffContext* context, const Layer* old_layer) {
 void ShaderMaskLayer::Preroll(PrerollContext* context) {
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
-  AutoCache cache(*this, context);
+  AutoCache cache = AutoCache(layer_raster_cache_item_.get(), context,
+                              context->state_stack.transform_3x3());
 
   ContainerLayer::Preroll(context);
   // We always paint with a saveLayer (or a cached rendering),

--- a/flow/layers/shader_mask_layer_unittests.cc
+++ b/flow/layers/shader_mask_layer_unittests.cc
@@ -334,78 +334,39 @@ TEST_F(ShaderMaskLayerTest, LayerCached) {
 
   use_mock_raster_cache();
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
+  const auto* cacheable_shader_masker_item = layer->raster_cache_item();
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item(), nullptr);
+  EXPECT_EQ(cacheable_shader_masker_item->cache_state(),
+            RasterCacheItem::CacheState::kNone);
+  EXPECT_FALSE(cacheable_shader_masker_item->GetId().has_value());
 
   // frame 1.
   layer->Preroll(preroll_context());
-  EXPECT_NE(layer->raster_cache_item(), nullptr);
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_shader_masker_item->cache_state(),
             RasterCacheItem::CacheState::kNone);
-  EXPECT_FALSE(layer->raster_cache_item()->GetId().has_value());
+  EXPECT_FALSE(cacheable_shader_masker_item->GetId().has_value());
 
   // frame 2.
   layer->Preroll(preroll_context());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_shader_masker_item->cache_state(),
             RasterCacheItem::CacheState::kNone);
-  EXPECT_FALSE(layer->raster_cache_item()->GetId().has_value());
+  EXPECT_FALSE(cacheable_shader_masker_item->GetId().has_value());
 
   // frame 3.
   layer->Preroll(preroll_context());
   LayerTree::TryToRasterCache(cacheable_items(), &paint_context());
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
-  EXPECT_EQ(layer->raster_cache_item()->cache_state(),
+  EXPECT_EQ(cacheable_shader_masker_item->cache_state(),
             RasterCacheItem::CacheState::kCurrent);
 
-  EXPECT_TRUE(raster_cache()->Draw(layer->raster_cache_item()->GetId().value(),
-                                   cache_canvas, &paint));
-}
-
-TEST_F(ShaderMaskLayerTest, NullRasterCacheResetsRasterCacheItem) {
-  auto dl_filter = MakeFilter(DlColor::kBlue());
-  DlPaint paint;
-  const SkRect layer_bounds = SkRect::MakeLTRB(2.0f, 4.0f, 20.5f, 20.5f);
-  const SkPath child_path = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
-  auto mock_layer = std::make_shared<MockLayer>(child_path);
-  auto layer = std::make_shared<ShaderMaskLayer>(dl_filter, layer_bounds,
-                                                 DlBlendMode::kSrc);
-  layer->Add(mock_layer);
-
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  layer->Preroll(preroll_context());
-  ASSERT_EQ(layer->raster_cache_item(), nullptr);
-
-  use_mock_raster_cache();
-
-  int limit = RasterCacheUtil::kMinimumRendersBeforeCachingFilterLayer;
-  for (int i = 1; i < limit; i++) {
-    layer->Preroll(preroll_context());
-    ASSERT_NE(layer->raster_cache_item(), nullptr);
-    ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-              RasterCacheItem::kNone);
-    ASSERT_FALSE(
-        layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-  }
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(),
-            RasterCacheItem::kCurrent);
-  ASSERT_TRUE(
-      layer->raster_cache_item()->TryToPrepareRasterCache(paint_context()));
-
-  use_null_raster_cache();
-
-  layer->Preroll(preroll_context());
-  ASSERT_NE(layer->raster_cache_item(), nullptr);
-  ASSERT_EQ(layer->raster_cache_item()->cache_state(), RasterCacheItem::kNone);
+  EXPECT_TRUE(raster_cache()->Draw(
+      cacheable_shader_masker_item->GetId().value(), cache_canvas, &paint));
 }
 
 TEST_F(ShaderMaskLayerTest, OpacityInheritance) {

--- a/flow/raster_cache_item.h
+++ b/flow/raster_cache_item.h
@@ -57,8 +57,6 @@ class RasterCacheItem {
 
   void set_matrix(const SkMatrix& matrix) { matrix_ = matrix; }
 
-  void reset_cache_state() { cache_state_ = kNone; }
-
   CacheState cache_state() const { return cache_state_; }
 
   bool need_caching() const { return cache_state_ != CacheState::kNone; }

--- a/flow/testing/mock_layer.cc
+++ b/flow/testing/mock_layer.cc
@@ -66,29 +66,17 @@ void MockLayer::Paint(PaintContext& context) const {
 void MockCacheableContainerLayer::Preroll(PrerollContext* context) {
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
-  AutoCache cache(*this, context);
+  auto cache = AutoCache(layer_raster_cache_item_.get(), context,
+                         context->state_stack.transform_3x3());
 
   ContainerLayer::Preroll(context);
-}
-
-RasterCacheItem* MockCacheableLayer::realize_raster_cache_item() {
-  if (!raster_cache_item_) {
-    raster_cache_item_ =
-        std::make_unique<MockLayerCacheableItem>(this, render_limit_);
-  }
-  return raster_cache_item_.get();
-}
-
-void MockCacheableLayer::disable_raster_cache_item() {
-  if (raster_cache_item_) {
-    raster_cache_item_->reset_cache_state();
-  }
 }
 
 void MockCacheableLayer::Preroll(PrerollContext* context) {
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
-  AutoCache cache(*this, context);
+  auto cache = AutoCache(raster_cache_item_.get(), context,
+                         context->state_stack.transform_3x3());
 
   MockLayer::Preroll(context);
 }

--- a/flow/testing/mock_layer.h
+++ b/flow/testing/mock_layer.h
@@ -150,12 +150,15 @@ class MockLayerCacheableItem : public LayerRasterCacheItem {
  public:
   using LayerRasterCacheItem::LayerRasterCacheItem;
 };
-class MockCacheableLayer : public MockLayer, public CacheableLayer {
+class MockCacheableLayer : public MockLayer {
  public:
   explicit MockCacheableLayer(SkPath path,
                               DlPaint paint = DlPaint(),
                               int render_limit = 3)
-      : MockLayer(path, paint), render_limit_(render_limit) {}
+      : MockLayer(path, paint) {
+    raster_cache_item_ =
+        std::make_unique<MockLayerCacheableItem>(this, render_limit);
+  }
 
   const LayerRasterCacheItem* raster_cache_item() const {
     return raster_cache_item_.get();
@@ -164,11 +167,7 @@ class MockCacheableLayer : public MockLayer, public CacheableLayer {
   void Preroll(PrerollContext* context) override;
 
  private:
-  RasterCacheItem* realize_raster_cache_item() override;
-  void disable_raster_cache_item() override;
   std::unique_ptr<LayerRasterCacheItem> raster_cache_item_;
-
-  int render_limit_;
 };
 
 }  // namespace testing

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -62,8 +62,7 @@ void MockRasterCache::AddMockPicture(int width, int height) {
   DisplayListRasterCacheItem display_list_item(display_list, SkPoint(), true,
                                                false);
   for (size_t i = 0; i < access_threshold(); i++) {
-    display_list_item.PrerollSetup(&preroll_context_, ctm);
-    display_list_item.PrerollFinalize(&preroll_context_, ctm);
+    AutoCache(&display_list_item, &preroll_context_, ctm);
   }
   RasterCache::Context r_context = {
       // clang-format off


### PR DESCRIPTION
…… (#45747)

…" (#45734)

Reverts flutter/engine#45211

b/298583505

preemptively cp the revert to the next roll i am looking at. I do see the recipe branch show up on https://flutter-review.googlesource.com/admin/repos/recipes,branches/q/filter:flutter-3.15 , I will assume the recipe branch is created for now. We will see the post submit results. If it doesn't work I will create the recipe branch manually.
