### PR TITLE
Implement JSObject instead of extending

### DIFF
--- a/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
@@ -73,7 +73,7 @@ abstract class FlutterEngineInitializer{
 @JS()
 @anonymous
 @staticInterop
-abstract class FlutterAppRunner extends JSObject {
+abstract class FlutterAppRunner implements JSObject {
   factory FlutterAppRunner({required RunAppFn runApp,}) => FlutterAppRunner._(
     runApp: (([RunAppFnParameters? args]) => futureToPromise(runApp(args))).toJS
   );
@@ -101,7 +101,7 @@ typedef RunAppFn = Future<FlutterApp> Function([RunAppFnParameters?]);
 @JS()
 @anonymous
 @staticInterop
-abstract class FlutterApp extends JSObject {
+abstract class FlutterApp implements JSObject {
   /// Cleans a Flutter app
   external factory FlutterApp();
 }


### PR DESCRIPTION
JSObject will have a factory constructor to create an object literal, so you can't extend it as it will no longer have a generative constructor (@staticInterop types can't have generative constructors).