### PR TITLE
[Android] Rename `allowChannelBufferOverflow` to `setWarnsOnChannelOv…

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
@@ -144,11 +144,11 @@ public final class BasicMessageChannel<T> {
 
   /**
    * Toggles whether the channel should show warning messages when discarding messages due to
-   * overflow. When 'allowed' is true the channel is expected to overflow and warning messages will
+   * overflow. When 'warns' is false the channel is expected to overflow and warning messages will
    * not be shown.
    */
-  public void allowChannelBufferOverflow(boolean allowed) {
-    allowChannelBufferOverflow(messenger, name, allowed);
+  public void setWarnsOnChannelOverflow(boolean warns) {
+    setWarnsOnChannelOverflow(messenger, name, warns);
   }
 
   private static ByteBuffer packetFromEncodedMessage(ByteBuffer message) {
@@ -182,13 +182,13 @@ public final class BasicMessageChannel<T> {
 
   /**
    * Toggles whether the channel should show warning messages when discarding messages due to
-   * overflow. When 'allowed' is true the channel is expected to overflow and warning messages will
+   * overflow. When 'warns' is false the channel is expected to overflow and warning messages will
    * not be shown.
    */
-  public static void allowChannelBufferOverflow(
-      @NonNull BinaryMessenger messenger, @NonNull String channel, boolean allowed) {
+  public static void setWarnsOnChannelOverflow(
+      @NonNull BinaryMessenger messenger, @NonNull String channel, boolean warns) {
     final StandardMethodCodec codec = StandardMethodCodec.INSTANCE;
-    Object[] arguments = {channel, allowed};
+    Object[] arguments = {channel, !warns};
     MethodCall methodCall = new MethodCall("overflow", Arrays.asList(arguments));
     ByteBuffer message = codec.encodeMethodCall(methodCall);
     ByteBuffer packet = packetFromEncodedMessage(message);

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -159,11 +159,11 @@ public class MethodChannel {
 
   /**
    * Toggles whether the channel should show warning messages when discarding messages due to
-   * overflow. When 'allowed' is true the channel is expected to overflow and warning messages will
+   * overflow. When 'warns' is false the channel is expected to overflow and warning messages will
    * not be shown.
    */
-  public void allowChannelBufferOverflow(boolean allowed) {
-    BasicMessageChannel.allowChannelBufferOverflow(messenger, name, allowed);
+  public void setWarnsOnChannelOverflow(boolean warns) {
+    BasicMessageChannel.setWarnsOnChannelOverflow(messenger, name, warns);
   }
 
   /** A handler of incoming method calls. */

--- a/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/common/MethodChannelTest.java
@@ -56,7 +56,7 @@ public class MethodChannelTest {
     String channel = "flutter/test";
     MethodChannel rawChannel = new MethodChannel(dartExecutor, channel);
 
-    rawChannel.allowChannelBufferOverflow(true);
+    rawChannel.setWarnsOnChannelOverflow(false);
 
     // Created from the following Dart code:
     //   MethodCall methodCall = const MethodCall('overflow', ['flutter/test', true]);


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/flutter/engine/pull/44434 which introduces the `allowChannelBufferOverflow` function. It renames this function to `setWarnsOnChannelOverflow`.

The previous naming was inspired by the framework side implementation.
https://github.com/flutter/engine/blob/93e8901490e78c7ba7e319cce4470d9c6478c6dc/lib/ui/channel_buffers.dart#L574

During the review of the iOS/macOS implementation, https://github.com/flutter/engine/pull/44848#discussion_r1310463864, we agreed that the existing naming is confusing because it implies that overflow will be allowed, but this not the case this function is used to enable/disable error messages when a channel overflows. 

## Related Issue

Follow-up for https://github.com/flutter/flutter/issues/132386.

## Tests

Updates 1 test.