### PR TITLE
[Impeller] Fallback to no index buffer when tesselation count is large, split up nonZero contours.

### DIFF
--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "impeller/entity/geometry/fill_path_geometry.h"
+#include "impeller/core/formats.h"
 
 namespace impeller {
 
@@ -48,10 +49,15 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
           size_t indices_count) {
         vertex_buffer.vertex_buffer = host_buffer.Emplace(
             vertices, vertices_count * sizeof(float), alignof(float));
-        vertex_buffer.index_buffer = host_buffer.Emplace(
-            indices, indices_count * sizeof(uint16_t), alignof(uint16_t));
-        vertex_buffer.vertex_count = indices_count;
-        vertex_buffer.index_type = IndexType::k16bit;
+        if (indices != nullptr) {
+          vertex_buffer.index_buffer = host_buffer.Emplace(
+              indices, indices_count * sizeof(uint16_t), alignof(uint16_t));
+          vertex_buffer.vertex_count = indices_count;
+          vertex_buffer.index_type = IndexType::k16bit;
+        } else {
+          vertex_buffer.vertex_count = vertices_count;
+          vertex_buffer.index_type = IndexType::kNone;
+        }
         return true;
       });
   if (tesselation_result != Tessellator::Result::kSuccess) {

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -48,7 +48,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
           const float* vertices, size_t vertices_count, const uint16_t* indices,
           size_t indices_count) {
         vertex_buffer.vertex_buffer = host_buffer.Emplace(
-            vertices, vertices_count * sizeof(float), alignof(float));
+            vertices, vertices_count * sizeof(float) * 2, alignof(float));
         if (indices != nullptr) {
           vertex_buffer.index_buffer = host_buffer.Emplace(
               indices, indices_count * sizeof(uint16_t), alignof(uint16_t));
@@ -56,7 +56,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
           vertex_buffer.index_type = IndexType::k16bit;
         } else {
           vertex_buffer.index_buffer = {};
-          vertex_buffer.vertex_count = indices_count;
+          vertex_buffer.vertex_count = vertices_count;
           vertex_buffer.index_type = IndexType::kNone;
         }
         return true;
@@ -119,7 +119,7 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
       [&vertex_builder, &texture_coverage, &effect_transform](
           const float* vertices, size_t vertices_count, const uint16_t* indices,
           size_t indices_count) {
-        for (auto i = 0u; i < vertices_count; i += 2) {
+        for (auto i = 0u; i < vertices_count * 2; i += 2) {
           VS::PerVertexData data;
           Point vtx = {vertices[i], vertices[i + 1]};
           data.position = vtx;
@@ -128,7 +128,7 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
                                 texture_coverage.size;
           vertex_builder.AppendVertex(data);
         }
-        FML_DCHECK(vertex_builder.GetVertexCount() == vertices_count / 2);
+        FML_DCHECK(vertex_builder.GetVertexCount() == vertices_count);
         if (indices != nullptr) {
           for (auto i = 0u; i < indices_count; i++) {
             vertex_builder.AppendIndex(indices[i]);

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -55,7 +55,8 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
           vertex_buffer.vertex_count = indices_count;
           vertex_buffer.index_type = IndexType::k16bit;
         } else {
-          vertex_buffer.vertex_count = vertices_count;
+          vertex_buffer.index_buffer = {};
+          vertex_buffer.vertex_count = indices_count;
           vertex_buffer.index_type = IndexType::kNone;
         }
         return true;
@@ -128,8 +129,10 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
           vertex_builder.AppendVertex(data);
         }
         FML_DCHECK(vertex_builder.GetVertexCount() == vertices_count / 2);
-        for (auto i = 0u; i < indices_count; i++) {
-          vertex_builder.AppendIndex(indices[i]);
+        if (indices != nullptr) {
+          for (auto i = 0u; i < indices_count; i++) {
+            vertex_builder.AppendIndex(indices[i]);
+          }
         }
         return true;
       });

--- a/impeller/geometry/geometry_benchmarks.cc
+++ b/impeller/geometry/geometry_benchmarks.cc
@@ -35,8 +35,8 @@ static void BM_Polyline(benchmark::State& state, Args&&... args) {
     if (tessellate) {
       tess.Tessellate(
           FillType::kNonZero, polyline,
-          [](const float* vertices, size_t vertices_size,
-             const uint16_t* indices, size_t indices_size) { return true; });
+          [](const float* vertices, size_t vertices_count,
+             const uint16_t* indices, size_t indices_count) { return true; });
     }
   }
   state.counters["SinglePointCount"] = single_point_count;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -404,14 +404,14 @@ TEST_P(RendererTest, CanRenderInstanced) {
                     .AddRect(Rect::MakeXYWH(10, 10, 100, 100))
                     .TakePath()
                     .CreatePolyline(1.0f),
-                [&builder](const float* vertices, size_t vertices_size,
-                           const uint16_t* indices, size_t indices_size) {
-                  for (auto i = 0u; i < vertices_size; i += 2) {
+                [&builder](const float* vertices, size_t vertices_count,
+                           const uint16_t* indices, size_t indices_count) {
+                  for (auto i = 0u; i < vertices_count * 2; i += 2) {
                     VS::PerVertexData data;
                     data.vtx = {vertices[i], vertices[i + 1]};
                     builder.AppendVertex(data);
                   }
-                  for (auto i = 0u; i < indices_size; i++) {
+                  for (auto i = 0u; i < indices_count; i++) {
                     builder.AppendIndex(indices[i]);
                   }
                   return true;

--- a/impeller/tessellator/c/tessellator.cc
+++ b/impeller/tessellator/c/tessellator.cc
@@ -45,14 +45,14 @@ struct Vertices* Tessellate(PathBuilder* builder,
   std::vector<float> points;
   if (Tessellator{}.Tessellate(
           path.GetFillType(), polyline,
-          [&points](const float* vertices, size_t vertices_size,
-                    const uint16_t* indices, size_t indices_size) {
+          [&points](const float* vertices, size_t vertices_count,
+                    const uint16_t* indices, size_t indices_count) {
             // Results are expected to be re-duplicated.
             std::vector<Point> raw_points;
-            for (auto i = 0u; i < vertices_size; i += 2) {
+            for (auto i = 0u; i < vertices_count * 2; i += 2) {
               raw_points.emplace_back(Point{vertices[i], vertices[i + 1]});
             }
-            for (auto i = 0u; i < indices_size; i++) {
+            for (auto i = 0u; i < indices_count; i++) {
               auto point = raw_points[indices[i]];
               points.push_back(point.x);
               points.push_back(point.y);

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -123,22 +123,22 @@ Tessellator::Result Tessellator::Tessellate(
         return Result::kTessellationError;
       }
 
-      int vertexItemCount = tessGetVertexCount(tessellator) * kVertexSize;
+      int vertex_item_count = tessGetVertexCount(tessellator) * kVertexSize;
       auto vertices = tessGetVertices(tessellator);
-      for (int i = 0; i < vertexItemCount; i += 2) {
+      for (int i = 0; i < vertex_item_count; i += 2) {
         points.emplace_back(vertices[i], vertices[i + 1]);
       }
 
-      int elementItemCount = tessGetElementCount(tessellator) * kPolygonSize;
+      int element_item_count = tessGetElementCount(tessellator) * kPolygonSize;
       auto elements = tessGetElements(tessellator);
-      total += elementItemCount;
-      for (int i = 0; i < elementItemCount; i++) {
+      total += element_item_count;
+      for (int i = 0; i < element_item_count; i++) {
         data.emplace_back(points[elements[i]].x);
         data.emplace_back(points[elements[i]].y);
       }
       points.clear();
     }
-    if (!callback(data.data(), data.size(), nullptr, total)) {
+    if (!callback(data.data(), total, nullptr, 0u)) {
       return Result::kInputError;
     }
   } else {
@@ -183,7 +183,7 @@ Tessellator::Result Tessellator::Tessellate(
     // a uint32 index buffer, but this is done for simplicity with the other
     // fast path above.
     if (elementItemCount < 65535) {
-      int vertexItemCount = tessGetVertexCount(tessellator) * kVertexSize;
+      int vertex_item_count = tessGetVertexCount(tessellator);
       auto vertices = tessGetVertices(tessellator);
       auto elements = tessGetElements(tessellator);
 
@@ -193,7 +193,7 @@ Tessellator::Result Tessellator::Tessellate(
       for (int i = 0; i < elementItemCount; i++) {
         indices[i] = static_cast<uint16_t>(elements[i]);
       }
-      if (!callback(vertices, vertexItemCount, indices.data(),
+      if (!callback(vertices, vertex_item_count, indices.data(),
                     elementItemCount)) {
         return Result::kInputError;
       }
@@ -201,19 +201,19 @@ Tessellator::Result Tessellator::Tessellate(
       std::vector<Point> points;
       std::vector<float> data;
 
-      int vertexItemCount = tessGetVertexCount(tessellator) * kVertexSize;
+      int vertex_item_count = tessGetVertexCount(tessellator) * kVertexSize;
       auto vertices = tessGetVertices(tessellator);
-      for (int i = 0; i < vertexItemCount; i += 2) {
+      for (int i = 0; i < vertex_item_count; i += 2) {
         points.emplace_back(vertices[i], vertices[i + 1]);
       }
 
-      int elementItemCount = tessGetElementCount(tessellator) * kPolygonSize;
+      int element_item_count = tessGetElementCount(tessellator) * kPolygonSize;
       auto elements = tessGetElements(tessellator);
       for (int i = 0; i < elementItemCount; i++) {
         data.emplace_back(points[elements[i]].x);
         data.emplace_back(points[elements[i]].y);
       }
-      if (!callback(data.data(), data.size(), nullptr, elementItemCount)) {
+      if (!callback(data.data(), element_item_count, nullptr, 0u)) {
         return Result::kInputError;
       }
     }

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -178,7 +178,7 @@ Tessellator::Result Tessellator::Tessellate(
     // dropping the index buffer entirely. Instead code could instead switch to
     // a uint32 index buffer, but this is done for simplicity with the other
     // fast path above.
-    if (elementItemCount < 65535) {
+    if (elementItemCount < USHRT_MAX) {
       int vertex_item_count = tessGetVertexCount(tessellator);
       auto vertices = tessGetVertices(tessellator);
       auto elements = tessGetElements(tessellator);

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -58,10 +58,6 @@ static int ToTessWindingRule(FillType fill_type) {
   return TESS_WINDING_ODD;
 }
 
-/// @brief An arbitrary value to determine when a multi-contour non-zero fill
-/// path should be split into multiple tessellations.
-static constexpr size_t kMultiContourThreshold = 30u;
-
 Tessellator::Result Tessellator::Tessellate(
     FillType fill_type,
     const Path::Polyline& polyline,

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -171,7 +171,7 @@ Tessellator::Result Tessellator::Tessellate(
       return Result::kTessellationError;
     }
 
-    int elementItemCount = tessGetElementCount(tessellator) * kPolygonSize;
+    int element_item_count = tessGetElementCount(tessellator) * kPolygonSize;
 
     // We default to using a 16bit index buffer, but in cases where we generate
     // more tessellated data than this can contain we need to fall back to

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -144,7 +144,8 @@ Tessellator::Result Tessellator::Tessellate(
       indices.emplace_back(elements[i]);
     }
 
-    if (!callback(reinterpret_cast<float*>(points.data()), points.size(), nullptr, 0u)) {
+    if (!callback(reinterpret_cast<float*>(points.data()), points.size(),
+                  nullptr, 0u)) {
       return Result::kInputError;
     }
   }

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -178,19 +178,19 @@ Tessellator::Result Tessellator::Tessellate(
     // dropping the index buffer entirely. Instead code could instead switch to
     // a uint32 index buffer, but this is done for simplicity with the other
     // fast path above.
-    if (elementItemCount < USHRT_MAX) {
+    if (element_item_count < USHRT_MAX) {
       int vertex_item_count = tessGetVertexCount(tessellator);
       auto vertices = tessGetVertices(tessellator);
       auto elements = tessGetElements(tessellator);
 
       // libtess uses an int index internally due to usage of -1 as a sentinel
       // value.
-      std::vector<uint16_t> indices(elementItemCount);
-      for (int i = 0; i < elementItemCount; i++) {
+      std::vector<uint16_t> indices(element_item_count);
+      for (int i = 0; i < element_item_count; i++) {
         indices[i] = static_cast<uint16_t>(elements[i]);
       }
       if (!callback(vertices, vertex_item_count, indices.data(),
-                    elementItemCount)) {
+                    element_item_count)) {
         return Result::kInputError;
       }
     } else {
@@ -205,7 +205,7 @@ Tessellator::Result Tessellator::Tessellate(
 
       int element_item_count = tessGetElementCount(tessellator) * kPolygonSize;
       auto elements = tessGetElements(tessellator);
-      for (int i = 0; i < elementItemCount; i++) {
+      for (int i = 0; i < element_item_count; i++) {
         data.emplace_back(points[elements[i]].x);
         data.emplace_back(points[elements[i]].y);
       }

--- a/impeller/tessellator/tessellator.h
+++ b/impeller/tessellator/tessellator.h
@@ -44,6 +44,10 @@ class Tessellator {
 
   ~Tessellator();
 
+  /// @brief An arbitrary value to determine when a multi-contour non-zero fill
+  /// path should be split into multiple tessellations.
+  static constexpr size_t kMultiContourThreshold = 30u;
+
   /// @brief A callback that returns the results of the tessellation.
   ///
   ///        The index buffer may not be populated, in which case [indices] will

--- a/impeller/tessellator/tessellator.h
+++ b/impeller/tessellator/tessellator.h
@@ -47,14 +47,11 @@ class Tessellator {
   /// @brief A callback that returns the results of the tessellation.
   ///
   ///        The index buffer may not be populated, in which case [indices] will
-  ///        be nullptr. The [vertices_size] is the size of the vertices array
-  ///        and not the number of vertices, which is usually vertices_size / 2.
-  ///        In cases where the indices is nullptr, vertex_or_index_count will
-  ///        contain the count of indices.
+  ///        be nullptr and indices_count will be 0.
   using BuilderCallback = std::function<bool(const float* vertices,
-                                             size_t vertices_size,
+                                             size_t vertices_count,
                                              const uint16_t* indices,
-                                             size_t vertex_or_index_count)>;
+                                             size_t indices_count)>;
 
   //----------------------------------------------------------------------------
   /// @brief      Generates filled triangles from the polyline. A callback is

--- a/impeller/tessellator/tessellator.h
+++ b/impeller/tessellator/tessellator.h
@@ -44,10 +44,17 @@ class Tessellator {
 
   ~Tessellator();
 
+  /// @brief A callback that returns the results of the tessellation.
+  ///
+  ///        The index buffer may not be populated, in which case [indices] will
+  ///        be nullptr. The [vertices_size] is the size of the vertices array
+  ///        and not the number of vertices, which is usually vertices_size / 2.
+  ///        In cases where the indices is nullptr, vertex_or_index_count will
+  ///        contain the count of indices.
   using BuilderCallback = std::function<bool(const float* vertices,
                                              size_t vertices_size,
                                              const uint16_t* indices,
-                                             size_t indices_size)>;
+                                             size_t vertex_or_index_count)>;
 
   //----------------------------------------------------------------------------
   /// @brief      Generates filled triangles from the polyline. A callback is

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -115,14 +115,15 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
     auto polyline = builder.TakePath(FillType::kOdd).CreatePolyline(1.0f);
     bool no_indices = false;
     size_t indices_count = 0u;
-    Tessellator::Result result = t.Tessellate(
-        FillType::kOdd, polyline,
-        [&no_indices, &indices_count](const float* vertices, size_t vertices_size,
-                      const uint16_t* indices, size_t indices_size) {
-          no_indices = indices == nullptr;
-          indices_count = indices_size;
-          return true;
-        });
+    Tessellator::Result result =
+        t.Tessellate(FillType::kOdd, polyline,
+                     [&no_indices, &indices_count](
+                         const float* vertices, size_t vertices_size,
+                         const uint16_t* indices, size_t indices_size) {
+                       no_indices = indices == nullptr;
+                       indices_count = indices_size;
+                       return true;
+                     });
 
     ASSERT_TRUE(no_indices);
     ASSERT_TRUE(indices_count >= 65535);

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -18,8 +18,8 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
     auto polyline = PathBuilder{}.TakePath().CreatePolyline(1.0f);
     Tessellator::Result result = t.Tessellate(
         FillType::kPositive, polyline,
-        [](const float* vertices, size_t vertices_size, const uint16_t* indices,
-           size_t indices_size) { return true; });
+        [](const float* vertices, size_t vertices_count,
+           const uint16_t* indices, size_t indices_count) { return true; });
 
     ASSERT_EQ(polyline.points.size(), 0u);
     ASSERT_EQ(result, Tessellator::Result::kInputError);
@@ -30,10 +30,11 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
     Tessellator t;
     auto polyline =
         PathBuilder{}.LineTo({0, 0}).TakePath().CreatePolyline(1.0f);
-    Tessellator::Result result = t.Tessellate(
-        FillType::kPositive, polyline,
-        [](const float* vertices, size_t vertices_size, const uint16_t* indices,
-           size_t indices_size) { return true; });
+    Tessellator::Result result =
+        t.Tessellate(FillType::kPositive, polyline,
+                     [](const float* vertices, size_t vertices_count,
+                        const uint16_t* indices_count,
+                        size_t indices_size) { return true; });
     ASSERT_EQ(polyline.points.size(), 1u);
     ASSERT_EQ(result, Tessellator::Result::kSuccess);
   }
@@ -43,10 +44,11 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
     Tessellator t;
     auto polyline =
         PathBuilder{}.AddLine({0, 0}, {0, 1}).TakePath().CreatePolyline(1.0f);
-    Tessellator::Result result = t.Tessellate(
-        FillType::kPositive, polyline,
-        [](const float* vertices, size_t vertices_size, const uint16_t* indices,
-           size_t indices_size) { return true; });
+    Tessellator::Result result =
+        t.Tessellate(FillType::kPositive, polyline,
+                     [](const float* vertices, size_t vertices_count,
+                        const uint16_t* indices_count,
+                        size_t indices_size) { return true; });
 
     ASSERT_EQ(polyline.points.size(), 2u);
     ASSERT_EQ(result, Tessellator::Result::kSuccess);
@@ -61,10 +63,11 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
       builder.AddLine({coord, coord}, {coord + 1, coord + 1});
     }
     auto polyline = builder.TakePath().CreatePolyline(1.0f);
-    Tessellator::Result result = t.Tessellate(
-        FillType::kPositive, polyline,
-        [](const float* vertices, size_t vertices_size, const uint16_t* indices,
-           size_t indices_size) { return true; });
+    Tessellator::Result result =
+        t.Tessellate(FillType::kPositive, polyline,
+                     [](const float* vertices, size_t vertices_count,
+                        const uint16_t* indices_count,
+                        size_t indices_size) { return true; });
 
     ASSERT_EQ(polyline.points.size(), 2000u);
     ASSERT_EQ(result, Tessellator::Result::kSuccess);
@@ -75,10 +78,11 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
     Tessellator t;
     auto polyline =
         PathBuilder{}.AddLine({0, 0}, {0, 1}).TakePath().CreatePolyline(1.0f);
-    Tessellator::Result result = t.Tessellate(
-        FillType::kPositive, polyline,
-        [](const float* vertices, size_t vertices_size, const uint16_t* indices,
-           size_t indices_size) { return false; });
+    Tessellator::Result result =
+        t.Tessellate(FillType::kPositive, polyline,
+                     [](const float* vertices, size_t vertices_count,
+                        const uint16_t* indices_count,
+                        size_t indices_size) { return false; });
 
     ASSERT_EQ(polyline.points.size(), 2u);
     ASSERT_EQ(result, Tessellator::Result::kInputError);
@@ -95,8 +99,8 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
     bool no_indices = false;
     Tessellator::Result result = t.Tessellate(
         FillType::kNonZero, polyline,
-        [&no_indices](const float* vertices, size_t vertices_size,
-                      const uint16_t* indices, size_t indices_size) {
+        [&no_indices](const float* vertices, size_t vertices_count,
+                      const uint16_t* indices, size_t indices_count) {
           no_indices = indices == nullptr;
           return true;
         });
@@ -114,19 +118,18 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
     }
     auto polyline = builder.TakePath(FillType::kOdd).CreatePolyline(1.0f);
     bool no_indices = false;
-    size_t indices_count = 0u;
-    Tessellator::Result result =
-        t.Tessellate(FillType::kOdd, polyline,
-                     [&no_indices, &indices_count](
-                         const float* vertices, size_t vertices_size,
-                         const uint16_t* indices, size_t indices_size) {
-                       no_indices = indices == nullptr;
-                       indices_count = indices_size;
-                       return true;
-                     });
+    size_t count = 0u;
+    Tessellator::Result result = t.Tessellate(
+        FillType::kOdd, polyline,
+        [&no_indices, &count](const float* vertices, size_t vertices_count,
+                              const uint16_t* indices, size_t indices_count) {
+          no_indices = indices == nullptr;
+          count = vertices_count;
+          return true;
+        });
 
     ASSERT_TRUE(no_indices);
-    ASSERT_TRUE(indices_count >= 65535);
+    ASSERT_TRUE(count >= 65535);
     ASSERT_EQ(result, Tessellator::Result::kSuccess);
   }
 }

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -129,7 +129,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
         });
 
     ASSERT_TRUE(no_indices);
-    ASSERT_TRUE(count >= 65535);
+    ASSERT_TRUE(count >= USHRT_MAX);
     ASSERT_EQ(result, Tessellator::Result::kSuccess);
   }
 }

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -92,7 +92,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
   {
     Tessellator t;
     PathBuilder builder = {};
-    for (auto i = 0; i < 60; i++) {
+    for (auto i = 0u; i < Tessellator::kMultiContourThreshold + 1; i++) {
       builder.AddCircle(Point(i, i), 4);
     }
     auto polyline = builder.TakePath().CreatePolyline(1.0f);


### PR DESCRIPTION
See example app in https://github.com/flutter/flutter/issues/135458

Because tessellation is generally nlogn best case (with allocation complexity as well), we can actually make it faster by breaking it into smaller pieces. For non zero fill modes, the contours can be tessellated individually without  losing fidelity.

In cases where this isn't possible, we need to check if we exceed the max uint16 index and fall back to no index buffer.


Fixes https://github.com/flutter/flutter/issues/135458

I Benchmarked signing my name.

### Before

 worst raster time 3+ seconds. Visual glitches

![flutter_03](https://github.com/flutter/engine/assets/8975114/7be57bd2-744f-4f0a-af0a-d2bd4fc9efaf)

### After
worst raster time 30 ms, looks correct (though my signature is still wrong)

![flutter_04](https://github.com/flutter/engine/assets/8975114/1fdf504e-7b4e-447a-8c29-063dd0ff34d0)


