### PR TITLE
[Impeller] Ensure that reused textures are cleared before getting sampled by backdrop textures

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2264,6 +2264,30 @@ TEST_P(AiksTest, DrawPaintAbsorbsClears) {
   ASSERT_EQ(render_pass->GetCommands().size(), 0llu);
 }
 
+// This is important to enforce with texture reuse, since cached textures need
+// to be cleared before reuse.
+TEST_P(AiksTest,
+       ParentSaveLayerCreatesRenderPassWhenChildBackdropFilterIsPresent) {
+  Canvas canvas;
+  canvas.SaveLayer({}, std::nullopt, ImageFilter::MakeMatrix(Matrix(), {}));
+  canvas.DrawPaint({.color = Color::Red(), .blend_mode = BlendMode::kSource});
+  canvas.DrawPaint({.color = Color::CornflowerBlue().WithAlpha(0.75),
+                    .blend_mode = BlendMode::kSourceOver});
+  canvas.Restore();
+
+  Picture picture = canvas.EndRecordingAsPicture();
+
+  std::shared_ptr<ContextSpy> spy = ContextSpy::Make();
+  std::shared_ptr<Context> real_context = GetContext();
+  std::shared_ptr<ContextMock> mock_context = spy->MakeContext(real_context);
+  AiksContext renderer(mock_context, nullptr);
+  std::shared_ptr<Image> image = picture.ToImage(renderer, {300, 300});
+
+  ASSERT_EQ(spy->render_passes_.size(), 3llu);
+  std::shared_ptr<RenderPass> render_pass = spy->render_passes_[0];
+  ASSERT_EQ(render_pass->GetCommands().size(), 0llu);
+}
+
 TEST_P(AiksTest, DrawRectAbsorbsClears) {
   Canvas canvas;
   canvas.DrawRect({0, 0, 300, 300},

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -537,6 +537,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       // The subpass will need to read from the current pass texture when
       // rendering the backdrop, so if there's an active pass, end it prior to
       // rendering the subpass.
+      pass_context.GetRenderPass(pass_depth);
       pass_context.EndPass();
     }
 
@@ -678,13 +679,6 @@ bool EntityPass::OnRender(
   if (!pass_context.IsValid()) {
     VALIDATION_LOG << SPrintF("Pass context invalid (Depth=%d)", pass_depth);
     return false;
-  }
-
-  if (!collapsed_parent_pass &&
-      !GetClearColor(root_pass_size).IsTransparent()) {
-    // Force the pass context to create at least one new pass if the clear color
-    // is present.
-    pass_context.GetRenderPass(pass_depth);
   }
 
   auto render_element = [&stencil_depth_floor, &pass_context, &pass_depth,

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -534,10 +534,17 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
           proc(FilterInput::Make(std::move(texture)),
                subpass->xformation_.Basis(), Entity::RenderingMode::kSubpass);
 
+      // If the very first thing we render in this EntityPass is a subpass that
+      // happens to have a backdrop filter, than that backdrop filter will end
+      // may wind up sampling from the raw, uncleared texture that came straight
+      // out of the texture cache. By calling `pass_context.GetRenderPass` here,
+      // we force the texture to pass through at least one RenderPass with the
+      // correct clear configuration before any sampling occurs.
+      pass_context.GetRenderPass(pass_depth);
+
       // The subpass will need to read from the current pass texture when
       // rendering the backdrop, so if there's an active pass, end it prior to
       // rendering the subpass.
-      pass_context.GetRenderPass(pass_depth);
       pass_context.EndPass();
     }
 
@@ -679,6 +686,13 @@ bool EntityPass::OnRender(
   if (!pass_context.IsValid()) {
     VALIDATION_LOG << SPrintF("Pass context invalid (Depth=%d)", pass_depth);
     return false;
+  }
+
+  if (!collapsed_parent_pass &&
+      !GetClearColor(root_pass_size).IsTransparent()) {
+    // Force the pass context to create at least one new pass if the clear color
+    // is present.
+    pass_context.GetRenderPass(pass_depth);
   }
 
   auto render_element = [&stencil_depth_floor, &pass_context, &pass_depth,


### PR DESCRIPTION
Fix for https://github.com/flutter/flutter/issues/135053.

I'm going to try and optimize out this case later, since Wondrous is inadvertently paying for a backdrop filter that contributes nothing to the final image.

Wondrous with all fixes applied:

https://github.com/flutter/engine/assets/919017/37b49b77-b0ec-42d4-964a-c61b9a2cca8f

