### PR TITLE
[flutter roll cp] Revert "[Impeller] construct text frames on UI thread." (#45910)

### DIFF
--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -87,7 +87,6 @@ source_set("display_list") {
   public_deps = [
     "//flutter/fml",
     "//flutter/impeller/runtime_stage",
-    "//flutter/impeller/typographer",
     "//third_party/skia",
   ]
 

--- a/display_list/benchmarking/dl_complexity_gl.cc
+++ b/display_list/benchmarking/dl_complexity_gl.cc
@@ -637,11 +637,6 @@ void DisplayListGLComplexityCalculator::GLHelper::drawTextBlob(
   draw_text_blob_count_++;
 }
 
-void DisplayListGLComplexityCalculator::GLHelper::drawTextFrame(
-    const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {}
-
 void DisplayListGLComplexityCalculator::GLHelper::drawShadow(
     const SkPath& path,
     const DlColor color,

--- a/display_list/benchmarking/dl_complexity_gl.h
+++ b/display_list/benchmarking/dl_complexity_gl.h
@@ -70,9 +70,6 @@ class DisplayListGLComplexityCalculator
     void drawTextBlob(const sk_sp<SkTextBlob> blob,
                       SkScalar x,
                       SkScalar y) override;
-    void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                       SkScalar x,
-                       SkScalar y) override;
     void drawShadow(const SkPath& path,
                     const DlColor color,
                     const SkScalar elevation,

--- a/display_list/benchmarking/dl_complexity_metal.cc
+++ b/display_list/benchmarking/dl_complexity_metal.cc
@@ -581,11 +581,6 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawTextBlob(
   draw_text_blob_count_++;
 }
 
-void DisplayListMetalComplexityCalculator::MetalHelper::drawTextFrame(
-    const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {}
-
 void DisplayListMetalComplexityCalculator::MetalHelper::drawShadow(
     const SkPath& path,
     const DlColor color,

--- a/display_list/benchmarking/dl_complexity_metal.h
+++ b/display_list/benchmarking/dl_complexity_metal.h
@@ -70,9 +70,6 @@ class DisplayListMetalComplexityCalculator
     void drawTextBlob(const sk_sp<SkTextBlob> blob,
                       SkScalar x,
                       SkScalar y) override;
-    void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                       SkScalar x,
-                       SkScalar y) override;
     void drawShadow(const SkPath& path,
                     const DlColor color,
                     const SkScalar elevation,

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -136,7 +136,6 @@ namespace flutter {
                                     \
   V(DrawDisplayList)                \
   V(DrawTextBlob)                   \
-  V(DrawTextFrame)                  \
                                     \
   V(DrawShadow)                     \
   V(DrawShadowTransparentOccluder)

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -1302,48 +1302,6 @@ void DisplayListBuilder::DrawTextBlob(const sk_sp<SkTextBlob>& blob,
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawTextBlobFlags);
   drawTextBlob(blob, x, y);
 }
-
-void DisplayListBuilder::drawTextFrame(
-    const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {
-  DisplayListAttributeFlags flags = kDrawTextBlobFlags;
-  OpResult result = PaintResult(current_, flags);
-  if (result == OpResult::kNoEffect) {
-    return;
-  }
-  impeller::Rect bounds = text_frame->GetBounds();
-  SkRect sk_bounds = SkRect::MakeLTRB(bounds.GetLeft(), bounds.GetTop(),
-                                      bounds.GetRight(), bounds.GetBottom());
-  bool unclipped = AccumulateOpBounds(sk_bounds.makeOffset(x, y), flags);
-  // TODO(https://github.com/flutter/flutter/issues/82202): Remove once the
-  // unit tests can use Fuchsia's font manager instead of the empty default.
-  // Until then we might encounter empty bounds for otherwise valid text and
-  // thus we ignore the results from AccumulateOpBounds.
-#if defined(OS_FUCHSIA)
-  unclipped = true;
-#endif  // OS_FUCHSIA
-  if (unclipped) {
-    Push<DrawTextFrameOp>(0, 1, text_frame, x, y);
-    // There is no way to query if the glyphs of a text blob overlap and
-    // there are no current guarantees from either Skia or Impeller that
-    // they will protect overlapping glyphs from the effects of overdraw
-    // so we must make the conservative assessment that this DL layer is
-    // not compatible with group opacity inheritance.
-    UpdateLayerOpacityCompatibility(false);
-    UpdateLayerResult(result);
-  }
-}
-
-void DisplayListBuilder::DrawTextFrame(
-    const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y,
-    const DlPaint& paint) {
-  SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawTextBlobFlags);
-  drawTextFrame(text_frame, x, y);
-}
-
 void DisplayListBuilder::DrawShadow(const SkPath& path,
                                     const DlColor color,
                                     const SkScalar elevation,

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -224,16 +224,6 @@ class DisplayListBuilder final : public virtual DlCanvas,
                     SkScalar x,
                     SkScalar y,
                     const DlPaint& paint) override;
-
-  void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
-
-  void DrawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y,
-                     const DlPaint& paint) override;
-
   // |DlCanvas|
   void DrawShadow(const SkPath& path,
                   const DlColor color,

--- a/display_list/dl_canvas.h
+++ b/display_list/dl_canvas.h
@@ -18,8 +18,6 @@
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
 
-#include "impeller/typographer/text_frame.h"
-
 namespace flutter {
 
 //------------------------------------------------------------------------------
@@ -154,7 +152,7 @@ class DlCanvas {
   virtual void DrawVertices(const DlVertices* vertices,
                             DlBlendMode mode,
                             const DlPaint& paint) = 0;
-  void DrawVertices(const std::shared_ptr<const DlVertices>& vertices,
+  void DrawVertices(const std::shared_ptr<const DlVertices> vertices,
                     DlBlendMode mode,
                     const DlPaint& paint) {
     DrawVertices(vertices.get(), mode, paint);
@@ -203,13 +201,6 @@ class DlCanvas {
                          const DlPaint* paint = nullptr) = 0;
   virtual void DrawDisplayList(const sk_sp<DisplayList> display_list,
                                SkScalar opacity = SK_Scalar1) = 0;
-
-  virtual void DrawTextFrame(
-      const std::shared_ptr<impeller::TextFrame>& text_frame,
-      SkScalar x,
-      SkScalar y,
-      const DlPaint& paint) = 0;
-
   virtual void DrawTextBlob(const sk_sp<SkTextBlob>& blob,
                             SkScalar x,
                             SkScalar y,

--- a/display_list/dl_op_receiver.h
+++ b/display_list/dl_op_receiver.h
@@ -257,10 +257,6 @@ class DlOpReceiver {
   virtual void drawTextBlob(const sk_sp<SkTextBlob> blob,
                             SkScalar x,
                             SkScalar y) = 0;
-  virtual void drawTextFrame(
-      const std::shared_ptr<impeller::TextFrame>& text_frame,
-      SkScalar x,
-      SkScalar y) = 0;
   virtual void drawShadow(const SkPath& path,
                           const DlColor color,
                           const SkScalar elevation,

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -12,7 +12,6 @@
 #include "flutter/display_list/effects/dl_color_source.h"
 #include "flutter/fml/macros.h"
 
-#include "impeller/typographer/text_frame.h"
 #include "third_party/skia/include/core/SkRSXform.h"
 
 namespace flutter {
@@ -1081,25 +1080,6 @@ struct DrawTextBlobOp final : DrawOpBase {
   void dispatch(DispatchContext& ctx) const {
     if (op_needed(ctx)) {
       ctx.receiver.drawTextBlob(blob, x, y);
-    }
-  }
-};
-
-struct DrawTextFrameOp final : DrawOpBase {
-  static const auto kType = DisplayListOpType::kDrawTextFrame;
-
-  DrawTextFrameOp(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                  SkScalar x,
-                  SkScalar y)
-      : x(x), y(y), text_frame(text_frame) {}
-
-  const SkScalar x;
-  const SkScalar y;
-  const std::shared_ptr<impeller::TextFrame> text_frame;
-
-  void dispatch(DispatchContext& ctx) const {
-    if (op_needed(ctx)) {
-      ctx.receiver.drawTextFrame(text_frame, x, y);
     }
   }
 };

--- a/display_list/skia/dl_sk_canvas.cc
+++ b/display_list/skia/dl_sk_canvas.cc
@@ -325,14 +325,6 @@ void DlSkCanvasAdapter::DrawTextBlob(const sk_sp<SkTextBlob>& blob,
   delegate_->drawTextBlob(blob, x, y, ToSk(paint));
 }
 
-void DlSkCanvasAdapter::DrawTextFrame(
-    const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y,
-    const DlPaint& paint) {
-  FML_CHECK(false);
-}
-
 void DlSkCanvasAdapter::DrawShadow(const SkPath& path,
                                    const DlColor color,
                                    const SkScalar elevation,

--- a/display_list/skia/dl_sk_canvas.h
+++ b/display_list/skia/dl_sk_canvas.h
@@ -7,7 +7,6 @@
 
 #include "flutter/display_list/dl_canvas.h"
 #include "flutter/display_list/skia/dl_sk_types.h"
-#include "impeller/typographer/text_frame.h"
 
 namespace flutter {
 
@@ -145,10 +144,6 @@ class DlSkCanvasAdapter final : public virtual DlCanvas {
                     SkScalar x,
                     SkScalar y,
                     const DlPaint& paint) override;
-  void DrawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y,
-                     const DlPaint& paint) override;
   void DrawShadow(const SkPath& path,
                   const DlColor color,
                   const SkScalar elevation,

--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -270,13 +270,6 @@ void DlSkCanvasDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
   canvas_->drawTextBlob(blob, x, y, paint());
 }
 
-void DlSkCanvasDispatcher::drawTextFrame(
-    const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {
-  FML_CHECK(false);
-}
-
 void DlSkCanvasDispatcher::DrawShadow(SkCanvas* canvas,
                                       const SkPath& path,
                                       DlColor color,

--- a/display_list/skia/dl_sk_dispatcher.h
+++ b/display_list/skia/dl_sk_dispatcher.h
@@ -98,9 +98,6 @@ class DlSkCanvasDispatcher : public virtual DlOpReceiver,
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,
                     SkScalar y) override;
-  void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
   void drawShadow(const SkPath& path,
                   const DlColor color,
                   const SkScalar elevation,

--- a/display_list/utils/dl_receiver_utils.h
+++ b/display_list/utils/dl_receiver_utils.h
@@ -129,9 +129,6 @@ class IgnoreDrawDispatchHelper : public virtual DlOpReceiver {
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,
                     SkScalar y) override {}
-  void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override {}
   void drawShadow(const SkPath& path,
                   const DlColor color,
                   const SkScalar elevation,

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -99,10 +99,7 @@ source_set("flow") {
   deps = [ "//third_party/skia" ]
 
   if (impeller_supports_rendering) {
-    deps += [
-      "//flutter/impeller",
-      "//flutter/impeller/typographer/backends/skia:typographer_skia_backend",
-    ]
+    deps += [ "//flutter/impeller" ]
   }
 }
 

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -14,9 +14,6 @@
 #include "flow/stopwatch_sk.h"
 #include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
-#ifdef IMPELLER_SUPPORTS_RENDERING
-#include "impeller/typographer/backends/skia/text_frame_skia.h"  // nogncheck
-#endif  // IMPELLER_SUPPORTS_RENDERING
 
 namespace flutter {
 namespace {
@@ -53,14 +50,7 @@ void VisualizeStopWatch(DlCanvas* canvas,
         stopwatch, label_prefix, font_path);
     // Historically SK_ColorGRAY (== 0xFF888888) was used here
     DlPaint paint(0xFF888888);
-#ifdef IMPELLER_SUPPORTS_RENDERING
-    if (impeller_enabled) {
-      canvas->DrawTextFrame(impeller::MakeTextFrameFromTextBlobSkia(text),
-                            x + label_x, y + height + label_y, paint);
-    }
-#endif  // IMPELLER_SUPPORTS_RENDERING
     canvas->DrawTextBlob(text, x + label_x, y + height + label_y, paint);
-    return;
   }
 }
 

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -5,6 +5,7 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -1309,7 +1310,11 @@ bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
   }
 
   // Create the Impeller text frame and draw it at the designated baseline.
-  auto frame = MakeTextFrameFromTextBlobSkia(blob);
+  auto maybe_frame = MakeTextFrameFromTextBlobSkia(blob);
+  if (!maybe_frame.has_value()) {
+    return false;
+  }
+  auto frame = maybe_frame.value();
 
   Paint text_paint;
   text_paint.color = Color::Yellow().WithAlpha(options.alpha);
@@ -1498,7 +1503,7 @@ TEST_P(AiksTest, CanRenderTextOutsideBoundaries) {
     {
       auto blob = SkTextBlob::MakeFromString(t.text, sk_font);
       ASSERT_NE(blob, nullptr);
-      auto frame = MakeTextFrameFromTextBlobSkia(blob);
+      auto frame = MakeTextFrameFromTextBlobSkia(blob).value();
       canvas.DrawTextFrame(frame, Point(), text_paint);
     }
     canvas.Restore();
@@ -3102,7 +3107,12 @@ TEST_P(AiksTest, TextForegroundShaderWithTransform) {
 
   auto blob = SkTextBlob::MakeFromString("Hello", sk_font);
   ASSERT_NE(blob, nullptr);
-  auto frame = MakeTextFrameFromTextBlobSkia(blob);
+  auto maybe_frame = MakeTextFrameFromTextBlobSkia(blob);
+  ASSERT_TRUE(maybe_frame.has_value());
+  if (!maybe_frame.has_value()) {
+    return;
+  }
+  auto frame = maybe_frame.value();
   canvas.DrawTextFrame(frame, Point(), text_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -545,7 +545,7 @@ void Canvas::SaveLayer(const Paint& paint,
   }
 }
 
-void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
+void Canvas::DrawTextFrame(const TextFrame& text_frame,
                            Point position,
                            const Paint& paint) {
   Entity entity;
@@ -553,7 +553,7 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
   entity.SetBlendMode(paint.blend_mode);
 
   auto text_contents = std::make_shared<TextContents>();
-  text_contents->SetTextFrame(text_frame);
+  text_contents->SetTextFrame(TextFrame(text_frame));
   text_contents->SetColor(paint.color);
 
   entity.SetTransformation(GetCurrentTransformation() *

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -140,7 +140,7 @@ class Canvas {
 
   void DrawPicture(const Picture& picture);
 
-  void DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
+  void DrawTextFrame(const TextFrame& text_frame,
                      Point position,
                      const Paint& paint);
 

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -34,6 +34,7 @@
 #include "impeller/geometry/path_builder.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/sigma.h"
+#include "impeller/typographer/backends/skia/text_frame_skia.h"
 
 #if IMPELLER_ENABLE_3D
 #include "impeller/entity/contents/scene_contents.h"
@@ -1060,14 +1061,20 @@ void DlDispatcher::drawDisplayList(
 void DlDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                 SkScalar x,
                                 SkScalar y) {
-  // When running with Impeller enabled Skia text blobs are converted to
-  // Impeller text frames in paragraph_skia.cc
-  UNIMPLEMENTED;
-}
+  const auto maybe_text_frame = MakeTextFrameFromTextBlobSkia(blob);
+  if (!maybe_text_frame.has_value()) {
+    return;
+  }
+  const auto text_frame = maybe_text_frame.value();
+  if (paint_.style == Paint::Style::kStroke ||
+      paint_.color_source.GetType() != ColorSource::Type::kColor) {
+    auto bounds = blob->bounds();
+    auto path = skia_conversions::PathDataFromTextBlob(
+        blob, Point(x + bounds.left(), y + bounds.top()));
+    canvas_.DrawPath(path, paint_);
+    return;
+  }
 
-void DlDispatcher::drawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
-                                 SkScalar x,
-                                 SkScalar y) {
   canvas_.DrawTextFrame(text_frame,             //
                         impeller::Point{x, y},  //
                         paint_                  //

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -213,11 +213,6 @@ class DlDispatcher final : public flutter::DlOpReceiver {
                     SkScalar y) override;
 
   // |flutter::DlOpReceiver|
-  void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
-
-  // |flutter::DlOpReceiver|
   void drawShadow(const SkPath& path,
                   const flutter::DlColor color,
                   const SkScalar elevation,

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -24,8 +24,8 @@ TextContents::TextContents() = default;
 
 TextContents::~TextContents() = default;
 
-void TextContents::SetTextFrame(const std::shared_ptr<TextFrame>& frame) {
-  frame_ = frame;
+void TextContents::SetTextFrame(TextFrame&& frame) {
+  frame_ = std::move(frame);
 }
 
 std::shared_ptr<GlyphAtlas> TextContents::ResolveAtlas(
@@ -49,7 +49,7 @@ Color TextContents::GetColor() const {
 }
 
 bool TextContents::CanInheritOpacity(const Entity& entity) const {
-  return !frame_->MaybeHasOverlapping();
+  return !frame_.MaybeHasOverlapping();
 }
 
 void TextContents::SetInheritedOpacity(Scalar opacity) {
@@ -61,13 +61,13 @@ void TextContents::SetOffset(Vector2 offset) {
 }
 
 std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
-  return frame_->GetBounds().TransformBounds(entity.GetTransformation());
+  return frame_.GetBounds().TransformBounds(entity.GetTransformation());
 }
 
 void TextContents::PopulateGlyphAtlas(
     const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
     Scalar scale) {
-  lazy_glyph_atlas->AddTextFrame(*frame_, scale);
+  lazy_glyph_atlas->AddTextFrame(frame_, scale);
   scale_ = scale;
 }
 
@@ -79,7 +79,7 @@ bool TextContents::Render(const ContentContext& renderer,
     return true;
   }
 
-  auto type = frame_->GetAtlasType();
+  auto type = frame_.GetAtlasType();
   auto atlas =
       ResolveAtlas(*renderer.GetContext(), type, renderer.GetLazyGlyphAtlas());
 
@@ -152,7 +152,7 @@ bool TextContents::Render(const ContentContext& renderer,
 
   auto& host_buffer = pass.GetTransientsBuffer();
   size_t vertex_count = 0;
-  for (const auto& run : frame_->GetRuns()) {
+  for (const auto& run : frame_.GetRuns()) {
     vertex_count += run.GetGlyphPositions().size();
   }
   vertex_count *= 6;
@@ -163,7 +163,7 @@ bool TextContents::Render(const ContentContext& renderer,
         VS::PerVertexData vtx;
         VS::PerVertexData* vtx_contents =
             reinterpret_cast<VS::PerVertexData*>(contents);
-        for (const TextRun& run : frame_->GetRuns()) {
+        for (const TextRun& run : frame_.GetRuns()) {
           const Font& font = run.GetFont();
           Scalar rounded_scale = TextFrame::RoundScaledFontSize(
               scale_, font.GetMetrics().point_size);

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -26,7 +26,7 @@ class TextContents final : public Contents {
 
   ~TextContents();
 
-  void SetTextFrame(const std::shared_ptr<TextFrame>& frame);
+  void SetTextFrame(TextFrame&& frame);
 
   void SetColor(Color color);
 
@@ -56,7 +56,7 @@ class TextContents final : public Contents {
               RenderPass& pass) const override;
 
  private:
-  std::shared_ptr<TextFrame> frame_;
+  TextFrame frame_;
   Scalar scale_ = 1.0;
   Color color_;
   Scalar inherited_opacity_ = 1.0;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2173,13 +2173,13 @@ TEST_P(EntityTest, InheritOpacityTest) {
   SkFont font;
   font.setSize(30);
   auto blob = SkTextBlob::MakeFromString("A", font);
-  auto frame = MakeTextFrameFromTextBlobSkia(blob);
+  auto frame = MakeTextFrameFromTextBlobSkia(blob).value();
   auto lazy_glyph_atlas =
       std::make_shared<LazyGlyphAtlas>(TypographerContextSkia::Make());
-  lazy_glyph_atlas->AddTextFrame(*frame, 1.0f);
+  lazy_glyph_atlas->AddTextFrame(frame, 1.0f);
 
   auto text_contents = std::make_shared<TextContents>();
-  text_contents->SetTextFrame(frame);
+  text_contents->SetTextFrame(std::move(frame));
   text_contents->SetColor(Color::Blue().WithAlpha(0.5));
 
   ASSERT_TRUE(text_contents->CanInheritOpacity(entity));

--- a/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -8,6 +8,7 @@
 
 #include "flutter/fml/logging.h"
 #include "impeller/typographer/backends/skia/typeface_skia.h"
+#include "include/core/SkFontTypes.h"
 #include "include/core/SkRect.h"
 #include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkFontMetrics.h"
@@ -38,10 +39,16 @@ static Rect ToRect(const SkRect& rect) {
 
 static constexpr Scalar kScaleSize = 100000.0f;
 
-std::shared_ptr<TextFrame> MakeTextFrameFromTextBlobSkia(
+std::optional<TextFrame> MakeTextFrameFromTextBlobSkia(
     const sk_sp<SkTextBlob>& blob) {
-  bool has_color = false;
+  // Handling nullptr text blobs feels overly defensive here, as I don't
+  // actually know if this happens.
+  if (!blob) {
+    return {};
+  }
+
   std::vector<TextRun> runs;
+  bool has_color = false;
   for (SkTextBlobRunIterator run(blob.get()); !run.done(); run.next()) {
     // TODO(jonahwilliams): ask Skia for a public API to look this up.
     // https://github.com/flutter/flutter/issues/112005
@@ -88,7 +95,7 @@ std::shared_ptr<TextFrame> MakeTextFrameFromTextBlobSkia(
         continue;
     }
   }
-  return std::make_shared<TextFrame>(runs, ToRect(blob->bounds()), has_color);
+  return TextFrame(runs, ToRect(blob->bounds()), has_color);
 }
 
 }  // namespace impeller

--- a/impeller/typographer/backends/skia/text_frame_skia.h
+++ b/impeller/typographer/backends/skia/text_frame_skia.h
@@ -4,12 +4,13 @@
 
 #pragma once
 
+#include "flutter/fml/macros.h"
 #include "impeller/typographer/text_frame.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
 
 namespace impeller {
 
-std::shared_ptr<impeller::TextFrame> MakeTextFrameFromTextBlobSkia(
+std::optional<TextFrame> MakeTextFrameFromTextBlobSkia(
     const sk_sp<SkTextBlob>& blob);
 
 }  // namespace impeller

--- a/impeller/typographer/backends/stb/text_frame_stb.cc
+++ b/impeller/typographer/backends/stb/text_frame_stb.cc
@@ -8,10 +8,9 @@
 
 namespace impeller {
 
-std::shared_ptr<TextFrame> MakeTextFrameSTB(
-    const std::shared_ptr<TypefaceSTB>& typeface_stb,
-    Font::Metrics metrics,
-    const std::string& text) {
+TextFrame MakeTextFrameSTB(const std::shared_ptr<TypefaceSTB>& typeface_stb,
+                           Font::Metrics metrics,
+                           const std::string& text) {
   TextRun run(Font(typeface_stb, metrics));
 
   // Shape the text run using STB. The glyph positions could also be resolved
@@ -62,8 +61,7 @@ std::shared_ptr<TextFrame> MakeTextFrameSTB(
   }
 
   std::vector<TextRun> runs = {run};
-  return std::make_shared<TextFrame>(
-      runs, result.value_or(Rect::MakeLTRB(0, 0, 0, 0)), false);
+  return TextFrame(runs, result.value_or(Rect::MakeLTRB(0, 0, 0, 0)), false);
 }
 
 }  // namespace impeller

--- a/impeller/typographer/backends/stb/text_frame_stb.h
+++ b/impeller/typographer/backends/stb/text_frame_stb.h
@@ -10,9 +10,8 @@
 
 namespace impeller {
 
-std::shared_ptr<TextFrame> MakeTextFrameSTB(
-    const std::shared_ptr<TypefaceSTB>& typeface_stb,
-    Font::Metrics metrics,
-    const std::string& text);
+TextFrame MakeTextFrameSTB(const std::shared_ptr<TypefaceSTB>& typeface_stb,
+                           Font::Metrics metrics,
+                           const std::string& text);
 
 }  // namespace impeller

--- a/impeller/typographer/typographer_context.h
+++ b/impeller/typographer/typographer_context.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 
 #include "flutter/fml/macros.h"

--- a/shell/common/dl_op_spy.cc
+++ b/shell/common/dl_op_spy.cc
@@ -127,14 +127,6 @@ void DlOpSpy::drawTextBlob(const sk_sp<SkTextBlob> blob,
                            SkScalar y) {
   did_draw_ |= will_draw_;
 }
-
-void DlOpSpy::drawTextFrame(
-    const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {
-  did_draw_ |= will_draw_;
-}
-
 void DlOpSpy::drawShadow(const SkPath& path,
                          const DlColor color,
                          const SkScalar elevation,

--- a/shell/common/dl_op_spy.h
+++ b/shell/common/dl_op_spy.h
@@ -90,9 +90,6 @@ class DlOpSpy final : public virtual DlOpReceiver,
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,
                     SkScalar y) override;
-  void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
   void drawShadow(const SkPath& path,
                   const DlColor color,
                   const SkScalar elevation,

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -859,15 +859,6 @@ void DisplayListStreamDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
            << blob.get() << ", "
            << x << ", " << y << ");" << std::endl;
 }
-
-void DisplayListStreamDispatcher::drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) {
-    startl() << "drawTextFrame("
-      << text_frame.get() << ", "
-      << x << ", " << y << ");" << std::endl;
-}
-
 void DisplayListStreamDispatcher::drawShadow(const SkPath& path,
                                              const DlColor color,
                                              const SkScalar elevation,

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -144,9 +144,6 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,
                     SkScalar y) override;
-  void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
   void drawShadow(const SkPath& path,
                   const DlColor color,
                   const SkScalar elevation,

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -160,14 +160,6 @@ void MockCanvas::DrawTextBlob(const sk_sp<SkTextBlob>& text,
                                    paint, SkPoint::Make(x, y)}});
 }
 
-void MockCanvas::DrawTextFrame(
-    const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y,
-    const DlPaint& paint) {
-  FML_DCHECK(false);
-}
-
 void MockCanvas::DrawRect(const SkRect& rect, const DlPaint& paint) {
   draw_calls_.emplace_back(DrawCall{current_layer_, DrawRectData{rect, paint}});
 }

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -273,10 +273,6 @@ class MockCanvas final : public DlCanvas {
                     SkScalar x,
                     SkScalar y,
                     const DlPaint& paint) override;
-  void DrawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y,
-                     const DlPaint& paint) override;
   void DrawShadow(const SkPath& path,
                   const DlColor color,
                   const SkScalar elevation,

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -81,7 +81,6 @@ source_set("txt") {
   public_deps = [
     "//flutter/display_list",
     "//flutter/fml",
-    "//flutter/impeller/typographer/backends/skia:typographer_skia_backend",
     "//third_party/harfbuzz",
     "//third_party/icu",
     "//third_party/skia",

--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -18,10 +18,7 @@
 
 #include <algorithm>
 #include <numeric>
-#include "display_list/dl_paint.h"
 #include "fml/logging.h"
-#include "impeller/typographer/backends/skia/text_frame_skia.h"
-#include "include/core/SkMatrix.h"
 
 namespace txt {
 
@@ -68,10 +65,10 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
   ///             decision (i.e. with `#ifdef`) instead of a runtime option.
   DisplayListParagraphPainter(DisplayListBuilder* builder,
                               const std::vector<DlPaint>& dl_paints,
-                              bool impeller_enabled)
+                              bool draw_path_effect)
       : builder_(builder),
         dl_paints_(dl_paints),
-        impeller_enabled_(impeller_enabled) {}
+        draw_path_effect_(draw_path_effect) {}
 
   void drawTextBlob(const sk_sp<SkTextBlob>& blob,
                     SkScalar x,
@@ -82,22 +79,6 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
     }
     size_t paint_id = std::get<PaintID>(paint);
     FML_DCHECK(paint_id < dl_paints_.size());
-
-#ifdef IMPELLER_SUPPORTS_RENDERING
-    if (impeller_enabled_) {
-      if (ShouldRenderAsPath(dl_paints_[paint_id])) {
-        auto path = skia::textlayout::Paragraph::GetPath(blob.get());
-        auto transformed = path.makeTransform(SkMatrix::Translate(
-            x + blob->bounds().left(), y + blob->bounds().top()));
-        builder_->DrawPath(transformed, dl_paints_[paint_id]);
-        return;
-      }
-
-      builder_->DrawTextFrame(impeller::MakeTextFrameFromTextBlobSkia(blob), x,
-                              y, dl_paints_[paint_id]);
-      return;
-    }
-#endif  // IMPELLER_SUPPORTS_RENDERING
     builder_->DrawTextBlob(blob, x, y, dl_paints_[paint_id]);
   }
 
@@ -114,11 +95,6 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
     if (blur_sigma > 0.0) {
       DlBlurMaskFilter filter(DlBlurStyle::kNormal, blur_sigma, false);
       paint.setMaskFilter(&filter);
-    }
-    if (impeller_enabled_) {
-      builder_->DrawTextFrame(impeller::MakeTextFrameFromTextBlobSkia(blob), x,
-                              y, paint);
-      return;
     }
     builder_->DrawTextBlob(blob, x, y, paint);
   }
@@ -153,13 +129,11 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
     // the line directly using the `drawLine` API instead of using a path effect
     // (because Impeller does not support path effects).
     auto dash_path_effect = decor_style.getDashPathEffect();
-#ifdef IMPELLER_SUPPORTS_RENDERING
-    if (impeller_enabled_ && dash_path_effect) {
+    if (draw_path_effect_ && dash_path_effect) {
       auto path = dashedLine(x0, x1, y0, *dash_path_effect);
       builder_->DrawPath(path, toDlPaint(decor_style));
       return;
     }
-#endif  // IMPELLER_SUPPORTS_RENDERING
 
     auto paint = toDlPaint(decor_style);
     if (dash_path_effect) {
@@ -206,16 +180,6 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
     return path;
   }
 
-  bool ShouldRenderAsPath(const DlPaint& paint) const {
-    FML_DCHECK(impeller_enabled_);
-    // Text with non-trivial color sources or stroke paint mode should be
-    // rendered as a path when running on Impeller for correctness. These
-    // filters rely on having the glyph coverage, whereas regular text is
-    // drawn as rectangular texture samples.
-    return ((paint.getColorSource() && !paint.getColorSource()->asColor()) ||
-            paint.getDrawStyle() == DlDrawStyle::kStroke);
-  }
-
   DlPaint toDlPaint(const DecorationStyle& decor_style,
                     DlDrawStyle draw_style = DlDrawStyle::kStroke) {
     DlPaint paint;
@@ -228,7 +192,7 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
 
   void setPathEffect(DlPaint& paint, const DashPathEffect& dash_path_effect) {
     // Impeller does not support path effects, so we should never be setting.
-    FML_DCHECK(!impeller_enabled_);
+    FML_DCHECK(!draw_path_effect_);
 
     std::array<SkScalar, 2> intervals{dash_path_effect.fOnLength,
                                       dash_path_effect.fOffLength};
@@ -238,7 +202,7 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
 
   DisplayListBuilder* builder_;
   const std::vector<DlPaint>& dl_paints_;
-  const bool impeller_enabled_;
+  bool draw_path_effect_;
 };
 
 }  // anonymous namespace

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -3,13 +3,8 @@
 // found in the LICENSE file.
 
 #include <memory>
-#include "display_list/dl_color.h"
-#include "display_list/dl_paint.h"
-#include "display_list/dl_tile_mode.h"
-#include "display_list/effects/dl_color_source.h"
 #include "display_list/utils/dl_receiver_utils.h"
 #include "gtest/gtest.h"
-#include "include/core/SkScalar.h"
 #include "runtime/test_font_data.h"
 #include "skia/paragraph_builder_skia.h"
 #include "testing/canvas_test.h"
@@ -28,25 +23,11 @@ class DlOpRecorder final : public virtual DlOpReceiver,
   int lineCount() const { return lines_.size(); }
   int rectCount() const { return rects_.size(); }
   int pathCount() const { return paths_.size(); }
-  int textFrameCount() const { return text_frames_.size(); }
-  int blobCount() const { return blobs_.size(); }
   bool hasPathEffect() const { return path_effect_ != nullptr; }
 
  private:
   void drawLine(const SkPoint& p0, const SkPoint& p1) override {
     lines_.emplace_back(p0, p1);
-  }
-
-  void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override {
-    text_frames_.push_back(text_frame);
-  }
-
-  void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                    SkScalar x,
-                    SkScalar y) override {
-    blobs_.push_back(blob);
   }
 
   void drawRect(const SkRect& rect) override { rects_.push_back(rect); }
@@ -57,8 +38,6 @@ class DlOpRecorder final : public virtual DlOpReceiver,
     path_effect_ = effect;
   }
 
-  std::vector<std::shared_ptr<impeller::TextFrame>> text_frames_;
-  std::vector<sk_sp<SkTextBlob>> blobs_;
   std::vector<std::pair<SkPoint, SkPoint>> lines_;
   std::vector<SkRect> rects_;
   std::vector<SkPath> paths_;
@@ -73,30 +52,10 @@ class PainterTestBase : public CanvasTestBase<T> {
   void PretendImpellerIsEnabled(bool impeller) { impeller_ = impeller; }
 
  protected:
-  txt::TextStyle makeDecoratedStyle(txt::TextDecorationStyle style) {
-    auto t_style = txt::TextStyle();
-    t_style.color = SK_ColorBLACK;                // default
-    t_style.font_weight = txt::FontWeight::w400;  // normal
-    t_style.font_size = 14;                       // default
-    t_style.decoration = txt::TextDecoration::kUnderline;
-    t_style.decoration_style = style;
-    t_style.decoration_color = SK_ColorBLACK;
-    t_style.font_families.push_back("ahem");
-    return t_style;
-  }
-
-  txt::TextStyle makeStyle() {
-    auto t_style = txt::TextStyle();
-    t_style.color = SK_ColorBLACK;                // default
-    t_style.font_weight = txt::FontWeight::w400;  // normal
-    t_style.font_size = 14;                       // default
-    t_style.font_families.push_back("ahem");
-    return t_style;
-  }
-
-  sk_sp<DisplayList> draw(txt::TextStyle style) const {
+  sk_sp<DisplayList> draw(txt::TextDecorationStyle style) const {
+    auto t_style = makeDecoratedStyle(style);
     auto pb_skia = makeParagraphBuilder();
-    pb_skia.PushStyle(style);
+    pb_skia.PushStyle(t_style);
     pb_skia.AddText(u"Hello World!");
     pb_skia.Pop();
 
@@ -126,6 +85,18 @@ class PainterTestBase : public CanvasTestBase<T> {
     return txt::ParagraphBuilderSkia(p_style, f_collection, impeller_);
   }
 
+  txt::TextStyle makeDecoratedStyle(txt::TextDecorationStyle style) const {
+    auto t_style = txt::TextStyle();
+    t_style.color = SK_ColorBLACK;                // default
+    t_style.font_weight = txt::FontWeight::w400;  // normal
+    t_style.font_size = 14;                       // default
+    t_style.decoration = txt::TextDecoration::kUnderline;
+    t_style.decoration_style = style;
+    t_style.decoration_color = SK_ColorBLACK;
+    t_style.font_families.push_back("ahem");
+    return t_style;
+  }
+
   bool impeller_ = false;
 };
 
@@ -135,8 +106,19 @@ TEST_F(PainterTest, DrawsSolidLineSkia) {
   PretendImpellerIsEnabled(false);
 
   auto recorder = DlOpRecorder();
-  draw(makeDecoratedStyle(txt::TextDecorationStyle::kSolid))
-      ->Dispatch(recorder);
+  draw(txt::TextDecorationStyle::kSolid)->Dispatch(recorder);
+
+  // Skia may draw a solid underline as a filled rectangle:
+  // https://skia.googlesource.com/skia/+/refs/heads/main/modules/skparagraph/src/Decorations.cpp#91
+  EXPECT_EQ(recorder.rectCount(), 1);
+  EXPECT_FALSE(recorder.hasPathEffect());
+}
+
+TEST_F(PainterTest, DrawsSolidLineImpeller) {
+  PretendImpellerIsEnabled(true);
+
+  auto recorder = DlOpRecorder();
+  draw(txt::TextDecorationStyle::kSolid)->Dispatch(recorder);
 
   // Skia may draw a solid underline as a filled rectangle:
   // https://skia.googlesource.com/skia/+/refs/heads/main/modules/skparagraph/src/Decorations.cpp#91
@@ -148,98 +130,23 @@ TEST_F(PainterTest, DrawDashedLineSkia) {
   PretendImpellerIsEnabled(false);
 
   auto recorder = DlOpRecorder();
-  draw(makeDecoratedStyle(txt::TextDecorationStyle::kDashed))
-      ->Dispatch(recorder);
+  draw(txt::TextDecorationStyle::kDashed)->Dispatch(recorder);
 
   // Skia draws a dashed underline as a filled rectangle with a path effect.
   EXPECT_EQ(recorder.lineCount(), 1);
   EXPECT_TRUE(recorder.hasPathEffect());
 }
 
-#ifdef IMPELLER_SUPPORTS_RENDERING
-TEST_F(PainterTest, DrawsSolidLineImpeller) {
-  PretendImpellerIsEnabled(true);
-
-  auto recorder = DlOpRecorder();
-  draw(makeDecoratedStyle(txt::TextDecorationStyle::kSolid))
-      ->Dispatch(recorder);
-
-  // Skia may draw a solid underline as a filled rectangle:
-  // https://skia.googlesource.com/skia/+/refs/heads/main/modules/skparagraph/src/Decorations.cpp#91
-  EXPECT_EQ(recorder.rectCount(), 1);
-  EXPECT_FALSE(recorder.hasPathEffect());
-}
-
 TEST_F(PainterTest, DrawDashedLineImpeller) {
   PretendImpellerIsEnabled(true);
 
   auto recorder = DlOpRecorder();
-  draw(makeDecoratedStyle(txt::TextDecorationStyle::kDashed))
-      ->Dispatch(recorder);
+  draw(txt::TextDecorationStyle::kDashed)->Dispatch(recorder);
 
   // Impeller draws a dashed underline as a path.
   EXPECT_EQ(recorder.pathCount(), 1);
   EXPECT_FALSE(recorder.hasPathEffect());
 }
-
-TEST_F(PainterTest, DrawTextFrameImpeller) {
-  PretendImpellerIsEnabled(true);
-
-  auto recorder = DlOpRecorder();
-  draw(makeStyle())->Dispatch(recorder);
-
-  EXPECT_EQ(recorder.textFrameCount(), 1);
-  EXPECT_EQ(recorder.blobCount(), 0);
-}
-
-TEST_F(PainterTest, DrawStrokedTextImpeller) {
-  PretendImpellerIsEnabled(true);
-
-  auto style = makeStyle();
-  // What is your shtyle?
-  DlPaint foreground;
-  foreground.setDrawStyle(DlDrawStyle::kStroke);
-  style.foreground = foreground;
-
-  auto recorder = DlOpRecorder();
-  draw(style)->Dispatch(recorder);
-
-  EXPECT_EQ(recorder.textFrameCount(), 0);
-  EXPECT_EQ(recorder.blobCount(), 0);
-  EXPECT_EQ(recorder.pathCount(), 1);
-}
-
-TEST_F(PainterTest, DrawTextWithGradientImpeller) {
-  PretendImpellerIsEnabled(true);
-
-  auto style = makeStyle();
-  // how do you like my shtyle?
-  DlPaint foreground;
-  std::vector<DlColor> colors = {DlColor::kRed(), DlColor::kCyan()};
-  std::vector<float> stops = {0.0, 1.0};
-  foreground.setColorSource(DlColorSource::MakeLinear(
-      SkPoint::Make(0, 0), SkPoint::Make(100, 100), 2, colors.data(),
-      stops.data(), DlTileMode::kClamp));
-  style.foreground = foreground;
-
-  auto recorder = DlOpRecorder();
-  draw(style)->Dispatch(recorder);
-
-  EXPECT_EQ(recorder.textFrameCount(), 0);
-  EXPECT_EQ(recorder.blobCount(), 0);
-  EXPECT_EQ(recorder.pathCount(), 1);
-}
-
-TEST_F(PainterTest, DrawTextBlobNoImpeller) {
-  PretendImpellerIsEnabled(false);
-
-  auto recorder = DlOpRecorder();
-  draw(makeStyle())->Dispatch(recorder);
-
-  EXPECT_EQ(recorder.textFrameCount(), 0);
-  EXPECT_EQ(recorder.blobCount(), 1);
-}
-#endif  // IMPELLER_SUPPORTS_RENDERING
 
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
Reverts flutter/engine#45418

Some google3 tests are hitting the CHECK I added in the DlSkCanvasDispatcher::drawTextFrame, which indicates that the SkParagraph code likely thinks impeller is enabled, whereas other code might be running with Skia.

Perhaps this could happen if its software rendering? It should be a fatal error on startup so we can track this down.

cherry pick for flutter roll
