### PR TITLE
Fix use of nested designators

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
@@ -62,16 +62,17 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
 - (FlutterRendererConfig)createRendererConfig {
   FlutterRendererConfig config = {
       .type = FlutterRendererType::kMetal,
-      .metal.struct_size = sizeof(FlutterMetalRendererConfig),
-      .metal.device = (__bridge FlutterMetalDeviceHandle)_device,
-      .metal.present_command_queue = (__bridge FlutterMetalCommandQueueHandle)_commandQueue,
-      .metal.get_next_drawable_callback =
-          reinterpret_cast<FlutterMetalTextureCallback>(OnGetNextDrawable),
-      .metal.present_drawable_callback =
-          reinterpret_cast<FlutterMetalPresentCallback>(OnPresentDrawable),
-      .metal.external_texture_frame_callback =
-          reinterpret_cast<FlutterMetalTextureFrameCallback>(OnAcquireExternalTexture),
-  };
+      .metal = {
+          .struct_size = sizeof(FlutterMetalRendererConfig),
+          .device = (__bridge FlutterMetalDeviceHandle)_device,
+          .present_command_queue = (__bridge FlutterMetalCommandQueueHandle)_commandQueue,
+          .get_next_drawable_callback =
+              reinterpret_cast<FlutterMetalTextureCallback>(OnGetNextDrawable),
+          .present_drawable_callback =
+              reinterpret_cast<FlutterMetalPresentCallback>(OnPresentDrawable),
+          .external_texture_frame_callback =
+              reinterpret_cast<FlutterMetalTextureFrameCallback>(OnAcquireExternalTexture),
+      }};
   return config;
 }
 


### PR DESCRIPTION
There was an internal global change which turned `-Wc99-designator`. This causes the following error:

```
error: nested designators are a C99 extension [-Werror,-Wc99-designator]
   65 |       .metal.struct_size = sizeof(FlutterMetalRendererConfig),
      |       ^~~~~~~~~~~~~~~~~~
```

This seems like a trivial (?) fix, so perhaps we can fix it properly and possibly remove https://github.com/flutter/buildroot/blob/b9fbd310d6fa68f888738d5236ea2f6caa2d2bfc/build/config/compiler/BUILD.gn#L667 after this PR lands.

*List which issues are fixed by this PR. You must list at least one issue.*

b/300573112

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
