### PR TITLE
[Impeller] temp work around for cmd pool validation issues.

### DIFF
--- a/impeller/renderer/backend/vulkan/surface_context_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.cc
@@ -80,7 +80,6 @@ std::unique_ptr<Surface> SurfaceContextVK::AcquireNextSurface() {
   if (auto allocator = parent_->GetResourceAllocator()) {
     allocator->DidAcquireSurfaceFrame();
   }
-  parent_->GetCommandPoolRecycler()->Dispose();
   return surface;
 }
 

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -424,6 +424,13 @@ bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
   //----------------------------------------------------------------------------
   /// Transition the image to color-attachment-optimal.
   ///
+
+  // Increment the frame count right before allocating the cmd buffer below to
+  // force this to use the next frame's pool. This cmd buffer is completely
+  // untracked, and so we may end up resetting the cmd pool before all buffers
+  // have been collected.
+  context.GetCommandPoolRecycler()->Dispose();
+
   sync->final_cmd_buffer = context.CreateCommandBuffer();
   if (!sync->final_cmd_buffer) {
     return false;


### PR DESCRIPTION
I'm not able to reproduce most validation errors in the macrobenchmark app with this change. THe real fix seems to be to track this last cmd buffer but I'm struggling to find a way to do this.