### PR TITLE
[Impeller] Fix OpenGLES EGL_BAD_ACCESS due to context being current on multiple threads.

### DIFF
--- a/shell/platform/embedder/embedder_surface_gl_impeller.cc
+++ b/shell/platform/embedder/embedder_surface_gl_impeller.cc
@@ -86,13 +86,13 @@ EmbedderSurfaceGLImpeller::EmbedderSurfaceGLImpeller(
     return;
   }
 
-  worker_->SetReactionsAllowedOnCurrentThread(true);
   auto worker_id = impeller_context_->AddReactorWorker(worker_);
   if (!worker_id.has_value()) {
     FML_LOG(ERROR) << "Could not add reactor worker.";
     return;
   }
 
+  gl_dispatch_table_.gl_clear_current_callback();
   FML_LOG(ERROR) << "Using the Impeller rendering backend (OpenGL).";
   valid_ = true;
 }


### PR DESCRIPTION
On Linux setting the EGL context from one thread, then setting from another thread will trigger a EGL_BAD_ACCESS error.  The resolution is to clear the context after use on the thread that set it.

https://github.com/flutter/flutter/issues/130619

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
