### PR TITLE
[ios] use python script to generate extension safe frameworks and code sign them

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -332,8 +332,8 @@
             "realm": "production"
         },
         {
-            "source": "out/release/extension_safe/Flutter.dSYM.zip",
-            "destination": "ios-release/extension_safe/Flutter.dSYM.zip",
+            "source": "out/release/extension_safe_Flutter.dSYM.zip",
+            "destination": "ios-release/extension_safe_Flutter.dSYM.zip",
             "realm": "production"
         }
     ]

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -332,7 +332,7 @@
             "realm": "production"
         },
         {
-            "source": "out/release_extension_safe/Flutter.dSYM.zip",
+            "source": "out/release/extension_safe/Flutter.dSYM.zip",
             "destination": "ios-release/extension_safe/Flutter.dSYM.zip",
             "realm": "production"
         }

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -290,53 +290,6 @@
                 "language": "python3"
             },
             {
-                "name": "Debug-ios-Flutter-Extension-Safe.xcframework",
-                "parameters": [
-                    "--dst",
-                    "out/debug_extension_safe",
-                    "--arm64-out-dir",
-                    "out/ios_debug_extension_safe",
-                    "--simulator-x64-out-dir",
-                    "out/ios_debug_sim_extension_safe",
-                    "--simulator-arm64-out-dir",
-                    "out/ios_debug_sim_arm64_extension_safe"
-                ],
-                "script": "flutter/sky/tools/create_full_ios_framework.py",
-                "language": "python3"
-            },
-            {
-                "name": "Profile-ios-Flutter-Extension-Safe.xcframework",
-                "parameters": [
-                    "--dst",
-                    "out/profile_extension_safe",
-                    "--arm64-out-dir",
-                    "out/ios_profile_extension_safe",
-                    "--simulator-x64-out-dir",
-                    "out/ios_debug_sim_extension_safe",
-                    "--simulator-arm64-out-dir",
-                    "out/ios_debug_sim_arm64_extension_safe"
-                ],
-                "script": "flutter/sky/tools/create_full_ios_framework.py",
-                "language": "python3"
-            },
-            {
-                "name": "Release-ios-Flutter-Extension-Safe.xcframework",
-                "parameters": [
-                    "--dst",
-                    "out/release_extension_safe",
-                    "--arm64-out-dir",
-                    "out/ios_release_extension_safe",
-                    "--simulator-x64-out-dir",
-                    "out/ios_debug_sim_extension_safe",
-                    "--simulator-arm64-out-dir",
-                    "out/ios_debug_sim_arm64_extension_safe",
-                    "--dsym",
-                    "--strip"
-                ],
-                "script": "flutter/sky/tools/create_full_ios_framework.py",
-                "language": "python3"
-            },
-            {
                 "name": "Release-macos-gen-snapshots",
                 "parameters": [
                     "--dst",
@@ -379,23 +332,8 @@
             "realm": "production"
         },
         {
-            "source": "out/debug_extension_safe/artifacts.zip",
-            "destination": "ios-extension-safe/artifacts.zip",
-            "realm": "production"
-        },
-        {
-            "source": "out/profile_extension_safe/artifacts.zip",
-            "destination": "ios-profile-extension-safe/artifacts.zip",
-            "realm": "production"
-        },
-        {
-            "source": "out/release_extension_safe/artifacts.zip",
-            "destination": "ios-release-extension-safe/artifacts.zip",
-            "realm": "production"
-        },
-        {
             "source": "out/release_extension_safe/Flutter.dSYM.zip",
-            "destination": "ios-release-extension-safe/Flutter.dSYM.zip",
+            "destination": "ios-release/extension_safe/Flutter.dSYM.zip",
             "realm": "production"
         }
     ]

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -106,6 +106,46 @@ def main():
       args, dst, framework, arm64_framework, simulator_framework,
       simulator_x64_framework, simulator_arm64_framework
   )
+
+  # build extension safe frameworks
+  extension_safe_dst = os.path.join(dst, 'extension_safe')
+  extension_safe_framework = os.path.join(
+      extension_safe_dst, 'Flutter.framework'
+  )
+  extension_safe_simulator_framework = os.path.join(
+      extension_safe_dst, 'sim', 'Flutter.framework'
+  )
+  extension_safe_arm64_framework = os.path.join(
+      arm64_out_dir + '_extension_safe', 'Flutter.framework'
+  )
+  extension_safe_simulator_x64_framework = os.path.join(
+      simulator_x64_out_dir + '_extension_safe', 'Flutter.framework'
+  )
+  extension_safe_simulator_arm64_framework = os.path.join(
+      simulator_arm64_out_dir + '_extension_safe', 'Flutter.framework'
+  )
+
+  if not os.path.isdir(extension_safe_arm64_framework):
+    print(
+        'Cannot find extension safe iOS arm64 Framework at %s' %
+        extension_safe_arm64_framework
+    )
+    return 1
+
+  if not os.path.isdir(extension_safe_simulator_x64_framework):
+    print(
+        'Cannot find extension safe iOS x64 simulator Framework at %s' %
+        extension_safe_simulator_x64_framework
+    )
+    return 1
+
+  create_framework(
+      args, extension_safe_dst, extension_safe_framework,
+      extension_safe_arm64_framework, extension_safe_simulator_framework,
+      extension_safe_simulator_x64_framework,
+      extension_safe_simulator_arm64_framework
+  )
+
   generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir)
   zip_archive(dst)
   return 0
@@ -173,7 +213,9 @@ def zip_archive(dst):
   ios_file_with_entitlements = ['gen_snapshot_arm64']
   ios_file_without_entitlements = [
       'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter'
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter'
   ]
   embed_codesign_configuration(
       os.path.join(dst, 'entitlements.txt'), ios_file_with_entitlements
@@ -192,6 +234,7 @@ def zip_archive(dst):
       'Flutter.xcframework',
       'entitlements.txt',
       'without_entitlements.txt',
+      'extension_safe',
   ],
                         cwd=dst)
   if os.path.exists(os.path.join(dst, 'Flutter.dSYM')):

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -243,7 +243,9 @@ def zip_archive(dst):
                           cwd=dst)
 
   if os.path.exists(os.path.join(dst, 'extension_safe', 'Flutter.dSYM')):
-    subprocess.check_call(['zip', '-r', 'extension_safe_Flutter.dSYM.zip', 'Flutter.dSYM'],
+    subprocess.check_call([
+        'zip', '-r', 'extension_safe_Flutter.dSYM.zip', 'Flutter.dSYM'
+    ],
                           cwd=dst)
 
 

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -107,22 +107,32 @@ def main():
       simulator_x64_framework, simulator_arm64_framework
   )
 
-  # build extension safe frameworks
   extension_safe_dst = os.path.join(dst, 'extension_safe')
-  extension_safe_framework = os.path.join(
-      extension_safe_dst, 'Flutter.framework'
+  create_extension_safe_framework(
+      args, extension_safe_dst, '%s_extension_safe' % arm64_out_dir,
+      '%s_extension_safe' % simulator_x64_out_dir,
+      '%s_extension_safe' % simulator_arm64_out_dir
   )
+
+  generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir)
+  zip_archive(dst)
+  return 0
+
+def create_extension_safe_framework( # pylint: disable=too-many-arguments
+    args, dst, arm64_out_dir, simulator_x64_out_dir, simulator_arm64_out_dir
+):
+  extension_safe_framework = os.path.join(dst, 'Flutter.framework')
   extension_safe_simulator_framework = os.path.join(
-      extension_safe_dst, 'sim', 'Flutter.framework'
+      dst, 'sim', 'Flutter.framework'
   )
   extension_safe_arm64_framework = os.path.join(
-      arm64_out_dir + '_extension_safe', 'Flutter.framework'
+      arm64_out_dir, 'Flutter.framework'
   )
   extension_safe_simulator_x64_framework = os.path.join(
-      simulator_x64_out_dir + '_extension_safe', 'Flutter.framework'
+      simulator_x64_out_dir, 'Flutter.framework'
   )
   extension_safe_simulator_arm64_framework = os.path.join(
-      simulator_arm64_out_dir + '_extension_safe', 'Flutter.framework'
+      simulator_arm64_out_dir, 'Flutter.framework'
   )
 
   if not os.path.isdir(extension_safe_arm64_framework):
@@ -140,16 +150,12 @@ def main():
     return 1
 
   create_framework(
-      args, extension_safe_dst, extension_safe_framework,
-      extension_safe_arm64_framework, extension_safe_simulator_framework,
+      args, dst, extension_safe_framework, extension_safe_arm64_framework,
+      extension_safe_simulator_framework,
       extension_safe_simulator_x64_framework,
       extension_safe_simulator_arm64_framework
   )
-
-  generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir)
-  zip_archive(dst)
   return 0
-
 
 def create_framework(  # pylint: disable=too-many-arguments
     args, dst, framework, arm64_framework, simulator_framework,

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -122,12 +122,8 @@ def create_extension_safe_framework( # pylint: disable=too-many-arguments
     args, dst, arm64_out_dir, simulator_x64_out_dir, simulator_arm64_out_dir
 ):
   framework = os.path.join(dst, 'Flutter.framework')
-  simulator_framework = os.path.join(
-      dst, 'sim', 'Flutter.framework'
-  )
-  arm64_framework = os.path.join(
-      arm64_out_dir, 'Flutter.framework'
-  )
+  simulator_framework = os.path.join(dst, 'sim', 'Flutter.framework')
+  arm64_framework = os.path.join(arm64_out_dir, 'Flutter.framework')
   simulator_x64_framework = os.path.join(
       simulator_x64_out_dir, 'Flutter.framework'
   )
@@ -137,8 +133,7 @@ def create_extension_safe_framework( # pylint: disable=too-many-arguments
 
   if not os.path.isdir(arm64_framework):
     print(
-        'Cannot find extension safe iOS arm64 Framework at %s' %
-        arm64_framework
+        'Cannot find extension safe iOS arm64 Framework at %s' % arm64_framework
     )
     return 1
 
@@ -150,10 +145,8 @@ def create_extension_safe_framework( # pylint: disable=too-many-arguments
     return 1
 
   create_framework(
-      args, dst, framework, arm64_framework,
-      simulator_framework,
-      simulator_x64_framework,
-      simulator_arm64_framework
+      args, dst, framework, arm64_framework, simulator_framework,
+      simulator_x64_framework, simulator_arm64_framework
   )
   return 0
 

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -233,11 +233,17 @@ def zip_archive(dst):
       'Flutter.xcframework',
       'entitlements.txt',
       'without_entitlements.txt',
-      'extension_safe',
+      'extension_safe/Flutter.framework',
+      'extension_safe/Flutter.xcframework',
+      'extension_safe/sim',
   ],
                         cwd=dst)
   if os.path.exists(os.path.join(dst, 'Flutter.dSYM')):
     subprocess.check_call(['zip', '-r', 'Flutter.dSYM.zip', 'Flutter.dSYM'],
+                          cwd=dst)
+
+  if os.path.exists(os.path.join(dst, 'extension_safe', 'Flutter.dSYM')):
+    subprocess.check_call(['zip', '-r', 'extension_safe_Flutter.dSYM.zip', 'Flutter.dSYM'],
                           cwd=dst)
 
 

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -121,39 +121,39 @@ def main():
 def create_extension_safe_framework( # pylint: disable=too-many-arguments
     args, dst, arm64_out_dir, simulator_x64_out_dir, simulator_arm64_out_dir
 ):
-  extension_safe_framework = os.path.join(dst, 'Flutter.framework')
-  extension_safe_simulator_framework = os.path.join(
+  framework = os.path.join(dst, 'Flutter.framework')
+  simulator_framework = os.path.join(
       dst, 'sim', 'Flutter.framework'
   )
-  extension_safe_arm64_framework = os.path.join(
+  arm64_framework = os.path.join(
       arm64_out_dir, 'Flutter.framework'
   )
-  extension_safe_simulator_x64_framework = os.path.join(
+  simulator_x64_framework = os.path.join(
       simulator_x64_out_dir, 'Flutter.framework'
   )
-  extension_safe_simulator_arm64_framework = os.path.join(
+  simulator_arm64_framework = os.path.join(
       simulator_arm64_out_dir, 'Flutter.framework'
   )
 
-  if not os.path.isdir(extension_safe_arm64_framework):
+  if not os.path.isdir(arm64_framework):
     print(
         'Cannot find extension safe iOS arm64 Framework at %s' %
-        extension_safe_arm64_framework
+        arm64_framework
     )
     return 1
 
-  if not os.path.isdir(extension_safe_simulator_x64_framework):
+  if not os.path.isdir(simulator_x64_framework):
     print(
         'Cannot find extension safe iOS x64 simulator Framework at %s' %
-        extension_safe_simulator_x64_framework
+        simulator_x64_framework
     )
     return 1
 
   create_framework(
-      args, dst, extension_safe_framework, extension_safe_arm64_framework,
-      extension_safe_simulator_framework,
-      extension_safe_simulator_x64_framework,
-      extension_safe_simulator_arm64_framework
+      args, dst, framework, arm64_framework,
+      simulator_framework,
+      simulator_x64_framework,
+      simulator_arm64_framework
   )
   return 0
 


### PR DESCRIPTION
Generates the fat framework for extension safe variants and add them to the code sign list.

Also reverts part of https://github.com/flutter/engine/pull/45664 where the variants are uploaded in separate archive. Now with this change, the extension safe is inside a "extension_safe" folder under existing archive. 

fixes https://github.com/flutter/flutter/issues/124291

The destination folder after this change:
- An extension_safe folder is added, which includes the extension safe Flutter.frameworks and dsym
- The artifacts.zip now includes the `extension_safe` except the dysm
- A extension_safe_Flutter.dsym.zip is created (under ios/release/) , which includes the extension_safe/Flutter.dsym

<img width="508" alt="Screenshot 2023-09-13 at 3 26 23 PM" src="https://github.com/flutter/engine/assets/3756895/84901ef1-af89-413f-94c7-74ed0aa36da6">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
