### PR TITLE
[Impeller] fallback to position data if texture coordinates are undefined.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3561,7 +3561,15 @@ TEST_P(AiksTest, ReleasesTextureOnTeardown) {
 
 // Regression test for https://github.com/flutter/flutter/issues/135441 .
 TEST_P(AiksTest, VerticesGeometryUVPositionData) {
-  auto vertices = {Point(0, 0), Point(1, 0), Point(0, 1)};
+  Canvas canvas;
+  Paint paint;
+  auto texture = CreateTextureForFixture("table_mountain_nx.png");
+
+  paint.color_source = ColorSource::MakeImage(texture, Entity::TileMode::kClamp,
+                                              Entity::TileMode::kClamp, {}, {});
+
+  auto vertices = {Point(0, 0), Point(texture->GetSize().width, 0),
+                   Point(0, texture->GetSize().height)};
   std::vector<uint16_t> indices = {0u, 1u, 2u};
   std::vector<Point> texture_coordinates = {};
   std::vector<Color> vertex_colors = {};
@@ -3569,8 +3577,6 @@ TEST_P(AiksTest, VerticesGeometryUVPositionData) {
       vertices, indices, texture_coordinates, vertex_colors,
       Rect::MakeLTRB(0, 0, 1, 1), VerticesGeometry::VertexMode::kTriangleStrip);
 
-  Canvas canvas;
-  Paint paint;
   canvas.DrawVertices(geometry, BlendMode::kSourceOver, paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3559,5 +3559,21 @@ TEST_P(AiksTest, ReleasesTextureOnTeardown) {
                                          "released.";
 }
 
+// Regression test for https://github.com/flutter/flutter/issues/135441 .
+TEST_P(AiksTest, VerticesGeometryUVPositionData) {
+  auto vertices = {Point(0, 0), Point(1, 0), Point(0, 1)};
+  std::vector<uint16_t> indices = {0u, 1u, 2u};
+  std::vector<Point> texture_coordinates = {};
+  std::vector<Color> vertex_colors = {};
+  auto geometry = std::make_shared<VerticesGeometry>(
+      vertices, indices, texture_coordinates, vertex_colors,
+      Rect::MakeLTRB(0, 0, 1, 1), VerticesGeometry::VertexMode::kTriangleStrip);
+
+  Canvas canvas;
+  Paint paint;
+  canvas.DrawVertices(geometry, BlendMode::kSourceOver, paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/geometry/vertices_geometry.cc
+++ b/impeller/entity/geometry/vertices_geometry.cc
@@ -229,11 +229,13 @@ GeometryResult VerticesGeometry::GetPositionUVBuffer(
   auto vertex_count = vertices_.size();
   auto size = texture_coverage.size;
   auto origin = texture_coverage.origin;
+  auto has_texture_coordinates = HasTextureCoordinates();
   std::vector<VS::PerVertexData> vertex_data(vertex_count);
   {
     for (auto i = 0u; i < vertex_count; i++) {
       auto vertex = vertices_[i];
-      auto texture_coord = texture_coordinates_[i];
+      auto texture_coord =
+          has_texture_coordinates ? texture_coordinates_[i] : vertices_[i];
       auto uv =
           effect_transform * Point((texture_coord.x - origin.x) / size.width,
                                    (texture_coord.y - origin.y) / size.height);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/135441

This check was lost in some refactor, I added a test for it.
