### PR TITLE
[Impeller] dont cache failed render target allocations.

### DIFF
--- a/impeller/entity/render_target_cache.cc
+++ b/impeller/entity/render_target_cache.cc
@@ -39,12 +39,16 @@ std::shared_ptr<Texture> RenderTargetCache::CreateTexture(
 
   for (auto& td : texture_data_) {
     const auto other_desc = td.texture->GetTextureDescriptor();
+    FML_DCHECK(td.texture != nullptr);
     if (!td.used_this_frame && desc == other_desc) {
       td.used_this_frame = true;
       return td.texture;
     }
   }
   auto result = RenderTargetAllocator::CreateTexture(desc);
+  if (result == nullptr) {
+    return result;
+  }
   texture_data_.push_back(
       TextureData{.used_this_frame = true, .texture = result});
   return result;


### PR DESCRIPTION
Otherwise we'll null de-ref when trying to create a texture with the same descriptor later on.
