### PR TITLE
Add initial support for 4x MSAA in OpenGLES backend.

### DIFF
--- a/impeller/renderer/backend/gles/gles.h
+++ b/impeller/renderer/backend/gles/gles.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+// IWYU pragma: begin_exports
 #include "GLES3/gl3.h"
 #define GL_GLEXT_PROTOTYPES
 #include "GLES2/gl2ext.h"
+// IWYU pragma: end_exports

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -6,12 +6,10 @@
 
 #include <functional>
 #include <string>
-#include <vector>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
-#include "flutter/fml/trace_event.h"
 #include "impeller/renderer/backend/gles/capabilities_gles.h"
 #include "impeller/renderer/backend/gles/description_gles.h"
 #include "impeller/renderer/backend/gles/gles.h"
@@ -170,11 +168,13 @@ struct GLProc {
 
 #define FOR_EACH_IMPELLER_GLES3_PROC(PROC) PROC(BlitFramebuffer);
 
-#define FOR_EACH_IMPELLER_EXT_PROC(PROC) \
-  PROC(DiscardFramebufferEXT);           \
-  PROC(PushDebugGroupKHR);               \
-  PROC(PopDebugGroupKHR);                \
-  PROC(ObjectLabelKHR);
+#define FOR_EACH_IMPELLER_EXT_PROC(PROC)   \
+  PROC(DiscardFramebufferEXT);             \
+  PROC(FramebufferTexture2DMultisampleEXT) \
+  PROC(PushDebugGroupKHR);                 \
+  PROC(PopDebugGroupKHR);                  \
+  PROC(ObjectLabelKHR);                    \
+  PROC(RenderbufferStorageMultisampleEXT);
 
 enum class DebugResourceType {
   kTexture,
@@ -188,7 +188,7 @@ enum class DebugResourceType {
 class ProcTableGLES {
  public:
   using Resolver = std::function<void*(const char* function_name)>;
-  ProcTableGLES(Resolver resolver);
+  explicit ProcTableGLES(Resolver resolver);
 
   ~ProcTableGLES();
 

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -4,10 +4,7 @@
 
 #include "impeller/renderer/backend/gles/render_pass_gles.h"
 
-#include <algorithm>
-
 #include "flutter/fml/trace_event.h"
-#include "impeller/base/config.h"
 #include "impeller/base/validation.h"
 #include "impeller/renderer/backend/gles/device_buffer_gles.h"
 #include "impeller/renderer/backend/gles/formats_gles.h"

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -18,6 +18,7 @@ class TextureGLES final : public Texture,
   enum class Type {
     kTexture,
     kRenderBuffer,
+    kRenderBufferMultisampled,
   };
 
   enum class IsWrapped {


### PR DESCRIPTION
Initial support _towards_ https://github.com/flutter/flutter/issues/130045.

This updates the `PROC_TABLE`, and adds (and supports) `Type::kRenderBufferMultisampled`.

The type remains unused in the actual engine, and will be in a follow-up PR once we like this one!

/cc @chinmaygarde 