### PR TITLE
[web] - receive and set text editing scroll state, `line-height`, `letter-spacing`

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1048,7 +1048,7 @@ abstract class TextEditingStrategy {
 
   /// Set style to the native DOM element used for text editing.
   void updateElementStyle(EditableTextStyle style);
-  
+
   /// Set scroll state on the input or textarea element.
   void setScrollState(EditableTextScrollState scrollState);
 
@@ -2484,7 +2484,7 @@ class EditableTextScrollState {
   void applyToDomElement(DomHTMLElement domElement) {
     domElement.scrollLeft = scrollLeft;
     domElement.scrollTop = scrollTop;
-  } 
+  }
 }
 
 /// Describes the location and size of the editing element on the screen.


### PR DESCRIPTION
Engine needs to receive scroll state from the framework and apply it to the text editing element.  Additionally, we need to set `line-height` and `letter-spacing` to better align the text input overlay.

Engine changes to support https://github.com/flutter/flutter/issues/135159

Framework changes are here: https://github.com/flutter/flutter/pull/135163

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
