### PR TITLE
Revert "[Windows] Update vsync on raster thread (#45310)"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -631,7 +631,7 @@ deps = {
    Var('swiftshader_git') + '/SwiftShader.git' + '@' + '5f9ed9b16931c7155171d31f75004f73f0a3abc8',
 
    'src/third_party/angle':
-   Var('chromium_git') + '/angle/angle.git' + '@' + '48e2c605adcd5bcc1622b18f357c7a73ebfb3543',
+   Var('chromium_git') + '/angle/angle.git' + '@' + '6a09e41ce6ea8c93524faae1a925eb01562f53b1',
 
    'src/third_party/vulkan_memory_allocator':
    Var('chromium_git') + '/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator' + '@' + '7de5cc00de50e71a3aab22dea52fbb7ff4efceb6',

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -991,7 +991,6 @@
 ../../../third_party/angle/.git
 ../../../third_party/angle/.gitattributes
 ../../../third_party/angle/.gitignore
-../../../third_party/angle/.gitmodules
 ../../../third_party/angle/.gn
 ../../../third_party/angle/.style.yapf
 ../../../third_party/angle/.vpython
@@ -1130,7 +1129,6 @@
 ../../../third_party/angle/src/third_party/ceval/package.json
 ../../../third_party/angle/src/third_party/libXNVCtrl/README.chromium
 ../../../third_party/angle/src/third_party/volk
-../../../third_party/angle/testing
 ../../../third_party/angle/third_party
 ../../../third_party/angle/tools
 ../../../third_party/angle/util

--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -343,13 +343,6 @@ void AngleSurfaceManager::SetVSyncEnabled(bool enabled) {
     LogEglError("Unable to update the swap interval");
     return;
   }
-
-  if (eglMakeCurrent(egl_display_, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                     EGL_NO_CONTEXT) != EGL_TRUE) {
-    LogEglError(
-        "Unable to release the context after updating the swap interval");
-    return;
-  }
 }
 
 bool AngleSurfaceManager::GetDevice(ID3D11Device** device) {

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -199,7 +199,7 @@ class FlutterWindowsEngine {
   bool MarkExternalTextureFrameAvailable(int64_t texture_id);
 
   // Posts the given callback onto the raster thread.
-  virtual bool PostRasterThreadTask(fml::closure callback);
+  bool PostRasterThreadTask(fml::closure callback);
 
   // Invoke on the embedder's vsync callback to schedule a frame.
   void OnVsync(intptr_t baton);

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -669,12 +669,7 @@ void FlutterWindowsView::UpdateSemanticsEnabled(bool enabled) {
 
 void FlutterWindowsView::OnDwmCompositionChanged() {
   if (engine_->surface_manager()) {
-    // Update the surface with the new composition state.
-    // Switch to the raster thread as this requires making the context current.
-    auto needs_vsync = binding_handler_->NeedsVSync();
-    engine_->PostRasterThreadTask([this, needs_vsync]() {
-      engine_->surface_manager()->SetVSyncEnabled(needs_vsync);
-    });
+    engine_->surface_manager()->SetVSyncEnabled(binding_handler_->NeedsVSync());
   }
 }
 

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -110,8 +110,8 @@ class MockFlutterWindowsEngine : public FlutterWindowsEngine {
  public:
   MockFlutterWindowsEngine() : FlutterWindowsEngine(GetTestProject()) {}
 
-  MOCK_METHOD(bool, Stop, (), (override));
-  MOCK_METHOD(bool, PostRasterThreadTask, (fml::closure), (override));
+  MOCK_METHOD(bool, Stop, (), ());
+  MOCK_METHOD(bool, PostRasterThreadTask, (fml::closure), ());
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsEngine);
@@ -1286,13 +1286,6 @@ TEST(FlutterWindowsViewTest, UpdatesVSyncOnDwmUpdates) {
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   std::unique_ptr<MockAngleSurfaceManager> surface_manager =
       std::make_unique<MockAngleSurfaceManager>();
-
-  EXPECT_CALL(*engine.get(), PostRasterThreadTask)
-      .Times(2)
-      .WillRepeatedly([](fml::closure callback) {
-        callback();
-        return true;
-      });
 
   EXPECT_CALL(*window_binding_handler.get(), NeedsVSync)
       .WillOnce(Return(true))


### PR DESCRIPTION
This also reverts the ANGLE roll (for which the original fix was landed) to 48e2c605adcd5bcc1622b18f357c7a73ebfb3543.

fixes: https://github.com/flutter/flutter/issues/134262

This reverts commit 708d82dc8a95a58c0f44b5c5e6758048aeff192e.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
