### PR TITLE
Declare the js context as nullable in skwasm surface callback

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
@@ -80,7 +80,7 @@ class SkwasmSurface {
 
   void _callbackHandler(JSNumber callbackId, JSNumber context, JSAny? jsContext) {
     final Completer<JSAny> completer = _pendingCallbacks.remove(callbackId.toDartInt)!;
-    if (jsContext == null) {
+    if (jsContext.isUndefinedOrNull) {
       completer.complete(context);
     } else {
       completer.complete(jsContext);

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/surface.dart
@@ -78,9 +78,9 @@ class SkwasmSurface {
     return completer.future;
   }
 
-  void _callbackHandler(JSNumber callbackId, JSNumber context, JSAny jsContext) {
+  void _callbackHandler(JSNumber callbackId, JSNumber context, JSAny? jsContext) {
     final Completer<JSAny> completer = _pendingCallbacks.remove(callbackId.toDartInt)!;
-    if (jsContext.isUndefinedOrNull) {
+    if (jsContext == null) {
       completer.complete(context);
     } else {
       completer.complete(jsContext);

--- a/lib/web_ui/skwasm/library_skwasm_support.js
+++ b/lib/web_ui/skwasm/library_skwasm_support.js
@@ -39,8 +39,9 @@ mergeInto(LibraryManager.library, {
               object.close();
             }
             associatedObjectsMap.delete(data.pointer);
+            return;
           default:
-            console.warn('unrecognized skwasm message');
+            console.warn(`unrecognized skwasm message: ${skwasmMessage}`);
         }
       };
       if (!threadId) {


### PR DESCRIPTION
Declaring this as non-nullable causes breakage with an incoming JS interop change from the SDK. Marking this as nullable fixes the issue.

This doesn't actually change any behavior. The breakages were in `test/ui/image_golden_test.dart`. No changes to the test are required (they did catch the issue when the dart roll happened).