### PR TITLE
[Impeller] Add Entity::RenderingMode enum.

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -64,7 +64,7 @@ void Canvas::Save(bool create_subpass,
   entry.cull_rect = xformation_stack_.back().cull_rect;
   entry.stencil_depth = xformation_stack_.back().stencil_depth;
   if (create_subpass) {
-    entry.is_subpass = true;
+    entry.rendering_mode = Entity::RenderingMode::kSubpass;
     auto subpass = std::make_unique<EntityPass>();
     subpass->SetEnableOffscreenCheckerboard(
         debug_options.offscreen_texture_checkerboard);
@@ -72,10 +72,10 @@ void Canvas::Save(bool create_subpass,
       EntityPass::BackdropFilterProc backdrop_filter_proc =
           [backdrop_filter = backdrop_filter->Clone()](
               const FilterInput::Ref& input, const Matrix& effect_transform,
-              bool is_subpass) {
+              Entity::RenderingMode rendering_mode) {
             auto filter = backdrop_filter->WrapInput(input);
             filter->SetEffectTransform(effect_transform);
-            filter->SetIsForSubpass(is_subpass);
+            filter->SetRenderingMode(rendering_mode);
             return filter;
           };
       subpass->SetBackdropFilter(backdrop_filter_proc);
@@ -93,7 +93,8 @@ bool Canvas::Restore() {
   if (xformation_stack_.size() == 1) {
     return false;
   }
-  if (xformation_stack_.back().is_subpass) {
+  if (xformation_stack_.back().rendering_mode ==
+      Entity::RenderingMode::kSubpass) {
     current_pass_ = GetCurrentPass().GetSuperpass();
     FML_DCHECK(current_pass_);
   }

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -35,7 +35,7 @@ struct CanvasStackEntry {
   // |cull_rect| is conservative screen-space bounds of the clipped output area
   std::optional<Rect> cull_rect;
   size_t stencil_depth = 0u;
-  bool is_subpass = false;
+  Entity::RenderingMode rendering_mode = Entity::RenderingMode::kDirect;
   bool contains_clips = false;
 };
 

--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -60,7 +60,8 @@ std::shared_ptr<Contents> Paint::WithFilters(
     std::shared_ptr<Contents> input) const {
   input = WithColorFilter(input, /*absorb_opacity=*/true);
   input = WithInvertFilter(input);
-  auto image_filter = WithImageFilter(input, Matrix(), /*is_subpass=*/false);
+  auto image_filter =
+      WithImageFilter(input, Matrix(), Entity::RenderingMode::kDirect);
   if (image_filter) {
     input = image_filter;
   }
@@ -71,7 +72,7 @@ std::shared_ptr<Contents> Paint::WithFiltersForSubpassTarget(
     std::shared_ptr<Contents> input,
     const Matrix& effect_transform) const {
   auto image_filter =
-      WithImageFilter(input, effect_transform, /*is_subpass=*/true);
+      WithImageFilter(input, effect_transform, Entity::RenderingMode::kSubpass);
   if (image_filter) {
     input = image_filter;
   }
@@ -91,12 +92,12 @@ std::shared_ptr<Contents> Paint::WithMaskBlur(std::shared_ptr<Contents> input,
 std::shared_ptr<FilterContents> Paint::WithImageFilter(
     const FilterInput::Variant& input,
     const Matrix& effect_transform,
-    bool is_subpass) const {
+    Entity::RenderingMode rendering_mode) const {
   if (!image_filter) {
     return nullptr;
   }
   auto filter = image_filter->WrapInput(FilterInput::Make(input));
-  filter->SetIsForSubpass(is_subpass);
+  filter->SetRenderingMode(rendering_mode);
   filter->SetEffectTransform(effect_transform);
   return filter;
 }

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -26,7 +26,7 @@ struct Paint {
   using ImageFilterProc = std::function<std::shared_ptr<FilterContents>(
       FilterInput::Ref,
       const Matrix& effect_transform,
-      bool is_subpass)>;
+      Entity::RenderingMode rendering_mode)>;
   using MaskFilterProc = std::function<std::shared_ptr<FilterContents>(
       FilterInput::Ref,
       bool is_solid_color,
@@ -101,7 +101,7 @@ struct Paint {
   std::shared_ptr<FilterContents> WithImageFilter(
       const FilterInput::Variant& input,
       const Matrix& effect_transform,
-      bool is_subpass) const;
+      Entity::RenderingMode rendering_mode) const;
 
  private:
   std::shared_ptr<Contents> WithColorFilter(std::shared_ptr<Contents> input,

--- a/impeller/aiks/paint_pass_delegate.cc
+++ b/impeller/aiks/paint_pass_delegate.cc
@@ -51,7 +51,8 @@ std::shared_ptr<Contents> PaintPassDelegate::CreateContentsForSubpassTarget(
 std::shared_ptr<FilterContents> PaintPassDelegate::WithImageFilter(
     const FilterInput::Variant& input,
     const Matrix& effect_transform) const {
-  return paint_.WithImageFilter(input, effect_transform, true);
+  return paint_.WithImageFilter(input, effect_transform,
+                                Entity::RenderingMode::kSubpass);
 }
 
 /// OpacityPeepholePassDelegate
@@ -151,7 +152,8 @@ OpacityPeepholePassDelegate::CreateContentsForSubpassTarget(
 std::shared_ptr<FilterContents> OpacityPeepholePassDelegate::WithImageFilter(
     const FilterInput::Variant& input,
     const Matrix& effect_transform) const {
-  return paint_.WithImageFilter(input, effect_transform, true);
+  return paint_.WithImageFilter(input, effect_transform,
+                                Entity::RenderingMode::kSubpass);
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -298,9 +298,9 @@ void FilterContents::SetLeafInputs(const FilterInput::Vector& inputs) {
   }
 }
 
-void FilterContents::SetIsForSubpass(bool is_subpass) {
+void FilterContents::SetRenderingMode(Entity::RenderingMode rendering_mode) {
   for (auto& input : inputs_) {
-    input->SetIsForSubpass(is_subpass);
+    input->SetRenderingMode(rendering_mode);
   }
 }
 

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -157,7 +157,7 @@ class FilterContents : public Contents {
   ///         that the current transformation matrix of the entity is not stored
   ///         in the Entity transformation matrix. Instead, the effect transform
   ///         is used in this case.
-  virtual void SetIsForSubpass(bool is_subpass);
+  virtual void SetRenderingMode(Entity::RenderingMode rendering_mode);
 
  private:
   virtual std::optional<Rect> GetFilterCoverage(

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
@@ -75,8 +75,9 @@ void FilterContentsFilterInput::SetEffectTransform(const Matrix& matrix) {
   filter_->SetEffectTransform(matrix);
 }
 
-void FilterContentsFilterInput::SetIsForSubpass(bool is_for_subpass) {
-  filter_->SetIsForSubpass(is_for_subpass);
+void FilterContentsFilterInput::SetRenderingMode(
+    Entity::RenderingMode rendering_mode) {
+  filter_->SetRenderingMode(rendering_mode);
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
@@ -49,7 +49,7 @@ class FilterContentsFilterInput final : public FilterInput {
   virtual void SetEffectTransform(const Matrix& matrix) override;
 
   // |FilterInput|
-  virtual void SetIsForSubpass(bool is_for_subpass) override;
+  virtual void SetRenderingMode(Entity::RenderingMode rendering_mode) override;
 
  private:
   explicit FilterContentsFilterInput(std::shared_ptr<FilterContents> filter);

--- a/impeller/entity/contents/filters/inputs/filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_input.cc
@@ -88,6 +88,6 @@ void FilterInput::SetLeafInputs(const FilterInput::Vector& inputs) {}
 
 void FilterInput::SetEffectTransform(const Matrix& matrix) {}
 
-void FilterInput::SetIsForSubpass(bool is_for_subpass) {}
+void FilterInput::SetRenderingMode(Entity::RenderingMode rendering_mode) {}
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/inputs/filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_input.h
@@ -85,7 +85,7 @@ class FilterInput {
   virtual void SetEffectTransform(const Matrix& matrix);
 
   /// @brief  Turns on subpass mode for filter inputs.
-  virtual void SetIsForSubpass(bool is_for_subpass);
+  virtual void SetRenderingMode(Entity::RenderingMode rendering_mode);
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -14,9 +14,10 @@ void MatrixFilterContents::SetMatrix(Matrix matrix) {
   matrix_ = matrix;
 }
 
-void MatrixFilterContents::SetIsForSubpass(bool is_subpass) {
-  is_for_subpass_ = is_subpass;
-  FilterContents::SetIsForSubpass(is_subpass);
+void MatrixFilterContents::SetRenderingMode(
+    Entity::RenderingMode rendering_mode) {
+  rendering_mode_ = rendering_mode;
+  FilterContents::SetRenderingMode(rendering_mode);
 }
 
 bool MatrixFilterContents::IsTranslationOnly() const {
@@ -54,8 +55,9 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
   // mentioned above). And so we sneak the subpass's captured CTM in through the
   // effect transform.
 
-  auto transform =
-      is_for_subpass_ ? effect_transform : entity.GetTransformation();
+  auto transform = rendering_mode_ == Entity::RenderingMode::kSubpass
+                       ? effect_transform
+                       : entity.GetTransformation();
   snapshot->transform = transform *           //
                         matrix_ *             //
                         transform.Invert() *  //
@@ -78,8 +80,9 @@ std::optional<Rect> MatrixFilterContents::GetFilterCoverage(
   if (!coverage.has_value()) {
     return std::nullopt;
   }
-  auto& m =
-      is_for_subpass_ ? effect_transform : inputs[0]->GetTransform(entity);
+  auto& m = rendering_mode_ == Entity::RenderingMode::kSubpass
+                ? effect_transform
+                : inputs[0]->GetTransform(entity);
   auto transform = m *          //
                    matrix_ *    //
                    m.Invert();  //

--- a/impeller/entity/contents/filters/matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/matrix_filter_contents.h
@@ -18,7 +18,7 @@ class MatrixFilterContents final : public FilterContents {
   void SetMatrix(Matrix matrix);
 
   // |FilterContents|
-  void SetIsForSubpass(bool is_for_subpass) override;
+  void SetRenderingMode(Entity::RenderingMode rendering_mode) override;
 
   // |FilterContents|
   bool IsTranslationOnly() const override;
@@ -43,7 +43,7 @@ class MatrixFilterContents final : public FilterContents {
 
   Matrix matrix_;
   SamplerDescriptor sampler_descriptor_ = {};
-  bool is_for_subpass_ = false;
+  Entity::RenderingMode rendering_mode_ = Entity::RenderingMode::kDirect;
 
   FML_DISALLOW_COPY_AND_ASSIGN(MatrixFilterContents);
 };

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -23,6 +23,17 @@ class Entity {
   static constexpr BlendMode kLastPipelineBlendMode = BlendMode::kModulate;
   static constexpr BlendMode kLastAdvancedBlendMode = BlendMode::kLuminosity;
 
+  enum class RenderingMode {
+    /// In direct mode, the Entity's transform is used as the current
+    /// local-to-screen transformation matrix.
+    kDirect,
+    /// In subpass mode, the Entity passed through the filter is in screen space
+    /// rather than local space, and so some filters (namely,
+    /// MatrixFilterContents) need to interpret the given EffectTransform as the
+    /// current transformation matrix.
+    kSubpass,
+  };
+
   /// An enum to define how to repeat, fold, or omit colors outside of the
   /// typically defined range of the source of the colors (such as the
   /// bounds of an image or the defining geometry of a gradient).

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -530,9 +530,9 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       auto texture = pass_context.GetTexture();
       // Render the backdrop texture before any of the pass elements.
       const auto& proc = subpass->backdrop_filter_proc_;
-      subpass_backdrop_filter_contents = proc(
-          FilterInput::Make(std::move(texture)), subpass->xformation_.Basis(),
-          /*is_subpass*/ true);
+      subpass_backdrop_filter_contents =
+          proc(FilterInput::Make(std::move(texture)),
+               subpass->xformation_.Basis(), Entity::RenderingMode::kSubpass);
 
       // The subpass will need to read from the current pass texture when
       // rendering the backdrop, so if there's an active pass, end it prior to

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -41,7 +41,7 @@ class EntityPass {
   using BackdropFilterProc = std::function<std::shared_ptr<FilterContents>(
       FilterInput::Ref,
       const Matrix& effect_transform,
-      bool is_subpass)>;
+      Entity::RenderingMode rendering_mode)>;
 
   struct StencilCoverageLayer {
     std::optional<Rect> coverage;


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/134681.

For the various places where we track if a rendered entity is a subpass or not. After landing this, I think the next winning move is to make this an Entity field and remove the `SetRenderingMode` junk from the filter graph. That refactor is a bit more risky, so I plan to do that separately.