### PR TITLE
[Impeller] Incorporate filters in subpass coverage.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3173,7 +3173,7 @@ TEST_P(AiksTest, MatrixSaveLayerFilter) {
     canvas.SaveLayer({.image_filter = ImageFilter::MakeMatrix(
                           Matrix::MakeTranslation(Vector2(1, 1) *
                                                   (200 + 100 * k1OverSqrt2)) *
-                              Matrix::MakeScale(Vector2(1, 1) * 0.2) *
+                              Matrix::MakeScale(Vector2(1, 1) * 0.5) *
                               Matrix::MakeTranslation(Vector2(-200, -200)),
                           SamplerDescriptor{})},
                      std::nullopt);
@@ -3201,7 +3201,7 @@ TEST_P(AiksTest, MatrixBackdropFilter) {
         {}, std::nullopt,
         ImageFilter::MakeMatrix(
             Matrix::MakeTranslation(Vector2(1, 1) * (100 + 100 * k1OverSqrt2)) *
-                Matrix::MakeScale(Vector2(1, 1) * 0.2) *
+                Matrix::MakeScale(Vector2(1, 1) * 0.5) *
                 Matrix::MakeTranslation(Vector2(-100, -100)),
             SamplerDescriptor{}));
     canvas.Restore();

--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -60,14 +60,21 @@ std::shared_ptr<Contents> Paint::WithFilters(
     std::shared_ptr<Contents> input) const {
   input = WithColorFilter(input, /*absorb_opacity=*/true);
   input = WithInvertFilter(input);
-  input = WithImageFilter(input, Matrix(), /*is_subpass=*/false);
+  auto image_filter = WithImageFilter(input, Matrix(), /*is_subpass=*/false);
+  if (image_filter) {
+    input = image_filter;
+  }
   return input;
 }
 
 std::shared_ptr<Contents> Paint::WithFiltersForSubpassTarget(
     std::shared_ptr<Contents> input,
     const Matrix& effect_transform) const {
-  input = WithImageFilter(input, effect_transform, /*is_subpass=*/true);
+  auto image_filter =
+      WithImageFilter(input, effect_transform, /*is_subpass=*/true);
+  if (image_filter) {
+    input = image_filter;
+  }
   input = WithColorFilter(input, /*absorb_opacity=*/true);
   return input;
 }
@@ -81,12 +88,12 @@ std::shared_ptr<Contents> Paint::WithMaskBlur(std::shared_ptr<Contents> input,
   return input;
 }
 
-std::shared_ptr<Contents> Paint::WithImageFilter(
-    std::shared_ptr<Contents> input,
+std::shared_ptr<FilterContents> Paint::WithImageFilter(
+    const FilterInput::Variant& input,
     const Matrix& effect_transform,
     bool is_subpass) const {
   if (!image_filter) {
-    return input;
+    return nullptr;
   }
   auto filter = image_filter->WrapInput(FilterInput::Make(input));
   filter->SetIsForSubpass(is_subpass);

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -98,11 +98,12 @@ struct Paint {
   std::shared_ptr<Contents> WithMaskBlur(std::shared_ptr<Contents> input,
                                          bool is_solid_color) const;
 
- private:
-  std::shared_ptr<Contents> WithImageFilter(std::shared_ptr<Contents> input,
-                                            const Matrix& effect_transform,
-                                            bool is_subpass) const;
+  std::shared_ptr<FilterContents> WithImageFilter(
+      const FilterInput::Variant& input,
+      const Matrix& effect_transform,
+      bool is_subpass) const;
 
+ private:
   std::shared_ptr<Contents> WithColorFilter(std::shared_ptr<Contents> input,
                                             bool absorb_opacity = false) const;
 

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -47,6 +47,13 @@ std::shared_ptr<Contents> PaintPassDelegate::CreateContentsForSubpassTarget(
                                             effect_transform);
 }
 
+// |EntityPassDelgate|
+std::shared_ptr<FilterContents> PaintPassDelegate::WithImageFilter(
+    const FilterInput::Variant& input,
+    const Matrix& effect_transform) const {
+  return paint_.WithImageFilter(input, effect_transform, true);
+}
+
 /// OpacityPeepholePassDelegate
 /// ----------------------------------------------
 
@@ -138,6 +145,13 @@ OpacityPeepholePassDelegate::CreateContentsForSubpassTarget(
 
   return paint_.WithFiltersForSubpassTarget(std::move(contents),
                                             effect_transform);
+}
+
+// |EntityPassDelgate|
+std::shared_ptr<FilterContents> OpacityPeepholePassDelegate::WithImageFilter(
+    const FilterInput::Variant& input,
+    const Matrix& effect_transform) const {
+  return paint_.WithImageFilter(input, effect_transform, true);
 }
 
 }  // namespace impeller

--- a/impeller/aiks/paint_pass_delegate.h
+++ b/impeller/aiks/paint_pass_delegate.h
@@ -32,6 +32,11 @@ class PaintPassDelegate final : public EntityPassDelegate {
       std::shared_ptr<Texture> target,
       const Matrix& effect_transform) override;
 
+  // |EntityPassDelgate|
+  std::shared_ptr<FilterContents> WithImageFilter(
+      const FilterInput::Variant& input,
+      const Matrix& effect_transform) const override;
+
  private:
   const Paint paint_;
 
@@ -60,6 +65,11 @@ class OpacityPeepholePassDelegate final : public EntityPassDelegate {
   std::shared_ptr<Contents> CreateContentsForSubpassTarget(
       std::shared_ptr<Texture> target,
       const Matrix& effect_transform) override;
+
+  // |EntityPassDelgate|
+  std::shared_ptr<FilterContents> WithImageFilter(
+      const FilterInput::Variant& input,
+      const Matrix& effect_transform) const override;
 
  private:
   const Paint paint_;

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -123,6 +123,10 @@ std::optional<Color> Contents::AsBackgroundColor(const Entity& entity,
   return {};
 }
 
+const FilterContents* Contents::AsFilter() const {
+  return nullptr;
+}
+
 bool Contents::ApplyColorFilter(
     const Contents::ColorFilterProc& color_filter_proc) {
   return false;

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -23,6 +23,7 @@ struct ContentContextOptions;
 class Entity;
 class Surface;
 class RenderPass;
+class FilterContents;
 
 ContentContextOptions OptionsFromPass(const RenderPass& pass);
 
@@ -154,6 +155,12 @@ class Contents {
   ///
   virtual std::optional<Color> AsBackgroundColor(const Entity& entity,
                                                  ISize target_size) const;
+
+  //----------------------------------------------------------------------------
+  /// @brief Cast to a filter. Returns `nullptr` if this Contents is not a
+  ///        filter.
+  ///
+  virtual const FilterContents* AsFilter() const;
 
   //----------------------------------------------------------------------------
   /// @brief      If possible, applies a color filter to this contents inputs on

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -259,12 +259,24 @@ std::optional<Snapshot> FilterContents::RenderToSnapshot(
   return std::nullopt;
 }
 
+const FilterContents* FilterContents::AsFilter() const {
+  return this;
+}
+
 Matrix FilterContents::GetLocalTransform(const Matrix& parent_transform) const {
   return Matrix();
 }
 
 Matrix FilterContents::GetTransform(const Matrix& parent_transform) const {
   return parent_transform * GetLocalTransform(parent_transform);
+}
+bool FilterContents::HasBasisTransformations() const {
+  for (auto& input : inputs_) {
+    if (!input->HasBasisTransformations()) {
+      return false;
+    }
+  }
+  return true;
 }
 
 bool FilterContents::IsLeaf() const {

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -270,9 +270,9 @@ Matrix FilterContents::GetLocalTransform(const Matrix& parent_transform) const {
 Matrix FilterContents::GetTransform(const Matrix& parent_transform) const {
   return parent_transform * GetLocalTransform(parent_transform);
 }
-bool FilterContents::HasBasisTransformations() const {
+bool FilterContents::IsTranslationOnly() const {
   for (auto& input : inputs_) {
-    if (!input->HasBasisTransformations()) {
+    if (!input->IsTranslationOnly()) {
       return false;
     }
   }

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -125,9 +125,21 @@ class FilterContents : public Contents {
       bool msaa_enabled = true,
       const std::string& label = "Filter Snapshot") const override;
 
+  // |Contents|
+  const FilterContents* AsFilter() const override;
+
   virtual Matrix GetLocalTransform(const Matrix& parent_transform) const;
 
   Matrix GetTransform(const Matrix& parent_transform) const;
+
+  /// @brief  Returns true of this filter graph performs basis transformations
+  ///         to the filtered content. For example: Rotating, scaling, and
+  ///         skewing are all basis transformations, but translating is not.
+  ///
+  ///         This is useful for determining whether a filtered object's space
+  ///         is compatible enough with the parent pass space to perform certain
+  ///         subpass optimizations.
+  virtual bool HasBasisTransformations() const;
 
   /// @brief  Returns `true` if this filter does not have any `FilterInput`
   ///         children.

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -132,14 +132,15 @@ class FilterContents : public Contents {
 
   Matrix GetTransform(const Matrix& parent_transform) const;
 
-  /// @brief  Returns true of this filter graph performs basis transformations
-  ///         to the filtered content. For example: Rotating, scaling, and
-  ///         skewing are all basis transformations, but translating is not.
+  /// @brief  Returns true if this filter graph doesn't perform any basis
+  ///         transformations to the filtered content. For example: Rotating,
+  ///         scaling, and skewing are all basis transformations, but
+  ///         translating is not.
   ///
   ///         This is useful for determining whether a filtered object's space
   ///         is compatible enough with the parent pass space to perform certain
-  ///         subpass optimizations.
-  virtual bool HasBasisTransformations() const;
+  ///         subpass clipping optimizations.
+  virtual bool IsTranslationOnly() const;
 
   /// @brief  Returns `true` if this filter does not have any `FilterInput`
   ///         children.

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
@@ -58,8 +58,8 @@ void FilterContentsFilterInput::PopulateGlyphAtlas(
   filter_->PopulateGlyphAtlas(lazy_glyph_atlas, scale);
 }
 
-bool FilterContentsFilterInput::HasBasisTransformations() const {
-  return filter_->HasBasisTransformations();
+bool FilterContentsFilterInput::IsTranslationOnly() const {
+  return filter_->IsTranslationOnly();
 }
 
 bool FilterContentsFilterInput::IsLeaf() const {

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
@@ -58,6 +58,10 @@ void FilterContentsFilterInput::PopulateGlyphAtlas(
   filter_->PopulateGlyphAtlas(lazy_glyph_atlas, scale);
 }
 
+bool FilterContentsFilterInput::HasBasisTransformations() const {
+  return filter_->HasBasisTransformations();
+}
+
 bool FilterContentsFilterInput::IsLeaf() const {
   return false;
 }

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
@@ -37,6 +37,9 @@ class FilterContentsFilterInput final : public FilterInput {
       Scalar scale) override;
 
   // |FilterInput|
+  bool HasBasisTransformations() const override;
+
+  // |FilterInput|
   bool IsLeaf() const override;
 
   // |FilterInput|

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
@@ -37,7 +37,7 @@ class FilterContentsFilterInput final : public FilterInput {
       Scalar scale) override;
 
   // |FilterInput|
-  bool HasBasisTransformations() const override;
+  bool IsTranslationOnly() const override;
 
   // |FilterInput|
   bool IsLeaf() const override;

--- a/impeller/entity/contents/filters/inputs/filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_input.cc
@@ -76,8 +76,8 @@ void FilterInput::PopulateGlyphAtlas(
 
 FilterInput::~FilterInput() = default;
 
-bool FilterInput::HasBasisTransformations() const {
-  return false;
+bool FilterInput::IsTranslationOnly() const {
+  return true;
 }
 
 bool FilterInput::IsLeaf() const {

--- a/impeller/entity/contents/filters/inputs/filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_input.cc
@@ -76,6 +76,10 @@ void FilterInput::PopulateGlyphAtlas(
 
 FilterInput::~FilterInput() = default;
 
+bool FilterInput::HasBasisTransformations() const {
+  return false;
+}
+
 bool FilterInput::IsLeaf() const {
   return true;
 }

--- a/impeller/entity/contents/filters/inputs/filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_input.h
@@ -69,6 +69,9 @@ class FilterInput {
       const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
       Scalar scale);
 
+  /// @see  `FilterContents::HasBasisTransformations`
+  virtual bool HasBasisTransformations() const;
+
   /// @brief  Returns `true` unless this input is a `FilterInput`, which may
   ///         take other inputs.
   virtual bool IsLeaf() const;

--- a/impeller/entity/contents/filters/inputs/filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_input.h
@@ -70,7 +70,7 @@ class FilterInput {
       Scalar scale);
 
   /// @see  `FilterContents::HasBasisTransformations`
-  virtual bool HasBasisTransformations() const;
+  virtual bool IsTranslationOnly() const;
 
   /// @brief  Returns `true` unless this input is a `FilterInput`, which may
   ///         take other inputs.

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -19,6 +19,11 @@ void MatrixFilterContents::SetIsForSubpass(bool is_subpass) {
   FilterContents::SetIsForSubpass(is_subpass);
 }
 
+bool MatrixFilterContents::HasBasisTransformations() const {
+  return !matrix_.Basis().IsIdentity() ||
+         FilterContents::HasBasisTransformations();
+}
+
 void MatrixFilterContents::SetSamplerDescriptor(SamplerDescriptor desc) {
   sampler_descriptor_ = std::move(desc);
 }

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -19,9 +19,8 @@ void MatrixFilterContents::SetIsForSubpass(bool is_subpass) {
   FilterContents::SetIsForSubpass(is_subpass);
 }
 
-bool MatrixFilterContents::HasBasisTransformations() const {
-  return !matrix_.Basis().IsIdentity() ||
-         FilterContents::HasBasisTransformations();
+bool MatrixFilterContents::IsTranslationOnly() const {
+  return matrix_.Basis().IsIdentity() && FilterContents::IsTranslationOnly();
 }
 
 void MatrixFilterContents::SetSamplerDescriptor(SamplerDescriptor desc) {

--- a/impeller/entity/contents/filters/matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/matrix_filter_contents.h
@@ -20,6 +20,9 @@ class MatrixFilterContents final : public FilterContents {
   // |FilterContents|
   void SetIsForSubpass(bool is_for_subpass) override;
 
+  // |FilterContents|
+  bool HasBasisTransformations() const override;
+
   void SetSamplerDescriptor(SamplerDescriptor desc);
 
   // |FilterContents|

--- a/impeller/entity/contents/filters/matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/matrix_filter_contents.h
@@ -21,7 +21,7 @@ class MatrixFilterContents final : public FilterContents {
   void SetIsForSubpass(bool is_for_subpass) override;
 
   // |FilterContents|
-  bool HasBasisTransformations() const override;
+  bool IsTranslationOnly() const override;
 
   void SetSamplerDescriptor(SamplerDescriptor desc);
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -114,7 +114,7 @@ std::optional<Rect> EntityPass::GetElementsCoverage(
       // as opposed to empty coverage.
       if (coverage.has_value() && coverage_limit.has_value()) {
         const auto* filter = entity->GetContents()->AsFilter();
-        if (!filter || !filter->HasBasisTransformations()) {
+        if (!filter || filter->IsTranslationOnly()) {
           coverage = coverage->Intersection(coverage_limit.value());
         }
       }
@@ -140,7 +140,7 @@ std::optional<Rect> EntityPass::GetElementsCoverage(
       }
 
       if (coverage.has_value() && coverage_limit.has_value() &&
-          (!image_filter || !image_filter->HasBasisTransformations())) {
+          (!image_filter || image_filter->IsTranslationOnly())) {
         coverage = coverage->Intersection(coverage_limit.value());
       }
     } else {
@@ -168,9 +168,9 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
   // If the filter graph transforms the basis of the subpass, then its space
   // has deviated too much from the parent pass to safely intersect with the
   // pass coverage limit.
-  coverage_limit = (image_filter && image_filter->HasBasisTransformations()
-                        ? std::nullopt
-                        : coverage_limit);
+  coverage_limit =
+      (image_filter && image_filter->IsTranslationOnly() ? std::nullopt
+                                                         : coverage_limit);
 
   auto entities_coverage = subpass.GetElementsCoverage(coverage_limit);
   // The entities don't cover anything. There is nothing to do.

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -110,12 +110,39 @@ std::optional<Rect> EntityPass::GetElementsCoverage(
     if (auto entity = std::get_if<Entity>(&element)) {
       coverage = entity->GetCoverage();
 
+      // When the coverage limit is std::nullopt, that means there is no limit,
+      // as opposed to empty coverage.
       if (coverage.has_value() && coverage_limit.has_value()) {
+        const auto* filter = entity->GetContents()->AsFilter();
+        if (!filter || !filter->HasBasisTransformations()) {
+          coverage = coverage->Intersection(coverage_limit.value());
+        }
+      }
+    } else if (auto subpass_ptr =
+                   std::get_if<std::unique_ptr<EntityPass>>(&element)) {
+      auto& subpass = *subpass_ptr->get();
+
+      std::optional<Rect> unfiltered_coverage =
+          GetSubpassCoverage(subpass, std::nullopt);
+      if (!unfiltered_coverage.has_value()) {
+        continue;
+      }
+
+      std::shared_ptr<FilterContents> image_filter =
+          subpass.delegate_->WithImageFilter(*unfiltered_coverage,
+                                             subpass.xformation_);
+      if (image_filter) {
+        Entity subpass_entity;
+        subpass_entity.SetTransformation(subpass.xformation_);
+        coverage = image_filter->GetCoverage(subpass_entity);
+      } else {
+        coverage = unfiltered_coverage;
+      }
+
+      if (coverage.has_value() && coverage_limit.has_value() &&
+          (!image_filter || !image_filter->HasBasisTransformations())) {
         coverage = coverage->Intersection(coverage_limit.value());
       }
-    } else if (auto subpass =
-                   std::get_if<std::unique_ptr<EntityPass>>(&element)) {
-      coverage = GetSubpassCoverage(*subpass->get(), coverage_limit);
     } else {
       FML_UNREACHABLE();
     }
@@ -135,6 +162,16 @@ std::optional<Rect> EntityPass::GetElementsCoverage(
 std::optional<Rect> EntityPass::GetSubpassCoverage(
     const EntityPass& subpass,
     std::optional<Rect> coverage_limit) const {
+  std::shared_ptr<FilterContents> image_filter =
+      subpass.delegate_->WithImageFilter(Rect(), subpass.xformation_);
+
+  // If the filter graph transforms the basis of the subpass, then its space
+  // has deviated too much from the parent pass to safely intersect with the
+  // pass coverage limit.
+  coverage_limit = (image_filter && image_filter->HasBasisTransformations()
+                        ? std::nullopt
+                        : coverage_limit);
+
   auto entities_coverage = subpass.GetElementsCoverage(coverage_limit);
   // The entities don't cover anything. There is nothing to do.
   if (!entities_coverage.has_value()) {

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -141,6 +141,9 @@ class EntityPass {
 
   void SetEnableOffscreenCheckerboard(bool enabled);
 
+  //----------------------------------------------------------------------------
+  /// @brief  Get the coverage of an unfiltered subpass.
+  ///
   std::optional<Rect> GetSubpassCoverage(
       const EntityPass& subpass,
       std::optional<Rect> coverage_limit) const;

--- a/impeller/entity/entity_pass_delegate.cc
+++ b/impeller/entity/entity_pass_delegate.cc
@@ -34,6 +34,13 @@ class DefaultEntityPassDelegate final : public EntityPassDelegate {
     FML_UNREACHABLE();
   }
 
+  // |EntityPassDelgate|
+  std::shared_ptr<FilterContents> WithImageFilter(
+      const FilterInput::Variant& input,
+      const Matrix& effect_transform) const override {
+    return nullptr;
+  }
+
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(DefaultEntityPassDelegate);
 };

--- a/impeller/entity/entity_pass_delegate.h
+++ b/impeller/entity/entity_pass_delegate.h
@@ -9,6 +9,8 @@
 #include "flutter/fml/macros.h"
 #include "impeller/core/texture.h"
 #include "impeller/entity/contents/contents.h"
+#include "impeller/entity/contents/filters/filter_contents.h"
+#include "impeller/entity/contents/filters/inputs/filter_input.h"
 
 namespace impeller {
 
@@ -31,6 +33,10 @@ class EntityPassDelegate {
   virtual std::shared_ptr<Contents> CreateContentsForSubpassTarget(
       std::shared_ptr<Texture> target,
       const Matrix& effect_transform) = 0;
+
+  virtual std::shared_ptr<FilterContents> WithImageFilter(
+      const FilterInput::Variant& input,
+      const Matrix& effect_transform) const = 0;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(EntityPassDelegate);

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -91,6 +91,13 @@ class TestPassDelegate final : public EntityPassDelegate {
     return nullptr;
   }
 
+  // |EntityPassDelegate|
+  std::shared_ptr<FilterContents> WithImageFilter(
+      const FilterInput::Variant& input,
+      const Matrix& effect_transform) const override {
+    return nullptr;
+  }
+
  private:
   const std::optional<Rect> coverage_;
   const bool collapse_;


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/131182.

I adjusted the size of the matrix filtered circle in both SaveLayer Matrix filter test variants (post-filter and backdrop filter) to move the transformed circle outside the coverage area that would be computed if subpass filters aren't being accounted for. Further, we need to avoid intersecting with the pass coverage hint when the transformation being applied by the paint's filter graph causes the Entity's space basis to deviate from the parent pass basis. We're still able to apply it for simple translations, though.

Before:

![Screenshot 2023-09-13 at 10 46 13 AM](https://github.com/flutter/engine/assets/919017/40a99d1c-f3d1-40d0-a62f-efdec5649664)

After:

![Screenshot 2023-09-13 at 10 48 38 AM](https://github.com/flutter/engine/assets/919017/66f85723-c7bf-4ddb-b593-9756e2bbe99b)
