### PR TITLE
Clang tidy-ify `DlColor` and friends.

### DIFF
--- a/display_list/benchmarking/dl_benchmarks.cc
+++ b/display_list/benchmarking/dl_benchmarks.cc
@@ -710,15 +710,15 @@ std::shared_ptr<DlVertices> GetTestVertices(SkPoint center,
       // the center point C, this should create a triangle fan with vertices
       // C, O_0, O_1, O_2, O_3, ...
       vertices.push_back(center);
-      colors.push_back(SK_ColorCYAN);
+      colors.push_back(DlColor(SK_ColorCYAN));
       for (size_t i = 0; i <= outer_points.size(); i++) {
         vertices.push_back(outer_points[i % outer_points.size()]);
         if (i % 3 == 0) {
-          colors.push_back(SK_ColorRED);
+          colors.push_back(DlColor(SK_ColorRED));
         } else if (i % 3 == 1) {
-          colors.push_back(SK_ColorGREEN);
+          colors.push_back(DlColor(SK_ColorGREEN));
         } else {
-          colors.push_back(SK_ColorBLUE);
+          colors.push_back(DlColor(SK_ColorBLUE));
         }
       }
       break;
@@ -728,11 +728,11 @@ std::shared_ptr<DlVertices> GetTestVertices(SkPoint center,
       // vertices O_0, O_1, C, O_1, O_2, C, O_2, O_3, C, ...
       for (size_t i = 0; i < outer_vertex_count; i++) {
         vertices.push_back(outer_points[i % outer_points.size()]);
-        colors.push_back(SK_ColorRED);
+        colors.push_back(DlColor(SK_ColorRED));
         vertices.push_back(outer_points[(i + 1) % outer_points.size()]);
-        colors.push_back(SK_ColorGREEN);
+        colors.push_back(DlColor(SK_ColorGREEN));
         vertices.push_back(center);
-        colors.push_back(SK_ColorBLUE);
+        colors.push_back(DlColor(SK_ColorBLUE));
       }
       break;
     case DlVertexMode::kTriangleStrip:
@@ -741,10 +741,10 @@ std::shared_ptr<DlVertices> GetTestVertices(SkPoint center,
       // O_0, O_1, C, O_2, O_3, C, O_4, O_5, C, ...
       for (size_t i = 0; i <= outer_vertex_count; i++) {
         vertices.push_back(outer_points[i % outer_points.size()]);
-        colors.push_back(i % 2 ? SK_ColorRED : SK_ColorGREEN);
+        colors.push_back(i % 2 ? DlColor(SK_ColorRED) : DlColor(SK_ColorGREEN));
         if (i % 2 == 1) {
           vertices.push_back(center);
-          colors.push_back(SK_ColorBLUE);
+          colors.push_back(DlColor(SK_ColorBLUE));
         }
       }
       break;
@@ -1270,7 +1270,8 @@ void BM_DrawShadow(benchmark::State& state,
 
   // We can hardcode dpr to 1.0f as we're varying elevation, and dpr is only
   // ever used in conjunction with elevation.
-  builder.DrawShadow(path, SK_ColorBLUE, elevation, transparent_occluder, 1.0f);
+  builder.DrawShadow(path, DlColor(SK_ColorBLUE), elevation,
+                     transparent_occluder, 1.0f);
   auto display_list = builder.Build();
 
   // We only want to time the actual rasterization.

--- a/display_list/benchmarking/dl_complexity_unittests.cc
+++ b/display_list/benchmarking/dl_complexity_unittests.cc
@@ -190,7 +190,7 @@ TEST(DisplayListComplexity, DrawShadow) {
   line_path.moveTo(SkPoint::Make(0, 0));
   line_path.lineTo(SkPoint::Make(10, 10));
   line_path.close();
-  builder_line.DrawShadow(line_path, SK_ColorRED, 10.0f, false, 1.0f);
+  builder_line.DrawShadow(line_path, DlColor(SK_ColorRED), 10.0f, false, 1.0f);
   auto display_list_line = builder_line.Build();
 
   DisplayListBuilder builder_quad;
@@ -198,7 +198,7 @@ TEST(DisplayListComplexity, DrawShadow) {
   quad_path.moveTo(SkPoint::Make(0, 0));
   quad_path.quadTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20));
   quad_path.close();
-  builder_quad.DrawShadow(quad_path, SK_ColorRED, 10.0f, false, 1.0f);
+  builder_quad.DrawShadow(quad_path, DlColor(SK_ColorRED), 10.0f, false, 1.0f);
   auto display_list_quad = builder_quad.Build();
 
   DisplayListBuilder builder_conic;
@@ -206,7 +206,8 @@ TEST(DisplayListComplexity, DrawShadow) {
   conic_path.moveTo(SkPoint::Make(0, 0));
   conic_path.conicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20), 1.5f);
   conic_path.close();
-  builder_conic.DrawShadow(conic_path, SK_ColorRED, 10.0f, false, 1.0f);
+  builder_conic.DrawShadow(conic_path, DlColor(SK_ColorRED), 10.0f, false,
+                           1.0f);
   auto display_list_conic = builder_conic.Build();
 
   DisplayListBuilder builder_cubic;
@@ -214,7 +215,8 @@ TEST(DisplayListComplexity, DrawShadow) {
   cubic_path.moveTo(SkPoint::Make(0, 0));
   cubic_path.cubicTo(SkPoint::Make(10, 10), SkPoint::Make(10, 20),
                      SkPoint::Make(20, 20));
-  builder_cubic.DrawShadow(cubic_path, SK_ColorRED, 10.0f, false, 1.0f);
+  builder_cubic.DrawShadow(cubic_path, DlColor(SK_ColorRED), 10.0f, false,
+                           1.0f);
   auto display_list_cubic = builder_cubic.Build();
 
   auto calculators = AccumulatorCalculators();

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -932,7 +932,8 @@ TEST_F(DisplayListTest, NestedOpCountMetricsSameAsSkPicture) {
   DlOpReceiver& receiver = ToReceiver(builder);
   for (int y = 10; y <= 60; y += 10) {
     for (int x = 10; x <= 60; x += 10) {
-      receiver.setColor(((x + y) % 20) == 10 ? SK_ColorRED : SK_ColorBLUE);
+      receiver.setColor(((x + y) % 20) == 10 ? DlColor(SK_ColorRED)
+                                             : DlColor(SK_ColorBLUE));
       receiver.drawRect(SkRect::MakeXYWH(x, y, 80, 80));
     }
   }
@@ -1066,8 +1067,10 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
       #body, [](DlOpReceiver& receiver) { body }, expect, expect)
 
   RUN_TESTS(receiver.drawPaint(););
-  RUN_TESTS2(receiver.drawColor(SK_ColorRED, DlBlendMode::kSrcOver);, true);
-  RUN_TESTS2(receiver.drawColor(SK_ColorRED, DlBlendMode::kSrc);, false);
+  RUN_TESTS2(receiver.drawColor(DlColor(SK_ColorRED), DlBlendMode::kSrcOver);
+             , true);
+  RUN_TESTS2(receiver.drawColor(DlColor(SK_ColorRED), DlBlendMode::kSrc);
+             , false);
   RUN_TESTS(receiver.drawLine({0, 0}, {10, 10}););
   RUN_TESTS(receiver.drawRect({0, 0, 10, 10}););
   RUN_TESTS(receiver.drawOval({0, 0, 10, 10}););
@@ -1119,8 +1122,9 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
     RUN_TESTS2(receiver.drawDisplayList(display_list);, false);
   }
   RUN_TESTS2(receiver.drawTextBlob(TestBlob1, 0, 0);, false);
-  RUN_TESTS2(receiver.drawShadow(kTestPath1, SK_ColorBLACK, 1.0, false, 1.0);
-             , false);
+  RUN_TESTS2(
+      receiver.drawShadow(kTestPath1, DlColor(SK_ColorBLACK), 1.0, false, 1.0);
+      , false);
 
 #undef RUN_TESTS2
 #undef RUN_TESTS
@@ -1250,7 +1254,7 @@ TEST_F(DisplayListTest, SaveLayerOneSimpleOpInheritsOpacity) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.drawRect({10, 10, 20, 20});
   receiver.restore();
@@ -1280,7 +1284,7 @@ TEST_F(DisplayListTest, SaveLayerTwoOverlappingOpsDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.drawRect({10, 10, 20, 20});
   receiver.drawRect({15, 15, 25, 25});
@@ -1300,7 +1304,7 @@ TEST_F(DisplayListTest, NestedSaveLayersMightInheritOpacity) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.drawRect({10, 10, 20, 20});
@@ -1323,7 +1327,7 @@ TEST_F(DisplayListTest, NestedSaveLayersCanBothSupportOpacityOptimization) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.saveLayer(nullptr, SaveLayerOptions::kNoAttributes);
   receiver.drawRect({10, 10, 20, 20});
@@ -1340,7 +1344,7 @@ TEST_F(DisplayListTest, SaveLayerImageFilterDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.setImageFilter(&kTestBlurImageFilter1);
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.setImageFilter(nullptr);
@@ -1357,7 +1361,7 @@ TEST_F(DisplayListTest, SaveLayerColorFilterDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.setColorFilter(&kTestMatrixColorFilter1);
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.setColorFilter(nullptr);
@@ -1374,7 +1378,7 @@ TEST_F(DisplayListTest, SaveLayerSrcBlendDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.setBlendMode(DlBlendMode::kSrc);
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.setBlendMode(DlBlendMode::kSrcOver);
@@ -1392,7 +1396,7 @@ TEST_F(DisplayListTest, SaveLayerImageFilterOnChildInheritsOpacity) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.setImageFilter(&kTestBlurImageFilter1);
   receiver.drawRect({10, 10, 20, 20});
@@ -1408,7 +1412,7 @@ TEST_F(DisplayListTest, SaveLayerColorFilterOnChildDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.setColorFilter(&kTestMatrixColorFilter1);
   receiver.drawRect({10, 10, 20, 20});
@@ -1424,7 +1428,7 @@ TEST_F(DisplayListTest, SaveLayerSrcBlendOnChildDoesNotInheritOpacity) {
 
   DisplayListBuilder builder;
   DlOpReceiver& receiver = ToReceiver(builder);
-  receiver.setColor(SkColorSetARGB(127, 255, 255, 255));
+  receiver.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   receiver.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
   receiver.setBlendMode(DlBlendMode::kSrc);
   receiver.drawRect({10, 10, 20, 20});

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -351,7 +351,7 @@ void DisplayListBuilder::SetAttributesFromPaint(
     setDither(paint.isDither());
   }
   if (flags.applies_alpha_or_color()) {
-    setColor(paint.getColor().argb);
+    setColor(paint.getColor());
   }
   if (flags.applies_blend()) {
     setBlendMode(paint.getBlendMode());

--- a/display_list/dl_color.h
+++ b/display_list/dl_color.h
@@ -11,36 +11,34 @@ namespace flutter {
 
 struct DlColor {
  public:
-  constexpr DlColor() : argb(0xFF000000) {}
-  constexpr DlColor(uint32_t argb) : argb(argb) {}
+  constexpr DlColor() : argb_(0xFF000000) {}
+  constexpr explicit DlColor(uint32_t argb) : argb_(argb) {}
 
   static constexpr uint8_t toAlpha(SkScalar opacity) { return toC(opacity); }
   static constexpr SkScalar toOpacity(uint8_t alpha) { return toF(alpha); }
 
   // clang-format off
-  static constexpr DlColor kTransparent()        {return 0x00000000;};
-  static constexpr DlColor kBlack()              {return 0xFF000000;};
-  static constexpr DlColor kWhite()              {return 0xFFFFFFFF;};
-  static constexpr DlColor kRed()                {return 0xFFFF0000;};
-  static constexpr DlColor kGreen()              {return 0xFF00FF00;};
-  static constexpr DlColor kBlue()               {return 0xFF0000FF;};
-  static constexpr DlColor kCyan()               {return 0xFF00FFFF;};
-  static constexpr DlColor kMagenta()            {return 0xFFFF00FF;};
-  static constexpr DlColor kYellow()             {return 0xFFFFFF00;};
-  static constexpr DlColor kDarkGrey()           {return 0xFF3F3F3F;};
-  static constexpr DlColor kMidGrey()            {return 0xFF808080;};
-  static constexpr DlColor kLightGrey()          {return 0xFFC0C0C0;};
+  static constexpr DlColor kTransparent()        {return DlColor(0x00000000);};
+  static constexpr DlColor kBlack()              {return DlColor(0xFF000000);};
+  static constexpr DlColor kWhite()              {return DlColor(0xFFFFFFFF);};
+  static constexpr DlColor kRed()                {return DlColor(0xFFFF0000);};
+  static constexpr DlColor kGreen()              {return DlColor(0xFF00FF00);};
+  static constexpr DlColor kBlue()               {return DlColor(0xFF0000FF);};
+  static constexpr DlColor kCyan()               {return DlColor(0xFF00FFFF);};
+  static constexpr DlColor kMagenta()            {return DlColor(0xFFFF00FF);};
+  static constexpr DlColor kYellow()             {return DlColor(0xFFFFFF00);};
+  static constexpr DlColor kDarkGrey()           {return DlColor(0xFF3F3F3F);};
+  static constexpr DlColor kMidGrey()            {return DlColor(0xFF808080);};
+  static constexpr DlColor kLightGrey()          {return DlColor(0xFFC0C0C0);};
   // clang-format on
-
-  uint32_t argb;
 
   constexpr bool isOpaque() const { return getAlpha() == 0xFF; }
   constexpr bool isTransparent() const { return getAlpha() == 0; }
 
-  constexpr int getAlpha() const { return argb >> 24; }
-  constexpr int getRed() const { return (argb >> 16) & 0xFF; }
-  constexpr int getGreen() const { return (argb >> 8) & 0xFF; }
-  constexpr int getBlue() const { return argb & 0xFF; }
+  constexpr int getAlpha() const { return argb_ >> 24; }
+  constexpr int getRed() const { return (argb_ >> 16) & 0xFF; }
+  constexpr int getGreen() const { return (argb_ >> 8) & 0xFF; }
+  constexpr int getBlue() const { return argb_ & 0xFF; }
 
   constexpr float getAlphaF() const { return toF(getAlpha()); }
   constexpr float getRedF() const { return toF(getRed()); }
@@ -49,26 +47,26 @@ struct DlColor {
 
   constexpr uint32_t premultipliedArgb() const {
     if (isOpaque()) {
-      return argb;
+      return argb_;
     }
     float f = getAlphaF();
-    return (argb & 0xFF000000) |        //
+    return (argb_ & 0xFF000000) |       //
            toC(getRedF() * f) << 16 |   //
            toC(getGreenF() * f) << 8 |  //
            toC(getBlueF() * f);
   }
 
   constexpr DlColor withAlpha(uint8_t alpha) const {  //
-    return (argb & 0x00FFFFFF) | (alpha << 24);
+    return DlColor((argb_ & 0x00FFFFFF) | (alpha << 24));
   }
   constexpr DlColor withRed(uint8_t red) const {  //
-    return (argb & 0xFF00FFFF) | (red << 16);
+    return DlColor((argb_ & 0xFF00FFFF) | (red << 16));
   }
   constexpr DlColor withGreen(uint8_t green) const {  //
-    return (argb & 0xFFFF00FF) | (green << 8);
+    return DlColor((argb_ & 0xFFFF00FF) | (green << 8));
   }
   constexpr DlColor withBlue(uint8_t blue) const {  //
-    return (argb & 0xFFFFFF00) | (blue << 0);
+    return DlColor((argb_ & 0xFFFFFF00) | (blue << 0));
   }
 
   constexpr DlColor modulateOpacity(float opacity) const {
@@ -77,13 +75,16 @@ struct DlColor {
                           : withAlpha(round(getAlpha() * opacity));
   }
 
-  operator uint32_t() const { return argb; }
-  bool operator==(DlColor const& other) const { return argb == other.argb; }
-  bool operator!=(DlColor const& other) const { return argb != other.argb; }
-  bool operator==(uint32_t const& other) const { return argb == other; }
-  bool operator!=(uint32_t const& other) const { return argb != other; }
+  constexpr uint32_t argb() const { return argb_; }
+
+  bool operator==(DlColor const& other) const { return argb_ == other.argb_; }
+  bool operator!=(DlColor const& other) const { return argb_ != other.argb_; }
+  bool operator==(uint32_t const& other) const { return argb_ == other; }
+  bool operator!=(uint32_t const& other) const { return argb_ != other; }
 
  private:
+  uint32_t argb_;
+
   static float toF(uint8_t comp) { return comp * (1.0f / 255); }
   static uint8_t toC(float fComp) { return round(fComp * 255); }
 };

--- a/display_list/dl_color_unittests.cc
+++ b/display_list/dl_color_unittests.cc
@@ -14,7 +14,7 @@ static void arraysEqual(const uint32_t* ints,
                         const DlColor* colors,
                         int count) {
   for (int i = 0; i < count; i++) {
-    EXPECT_TRUE(ints[i] == colors[i]);
+    EXPECT_TRUE(ints[i] == colors[i].argb());
   }
 }
 

--- a/display_list/dl_paint.h
+++ b/display_list/dl_paint.h
@@ -78,11 +78,8 @@ class DlPaint {
     return *this;
   }
 
-  uint8_t getAlpha() const { return color_.argb >> 24; }
-  DlPaint& setAlpha(uint8_t alpha) {
-    color_.argb = alpha << 24 | (color_.argb & 0x00FFFFFF);
-    return *this;
-  }
+  uint8_t getAlpha() const { return color_.argb() >> 24; }
+  DlPaint& setAlpha(uint8_t alpha) { return setColor(color_.withAlpha(alpha)); }
   SkScalar getOpacity() const { return color_.getAlphaF(); }
   DlPaint& setOpacity(SkScalar opacity) {
     setAlpha(SkScalarRoundToInt(opacity * 0xff));

--- a/display_list/dl_paint_unittests.cc
+++ b/display_list/dl_paint_unittests.cc
@@ -42,14 +42,14 @@ TEST(DisplayListPaint, ConstructorDefaults) {
 
   EXPECT_EQ(paint, DlPaint());
   EXPECT_EQ(paint, DlPaint(DlColor::kBlack()));
-  EXPECT_EQ(paint, DlPaint(0xFF000000));
+  EXPECT_EQ(paint, DlPaint(DlColor(0xFF000000)));
 
   EXPECT_NE(paint, DlPaint().setAntiAlias(true));
   EXPECT_NE(paint, DlPaint().setDither(true));
   EXPECT_NE(paint, DlPaint().setInvertColors(true));
   EXPECT_NE(paint, DlPaint().setColor(DlColor::kGreen()));
   EXPECT_NE(paint, DlPaint(DlColor::kGreen()));
-  EXPECT_NE(paint, DlPaint(0xFF00FF00));
+  EXPECT_NE(paint, DlPaint(DlColor(0xFF00FF00)));
   EXPECT_NE(paint, DlPaint().setAlpha(0x7f));
   EXPECT_NE(paint, DlPaint().setBlendMode(DlBlendMode::kDstIn));
   EXPECT_NE(paint, DlPaint().setDrawStyle(DlDrawStyle::kStrokeAndFill));

--- a/display_list/effects/dl_color_source.h
+++ b/display_list/effects/dl_color_source.h
@@ -191,7 +191,7 @@ class DlColorColorSource final : public DlColorSource {
   DlColorSourceType type() const override { return DlColorSourceType::kColor; }
   size_t size() const override { return sizeof(*this); }
 
-  bool is_opaque() const override { return (color_ >> 24) == 255; }
+  bool is_opaque() const override { return color_.getAlpha() == 255; }
 
   DlColor color() const { return color_; }
 
@@ -290,7 +290,7 @@ class DlGradientColorSourceBase : public DlMatrixColorSourceBase {
     }
     const DlColor* my_colors = colors();
     for (uint32_t i = 0; i < stop_count_; i++) {
-      if ((my_colors[i] >> 24) < 255) {
+      if (my_colors[i].getAlpha() < 255) {
         return false;
       }
     }

--- a/display_list/effects/dl_color_source_unittests.cc
+++ b/display_list/effects/dl_color_source_unittests.cc
@@ -5,6 +5,7 @@
 #include <memory>
 #include <vector>
 
+#include "display_list/dl_color.h"
 #include "flutter/display_list/dl_sampling_options.h"
 #include "flutter/display_list/effects/dl_color_source.h"
 #include "flutter/display_list/effects/dl_runtime_effect.h"
@@ -86,17 +87,17 @@ static constexpr SkPoint kTestPoints2[2] = {
 };
 
 TEST(DisplayListColorSource, ColorConstructor) {
-  DlColorColorSource source(SK_ColorRED);
+  DlColorColorSource source(DlColor::kRed());
 }
 
 TEST(DisplayListColorSource, ColorShared) {
-  DlColorColorSource source(SK_ColorRED);
+  DlColorColorSource source(DlColor::kRed());
   ASSERT_NE(source.shared().get(), &source);
   ASSERT_EQ(*source.shared(), source);
 }
 
 TEST(DisplayListColorSource, ColorAsColor) {
-  DlColorColorSource source(SK_ColorRED);
+  DlColorColorSource source(DlColor::kRed());
   ASSERT_NE(source.asColor(), nullptr);
   ASSERT_EQ(source.asColor(), &source);
 
@@ -109,26 +110,26 @@ TEST(DisplayListColorSource, ColorAsColor) {
 }
 
 TEST(DisplayListColorSource, ColorContents) {
-  DlColorColorSource source(SK_ColorRED);
-  ASSERT_EQ(source.color(), SK_ColorRED);
+  DlColorColorSource source(DlColor::kRed());
+  ASSERT_EQ(source.color(), DlColor::kRed());
   ASSERT_EQ(source.is_opaque(), true);
   for (int i = 0; i < 255; i++) {
     SkColor alpha_color = SkColorSetA(SK_ColorRED, i);
-    DlColorColorSource alpha_source(alpha_color);
+    auto const alpha_source = DlColorColorSource(DlColor(alpha_color));
     ASSERT_EQ(alpha_source.color(), alpha_color);
     ASSERT_EQ(alpha_source.is_opaque(), false);
   }
 }
 
 TEST(DisplayListColorSource, ColorEquals) {
-  DlColorColorSource source1(SK_ColorRED);
-  DlColorColorSource source2(SK_ColorRED);
+  DlColorColorSource source1(DlColor::kRed());
+  DlColorColorSource source2(DlColor::kRed());
   TestEquals(source1, source2);
 }
 
 TEST(DisplayListColorSource, ColorNotEquals) {
-  DlColorColorSource source1(SK_ColorRED);
-  DlColorColorSource source2(SK_ColorBLUE);
+  DlColorColorSource source1(DlColor::kRed());
+  DlColorColorSource source2(DlColor::kBlue());
   TestNotEquals(source1, source2, "Color differs");
 }
 

--- a/display_list/skia/dl_sk_canvas.cc
+++ b/display_list/skia/dl_sk_canvas.cc
@@ -187,7 +187,7 @@ void DlSkCanvasAdapter::DrawPaint(const DlPaint& paint) {
 }
 
 void DlSkCanvasAdapter::DrawColor(DlColor color, DlBlendMode mode) {
-  delegate_->drawColor(color, ToSk(mode));
+  delegate_->drawColor(ToSk(color), ToSk(mode));
 }
 
 void DlSkCanvasAdapter::DrawLine(const SkPoint& p0,

--- a/display_list/skia/dl_sk_conversions.cc
+++ b/display_list/skia/dl_sk_conversions.cc
@@ -23,7 +23,7 @@ SkPaint ToSk(const DlPaint& paint, bool force_stroke) {
   SkPaint sk_paint;
 
   sk_paint.setAntiAlias(paint.isAntiAlias());
-  sk_paint.setColor(paint.getColor());
+  sk_paint.setColor(ToSk(paint.getColor()));
   sk_paint.setBlendMode(ToSk(paint.getBlendMode()));
   sk_paint.setStyle(force_stroke ? SkPaint::kStroke_Style
                                  : ToSk(paint.getDrawStyle()));
@@ -76,7 +76,7 @@ sk_sp<SkShader> ToSk(const DlColorSource* source) {
     case DlColorSourceType::kColor: {
       const DlColorColorSource* color_source = source->asColor();
       FML_DCHECK(color_source != nullptr);
-      return SkShaders::Color(color_source->color());
+      return SkShaders::Color(ToSk(color_source->color()));
     }
     case DlColorSourceType::kImage: {
       const DlImageColorSource* image_source = source->asImage();
@@ -240,7 +240,7 @@ sk_sp<SkColorFilter> ToSk(const DlColorFilter* filter) {
     case DlColorFilterType::kBlend: {
       const DlBlendColorFilter* blend_filter = filter->asBlend();
       FML_DCHECK(blend_filter != nullptr);
-      return SkColorFilters::Blend(blend_filter->color(),
+      return SkColorFilters::Blend(ToSk(blend_filter->color()),
                                    ToSk(blend_filter->mode()));
     }
     case DlColorFilterType::kMatrix: {

--- a/display_list/skia/dl_sk_conversions.h
+++ b/display_list/skia/dl_sk_conversions.h
@@ -16,6 +16,12 @@ inline SkBlendMode ToSk(DlBlendMode mode) {
   return static_cast<SkBlendMode>(mode);
 }
 
+inline SkColor ToSk(DlColor color) {
+  // This is safe because both SkColor and DlColor are backed by ARGB uint32_t.
+  // See dl_sk_conversions_unittests.cc.
+  return reinterpret_cast<SkColor&>(color);
+}
+
 inline SkPaint::Style ToSk(DlDrawStyle style) {
   return static_cast<SkPaint::Style>(style);
 }

--- a/display_list/skia/dl_sk_conversions_unittests.cc
+++ b/display_list/skia/dl_sk_conversions_unittests.cc
@@ -26,6 +26,21 @@ TEST(DisplayListImageFilter, LocalImageSkiaNull) {
   ASSERT_EQ(ToSk(dl_local_matrix_filter), nullptr);
 }
 
+TEST(DisplayListSkConversions, ToSkColor) {
+  // Red
+  ASSERT_EQ(ToSk(DlColor::kRed()), SK_ColorRED);
+
+  // Green
+  ASSERT_EQ(ToSk(DlColor::kGreen()), SK_ColorGREEN);
+
+  // Blue
+  ASSERT_EQ(ToSk(DlColor::kBlue()), SK_ColorBLUE);
+
+  // Half transparent grey
+  auto const grey_hex_half_opaque = 0x7F999999;
+  ASSERT_EQ(ToSk(DlColor(grey_hex_half_opaque)), SkColor(grey_hex_half_opaque));
+}
+
 TEST(DisplayListSkConversions, ToSkTileMode) {
   ASSERT_EQ(ToSk(DlTileMode::kClamp), SkTileMode::kClamp);
   ASSERT_EQ(ToSk(DlTileMode::kRepeat), SkTileMode::kRepeat);
@@ -136,7 +151,8 @@ TEST(DisplayListSkConversions, ToSkBlendMode) {
 TEST(DisplayListSkConversions, BlendColorFilterModifiesTransparency) {
   auto test_mode_color = [](DlBlendMode mode, DlColor color) {
     std::stringstream desc_str;
-    desc_str << "blend[" << static_cast<int>(mode) << ", " << color << "]";
+    desc_str << "blend[" << static_cast<int>(mode) << ", " << color.argb()
+             << "]";
     std::string desc = desc_str.str();
     DlBlendColorFilter filter(color, mode);
     if (filter.modifies_transparent_black()) {

--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -141,7 +141,7 @@ void DlSkCanvasDispatcher::drawPaint() {
 void DlSkCanvasDispatcher::drawColor(DlColor color, DlBlendMode mode) {
   // SkCanvas::drawColor(SkColor) does the following conversion anyway
   // We do it here manually to increase precision on applying opacity
-  SkColor4f color4f = SkColor4f::FromColor(color);
+  SkColor4f color4f = SkColor4f::FromColor(ToSk(color));
   color4f.fA *= opacity();
   canvas_->drawColor(color4f, ToSk(mode));
 }
@@ -283,8 +283,9 @@ void DlSkCanvasDispatcher::DrawShadow(SkCanvas* canvas,
                        ? SkShadowFlags::kTransparentOccluder_ShadowFlag
                        : SkShadowFlags::kNone_ShadowFlag;
   flags |= SkShadowFlags::kDirectionalLight_ShadowFlag;
-  SkColor in_ambient = SkColorSetA(color, kAmbientAlpha * SkColorGetA(color));
-  SkColor in_spot = SkColorSetA(color, kSpotAlpha * SkColorGetA(color));
+  SkColor in_ambient =
+      SkColorSetA(ToSk(color), kAmbientAlpha * color.getAlpha());
+  SkColor in_spot = SkColorSetA(ToSk(color), kSpotAlpha * color.getAlpha());
   SkColor ambient_color, spot_color;
   SkShadowUtils::ComputeTonalColors(in_ambient, in_spot, &ambient_color,
                                     &spot_color);

--- a/display_list/skia/dl_sk_paint_dispatcher.cc
+++ b/display_list/skia/dl_sk_paint_dispatcher.cc
@@ -63,8 +63,8 @@ void DlSkPaintDispatchHelper::setStrokeMiter(SkScalar limit) {
   paint_.setStrokeMiter(limit);
 }
 void DlSkPaintDispatchHelper::setColor(DlColor color) {
-  current_color_ = color;
-  paint_.setColor(color);
+  current_color_ = ToSk(color);
+  paint_.setColor(ToSk(color));
   if (has_opacity()) {
     paint_.setAlphaf(paint_.getAlphaf() * opacity());
   }

--- a/display_list/skia/dl_sk_paint_dispatcher.h
+++ b/display_list/skia/dl_sk_paint_dispatcher.h
@@ -85,7 +85,7 @@ class DlSkPaintDispatchHelper : public virtual DlOpReceiver {
   void set_opacity(SkScalar opacity) {
     if (opacity_ != opacity) {
       opacity_ = opacity;
-      setColor(current_color_);
+      setColor(DlColor(current_color_));
     }
   }
 

--- a/display_list/skia/dl_sk_paint_dispatcher_unittests.cc
+++ b/display_list/skia/dl_sk_paint_dispatcher_unittests.cc
@@ -22,7 +22,8 @@ class MockDispatchHelper final : public virtual DlOpReceiver,
   void restore() override { DlSkPaintDispatchHelper::restore_opacity(); }
 };
 
-static const DlColor kTestColors[2] = {0xFF000000, 0xFFFFFFFF};
+static const DlColor kTestColors[2] = {DlColor(0xFF000000),
+                                       DlColor(0xFFFFFFFF)};
 static const float kTestStops[2] = {0.0f, 1.0f};
 static const auto kTestLinearGradient =
     DlColorSource::MakeLinear(SkPoint::Make(0.0f, 0.0f),

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -493,7 +493,7 @@ class RenderEnvironment {
     auto surface = getSurface(info.width, info.height);
     FML_DCHECK(surface != nullptr);
     auto canvas = surface->getCanvas();
-    canvas->clear(info.bg);
+    canvas->clear(ToSk(info.bg));
 
     int restore_count = canvas->save();
     canvas->scale(info.scale, info.scale);
@@ -564,7 +564,7 @@ class CaseParameters {
                        dl_setup,
                        kEmptySkRenderer,
                        kEmptyDlRenderer,
-                       SK_ColorTRANSPARENT,
+                       DlColor(SK_ColorTRANSPARENT),
                        false,
                        false,
                        false) {}
@@ -985,7 +985,7 @@ class CanvasCompareTester {
                    "saveLayer with alpha, no bounds",
                    [=](SkCanvas* cv, SkPaint& p) {
                      SkPaint save_p;
-                     save_p.setColor(alpha_layer_color);
+                     save_p.setColor(ToSk(alpha_layer_color));
                      cv->saveLayer(nullptr, &save_p);
                    },
                    [=](DlCanvas* cv, DlPaint& p) {
@@ -999,7 +999,7 @@ class CanvasCompareTester {
                    "saveLayer with peephole alpha, no bounds",
                    [=](SkCanvas* cv, SkPaint& p) {
                      SkPaint save_p;
-                     save_p.setColor(alpha_layer_color);
+                     save_p.setColor(ToSk(alpha_layer_color));
                      cv->saveLayer(nullptr, &save_p);
                    },
                    [=](DlCanvas* cv, DlPaint& p) {
@@ -1013,7 +1013,7 @@ class CanvasCompareTester {
                    "saveLayer with alpha and bounds",
                    [=](SkCanvas* cv, SkPaint& p) {
                      SkPaint save_p;
-                     save_p.setColor(alpha_layer_color);
+                     save_p.setColor(ToSk(alpha_layer_color));
                      cv->saveLayer(layer_bounds, &save_p);
                    },
                    [=](DlCanvas* cv, DlPaint& p) {
@@ -1273,7 +1273,7 @@ class CanvasCompareTester {
                      "Blend == SrcIn",
                      [=](SkCanvas*, SkPaint& p) {
                        p.setBlendMode(SkBlendMode::kSrcIn);
-                       p.setColor(blendable_color);
+                       p.setColor(ToSk(blendable_color));
                      },
                      [=](DlCanvas*, DlPaint& p) {
                        p.setBlendMode(DlBlendMode::kSrcIn);
@@ -1285,7 +1285,7 @@ class CanvasCompareTester {
                      "Blend == DstIn",
                      [=](SkCanvas*, SkPaint& p) {
                        p.setBlendMode(SkBlendMode::kDstIn);
-                       p.setColor(blendable_color);
+                       p.setColor(ToSk(blendable_color));
                      },
                      [=](DlCanvas*, DlPaint& p) {
                        p.setBlendMode(DlBlendMode::kDstIn);
@@ -1432,7 +1432,7 @@ class CanvasCompareTester {
                    CaseParameters(
                        "ColorFilter == RotateRGB",
                        [=](SkCanvas*, SkPaint& p) {
-                         p.setColor(DlColor::kYellow());
+                         p.setColor(ToSk(DlColor::kYellow()));
                          p.setColorFilter(sk_color_filter);
                        },
                        [=](DlCanvas*, DlPaint& p) {
@@ -1448,7 +1448,7 @@ class CanvasCompareTester {
             CaseParameters(
                 "ColorFilter == Invert",
                 [=](SkCanvas*, SkPaint& p) {
-                  p.setColor(DlColor::kYellow());
+                  p.setColor(ToSk(DlColor::kYellow()));
                   p.setColorFilter(SkColorFilters::Matrix(invert_color_matrix));
                 },
                 [=](DlCanvas*, DlPaint& p) {
@@ -2130,11 +2130,11 @@ class CanvasCompareTester {
       for (int x = 0; x < kTestWidth; x++) {
         uint32_t ref_pixel = ref_row[x];
         uint32_t test_pixel = test_row[x];
-        if (ref_pixel != bg.argb || test_pixel != bg.argb) {
+        if (ref_pixel != bg.argb() || test_pixel != bg.argb()) {
           pixels_touched++;
           for (int i = 0; i < 32; i += 8) {
             int ref_comp = (ref_pixel >> i) & 0xff;
-            int bg_comp = (bg.argb >> i) & 0xff;
+            int bg_comp = (bg.argb() >> i) & 0xff;
             SkScalar faded_comp = bg_comp + (ref_comp - bg_comp) * opacity;
             int test_comp = (test_pixel >> i) & 0xff;
             if (std::abs(faded_comp - test_comp) > fudge) {
@@ -3272,16 +3272,16 @@ sk_sp<DisplayList> makeTestDisplayList() {
   DisplayListBuilder builder;
   DlPaint paint;
   paint.setDrawStyle(DlDrawStyle::kFill);
-  paint.setColor(SK_ColorRED);
+  paint.setColor(DlColor(SK_ColorRED));
   builder.DrawRect({kRenderLeft, kRenderTop, kRenderCenterX, kRenderCenterY},
                    paint);
-  paint.setColor(SK_ColorBLUE);
+  paint.setColor(DlColor(SK_ColorBLUE));
   builder.DrawRect({kRenderCenterX, kRenderTop, kRenderRight, kRenderCenterY},
                    paint);
-  paint.setColor(SK_ColorGREEN);
+  paint.setColor(DlColor(SK_ColorGREEN));
   builder.DrawRect({kRenderLeft, kRenderCenterY, kRenderCenterX, kRenderBottom},
                    paint);
-  paint.setColor(SK_ColorYELLOW);
+  paint.setColor(DlColor(SK_ColorYELLOW));
   builder.DrawRect(
       {kRenderCenterX, kRenderCenterY, kRenderRight, kRenderBottom}, paint);
   return builder.Build();
@@ -3666,7 +3666,7 @@ TEST_F(DisplayListCanvas, MatrixColorFilterModifyTransparencyCheck) {
     auto dl_filter = DlMatrixColorFilter::Make(matrix);
     bool is_identity = (dl_filter == nullptr || original_value == value);
 
-    DlPaint paint(0x7f7f7f7f);
+    DlPaint paint(DlColor(0x7f7f7f7f));
     DlPaint filter_save_paint = DlPaint().setColorFilter(&filter);
 
     DisplayListBuilder builder1;
@@ -3738,7 +3738,7 @@ TEST_F(DisplayListCanvas, MatrixColorFilterOpacityCommuteCheck) {
     auto filter = DlMatrixColorFilter::Make(matrix);
     EXPECT_EQ(SkScalarIsFinite(value), filter != nullptr);
 
-    DlPaint paint(0x80808080);
+    DlPaint paint(DlColor(0x80808080));
     DlPaint opacity_save_paint = DlPaint().setOpacity(0.5);
     DlPaint filter_save_paint = DlPaint().setColorFilter(filter);
 
@@ -3850,7 +3850,7 @@ TEST_F(DisplayListCanvas, BlendColorFilterModifyTransparencyCheck) {
       ASSERT_NE(DlBlendColorFilter::Make(color, mode), nullptr) << desc;
     }
 
-    DlPaint paint(0x7f7f7f7f);
+    DlPaint paint(DlColor(0x7f7f7f7f));
     DlPaint filter_save_paint = DlPaint().setColorFilter(&filter);
 
     DisplayListBuilder builder1;
@@ -3915,7 +3915,7 @@ TEST_F(DisplayListCanvas, BlendColorFilterOpacityCommuteCheck) {
       ASSERT_NE(DlBlendColorFilter::Make(color, mode), nullptr) << desc;
     }
 
-    DlPaint paint(0x80808080);
+    DlPaint paint(DlColor(0x80808080));
     DlPaint opacity_save_paint = DlPaint().setOpacity(0.5);
     DlPaint filter_save_paint = DlPaint().setColorFilter(&filter);
 
@@ -4019,7 +4019,7 @@ class DisplayListNopTest : public DisplayListCanvas {
           int x = 0;
           for (DlColor color : test_dst_colors) {
             SkPaint paint;
-            paint.setColor(color);
+            paint.setColor(ToSk(color));
             paint.setBlendMode(SkBlendMode::kSrc);
             canvas->drawRect(SkRect::MakeXYWH(x, 0, 1, 1), paint);
             x++;
@@ -4121,8 +4121,8 @@ class DisplayListNopTest : public DisplayListCanvas {
       const uint32_t* dst_pixels = dst_data->addr32(0, y);
       const uint32_t* result_pixels = result_data->addr32(0, y);
       for (int x = 0; x < dst_data->width(); x++) {
-        all_flags |=
-            check_color_result(dst_pixels[x], result_pixels[x], dl, desc);
+        all_flags |= check_color_result(DlColor(dst_pixels[x]),
+                                        DlColor(result_pixels[x]), dl, desc);
       }
     }
     return all_flags;
@@ -4158,11 +4158,11 @@ class DisplayListNopTest : public DisplayListCanvas {
     }
 
     auto sk_mode = static_cast<SkBlendMode>(mode);
-    auto sk_color_filter = SkColorFilters::Blend(color, sk_mode);
+    auto sk_color_filter = SkColorFilters::Blend(ToSk(color), sk_mode);
     int all_flags = 0;
     if (sk_color_filter) {
       for (DlColor dst_color : test_dst_colors) {
-        DlColor result = sk_color_filter->filterColor(dst_color);
+        DlColor result = DlColor(sk_color_filter->filterColor(ToSk(dst_color)));
         all_flags |= check_color_result(dst_color, result, dl, desc);
       }
       if ((all_flags & kWasMTB) != 0) {
@@ -4192,7 +4192,7 @@ class DisplayListNopTest : public DisplayListCanvas {
     auto sk_mode = static_cast<SkBlendMode>(mode);
     SkPaint sk_paint;
     sk_paint.setBlendMode(sk_mode);
-    sk_paint.setColor(color);
+    sk_paint.setColor(ToSk(color));
     for (auto& provider : CanvasCompareTester::kTestProviders) {
       auto result_surface = provider->MakeOffscreenSurface(
           test_image->width(), test_image->height(),
@@ -4252,7 +4252,7 @@ class DisplayListNopTest : public DisplayListCanvas {
     auto sk_mode = static_cast<SkBlendMode>(mode);
     SkPaint sk_paint;
     sk_paint.setBlendMode(sk_mode);
-    sk_paint.setColor(color);
+    sk_paint.setColor(ToSk(color));
     sk_paint.setColorFilter(ToSk(color_filter));
     sk_paint.setImageFilter(ToSk(image_filter));
     for (auto& provider : CanvasCompareTester::kTestProviders) {

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -20,7 +20,8 @@ sk_sp<DisplayList> GetSampleNestedDisplayList() {
   DlPaint paint;
   for (int y = 10; y <= 60; y += 10) {
     for (int x = 10; x <= 60; x += 10) {
-      paint.setColor(((x + y) % 20) == 10 ? SK_ColorRED : SK_ColorBLUE);
+      paint.setColor(((x + y) % 20) == 10 ? DlColor(SK_ColorRED)
+                                          : DlColor(SK_ColorBLUE));
       builder.DrawRect(SkRect::MakeXYWH(x, y, 80, 80), paint);
     }
   }
@@ -101,9 +102,12 @@ std::vector<DisplayListInvocationGroup> CreateAllAttributesOps() {
        }},
       {"SetColor",
        {
-           {0, 8, 0, 0, [](DlOpReceiver& r) { r.setColor(SK_ColorGREEN); }},
-           {0, 8, 0, 0, [](DlOpReceiver& r) { r.setColor(SK_ColorBLUE); }},
-           {0, 0, 0, 0, [](DlOpReceiver& r) { r.setColor(SK_ColorBLACK); }},
+           {0, 8, 0, 0,
+            [](DlOpReceiver& r) { r.setColor(DlColor(SK_ColorGREEN)); }},
+           {0, 8, 0, 0,
+            [](DlOpReceiver& r) { r.setColor(DlColor(SK_ColorBLUE)); }},
+           {0, 0, 0, 0,
+            [](DlOpReceiver& r) { r.setColor(DlColor(SK_ColorBLACK)); }},
        }},
       {"SetBlendMode",
        {
@@ -513,15 +517,15 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            // cv.drawColor becomes cv.drawPaint(paint)
            {1, 16, 1, 24,
             [](DlOpReceiver& r) {
-              r.drawColor(SK_ColorBLUE, DlBlendMode::kSrcIn);
+              r.drawColor(DlColor(SK_ColorBLUE), DlBlendMode::kSrcIn);
             }},
            {1, 16, 1, 24,
             [](DlOpReceiver& r) {
-              r.drawColor(SK_ColorBLUE, DlBlendMode::kDstOut);
+              r.drawColor(DlColor(SK_ColorBLUE), DlBlendMode::kDstOut);
             }},
            {1, 16, 1, 24,
             [](DlOpReceiver& r) {
-              r.drawColor(SK_ColorCYAN, DlBlendMode::kSrcIn);
+              r.drawColor(DlColor(SK_ColorCYAN), DlBlendMode::kSrcIn);
             }},
        }},
       {"DrawLine",
@@ -921,27 +925,27 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            // exposed
            {1, 32, -1, 32,
             [](DlOpReceiver& r) {
-              r.drawShadow(kTestPath1, SK_ColorGREEN, 1.0, false, 1.0);
+              r.drawShadow(kTestPath1, DlColor(SK_ColorGREEN), 1.0, false, 1.0);
             }},
            {1, 32, -1, 32,
             [](DlOpReceiver& r) {
-              r.drawShadow(kTestPath2, SK_ColorGREEN, 1.0, false, 1.0);
+              r.drawShadow(kTestPath2, DlColor(SK_ColorGREEN), 1.0, false, 1.0);
             }},
            {1, 32, -1, 32,
             [](DlOpReceiver& r) {
-              r.drawShadow(kTestPath1, SK_ColorBLUE, 1.0, false, 1.0);
+              r.drawShadow(kTestPath1, DlColor(SK_ColorBLUE), 1.0, false, 1.0);
             }},
            {1, 32, -1, 32,
             [](DlOpReceiver& r) {
-              r.drawShadow(kTestPath1, SK_ColorGREEN, 2.0, false, 1.0);
+              r.drawShadow(kTestPath1, DlColor(SK_ColorGREEN), 2.0, false, 1.0);
             }},
            {1, 32, -1, 32,
             [](DlOpReceiver& r) {
-              r.drawShadow(kTestPath1, SK_ColorGREEN, 1.0, true, 1.0);
+              r.drawShadow(kTestPath1, DlColor(SK_ColorGREEN), 1.0, true, 1.0);
             }},
            {1, 32, -1, 32,
             [](DlOpReceiver& r) {
-              r.drawShadow(kTestPath1, SK_ColorGREEN, 1.0, false, 2.5);
+              r.drawShadow(kTestPath1, DlColor(SK_ColorGREEN), 1.0, false, 2.5);
             }},
        }},
   };

--- a/display_list/testing/dl_test_snippets.h
+++ b/display_list/testing/dl_test_snippets.h
@@ -37,8 +37,6 @@ constexpr float kStops[] = {
     0.5,
     1.0,
 };
-static std::vector<uint32_t> color_vector(kColors, kColors + 3);
-static std::vector<float> stops_vector(kStops, kStops + 3);
 
 // clang-format off
 constexpr float kRotateColorMatrix[20] = {
@@ -216,7 +214,7 @@ static std::shared_ptr<const DlVertices> TestVertices2 =
 
 static sk_sp<DisplayList> MakeTestDisplayList(int w, int h, SkColor color) {
   DisplayListBuilder builder;
-  builder.DrawRect(SkRect::MakeWH(w, h), DlPaint(color));
+  builder.DrawRect(SkRect::MakeWH(w, h), DlPaint(DlColor(color)));
   return builder.Build();
 }
 static sk_sp<DisplayList> TestDisplayList1 =

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -439,11 +439,11 @@ TEST_F(ColorFilterLayerTest, OpacityInheritance) {
       expected_builder.Translate(offset.fX, offset.fY);
       /* ColorFilterLayer::Paint() */ {
         DlPaint dl_paint;
-        dl_paint.setColor(opacity_alpha << 24);
+        dl_paint.setColor(DlColor(opacity_alpha << 24));
         dl_paint.setColorFilter(&layer_filter);
         expected_builder.SaveLayer(&child_path.getBounds(), &dl_paint);
         /* MockLayer::Paint() */ {
-          expected_builder.DrawPath(child_path, DlPaint(0xFF000000));
+          expected_builder.DrawPath(child_path, DlPaint(DlColor(0xFF000000)));
         }
         expected_builder.Restore();
       }

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -603,7 +603,7 @@ TEST_F(ImageFilterLayerTest, OpacityInheritance) {
       expected_builder.Translate(offset.fX, offset.fY);
       /* ImageFilterLayer::Paint() */ {
         DlPaint image_filter_paint;
-        image_filter_paint.setColor(opacity_alpha << 24);
+        image_filter_paint.setColor(DlColor(opacity_alpha << 24));
         image_filter_paint.setImageFilter(dl_image_filter.get());
         expected_builder.SaveLayer(&child_path.getBounds(),
                                    &image_filter_paint);

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -49,7 +49,7 @@ void VisualizeStopWatch(DlCanvas* canvas,
     auto text = PerformanceOverlayLayer::MakeStatisticsText(
         stopwatch, label_prefix, font_path);
     // Historically SK_ColorGRAY (== 0xFF888888) was used here
-    DlPaint paint(0xFF888888);
+    DlPaint paint(DlColor(0xFF888888));
     canvas->DrawTextBlob(text, x + label_x, y + height + label_y, paint);
   }
 }

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -181,7 +181,7 @@ TEST_F(PerformanceOverlayLayerTest, SimpleRasterizerStatistics) {
       paint_context().raster_time, "Raster", "");
   auto overlay_text_data = overlay_text->serialize(SkSerialProcs{});
   // Historically SK_ColorGRAY (== 0xFF888888) was used here
-  DlPaint text_paint(0xFF888888);
+  DlPaint text_paint(DlColor(0xFF888888));
   SkPoint text_position = SkPoint::Make(16.0f, 22.0f);
 
   // TODO(https://github.com/flutter/flutter/issues/82202): Remove once the

--- a/flow/layers/shader_mask_layer_unittests.cc
+++ b/flow/layers/shader_mask_layer_unittests.cc
@@ -396,7 +396,7 @@ TEST_F(ShaderMaskLayerTest, OpacityInheritance) {
     {
       expected_builder.Translate(offset.fX, offset.fY);
       /* ShaderMaskLayer::Paint() */ {
-        DlPaint sl_paint = DlPaint(opacity_alpha << 24);
+        DlPaint sl_paint = DlPaint(DlColor(opacity_alpha << 24));
         expected_builder.SaveLayer(&child_path.getBounds(), &sl_paint);
         {
           /* child layer paint */ {

--- a/flow/paint_utils.cc
+++ b/flow/paint_utils.cc
@@ -49,7 +49,7 @@ void DrawCheckerboard(DlCanvas* canvas, const SkRect& rect) {
   // Stroke the drawn area
   DlPaint debug_paint;
   debug_paint.setStrokeWidth(8);
-  debug_paint.setColor(SkColorSetA(checkerboard_color, 255));
+  debug_paint.setColor(DlColor(SkColorSetA(checkerboard_color, 255)));
   debug_paint.setDrawStyle(DlDrawStyle::kStroke);
   canvas->DrawRect(rect, debug_paint);
 }

--- a/flow/stopwatch_dl.cc
+++ b/flow/stopwatch_dl.cc
@@ -36,7 +36,7 @@ void DlStopwatchVisualizer::Visualize(DlCanvas* canvas,
   auto const sample_unit_width = (1.0 / kMaxSamples);
 
   // Provide a semi-transparent background for the graph.
-  painter.DrawRect(rect, 0x99FFFFFF);
+  painter.DrawRect(rect, DlColor(0x99FFFFFF));
 
   // Prepare a path for the data; we start at the height of the last point so
   // it looks like we wrap around.
@@ -54,7 +54,7 @@ void DlStopwatchVisualizer::Visualize(DlCanvas* canvas,
                                         /*top=*/y + bar_height,
                                         /*right=*/bar_left + bar_width,
                                         /*bottom=*/bottom),
-                       0xAA0000FF);
+                       DlColor(0xAA0000FF));
     }
   }
 
@@ -79,7 +79,7 @@ void DlStopwatchVisualizer::Visualize(DlCanvas* canvas,
                                           /*top=*/y + frame_height,
                                           /*right=*/width,
                                           /*bottom=*/y + frame_height + 1),
-                         0xCC000000);
+                         DlColor(0xCC000000));
       }
     }
   }

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -5,6 +5,7 @@
 #ifndef FLOW_TESTING_LAYER_TEST_H_
 #define FLOW_TESTING_LAYER_TEST_H_
 
+#include "display_list/dl_color.h"
 #include "flutter/flow/layer_snapshot_store.h"
 #include "flutter/flow/layers/layer.h"
 
@@ -40,7 +41,7 @@ template <typename BaseT>
 class LayerTestBase : public CanvasTestBase<BaseT> {
   using TestT = CanvasTestBase<BaseT>;
 
-  const SkRect kDlBounds = SkRect::MakeWH(500, 500);
+  const SkRect k_dl_bounds_ = SkRect::MakeWH(500, 500);
 
  public:
   LayerTestBase()
@@ -72,7 +73,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
             .raster_cache                  = nullptr,
             // clang-format on
         },
-        display_list_builder_(kDlBounds),
+        display_list_builder_(k_dl_bounds_),
         display_list_paint_context_{
             // clang-format off
             .state_stack                   = display_list_state_stack_,
@@ -103,7 +104,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
     display_list_state_stack_.set_delegate(&display_list_builder_);
     checkerboard_state_stack_.set_delegate(&display_list_builder_);
     checkerboard_state_stack_.set_checkerboard_func(draw_checkerboard);
-    checkerboard_paint_.setColor(checkerboard_color_);
+    checkerboard_paint_.setColor(kCheckerboardColor);
   }
 
   /**
@@ -209,12 +210,12 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
     display_list_paint_context_.raster_cache = raster_cache_.get();
   }
 
-  static constexpr SkColor checkerboard_color_ = 0x42424242;
+  static constexpr DlColor kCheckerboardColor = DlColor(0x42424242);
 
   static void draw_checkerboard(DlCanvas* canvas, const SkRect& rect) {
     if (canvas) {
       DlPaint paint;
-      paint.setColor(checkerboard_color_);
+      paint.setColor(kCheckerboardColor);
       canvas->DrawRect(rect, paint);
     }
   }

--- a/impeller/display_list/skia_conversions_unittests.cc
+++ b/impeller/display_list/skia_conversions_unittests.cc
@@ -13,8 +13,8 @@ TEST(SkiaConversionsTest, ToColor) {
   // Create a color with alpha, red, green, and blue values that are all
   // trivially divisible by 255 so that we can test the conversion results in
   // correct scalar values.
-  //                               AARRGGBB
-  const flutter::DlColor color = 0x8040C020;
+  //                                                AARRGGBB
+  const flutter::DlColor color = flutter::DlColor(0x8040C020);
   auto converted_color = skia_conversions::ToColor(color);
 
   ASSERT_TRUE(ScalarNearlyEqual(converted_color.alpha, 0x80 * (1.0f / 255)));

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -214,7 +214,7 @@ void Canvas::getLocalClipBounds(Dart_Handle rect_handle) {
 
 void Canvas::drawColor(SkColor color, DlBlendMode blend_mode) {
   if (display_list_builder_) {
-    builder()->DrawColor(color, blend_mode);
+    builder()->DrawColor(DlColor(color), blend_mode);
   }
 }
 
@@ -638,7 +638,7 @@ void Canvas::drawShadow(const CanvasPath* path,
     // that situation we bypass the canvas interface and inject the
     // shadow parameters directly into the underlying DisplayList.
     // See: https://bugs.chromium.org/p/skia/issues/detail?id=12125
-    builder()->DrawShadow(path->path(), color, SafeNarrow(elevation),
+    builder()->DrawShadow(path->path(), DlColor(color), SafeNarrow(elevation),
                           transparentOccluder, dpr);
   }
 }

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -137,7 +137,7 @@ const DlPaint* Paint::paint(DlPaint& paint,
 
   if (flags.applies_alpha_or_color()) {
     uint32_t encoded_color = uint_data[kColorIndex];
-    paint.setColor(encoded_color ^ kColorDefault);
+    paint.setColor(DlColor(encoded_color ^ kColorDefault));
   }
 
   if (flags.applies_blend()) {
@@ -248,7 +248,7 @@ void Paint::toDlPaint(DlPaint& paint) const {
   paint.setAntiAlias(uint_data[kIsAntiAliasIndex] == 0);
 
   uint32_t encoded_color = uint_data[kColorIndex];
-  paint.setColor(encoded_color ^ kColorDefault);
+  paint.setColor(DlColor(encoded_color ^ kColorDefault));
 
   uint32_t encoded_blend_mode = uint_data[kBlendModeIndex];
   uint32_t blend_mode = encoded_blend_mode ^ kBlendModeDefault;

--- a/lib/ui/painting/paint_unittests.cc
+++ b/lib/ui/painting/paint_unittests.cc
@@ -50,9 +50,9 @@ TEST_F(ShellTest, ConvertPaintToDlPaint) {
   DestroyShell(std::move(shell), task_runners);
 
   ASSERT_EQ(dl_paint.getBlendMode(), DlBlendMode::kModulate);
-  ASSERT_EQ(static_cast<uint32_t>(dl_paint.getColor()), 0x11223344u);
+  ASSERT_EQ(static_cast<uint32_t>(dl_paint.getColor().argb()), 0x11223344u);
   ASSERT_EQ(*dl_paint.getColorFilter(),
-            DlBlendColorFilter(0x55667788, DlBlendMode::kXor));
+            DlBlendColorFilter(DlColor(0x55667788), DlBlendMode::kXor));
   ASSERT_EQ(*dl_paint.getMaskFilter(),
             DlBlurMaskFilter(DlBlurStyle::kInner, 0.75));
   ASSERT_EQ(dl_paint.getDrawStyle(), DlDrawStyle::kStroke);

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -260,7 +260,7 @@ std::ostream& operator<<(std::ostream& os, const DlFilterMode& mode) {
 }
 
 std::ostream& operator<<(std::ostream& os, const DlColor& color) {
-  return os << "DlColor(" << std::hex << color.argb << std::dec << ")";
+  return os << "DlColor(" << std::hex << color.argb() << std::dec << ")";
 }
 
 std::ostream& operator<<(std::ostream& os, DlImageSampling sampling) {

--- a/third_party/txt/src/skia/paragraph_builder_skia.cc
+++ b/third_party/txt/src/skia/paragraph_builder_skia.cc
@@ -102,7 +102,7 @@ skt::ParagraphStyle ParagraphBuilderSkia::TxtToSkia(const ParagraphStyle& txt) {
 
   // Convert the default color of an SkParagraph text style into a DlPaint.
   flutter::DlPaint dl_paint;
-  dl_paint.setColor(text_style.getColor());
+  dl_paint.setColor(flutter::DlColor(text_style.getColor()));
   text_style.setForegroundPaintID(CreatePaintID(dl_paint));
 
   text_style.setFontStyle(MakeSkFontStyle(txt.font_weight, txt.font_style));
@@ -178,7 +178,7 @@ skt::TextStyle ParagraphBuilderSkia::TxtToSkia(const TextStyle& txt) {
     skia.setForegroundPaintID(CreatePaintID(txt.foreground.value()));
   } else {
     flutter::DlPaint dl_paint;
-    dl_paint.setColor(txt.color);
+    dl_paint.setColor(flutter::DlColor(txt.color));
     skia.setForegroundPaintID(CreatePaintID(dl_paint));
   }
 

--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -91,7 +91,7 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
       return;
     }
     DlPaint paint;
-    paint.setColor(color);
+    paint.setColor(DlColor(color));
     if (blur_sigma > 0.0) {
       DlBlurMaskFilter filter(DlBlurStyle::kNormal, blur_sigma, false);
       paint.setMaskFilter(&filter);
@@ -185,7 +185,7 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
     DlPaint paint;
     paint.setDrawStyle(draw_style);
     paint.setAntiAlias(true);
-    paint.setColor(decor_style.getColor());
+    paint.setColor(DlColor(decor_style.getColor()));
     paint.setStrokeWidth(decor_style.getStrokeWidth());
     return paint;
   }


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/135057.

This is a fair bit more involved than previous changes, just due to the sheer number of implicit conversions.

Highlights:

- Made `public uint32_t argb` `private uint32_t argb_`, and added `argb()` instead.
- Added `ToSk(DlColor)` instead of using implicit conversions.

There were a bunch of places where I had to make a judgement call (particularly in tests) to keep the code a bit "messy", i.e. `DlColor(SK_RED)`, just to make the diff as small as possible and to prevent silly copy and paste bugs. I'd be open to filing a follow-up issue to reduce unnecessary wrapping.