### PR TITLE
Remove opacity layer dcheck.

### DIFF
--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -36,8 +36,6 @@ void OpacityLayer::Diff(DiffContext* context, const Layer* old_layer) {
 }
 
 void OpacityLayer::Preroll(PrerollContext* context) {
-  FML_DCHECK(!layers().empty());  // We can't be a leaf.
-
   auto mutator = context->state_stack.save();
   mutator.translate(offset_);
   mutator.applyOpacity(SkRect(), DlColor::toOpacity(alpha_));

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -27,14 +27,6 @@ namespace testing {
 using OpacityLayerTest = LayerTest;
 
 #ifndef NDEBUG
-TEST_F(OpacityLayerTest, LeafLayer) {
-  auto layer =
-      std::make_shared<OpacityLayer>(SK_AlphaOPAQUE, SkPoint::Make(0.0f, 0.0f));
-
-  EXPECT_DEATH_IF_SUPPORTED(layer->Preroll(preroll_context()),
-                            "\\!layers\\(\\)\\.empty\\(\\)");
-}
-
 TEST_F(OpacityLayerTest, PaintingEmptyLayerDies) {
   auto mock_layer = std::make_shared<MockLayer>(SkPath());
   auto layer =


### PR DESCRIPTION
In https://github.com/flutter/flutter/issues/132849 it was found that rendering happens fine when this dcheck is removed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
