### PR TITLE
[Impeller] Assert IMPELLER_ENABLE_3D when importing scene_contents.h.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -22,7 +22,6 @@
 #include "impeller/entity/contents/conical_gradient_contents.h"
 #include "impeller/entity/contents/filters/inputs/filter_input.h"
 #include "impeller/entity/contents/linear_gradient_contents.h"
-#include "impeller/entity/contents/scene_contents.h"
 #include "impeller/entity/contents/solid_color_contents.h"
 #include "impeller/entity/contents/tiled_texture_contents.h"
 #include "impeller/geometry/color.h"

--- a/impeller/entity/contents/scene_contents.h
+++ b/impeller/entity/contents/scene_contents.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#if !IMPELLER_ENABLE_3D
+static_assert(false);
+#endif
+
 #include <memory>
 
 #include "impeller/entity/contents/color_source_contents.h"


### PR DESCRIPTION
Noticed we had a residual unguarded import of scene_contents.h while investigating https://github.com/flutter/flutter/issues/134745.