### PR TITLE
[Impeller] revert stencil config changes.

### DIFF
--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -66,23 +66,17 @@ std::shared_ptr<Texture> Picture::RenderToTexture(
         size,                     // size
         "Picture Snapshot MSAA",  // label
         RenderTarget::
-            kDefaultColorAttachmentConfigMSAA  // color_attachment_config
-#ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.
-        ,
-        std::nullopt  // stencil_attachment_config
-#endif                // FML_OS_ANDROID
+            kDefaultColorAttachmentConfigMSAA,  // color_attachment_config
+        std::nullopt                            // stencil_attachment_config
     );
   } else {
     target = RenderTarget::CreateOffscreen(
-        *impeller_context,                           // context
-        render_target_allocator,                     // allocator
-        size,                                        // size
-        "Picture Snapshot",                          // label
-        RenderTarget::kDefaultColorAttachmentConfig  // color_attachment_config
-#ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.
-        ,
+        *impeller_context,                            // context
+        render_target_allocator,                      // allocator
+        size,                                         // size
+        "Picture Snapshot",                           // label
+        RenderTarget::kDefaultColorAttachmentConfig,  // color_attachment_config
         std::nullopt  // stencil_attachment_config
-#endif                // FML_OS_ANDROID
     );
   }
   if (!target.IsValid()) {

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -382,21 +382,15 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
     subpass_target = RenderTarget::CreateOffscreenMSAA(
         *context, *GetRenderTargetCache(), texture_size,
         SPrintF("%s Offscreen", label.c_str()),
-        RenderTarget::kDefaultColorAttachmentConfigMSAA  //
-#ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.
-        ,
+        RenderTarget::kDefaultColorAttachmentConfigMSAA,
         std::nullopt  // stencil_attachment_config
-#endif                // FML_OS_ANDROID
     );
   } else {
     subpass_target = RenderTarget::CreateOffscreen(
         *context, *GetRenderTargetCache(), texture_size,
         SPrintF("%s Offscreen", label.c_str()),
-        RenderTarget::kDefaultColorAttachmentConfig  //
-#ifndef FML_OS_ANDROID  // Reduce PSO variants for Vulkan.
-        ,
+        RenderTarget::kDefaultColorAttachmentConfig,  //
         std::nullopt  // stencil_attachment_config
-#endif                // FML_OS_ANDROID
     );
   }
   auto subpass_texture = subpass_target.GetRenderTargetTexture();

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -231,11 +231,6 @@ RenderTarget RenderTarget::CreateOffscreen(
     return {};
   }
 
-// Dont force additional PSO variants on Vulkan.
-#ifdef FML_OS_ANDROID
-  FML_DCHECK(stencil_attachment_config.has_value());
-#endif  // FML_OS_ANDROID
-
   RenderTarget target;
   PixelFormat pixel_format = context.GetCapabilities()->GetDefaultColorFormat();
   TextureDescriptor color_tex0;
@@ -277,11 +272,6 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   if (size.IsEmpty()) {
     return {};
   }
-
-// Dont force additional PSO variants on Vulkan.
-#ifdef FML_OS_ANDROID
-  FML_DCHECK(stencil_attachment_config.has_value());
-#endif  // FML_OS_ANDROID
 
   RenderTarget target;
   PixelFormat pixel_format = context.GetCapabilities()->GetDefaultColorFormat();


### PR DESCRIPTION
This was an experiment that didn't really pan out. Revert the changes to simplify rendering logic.
