### PR TITLE
[macOS] TextInputPlugin should mark navigation events in IME popover as handled

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -64,5 +64,6 @@
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 - (NSRect)firstRectForCharacterRange:(NSRange)range actualRange:(NSRangePointer)actualRange;
 - (NSDictionary*)editingState;
+@property(nonatomic) NSTextInputContext* textInputContext;
 @property(readwrite, nonatomic) NSString* customRunLoopMode;
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -620,7 +620,15 @@ static char markerKey;
   // text command (indicated by calling doCommandBySelector) or might not (for example, Cmd+Q). In
   // the latter case, this command somehow has not been executed yet and Flutter must dispatch it to
   // the next responder. See https://github.com/flutter/flutter/issues/106354 .
-  if (event.isKeyEquivalent && !_eventProducedOutput) {
+  // The event is also not redispatched if there is IME composition active, because it might be
+  // handled by the IME. See https://github.com/flutter/flutter/issues/134699
+
+  // both NSEventModifierFlagNumericPad and NSEventModifierFlagFunction are set for arrow keys.
+  bool is_navigation = event.modifierFlags & NSEventModifierFlagFunction &&
+                       event.modifierFlags & NSEventModifierFlagNumericPad;
+  bool is_navigation_in_ime = is_navigation && self.hasMarkedText;
+
+  if (event.isKeyEquivalent && !is_navigation_in_ime && !_eventProducedOutput) {
     return NO;
   }
   return res;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/134699

Because of NSTextInputContext API limitations it is not straightforward to determine whether `TextInputPlugin` has handled a text equivalent event or whether it should pass it on. Previously we marked all event  that didn't result in a TextInputClient action as unhandled, but that's does not work for arrow key events while the IME popover is active.

This PR will mark arrow keys event as handled if there is active composition.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
