### PR TITLE
Do not convert an open path to a closed rect.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1262,6 +1262,32 @@ TEST_P(AiksTest, CanRenderDifferencePaths) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+// Regression test for https://github.com/flutter/flutter/issues/134816.
+//
+// It should be possible to draw 3 lines, and not have an implicit close path.
+TEST_P(AiksTest, CanDrawAnOpenPath) {
+  Canvas canvas;
+
+  // Starting at (50, 50), draw lines from:
+  // 1. (50, height)
+  // 2. (width, height)
+  // 3. (width, 50)
+  PathBuilder builder;
+  builder.MoveTo({50, 50});
+  builder.LineTo({50, 100});
+  builder.LineTo({100, 100});
+  builder.LineTo({100, 50});
+
+  Paint paint;
+  paint.color = Color::Red();
+  paint.style = Paint::Style::kStroke;
+  paint.stroke_width = 10;
+
+  canvas.DrawPath(builder.TakePath(), paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 static sk_sp<SkData> OpenFixtureAsSkData(const char* fixture_name) {
   auto mapping = flutter::testing::OpenFixtureAsMapping(fixture_name);
   if (!mapping) {

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -848,19 +848,29 @@ void DlDispatcher::drawDRRect(const SkRRect& outer, const SkRRect& inner) {
 // |flutter::DlOpReceiver|
 void DlDispatcher::drawPath(const SkPath& path) {
   SkRect rect;
-  SkRRect rrect;
-  SkRect oval;
-  if (path.isRect(&rect)) {
+
+  // We can't "optimize" a path into a rectangle if it's open.
+  bool closed;
+  if (path.isRect(&rect, &closed); closed) {
     canvas_.DrawRect(skia_conversions::ToRect(rect), paint_);
-  } else if (path.isRRect(&rrect) && rrect.isSimple()) {
+    return;
+  }
+
+  SkRRect rrect;
+  if (path.isRRect(&rrect) && rrect.isSimple()) {
     canvas_.DrawRRect(skia_conversions::ToRect(rrect.rect()),
                       rrect.getSimpleRadii().fX, paint_);
-  } else if (path.isOval(&oval) && oval.width() == oval.height()) {
+    return;
+  }
+
+  SkRect oval;
+  if (path.isOval(&oval) && oval.width() == oval.height()) {
     canvas_.DrawCircle(skia_conversions::ToPoint(oval.center()),
                        oval.width() * 0.5, paint_);
-  } else {
-    canvas_.DrawPath(skia_conversions::ToPath(path), paint_);
+    return;
   }
+
+  canvas_.DrawPath(skia_conversions::ToPath(path), paint_);
 }
 
 // |flutter::DlOpReceiver|

--- a/impeller/display_list/dl_unittests.cc
+++ b/impeller/display_list/dl_unittests.cc
@@ -411,6 +411,33 @@ TEST_P(DisplayListTest, CanDrawWithOddPathWinding) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+// Regression test for https://github.com/flutter/flutter/issues/134816.
+//
+// It should be possible to draw 3 lines, and not have an implicit close path.
+TEST_P(DisplayListTest, CanDrawAnOpenPath) {
+  flutter::DisplayListBuilder builder;
+  flutter::DlPaint paint;
+
+  paint.setColor(flutter::DlColor::kRed());
+  paint.setDrawStyle(flutter::DlDrawStyle::kStroke);
+  paint.setStrokeWidth(10);
+
+  builder.Translate(300, 300);
+
+  // Move to (50, 50) and draw lines from:
+  // 1. (50, height)
+  // 2. (width, height)
+  // 3. (width, 50)
+  SkPath path;
+  path.moveTo(50, 50);
+  path.lineTo(50, 100);
+  path.lineTo(100, 100);
+  path.lineTo(100, 50);
+  builder.DrawPath(path, paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 TEST_P(DisplayListTest, CanDrawWithMaskBlur) {
   auto texture = CreateTextureForFixture("embarcadero.jpg");
   flutter::DisplayListBuilder builder;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/134816.

---

Confirmed this only happens when utilizing `DisplayListBuilder`. Consider:

```cc
TEST_P(DisplayListTest, CanDrawAnOpenPath) {
  flutter::DisplayListBuilder builder;
  flutter::DlPaint paint;

  paint.setColor(flutter::DlColor::kRed());
  paint.setDrawStyle(flutter::DlDrawStyle::kStroke);
  paint.setStrokeWidth(10);

  builder.Translate(300, 300);

  // Move to (50, 50) and draw lines from:
  // 1. (50, height)
  // 2. (width, height)
  // 3. (width, 50)
  SkPath path;
  path.moveTo(50, 50);
  path.lineTo(50, 100);
  path.lineTo(100, 100);
  path.lineTo(100, 50);
  builder.DrawPath(path, paint);

  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
}
```

![Screenshot 2023-09-15 at 2 06 53 PM](https://github.com/flutter/flutter/assets/168174/3a3868e1-f1d1-4e29-affa-4bd32d26ccdc)

---

The bug is in `dl_dispatcher.cc`:

```cc
// |flutter::DlOpReceiver|
void DlDispatcher::drawPath(const SkPath& path) {
  SkRect rect;
  SkRRect rrect;
  SkRect oval;

  if (path.isRect(&rect)) {
    canvas_.DrawRect(skia_conversions::ToRect(rect), paint_);
  } else if (path.isRRect(&rrect) && rrect.isSimple()) {
    canvas_.DrawRRect(skia_conversions::ToRect(rrect.rect()),
                      rrect.getSimpleRadii().fX, paint_);
  } else if (path.isOval(&oval) && oval.width() == oval.height()) {
    canvas_.DrawCircle(skia_conversions::ToPoint(oval.center()),
                       oval.width() * 0.5, paint_);
  } else {
    canvas_.DrawPath(skia_conversions::ToPath(path), paint_);
  }
}
```

Note the documentation for `isRect`:

```cc
/** Returns true if SkPath is equivalent to SkRect when filled.
    If false: rect, isClosed, and direction are unchanged.
    If true: rect, isClosed, and direction are written to if not nullptr.

    rect may be smaller than the SkPath bounds. SkPath bounds may include kMove_Verb points
    that do not alter the area drawn by the returned rect.

    @param rect       storage for bounds of SkRect; may be nullptr
    @param isClosed   storage set to true if SkPath is closed; may be nullptr
    @param direction  storage set to SkRect direction; may be nullptr
    @return           true if SkPath contains SkRect

    example: https://fiddle.skia.org/c/@Path_isRect
*/
bool isRect(SkRect* rect, bool* isClosed = nullptr, SkPathDirection* direction = nullptr) const;
```

... the `isClosed` is critical, without checking that we're doing an incorrect optimization.

I'll send a fix and test.