### PR TITLE
[Impeller] dont treat non-rects as rects.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1292,15 +1292,14 @@ TEST_P(AiksTest, CanDrawAnOpenPath) {
 TEST_P(AiksTest, CanDrawAnOpenPathThatIsntARect) {
   Canvas canvas;
 
-  // Starting at (50, 50), draw lines from:
-  // 1. (50, height)
-  // 2. (width, height)
-  // 3. (width, 50)
+  // Draw a stroked path that is explicitly closed to verify
+  // It doesn't become a rectangle.
   PathBuilder builder;
   builder.MoveTo({50, 50});
   builder.LineTo({520, 120});
   builder.LineTo({300, 310});
   builder.LineTo({100, 50});
+  builder.Close();
 
   Paint paint;
   paint.color = Color::Red();

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1289,6 +1289,29 @@ TEST_P(AiksTest, CanDrawAnOpenPath) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanDrawAnOpenPathThatIsntARect) {
+  Canvas canvas;
+
+  // Starting at (50, 50), draw lines from:
+  // 1. (50, height)
+  // 2. (width, height)
+  // 3. (width, 50)
+  PathBuilder builder;
+  builder.MoveTo({50, 50});
+  builder.LineTo({520, 120});
+  builder.LineTo({300, 310});
+  builder.LineTo({100, 50});
+
+  Paint paint;
+  paint.color = Color::Red();
+  paint.style = Paint::Style::kStroke;
+  paint.stroke_width = 10;
+
+  canvas.DrawPath(builder.TakePath(), paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 static sk_sp<SkData> OpenFixtureAsSkData(const char* fixture_name) {
   auto mapping = flutter::testing::OpenFixtureAsMapping(fixture_name);
   if (!mapping) {

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -852,7 +852,7 @@ void DlDispatcher::drawPath(const SkPath& path) {
 
   // We can't "optimize" a path into a rectangle if it's open.
   bool closed;
-  if (path.isRect(&rect, &closed); closed) {
+  if (path.isRect(&rect, &closed) && closed) {
     canvas_.DrawRect(skia_conversions::ToRect(rect), paint_);
     return;
   }


### PR DESCRIPTION
We were going down this branch for all closed paths, but we should only be taking it for closed paths that are also rectangles.
