### PR TITLE
[Android] Fix enableSuggestions set to false not honored

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -275,7 +275,7 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       if (!enableSuggestions) {
         // Note: both required. Some devices ignore TYPE_TEXT_FLAG_NO_SUGGESTIONS.
         textType |= InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
-        textType |= InputType.TYPE_TEXT_VARIATION_PASSWORD;
+        textType |= InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
       }
     }
 

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -272,7 +272,11 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       textType |= InputType.TYPE_TEXT_VARIATION_PASSWORD;
     } else {
       if (autocorrect) textType |= InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
-      if (!enableSuggestions) textType |= InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+      if (!enableSuggestions) {
+        // Note: both required. Some devices ignore TYPE_TEXT_FLAG_NO_SUGGESTIONS.
+        textType |= InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+        textType |= InputType.TYPE_TEXT_VARIATION_PASSWORD;
+      }
     }
 
     if (textCapitalization == TextInputChannel.TextCapitalization.CHARACTERS) {

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -273,7 +273,7 @@ public class TextInputPluginTest {
             true,
             false, // Delta model is disabled.
             TextInputChannel.TextCapitalization.NONE,
-            new TextInputChannel.InputType(TextInputChannel.TextInputType.MULTILINE, false, false),
+            new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false),
             null,
             null,
             null,
@@ -1339,7 +1339,7 @@ public class TextInputPluginTest {
         InputType.TYPE_CLASS_TEXT
             | InputType.TYPE_TEXT_FLAG_MULTI_LINE
             | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
-            | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+            | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
   }
 
   // -------- Start: Autofill Tests -------

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -273,7 +273,7 @@ public class TextInputPluginTest {
             true,
             false, // Delta model is disabled.
             TextInputChannel.TextCapitalization.NONE,
-            new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false),
+            new TextInputChannel.InputType(TextInputChannel.TextInputType.MULTILINE, false, false),
             null,
             null,
             null,
@@ -1304,6 +1304,42 @@ public class TextInputPluginTest {
 
     textInputPlugin.showTextInput(testView);
     assertEquals(testImm.isSoftInputVisible(), false);
+  }
+
+  @Test
+  public void inputConnection_textInputTypeMultilineAndSuggestionsDisabled() {
+    // Regression test for https://github.com/flutter/flutter/issues/71679.
+    View testView = new View(ctx);
+    DartExecutor dartExecutor = mock(DartExecutor.class);
+    TextInputChannel textInputChannel = new TextInputChannel(dartExecutor);
+    TextInputPlugin textInputPlugin =
+        new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
+    textInputPlugin.setTextInputClient(
+        0,
+        new TextInputChannel.Configuration(
+            false,
+            false,
+            false, // Disable suggestions.
+            true,
+            false,
+            TextInputChannel.TextCapitalization.NONE,
+            new TextInputChannel.InputType(TextInputChannel.TextInputType.MULTILINE, false, false),
+            null,
+            null,
+            null,
+            null,
+            null));
+
+    EditorInfo editorInfo = new EditorInfo();
+    InputConnection connection =
+        textInputPlugin.createInputConnection(testView, mock(KeyboardManager.class), editorInfo);
+
+    assertEquals(
+        editorInfo.inputType,
+        InputType.TYPE_CLASS_TEXT
+            | InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+            | InputType.TYPE_TEXT_VARIATION_PASSWORD);
   }
 
   // -------- Start: Autofill Tests -------


### PR DESCRIPTION
## Description

This PR fixes an issue where setting `TextField.enableSuggestions` to false was not honored on Android.

Several Android devices (Samsung) and/or IMEs (including GBoard) does not disabled suggestions when `InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS `flag is set. The common solution is to rely on the following flag:  ~~`InputType.TYPE_TEXT_VARIATION_PASSWORD`~~ `InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD`.

Reference:
- https://issuetracker.google.com/issues/36934423#comment4
- https://stackoverflow.com/questions/33148168/inputtype-type-text-flag-no-suggestions-in-samsung/33227237#33227237
- Existing comment on the codebase:
https://github.com/flutter/engine/blob/53430c7c96a3ef1fc78d63ea6b0c35e5ff46c45e/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java#L270

## Related Issue

Fixes https://github.com/flutter/flutter/issues/71679.

## Tests

Adds 1 test.