### PR TITLE
Revert "Reenable HardwareBuffer backed Android Platform Views on SDK …

### DIFF
--- a/shell/platform/android/hardware_buffer_external_texture.cc
+++ b/shell/platform/android/hardware_buffer_external_texture.cc
@@ -39,8 +39,7 @@ void HardwareBufferExternalTexture::Paint(PaintContext& context,
         flutter::DlCanvas::SrcRectConstraint::kStrict  // enforce edges
     );
   } else {
-    FML_LOG(WARNING)
-        << "No DlImage available for HardwareBufferExternalTexture to paint.";
+    FML_LOG(WARNING) << "No DlImage available.";
   }
 }
 

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -336,7 +336,6 @@ public class FlutterRenderer implements TextureRegistry {
 
   @Keep
   final class ImageTextureRegistryEntry implements TextureRegistry.ImageTextureEntry {
-    private static final String TAG = "ImageTextureRegistryEntry";
     private final long id;
     private boolean released;
     private Image image;
@@ -371,10 +370,8 @@ public class FlutterRenderer implements TextureRegistry {
       if (toClose != null) {
         toClose.close();
       }
-      if (image != null) {
-        // Mark that we have a new frame available.
-        markTextureFrameAvailable(id);
-      }
+      // Mark that we have a new frame available.
+      markTextureFrameAvailable(id);
     }
 
     @Override

--- a/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
@@ -11,9 +11,10 @@ import android.os.Handler;
 import android.view.Surface;
 import io.flutter.view.TextureRegistry.ImageTextureEntry;
 
-@TargetApi(29)
+@TargetApi(26)
 public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTarget {
   private ImageTextureEntry textureEntry;
+  private boolean mustRecreateImageReader = false;
   private ImageReader reader;
   private int bufferWidth = 0;
   private int bufferHeight = 0;
@@ -21,12 +22,18 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
 
   private void closeReader() {
     if (this.reader != null) {
-      // Push a null image, forcing the texture entry to close any cached images.
-      textureEntry.pushImage(null);
-      // Close the reader, which also closes any produced images.
       this.reader.close();
       this.reader = null;
     }
+  }
+
+  private void recreateImageReaderIfNeeded() {
+    if (!mustRecreateImageReader) {
+      return;
+    }
+    mustRecreateImageReader = false;
+    closeReader();
+    this.reader = createImageReader();
   }
 
   private final Handler onImageAvailableHandler = new Handler();
@@ -48,12 +55,9 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
     // Allow for double buffering.
     builder.setMaxImages(3);
     // Use PRIVATE image format so that we can support video decoding.
-    // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our
-    // ability to read back texture data. If we don't always want to use it, how do we
-    // decide when to use it or not? Perhaps PlatformViews can indicate if they may contain
-    // DRM'd content.
-    // I need to investigate how PRIVATE impacts our ability to take screenshots or capture
-    // the output of Flutter application.
+    // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our ability
+    // to read back texture data. If we don't always want to use it, how do we decide when
+    // to use it or not? Perhaps PlatformViews can indicate if they may contain DRM'd content.
     builder.setImageFormat(ImageFormat.PRIVATE);
     // Hint that consumed images will only be read by GPU.
     builder.setUsage(HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
@@ -64,15 +68,13 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
 
   @TargetApi(29)
   protected ImageReader createImageReader29() {
-    final ImageReader reader =
-        ImageReader.newInstance(
-            bufferWidth,
-            bufferHeight,
-            ImageFormat.PRIVATE,
-            2,
-            HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
-    reader.setOnImageAvailableListener(this.onImageAvailableListener, onImageAvailableHandler);
-    return reader;
+    return ImageReader.newInstance(
+        bufferWidth, bufferHeight, ImageFormat.PRIVATE, 2, HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
+  }
+
+  @TargetApi(26)
+  protected ImageReader createImageReader26() {
+    return ImageReader.newInstance(bufferWidth, bufferHeight, ImageFormat.PRIVATE, 2);
   }
 
   protected ImageReader createImageReader() {
@@ -80,15 +82,15 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
       return createImageReader33();
     } else if (Build.VERSION.SDK_INT >= 29) {
       return createImageReader29();
+    } else {
+      return createImageReader26();
     }
-    throw new UnsupportedOperationException(
-        "ImageReaderPlatformViewRenderTarget requires API version 29+");
   }
 
   public ImageReaderPlatformViewRenderTarget(ImageTextureEntry textureEntry) {
-    if (Build.VERSION.SDK_INT < 29) {
+    if (Build.VERSION.SDK_INT < 26) {
       throw new UnsupportedOperationException(
-          "ImageReaderPlatformViewRenderTarget requires API version 29+");
+          "ImageReaderPlatformViewRenderTarget requires API version 26+");
     }
     this.textureEntry = textureEntry;
   }
@@ -125,9 +127,9 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
   }
 
   public void release() {
-    closeReader();
     // textureEntry has a finalizer attached.
     textureEntry = null;
+    closeReader();
   }
 
   public boolean isReleased() {
@@ -135,6 +137,7 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
   }
 
   public Surface getSurface() {
+    recreateImageReaderIfNeeded();
     return this.reader.getSurface();
   }
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -968,7 +968,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
 
   private static PlatformViewRenderTarget makePlatformViewRenderTarget(
       TextureRegistry textureRegistry) {
-    if (Build.VERSION.SDK_INT >= 29) {
+    // TODO(johnmccutchan): Enable ImageReaderPlatformViewRenderTarget for public use.
+    if (false) {
       final TextureRegistry.ImageTextureEntry textureEntry = textureRegistry.createImageTexture();
       return new ImageReaderPlatformViewRenderTarget(textureEntry);
     }

--- a/shell/platform/android/surface_texture_external_texture.cc
+++ b/shell/platform/android/surface_texture_external_texture.cc
@@ -78,8 +78,7 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
       context.canvas->DrawImage(dl_image_, {0, 0}, sampling, context.paint);
     }
   } else {
-    FML_LOG(WARNING)
-        << "No DlImage available for SurfaceTextureExternalTexture to paint.";
+    FML_LOG(WARNING) << "No DlImage available.";
   }
 }
 


### PR DESCRIPTION
…>= 29 (#44790)"

This reverts commit d259a5260697d5d3e94870f9b864ef482bbacf1b.

Breaks `customer: money` in b/300555779.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
