### PR TITLE
Revert #46131, don't store `vkImage`, reset `vkComandPool` synchronously

### DIFF
--- a/impeller/renderer/backend/vulkan/surface_context_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.cc
@@ -80,6 +80,7 @@ std::unique_ptr<Surface> SurfaceContextVK::AcquireNextSurface() {
   if (auto allocator = parent_->GetResourceAllocator()) {
     allocator->DidAcquireSurfaceFrame();
   }
+  parent_->GetCommandPoolRecycler()->Dispose();
   return surface;
 }
 

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -470,7 +470,7 @@ bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
     }
   }
 
-  auto task = [&, index, image, current_frame = current_frame_] {
+  auto task = [&, index, current_frame = current_frame_] {
     auto context_strong = context_.lock();
     if (!context_strong) {
       return;

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -424,13 +424,6 @@ bool SwapchainImplVK::Present(const std::shared_ptr<SwapchainImageVK>& image,
   //----------------------------------------------------------------------------
   /// Transition the image to color-attachment-optimal.
   ///
-
-  // Increment the frame count right before allocating the cmd buffer below to
-  // force this to use the next frame's pool. This cmd buffer is completely
-  // untracked, and so we may end up resetting the cmd pool before all buffers
-  // have been collected.
-  context.GetCommandPoolRecycler()->Dispose();
-
   sync->final_cmd_buffer = context.CreateCommandBuffer();
   if (!sync->final_cmd_buffer) {
     return false;


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/135086.

Reverts https://github.com/flutter/engine/pull/46131.

This PR bundles together 3 changes that removes all validation errors on the `macrobenchmark` apps I could manually find:

1. Reverts https://github.com/flutter/engine/pull/46131, which did not fix the original issue.
2. Added `kResetOnBackgroundThread = false`, which drops performance benefits, but doesn't cause threading issues.
3. Stop tracking `image` for Swapchain presentation (was hitting Vulkan assertion errors about acquired images).

/cc @gaaclarke I'd love to talk about how we could run the macrobenchmarks app on CI, with validation errors, after landing.