### PR TITLE
[Impeller] allow Vulkan textures to be recycled intra frame.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -171,7 +171,8 @@ ContentContext::ContentContext(
       scene_context_(std::make_shared<scene::SceneContext>(context_)),
 #endif  // IMPELLER_ENABLE_3D
       render_target_cache_(std::make_shared<RenderTargetCache>(
-          context_->GetResourceAllocator())) {
+          context_->GetResourceAllocator(),
+          context_->GetBackendType() == Context::BackendType::kVulkan)) {
   if (!context_ || !context_->IsValid()) {
     return;
   }

--- a/impeller/entity/render_target_cache.h
+++ b/impeller/entity/render_target_cache.h
@@ -11,10 +11,14 @@ namespace impeller {
 /// @brief An implementation of the [RenderTargetAllocator] that caches all
 ///        allocated texture data for one frame.
 ///
-///        Any textures unused after a frame are immediately discarded.
+///        Any textures unused after a frame are immediately discarded. Textures
+///        may be used multiple times in the same frame if it is safe to do
+///        so. Currently, Only the Vulkan backend has correct tracking to use
+///        this feature.
 class RenderTargetCache : public RenderTargetAllocator {
  public:
-  explicit RenderTargetCache(std::shared_ptr<Allocator> allocator);
+  explicit RenderTargetCache(std::shared_ptr<Allocator> allocator,
+                             bool allow_intraframe_use = false);
 
   ~RenderTargetCache() = default;
 
@@ -38,6 +42,7 @@ class RenderTargetCache : public RenderTargetAllocator {
   };
 
   std::vector<TextureData> texture_data_;
+  bool allow_intraframe_use_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RenderTargetCache);
 };


### PR DESCRIPTION
The Vulkan backend is the only backend where we track the complete lifetime of a texture. Because textures shared ptr are kept alive via the fence waiter, I believe that it should be safe to use the shared_ptr use count as an approximation if all of the fences tracking a texture have fired. In this case, it should be safe to use the same texture even if it has already been used that frame.

On Metal/OpenGL backends we don't have as fine grained of tracking so we can't do this safely.