### PR TITLE
More Clang Tidy --fix[es] to header files

### DIFF
--- a/display_list/benchmarking/dl_benchmarks.h
+++ b/display_list/benchmarking/dl_benchmarks.h
@@ -102,7 +102,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawLine
 #define DRAW_LINE_BENCHMARKS(BACKEND, ATTRIBUTES)                       \
   BENCHMARK_CAPTURE(BM_DrawLine, BACKEND,                               \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 2048)                                                 \
@@ -112,7 +112,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawRect
 #define DRAW_RECT_BENCHMARKS(BACKEND, ATTRIBUTES)                       \
   BENCHMARK_CAPTURE(BM_DrawRect, BACKEND,                               \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 2048)                                                 \
@@ -122,7 +122,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawOval
 #define DRAW_OVAL_BENCHMARKS(BACKEND, ATTRIBUTES)                       \
   BENCHMARK_CAPTURE(BM_DrawOval, BACKEND,                               \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 2048)                                                 \
@@ -132,7 +132,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawCircle
 #define DRAW_CIRCLE_BENCHMARKS(BACKEND, ATTRIBUTES)                     \
   BENCHMARK_CAPTURE(BM_DrawCircle, BACKEND,                             \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(16, 2048)                                                 \
@@ -142,7 +142,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawArc
 #define DRAW_ARC_BENCHMARKS(BACKEND, ATTRIBUTES)                        \
   BENCHMARK_CAPTURE(BM_DrawArc, BACKEND,                                \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(128, 2048)                                                \
@@ -153,7 +153,7 @@ void BM_SaveLayer(benchmark::State& state,
 #define DRAW_PATH_BENCHMARKS(BACKEND, ATTRIBUTES)                       \
   BENCHMARK_CAPTURE(BM_DrawPath,                                        \
                     Lines/BACKEND,                                      \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkPath::Verb::kLine_Verb)                           \
       ->RangeMultiplier(2)                                              \
@@ -164,7 +164,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPath,                                        \
                     Quads/BACKEND,                                      \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkPath::Verb::kQuad_Verb)                           \
       ->RangeMultiplier(2)                                              \
@@ -175,7 +175,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPath,                                        \
                     Conics/BACKEND,                                     \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkPath::Verb::kConic_Verb)                          \
       ->RangeMultiplier(2)                                              \
@@ -186,7 +186,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPath,                                        \
                     Cubics/BACKEND,                                     \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkPath::Verb::kCubic_Verb)                          \
       ->RangeMultiplier(2)                                              \
@@ -198,7 +198,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawPoints
 #define DRAW_POINTS_BENCHMARKS(BACKEND, ATTRIBUTES)                     \
   BENCHMARK_CAPTURE(BM_DrawPoints, Points/BACKEND,                      \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlCanvas::PointMode::kPoints)                       \
       ->RangeMultiplier(2)                                              \
@@ -207,7 +207,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPoints, Lines/BACKEND,                       \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlCanvas::PointMode::kLines)                        \
       ->RangeMultiplier(2)                                              \
@@ -216,7 +216,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawPoints, Polygon/BACKEND,                     \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlCanvas::PointMode::kPolygon)                      \
       ->RangeMultiplier(2)                                              \
@@ -228,7 +228,7 @@ void BM_SaveLayer(benchmark::State& state,
 #define DRAW_VERTICES_BENCHMARKS(BACKEND, ATTRIBUTES)                   \
   BENCHMARK_CAPTURE(BM_DrawVertices,                                    \
                     TriangleStrip/BACKEND,                              \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlVertexMode::kTriangleStrip)                       \
       ->RangeMultiplier(2)                                              \
@@ -239,7 +239,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawVertices,                                    \
                     TriangleFan/BACKEND,                                \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlVertexMode::kTriangleFan)                         \
       ->RangeMultiplier(2)                                              \
@@ -250,7 +250,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawVertices,                                    \
                     Triangles/BACKEND,                                  \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlVertexMode::kTriangles)                           \
       ->RangeMultiplier(2)                                              \
@@ -262,7 +262,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawRRect
 #define DRAW_RRECT_BENCHMARKS(BACKEND, ATTRIBUTES)                      \
   BENCHMARK_CAPTURE(BM_DrawRRect, Symmetric/BACKEND,                    \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkRRect::Type::kSimple_Type)                        \
       ->RangeMultiplier(2)                                              \
@@ -271,7 +271,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawRRect, NinePatch/BACKEND,                    \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkRRect::Type::kNinePatch_Type)                     \
       ->RangeMultiplier(2)                                              \
@@ -280,7 +280,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawRRect, Complex/BACKEND,                      \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkRRect::Type::kComplex_Type)                       \
       ->RangeMultiplier(2)                                              \
@@ -291,7 +291,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawDRRect
 #define DRAW_DRRECT_BENCHMARKS(BACKEND, ATTRIBUTES)                     \
   BENCHMARK_CAPTURE(BM_DrawDRRect, Symmetric/BACKEND,                   \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkRRect::Type::kSimple_Type)                        \
       ->RangeMultiplier(2)                                              \
@@ -300,7 +300,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawDRRect, NinePatch/BACKEND,                   \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkRRect::Type::kNinePatch_Type)                     \
       ->RangeMultiplier(2)                                              \
@@ -309,7 +309,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawDRRect, Complex/BACKEND,                     \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     SkRRect::Type::kComplex_Type)                       \
       ->RangeMultiplier(2)                                              \
@@ -320,7 +320,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawImage
 #define DRAW_IMAGE_BENCHMARKS(BACKEND, ATTRIBUTES)                      \
   BENCHMARK_CAPTURE(BM_DrawImage, Texture/BACKEND,                      \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlImageSampling::kNearestNeighbor, false)                         \
       ->RangeMultiplier(2)                                              \
@@ -329,7 +329,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawImage, Upload/BACKEND,                       \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlImageSampling::kNearestNeighbor, true)                          \
       ->RangeMultiplier(2)                                              \
@@ -341,7 +341,7 @@ void BM_SaveLayer(benchmark::State& state,
 #define DRAW_IMAGE_RECT_BENCHMARKS(BACKEND, ATTRIBUTES)                 \
   BENCHMARK_CAPTURE(                                                    \
       BM_DrawImageRect, Texture/Strict/BACKEND,                         \
-      BackendType::k##BACKEND##_Backend,                                \
+      BackendType::k##BACKEND##Backend,                                \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
       DlCanvas::SrcRectConstraint::kStrict, false)                      \
@@ -352,7 +352,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(                                                    \
       BM_DrawImageRect, Texture/Fast/BACKEND,                           \
-      BackendType::k##BACKEND##_Backend,                                \
+      BackendType::k##BACKEND##Backend,                                \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
       DlCanvas::SrcRectConstraint::kFast, false)                        \
@@ -363,7 +363,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(                                                    \
       BM_DrawImageRect, Upload/Strict/BACKEND,                          \
-      BackendType::k##BACKEND##_Backend,                                \
+      BackendType::k##BACKEND##Backend,                                \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
       DlCanvas::SrcRectConstraint::kStrict, true)                       \
@@ -374,7 +374,7 @@ void BM_SaveLayer(benchmark::State& state,
                                                                         \
   BENCHMARK_CAPTURE(                                                    \
       BM_DrawImageRect, Upload/Fast/BACKEND,                            \
-      BackendType::k##BACKEND##_Backend,                                \
+      BackendType::k##BACKEND##Backend,                                \
       ATTRIBUTES,                                                       \
       DlImageSampling::kNearestNeighbor,                                \
       DlCanvas::SrcRectConstraint::kFast, true)                         \
@@ -386,7 +386,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawImageNine
 #define DRAW_IMAGE_NINE_BENCHMARKS(BACKEND, ATTRIBUTES)                 \
   BENCHMARK_CAPTURE(BM_DrawImageNine, Texture/Nearest/BACKEND,          \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlFilterMode::kNearest, false)                      \
       ->RangeMultiplier(2)                                              \
@@ -395,7 +395,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawImageNine, Upload/Nearest/BACKEND,           \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlFilterMode::kNearest, true)                       \
       ->RangeMultiplier(2)                                              \
@@ -404,7 +404,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawImageNine, Texture/Linear/BACKEND,           \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlFilterMode::kLinear, false)                       \
       ->RangeMultiplier(2)                                              \
@@ -413,7 +413,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawImageNine, Upload/Linear/BACKEND,            \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     DlFilterMode::kLinear, true)                        \
       ->RangeMultiplier(2)                                              \
@@ -424,7 +424,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawTextBlob
 #define DRAW_TEXT_BLOB_BENCHMARKS(BACKEND, ATTRIBUTES)                  \
   BENCHMARK_CAPTURE(BM_DrawTextBlob, BACKEND,                           \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES)                                         \
       ->RangeMultiplier(2)                                              \
       ->Range(1, 256)                                                   \
@@ -435,7 +435,7 @@ void BM_SaveLayer(benchmark::State& state,
 // DrawShadow
 #define DRAW_SHADOW_BENCHMARKS(BACKEND, ATTRIBUTES)                     \
   BENCHMARK_CAPTURE(BM_DrawShadow, Lines/Transparent/BACKEND,           \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     true,                                               \
                     SkPath::Verb::kLine_Verb)                           \
@@ -445,7 +445,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Quads/Transparent/BACKEND,           \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     true,                                               \
                     SkPath::Verb::kQuad_Verb)                           \
@@ -455,7 +455,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Conics/Transparent/BACKEND,          \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     true,                                               \
                     SkPath::Verb::kConic_Verb)                          \
@@ -465,7 +465,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Cubics/Transparent/BACKEND,          \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     true,                                               \
                     SkPath::Verb::kCubic_Verb)                          \
@@ -475,7 +475,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Lines/Opaque/BACKEND,                \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     false,                                              \
                     SkPath::Verb::kLine_Verb)                           \
@@ -485,7 +485,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Quads/Opaque/BACKEND,                \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     false,                                              \
                     SkPath::Verb::kQuad_Verb)                           \
@@ -495,7 +495,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Conics/Opaque/BACKEND,               \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     false,                                              \
                     SkPath::Verb::kConic_Verb)                          \
@@ -505,7 +505,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_DrawShadow, Cubics/Opaque/BACKEND,               \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     false,                                              \
                     SkPath::Verb::kCubic_Verb)                          \
@@ -517,7 +517,7 @@ void BM_SaveLayer(benchmark::State& state,
 // SaveLayer
 #define SAVE_LAYER_BENCHMARKS(BACKEND, ATTRIBUTES)                      \
   BENCHMARK_CAPTURE(BM_SaveLayer, Depth 1/BACKEND,                      \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     1)                                                  \
       ->RangeMultiplier(2)                                              \
@@ -526,7 +526,7 @@ void BM_SaveLayer(benchmark::State& state,
       ->Unit(benchmark::kMillisecond);                                  \
                                                                         \
   BENCHMARK_CAPTURE(BM_SaveLayer, Depth 8/BACKEND,                      \
-                    BackendType::k##BACKEND##_Backend,                  \
+                    BackendType::k##BACKEND##Backend,                  \
                     ATTRIBUTES,                                         \
                     8)                                                  \
       ->RangeMultiplier(2)                                              \

--- a/display_list/benchmarking/dl_complexity_gl.h
+++ b/display_list/benchmarking/dl_complexity_gl.h
@@ -32,7 +32,7 @@ class DisplayListGLComplexityCalculator
  private:
   class GLHelper : public ComplexityCalculatorHelper {
    public:
-    GLHelper(unsigned int ceiling)
+    explicit GLHelper(unsigned int ceiling)
         : ComplexityCalculatorHelper(ceiling),
           save_layer_count_(0),
           draw_text_blob_count_(0) {}

--- a/display_list/benchmarking/dl_complexity_helper.h
+++ b/display_list/benchmarking/dl_complexity_helper.h
@@ -96,8 +96,8 @@ class ComplexityCalculatorHelper
       public virtual IgnoreClipDispatchHelper,
       public virtual IgnoreTransformDispatchHelper {
  public:
-  ComplexityCalculatorHelper(unsigned int ceiling)
-      : is_complex_(false), ceiling_(ceiling), complexity_score_(0) {}
+  explicit ComplexityCalculatorHelper(unsigned int ceiling)
+      : ceiling_(ceiling) {}
 
   virtual ~ComplexityCalculatorHelper() = default;
 
@@ -261,10 +261,10 @@ class ComplexityCalculatorHelper
   // If we exceed the ceiling (defaults to the largest number representable
   // by unsigned int), then set the is_complex_ bool and we no longer
   // accumulate.
-  bool is_complex_;
+  bool is_complex_ = false;
   unsigned int ceiling_;
 
-  unsigned int complexity_score_;
+  unsigned int complexity_score_ = 0;
 };
 
 }  // namespace flutter

--- a/display_list/benchmarking/dl_complexity_metal.h
+++ b/display_list/benchmarking/dl_complexity_metal.h
@@ -32,10 +32,8 @@ class DisplayListMetalComplexityCalculator
  private:
   class MetalHelper : public ComplexityCalculatorHelper {
    public:
-    MetalHelper(unsigned int ceiling)
-        : ComplexityCalculatorHelper(ceiling),
-          save_layer_count_(0),
-          draw_text_blob_count_(0) {}
+    explicit MetalHelper(unsigned int ceiling)
+        : ComplexityCalculatorHelper(ceiling) {}
 
     void saveLayer(const SkRect* bounds,
                    const SaveLayerOptions options,
@@ -85,8 +83,8 @@ class DisplayListMetalComplexityCalculator
     unsigned int BatchedComplexity() override;
 
    private:
-    unsigned int save_layer_count_;
-    unsigned int draw_text_blob_count_;
+    unsigned int save_layer_count_ = 0;
+    unsigned int draw_text_blob_count_ = 0;
   };
 
   DisplayListMetalComplexityCalculator()

--- a/display_list/dl_op_flags.cc
+++ b/display_list/dl_op_flags.cc
@@ -21,7 +21,7 @@ const DisplayListSpecialGeometryFlags DisplayListAttributeFlags::WithPathEffect(
           // end caps to areas that might not have had them before so all
           // we need to do is to indicate the potential for diagonal
           // end caps and move on.
-          return special_flags_.with(kMayHaveCaps_ | kMayHaveDiagonalCaps_);
+          return special_flags_.with(kMayHaveCaps | kMayHaveDiagonalCaps);
         }
       }
     }

--- a/display_list/dl_op_flags.h
+++ b/display_list/dl_op_flags.h
@@ -23,36 +23,36 @@ class DlPathEffect;
 class DisplayListFlags {
  protected:
   // A drawing operation that is not geometric in nature (but which
-  // may still apply a MaskFilter - see |kUsesMaskFilter_| below).
-  static constexpr int kIsNonGeometric_ = 0;
+  // may still apply a MaskFilter - see |kUsesMaskFilter| below).
+  static constexpr int kIsNonGeometric = 0;
 
   // A geometric operation that is defined as a fill operation
   // regardless of what the current paint Style is set to.
-  // This flag will automatically assume |kUsesMaskFilter_|.
-  static constexpr int kIsFilledGeometry_ = 1 << 0;
+  // This flag will automatically assume |kUsesMaskFilter|.
+  static constexpr int kIsFilledGeometry = 1 << 0;
 
   // A geometric operation that is defined as a stroke operation
   // regardless of what the current paint Style is set to.
-  // This flag will automatically assume |kUsesMaskFilter_|.
-  static constexpr int kIsStrokedGeometry_ = 1 << 1;
+  // This flag will automatically assume |kUsesMaskFilter|.
+  static constexpr int kIsStrokedGeometry = 1 << 1;
 
   // A geometric operation that may be a stroke or fill operation
   // depending on the current state of the paint Style attribute.
-  // This flag will automatically assume |kUsesMaskFilter_|.
-  static constexpr int kIsDrawnGeometry_ = 1 << 2;
+  // This flag will automatically assume |kUsesMaskFilter|.
+  static constexpr int kIsDrawnGeometry = 1 << 2;
 
-  static constexpr int kIsAnyGeometryMask_ =  //
-      kIsFilledGeometry_ |                    //
-      kIsStrokedGeometry_ |                   //
-      kIsDrawnGeometry_;
+  static constexpr int kIsAnyGeometryMask =  //
+      kIsFilledGeometry |                    //
+      kIsStrokedGeometry |                   //
+      kIsDrawnGeometry;
 
   // A primitive that floods the surface (or clip) with no
   // natural bounds, such as |drawColor| or |drawPaint|.
-  static constexpr int kFloodsSurface_ = 1 << 3;
+  static constexpr int kFloodsSurface = 1 << 3;
 
-  static constexpr int kMayHaveCaps_ = 1 << 4;
-  static constexpr int kMayHaveJoins_ = 1 << 5;
-  static constexpr int kButtCapIsSquare_ = 1 << 6;
+  static constexpr int kMayHaveCaps = 1 << 4;
+  static constexpr int kMayHaveJoins = 1 << 5;
+  static constexpr int kButtCapIsSquare = 1 << 6;
 
   // A geometric operation which has a path that might have
   // end caps that are not rectilinear which means that square
@@ -62,7 +62,7 @@ class DisplayListFlags {
   // diagonal end caps. |drawLine| might have diagonal end
   // caps depending on the angle of the line, and more likely
   // |drawPath| will often have such end caps.
-  static constexpr int kMayHaveDiagonalCaps_ = 1 << 7;
+  static constexpr int kMayHaveDiagonalCaps = 1 << 7;
 
   // A geometric operation which has joined vertices that are
   // not guaranteed to be smooth (angles of incoming and outgoing)
@@ -73,23 +73,23 @@ class DisplayListFlags {
   // |drawRect|, |drawOval| and |drawRRect| all have well
   // behaved joins, but |drawPath| might have joins that cause
   // mitered extensions outside the pre-transformed bounding box.
-  static constexpr int kMayHaveAcuteJoins_ = 1 << 8;
+  static constexpr int kMayHaveAcuteJoins = 1 << 8;
 
-  static constexpr int kAnySpecialGeometryMask_ =           //
-      kMayHaveCaps_ | kMayHaveJoins_ | kButtCapIsSquare_ |  //
-      kMayHaveDiagonalCaps_ | kMayHaveAcuteJoins_;
+  static constexpr int kAnySpecialGeometryMask =         //
+      kMayHaveCaps | kMayHaveJoins | kButtCapIsSquare |  //
+      kMayHaveDiagonalCaps | kMayHaveAcuteJoins;
 
   // clang-format off
-  static constexpr int kUsesAntiAlias_       = 1 << 10;
-  static constexpr int kUsesDither_          = 1 << 11;
-  static constexpr int kUsesAlpha_           = 1 << 12;
-  static constexpr int kUsesColor_           = 1 << 13;
-  static constexpr int kUsesBlend_           = 1 << 14;
-  static constexpr int kUsesShader_          = 1 << 15;
-  static constexpr int kUsesColorFilter_     = 1 << 16;
-  static constexpr int kUsesPathEffect_      = 1 << 17;
-  static constexpr int kUsesMaskFilter_      = 1 << 18;
-  static constexpr int kUsesImageFilter_     = 1 << 19;
+  static constexpr int kUsesAntiAlias       = 1 << 10;
+  static constexpr int kUsesDither          = 1 << 11;
+  static constexpr int kUsesAlpha           = 1 << 12;
+  static constexpr int kUsesColor           = 1 << 13;
+  static constexpr int kUsesBlend           = 1 << 14;
+  static constexpr int kUsesShader          = 1 << 15;
+  static constexpr int kUsesColorFilter     = 1 << 16;
+  static constexpr int kUsesPathEffect      = 1 << 17;
+  static constexpr int kUsesMaskFilter      = 1 << 18;
+  static constexpr int kUsesImageFilter     = 1 << 19;
 
   // Some ops have an optional paint argument. If the version
   // stored in the DisplayList ignores the paint, but there
@@ -98,13 +98,13 @@ class DisplayListFlags {
   // a default paint object can be constructed when rendering
   // the op to carry information imposed from outside the
   // DisplayList (for example, the opacity override).
-  static constexpr int kIgnoresPaint_        = 1 << 30;
+  static constexpr int kIgnoresPaint        = 1 << 30;
   // clang-format on
 
-  static constexpr int kAnyAttributeMask_ =  //
-      kUsesAntiAlias_ | kUsesDither_ | kUsesAlpha_ | kUsesColor_ | kUsesBlend_ |
-      kUsesShader_ | kUsesColorFilter_ | kUsesPathEffect_ | kUsesMaskFilter_ |
-      kUsesImageFilter_;
+  static constexpr int kAnyAttributeMask =  //
+      kUsesAntiAlias | kUsesDither | kUsesAlpha | kUsesColor | kUsesBlend |
+      kUsesShader | kUsesColorFilter | kUsesPathEffect | kUsesMaskFilter |
+      kUsesImageFilter;
 };
 
 class DisplayListFlagsBase : protected DisplayListFlags {
@@ -126,21 +126,21 @@ class DisplayListFlagsBase : protected DisplayListFlags {
 class DisplayListSpecialGeometryFlags : DisplayListFlagsBase {
  public:
   /// The geometry may have segments that end without closing the path.
-  constexpr bool may_have_end_caps() const { return has_any(kMayHaveCaps_); }
+  constexpr bool may_have_end_caps() const { return has_any(kMayHaveCaps); }
 
   /// The geometry may have segments connect non-continuously.
-  constexpr bool may_have_joins() const { return has_any(kMayHaveJoins_); }
+  constexpr bool may_have_joins() const { return has_any(kMayHaveJoins); }
 
   /// Mainly for drawPoints(PointMode) where Butt caps are rendered as squares.
   constexpr bool butt_cap_becomes_square() const {
-    return has_any(kButtCapIsSquare_);
+    return has_any(kButtCapIsSquare);
   }
 
   /// The geometry may have segments that end on a diagonal
   /// such that their end caps extend further than the default
   /// |strokeWidth * 0.5| margin around the geometry.
   constexpr bool may_have_diagonal_caps() const {
-    return has_any(kMayHaveDiagonalCaps_);
+    return has_any(kMayHaveDiagonalCaps);
   }
 
   /// The geometry may have segments that meet at vertices at
@@ -148,13 +148,13 @@ class DisplayListSpecialGeometryFlags : DisplayListFlagsBase {
   /// further than the default |strokeWidth * 0.5| margin around
   /// the geometry.
   constexpr bool may_have_acute_joins() const {
-    return has_any(kMayHaveAcuteJoins_);
+    return has_any(kMayHaveAcuteJoins);
   }
 
  private:
   explicit constexpr DisplayListSpecialGeometryFlags(int flags)
       : DisplayListFlagsBase(flags) {
-    FML_DCHECK((flags & kAnySpecialGeometryMask_) == flags);
+    FML_DCHECK((flags & kAnySpecialGeometryMask) == flags);
   }
 
   const DisplayListSpecialGeometryFlags with(int extra) const {
@@ -170,19 +170,19 @@ class DisplayListAttributeFlags : DisplayListFlagsBase {
       const DlPathEffect* effect,
       bool is_stroked) const;
 
-  constexpr bool ignores_paint() const { return has_any(kIgnoresPaint_); }
+  constexpr bool ignores_paint() const { return has_any(kIgnoresPaint); }
 
-  constexpr bool applies_anti_alias() const { return has_any(kUsesAntiAlias_); }
-  constexpr bool applies_dither() const { return has_any(kUsesDither_); }
-  constexpr bool applies_color() const { return has_any(kUsesColor_); }
-  constexpr bool applies_alpha() const { return has_any(kUsesAlpha_); }
+  constexpr bool applies_anti_alias() const { return has_any(kUsesAntiAlias); }
+  constexpr bool applies_dither() const { return has_any(kUsesDither); }
+  constexpr bool applies_color() const { return has_any(kUsesColor); }
+  constexpr bool applies_alpha() const { return has_any(kUsesAlpha); }
   constexpr bool applies_alpha_or_color() const {
-    return has_any(kUsesAlpha_ | kUsesColor_);
+    return has_any(kUsesAlpha | kUsesColor);
   }
 
   /// The primitive dynamically determines whether it is a stroke or fill
   /// operation (or both) based on the setting of the |Style| attribute.
-  constexpr bool applies_style() const { return has_any(kIsDrawnGeometry_); }
+  constexpr bool applies_style() const { return has_any(kIsDrawnGeometry); }
   /// The primitive can use any of the stroke attributes, such as
   /// StrokeWidth, StrokeMiter, StrokeCap, or StrokeJoin. This
   /// method will return if the primitive is defined as one that
@@ -193,34 +193,34 @@ class DisplayListAttributeFlags : DisplayListFlagsBase {
   /// the style.
   // bool applies_stroke_attributes() const { return is_stroked(); }
 
-  constexpr bool applies_shader() const { return has_any(kUsesShader_); }
+  constexpr bool applies_shader() const { return has_any(kUsesShader); }
   /// The primitive honors the current DlColorFilter, including
   /// the related attribute InvertColors
   constexpr bool applies_color_filter() const {
-    return has_any(kUsesColorFilter_);
+    return has_any(kUsesColorFilter);
   }
   /// The primitive honors the DlBlendMode
-  constexpr bool applies_blend() const { return has_any(kUsesBlend_); }
+  constexpr bool applies_blend() const { return has_any(kUsesBlend); }
   constexpr bool applies_path_effect() const {
-    return has_any(kUsesPathEffect_);
+    return has_any(kUsesPathEffect);
   }
   /// The primitive honors the DlMaskFilter whether set using the
   /// filter object or using the convenience method |setMaskBlurFilter|
   constexpr bool applies_mask_filter() const {
-    return has_any(kUsesMaskFilter_);
+    return has_any(kUsesMaskFilter);
   }
   constexpr bool applies_image_filter() const {
-    return has_any(kUsesImageFilter_);
+    return has_any(kUsesImageFilter);
   }
 
-  constexpr bool is_geometric() const { return has_any(kIsAnyGeometryMask_); }
-  constexpr bool always_stroked() const { return has_any(kIsStrokedGeometry_); }
+  constexpr bool is_geometric() const { return has_any(kIsAnyGeometryMask); }
+  constexpr bool always_stroked() const { return has_any(kIsStrokedGeometry); }
   constexpr bool is_stroked(DlDrawStyle style = DlDrawStyle::kStroke) const {
-    return (has_any(kIsStrokedGeometry_) ||
-            (style != DlDrawStyle::kFill && has_any(kIsDrawnGeometry_)));
+    return (has_any(kIsStrokedGeometry) ||
+            (style != DlDrawStyle::kFill && has_any(kIsDrawnGeometry)));
   }
 
-  constexpr bool is_flood() const { return has_any(kFloodsSurface_); }
+  constexpr bool is_flood() const { return has_any(kFloodsSurface); }
 
   constexpr bool operator==(DisplayListAttributeFlags const& other) const {
     return flags_ == other.flags_;
@@ -229,15 +229,15 @@ class DisplayListAttributeFlags : DisplayListFlagsBase {
  private:
   explicit constexpr DisplayListAttributeFlags(int flags)
       : DisplayListFlagsBase(flags),
-        special_flags_(flags & kAnySpecialGeometryMask_) {
-    FML_DCHECK((flags & kIsAnyGeometryMask_) == kIsNonGeometric_ ||
-               (flags & kIsAnyGeometryMask_) == kIsFilledGeometry_ ||
-               (flags & kIsAnyGeometryMask_) == kIsStrokedGeometry_ ||
-               (flags & kIsAnyGeometryMask_) == kIsDrawnGeometry_);
-    FML_DCHECK(((flags & kAnyAttributeMask_) == 0) !=
-               ((flags & kIgnoresPaint_) == 0));
-    FML_DCHECK((flags & kIsAnyGeometryMask_) != 0 ||
-               (flags & kAnySpecialGeometryMask_) == 0);
+        special_flags_(flags & kAnySpecialGeometryMask) {
+    FML_DCHECK((flags & kIsAnyGeometryMask) == kIsNonGeometric ||
+               (flags & kIsAnyGeometryMask) == kIsFilledGeometry ||
+               (flags & kIsAnyGeometryMask) == kIsStrokedGeometry ||
+               (flags & kIsAnyGeometryMask) == kIsDrawnGeometry);
+    FML_DCHECK(((flags & kAnyAttributeMask) == 0) !=
+               ((flags & kIgnoresPaint) == 0));
+    FML_DCHECK((flags & kIsAnyGeometryMask) != 0 ||
+               (flags & kAnySpecialGeometryMask) == 0);
   }
 
   constexpr DisplayListAttributeFlags operator+(int extra) const {
@@ -257,171 +257,171 @@ class DisplayListAttributeFlags : DisplayListFlagsBase {
 class DisplayListOpFlags : DisplayListFlags {
  private:
   // Flags common to all primitives that apply colors
-  static constexpr int kBASE_PaintFlags_ = (kUsesDither_ |       //
-                                            kUsesColor_ |        //
-                                            kUsesAlpha_ |        //
-                                            kUsesBlend_ |        //
-                                            kUsesShader_ |       //
-                                            kUsesColorFilter_ |  //
-                                            kUsesImageFilter_);
+  static constexpr int kBasePaintFlags = (kUsesDither |       //
+                                          kUsesColor |        //
+                                          kUsesAlpha |        //
+                                          kUsesBlend |        //
+                                          kUsesShader |       //
+                                          kUsesColorFilter |  //
+                                          kUsesImageFilter);
 
   // Flags common to all primitives that stroke or fill
-  static constexpr int kBASE_StrokeOrFillFlags_ = (kIsDrawnGeometry_ |  //
-                                                   kUsesAntiAlias_ |    //
-                                                   kUsesMaskFilter_ |   //
-                                                   kUsesPathEffect_);
+  static constexpr int kBaseStrokeOrFillFlags = (kIsDrawnGeometry |  //
+                                                 kUsesAntiAlias |    //
+                                                 kUsesMaskFilter |   //
+                                                 kUsesPathEffect);
 
   // Flags common to primitives that stroke geometry
-  static constexpr int kBASE_StrokeFlags_ = (kIsStrokedGeometry_ |  //
-                                             kUsesAntiAlias_ |      //
-                                             kUsesMaskFilter_ |     //
-                                             kUsesPathEffect_);
+  static constexpr int kBaseStrokeFlags = (kIsStrokedGeometry |  //
+                                           kUsesAntiAlias |      //
+                                           kUsesMaskFilter |     //
+                                           kUsesPathEffect);
 
   // Flags common to primitives that render an image with paint attributes
-  static constexpr int kBASE_ImageFlags_ = (kIsNonGeometric_ |   //
-                                            kUsesAlpha_ |        //
-                                            kUsesDither_ |       //
-                                            kUsesBlend_ |        //
-                                            kUsesColorFilter_ |  //
-                                            kUsesImageFilter_);
+  static constexpr int kBaseImageFlags = (kIsNonGeometric |   //
+                                          kUsesAlpha |        //
+                                          kUsesDither |       //
+                                          kUsesBlend |        //
+                                          kUsesColorFilter |  //
+                                          kUsesImageFilter);
 
  public:
   static constexpr DisplayListAttributeFlags kSaveLayerFlags{
-      kIgnoresPaint_  //
+      kIgnoresPaint  //
   };
   static constexpr DisplayListAttributeFlags kSaveLayerWithPaintFlags{
-      kIsNonGeometric_ |   //
-      kUsesAlpha_ |        //
-      kUsesBlend_ |        //
-      kUsesColorFilter_ |  //
-      kUsesImageFilter_    //
+      kIsNonGeometric |   //
+      kUsesAlpha |        //
+      kUsesBlend |        //
+      kUsesColorFilter |  //
+      kUsesImageFilter    //
   };
   static constexpr DisplayListAttributeFlags kDrawColorFlags{
-      kFloodsSurface_ |  //
-      kIgnoresPaint_     //
+      kFloodsSurface |  //
+      kIgnoresPaint     //
   };
   static constexpr DisplayListAttributeFlags kDrawPaintFlags{
-      kBASE_PaintFlags_ |  //
-      kFloodsSurface_      //
+      kBasePaintFlags |  //
+      kFloodsSurface     //
   };
   // Special case flags for horizonal and vertical lines
   static constexpr DisplayListAttributeFlags kDrawHVLineFlags{
-      kBASE_PaintFlags_ |   //
-      kBASE_StrokeFlags_ |  //
-      kMayHaveCaps_         //
+      kBasePaintFlags |   //
+      kBaseStrokeFlags |  //
+      kMayHaveCaps        //
   };
   static constexpr DisplayListAttributeFlags kDrawLineFlags{
-      kDrawHVLineFlags         //
-      + kMayHaveDiagonalCaps_  //
+      kDrawHVLineFlags        //
+      + kMayHaveDiagonalCaps  //
   };
   static constexpr DisplayListAttributeFlags kDrawRectFlags{
-      kBASE_PaintFlags_ |         //
-      kBASE_StrokeOrFillFlags_ |  //
-      kMayHaveJoins_              //
+      kBasePaintFlags |         //
+      kBaseStrokeOrFillFlags |  //
+      kMayHaveJoins             //
   };
   static constexpr DisplayListAttributeFlags kDrawOvalFlags{
-      kBASE_PaintFlags_ |       //
-      kBASE_StrokeOrFillFlags_  //
+      kBasePaintFlags |       //
+      kBaseStrokeOrFillFlags  //
   };
   static constexpr DisplayListAttributeFlags kDrawCircleFlags{
-      kBASE_PaintFlags_ |       //
-      kBASE_StrokeOrFillFlags_  //
+      kBasePaintFlags |       //
+      kBaseStrokeOrFillFlags  //
   };
   static constexpr DisplayListAttributeFlags kDrawRRectFlags{
-      kBASE_PaintFlags_ |       //
-      kBASE_StrokeOrFillFlags_  //
+      kBasePaintFlags |       //
+      kBaseStrokeOrFillFlags  //
   };
   static constexpr DisplayListAttributeFlags kDrawDRRectFlags{
-      kBASE_PaintFlags_ |       //
-      kBASE_StrokeOrFillFlags_  //
+      kBasePaintFlags |       //
+      kBaseStrokeOrFillFlags  //
   };
   static constexpr DisplayListAttributeFlags kDrawPathFlags{
-      kBASE_PaintFlags_ |         //
-      kBASE_StrokeOrFillFlags_ |  //
-      kMayHaveCaps_ |             //
-      kMayHaveDiagonalCaps_ |     //
-      kMayHaveJoins_ |            //
-      kMayHaveAcuteJoins_         //
+      kBasePaintFlags |         //
+      kBaseStrokeOrFillFlags |  //
+      kMayHaveCaps |            //
+      kMayHaveDiagonalCaps |    //
+      kMayHaveJoins |           //
+      kMayHaveAcuteJoins        //
   };
   static constexpr DisplayListAttributeFlags kDrawArcNoCenterFlags{
-      kBASE_PaintFlags_ |         //
-      kBASE_StrokeOrFillFlags_ |  //
-      kMayHaveCaps_ |             //
-      kMayHaveDiagonalCaps_       //
+      kBasePaintFlags |         //
+      kBaseStrokeOrFillFlags |  //
+      kMayHaveCaps |            //
+      kMayHaveDiagonalCaps      //
   };
   static constexpr DisplayListAttributeFlags kDrawArcWithCenterFlags{
-      kBASE_PaintFlags_ |         //
-      kBASE_StrokeOrFillFlags_ |  //
-      kMayHaveJoins_ |            //
-      kMayHaveAcuteJoins_         //
+      kBasePaintFlags |         //
+      kBaseStrokeOrFillFlags |  //
+      kMayHaveJoins |           //
+      kMayHaveAcuteJoins        //
   };
   static constexpr DisplayListAttributeFlags kDrawPointsAsPointsFlags{
-      kBASE_PaintFlags_ |   //
-      kBASE_StrokeFlags_ |  //
-      kMayHaveCaps_ |       //
-      kButtCapIsSquare_     //
+      kBasePaintFlags |   //
+      kBaseStrokeFlags |  //
+      kMayHaveCaps |      //
+      kButtCapIsSquare    //
   };
   static constexpr DisplayListAttributeFlags kDrawPointsAsLinesFlags{
-      kBASE_PaintFlags_ |    //
-      kBASE_StrokeFlags_ |   //
-      kMayHaveCaps_ |        //
-      kMayHaveDiagonalCaps_  //
+      kBasePaintFlags |     //
+      kBaseStrokeFlags |    //
+      kMayHaveCaps |        //
+      kMayHaveDiagonalCaps  //
   };
   // Polygon mode just draws (count-1) separate lines, no joins
   static constexpr DisplayListAttributeFlags kDrawPointsAsPolygonFlags{
-      kBASE_PaintFlags_ |    //
-      kBASE_StrokeFlags_ |   //
-      kMayHaveCaps_ |        //
-      kMayHaveDiagonalCaps_  //
+      kBasePaintFlags |     //
+      kBaseStrokeFlags |    //
+      kMayHaveCaps |        //
+      kMayHaveDiagonalCaps  //
   };
   static constexpr DisplayListAttributeFlags kDrawVerticesFlags{
-      kIsNonGeometric_ |   //
-      kUsesDither_ |       //
-      kUsesAlpha_ |        //
-      kUsesShader_ |       //
-      kUsesBlend_ |        //
-      kUsesColorFilter_ |  //
-      kUsesImageFilter_    //
+      kIsNonGeometric |   //
+      kUsesDither |       //
+      kUsesAlpha |        //
+      kUsesShader |       //
+      kUsesBlend |        //
+      kUsesColorFilter |  //
+      kUsesImageFilter    //
   };
   static constexpr DisplayListAttributeFlags kDrawImageFlags{
-      kIgnoresPaint_  //
+      kIgnoresPaint  //
   };
   static constexpr DisplayListAttributeFlags kDrawImageWithPaintFlags{
-      kBASE_ImageFlags_ |  //
-      kUsesAntiAlias_ |    //
-      kUsesMaskFilter_     //
+      kBaseImageFlags |  //
+      kUsesAntiAlias |   //
+      kUsesMaskFilter    //
   };
   static constexpr DisplayListAttributeFlags kDrawImageRectFlags{
-      kIgnoresPaint_  //
+      kIgnoresPaint  //
   };
   static constexpr DisplayListAttributeFlags kDrawImageRectWithPaintFlags{
-      kBASE_ImageFlags_ |  //
-      kUsesAntiAlias_ |    //
-      kUsesMaskFilter_     //
+      kBaseImageFlags |  //
+      kUsesAntiAlias |   //
+      kUsesMaskFilter    //
   };
   static constexpr DisplayListAttributeFlags kDrawImageNineFlags{
-      kIgnoresPaint_  //
+      kIgnoresPaint  //
   };
   static constexpr DisplayListAttributeFlags kDrawImageNineWithPaintFlags{
-      kBASE_ImageFlags_  //
+      kBaseImageFlags  //
   };
   static constexpr DisplayListAttributeFlags kDrawAtlasFlags{
-      kIgnoresPaint_  //
+      kIgnoresPaint  //
   };
   static constexpr DisplayListAttributeFlags kDrawAtlasWithPaintFlags{
-      kBASE_ImageFlags_  //
+      kBaseImageFlags  //
   };
   static constexpr DisplayListAttributeFlags kDrawDisplayListFlags{
-      kIgnoresPaint_  //
+      kIgnoresPaint  //
   };
   static constexpr DisplayListAttributeFlags kDrawTextBlobFlags{
-      DisplayListAttributeFlags(kBASE_PaintFlags_ |         //
-                                kBASE_StrokeOrFillFlags_ |  //
-                                kMayHaveJoins_)             //
-      - kUsesAntiAlias_                                     //
+      DisplayListAttributeFlags(kBasePaintFlags |         //
+                                kBaseStrokeOrFillFlags |  //
+                                kMayHaveJoins)            //
+      - kUsesAntiAlias                                    //
   };
   static constexpr DisplayListAttributeFlags kDrawShadowFlags{
-      kIgnoresPaint_  //
+      kIgnoresPaint  //
   };
 };
 

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -235,7 +235,7 @@ DEFINE_SET_CLEAR_DLATTR_OP(PathEffect, PathEffect, effect)
 struct SetImageColorSourceOp : DLOp {
   static const auto kType = DisplayListOpType::kSetImageColorSource;
 
-  SetImageColorSourceOp(const DlImageColorSource* source)
+  explicit SetImageColorSourceOp(const DlImageColorSource* source)
       : source(source->image(),
                source->horizontal_tile_mode(),
                source->vertical_tile_mode(),
@@ -254,7 +254,8 @@ struct SetImageColorSourceOp : DLOp {
 struct SetRuntimeEffectColorSourceOp : DLOp {
   static const auto kType = DisplayListOpType::kSetRuntimeEffectColorSource;
 
-  SetRuntimeEffectColorSourceOp(const DlRuntimeEffectColorSource* source)
+  explicit SetRuntimeEffectColorSourceOp(
+      const DlRuntimeEffectColorSource* source)
       : source(source->runtime_effect(),
                source->samplers(),
                source->uniform_data()) {}
@@ -295,7 +296,7 @@ struct SetSceneColorSourceOp : DLOp {
 struct SetSharedImageFilterOp : DLOp {
   static const auto kType = DisplayListOpType::kSetSharedImageFilter;
 
-  SetSharedImageFilterOp(const DlImageFilter* filter)
+  explicit SetSharedImageFilterOp(const DlImageFilter* filter)
       : filter(filter->shared()) {}
 
   const std::shared_ptr<DlImageFilter> filter;
@@ -315,7 +316,7 @@ struct SetSharedImageFilterOp : DLOp {
 struct SaveOpBase : DLOp {
   SaveOpBase() : options(), restore_index(0) {}
 
-  SaveOpBase(const SaveLayerOptions options)
+  explicit SaveOpBase(const SaveLayerOptions& options)
       : options(options), restore_index(0) {}
 
   // options parameter is only used by saveLayer operations, but since
@@ -347,7 +348,7 @@ struct SaveOp final : SaveOpBase {
 struct SaveLayerOp final : SaveOpBase {
   static const auto kType = DisplayListOpType::kSaveLayer;
 
-  explicit SaveLayerOp(const SaveLayerOptions options) : SaveOpBase(options) {}
+  explicit SaveLayerOp(const SaveLayerOptions& options) : SaveOpBase(options) {}
 
   void dispatch(DispatchContext& ctx) const {
     if (save_needed(ctx)) {
@@ -359,7 +360,7 @@ struct SaveLayerOp final : SaveOpBase {
 struct SaveLayerBoundsOp final : SaveOpBase {
   static const auto kType = DisplayListOpType::kSaveLayerBounds;
 
-  SaveLayerBoundsOp(const SaveLayerOptions options, const SkRect& rect)
+  SaveLayerBoundsOp(const SaveLayerOptions& options, const SkRect& rect)
       : SaveOpBase(options), rect(rect) {}
 
   const SkRect rect;
@@ -374,7 +375,7 @@ struct SaveLayerBoundsOp final : SaveOpBase {
 struct SaveLayerBackdropOp final : SaveOpBase {
   static const auto kType = DisplayListOpType::kSaveLayerBackdrop;
 
-  explicit SaveLayerBackdropOp(const SaveLayerOptions options,
+  explicit SaveLayerBackdropOp(const SaveLayerOptions& options,
                                const DlImageFilter* backdrop)
       : SaveOpBase(options), backdrop(backdrop->shared()) {}
 
@@ -396,7 +397,7 @@ struct SaveLayerBackdropOp final : SaveOpBase {
 struct SaveLayerBackdropBoundsOp final : SaveOpBase {
   static const auto kType = DisplayListOpType::kSaveLayerBackdropBounds;
 
-  SaveLayerBackdropBoundsOp(const SaveLayerOptions options,
+  SaveLayerBackdropBoundsOp(const SaveLayerOptions& options,
                             const SkRect& rect,
                             const DlImageFilter* backdrop)
       : SaveOpBase(options), rect(rect), backdrop(backdrop->shared()) {}
@@ -603,11 +604,11 @@ DEFINE_CLIP_SHAPE_OP(RRect, Difference)
   struct Clip##clipop##PathOp final : TransformClipOpBase {              \
     static const auto kType = DisplayListOpType::kClip##clipop##Path;    \
                                                                          \
-    Clip##clipop##PathOp(SkPath path, bool is_aa)                        \
+    Clip##clipop##PathOp(const SkPath& path, bool is_aa)                 \
         : is_aa(is_aa), path(path) {}                                    \
                                                                          \
     const bool is_aa;                                                    \
-    const SkPath path;                                                   \
+    const SkPath& path;                                                  \
                                                                          \
     void dispatch(DispatchContext& ctx) const {                          \
       if (op_needed(ctx)) {                                              \
@@ -689,7 +690,7 @@ DEFINE_DRAW_1ARG_OP(RRect, SkRRect, rrect)
 struct DrawPathOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawPath;
 
-  explicit DrawPathOp(SkPath path) : path(path) {}
+  explicit DrawPathOp(const SkPath& path) : path(path) {}
 
   const SkPath path;
 
@@ -787,7 +788,7 @@ DEFINE_DRAW_POINTS_OP(Polygon, kPolygon);
 struct DrawVerticesOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawVertices;
 
-  DrawVerticesOp(DlBlendMode mode) : mode(mode) {}
+  explicit DrawVerticesOp(DlBlendMode mode) : mode(mode) {}
 
   const DlBlendMode mode;
 
@@ -806,14 +807,14 @@ struct DrawVerticesOp final : DrawOpBase {
   struct name##Op final : DrawOpBase {                                   \
     static const auto kType = DisplayListOpType::k##name;                \
                                                                          \
-    name##Op(const sk_sp<DlImage> image,                                 \
+    name##Op(const sk_sp<DlImage>& image,                                \
              const SkPoint& point,                                       \
              DlImageSampling sampling)                                   \
         : point(point), sampling(sampling), image(std::move(image)) {}   \
                                                                          \
     const SkPoint point;                                                 \
     const DlImageSampling sampling;                                      \
-    const sk_sp<DlImage> image;                                          \
+    const sk_sp<DlImage>& image;                                         \
                                                                          \
     void dispatch(DispatchContext& ctx) const {                          \
       if (op_needed(ctx)) {                                              \
@@ -837,7 +838,7 @@ DEFINE_DRAW_IMAGE_OP(DrawImageWithAttr, true)
 struct DrawImageRectOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawImageRect;
 
-  DrawImageRectOp(const sk_sp<DlImage> image,
+  DrawImageRectOp(const sk_sp<DlImage>& image,
                   const SkRect& src,
                   const SkRect& dst,
                   DlImageSampling sampling,
@@ -848,7 +849,7 @@ struct DrawImageRectOp final : DrawOpBase {
         sampling(sampling),
         render_with_attributes(render_with_attributes),
         constraint(constraint),
-        image(std::move(image)) {}
+        image(image) {}
 
   const SkRect src;
   const SkRect dst;
@@ -879,7 +880,7 @@ struct DrawImageRectOp final : DrawOpBase {
   struct name##Op final : DrawOpBase {                                     \
     static const auto kType = DisplayListOpType::k##name;                  \
                                                                            \
-    name##Op(const sk_sp<DlImage> image,                                   \
+    name##Op(const sk_sp<DlImage>& image,                                  \
              const SkIRect& center,                                        \
              const SkRect& dst,                                            \
              DlFilterMode mode)                                            \
@@ -888,7 +889,7 @@ struct DrawImageRectOp final : DrawOpBase {
     const SkIRect center;                                                  \
     const SkRect dst;                                                      \
     const DlFilterMode mode;                                               \
-    const sk_sp<DlImage> image;                                            \
+    const sk_sp<DlImage>& image;                                           \
                                                                            \
     void dispatch(DispatchContext& ctx) const {                            \
       if (op_needed(ctx)) {                                                \
@@ -916,7 +917,7 @@ DEFINE_DRAW_IMAGE_NINE_OP(DrawImageNineWithAttr, true)
 // DlColor list only packs well if the count is even, otherwise there
 // can be 4 unusued bytes at the end.
 struct DrawAtlasBaseOp : DrawOpBase {
-  DrawAtlasBaseOp(const sk_sp<DlImage> atlas,
+  DrawAtlasBaseOp(const sk_sp<DlImage>& atlas,
                   int count,
                   DlBlendMode mode,
                   DlImageSampling sampling,
@@ -927,7 +928,7 @@ struct DrawAtlasBaseOp : DrawOpBase {
         has_colors(has_colors),
         render_with_attributes(render_with_attributes),
         sampling(sampling),
-        atlas(std::move(atlas)) {}
+        atlas(atlas) {}
 
   const int count;
   const uint16_t mode_index;
@@ -959,7 +960,7 @@ struct DrawAtlasBaseOp : DrawOpBase {
 struct DrawAtlasOp final : DrawAtlasBaseOp {
   static const auto kType = DisplayListOpType::kDrawAtlas;
 
-  DrawAtlasOp(const sk_sp<DlImage> atlas,
+  DrawAtlasOp(const sk_sp<DlImage>& atlas,
               int count,
               DlBlendMode mode,
               DlImageSampling sampling,
@@ -1000,7 +1001,7 @@ struct DrawAtlasOp final : DrawAtlasBaseOp {
 struct DrawAtlasCulledOp final : DrawAtlasBaseOp {
   static const auto kType = DisplayListOpType::kDrawAtlasCulled;
 
-  DrawAtlasCulledOp(const sk_sp<DlImage> atlas,
+  DrawAtlasCulledOp(const sk_sp<DlImage>& atlas,
                     int count,
                     DlBlendMode mode,
                     DlImageSampling sampling,
@@ -1044,9 +1045,9 @@ struct DrawAtlasCulledOp final : DrawAtlasBaseOp {
 struct DrawDisplayListOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawDisplayList;
 
-  explicit DrawDisplayListOp(const sk_sp<DisplayList> display_list,
+  explicit DrawDisplayListOp(const sk_sp<DisplayList>& display_list,
                              SkScalar opacity)
-      : opacity(opacity), display_list(std::move(display_list)) {}
+      : opacity(opacity), display_list(display_list) {}
 
   SkScalar opacity;
   const sk_sp<DisplayList> display_list;
@@ -1070,8 +1071,8 @@ struct DrawDisplayListOp final : DrawOpBase {
 struct DrawTextBlobOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawTextBlob;
 
-  DrawTextBlobOp(const sk_sp<SkTextBlob> blob, SkScalar x, SkScalar y)
-      : x(x), y(y), blob(std::move(blob)) {}
+  DrawTextBlobOp(const sk_sp<SkTextBlob>& blob, SkScalar x, SkScalar y)
+      : x(x), y(y), blob(blob) {}
 
   const SkScalar x;
   const SkScalar y;

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -604,11 +604,11 @@ DEFINE_CLIP_SHAPE_OP(RRect, Difference)
   struct Clip##clipop##PathOp final : TransformClipOpBase {              \
     static const auto kType = DisplayListOpType::kClip##clipop##Path;    \
                                                                          \
-    Clip##clipop##PathOp(const SkPath& path, bool is_aa)                 \
+    Clip##clipop##PathOp(SkPath path, bool is_aa)                        \
         : is_aa(is_aa), path(path) {}                                    \
                                                                          \
     const bool is_aa;                                                    \
-    const SkPath& path;                                                  \
+    const SkPath path;                                                   \
                                                                          \
     void dispatch(DispatchContext& ctx) const {                          \
       if (op_needed(ctx)) {                                              \
@@ -807,14 +807,14 @@ struct DrawVerticesOp final : DrawOpBase {
   struct name##Op final : DrawOpBase {                                   \
     static const auto kType = DisplayListOpType::k##name;                \
                                                                          \
-    name##Op(const sk_sp<DlImage>& image,                                \
+    name##Op(const sk_sp<DlImage> image,                                 \
              const SkPoint& point,                                       \
              DlImageSampling sampling)                                   \
         : point(point), sampling(sampling), image(std::move(image)) {}   \
                                                                          \
     const SkPoint point;                                                 \
     const DlImageSampling sampling;                                      \
-    const sk_sp<DlImage>& image;                                         \
+    const sk_sp<DlImage> image;                                          \
                                                                          \
     void dispatch(DispatchContext& ctx) const {                          \
       if (op_needed(ctx)) {                                              \
@@ -838,7 +838,7 @@ DEFINE_DRAW_IMAGE_OP(DrawImageWithAttr, true)
 struct DrawImageRectOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawImageRect;
 
-  DrawImageRectOp(const sk_sp<DlImage>& image,
+  DrawImageRectOp(const sk_sp<DlImage> image,
                   const SkRect& src,
                   const SkRect& dst,
                   DlImageSampling sampling,
@@ -849,7 +849,7 @@ struct DrawImageRectOp final : DrawOpBase {
         sampling(sampling),
         render_with_attributes(render_with_attributes),
         constraint(constraint),
-        image(image) {}
+        image(std::move(image)) {}
 
   const SkRect src;
   const SkRect dst;
@@ -880,7 +880,7 @@ struct DrawImageRectOp final : DrawOpBase {
   struct name##Op final : DrawOpBase {                                     \
     static const auto kType = DisplayListOpType::k##name;                  \
                                                                            \
-    name##Op(const sk_sp<DlImage>& image,                                  \
+    name##Op(const sk_sp<DlImage> image,                                   \
              const SkIRect& center,                                        \
              const SkRect& dst,                                            \
              DlFilterMode mode)                                            \
@@ -889,7 +889,7 @@ struct DrawImageRectOp final : DrawOpBase {
     const SkIRect center;                                                  \
     const SkRect dst;                                                      \
     const DlFilterMode mode;                                               \
-    const sk_sp<DlImage>& image;                                           \
+    const sk_sp<DlImage> image;                                            \
                                                                            \
     void dispatch(DispatchContext& ctx) const {                            \
       if (op_needed(ctx)) {                                                \

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -604,7 +604,7 @@ DEFINE_CLIP_SHAPE_OP(RRect, Difference)
   struct Clip##clipop##PathOp final : TransformClipOpBase {              \
     static const auto kType = DisplayListOpType::kClip##clipop##Path;    \
                                                                          \
-    Clip##clipop##PathOp(SkPath path, bool is_aa)                        \
+    Clip##clipop##PathOp(const SkPath& path, bool is_aa)                 \
         : is_aa(is_aa), path(path) {}                                    \
                                                                          \
     const bool is_aa;                                                    \
@@ -807,7 +807,7 @@ struct DrawVerticesOp final : DrawOpBase {
   struct name##Op final : DrawOpBase {                                   \
     static const auto kType = DisplayListOpType::k##name;                \
                                                                          \
-    name##Op(const sk_sp<DlImage> image,                                 \
+    name##Op(const sk_sp<DlImage>& image,                                \
              const SkPoint& point,                                       \
              DlImageSampling sampling)                                   \
         : point(point), sampling(sampling), image(std::move(image)) {}   \
@@ -838,7 +838,7 @@ DEFINE_DRAW_IMAGE_OP(DrawImageWithAttr, true)
 struct DrawImageRectOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawImageRect;
 
-  DrawImageRectOp(const sk_sp<DlImage> image,
+  DrawImageRectOp(const sk_sp<DlImage>& image,
                   const SkRect& src,
                   const SkRect& dst,
                   DlImageSampling sampling,
@@ -849,7 +849,7 @@ struct DrawImageRectOp final : DrawOpBase {
         sampling(sampling),
         render_with_attributes(render_with_attributes),
         constraint(constraint),
-        image(std::move(image)) {}
+        image(image) {}
 
   const SkRect src;
   const SkRect dst;
@@ -880,7 +880,7 @@ struct DrawImageRectOp final : DrawOpBase {
   struct name##Op final : DrawOpBase {                                     \
     static const auto kType = DisplayListOpType::k##name;                  \
                                                                            \
-    name##Op(const sk_sp<DlImage> image,                                   \
+    name##Op(const sk_sp<DlImage>& image,                                  \
              const SkIRect& center,                                        \
              const SkRect& dst,                                            \
              DlFilterMode mode)                                            \

--- a/display_list/effects/dl_image_filter.h
+++ b/display_list/effects/dl_image_filter.h
@@ -592,7 +592,7 @@ class DlColorFilterImageFilter final : public DlImageFilter {
       : DlColorFilterImageFilter(&filter) {}
 
   static std::shared_ptr<DlImageFilter> Make(
-      std::shared_ptr<const DlColorFilter> filter) {
+      const std::shared_ptr<const DlColorFilter>& filter) {
     if (filter) {
       return std::make_shared<DlColorFilterImageFilter>(filter);
     }

--- a/display_list/skia/dl_sk_paint_dispatcher.h
+++ b/display_list/skia/dl_sk_paint_dispatcher.h
@@ -15,7 +15,7 @@ namespace flutter {
 // which can be accessed at any time via paint().
 class DlSkPaintDispatchHelper : public virtual DlOpReceiver {
  public:
-  DlSkPaintDispatchHelper(SkScalar opacity = SK_Scalar1)
+  explicit DlSkPaintDispatchHelper(SkScalar opacity = SK_Scalar1)
       : current_color_(SK_ColorBLACK), opacity_(opacity) {
     if (opacity < SK_Scalar1) {
       paint_.setAlphaf(opacity);
@@ -76,7 +76,7 @@ class DlSkPaintDispatchHelper : public virtual DlOpReceiver {
   sk_sp<SkColorFilter> makeColorFilter() const;
 
   struct SaveInfo {
-    SaveInfo(SkScalar opacity) : opacity(opacity) {}
+    explicit SaveInfo(SkScalar opacity) : opacity(opacity) {}
 
     SkScalar opacity;
   };

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -456,11 +456,11 @@ class RenderEnvironment {
   }
 
   static RenderEnvironment Make565(const DlSurfaceProvider* provider) {
-    return RenderEnvironment(provider, PixelFormat::k565_PixelFormat);
+    return RenderEnvironment(provider, PixelFormat::k565PixelFormat);
   }
 
   static RenderEnvironment MakeN32(const DlSurfaceProvider* provider) {
-    return RenderEnvironment(provider, PixelFormat::kN32Premul_PixelFormat);
+    return RenderEnvironment(provider, PixelFormat::kN32PremulPixelFormat);
   }
 
   void init_ref(SkRenderer& sk_renderer,
@@ -1540,7 +1540,7 @@ class CanvasCompareTester {
     // See https://bugs.chromium.org/p/skia/issues/detail?id=14046
     bool no_hairlines =
         testP.is_draw_path() &&
-        env.provider()->backend_type() != BackendType::kSoftware_Backend;
+        env.provider()->backend_type() != BackendType::kSoftwareBackend;
     RenderWith(testP, env, tolerance,
                CaseParameters(
                    "Stroke + defaults",
@@ -2082,10 +2082,10 @@ class CanvasCompareTester {
   }
 
   static int groupOpacityFudgeFactor(const RenderEnvironment& env) {
-    if (env.format() == PixelFormat::k565_PixelFormat) {
+    if (env.format() == PixelFormat::k565PixelFormat) {
       return 9;
     }
-    if (env.provider()->backend_type() == BackendType::kOpenGL_Backend) {
+    if (env.provider()->backend_type() == BackendType::kOpenGlBackend) {
       // OpenGL gets a little fuzzy at times. Still, "within 5" (aka +/-4)
       // for byte samples is not bad, though the other backends give +/-1
       return 5;
@@ -2421,7 +2421,7 @@ class DisplayListCanvasTestBase : public BaseT, protected DisplayListOpFlags {
       return;
     }
     provider->InitializeSurface(kTestWidth, kTestHeight,
-                                PixelFormat::kN32Premul_PixelFormat);
+                                PixelFormat::kN32PremulPixelFormat);
     CanvasCompareTester::kTestProviders.push_back(std::move(provider));
   }
 
@@ -2446,13 +2446,13 @@ class DisplayListCanvasTestBase : public BaseT, protected DisplayListOpFlags {
       }
     }
     if (do_software) {
-      AddProvider(BackendType::kSoftware_Backend, "Software");
+      AddProvider(BackendType::kSoftwareBackend, "Software");
     }
     if (do_opengl) {
-      AddProvider(BackendType::kOpenGL_Backend, "OpenGL");
+      AddProvider(BackendType::kOpenGlBackend, "OpenGL");
     }
     if (do_metal) {
-      AddProvider(BackendType::kMetal_Backend, "Metal");
+      AddProvider(BackendType::kMetalBackend, "Metal");
     }
     std::string providers = "";
     auto begin = CanvasCompareTester::kTestProviders.cbegin();
@@ -3501,7 +3501,7 @@ TEST_F(DisplayListCanvas, SaveLayerConsolidation) {
   std::vector<std::unique_ptr<RenderEnvironment>> environments;
   for (auto& provider : CanvasCompareTester::kTestProviders) {
     auto env = std::make_unique<RenderEnvironment>(
-        provider.get(), PixelFormat::kN32Premul_PixelFormat);
+        provider.get(), PixelFormat::kN32PremulPixelFormat);
     environments.push_back(std::move(env));
   }
 
@@ -3645,7 +3645,7 @@ TEST_F(DisplayListCanvas, MatrixColorFilterModifyTransparencyCheck) {
   std::vector<std::unique_ptr<RenderEnvironment>> environments;
   for (auto& provider : CanvasCompareTester::kTestProviders) {
     auto env = std::make_unique<RenderEnvironment>(
-        provider.get(), PixelFormat::kN32Premul_PixelFormat);
+        provider.get(), PixelFormat::kN32PremulPixelFormat);
     environments.push_back(std::move(env));
   }
 
@@ -3719,7 +3719,7 @@ TEST_F(DisplayListCanvas, MatrixColorFilterOpacityCommuteCheck) {
   std::vector<std::unique_ptr<RenderEnvironment>> environments;
   for (auto& provider : CanvasCompareTester::kTestProviders) {
     auto env = std::make_unique<RenderEnvironment>(
-        provider.get(), PixelFormat::kN32Premul_PixelFormat);
+        provider.get(), PixelFormat::kN32PremulPixelFormat);
     environments.push_back(std::move(env));
   }
 
@@ -3836,7 +3836,7 @@ TEST_F(DisplayListCanvas, BlendColorFilterModifyTransparencyCheck) {
   std::vector<std::unique_ptr<RenderEnvironment>> environments;
   for (auto& provider : CanvasCompareTester::kTestProviders) {
     auto env = std::make_unique<RenderEnvironment>(
-        provider.get(), PixelFormat::kN32Premul_PixelFormat);
+        provider.get(), PixelFormat::kN32PremulPixelFormat);
     environments.push_back(std::move(env));
   }
 
@@ -3898,7 +3898,7 @@ TEST_F(DisplayListCanvas, BlendColorFilterOpacityCommuteCheck) {
   std::vector<std::unique_ptr<RenderEnvironment>> environments;
   for (auto& provider : CanvasCompareTester::kTestProviders) {
     auto env = std::make_unique<RenderEnvironment>(
-        provider.get(), PixelFormat::kN32Premul_PixelFormat);
+        provider.get(), PixelFormat::kN32PremulPixelFormat);
     environments.push_back(std::move(env));
   }
 
@@ -4196,7 +4196,7 @@ class DisplayListNopTest : public DisplayListCanvas {
     for (auto& provider : CanvasCompareTester::kTestProviders) {
       auto result_surface = provider->MakeOffscreenSurface(
           test_image->width(), test_image->height(),
-          DlSurfaceProvider::kN32Premul_PixelFormat);
+          DlSurfaceProvider::kN32PremulPixelFormat);
       SkCanvas* result_canvas = result_surface->sk_surface()->getCanvas();
       result_canvas->clear(SK_ColorTRANSPARENT);
       result_canvas->drawImage(test_image.get(), 0, 0);
@@ -4257,7 +4257,7 @@ class DisplayListNopTest : public DisplayListCanvas {
     sk_paint.setImageFilter(ToSk(image_filter));
     for (auto& provider : CanvasCompareTester::kTestProviders) {
       auto result_surface = provider->MakeOffscreenSurface(
-          w, h, DlSurfaceProvider::kN32Premul_PixelFormat);
+          w, h, DlSurfaceProvider::kN32PremulPixelFormat);
       SkCanvas* result_canvas = result_surface->sk_surface()->getCanvas();
       result_canvas->clear(SK_ColorTRANSPARENT);
       result_canvas->drawImage(test_image_dst_data->image(), 0, 0);

--- a/display_list/testing/dl_test_equality.h
+++ b/display_list/testing/dl_test_equality.h
@@ -25,7 +25,7 @@ static void TestEquals(T& source1, T& source2) {
 }
 
 template <class T>
-static void TestNotEquals(T& source1, T& source2, std::string label) {
+static void TestNotEquals(T& source1, T& source2, const std::string& label) {
   ASSERT_FALSE(source1 == source2) << label;
   ASSERT_FALSE(source2 == source1) << label;
   ASSERT_TRUE(source1 != source2) << label;

--- a/display_list/testing/dl_test_surface_gl.h
+++ b/display_list/testing/dl_test_surface_gl.h
@@ -26,9 +26,9 @@ class DlOpenGLSurfaceProvider : public DlSurfaceProvider {
       size_t height,
       PixelFormat format) const override;
   const std::string backend_name() const override { return "OpenGL"; }
-  BackendType backend_type() const override { return kOpenGL_Backend; }
+  BackendType backend_type() const override { return kOpenGlBackend; }
   bool supports(PixelFormat format) const override {
-    return format == kN32Premul_PixelFormat;
+    return format == kN32PremulPixelFormat;
   }
 
  private:

--- a/display_list/testing/dl_test_surface_metal.cc
+++ b/display_list/testing/dl_test_surface_metal.cc
@@ -28,7 +28,7 @@ class DlMetalSurfaceInstance : public DlSurfaceInstance {
 bool DlMetalSurfaceProvider::InitializeSurface(size_t width,
                                                size_t height,
                                                PixelFormat format) {
-  if (format != kN32Premul_PixelFormat) {
+  if (format != kN32PremulPixelFormat) {
     return false;
   }
   metal_context_ = std::make_unique<TestMetalContext>();

--- a/display_list/testing/dl_test_surface_metal.h
+++ b/display_list/testing/dl_test_surface_metal.h
@@ -26,9 +26,9 @@ class DlMetalSurfaceProvider : public DlSurfaceProvider {
       size_t height,
       PixelFormat format) const override;
   const std::string backend_name() const override { return "Metal"; }
-  BackendType backend_type() const override { return kMetal_Backend; }
+  BackendType backend_type() const override { return kMetalBackend; }
   bool supports(PixelFormat format) const override {
-    return format == kN32Premul_PixelFormat;
+    return format == kN32PremulPixelFormat;
   }
 
  private:

--- a/display_list/testing/dl_test_surface_provider.cc
+++ b/display_list/testing/dl_test_surface_provider.cc
@@ -27,15 +27,15 @@ std::unique_ptr<DlSurfaceProvider> DlSurfaceProvider::Create(
     BackendType backend_type) {
   switch (backend_type) {
 #ifdef ENABLE_SOFTWARE_BENCHMARKS
-    case kSoftware_Backend:
+    case kSoftwareBackend:
       return std::make_unique<DlSoftwareSurfaceProvider>();
 #endif
 #ifdef ENABLE_OPENGL_BENCHMARKS
-    case kOpenGL_Backend:
+    case kOpenGLBackend:
       return std::make_unique<DlOpenGLSurfaceProvider>();
 #endif
 #ifdef ENABLE_METAL_BENCHMARKS
-    case kMetal_Backend:
+    case kMetalBackend:
       return std::make_unique<DlMetalSurfaceProvider>();
 #endif
     default:

--- a/display_list/testing/dl_test_surface_provider.h
+++ b/display_list/testing/dl_test_surface_provider.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_DISPLAY_LIST_TESTING_DL_TEST_SURFACE_PROVIDER_H_
 #define FLUTTER_DISPLAY_LIST_TESTING_DL_TEST_SURFACE_PROVIDER_H_
 
+#include <utility>
+
 #include "flutter/fml/mapping.h"
 #include "flutter/testing/testing.h"
 
@@ -25,7 +27,8 @@ class DlSurfaceInstance {
 
 class DlSurfaceInstanceBase : public DlSurfaceInstance {
  public:
-  DlSurfaceInstanceBase(sk_sp<SkSurface> surface) : surface_(surface) {}
+  explicit DlSurfaceInstanceBase(sk_sp<SkSurface> surface)
+      : surface_(std::move(surface)) {}
   ~DlSurfaceInstanceBase() = default;
 
   sk_sp<SkSurface> sk_surface() const override { return surface_; }
@@ -36,18 +39,14 @@ class DlSurfaceInstanceBase : public DlSurfaceInstance {
 
 class DlSurfaceProvider {
  public:
-  typedef enum { kN32Premul_PixelFormat, k565_PixelFormat } PixelFormat;
-  typedef enum {
-    kSoftware_Backend,
-    kOpenGL_Backend,
-    kMetal_Backend
-  } BackendType;
+  typedef enum { kN32PremulPixelFormat, k565PixelFormat } PixelFormat;
+  typedef enum { kSoftwareBackend, kOpenGlBackend, kMetalBackend } BackendType;
 
   static SkImageInfo MakeInfo(PixelFormat format, int w, int h) {
     switch (format) {
-      case kN32Premul_PixelFormat:
+      case kN32PremulPixelFormat:
         return SkImageInfo::MakeN32Premul(w, h);
-      case k565_PixelFormat:
+      case k565PixelFormat:
         return SkImageInfo::Make(SkISize::Make(w, h), kRGB_565_SkColorType,
                                  kOpaque_SkAlphaType);
     }
@@ -63,12 +62,12 @@ class DlSurfaceProvider {
   virtual bool InitializeSurface(
       size_t width,
       size_t height,
-      PixelFormat format = kN32Premul_PixelFormat) = 0;
+      PixelFormat format = kN32PremulPixelFormat) = 0;
   virtual std::shared_ptr<DlSurfaceInstance> GetPrimarySurface() const = 0;
   virtual std::shared_ptr<DlSurfaceInstance> MakeOffscreenSurface(
       size_t width,
       size_t height,
-      PixelFormat format = kN32Premul_PixelFormat) const = 0;
+      PixelFormat format = kN32PremulPixelFormat) const = 0;
 
   virtual bool Snapshot(std::string& filename) const;
 

--- a/display_list/testing/dl_test_surface_software.h
+++ b/display_list/testing/dl_test_surface_software.h
@@ -26,7 +26,7 @@ class DlSoftwareSurfaceProvider : public DlSurfaceProvider {
       size_t height,
       PixelFormat format) const override;
   const std::string backend_name() const override { return "Software"; }
-  BackendType backend_type() const override { return kSoftware_Backend; }
+  BackendType backend_type() const override { return kSoftwareBackend; }
   bool supports(PixelFormat format) const override { return true; }
 
  private:

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -124,7 +124,7 @@ class DisplayListMatrixClipTracker {
     virtual void resetBounds(const SkRect& cull_rect);
 
    protected:
-    Data(const SkRect& rect) : cull_rect_(rect) {}
+    explicit Data(const SkRect& rect) : cull_rect_(rect) {}
 
     virtual bool has_perspective() const = 0;
 

--- a/fml/log_level.h
+++ b/fml/log_level.h
@@ -16,6 +16,26 @@ constexpr LogSeverity kLogError = 2;
 constexpr LogSeverity kLogFatal = 3;
 constexpr LogSeverity kLogNumSeverities = 4;
 
+// DEPRECATED: Use |kLogInfo|.
+// NOLINTNEXTLINE(readability-identifier-naming)
+constexpr LogSeverity LOG_INFO = kLogInfo;
+
+// DEPRECATED: Use |kLogWarning|.
+// NOLINTNEXTLINE(readability-identifier-naming)
+constexpr LogSeverity LOG_WARNING = kLogWarning;
+
+// DEPRECATED: Use |kLogError|.
+// NOLINTNEXTLINE(readability-identifier-naming)
+constexpr LogSeverity LOG_ERROR = kLogError;
+
+// DEPRECATED: Use |kLogFatal|.
+// NOLINTNEXTLINE(readability-identifier-naming)
+constexpr LogSeverity LOG_FATAL = kLogFatal;
+
+// DEPRECATED: Use |kLogNumSeverities|.
+// NOLINTNEXTLINE(readability-identifier-naming)
+constexpr LogSeverity LOG_NUM_SEVERITIES = kLogNumSeverities;
+
 // One of the Windows headers defines ERROR to 0. This makes the token
 // concatenation in FML_LOG(ERROR) to resolve to LOG_0. We define this back to
 // the appropriate log level.
@@ -29,6 +49,10 @@ const LogSeverity kLogDFatal = kLogError;
 #else
 const LogSeverity kLogDFatal = kLogFatal;
 #endif
+
+// DEPRECATED: Use |kLogDFatal|.
+// NOLINTNEXTLINE(readability-identifier-naming)
+const LogSeverity LOG_DFATAL = kLogDFatal;
 
 }  // namespace fml
 

--- a/fml/log_level.h
+++ b/fml/log_level.h
@@ -17,24 +17,24 @@ constexpr LogSeverity kLogFatal = 3;
 constexpr LogSeverity kLogNumSeverities = 4;
 
 // DEPRECATED: Use |kLogInfo|.
+// Ignoring Clang Tidy because this is used in a very common substitution macro.
 // NOLINTNEXTLINE(readability-identifier-naming)
 constexpr LogSeverity LOG_INFO = kLogInfo;
 
 // DEPRECATED: Use |kLogWarning|.
+// Ignoring Clang Tidy because this is used in a very common substitution macro.
 // NOLINTNEXTLINE(readability-identifier-naming)
 constexpr LogSeverity LOG_WARNING = kLogWarning;
 
 // DEPRECATED: Use |kLogError|.
+// Ignoring Clang Tidy because this is used in a very common substitution macro.
 // NOLINTNEXTLINE(readability-identifier-naming)
 constexpr LogSeverity LOG_ERROR = kLogError;
 
 // DEPRECATED: Use |kLogFatal|.
+// Ignoring Clang Tidy because this is used in a very common substitution macro.
 // NOLINTNEXTLINE(readability-identifier-naming)
 constexpr LogSeverity LOG_FATAL = kLogFatal;
-
-// DEPRECATED: Use |kLogNumSeverities|.
-// NOLINTNEXTLINE(readability-identifier-naming)
-constexpr LogSeverity LOG_NUM_SEVERITIES = kLogNumSeverities;
 
 // One of the Windows headers defines ERROR to 0. This makes the token
 // concatenation in FML_LOG(ERROR) to resolve to LOG_0. We define this back to
@@ -51,6 +51,7 @@ const LogSeverity kLogDFatal = kLogFatal;
 #endif
 
 // DEPRECATED: Use |kLogDFatal|.
+// Ignoring Clang Tidy because this is used in a very common substitution macro.
 // NOLINTNEXTLINE(readability-identifier-naming)
 const LogSeverity LOG_DFATAL = kLogDFatal;
 

--- a/fml/log_level.h
+++ b/fml/log_level.h
@@ -16,21 +16,6 @@ constexpr LogSeverity kLogError = 2;
 constexpr LogSeverity kLogFatal = 3;
 constexpr LogSeverity kLogNumSeverities = 4;
 
-// DEPRECATED: Use |kLogInfo|.
-constexpr LogSeverity LOG_INFO = kLogInfo;
-
-// DEPRECATED: Use |kLogWarning|.
-constexpr LogSeverity LOG_WARNING = kLogWarning;
-
-// DEPRECATED: Use |kLogError|.
-constexpr LogSeverity LOG_ERROR = kLogError;
-
-// DEPRECATED: Use |kLogFatal|.
-constexpr LogSeverity LOG_FATAL = kLogFatal;
-
-// DEPRECATED: Use |kLogNumSeverities|.
-constexpr LogSeverity LOG_NUM_SEVERITIES = kLogNumSeverities;
-
 // One of the Windows headers defines ERROR to 0. This makes the token
 // concatenation in FML_LOG(ERROR) to resolve to LOG_0. We define this back to
 // the appropriate log level.
@@ -44,9 +29,6 @@ const LogSeverity kLogDFatal = kLogError;
 #else
 const LogSeverity kLogDFatal = kLogFatal;
 #endif
-
-// DEPRECATED: Use |kLogDFatal|.
-const LogSeverity LOG_DFATAL = kLogDFatal;
 
 }  // namespace fml
 

--- a/fml/memory/ref_counted_internal.h
+++ b/fml/memory/ref_counted_internal.h
@@ -76,8 +76,8 @@ class RefCountedThreadSafeBase {
   mutable std::atomic_uint_fast32_t ref_count_;
 
 #ifndef NDEBUG
-  mutable bool adoption_required_;
-  mutable bool destruction_started_;
+  mutable bool adoption_required_ = false;
+  mutable bool destruction_started_ = false;
 #endif
 
   FML_DISALLOW_COPY_AND_ASSIGN(RefCountedThreadSafeBase);

--- a/lib/ui/painting/image.h
+++ b/lib/ui/painting/image.h
@@ -39,7 +39,7 @@ class CanvasImage final : public RefCountedDartWrappable<CanvasImage> {
 
   sk_sp<DlImage> image() const { return image_; }
 
-  void set_image(sk_sp<DlImage> image) {
+  void set_image(const sk_sp<DlImage>& image) {
     FML_DCHECK(image->isUIThreadSafe());
     image_ = image;
   }

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -17,16 +17,16 @@ bool DisplayListsEQ_Verbose(const DisplayList* a, const DisplayList* b);
 bool inline DisplayListsEQ_Verbose(const DisplayList& a, const DisplayList& b) {
   return DisplayListsEQ_Verbose(&a, &b);
 }
-bool inline DisplayListsEQ_Verbose(sk_sp<const DisplayList> a,
-                                   sk_sp<const DisplayList> b) {
+bool inline DisplayListsEQ_Verbose(const sk_sp<const DisplayList>& a,
+                                   const sk_sp<const DisplayList>& b) {
   return DisplayListsEQ_Verbose(a.get(), b.get());
 }
 bool DisplayListsNE_Verbose(const DisplayList* a, const DisplayList* b);
 bool inline DisplayListsNE_Verbose(const DisplayList& a, const DisplayList& b) {
   return DisplayListsNE_Verbose(&a, &b);
 }
-bool inline DisplayListsNE_Verbose(sk_sp<const DisplayList> a,
-                                   sk_sp<const DisplayList> b) {
+bool inline DisplayListsNE_Verbose(const sk_sp<const DisplayList>& a,
+                                   const sk_sp<const DisplayList>& b) {
   return DisplayListsNE_Verbose(a.get(), b.get());
 }
 
@@ -52,9 +52,9 @@ extern std::ostream& operator<<(std::ostream& os, const DlImage* image);
 
 class DisplayListStreamDispatcher final : public DlOpReceiver {
  public:
-  DisplayListStreamDispatcher(std::ostream& os,
-                              int cur_indent = 2,
-                              int indent = 2)
+  explicit DisplayListStreamDispatcher(std::ostream& os,
+                                       int cur_indent = 2,
+                                       int indent = 2)
       : os_(os), cur_indent_(cur_indent), indent_(indent) {}
 
   void setAntiAlias(bool aa) override;

--- a/testing/test_metal_context.h
+++ b/testing/test_metal_context.h
@@ -41,7 +41,7 @@ class TestMetalContext {
   void* device_;
   void* command_queue_;
   sk_sp<GrDirectContext> skia_context_;
-  std::mutex textures_mutex;
+  std::mutex textures_mutex_;
   int64_t texture_id_ctr_ = 1;                 // guarded by textures_mutex
   std::map<int64_t, sk_cfp<void*>> textures_;  // guarded by textures_mutex
 };

--- a/testing/test_metal_context.mm
+++ b/testing/test_metal_context.mm
@@ -41,7 +41,7 @@ TestMetalContext::TestMetalContext() {
 }
 
 TestMetalContext::~TestMetalContext() {
-  std::scoped_lock lock(textures_mutex);
+  std::scoped_lock lock(textures_mutex_);
   textures_.clear();
   if (device_) {
     [(__bridge id)device_ release];
@@ -64,7 +64,7 @@ sk_sp<GrDirectContext> TestMetalContext::GetSkiaContext() const {
 }
 
 TestMetalContext::TextureInfo TestMetalContext::CreateMetalTexture(const SkISize& size) {
-  std::scoped_lock lock(textures_mutex);
+  std::scoped_lock lock(textures_mutex_);
   auto texture_descriptor = fml::scoped_nsobject{
       [[MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
                                                           width:size.width()
@@ -100,7 +100,7 @@ TestMetalContext::TextureInfo TestMetalContext::CreateMetalTexture(const SkISize
 
 // Don't remove the texture from the map here.
 bool TestMetalContext::Present(int64_t texture_id) {
-  std::scoped_lock lock(textures_mutex);
+  std::scoped_lock lock(textures_mutex_);
   if (textures_.find(texture_id) == textures_.end()) {
     return false;
   } else {
@@ -109,7 +109,7 @@ bool TestMetalContext::Present(int64_t texture_id) {
 }
 
 TestMetalContext::TextureInfo TestMetalContext::GetTextureInfo(int64_t texture_id) {
-  std::scoped_lock lock(textures_mutex);
+  std::scoped_lock lock(textures_mutex_);
   if (textures_.find(texture_id) == textures_.end()) {
     FML_CHECK(false) << "Invalid texture id: " << texture_id;
     return {.texture_id = -1, .texture = nullptr};


### PR DESCRIPTION
More work towards https://github.com/flutter/flutter/issues/134969.

I decided not to touch the `LOG_X` variables since they are just used in macro expansion.