### PR TITLE
Re-add package tar to DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -471,6 +471,9 @@ deps = {
   'src/third_party/dart/third_party/pkg/string_scanner':
    Var('dart_git') + '/string_scanner.git@da9142cf9809e7e1364144b8193ec60d87f0a4b8',
 
+  'src/third_party/dart/third_party/pkg/tar':
+   Var('dart_git') + '/external/github.com/simolus3/tar.git@3c68cba8e51c569428222b9185469249206172c6',
+
   'src/third_party/dart/third_party/pkg/term_glyph':
    Var('dart_git') + '/term_glyph.git@1b28285a7e818b8e87c4d2119d968c5b36d73c7a',
 


### PR DESCRIPTION
A partial roll of the Dart SDK removed a manually added third-party dependency on package tar, since the roll was to an earlier SDK version that didn't have the new package.

Relanding the package addition from
https://github.com/flutter/engine/pull/46140
that was partially reverted by autoroll
https://github.com/flutter/engine/pull/46176

This should not happen again, because the next Dart SDK dev version should include the new package.

Manual addition of new packages from Dart SDK DEPS to Flutter engine DEPS is needed because the autoroller cannot add new packages.  An early signal that this needs done is failures on the monorepo builders that build the main branches of Dart SDK, Flutter engine, and Flutter framework together. This PR will fix those failures, and allow the next autoroll to succeed.