### PR TITLE
Handle external window's `WM_CLOSE` in lifecycle manager

### DIFF
--- a/shell/platform/windows/windows_lifecycle_manager.cc
+++ b/shell/platform/windows/windows_lifecycle_manager.cc
@@ -288,6 +288,11 @@ std::optional<LRESULT> WindowsLifecycleManager::ExternalWindowMessage(
     case WM_DESTROY:
       event = flutter::WindowStateEvent::kHide;
       break;
+    case WM_CLOSE:
+      if (HandleCloseMessage(hwnd, wparam, lparam)) {
+        return NULL;
+      }
+      break;
   }
 
   if (event.has_value()) {

--- a/shell/platform/windows/windows_lifecycle_manager.cc
+++ b/shell/platform/windows/windows_lifecycle_manager.cc
@@ -38,6 +38,28 @@ void WindowsLifecycleManager::DispatchMessage(HWND hwnd,
   PostMessage(hwnd, message, wparam, lparam);
 }
 
+bool WindowsLifecycleManager::HandleCloseMessage(HWND hwnd, WPARAM wparam, LPARAM lparam) {
+  if (!process_exit_) {
+    return false;
+  }
+  auto key = std::make_tuple(hwnd, wparam, lparam);
+  auto itr = sent_close_messages_.find(key);
+  if (itr != sent_close_messages_.end()) {
+    if (itr->second == 1) {
+      sent_close_messages_.erase(itr);
+    } else {
+      sent_close_messages_[key]--;
+    }
+    return false;
+  }
+  if (IsLastWindowOfProcess()) {
+    engine_->RequestApplicationQuit(hwnd, wparam, lparam,
+                                    AppExitType::cancelable);
+    return true;
+  }
+  return false;
+}
+
 bool WindowsLifecycleManager::WindowProc(HWND hwnd,
                                          UINT msg,
                                          WPARAM wpar,
@@ -48,27 +70,8 @@ bool WindowsLifecycleManager::WindowProc(HWND hwnd,
     // send a request to the framework to see if the app should exit. If it
     // is, we re-dispatch a new WM_CLOSE message. In order to allow the new
     // message to reach other delegates, we ignore it here.
-    case WM_CLOSE: {
-      if (!process_exit_) {
-        return false;
-      }
-      auto key = std::make_tuple(hwnd, wpar, lpar);
-      auto itr = sent_close_messages_.find(key);
-      if (itr != sent_close_messages_.end()) {
-        if (itr->second == 1) {
-          sent_close_messages_.erase(itr);
-        } else {
-          sent_close_messages_[key]--;
-        }
-        return false;
-      }
-      if (IsLastWindowOfProcess()) {
-        engine_->RequestApplicationQuit(hwnd, wpar, lpar,
-                                        AppExitType::cancelable);
-        return true;
-      }
-      break;
-    }
+    case WM_CLOSE:
+      return HandleCloseMessage(hwnd, wpar, lpar);
 
     // DWM composition can be disabled on Windows 7.
     // Notify the engine as this can result in screen tearing.

--- a/shell/platform/windows/windows_lifecycle_manager.cc
+++ b/shell/platform/windows/windows_lifecycle_manager.cc
@@ -38,7 +38,9 @@ void WindowsLifecycleManager::DispatchMessage(HWND hwnd,
   PostMessage(hwnd, message, wparam, lparam);
 }
 
-bool WindowsLifecycleManager::HandleCloseMessage(HWND hwnd, WPARAM wparam, LPARAM lparam) {
+bool WindowsLifecycleManager::HandleCloseMessage(HWND hwnd,
+                                                 WPARAM wparam,
+                                                 LPARAM lparam) {
   if (!process_exit_) {
     return false;
   }

--- a/shell/platform/windows/windows_lifecycle_manager.h
+++ b/shell/platform/windows/windows_lifecycle_manager.h
@@ -99,6 +99,8 @@ class WindowsLifecycleManager {
                                LPARAM lparam);
 
  private:
+  bool HandleCloseMessage(HWND hwnd, WPARAM wparam, LPARAM lparam);
+
   FlutterWindowsEngine* engine_;
 
   std::map<std::tuple<HWND, WPARAM, LPARAM>, int> sent_close_messages_;

--- a/shell/platform/windows/windows_lifecycle_manager.h
+++ b/shell/platform/windows/windows_lifecycle_manager.h
@@ -99,6 +99,11 @@ class WindowsLifecycleManager {
                                LPARAM lparam);
 
  private:
+  // Pass top-level window close notifications to the application lifecycle
+  // logic. If the last window of the process receives WM_CLOSE and a listener
+  // is registered for WidgetsBindingObserver.didRequestAppExit, the message is
+  // sent to the framework to query whether the application should be allowed
+  // to quit.
   bool HandleCloseMessage(HWND hwnd, WPARAM wparam, LPARAM lparam);
 
   FlutterWindowsEngine* engine_;


### PR DESCRIPTION
Handle the close messages from non-Flutter windows similarly to how we handle our own, for graceful app exit purposes.

https://github.com/flutter/flutter/issues/131497

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
