### PR TITLE
[Impeller] Support applying color filters on the CPU for the RRect fast path.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2988,7 +2988,7 @@ TEST_P(AiksTest, CanRenderForegroundAdvancedBlendWithMaskBlur) {
   canvas.ClipRect(Rect::MakeXYWH(100, 150, 400, 400));
   canvas.DrawCircle({400, 400}, 200,
                     {
-                        .color = Color::White(),
+                        .color = Color::Grey(),
                         .color_filter = ColorFilter::MakeBlend(
                             BlendMode::kColor, Color::Green()),
                         .mask_blur_descriptor =

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -117,4 +117,10 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
   return true;
 }
 
+bool SolidRRectBlurContents::ApplyColorFilter(
+    const ColorFilterProc& color_filter_proc) {
+  color_ = color_filter_proc(color_);
+  return true;
+}
+
 }  // namespace impeller

--- a/impeller/entity/contents/solid_rrect_blur_contents.h
+++ b/impeller/entity/contents/solid_rrect_blur_contents.h
@@ -43,6 +43,10 @@ class SolidRRectBlurContents final : public Contents {
               const Entity& entity,
               RenderPass& pass) const override;
 
+  // |Contents|
+  [[nodiscard]] bool ApplyColorFilter(
+      const ColorFilterProc& color_filter_proc) override;
+
  private:
   std::optional<Rect> rect_;
   Scalar corner_radius_;


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/133354.

Fixes and speeds up blended rrect blurs.

Before:

![Screenshot 2023-09-25 at 3 46 47 PM](https://github.com/flutter/engine/assets/919017/2597e4eb-1fe4-402a-8a73-30bee1ea8424)

After:

![Screenshot 2023-09-25 at 3 47 56 PM](https://github.com/flutter/engine/assets/919017/4073c382-f4f1-4cca-a36d-222176f84705)
