### PR TITLE
Declare native wrapper classes in Fuchsia packages as base classes

### DIFF
--- a/lib/gpu/lib/src/context.dart
+++ b/lib/gpu/lib/src/context.dart
@@ -8,7 +8,7 @@ import 'dart:nativewrappers';
 /// A handle to a graphics context. Used to create and manage GPU resources.
 ///
 /// To obtain the default graphics context, use [getContext].
-class GpuContext extends NativeFieldWrapperClass1 {
+base class GpuContext extends NativeFieldWrapperClass1 {
   /// Creates a new graphics context that corresponds to the default Impeller
   /// context.
   GpuContext._createDefault() {

--- a/lib/ui/experiments/gpu.dart
+++ b/lib/ui/experiments/gpu.dart
@@ -147,7 +147,7 @@ class RasterPipeline {}
 /// A handle to a graphics context. Used to create and manage GPU resources.
 ///
 /// To obtain the default graphics context, use [getGpuContext].
-class GpuContext extends NativeFieldWrapperClass1 {
+base class GpuContext extends NativeFieldWrapperClass1 {
   /// Creates a new graphics context that corresponds to the default Impeller
   /// context.
   GpuContext._createDefault() {

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
@@ -8,7 +8,7 @@ part of zircon;
 // ignore_for_file: public_member_api_docs
 
 @pragma('vm:entry-point')
-class Handle extends NativeFieldWrapperClass1 {
+base class Handle extends NativeFieldWrapperClass1 {
   // No public constructor - this can only be created from native code.
   @pragma('vm:entry-point')
   Handle._();

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_disposition.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_disposition.dart
@@ -8,7 +8,7 @@ part of zircon;
 // ignore_for_file: public_member_api_docs
 
 @pragma('vm:entry-point')
-class HandleDisposition extends NativeFieldWrapperClass1 {
+base class HandleDisposition extends NativeFieldWrapperClass1 {
   @pragma('vm:entry-point')
   HandleDisposition(int operation, Handle handle, int type, int rights) {
     _constructor(operation, handle, type, rights);

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_waiter.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_waiter.dart
@@ -10,7 +10,7 @@ part of zircon;
 typedef AsyncWaitCallback = void Function(int status, int pending);
 
 @pragma('vm:entry-point')
-class HandleWaiter extends NativeFieldWrapperClass1 {
+base class HandleWaiter extends NativeFieldWrapperClass1 {
   // Private constructor.
   @pragma('vm:entry-point')
   HandleWaiter._();

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
@@ -193,7 +193,7 @@ class MapResult extends _Result {
 }
 
 @pragma('vm:entry-point')
-class System extends NativeFieldWrapperClass1 {
+base class System extends NativeFieldWrapperClass1 {
   // No public constructor - this only has static methods.
   System._();
 


### PR DESCRIPTION
This prohibits other implementations of the class interface that can not act as native wrappers.

See https://github.com/flutter/flutter/issues/123756