### PR TITLE
[Impeller] Fix validation error about incorrect aspect on buffer to texture copies.

### DIFF
--- a/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -93,7 +93,8 @@ bool TextureVK::OnSetContents(const uint8_t* contents,
   copy.imageExtent.width = desc.size.width;
   copy.imageExtent.height = desc.size.height;
   copy.imageExtent.depth = 1u;
-  copy.imageSubresource.aspectMask = vk::ImageAspectFlagBits::eColor;
+  copy.imageSubresource.aspectMask =
+      ToImageAspectFlags(GetTextureDescriptor().format);
   copy.imageSubresource.mipLevel = 0u;
   copy.imageSubresource.baseArrayLayer = slice;
   copy.imageSubresource.layerCount = 1u;


### PR DESCRIPTION
This shows up when we try to set the contents of a depth of stencil image. The aspect was assumed to be color only because typical Impeller workloads have device-transient depth and stencil images. But the "stencil mask" test apparently does set the context directly. Besides, this is perfectly valid usage. This makes Vulkan resilient to said usage.