### PR TITLE
Set tests to run on macOS 12

### DIFF
--- a/ci/builders/linux_web_engine.json
+++ b/ci/builders/linux_web_engine.json
@@ -1095,7 +1095,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac"
+        "os=Mac-12"
       ],
       "gclient_variables": {
         "download_android_deps": false
@@ -1127,7 +1127,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac"
+        "os=Mac-12"
       ],
       "gclient_variables": {
         "download_android_deps": false
@@ -1159,7 +1159,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac"
+        "os=Mac-12"
       ],
       "gclient_variables": {
         "download_android_deps": false
@@ -1191,7 +1191,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac"
+        "os=Mac-12"
       ],
       "gclient_variables": {
         "download_android_deps": false
@@ -1223,7 +1223,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac"
+        "os=Mac-12"
       ],
       "gclient_variables": {
         "download_android_deps": false

--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -50,7 +50,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac",
+                "os=Mac-12",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -82,7 +82,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac",
+                "os=Mac-12",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -114,7 +114,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac",
+                "os=Mac-12",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -146,7 +146,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac",
+                "os=Mac-12",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -178,7 +178,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac",
+                "os=Mac-12",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_clang_tidy_presubmit.json
+++ b/ci/builders/mac_clang_tidy_presubmit.json
@@ -50,7 +50,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac",
+                "os=Mac-12",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -82,7 +82,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac",
+                "os=Mac-12",
                 "cpu=arm64"
             ],
             "gclient_variables": {


### PR DESCRIPTION
We recently upgraded a bot in the try pool to macOS 13 and I noticed a couple of tests have leaked through to it and we're not ready for tests to run on macOS 13 yet.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
