### PR TITLE
[ios] scenario test make parent view controller hide status bar

### DIFF
--- a/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
@@ -10,6 +10,8 @@
 #import "TextPlatformView.h"
 
 // A UIViewController that sets YES for its preferedStatusBarHidden property.
+// StatusBar includes current time, which is non-deterministic. This ViewController
+// removes the StatusBar to make the screenshot deterministic.
 @interface NoStatusBarViewController : UIViewController
 
 @end

--- a/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
@@ -9,6 +9,18 @@
 #import "ScreenBeforeFlutter.h"
 #import "TextPlatformView.h"
 
+// A UIViewController that sets YES for its preferedStatusBarHidden property.
+@interface NoStatusBarViewController : UIViewController
+
+@end
+
+@implementation NoStatusBarViewController
+- (BOOL)prefersStatusBarHidden {
+  return YES;
+}
+@end
+
+// The FlutterViewController version of NoStatusBarViewController
 @interface NoStatusBarFlutterViewController : FlutterViewController
 
 @end
@@ -166,7 +178,7 @@
   UIViewController* rootViewController = flutterViewController;
   // Make Flutter View's origin x/y not 0.
   if ([scenarioIdentifier isEqualToString:@"non_full_screen_flutter_view_platform_view"]) {
-    rootViewController = [UIViewController new];
+    rootViewController = [[NoStatusBarViewController alloc] init];
     [rootViewController.view addSubview:flutterViewController.view];
     flutterViewController.view.frame = CGRectMake(150, 150, 500, 500);
   }


### PR DESCRIPTION
The parent view controller of FlutterViewController in `non_full_screen_flutter_view_platform_view` does not explicitly set the status bar hidden. iOS 17 will show the status bar causing the golden to be no deterministic. 

Part of https://github.com/flutter/flutter/issues/133207

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
