### PR TITLE
[iOS] Disable spelling corrections when auto correction is disabled

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -878,9 +878,11 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
     self.keyboardAppearance = UIKeyboardAppearanceDefault;
   }
   NSString* autocorrect = configuration[kAutocorrectionType];
-  self.autocorrectionType = autocorrect && ![autocorrect boolValue]
-                                ? UITextAutocorrectionTypeNo
-                                : UITextAutocorrectionTypeDefault;
+  bool autocorrectIsDisabled = autocorrect && ![autocorrect boolValue];
+  self.autocorrectionType =
+      autocorrectIsDisabled ? UITextAutocorrectionTypeNo : UITextAutocorrectionTypeDefault;
+  self.spellCheckingType =
+      autocorrectIsDisabled ? UITextSpellCheckingTypeNo : UITextSpellCheckingTypeDefault;
   self.autofillId = AutofillIdFromDictionary(configuration);
   if (autofill == nil) {
     self.textContentType = @"";

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -769,6 +769,23 @@ FLUTTER_ASSERT_ARC
   OCMVerify([mockBinaryMessenger sendOnChannel:@"flutter/textinput" message:encodedMethodCall]);
 }
 
+- (void)testDisablingAutocorrectDisablesSpellChecking {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+
+  // Disable the interactive selection.
+  NSDictionary* config = self.mutableTemplateCopy;
+  [inputView configureWithDictionary:config];
+
+  XCTAssertEqual(inputView.autocorrectionType, UITextAutocorrectionTypeDefault);
+  XCTAssertEqual(inputView.spellCheckingType, UITextSpellCheckingTypeDefault);
+
+  [config setValue:@(NO) forKey:@"autocorrect"];
+  [inputView configureWithDictionary:config];
+
+  XCTAssertEqual(inputView.autocorrectionType, UITextAutocorrectionTypeNo);
+  XCTAssertEqual(inputView.spellCheckingType, UITextSpellCheckingTypeNo);
+}
+
 #pragma mark - TextEditingDelta tests
 - (void)testTextEditingDeltasAreGeneratedOnTextInput {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];


### PR DESCRIPTION
## Description

This iOS PR disables spellchecking when auto correction is disabled.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/134881.

## Tests

Adds 1 test.