### PR TITLE
In run_tests.py, separate Dart package unit tests from other tests

### DIFF
--- a/ci/builders/linux_android_debug_engine.json
+++ b/ci/builders/linux_android_debug_engine.json
@@ -38,6 +38,7 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for android_jit_release_x86",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "android_jit_release_x86",
@@ -46,8 +47,7 @@
                         "--engine-capture-core-dump",
                         "--android-variant",
                         "android_jit_release_x86"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 }
             ]
         },
@@ -93,6 +93,7 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for android_debug",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "android_debug",
@@ -101,8 +102,7 @@
                         "--engine-capture-core-dump",
                         "--android-variant",
                         "android_debug"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 }
             ]
         },

--- a/ci/builders/linux_fuchsia.json
+++ b/ci/builders/linux_fuchsia.json
@@ -154,7 +154,7 @@
                     "--engine-version",
                     "${REVISION}",
                     "--skip-build",
-		    "--upload"
+                    "--upload"
                 ],
                 "script": "flutter/tools/fuchsia/build_fuchsia_artifacts.py",
                 "language": "python3"

--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -53,14 +53,14 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for host_debug_impeller_vulkan",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_debug_impeller_vulkan",
                         "--type",
                         "impeller-vulkan",
                         "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 }
             ]
         },
@@ -110,14 +110,14 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for host_debug",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_debug",
                         "--type",
-                        "dart",
+                        "dart,dart-host",
                         "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 }
             ]
         },
@@ -158,14 +158,14 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for host_profile",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_profile",
                         "--type",
-                        "dart,engine",
+                        "dart,dart-host,engine",
                         "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 }
             ]
         },
@@ -216,14 +216,14 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for host_release",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_release",
                         "--type",
-                        "dart,engine,benchmarks",
+                        "dart,dart-host,engine,benchmarks",
                         "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 },
                 {
                     "language": "bash",
@@ -233,10 +233,10 @@
                 {
                     "language": "bash",
                     "name": "Upload metrics dry-run",
-		    "parameters": [
+                    "script": "flutter/testing/benchmark/upload_metrics.sh",
+                    "parameters": [
                         "--no-upload"
-                    ],
-                    "script": "flutter/testing/benchmark/upload_metrics.sh"
+                    ]
                 }
             ]
         }

--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -38,15 +38,15 @@
                 {
                     "language": "python3",
                     "name": "test: Host_Tests_for_host_debug_unopt",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_debug_unopt",
                         "--type",
-                        "dart,engine",
+                        "dart,dart-host,engine",
                         "--engine-capture-core-dump",
                         "--use-sanitizer-suppressions"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 },
                 {
                     "name": "analyze_dart_ui",
@@ -104,6 +104,7 @@
                 {
                     "language": "python3",
                     "name": "test: Host Tests for android_debug_unopt",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "android_debug_unopt",
@@ -112,20 +113,19 @@
                         "--engine-capture-core-dump",
                         "--android-variant",
                         "android_debug_unopt"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 },
                 {
                     "language": "python3",
                     "name": "malioc diff",
+                    "script": "flutter/impeller/tools/malioc_diff.py",
                     "parameters": [
                         "--before-relative-to-src",
                         "flutter/impeller/tools/malioc.json",
                         "--after-relative-to-src",
                         "out/android_debug_unopt/gen/malioc",
                         "--print-diff"
-                    ],
-                    "script": "flutter/impeller/tools/malioc_diff.py"
+                    ]
                 }
             ]
         }

--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -9,7 +9,7 @@
                         "out/android_profile/zip_archives/android-arm-profile/darwin-x64.zip"
                     ],
                     "name": "android_profile",
-		    "realm": "production"
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -48,7 +48,7 @@
                         "out/android_profile_arm64/zip_archives/android-arm64-profile/darwin-x64.zip"
                     ],
                     "name": "android_profile_arm64",
-		    "realm": "production"
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -88,7 +88,7 @@
                         "out/android_profile_x64/zip_archives/android-x64-profile/darwin-x64.zip"
                     ],
                     "name": "android_profile_x64",
-		    "realm": "production"
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -128,7 +128,7 @@
                         "out/android_release/zip_archives/android-arm-release/darwin-x64.zip"
                     ],
                     "name": "android_release",
-		    "realm": "production"
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -167,7 +167,7 @@
                         "out/android_release_arm64/zip_archives/android-arm64-release/darwin-x64.zip"
                     ],
                     "name": "android_release_arm64",
-		    "realm": "production"
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [
@@ -207,7 +207,7 @@
                         "out/android_release_x64/zip_archives/android-x64-release/darwin-x64.zip"
                     ],
                     "name": "android_release_x64",
-		    "realm": "production"
+                    "realm": "production"
                 }
             ],
             "drone_dimensions": [

--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -72,7 +72,7 @@
                         "--shard-id=0",
                         "--shard-variants=host_debug,host_debug,host_debug"
                     ],
-		    "max_attempts": 1,
+                    "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
                 }
             ]
@@ -201,7 +201,7 @@
                         "--shard-id=0",
                         "--shard-variants=host_debug"
                     ],
-		    "max_attempts": 1,
+                    "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
                 }
             ]

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -54,14 +54,14 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for host_debug",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_debug",
                         "--type",
-                        "dart,engine",
+                        "dart,dart-host,engine",
                         "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 }
             ]
         },
@@ -113,14 +113,14 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for host_profile",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_profile",
                         "--type",
-                        "dart,engine",
+                        "dart,dart-host,engine",
                         "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 }
             ]
         },
@@ -183,13 +183,13 @@
                 {
                     "language": "python3",
                     "name": "Impeller-golden, dart and engine tests for host_release",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_release",
                         "--type",
-                        "dart,engine,impeller-golden"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                        "dart,dart-host,engine,impeller-golden"
+                    ]
                 }
             ]
         },

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -40,14 +40,14 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for host_debug_unopt",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_debug_unopt",
                         "--type",
-                        "dart,engine",
+                        "dart,dart-host,engine",
                         "--engine-capture-core-dump"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 }
             ]
         },
@@ -96,6 +96,7 @@
                 {
                     "language": "python3",
                     "name": "Tests for ios_debug_sim",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "ios_debug_sim",
@@ -104,8 +105,7 @@
                         "--engine-capture-core-dump",
                         "--ios-variant",
                         "ios_debug_sim"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 },
                 {
                     "name": "Scenario App Integration Tests",
@@ -205,6 +205,7 @@
                 {
                     "language": "python3",
                     "name": "Tests for ios_debug_sim_arm64",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "ios_debug_sim_arm64",
@@ -213,8 +214,7 @@
                         "--engine-capture-core-dump",
                         "--ios-variant",
                         "ios_debug_sim_arm64"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 },
                 {
                     "name": "Scenario App Integration Tests",
@@ -276,6 +276,7 @@
                 {
                     "language": "python3",
                     "name": "Tests for ios_debug_sim_arm64_extension_safe",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "ios_debug_sim_arm64_extension_safe",
@@ -284,8 +285,7 @@
                         "--engine-capture-core-dump",
                         "--ios-variant",
                         "ios_debug_sim_arm64_extension_safe"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 },
                 {
                     "name": "Scenario App Integration Tests",

--- a/ci/builders/standalone/linux_android_emulator.json
+++ b/ci/builders/standalone/linux_android_emulator.json
@@ -25,13 +25,13 @@
             "contexts": [
                 "android_virtual_device"
             ],
-	    "parameters": [
-                "--android-variant",
-                "android_debug_x64",
-                "--type",
-                "android"
-	    ],
-            "script": "flutter/testing/run_tests.py"
+            "script": "flutter/testing/run_tests.py",
+            "parameters": [
+                    "--android-variant",
+                    "android_debug_x64",
+                    "--type",
+                    "android"
+            ]
         },
         {
             "language": "bash",
@@ -39,10 +39,10 @@
             "contexts": [
                 "android_virtual_device"
             ],
-	    "parameters": [
-                "android_debug_x64"
-	    ],
-            "script": "flutter/testing/scenario_app/run_android_tests.sh"
+            "script": "flutter/testing/scenario_app/run_android_tests.sh",
+            "parameters": [
+                    "android_debug_x64"
+            ]
         }
     ]
 }

--- a/ci/builders/standalone/linux_license.json
+++ b/ci/builders/standalone/linux_license.json
@@ -11,7 +11,7 @@
     "tests": [
         {
             "name": "licenses check",
-	    "max_attempts": 1,
+            "max_attempts": 1,
             "script": "flutter/ci/licenses.sh"
         }
     ]

--- a/ci/builders/standalone/windows_unopt.json
+++ b/ci/builders/standalone/windows_unopt.json
@@ -26,14 +26,14 @@
         {
             "language": "python3",
             "name": "test: Host Tests for host_debug_unopt",
+            "script": "flutter/testing/run_tests.py",
             "parameters": [
                 "--variant",
                 "host_debug_unopt",
                 "--type",
                 "engine",
                 "--engine-capture-core-dump"
-            ],
-            "script": "flutter/testing/run_tests.py"
+            ]
         }
     ]
 }

--- a/ci/builders/windows_host_engine.json
+++ b/ci/builders/windows_host_engine.json
@@ -46,13 +46,13 @@
                 {
                     "language": "python3",
                     "name": "Host Tests for host_debug",
+                    "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
                         "host_debug",
                         "--type",
                         "engine"
-                    ],
-                    "script": "flutter/testing/run_tests.py"
+                    ]
                 }
             ]
         },

--- a/tools/pkg/engine_repo_tools/test/engine_repo_tools_test.dart
+++ b/tools/pkg/engine_repo_tools/test/engine_repo_tools_test.dart
@@ -202,20 +202,36 @@ void main() {
 
     try {
       // Create a valid engine.
-      io.Directory(p.join(emptyDir.path, 'src', 'flutter')).createSync(recursive: true);
-      io.Directory(p.join(emptyDir.path, 'src', 'out')).createSync(recursive: true);
+      final io.Directory srcDir = io.Directory(p.join(emptyDir.path, 'src'))
+        ..createSync(recursive: true);
+      final io.Directory flutterDir = io.Directory(p.join(srcDir.path, 'flutter'))
+        ..createSync(recursive: true);
+      final io.Directory outDir = io.Directory(p.join(srcDir.path, 'out'))
+        ..createSync(recursive: true);
 
       // Create two targets in out: host_debug and host_debug_unopt_arm64.
-      io.Directory(p.join(emptyDir.path, 'src', 'out', 'host_debug')).createSync(recursive: true);
-      io.Directory(p.join(emptyDir.path, 'src', 'out', 'host_debug_unopt_arm64')).createSync(recursive: true);
+      final io.Directory hostDebug = io.Directory(p.join(outDir.path, 'host_debug'))
+        ..createSync(recursive: true);
+      final io.Directory hostDebugUnoptArm64 = io.Directory(
+        p.join(outDir.path, 'host_debug_unopt_arm64'),
+      )..createSync(recursive: true);
 
-      // Intentionnally make host_debug a day old to ensure it is not picked.
-      final io.File oldJson = io.File(p.join(emptyDir.path, 'src', 'out', 'host_debug', 'compile_commands.json'))..createSync();
-      oldJson.setLastModifiedSync(oldJson.lastModifiedSync().subtract(const Duration(days: 1)));
+      final Engine engine = TestEngine.withPaths(
+        srcDir: srcDir,
+        flutterDir: flutterDir,
+        outDir: outDir,
+        outputs: <TestOutput>[
+          TestOutput(
+            hostDebug,
+            lastModified: DateTime.utc(2023, 9, 23, 21, 16),
+          ),
+          TestOutput(
+            hostDebugUnoptArm64,
+            lastModified: DateTime.utc(2023, 9, 23, 22, 16),
+          ),
+        ],
+      );
 
-      io.File(p.join(emptyDir.path, 'src', 'out', 'host_debug_unopt_arm64', 'compile_commands.json')).createSync();
-
-      final Engine engine = Engine.fromSrcPath(p.join(emptyDir.path, 'src'));
       final Output? latestOutput = engine.latestOutput();
       expect(latestOutput, isNotNull);
       expect(p.basename(latestOutput!.path.path), 'host_debug_unopt_arm64');


### PR DESCRIPTION
This PR creates a new test type for `run_tests.py` called `dart-host`. The tests remaining under the `dart` type are tests that run in `flutter_tester`. The `dart-host` tests run in the Dart CLI. This allows `run_tests.py` to be simplified a bit, and while doing this I spotted a couple of mistakes that were causing some tests not to run.

This PR also makes a couple of small style fixes to the build config json files, converting tabs to spaces, and moving some "script" fields before the "parameters" fields.