### PR TITLE
[Impeller] Adds unit test to make sure we can encode bgr101010xr to png.

### DIFF
--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -34,15 +34,6 @@ class Context;
 namespace flutter {
 namespace {
 
-// This must be kept in sync with the enum in painting.dart
-enum ImageByteFormat {
-  kRawRGBA,
-  kRawStraightRGBA,
-  kRawUnmodified,
-  kRawExtendedRgba128,
-  kPNG,
-};
-
 void FinalizeSkData(void* isolate_callback_data, void* peer) {
   SkData* buffer = reinterpret_cast<SkData*>(peer);
   buffer->unref();
@@ -105,44 +96,6 @@ sk_sp<SkData> CopyImageByteData(const sk_sp<SkImage>& raster_image,
   }
 
   return SkData::MakeWithCopy(pixmap.addr(), pixmap.computeByteSize());
-}
-
-sk_sp<SkData> EncodeImage(const sk_sp<SkImage>& raster_image,
-                          ImageByteFormat format) {
-  TRACE_EVENT0("flutter", __FUNCTION__);
-
-  if (!raster_image) {
-    return nullptr;
-  }
-
-  switch (format) {
-    case kPNG: {
-      auto png_image = SkPngEncoder::Encode(nullptr, raster_image.get(), {});
-
-      if (png_image == nullptr) {
-        FML_LOG(ERROR) << "Could not convert raster image to PNG.";
-        return nullptr;
-      };
-      return png_image;
-    }
-    case kRawRGBA:
-      return CopyImageByteData(raster_image, kRGBA_8888_SkColorType,
-                               kPremul_SkAlphaType);
-
-    case kRawStraightRGBA:
-      return CopyImageByteData(raster_image, kRGBA_8888_SkColorType,
-                               kUnpremul_SkAlphaType);
-
-    case kRawUnmodified:
-      return CopyImageByteData(raster_image, raster_image->colorType(),
-                               raster_image->alphaType());
-    case kRawExtendedRgba128:
-      return CopyImageByteData(raster_image, kRGBA_F32_SkColorType,
-                               kUnpremul_SkAlphaType);
-  }
-
-  FML_LOG(ERROR) << "Unknown error encoding image.";
-  return nullptr;
 }
 
 void EncodeImageAndInvokeDataCallback(
@@ -227,6 +180,44 @@ Dart_Handle EncodeImage(CanvasImage* canvas_image,
       }));
 
   return Dart_Null();
+}
+
+sk_sp<SkData> EncodeImage(const sk_sp<SkImage>& raster_image,
+                          ImageByteFormat format) {
+  TRACE_EVENT0("flutter", __FUNCTION__);
+
+  if (!raster_image) {
+    return nullptr;
+  }
+
+  switch (format) {
+    case kPNG: {
+      auto png_image = SkPngEncoder::Encode(nullptr, raster_image.get(), {});
+
+      if (png_image == nullptr) {
+        FML_LOG(ERROR) << "Could not convert raster image to PNG.";
+        return nullptr;
+      };
+      return png_image;
+    }
+    case kRawRGBA:
+      return CopyImageByteData(raster_image, kRGBA_8888_SkColorType,
+                               kPremul_SkAlphaType);
+
+    case kRawStraightRGBA:
+      return CopyImageByteData(raster_image, kRGBA_8888_SkColorType,
+                               kUnpremul_SkAlphaType);
+
+    case kRawUnmodified:
+      return CopyImageByteData(raster_image, raster_image->colorType(),
+                               raster_image->alphaType());
+    case kRawExtendedRgba128:
+      return CopyImageByteData(raster_image, kRGBA_F32_SkColorType,
+                               kUnpremul_SkAlphaType);
+  }
+
+  FML_LOG(ERROR) << "Unknown error encoding image.";
+  return nullptr;
 }
 
 }  // namespace flutter

--- a/lib/ui/painting/image_encoding.h
+++ b/lib/ui/painting/image_encoding.h
@@ -5,15 +5,28 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_IMAGE_ENCODING_H_
 #define FLUTTER_LIB_UI_PAINTING_IMAGE_ENCODING_H_
 
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/tonic/dart_library_natives.h"
 
 namespace flutter {
 
 class CanvasImage;
 
+// This must be kept in sync with the enum in painting.dart
+enum ImageByteFormat {
+  kRawRGBA,
+  kRawStraightRGBA,
+  kRawUnmodified,
+  kRawExtendedRgba128,
+  kPNG,
+};
+
 Dart_Handle EncodeImage(CanvasImage* canvas_image,
                         int format,
                         Dart_Handle callback_handle);
+
+sk_sp<SkData> EncodeImage(const sk_sp<SkImage>& raster_image,
+                          ImageByteFormat format);
 
 }  // namespace flutter
 

--- a/lib/ui/painting/image_encoding_unittests.cc
+++ b/lib/ui/painting/image_encoding_unittests.cc
@@ -275,6 +275,29 @@ TEST(ImageEncodingImpellerTest, ConvertDlImageToSkImage10XR) {
       context);
   EXPECT_TRUE(did_call);
 }
+
+TEST(ImageEncodingImpellerTest, PngEncoding10XR) {
+  int width = 100;
+  int height = 100;
+  SkImageInfo info = SkImageInfo::Make(
+      width, height, kBGR_101010x_XR_SkColorType, kUnpremul_SkAlphaType);
+
+  auto surface = SkSurfaces::Raster(info);
+  SkCanvas* canvas = surface->getCanvas();
+
+  SkPaint paint;
+  paint.setColor(SK_ColorBLUE);
+  paint.setAntiAlias(true);
+
+  canvas->clear(SK_ColorWHITE);
+  canvas->drawCircle(width / 2, height / 2, 100, paint);
+
+  sk_sp<SkImage> image = surface->makeImageSnapshot();
+
+  sk_sp<SkData> png = EncodeImage(image, ImageByteFormat::kPNG);
+  EXPECT_TRUE(png);
+}
+
 #endif  // IMPELLER_SUPPORTS_RENDERING
 
 }  // namespace testing


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/133942

This is current blocked on the skia bug: https://g-issues.skia.org/issues/300986800
Depends on skia fix: https://skia-review.googlesource.com/c/skia/+/757816

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
