### PR TITLE
Enable strict-inference

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,7 @@
 analyzer:
   language:
     strict-casts: true
+    strict-inference: true
     strict-raw-types: true
   errors:
     # allow self-reference to deprecated members (we do this because otherwise we have

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -99,7 +99,7 @@ Future<String> _runGit(
   return result.stdout;
 }
 
-typedef MessageCallback = Function(String? message, {MessageType type});
+typedef MessageCallback = void Function(String? message, {MessageType type});
 
 /// Base class for format checkers.
 ///

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -288,8 +288,7 @@ bool _onError(Object error, StackTrace? stackTrace) {
   return PlatformDispatcher.instance._dispatchError(error, stackTrace ?? StackTrace.empty);
 }
 
-// ignore: always_declare_return_types, prefer_generic_function_type_aliases
-typedef _ListStringArgFunction(List<String> args);
+typedef _ListStringArgFunction = Object? Function(List<String> args);
 
 @pragma('vm:entry-point')
 void _runMain(Function startMainIsolateFunction,

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -150,7 +150,7 @@ void testMain() {
           'getExtension',
           <String>['WEBGL_lose_context'],
         );
-        js_util.callMethod(loseContextExtension, 'loseContext', const <void>[]);
+        js_util.callMethod<void>(loseContextExtension, 'loseContext', const <void>[]);
 
         // Pump a timer to allow the "lose context" event to propagate.
         await Future<void>.delayed(Duration.zero);
@@ -160,7 +160,7 @@ void testMain() {
         expect(isContextLost, isTrue);
 
         // Emulate WebGL context restoration.
-        js_util.callMethod(loseContextExtension, 'restoreContext', const <void>[]);
+        js_util.callMethod<void>(loseContextExtension, 'restoreContext', const <void>[]);
 
         // Pump a timer to allow the "restore context" event to propagate.
         await Future<void>.delayed(Duration.zero);

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -3606,7 +3606,7 @@ mixin _ButtonedEventMixin on _BasicEventContext {
     });
     // timeStamp can't be set in the constructor, need to override the getter.
     if (timeStamp != null) {
-      js_util.callMethod(
+      js_util.callMethod<void>(
         objectConstructor,
         'defineProperty',
         <dynamic>[

--- a/testing/scenario_app/bin/utils/logs.dart
+++ b/testing/scenario_app/bin/utils/logs.dart
@@ -10,7 +10,7 @@ String _red = _supportsAnsi ? '\u001b[31m' : '';
 String _gray = _supportsAnsi ? '\u001b[90m' : '';
 String _reset = _supportsAnsi? '\u001B[0m' : '';
 
-Future<void> step(String msg, Function() fn) async {
+Future<void> step(String msg, Future<void> Function() fn) async {
   stdout.writeln('-> $_green$msg$_reset');
   try {
     await fn();


### PR DESCRIPTION
Avoids that dynamic accidentally sneaks in, see https://dart.dev/tools/analysis#enabling-additional-type-checks