### PR TITLE
[ios] Fix default assets url

### DIFF
--- a/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterNSBundleUtils.mm
@@ -54,7 +54,7 @@ NSBundle* FLTFrameworkBundleWithIdentifier(NSString* flutterFrameworkBundleID) {
 }
 
 NSString* FLTAssetPath(NSBundle* bundle) {
-  return [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"] ?: @"flutter_assets";
+  return [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"] ?: kDefaultAssetPath;
 }
 
 NSString* FLTAssetsPathFromBundle(NSBundle* bundle) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -102,7 +102,8 @@ FLUTTER_ASSERT_ARC
     id mockBundle = OCMClassMock([NSBundle class]);
     id mockMainBundle = OCMPartialMock([NSBundle mainBundle]);
     NSString* resultAssetsPath = @"path/to/foo/assets";
-    OCMStub([mockBundle pathForResource:@"Frameworks/App.framework/flutter_assets" ofType:@""]).andReturn(nil);
+    OCMStub([mockBundle pathForResource:@"Frameworks/App.framework/flutter_assets" ofType:@""])
+        .andReturn(nil);
     OCMStub([mockMainBundle pathForResource:@"Frameworks/App.framework/flutter_assets" ofType:@""])
         .andReturn(resultAssetsPath);
     NSString* path = FLTAssetsPathFromBundle(mockBundle);
@@ -112,16 +113,102 @@ FLUTTER_ASSERT_ARC
 
 - (void)testFLTAssetPathReturnsTheCorrectValue {
   {
-    // Found asset path in info.plist
+    // Found assets path in info.plist
     id mockBundle = OCMClassMock([NSBundle class]);
     OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(@"foo/assets");
     XCTAssertEqualObjects(FLTAssetPath(mockBundle), @"foo/assets");
   }
   {
-    // No asset path in info.plist, use default value
+    // No assets path in info.plist, use default value
     id mockBundle = OCMClassMock([NSBundle class]);
     OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(nil);
     XCTAssertEqualObjects(FLTAssetPath(mockBundle), kDefaultAssetPath);
+  }
+}
+
+- (void)testLookUpForAssets {
+  {
+    id mockBundle = OCMPartialMock([NSBundle mainBundle]);
+    // Found assets path in info.plist
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(@"foo/assets");
+    NSString* assetsPath = [FlutterDartProject lookupKeyForAsset:@"bar"];
+    // This is testing public API, changing this assert is likely to break plugins.
+    XCTAssertEqualObjects(assetsPath, @"foo/assets/bar");
+    [mockBundle stopMocking];
+  }
+  {
+    id mockBundle = OCMPartialMock([NSBundle mainBundle]);
+    // No assets path in info.plist, use default value
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(nil);
+    NSString* assetsPath = [FlutterDartProject lookupKeyForAsset:@"bar"];
+    // This is testing public API, changing this assert is likely to break plugins.
+    XCTAssertEqualObjects(assetsPath, @"Frameworks/App.framework/flutter_assets/bar");
+    [mockBundle stopMocking];
+  }
+}
+
+- (void)testLookUpForAssetsFromBundle {
+  {
+    id mockBundle = OCMClassMock([NSBundle class]);
+    // Found assets path in info.plist
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(@"foo/assets");
+    NSString* assetsPath = [FlutterDartProject lookupKeyForAsset:@"bar" fromBundle:mockBundle];
+    // This is testing public API, changing this assert is likely to break plugins.
+    XCTAssertEqualObjects(assetsPath, @"foo/assets/bar");
+  }
+  {
+    // No assets path in info.plist, use default value
+    id mockBundle = OCMClassMock([NSBundle class]);
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(nil);
+    NSString* assetsPath = [FlutterDartProject lookupKeyForAsset:@"bar" fromBundle:mockBundle];
+    // This is testing public API, changing this assert is likely to break plugins.
+    XCTAssertEqualObjects(assetsPath, @"Frameworks/App.framework/flutter_assets/bar");
+  }
+}
+
+- (void)testLookUpForAssetsFromPackage {
+  {
+    id mockBundle = OCMPartialMock([NSBundle mainBundle]);
+    // Found assets path in info.plist
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(@"foo/assets");
+    NSString* assetsPath = [FlutterDartProject lookupKeyForAsset:@"bar" fromPackage:@"bar_package"];
+    // This is testing public API, changing this assert is likely to break plugins.
+    XCTAssertEqualObjects(assetsPath, @"foo/assets/packages/bar_package/bar");
+    [mockBundle stopMocking];
+  }
+  {
+    id mockBundle = OCMPartialMock([NSBundle mainBundle]);
+    // No assets path in info.plist, use default value
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(nil);
+    NSString* assetsPath = [FlutterDartProject lookupKeyForAsset:@"bar" fromPackage:@"bar_package"];
+    // This is testing public API, changing this assert is likely to break plugins.
+    XCTAssertEqualObjects(assetsPath,
+                          @"Frameworks/App.framework/flutter_assets/packages/bar_package/bar");
+    [mockBundle stopMocking];
+  }
+}
+
+- (void)testLookUpForAssetsFromPackageFromBundle {
+  {
+    id mockBundle = OCMClassMock([NSBundle class]);
+    // Found assets path in info.plist
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(@"foo/assets");
+    NSString* assetsPath = [FlutterDartProject lookupKeyForAsset:@"bar"
+                                                     fromPackage:@"bar_package"
+                                                      fromBundle:mockBundle];
+    // This is testing public API, changing this assert is likely to break plugins.
+    XCTAssertEqualObjects(assetsPath, @"foo/assets/packages/bar_package/bar");
+  }
+  {
+    id mockBundle = OCMClassMock([NSBundle class]);
+    // No assets path in info.plist, use default value
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(nil);
+    NSString* assetsPath = [FlutterDartProject lookupKeyForAsset:@"bar"
+                                                     fromPackage:@"bar_package"
+                                                      fromBundle:mockBundle];
+    // This is testing public API, changing this assert is likely to break plugins.
+    XCTAssertEqualObjects(assetsPath,
+                          @"Frameworks/App.framework/flutter_assets/packages/bar_package/bar");
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -102,11 +102,26 @@ FLUTTER_ASSERT_ARC
     id mockBundle = OCMClassMock([NSBundle class]);
     id mockMainBundle = OCMPartialMock([NSBundle mainBundle]);
     NSString* resultAssetsPath = @"path/to/foo/assets";
-    OCMStub([mockBundle pathForResource:@"flutter_assets" ofType:@""]).andReturn(nil);
-    OCMStub([mockMainBundle pathForResource:@"flutter_assets" ofType:@""])
+    OCMStub([mockBundle pathForResource:@"Frameworks/App.framework/flutter_assets" ofType:@""]).andReturn(nil);
+    OCMStub([mockMainBundle pathForResource:@"Frameworks/App.framework/flutter_assets" ofType:@""])
         .andReturn(resultAssetsPath);
     NSString* path = FLTAssetsPathFromBundle(mockBundle);
     XCTAssertEqualObjects(path, @"path/to/foo/assets");
+  }
+}
+
+- (void)testFLTAssetPathReturnsTheCorrectValue {
+  {
+    // Found asset path in info.plist
+    id mockBundle = OCMClassMock([NSBundle class]);
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(@"foo/assets");
+    XCTAssertEqualObjects(FLTAssetPath(mockBundle), @"foo/assets");
+  }
+  {
+    // No asset path in info.plist, use default value
+    id mockBundle = OCMClassMock([NSBundle class]);
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"FLTAssetsPath"]).andReturn(nil);
+    XCTAssertEqualObjects(FLTAssetPath(mockBundle), kDefaultAssetPath);
   }
 }
 


### PR DESCRIPTION
When reverting the default asset url code, the old "flutter_assets" path was also copied in https://github.com/flutter/engine/pull/46073
This PR uses the correct URL. Although I'm unsure why the video player test passed before my change for the asset urls. 

I'm going to take another look at it but meanwhile this PR can unblock the roll once rolled into the framework.

fixes of https://github.com/flutter/flutter/issues/135323

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
