### PR TITLE
Properly transfer objects between the main thread and web worker.

### DIFF
--- a/lib/web_ui/skwasm/library_skwasm_support.js
+++ b/lib/web_ui/skwasm/library_skwasm_support.js
@@ -15,7 +15,7 @@ mergeInto(LibraryManager.library, {
         skwasmMessage: 'setAssociatedObject',
         pointer,
         object,
-      });
+      }, [object]);
     };
     _skwasm_getAssociatedObject = function(pointer) {
       return associatedObjectsMap.get(pointer);
@@ -34,11 +34,12 @@ mergeInto(LibraryManager.library, {
             associatedObjectsMap.set(data.pointer, data.object);
             return;
           case 'disposeAssociatedObject':
-            const object = { data };
+            const pointer = data.pointer;
+            const object = associatedObjectsMap.get(pointer);
             if (object.close) {
               object.close();
             }
-            associatedObjectsMap.delete(data.pointer);
+            associatedObjectsMap.delete(pointer);
             return;
           default:
             console.warn(`unrecognized skwasm message: ${skwasmMessage}`);
@@ -81,7 +82,7 @@ mergeInto(LibraryManager.library, {
         surface: surfaceHandle,
         callbackId,
         imageBitmap,
-      });
+      }, [imageBitmap]);
     };
     _skwasm_createGlTextureFromTextureSource = function(textureSource, width, height) {
       const glCtx = GL.currentContext.GLctx;
@@ -98,10 +99,10 @@ mergeInto(LibraryManager.library, {
       GL.textures[textureId] = newTexture;
       return textureId;
     };
-    _skwasm_disposeAssociatedObjectOnThread = function(threadId, object) {
+    _skwasm_disposeAssociatedObjectOnThread = function(threadId, pointer) {
       PThread.pthreads[threadId].postMessage({
         skwasmMessage: 'disposeAssociatedObject',
-        object,
+        pointer,
       });
     };
   },

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -319,7 +319,17 @@ Future<void> testMain() async {
       await completer.future;
 
       final DomImageBitmap bitmap = (await createImageBitmap(image).toDart)! as DomImageBitmap;
-      return renderer.createImageFromImageBitmap(bitmap);
+
+      expect(bitmap.width.toDartInt, 150);
+      expect(bitmap.height.toDartInt, 150);
+      final ui.Image uiImage = await renderer.createImageFromImageBitmap(bitmap);
+
+      if (isSkwasm) {
+        // Skwasm transfers the bitmap to the web worker, so it should be disposed/consumed.
+        expect(bitmap.width.toDartInt, 0);
+        expect(bitmap.height.toDartInt, 0);
+      }
+      return uiImage;
     });
   }
 


### PR DESCRIPTION
We need to make sure to add objects to the transfer list when we send them across the ui thread/web worker boundary. Otherwise, they get copied, which is very expensive.

On my M1 MacBook Pro, I took measurements of scrolling in the material 3 demo. Before this change, the work on the web worker thread was taking about 25-40ms per frame. After the change, it's around 2ms.