### PR TITLE
[macOS] FlutterTextInputPlugin should clip to bounds

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -9,6 +9,11 @@
 
 @class FlutterTextField;
 
+@interface NSView (ClipsToBounds)
+// This property is available since macOS 10.9 but only declared in macOS 14 SDK.
+@property BOOL clipsToBounds API_AVAILABLE(macos(10.9));
+@end
+
 /**
  * A plugin to handle text input.
  *

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -342,6 +342,7 @@ static char markerKey;
   // The view needs an empty frame otherwise it is visible on dark background.
   // https://github.com/flutter/flutter/issues/118504
   self = [super initWithFrame:NSZeroRect];
+  self.clipsToBounds = YES;
   if (self != nil) {
     _flutterViewController = viewController;
     _channel = [FlutterMethodChannel methodChannelWithName:kTextInputChannel

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1962,7 +1962,7 @@ TEST(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
   ASSERT_FALSE(window.firstResponder == viewController.textInputPlugin);
 }
 
-TEST(FlutterTextInputPluginTest, HasZeroSize) {
+TEST(FlutterTextInputPluginTest, HasZeroSizeAndClipsToBounds) {
   id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
@@ -1977,6 +1977,7 @@ TEST(FlutterTextInputPluginTest, HasZeroSize) {
       [[FlutterTextInputPlugin alloc] initWithViewController:viewController];
 
   ASSERT_TRUE(NSIsEmptyRect(plugin.frame));
+  ASSERT_TRUE(plugin.clipsToBounds);
 }
 
 }  // namespace flutter::testing


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/135219
(formerly https://github.com/flutter/flutter/issues/128956)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
