### PR TITLE
Revert "Switch goma to reclient for Linux clang_tidy targets (#45898)"

### DIFF
--- a/ci/builders/linux_clang_tidy.json
+++ b/ci/builders/linux_clang_tidy.json
@@ -10,9 +10,7 @@
                 "--android",
                 "--android-cpu",
                 "arm64",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
+                "--no-lto"
             ],
             "name": "android_debug_arm64",
             "ninja": {
@@ -29,9 +27,7 @@
                 "--runtime-mode",
                 "debug",
                 "--prebuilt-dart-sdk",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
+                "--no-lto"
             ],
             "name": "host_debug",
             "ninja": {

--- a/ci/builders/linux_clang_tidy_presubmit.json
+++ b/ci/builders/linux_clang_tidy_presubmit.json
@@ -11,9 +11,7 @@
                 "--android",
                 "--android-cpu",
                 "arm64",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
+                "--no-lto"
             ],
             "ninja": {
                 "config": "android_debug_arm64"
@@ -30,9 +28,7 @@
                 "--runtime-mode",
                 "debug",
                 "--prebuilt-dart-sdk",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
+                "--no-lto"
             ],
             "ninja": {
                 "config": "host_debug"


### PR DESCRIPTION
Clang tidy is now failing on CI: https://flutter-dashboard.appspot.com/#/build?repo=engine&branch=master
