### PR TITLE
[Linux] Rename 'set_allow_channel_overflow' to 'set_warns_on_channel_…

### DIFF
--- a/shell/platform/linux/fl_binary_messenger.cc
+++ b/shell/platform/linux/fl_binary_messenger.cc
@@ -359,28 +359,28 @@ static void resize_channel(FlBinaryMessenger* messenger,
                                       nullptr);
 }
 
-// Called when a response is received for the allow channel overflow message.
-static void set_allow_channel_overflowl_response_cb(GObject* object,
-                                                    GAsyncResult* result,
-                                                    gpointer user_data) {
+// Called when a response is received for the warns on overflow message.
+static void set_warns_on_channel_overflow_response_cb(GObject* object,
+                                                      GAsyncResult* result,
+                                                      gpointer user_data) {
   g_autoptr(GError) error = nullptr;
   if (!finish_method(object, result, &error)) {
-    g_warning("Failed to set allow channel overflow: %s", error->message);
+    g_warning("Failed to set warns on channel overflow: %s", error->message);
   }
 }
 
-static void set_allow_channel_overflow(FlBinaryMessenger* messenger,
-                                       const gchar* channel,
-                                       bool allowed) {
+static void set_warns_on_channel_overflow(FlBinaryMessenger* messenger,
+                                          const gchar* channel,
+                                          bool warns) {
   g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
   g_autoptr(FlValue) args = fl_value_new_list();
   fl_value_append_take(args, fl_value_new_string(channel));
-  fl_value_append_take(args, fl_value_new_bool(allowed));
+  fl_value_append_take(args, fl_value_new_bool(!warns));
   g_autoptr(GBytes) message = fl_method_codec_encode_method_call(
       FL_METHOD_CODEC(codec), kOverflowMethod, args, nullptr);
   fl_binary_messenger_send_on_channel(
       messenger, kControlChannelName, message, nullptr,
-      set_allow_channel_overflowl_response_cb, nullptr);
+      set_warns_on_channel_overflow_response_cb, nullptr);
 }
 
 static void fl_binary_messenger_impl_class_init(
@@ -395,7 +395,7 @@ static void fl_binary_messenger_impl_iface_init(
   iface->send_on_channel = send_on_channel;
   iface->send_on_channel_finish = send_on_channel_finish;
   iface->resize_channel = resize_channel;
-  iface->set_allow_channel_overflow = set_allow_channel_overflow;
+  iface->set_warns_on_channel_overflow = set_warns_on_channel_overflow;
 }
 
 static void fl_binary_messenger_impl_init(FlBinaryMessengerImpl* self) {
@@ -481,12 +481,12 @@ G_MODULE_EXPORT void fl_binary_messenger_resize_channel(FlBinaryMessenger* self,
                                                              new_size);
 }
 
-G_MODULE_EXPORT void fl_binary_messenger_set_allow_channel_overflow(
+G_MODULE_EXPORT void fl_binary_messenger_set_warns_on_channel_overflow(
     FlBinaryMessenger* self,
     const gchar* channel,
-    bool allowed) {
+    bool warns) {
   g_return_if_fail(FL_IS_BINARY_MESSENGER(self));
 
-  return FL_BINARY_MESSENGER_GET_IFACE(self)->set_allow_channel_overflow(
-      self, channel, allowed);
+  return FL_BINARY_MESSENGER_GET_IFACE(self)->set_warns_on_channel_overflow(
+      self, channel, warns);
 }

--- a/shell/platform/linux/fl_binary_messenger_test.cc
+++ b/shell/platform/linux/fl_binary_messenger_test.cc
@@ -136,9 +136,9 @@ static void resize_channel(FlBinaryMessenger* messenger,
   // Fake implementation. Do nothing.
 }
 
-static void set_allow_channel_overflow(FlBinaryMessenger* messenger,
-                                       const gchar* channel,
-                                       bool allowed) {
+static void set_warns_on_channel_overflow(FlBinaryMessenger* messenger,
+                                          const gchar* channel,
+                                          bool warns) {
   // Fake implementation. Do nothing.
 }
 
@@ -149,7 +149,7 @@ static void fl_fake_binary_messenger_iface_init(
   iface->send_on_channel = send_on_channel;
   iface->send_on_channel_finish = send_on_channel_finish;
   iface->resize_channel = resize_channel;
-  iface->set_allow_channel_overflow = set_allow_channel_overflow;
+  iface->set_warns_on_channel_overflow = set_warns_on_channel_overflow;
 }
 
 static void fl_fake_binary_messenger_init(FlFakeBinaryMessenger* self) {}
@@ -455,7 +455,7 @@ TEST(FlBinaryMessengerTest, ResizeChannel) {
 }
 
 // Checks if the 'overflow' command is sent and is well-formed.
-TEST(FlBinaryMessengerTest, AllowOverflowChannel) {
+TEST(FlBinaryMessengerTest, WarnsOnOverflowChannel) {
   g_autoptr(FlEngine) engine = make_mock_engine();
   FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
 
@@ -495,8 +495,8 @@ TEST(FlBinaryMessengerTest, AllowOverflowChannel) {
   EXPECT_EQ(error, nullptr);
 
   FlBinaryMessenger* messenger = fl_binary_messenger_new(engine);
-  fl_binary_messenger_set_allow_channel_overflow(messenger, "flutter/test",
-                                                 true);
+  fl_binary_messenger_set_warns_on_channel_overflow(messenger, "flutter/test",
+                                                    false);
 
   EXPECT_TRUE(called);
 }
@@ -542,8 +542,8 @@ TEST(FlBinaryMessengerTest, ControlChannelErrorResponse) {
         return kInvalidArguments;
       }));
 
-  fl_binary_messenger_set_allow_channel_overflow(messenger, "flutter/test",
-                                                 true);
+  fl_binary_messenger_set_warns_on_channel_overflow(messenger, "flutter/test",
+                                                    false);
 
   EXPECT_TRUE(called);
 

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -222,10 +222,10 @@ static void fl_mock_binary_messenger_resize_channel(
   // Mock implementation. Do nothing.
 }
 
-static void fl_mock_binary_messenger_set_allow_channel_overflow(
+static void fl_mock_binary_messenger_set_warns_on_channel_overflow(
     FlBinaryMessenger* messenger,
     const gchar* channel,
-    bool allowed) {
+    bool warns) {
   // Mock implementation. Do nothing.
 }
 
@@ -251,8 +251,8 @@ static void fl_mock_key_binary_messenger_iface_init(
   iface->send_on_channel_finish =
       fl_mock_key_binary_messenger_send_on_channel_finish;
   iface->resize_channel = fl_mock_binary_messenger_resize_channel;
-  iface->set_allow_channel_overflow =
-      fl_mock_binary_messenger_set_allow_channel_overflow;
+  iface->set_warns_on_channel_overflow =
+      fl_mock_binary_messenger_set_warns_on_channel_overflow;
 }
 
 static void fl_mock_key_binary_messenger_init(FlMockKeyBinaryMessenger* self) {}

--- a/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
+++ b/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
@@ -98,9 +98,9 @@ struct _FlBinaryMessengerInterface {
                          const gchar* channel,
                          int64_t new_size);
 
-  void (*set_allow_channel_overflow)(FlBinaryMessenger* messenger,
-                                     const gchar* channel,
-                                     bool allowed);
+  void (*set_warns_on_channel_overflow)(FlBinaryMessenger* messenger,
+                                        const gchar* channel,
+                                        bool warns);
 };
 
 struct _FlBinaryMessengerResponseHandleClass {
@@ -210,19 +210,19 @@ void fl_binary_messenger_resize_channel(FlBinaryMessenger* messenger,
                                         int64_t new_size);
 
 /**
- * fl_binary_messenger_set_allow_channel_overflow:
+ * fl_binary_messenger_set_warns_on_channel_overflow:
  * @messenger: an #FlBinaryMessenger.
  * @channel: channel to be allowed to overflow silently.
- * @allowed: when true the channel is expected to overflow and warning messages
+ * @warns: when false, the channel is expected to overflow and warning messages
  * will not be shown.
  *
  * Sends a message to the control channel asking to allow or disallow a channel
  * to overflow silently.
  */
-void fl_binary_messenger_set_allow_channel_overflow(
+void fl_binary_messenger_set_warns_on_channel_overflow(
     FlBinaryMessenger* messenger,
     const gchar* channel,
-    bool allowed);
+    bool warns);
 
 G_END_DECLS
 

--- a/shell/platform/linux/testing/mock_binary_messenger.cc
+++ b/shell/platform/linux/testing/mock_binary_messenger.cc
@@ -131,14 +131,14 @@ static void fl_mock_binary_messenger_resize_channel(
   self->mock->fl_binary_messenger_resize_channel(messenger, channel, new_size);
 }
 
-static void fl_mock_binary_messenger_set_allow_channel_overflow(
+static void fl_mock_binary_messenger_set_warns_on_channel_overflow(
     FlBinaryMessenger* messenger,
     const gchar* channel,
-    bool allowed) {
+    bool warns) {
   g_return_if_fail(FL_IS_MOCK_BINARY_MESSENGER(messenger));
   FlMockBinaryMessenger* self = FL_MOCK_BINARY_MESSENGER(messenger);
-  self->mock->fl_binary_messenger_set_allow_channel_overflow(messenger, channel,
-                                                             allowed);
+  self->mock->fl_binary_messenger_set_warns_on_channel_overflow(messenger,
+                                                                channel, warns);
 }
 
 static void fl_mock_binary_messenger_iface_init(
@@ -150,8 +150,8 @@ static void fl_mock_binary_messenger_iface_init(
   iface->send_on_channel_finish =
       fl_mock_binary_messenger_send_on_channel_finish;
   iface->resize_channel = fl_mock_binary_messenger_resize_channel;
-  iface->set_allow_channel_overflow =
-      fl_mock_binary_messenger_set_allow_channel_overflow;
+  iface->set_warns_on_channel_overflow =
+      fl_mock_binary_messenger_set_warns_on_channel_overflow;
 }
 
 static void fl_mock_binary_messenger_init(FlMockBinaryMessenger* self) {}

--- a/shell/platform/linux/testing/mock_binary_messenger.h
+++ b/shell/platform/linux/testing/mock_binary_messenger.h
@@ -59,10 +59,10 @@ class MockBinaryMessenger {
                int64_t new_size));
 
   MOCK_METHOD(void,
-              fl_binary_messenger_set_allow_channel_overflow,
+              fl_binary_messenger_set_warns_on_channel_overflow,
               (FlBinaryMessenger * messenger,
                const gchar* channel,
-               bool allowed));
+               bool warns));
 
   bool HasMessageHandler(const gchar* channel) const;
 


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/flutter/engine/pull/44636 which introduces the `set_allow_channel_overflow` function. It renames this function to `set_warns_on_channel_overflow`.

The previous naming was inspired by the framework side implementation.
https://github.com/flutter/engine/blob/93e8901490e78c7ba7e319cce4470d9c6478c6dc/lib/ui/channel_buffers.dart#L574

During the review of the iOS/macOS implementation, https://github.com/flutter/engine/pull/44848#discussion_r1310463864, we agreed that the existing naming is confusing because it implies that overflow will be allowed, but this not the case this function is used to enable/disable error messages when a channel overflows. 

## Related Issue

Follow-up for https://github.com/flutter/flutter/issues/132386.

## Tests

Updates 2 tests.