### PR TITLE
Don't respond to the `insertionPointColor` selector on iOS 17+

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -943,7 +943,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
       return NO;
     }
   }
-  return [FlutterTextInputView instancesRespondToSelector:selector];
+  return [super respondsToSelector:selector];
 }
 
 - (void)setTextInputClient:(int)client {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -902,10 +902,11 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
 // Prevent UIKit from showing selection handles or highlights. This is needed
 // because Scribble interactions require the view to have it's actual frame on
-// the screen.
+// the screen. They're not needed on iOS 17 with the new
+// UITextSelectionDisplayInteraction API.
 //
-// These are not documented methods. On iOS 17, the insertion point color is also
-// used to paint the highlighted background of the selected IME candidate:
+// These are undocumented methods. On iOS 17, the insertion point color is also
+// used as the highlighted background of the selected IME candidate:
 // https://github.com/flutter/flutter/issues/132548
 // So the respondsToSelector method is overridden to return NO for this method
 // on iOS 17+.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -903,6 +903,12 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 // Prevent UIKit from showing selection handles or highlights. This is needed
 // because Scribble interactions require the view to have it's actual frame on
 // the screen.
+//
+// These are not documented methods. On iOS 17, the insertion point color is also
+// used to paint the highlighted background of the selected IME candidate:
+// https://github.com/flutter/flutter/issues/132548
+// So the respondsToSelector method is overridden to return NO for this method
+// on iOS 17+.
 - (UIColor*)insertionPointColor {
   return [UIColor clearColor];
 }
@@ -932,6 +938,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
 - (BOOL)respondsToSelector:(SEL)selector {
   if (@available(iOS 17.0, *)) {
+    // See the comment on this method.
     if (selector == @selector(insertionPointColor)) {
       return NO;
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -930,6 +930,15 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   return _textInputPlugin.textInputDelegate;
 }
 
+- (BOOL)respondsToSelector:(SEL)selector {
+  if (@available(iOS 17.0, *)) {
+    if (selector == @selector(insertionPointColor)) {
+      return NO;
+    }
+  }
+  return [FlutterTextInputView instancesRespondToSelector:selector];
+}
+
 - (void)setTextInputClient:(int)client {
   _textInputClient = client;
   _hasPlaceholder = NO;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -786,6 +786,13 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(inputView.spellCheckingType, UITextSpellCheckingTypeNo);
 }
 
+- (void)testFlutterTextInputViewOnlyRespondsToInsertionPointColorBelowIOS17 {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  BOOL respondsToInsertionPointColor =
+      [inputView respondsToSelector:@selector(insertionPointColor)];
+  XCAssertEqual(respondsToInsertionPointColor, !@available(iOS 17, *));
+}
+
 #pragma mark - TextEditingDelta tests
 - (void)testTextEditingDeltasAreGeneratedOnTextInput {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -790,7 +790,11 @@ FLUTTER_ASSERT_ARC
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
   BOOL respondsToInsertionPointColor =
       [inputView respondsToSelector:@selector(insertionPointColor)];
-  XCAssertEqual(respondsToInsertionPointColor, !@available(iOS 17, *));
+  if (@available(iOS 17, *)) {
+    XCTAssertFalse(respondsToInsertionPointColor);
+  } else {
+    XCTAssertTrue(respondsToInsertionPointColor);
+  }
 }
 
 #pragma mark - TextEditingDelta tests


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/132548

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
