### PR TITLE
[Impeller] Use BlackTransparent clear color when backdrop filters are present.

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -1091,6 +1091,10 @@ void EntityPass::SetBlendMode(BlendMode blend_mode) {
 
 Color EntityPass::GetClearColor(ISize target_size) const {
   Color result = Color::BlackTransparent();
+  if (backdrop_filter_proc_) {
+    return result;
+  }
+
   for (const Element& element : elements_) {
     auto [entity_color, blend_mode] =
         ElementAsBackgroundColor(element, target_size);


### PR DESCRIPTION
Fix for https://github.com/flutter/flutter/issues/135053.

We already duck out of the Entity absorbing part of the optimization, but we also need to duck here when computing clear colors, otherwise we end up double-applying the effect of clearing entities at the beginning of a pass in some cases.

Wondrous with all fixes applied:

https://github.com/flutter/engine/assets/919017/37b49b77-b0ec-42d4-964a-c61b9a2cca8f