### PR TITLE
Declare native wrapper classes in the GPU package as base classes

### DIFF
--- a/lib/gpu/lib/src/context.dart
+++ b/lib/gpu/lib/src/context.dart
@@ -8,7 +8,7 @@ import 'dart:nativewrappers';
 /// A handle to a graphics context. Used to create and manage GPU resources.
 ///
 /// To obtain the default graphics context, use [getContext].
-class GpuContext extends NativeFieldWrapperClass1 {
+base class GpuContext extends NativeFieldWrapperClass1 {
   /// Creates a new graphics context that corresponds to the default Impeller
   /// context.
   GpuContext._createDefault() {

--- a/lib/ui/experiments/gpu.dart
+++ b/lib/ui/experiments/gpu.dart
@@ -147,7 +147,7 @@ class RasterPipeline {}
 /// A handle to a graphics context. Used to create and manage GPU resources.
 ///
 /// To obtain the default graphics context, use [getGpuContext].
-class GpuContext extends NativeFieldWrapperClass1 {
+base class GpuContext extends NativeFieldWrapperClass1 {
   /// Creates a new graphics context that corresponds to the default Impeller
   /// context.
   GpuContext._createDefault() {


### PR DESCRIPTION
This prohibits other implementations of the class interface that can not act as native wrappers.

See https://github.com/flutter/flutter/issues/123756