### PR TITLE
Prepare fuchsia script to coexist with v1 and v2 of fuchsia builders.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -159,9 +159,9 @@ targets:
     timeout: 60
 
   - name: Linux Fuchsia
-    bringup: true
     recipe: engine/engine
     properties:
+      add_recipes_cq: "true"
       build_fuchsia: "true"
       fuchsia_ctl_version: version:0.0.27
       # ensure files from pre-production Fuchsia SDK tests are purged from cache
@@ -217,10 +217,10 @@ targets:
       - web_sdk/**
 
   - name: Linux linux_fuchsia
+    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
-      add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_fuchsia
     drone_dimensions:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -159,6 +159,7 @@ targets:
     timeout: 60
 
   - name: Linux Fuchsia
+    bringup: true
     recipe: engine/engine
     properties:
       build_fuchsia: "true"
@@ -216,10 +217,10 @@ targets:
       - web_sdk/**
 
   - name: Linux linux_fuchsia
-    bringup: true
     recipe: engine_v2/engine_v2
     timeout: 60
     properties:
+      add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_fuchsia
     drone_dimensions:

--- a/ci/builders/README.md
+++ b/ci/builders/README.md
@@ -122,7 +122,8 @@ The current list of supported magic variables is:
   folder where logs are being placed.
 * `${LUCI_WORKDIR}` - translated to the LUCI chroot working directory.
 * `${LUCI_CLEANUP}` - translated to the LUCI chroot temp directory.
-* `${REVISION}` - translated to the engine commit under test.
+* `${REVISION}` - translated to the engine commit in postsubmit. In presubmit
+  it is translated to an empty string.
 
 ### Build
 

--- a/ci/builders/linux_fuchsia.json
+++ b/ci/builders/linux_fuchsia.json
@@ -164,6 +164,7 @@
                 "parameters": [
                     "--engine-version",
                     "${REVISION}",
+		    "--upload",
                     "--target-arch",
                     "arm64",
                     "--out-dir",
@@ -181,6 +182,7 @@
                 "parameters": [
                     "--engine-version",
                     "${REVISION}",
+		    "--upload",
                     "--target-arch",
                     "x64",
                     "--out-dir",

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -495,9 +495,17 @@ def main():
         if args.copy_unoptimized_debug_artifacts and runtime_mode == 'debug' and optimized:
           CopyBuildToBucket(runtime_mode, arch, not optimized, product)
 
+  # Set revision to HEAD if empty and remove upload. This is to support
+  # presubmit workflows.
+  should_upload = args.upload
+  engine_version = args.engine_version
+  if not engine_version:
+    engine_version = 'HEAD'
+    should_upload = False
+
   # Create and optionally upload CIPD package
   if args.cipd_dry_run or args.upload:
-    ProcessCIPDPackage(args.upload, args.engine_version)
+    ProcessCIPDPackage(should_upload, engine_version)
 
   return 0
 

--- a/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -214,7 +214,17 @@ def main():
 
   arch = args.target_arch
   cipd_def = WriteCIPDDefinition(arch, out_dir, internal_symbol_dirs)
-  ProcessCIPDPackage(args.upload, cipd_def, args.engine_version, out_dir, arch)
+
+  # Set revision to HEAD if empty and remove upload. This is to support
+  # presubmit workflows. An empty engine_version means this script is running
+  # on presubmit.
+  should_upload = args.upload
+  engine_version = args.engine_version
+  if not engine_version:
+    engine_version = 'HEAD'
+    should_upload = False
+
+  ProcessCIPDPackage(should_upload, cipd_def, engine_version, out_dir, arch)
   return 0
 
 


### PR DESCRIPTION
Prepares fuchsia scripts to work correctly when both v1 and v2 of the fuchsia build are running in their respective environments.

Bug: https://github.com/flutter/flutter/issues/126461
Bug: https://github.com/flutter/flutter/issues/135189

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
