### PR TITLE
[Impeller] simplify invert colors flag by supporting composed color filters.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -13,6 +13,7 @@
 #include "flutter/testing/testing.h"
 #include "impeller/aiks/aiks_playground.h"
 #include "impeller/aiks/canvas.h"
+#include "impeller/aiks/color_filter.h"
 #include "impeller/aiks/image.h"
 #include "impeller/aiks/image_filter.h"
 #include "impeller/aiks/paint_pass_delegate.h"
@@ -123,13 +124,44 @@ TEST_P(AiksTest, CanRenderImage) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
-TEST_P(AiksTest, CanRenderInvertedImage) {
+constexpr ColorMatrix kColorInversion = {.array = {
+                                             -1.0, 0,    0,    1.0, 0,  //
+                                             0,    -1.0, 0,    1.0, 0,  //
+                                             0,    0,    -1.0, 1.0, 0,  //
+                                             1.0,  1.0,  1.0,  1.0, 0   //
+                                         }};
+
+TEST_P(AiksTest, CanRenderMergedColorFilterImage) {
   Canvas canvas;
   Paint paint;
   auto image = std::make_shared<Image>(CreateTextureForFixture("kalimba.jpg"));
   paint.color = Color::Red();
-  paint.invert_colors = true;
+  paint.color_filter = std::make_shared<MergedColorFilter>(
+      ColorFilter::MakeMatrix(kColorInversion),
+      ColorFilter::MakeBlend(BlendMode::kColorDodge, Color::Aqua()));
   canvas.DrawImage(image, Point::MakeXY(100.0, 100.0), paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, CanRenderMergedColorFilter) {
+  Canvas canvas;
+  Paint paint;
+  paint.color = Color::Red();
+  paint.color_filter = std::make_shared<MergedColorFilter>(
+      ColorFilter::MakeMatrix(kColorInversion),
+      ColorFilter::MakeBlend(BlendMode::kColorDodge, Color::Aqua()));
+  canvas.DrawRect(Rect::MakeLTRB(0, 0, 100, 100), paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, CanRenderMergedColorFilterDrawPaint) {
+  Canvas canvas;
+  Paint paint;
+  paint.color = Color::Red();
+  paint.color_filter = std::make_shared<MergedColorFilter>(
+      ColorFilter::MakeMatrix(kColorInversion),
+      ColorFilter::MakeBlend(BlendMode::kColorDodge, Color::Aqua()));
+  canvas.DrawPaint(paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -138,7 +138,7 @@ TEST_P(AiksTest, CanRenderMergedColorFilterImage) {
   paint.color = Color::Red();
   paint.color_filter = ColorFilter::MakeComposed(
       ColorFilter::MakeMatrix(kColorInversion),
-      ColorFilter::MakeBlend(BlendMode::kColorDodge, Color::Aqua()));
+      ColorFilter::MakeBlend(BlendMode::kSourceOver, Color::Yellow()));
   canvas.DrawImage(image, Point::MakeXY(100.0, 100.0), paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -149,7 +149,7 @@ TEST_P(AiksTest, CanRenderMergedColorFilter) {
   paint.color = Color::Red();
   paint.color_filter = ColorFilter::MakeComposed(
       ColorFilter::MakeMatrix(kColorInversion),
-      ColorFilter::MakeBlend(BlendMode::kColorDodge, Color::Aqua()));
+      ColorFilter::MakeBlend(BlendMode::kSourceOver, Color::Yellow()));
   canvas.DrawRect(Rect::MakeLTRB(0, 0, 100, 100), paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -160,7 +160,7 @@ TEST_P(AiksTest, CanRenderMergedColorFilterDrawPaint) {
   paint.color = Color::Red();
   paint.color_filter = ColorFilter::MakeComposed(
       ColorFilter::MakeMatrix(kColorInversion),
-      ColorFilter::MakeBlend(BlendMode::kColorDodge, Color::Aqua()));
+      ColorFilter::MakeBlend(BlendMode::kSourceOver, Color::Yellow()));
   canvas.DrawPaint(paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -136,7 +136,7 @@ TEST_P(AiksTest, CanRenderMergedColorFilterImage) {
   Paint paint;
   auto image = std::make_shared<Image>(CreateTextureForFixture("kalimba.jpg"));
   paint.color = Color::Red();
-  paint.color_filter = std::make_shared<MergedColorFilter>(
+  paint.color_filter = ColorFilter::MakeComposed(
       ColorFilter::MakeMatrix(kColorInversion),
       ColorFilter::MakeBlend(BlendMode::kColorDodge, Color::Aqua()));
   canvas.DrawImage(image, Point::MakeXY(100.0, 100.0), paint);
@@ -147,7 +147,7 @@ TEST_P(AiksTest, CanRenderMergedColorFilter) {
   Canvas canvas;
   Paint paint;
   paint.color = Color::Red();
-  paint.color_filter = std::make_shared<MergedColorFilter>(
+  paint.color_filter = ColorFilter::MakeComposed(
       ColorFilter::MakeMatrix(kColorInversion),
       ColorFilter::MakeBlend(BlendMode::kColorDodge, Color::Aqua()));
   canvas.DrawRect(Rect::MakeLTRB(0, 0, 100, 100), paint);
@@ -158,7 +158,7 @@ TEST_P(AiksTest, CanRenderMergedColorFilterDrawPaint) {
   Canvas canvas;
   Paint paint;
   paint.color = Color::Red();
-  paint.color_filter = std::make_shared<MergedColorFilter>(
+  paint.color_filter = ColorFilter::MakeComposed(
       ColorFilter::MakeMatrix(kColorInversion),
       ColorFilter::MakeBlend(BlendMode::kColorDodge, Color::Aqua()));
   canvas.DrawPaint(paint);

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -4,7 +4,6 @@
 
 #include "impeller/aiks/canvas.h"
 
-#include <algorithm>
 #include <optional>
 #include <utility>
 

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -181,6 +181,7 @@ void Canvas::DrawPath(const Path& path, const Paint& paint) {
 }
 
 void Canvas::DrawPaint(const Paint& paint) {
+  FML_LOG(ERROR) << "Draw Paint";
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -180,7 +180,6 @@ void Canvas::DrawPath(const Path& path, const Paint& paint) {
 }
 
 void Canvas::DrawPaint(const Paint& paint) {
-  FML_LOG(ERROR) << "Draw Paint";
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetStencilDepth(GetStencilDepth());

--- a/impeller/aiks/color_filter.cc
+++ b/impeller/aiks/color_filter.cc
@@ -174,9 +174,9 @@ ComposedColorFilter::WrapWithGPUColorFilter(
 // |ColorFilter|
 ColorFilter::ColorFilterProc ComposedColorFilter::GetCPUColorFilterProc()
     const {
-  auto inner_proc = inner_->GetCPUColorFilterProc();
-  auto outer_proc = outer_->GetCPUColorFilterProc();
-  return [inner_proc, outer_proc](Color color) {
+  return [inner = inner_, outer = outer_](Color color) {
+    auto inner_proc = inner->GetCPUColorFilterProc();
+    auto outer_proc = outer->GetCPUColorFilterProc();
     return outer_proc(inner_proc(color));
   };
 }

--- a/impeller/aiks/color_filter.cc
+++ b/impeller/aiks/color_filter.cc
@@ -38,8 +38,8 @@ std::shared_ptr<ColorFilter> ColorFilter::MakeLinearToSrgb() {
 }
 
 std::shared_ptr<ColorFilter> ColorFilter::MakeComposed(
-    std::shared_ptr<ColorFilter> outer,
-    std::shared_ptr<ColorFilter> inner) {
+    const std::shared_ptr<ColorFilter>& outer,
+    const std::shared_ptr<ColorFilter>& inner) {
   return std::make_shared<ComposedColorFilter>(outer, inner);
 }
 
@@ -155,9 +155,10 @@ std::shared_ptr<ColorFilter> LinearToSrgbColorFilter::Clone() const {
  ******* ComposedColorFilter
  ******************************************************************************/
 
-ComposedColorFilter::ComposedColorFilter(std::shared_ptr<ColorFilter> outer,
-                                         std::shared_ptr<ColorFilter> inner)
-    : outer_(std::move(outer)), inner_(std::move(inner)) {}
+ComposedColorFilter::ComposedColorFilter(
+    const std::shared_ptr<ColorFilter>& outer,
+    const std::shared_ptr<ColorFilter>& inner)
+    : outer_(outer), inner_(inner) {}
 
 ComposedColorFilter::~ComposedColorFilter() = default;
 

--- a/impeller/aiks/color_filter.h
+++ b/impeller/aiks/color_filter.h
@@ -34,6 +34,10 @@ class ColorFilter {
 
   static std::shared_ptr<ColorFilter> MakeLinearToSrgb();
 
+  static std::shared_ptr<ColorFilter> MakeComposed(
+      std::shared_ptr<ColorFilter> outer,
+      std::shared_ptr<ColorFilter> inner);
+
   /// @brief  Wraps the given filter input with a GPU-based filter that will
   ///         perform the color operation. The given input will first be
   ///         rendered to a texture and then filtered.
@@ -148,12 +152,12 @@ class LinearToSrgbColorFilter final : public ColorFilter {
 };
 
 /// @brief Applies color filters as f(g(x)), where x is the input color.
-class MergedColorFilter final : public ColorFilter {
+class ComposedColorFilter final : public ColorFilter {
  public:
-  explicit MergedColorFilter(std::shared_ptr<ColorFilter> outer_,
-                             std::shared_ptr<ColorFilter> inner_);
+  explicit ComposedColorFilter(std::shared_ptr<ColorFilter> outer_,
+                               std::shared_ptr<ColorFilter> inner_);
 
-  ~MergedColorFilter() override;
+  ~ComposedColorFilter() override;
 
   // |ColorFilter|
   std::shared_ptr<ColorFilterContents> WrapWithGPUColorFilter(

--- a/impeller/aiks/color_filter.h
+++ b/impeller/aiks/color_filter.h
@@ -35,8 +35,8 @@ class ColorFilter {
   static std::shared_ptr<ColorFilter> MakeLinearToSrgb();
 
   static std::shared_ptr<ColorFilter> MakeComposed(
-      std::shared_ptr<ColorFilter> outer,
-      std::shared_ptr<ColorFilter> inner);
+      const std::shared_ptr<ColorFilter>& outer,
+      const std::shared_ptr<ColorFilter>& inner);
 
   /// @brief  Wraps the given filter input with a GPU-based filter that will
   ///         perform the color operation. The given input will first be
@@ -154,8 +154,8 @@ class LinearToSrgbColorFilter final : public ColorFilter {
 /// @brief Applies color filters as f(g(x)), where x is the input color.
 class ComposedColorFilter final : public ColorFilter {
  public:
-  ComposedColorFilter(std::shared_ptr<ColorFilter> outer,
-                      std::shared_ptr<ColorFilter> inner);
+  ComposedColorFilter(const std::shared_ptr<ColorFilter>& outer,
+                      const std::shared_ptr<ColorFilter>& inner);
 
   ~ComposedColorFilter() override;
 

--- a/impeller/aiks/color_filter.h
+++ b/impeller/aiks/color_filter.h
@@ -155,7 +155,7 @@ class LinearToSrgbColorFilter final : public ColorFilter {
 class ComposedColorFilter final : public ColorFilter {
  public:
   ComposedColorFilter(std::shared_ptr<ColorFilter> outer,
-                               std::shared_ptr<ColorFilter> inner);
+                      std::shared_ptr<ColorFilter> inner);
 
   ~ComposedColorFilter() override;
 

--- a/impeller/aiks/color_filter.h
+++ b/impeller/aiks/color_filter.h
@@ -166,9 +166,9 @@ class MergedColorFilter final : public ColorFilter {
   // |ColorFilter|
   std::shared_ptr<ColorFilter> Clone() const override;
 
-  private:
-    std::shared_ptr<ColorFilter> outer_;
-    std::shared_ptr<ColorFilter> inner_;
+ private:
+  std::shared_ptr<ColorFilter> outer_;
+  std::shared_ptr<ColorFilter> inner_;
 };
 
 }  // namespace impeller

--- a/impeller/aiks/color_filter.h
+++ b/impeller/aiks/color_filter.h
@@ -154,8 +154,8 @@ class LinearToSrgbColorFilter final : public ColorFilter {
 /// @brief Applies color filters as f(g(x)), where x is the input color.
 class ComposedColorFilter final : public ColorFilter {
  public:
-  explicit ComposedColorFilter(std::shared_ptr<ColorFilter> outer_,
-                               std::shared_ptr<ColorFilter> inner_);
+  ComposedColorFilter(std::shared_ptr<ColorFilter> outer,
+                               std::shared_ptr<ColorFilter> inner);
 
   ~ComposedColorFilter() override;
 

--- a/impeller/aiks/color_filter.h
+++ b/impeller/aiks/color_filter.h
@@ -147,4 +147,28 @@ class LinearToSrgbColorFilter final : public ColorFilter {
   std::shared_ptr<ColorFilter> Clone() const override;
 };
 
+/// @brief Applies color filters as f(g(x)), where x is the input color.
+class MergedColorFilter final : public ColorFilter {
+ public:
+  explicit MergedColorFilter(std::shared_ptr<ColorFilter> outer_,
+                             std::shared_ptr<ColorFilter> inner_);
+
+  ~MergedColorFilter() override;
+
+  // |ColorFilter|
+  std::shared_ptr<ColorFilterContents> WrapWithGPUColorFilter(
+      std::shared_ptr<FilterInput> input,
+      ColorFilterContents::AbsorbOpacity absorb_opacity) const override;
+
+  // |ColorFilter|
+  ColorFilterProc GetCPUColorFilterProc() const override;
+
+  // |ColorFilter|
+  std::shared_ptr<ColorFilter> Clone() const override;
+
+  private:
+    std::shared_ptr<ColorFilter> outer_;
+    std::shared_ptr<ColorFilter> inner_;
+};
+
 }  // namespace impeller

--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -59,7 +59,6 @@ std::shared_ptr<Contents> Paint::CreateContentsForGeometry(
 std::shared_ptr<Contents> Paint::WithFilters(
     std::shared_ptr<Contents> input) const {
   input = WithColorFilter(input, ColorFilterContents::AbsorbOpacity::kYes);
-  input = WithInvertFilter(input);
   auto image_filter =
       WithImageFilter(input, Matrix(), Entity::RenderingMode::kDirect);
   if (image_filter) {
@@ -121,31 +120,8 @@ std::shared_ptr<Contents> Paint::WithColorFilter(
   if (input->ApplyColorFilter(color_filter->GetCPUColorFilterProc())) {
     return input;
   }
-
   return color_filter->WrapWithGPUColorFilter(FilterInput::Make(input),
                                               absorb_opacity);
-}
-
-/// A color matrix which inverts colors.
-// clang-format off
-constexpr ColorMatrix kColorInversion = {
-  .array = {
-    -1.0,    0,    0, 1.0, 0, //
-       0, -1.0,    0, 1.0, 0, //
-       0,    0, -1.0, 1.0, 0, //
-     1.0,  1.0,  1.0, 1.0, 0  //
-  }
-};
-// clang-format on
-
-std::shared_ptr<Contents> Paint::WithInvertFilter(
-    std::shared_ptr<Contents> input) const {
-  if (!invert_colors) {
-    return input;
-  }
-
-  return ColorFilterContents::MakeColorMatrix(
-      {FilterInput::Make(std::move(input))}, kColorInversion);
 }
 
 std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -61,7 +61,6 @@ struct Paint {
   Scalar stroke_miter = 4.0;
   Style style = Style::kFill;
   BlendMode blend_mode = BlendMode::kSourceOver;
-  bool invert_colors = false;
 
   std::shared_ptr<ImageFilter> image_filter;
   std::shared_ptr<ColorFilter> color_filter;
@@ -108,9 +107,6 @@ struct Paint {
       std::shared_ptr<Contents> input,
       ColorFilterContents::AbsorbOpacity absorb_opacity =
           ColorFilterContents::AbsorbOpacity::kNo) const;
-
-  std::shared_ptr<Contents> WithInvertFilter(
-      std::shared_ptr<Contents> input) const;
 };
 
 }  // namespace impeller

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -490,8 +490,8 @@ void DlDispatcher::setColorFilter(const flutter::DlColorFilter* filter) {
   // Needs https://github.com/flutter/flutter/issues/95434
   if (paint_.color_filter) {
     auto color_filter = ToColorFilter(filter);
-    paint_.color_filter = std::make_shared<MergedColorFilter>(
-        std::move(paint_.color_filter), color_filter);
+    paint_.color_filter =
+        ColorFilter::MakeComposed(std::move(paint_.color_filter), color_filter);
   } else {
     paint_.color_filter = ToColorFilter(filter);
   }
@@ -501,7 +501,7 @@ void DlDispatcher::setColorFilter(const flutter::DlColorFilter* filter) {
 void DlDispatcher::setInvertColors(bool invert) {
   if (paint_.color_filter) {
     auto invert_filter = ColorFilter::MakeMatrix(kColorInversion);
-    paint_.color_filter = std::make_shared<MergedColorFilter>(
+    paint_.color_filter = ColorFilter::MakeComposed(
         invert_filter, std::move(paint_.color_filter));
   } else {
     paint_.color_filter = ColorFilter::MakeMatrix(kColorInversion);

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -8,7 +8,6 @@
 #include <cstring>
 #include <memory>
 #include <optional>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -16,20 +15,13 @@
 #include "flutter/fml/trace_event.h"
 #include "impeller/aiks/color_filter.h"
 #include "impeller/core/formats.h"
-#include "impeller/display_list/dl_image_impeller.h"
 #include "impeller/display_list/dl_vertices_geometry.h"
 #include "impeller/display_list/nine_patch_converter.h"
 #include "impeller/display_list/skia_conversions.h"
-#include "impeller/entity/contents/conical_gradient_contents.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/contents/filters/inputs/filter_input.h"
-#include "impeller/entity/contents/linear_gradient_contents.h"
-#include "impeller/entity/contents/radial_gradient_contents.h"
 #include "impeller/entity/contents/runtime_effect_contents.h"
-#include "impeller/entity/contents/sweep_gradient_contents.h"
-#include "impeller/entity/contents/tiled_texture_contents.h"
 #include "impeller/entity/entity.h"
-#include "impeller/entity/geometry/geometry.h"
 #include "impeller/geometry/path.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/geometry/scalar.h"
@@ -40,6 +32,18 @@
 #endif  // IMPELLER_ENABLE_3D
 
 namespace impeller {
+
+/// A color matrix which inverts colors.
+// clang-format off
+constexpr ColorMatrix kColorInversion = {
+  .array = {
+    -1.0,    0,    0, 1.0, 0, //
+       0, -1.0,    0, 1.0, 0, //
+       0,    0, -1.0, 1.0, 0, //
+     1.0,  1.0,  1.0, 1.0, 0  //
+  }
+};
+// clang-format on
 
 #define UNIMPLEMENTED \
   FML_DLOG(ERROR) << "Unimplemented detail in " << __FUNCTION__;
@@ -484,12 +488,24 @@ static std::shared_ptr<ColorFilter> ToColorFilter(
 // |flutter::DlOpReceiver|
 void DlDispatcher::setColorFilter(const flutter::DlColorFilter* filter) {
   // Needs https://github.com/flutter/flutter/issues/95434
-  paint_.color_filter = ToColorFilter(filter);
+  if (paint_.color_filter) {
+    auto color_filter = ToColorFilter(filter);
+    paint_.color_filter = std::make_shared<MergedColorFilter>(
+        std::move(paint_.color_filter), color_filter);
+  } else {
+    paint_.color_filter = ToColorFilter(filter);
+  }
 }
 
 // |flutter::DlOpReceiver|
 void DlDispatcher::setInvertColors(bool invert) {
-  paint_.invert_colors = invert;
+  if (paint_.color_filter) {
+    auto invert_filter = ColorFilter::MakeMatrix(kColorInversion);
+    paint_.color_filter = std::make_shared<MergedColorFilter>(
+        invert_filter, std::move(paint_.color_filter));
+  } else {
+    paint_.color_filter = ColorFilter::MakeMatrix(kColorInversion);
+  }
 }
 
 // |flutter::DlOpReceiver|

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -501,7 +501,8 @@ void DlDispatcher::setColorFilter(const flutter::DlColorFilter* filter) {
 void DlDispatcher::setInvertColors(bool invert) {
   if (paint_.color_filter) {
     auto invert_filter = ColorFilter::MakeMatrix(kColorInversion);
-    paint_.color_filter = ColorFilter::MakeComposed(invert_filter, paint_.color_filter);
+    paint_.color_filter =
+        ColorFilter::MakeComposed(invert_filter, paint_.color_filter);
   } else {
     paint_.color_filter = ColorFilter::MakeMatrix(kColorInversion);
   }

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -501,8 +501,7 @@ void DlDispatcher::setColorFilter(const flutter::DlColorFilter* filter) {
 void DlDispatcher::setInvertColors(bool invert) {
   if (paint_.color_filter) {
     auto invert_filter = ColorFilter::MakeMatrix(kColorInversion);
-    paint_.color_filter = ColorFilter::MakeComposed(
-        invert_filter, paint_.color_filter);
+    paint_.color_filter = ColorFilter::MakeComposed(invert_filter, paint_.color_filter);
   } else {
     paint_.color_filter = ColorFilter::MakeMatrix(kColorInversion);
   }

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -491,7 +491,7 @@ void DlDispatcher::setColorFilter(const flutter::DlColorFilter* filter) {
   if (paint_.color_filter) {
     auto color_filter = ToColorFilter(filter);
     paint_.color_filter =
-        ColorFilter::MakeComposed(std::move(paint_.color_filter), color_filter);
+        ColorFilter::MakeComposed(paint_.color_filter, color_filter);
   } else {
     paint_.color_filter = ToColorFilter(filter);
   }
@@ -502,7 +502,7 @@ void DlDispatcher::setInvertColors(bool invert) {
   if (paint_.color_filter) {
     auto invert_filter = ColorFilter::MakeMatrix(kColorInversion);
     paint_.color_filter = ColorFilter::MakeComposed(
-        invert_filter, std::move(paint_.color_filter));
+        invert_filter, paint_.color_filter);
   } else {
     paint_.color_filter = ColorFilter::MakeMatrix(kColorInversion);
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/135699

To avoid the ugly complicated code for conditionally applying both colorfilters, make the dl dispatcher handle merging these filters together in a defined order. The original bug is caused by not checking for invert colors in a CPU fast path.
