### PR TITLE
Show Aaron an example of faking/mocking vk::Fence and friends.

### DIFF
--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -11,6 +11,7 @@ impeller_component("vulkan_unittests") {
     "blit_command_vk_unittests.cc",
     "command_encoder_vk_unittests.cc",
     "context_vk_unittests.cc",
+    "fence_waiter_vk_unittests.cc",
     "pass_bindings_cache_unittests.cc",
     "resource_manager_vk_unittests.cc",
     "test/mock_vulkan.cc",

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -65,6 +65,9 @@ bool FenceWaiterVK::AddFence(vk::UniqueFence fence,
                              const fml::closure& callback) {
   TRACE_EVENT0("flutter", "FenceWaiterVK::AddFence");
   if (!IsValid() || !fence || !callback) {
+    // Fence is '0' when a reinterpreted mock fence is passed in.
+    FML_LOG(ERROR) << "Invalid fence waiter. Fence: " << !!fence
+                   << " Callback: " << !!callback << ".";
     return false;
   }
   {

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk_unittests.cc
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "fml/macros.h"
+#include "impeller/renderer/backend/vulkan/fence_waiter_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
+#include "impeller/renderer/backend/vulkan/vk.h"  // IWYU pragma: keep
+
+namespace impeller {
+namespace testing {
+
+// FIXME: Move this to mock_vulkan.cc assuming it's the right abstraction.
+namespace {
+
+static int next_fence_id = 1;
+
+class FakeUniqueFence final {
+ public:
+  static vk::UniqueFence* Create() {
+    auto fence = new FakeUniqueFence();
+    return reinterpret_cast<vk::UniqueFence*>(fence);
+  }
+
+  FakeUniqueFence() : id_(next_fence_id++) {}
+
+  int id() const { return id_; }
+
+ private:
+  int id_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FakeUniqueFence);
+};
+
+}  // namespace
+
+TEST(FenceWaiterVKTest, RunsCallbackWhenFenceSignalled) {
+  auto waiter = CreateMockVulkanContext()->GetFenceWaiter();
+  auto fence = FakeUniqueFence::Create();
+
+  FML_LOG(ERROR) << "Adding fence";
+  auto success = waiter->AddFence(
+      std::move(*fence), []() { FML_LOG(ERROR) << "Callback called"; });
+  if (success) {
+    FML_LOG(ERROR) << "Added fence";
+  } else {
+    FML_LOG(ERROR) << "Failed to add fence";
+  }
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
Lmk if you prefer to jump on a call, but basically I found out that `->AddFence` expects a _UniqueFence_, and mocking one of those is difficult because it has lifecycle implications that I can't ignore with `reinterpret_cast`. With the provided test, `AddFence` always fails.

_Not for submission_.