### PR TITLE
Rename `layoutGoals` to `kLayoutGoals` to enforce lints on headers.

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterKeyboardManager.mm
@@ -275,7 +275,7 @@ typedef _Nullable _NSResponderPtr (^NextResponderProvider)();
 
   std::map<uint32_t, LayoutGoal> mandatoryGoalsByChar;
   std::map<uint32_t, LayoutGoal> usLayoutGoalsByKeyCode;
-  for (const LayoutGoal& goal : flutter::layoutGoals) {
+  for (const LayoutGoal& goal : flutter::kLayoutGoals) {
     if (goal.mandatory) {
       mandatoryGoalsByChar[goal.keyChar] = goal;
     } else {

--- a/shell/platform/darwin/macos/framework/Source/KeyCodeMap.g.mm
+++ b/shell/platform/darwin/macos/framework/Source/KeyCodeMap.g.mm
@@ -245,7 +245,7 @@ const NSDictionary* modifierFlagToKeyCode = @{
 const uint64_t kCapsLockPhysicalKey = 0x00070039;
 const uint64_t kCapsLockLogicalKey = 0x100000104;
 
-const std::vector<LayoutGoal> layoutGoals = {
+const std::vector<LayoutGoal> kLayoutGoals = {
     LayoutGoal{0x31, 0x20, false},  // Space
     LayoutGoal{0x27, 0x22, false},  // Quote
     LayoutGoal{0x2b, 0x2c, false},  // Comma

--- a/shell/platform/darwin/macos/framework/Source/KeyCodeMap_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/KeyCodeMap_Internal.h
@@ -104,6 +104,6 @@ typedef struct {
  * All keys that Flutter wants to derive layout for, and guides on how to derive
  * them.
  */
-extern const std::vector<LayoutGoal> layoutGoals;
+extern const std::vector<LayoutGoal> kLayoutGoals;
 
 }  // namespace flutter


### PR DESCRIPTION
This is required to eventually land https://github.com/flutter/flutter/issues/134969 (lint header files).