### PR TITLE
[web] implement a workaround for JAWS for text nodes

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -2,8 +2,28 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../browser_detection.dart';
 import '../dom.dart';
 import 'semantics.dart';
+
+/// If true, labels will apply a JAWS-specific workaround to make sure it can
+/// read labels on leaf text nodes.
+///
+/// Even though the workaround is only needed for JAWS, the workaround is
+/// applied on all Windows systems because we can't know in advance what screen
+/// reader will be used, and NVDA is also OK with the workaround.
+///
+/// The workaround is _not_ used on other systems because it breaks the
+/// navigation on some screen readers. For example, VoiceOver on macOS creates
+/// intermediate nodes that result in the label read multiple times as the user
+/// invokes next/previous actions. The workaround also adds extra performance
+/// cost because it requires an extra span element.
+///
+/// See also:
+///
+///   * https://github.com/flutter/flutter/issues/122607
+///   * https://github.com/FreedomScientific/standards-support/issues/759
+bool useJawsWorkaroundForLabels = operatingSystem == OperatingSystem.windows;
 
 /// Renders [SemanticsObject.label] and/or [SemanticsObject.value] to the semantics DOM.
 ///
@@ -40,7 +60,7 @@ class LabelAndValue extends RoleManager {
     final bool shouldDisplayValue = hasValue && !semanticsObject.isIncrementable;
 
     if (!hasLabel && !shouldDisplayValue && !hasTooltip) {
-      _cleanUpDom();
+      _setLabel(null);
       return;
     }
 
@@ -62,17 +82,50 @@ class LabelAndValue extends RoleManager {
       combinedValue.write(semanticsObject.value);
     }
 
-    semanticsObject.element
-        .setAttribute('aria-label', combinedValue.toString());
+    _setLabel(combinedValue.toString());
   }
 
-  void _cleanUpDom() {
-    semanticsObject.element.removeAttribute('aria-label');
+  void _setLabel(String? label) {
+    // TODO(yjbanov): revisit when/if this is fixed https://github.com/FreedomScientific/standards-support/issues/759
+    if (useJawsWorkaroundForLabels) {
+      _setLabelWithWindowsWorkaround(label);
+    } else {
+      if (label != null && label.isNotEmpty) {
+        semanticsObject.element.setAttribute('aria-label', label);
+      } else {
+        semanticsObject.element.removeAttribute('aria-label');
+      }
+    }
+  }
+
+  DomElement? _windowsSpan;
+
+  void _setLabelWithWindowsWorkaround(String? label) {
+    DomElement? span = _windowsSpan;
+    if (label == null || label.isEmpty) {
+      // Empty label => clean up
+      if (span != null && (span.isConnected ?? false)) {
+        span.remove();
+      } // nothing to clean up in the else case
+    } else {
+      // Non-empty label => set the ARIA labels
+
+      // If the span does not exist, create one
+      if (span == null) {
+        _windowsSpan = span = createDomElement('span');
+      }
+      span.setAttribute('aria-label', label);
+
+      // If the span did exist but was detached, attach it.
+      if (!(span.isConnected ?? false)) {
+        semanticsObject.element.appendChild(span);
+      }
+    }
   }
 
   @override
   void dispose() {
     super.dispose();
-    _cleanUpDom();
+    _setLabel(null);
   }
 }

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -47,6 +47,12 @@ void runSemanticsTests() {
   group('Role managers', () {
     _testRoleManagerLifecycle();
   });
+  group('labels', () {
+    _testLabels();
+  });
+  group('labels for JAWS', () {
+    _testLabelsForJaws();
+  });
   group('container', () {
     _testContainer();
   });
@@ -337,120 +343,19 @@ void _testEngineSemanticsOwner() {
     expect(placeholder.isConnected, isFalse);
   });
 
-  void renderSemantics({String? label, String? tooltip}) {
-    final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
-    updateNode(
-      builder,
-      transform: Matrix4.identity().toFloat64(),
-      rect: const ui.Rect.fromLTRB(0, 0, 20, 20),
-      childrenInHitTestOrder: Int32List.fromList(<int>[1]),
-      childrenInTraversalOrder: Int32List.fromList(<int>[1]),
-    );
-    updateNode(
-      builder,
-      id: 1,
-      label: label ?? '',
-      tooltip: tooltip ?? '',
-      transform: Matrix4.identity().toFloat64(),
-      rect: const ui.Rect.fromLTRB(0, 0, 20, 20),
-    );
-    semantics().updateSemantics(builder.build());
-  }
-
-  void renderLabel(String label) {
-    renderSemantics(label: label);
-  }
-
-  test('produces an aria-label', () async {
-    semantics().semanticsEnabled = true;
-
-    // Create
-    renderLabel('Hello');
-
-    final Map<int, SemanticsObject> tree = semantics().debugSemanticsTree!;
-    expect(tree.length, 2);
-    expect(tree[0]!.id, 0);
-    expect(tree[0]!.element.tagName.toLowerCase(), 'flt-semantics');
-    expect(tree[1]!.id, 1);
-    expect(tree[1]!.label, 'Hello');
-
-    expectSemanticsTree('''
-<sem style="$rootSemanticStyle">
-  <sem-c>
-    <sem role="text" aria-label="Hello"></sem>
-  </sem-c>
-</sem>''');
-
-    // Update
-    renderLabel('World');
-
-    expectSemanticsTree('''
-<sem style="$rootSemanticStyle">
-  <sem-c>
-    <sem role="text" aria-label="World"></sem>
-  </sem-c>
-</sem>''');
-
-    // Remove
-    renderLabel('');
-
-    expectSemanticsTree('''
-<sem style="$rootSemanticStyle">
-  <sem-c>
-    <sem role="text"></sem>
-  </sem-c>
-</sem>''');
-
-    semantics().semanticsEnabled = false;
-  });
-
-  test('tooltip is part of label', () async {
-    semantics().semanticsEnabled = true;
-
-    // Create
-    renderSemantics(tooltip: 'tooltip');
-
-    final Map<int, SemanticsObject> tree = semantics().debugSemanticsTree!;
-    expect(tree.length, 2);
-    expect(tree[0]!.id, 0);
-    expect(tree[0]!.element.tagName.toLowerCase(), 'flt-semantics');
-    expect(tree[1]!.id, 1);
-    expect(tree[1]!.tooltip, 'tooltip');
-
-    expectSemanticsTree('''
-<sem style="$rootSemanticStyle">
-  <sem-c>
-    <sem aria-label="tooltip"></sem>
-  </sem-c>
-</sem>''');
-
-    // Update
-    renderSemantics(label: 'Hello', tooltip: 'tooltip');
-
-    expectSemanticsTree('''
-<sem style="$rootSemanticStyle">
-  <sem-c>
-    <sem role="text" aria-label="tooltip\nHello"></sem>
-  </sem-c>
-</sem>''');
-
-    // Remove
-    renderSemantics();
-
-    expectSemanticsTree('''
-<sem style="$rootSemanticStyle">
-  <sem-c>
-    <sem role="text"></sem>
-  </sem-c>
-</sem>''');
-
-    semantics().semanticsEnabled = false;
-  });
-
   test('clears semantics tree when disabled', () {
     expect(semantics().debugSemanticsTree, isEmpty);
     semantics().semanticsEnabled = true;
-    renderLabel('Hello');
+
+    final SemanticsTester tester = SemanticsTester(semantics());
+    tester.updateNode(
+      id: 0,
+      label: 'd',
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+    tester.apply();
+
     expect(semantics().debugSemanticsTree, isNotEmpty);
     semantics().semanticsEnabled = false;
     expect(semantics().debugSemanticsTree, isEmpty);
@@ -554,6 +459,197 @@ void _testEngineSemanticsOwner() {
       <MockRoleManagerLogEntry>[
         (method: 'update', phase: SemanticsUpdatePhase.updating),
       ],
+    );
+
+    semantics().semanticsEnabled = false;
+  });
+}
+
+void renderLabelAndValue({String? label, String? tooltip}) {
+  final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
+  updateNode(
+    builder,
+    transform: Matrix4.identity().toFloat64(),
+    rect: const ui.Rect.fromLTRB(0, 0, 20, 20),
+    childrenInHitTestOrder: Int32List.fromList(<int>[1]),
+    childrenInTraversalOrder: Int32List.fromList(<int>[1]),
+  );
+  updateNode(
+    builder,
+    id: 1,
+    label: label ?? '',
+    tooltip: tooltip ?? '',
+    transform: Matrix4.identity().toFloat64(),
+    rect: const ui.Rect.fromLTRB(0, 0, 20, 20),
+  );
+  semantics().updateSemantics(builder.build());
+}
+
+void _testLabels() {
+  test('produces an aria-label', () async {
+    semantics().semanticsEnabled = true;
+
+    // Create
+    renderLabelAndValue(label: 'Hello');
+
+    final Map<int, SemanticsObject> tree = semantics().debugSemanticsTree!;
+    expect(tree.length, 2);
+    expect(tree[0]!.id, 0);
+    expect(tree[0]!.element.tagName.toLowerCase(), 'flt-semantics');
+    expect(tree[1]!.id, 1);
+    expect(tree[1]!.label, 'Hello');
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem role="text" aria-label="Hello"></sem>
+  </sem-c>
+</sem>''');
+
+    // Update
+    renderLabelAndValue(label: 'World');
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem role="text" aria-label="World"></sem>
+  </sem-c>
+</sem>''');
+
+    // Remove
+    renderLabelAndValue(label: '');
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem role="text"></sem>
+  </sem-c>
+</sem>''');
+
+    semantics().semanticsEnabled = false;
+  });
+
+  test('tooltip is part of label', () async {
+    semantics().semanticsEnabled = true;
+
+    // Create
+    renderLabelAndValue(tooltip: 'tooltip');
+
+    final Map<int, SemanticsObject> tree = semantics().debugSemanticsTree!;
+    expect(tree.length, 2);
+    expect(tree[0]!.id, 0);
+    expect(tree[0]!.element.tagName.toLowerCase(), 'flt-semantics');
+    expect(tree[1]!.id, 1);
+    expect(tree[1]!.tooltip, 'tooltip');
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem aria-label="tooltip"></sem>
+  </sem-c>
+</sem>''');
+
+    // Update
+    renderLabelAndValue(label: 'Hello', tooltip: 'tooltip');
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem role="text" aria-label="tooltip\nHello"></sem>
+  </sem-c>
+</sem>''');
+
+    // Remove
+    renderLabelAndValue();
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem role="text"></sem>
+  </sem-c>
+</sem>''');
+
+    semantics().semanticsEnabled = false;
+  });
+}
+
+void _testLabelsForJaws() {
+  setUp(() {
+    useJawsWorkaroundForLabels = true;
+  });
+
+  tearDown(() {
+    useJawsWorkaroundForLabels = false;
+  });
+
+  test('puts aria-label into a child span', () async {
+    semantics().semanticsEnabled = true;
+
+    // Create
+    renderLabelAndValue(label: 'Hello');
+
+    final Map<int, SemanticsObject> tree = semantics().debugSemanticsTree!;
+    expect(tree.length, 2);
+    expect(tree[0]!.id, 0);
+    expect(tree[0]!.element.tagName.toLowerCase(), 'flt-semantics');
+    expect(tree[1]!.id, 1);
+    expect(tree[1]!.label, 'Hello');
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem role="text">
+      <span aria-label="Hello"></span>
+    </sem>
+  </sem-c>
+</sem>''');
+
+    final DomElement originalSpan = domDocument.querySelector('span[aria-label="Hello"]')!;
+
+    // Update
+    renderLabelAndValue(label: 'World');
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem role="text">
+      <span aria-label="World"></span>
+    </sem>
+  </sem-c>
+</sem>''');
+
+    expect(
+      reason: 'Expect the previous span to be reused',
+      domDocument.querySelector('span[aria-label="World"]'),
+      originalSpan,
+    );
+
+    // Remove
+    renderLabelAndValue();
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem role="text"></sem>
+  </sem-c>
+</sem>''');
+
+    // Another update
+    renderLabelAndValue(label: 'Bonjour le monde');
+
+    expectSemanticsTree('''
+<sem style="$rootSemanticStyle">
+  <sem-c>
+    <sem role="text">
+      <span aria-label="Bonjour le monde"></span>
+    </sem>
+  </sem-c>
+</sem>''');
+
+    expect(
+      reason: 'Expect the previous span to be reused',
+      domDocument.querySelector('span[aria-label="Bonjour le monde"]'),
+      originalSpan,
     );
 
     semantics().semanticsEnabled = false;


### PR DESCRIPTION
This implements a workaround for https://github.com/FreedomScientific/standards-support/issues/759 by moving the `aria-label` to an artificially added child span:

BEFORE:

```
<flt-semantics role="text" aria-label="Hello"></flt-semantics>
```

AFTER:

```
<flt-semantics role="text">
  <span aria-label="Hello"></span>
</flt-semantics>
```

The workaround is only used on Windows. Screen readers on other systems are happy with the original DOM structure. In fact, NVDA on Windows is also happy with the original, but we can't tell what screen reader is used on Windows, so we have to use the workaround for all of them.