### PR TITLE
[web] DOM objects implement JS object

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -240,7 +240,7 @@ extension CanvasKitExtension on CanvasKit {
     DomImageBitmap imageBitmap,
     bool hasPremultipliedAlpha,
   ) => _MakeLazyImageFromTextureSource3(
-    imageBitmap as JSAny,
+    imageBitmap,
     0.toJS,
     hasPremultipliedAlpha.toJS,
   );

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -322,7 +322,7 @@ external DomHTMLDocument get domDocument;
 
 @JS()
 @staticInterop
-class DomEventTarget {}
+class DomEventTarget implements JSObject {}
 
 extension DomEventTargetExtension on DomEventTarget {
   @JS('addEventListener')
@@ -1134,7 +1134,7 @@ extension WebGLContextExtension on WebGLContext {
 
 @JS()
 @staticInterop
-abstract class DomCanvasImageSource {}
+abstract class DomCanvasImageSource implements JSObject {}
 
 @JS()
 @staticInterop
@@ -1427,7 +1427,7 @@ extension DomImageDataExtension on DomImageData {
 
 @JS('ImageBitmap')
 @staticInterop
-class DomImageBitmap {}
+class DomImageBitmap implements JSObject {}
 
 extension DomImageBitmapExtension on DomImageBitmap {
   external JSNumber get width;
@@ -1830,7 +1830,7 @@ class HttpFetchError implements Exception {
 
 @JS()
 @staticInterop
-class DomResponse {}
+class DomResponse implements JSObject {}
 
 extension DomResponseExtension on DomResponse {
   @JS('status')
@@ -1867,7 +1867,7 @@ extension DomHeadersExtension on DomHeaders {
 
 @JS()
 @staticInterop
-class _DomReadableStream {}
+class _DomReadableStream implements JSObject {}
 
 extension _DomReadableStreamExtension on _DomReadableStream {
   external _DomStreamReader getReader();

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/codecs.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/codecs.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
-
 import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
@@ -21,7 +19,7 @@ class SkwasmImageDecoder extends BrowserImageDecoder {
     final int height = frame.codedHeight.toInt();
     final SkwasmSurface surface = (renderer as SkwasmRenderer).surface;
     return SkwasmImage(imageCreateFromTextureSource(
-      frame as JSAny,
+      frame,
       width,
       height,
       surface.handle,

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -391,7 +391,7 @@ class SkwasmRenderer implements Renderer {
     }
     final SkwasmImageDecoder decoder = SkwasmImageDecoder(
       contentType: contentType,
-      dataSource: response.body as JSAny,
+      dataSource: response.body,
       debugSource: uri.toString(),
     );
     await decoder.initialize();
@@ -452,7 +452,7 @@ class SkwasmRenderer implements Renderer {
   @override
   ui.Image createImageFromImageBitmap(DomImageBitmap imageSource) {
     return SkwasmImage(imageCreateFromTextureSource(
-      imageSource as JSAny,
+      imageSource,
       imageSource.width.toDartInt,
       imageSource.height.toDartInt,
       surface.handle,

--- a/lib/web_ui/test/engine/scene_view_test.dart
+++ b/lib/web_ui/test/engine/scene_view_test.dart
@@ -27,7 +27,7 @@ class StubPictureRenderer implements PictureRenderer {
   Future<DomImageBitmap> renderPicture(ScenePicture picture) async {
     final ui.Rect cullRect = picture.cullRect;
     final DomImageBitmap bitmap = (await createImageBitmap(
-      scratchCanvasElement as JSAny,
+      scratchCanvasElement,
       (x: 0, y: 0, width: cullRect.width.toInt(), height: cullRect.height.toInt())
     ).toDart)! as DomImageBitmap;
     return bitmap;

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -318,7 +318,7 @@ Future<void> testMain() async {
       image.src = url;
       await completer.future;
 
-      final DomImageBitmap bitmap = (await createImageBitmap(image as JSAny).toDart)! as DomImageBitmap;
+      final DomImageBitmap bitmap = (await createImageBitmap(image).toDart)! as DomImageBitmap;
       return renderer.createImageFromImageBitmap(bitmap);
     });
   }


### PR DESCRIPTION
Instead of doing `as JSAny` for DOM objects that are defined in static JS interop, let's make them `implements JSObject`?

cc @eyebrowsoffire @srujzs thoughts?