### PR TITLE
[Impeller] Adds playgrounds test to CI.

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -508,12 +508,29 @@ def run_cc_tests(build_dir, executable_filter, coverage, capture_core_dump):
           'METAL_DEBUG_ERROR_MODE': '0',  # Enables metal validation.
           'METAL_DEVICE_WRAPPER_TYPE': '1',  # Enables metal validation.
       })
-    # Impeller tests are only supported on macOS for now.
     run_engine_executable(
         build_dir,
         'impeller_unittests',
         executable_filter,
         shuffle_flags + ['--enable_vulkan_validation'],
+        coverage=coverage,
+        extra_env=extra_env,
+        # TODO(117122): Remove this allowlist.
+        # https://github.com/flutter/flutter/issues/114872
+        allowed_failure_output=[
+            '[MTLCompiler createVertexStageAndLinkPipelineWithFragment:',
+            '[MTLCompiler pipelineStateWithVariant:',
+        ]
+    )
+    # Run one playgrounds test to try to avoid breaking them.
+    run_engine_executable(
+        build_dir,
+        'impeller_unittests',
+        executable_filter,
+        shuffle_flags + [
+            '--enable_vulkan_validation', '--gtest_filter=*ColorWheel/Vulkan',
+            '--enable-playground', '--playground_timeout_ms=4000'
+        ],
         coverage=coverage,
         extra_env=extra_env,
         # TODO(117122): Remove this allowlist.


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/133506

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
