### PR TITLE
[Impeller] Destroy all per-thread command pools tied to a context before deleting the context

### DIFF
--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -113,9 +113,7 @@ ContextVK::~ContextVK() {
   if (device_holder_ && device_holder_->device) {
     [[maybe_unused]] auto result = device_holder_->device->waitIdle();
   }
-  if (command_pool_recycler_) {
-    command_pool_recycler_.get()->Dispose();
-  }
+  CommandPoolRecyclerVK::DestroyThreadLocalPools(this);
 }
 
 Context::BackendType ContextVK::GetBackendType() const {


### PR DESCRIPTION
Vulkan requires that all objects created using a device be destroyed before the device is destroyed.  The CommandPoolRecyclerVK maintains a thread-local map of each context's currently active command pool. Before the context deletes the device, it must force cleanup of all such command pools associated with that context.

This PR reinstates a mechanism that was used prior to the refactoring that introduced command pool recycling.