### PR TITLE
[macOS] FlutterMutatorView should clip to bounds

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2859,6 +2859,7 @@ ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterVie
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap.g.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap_Internal.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/NSView+ClipsToBounds.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/embedder/embedder.cc + ../../../flutter/LICENSE
@@ -5633,6 +5634,7 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewP
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap.g.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/KeyCodeMap_Internal.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/NSView+ClipsToBounds.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/TestFlutterPlatformView.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/module.modulemap

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm
@@ -5,11 +5,12 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.h"
 
 #include <QuartzCore/QuartzCore.h>
-
 #include <vector>
 
 #include "flutter/fml/logging.h"
 #include "flutter/shell/platform/embedder/embedder.h"
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/NSView+ClipsToBounds.h"
 
 @interface FlutterMutatorView () {
   // Each of these views clips to a CGPathRef. These views, if present,
@@ -395,6 +396,7 @@ NSMutableArray* ClipPathFromMutations(CGRect master_clip, const MutationVector& 
     _platformView = platformView;
     _pathClipViews = [NSMutableArray array];
     self.wantsLayer = YES;
+    self.clipsToBounds = YES;
   }
   return self;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMutatorViewTest.mm
@@ -6,6 +6,8 @@
 
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
+#import "flutter/shell/platform/darwin/macos/framework/Source/NSView+ClipsToBounds.h"
+
 @interface FlutterMutatorView (Private)
 
 @property(readonly, nonatomic, nonnull) NSMutableArray<NSView*>* pathClipViews;
@@ -94,6 +96,12 @@ TEST(FlutterMutatorViewTest, BasicFrameIsCorrect) {
   EXPECT_TRUE(CGRectEqualToRect(platformView.frame, CGRectMake(0, 0, 30, 20)));
   EXPECT_EQ(mutatorView.pathClipViews.count, 0ull);
   EXPECT_NE(mutatorView.platformViewContainer, nil);
+}
+
+TEST(FlutterMutatorViewTest, ClipsToBounds) {
+  NSView* platformView = [[NSView alloc] init];
+  FlutterMutatorView* mutatorView = [[FlutterMutatorView alloc] initWithPlatformView:platformView];
+  EXPECT_TRUE(mutatorView.clipsToBounds);
 }
 
 TEST(FlutterMutatorViewTest, TransformedFrameIsCorrect) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -9,11 +9,6 @@
 
 @class FlutterTextField;
 
-@interface NSView (ClipsToBounds)
-// This property is available since macOS 10.9 but only declared in macOS 14 SDK.
-@property BOOL clipsToBounds API_AVAILABLE(macos(10.9));
-@end
-
 /**
  * A plugin to handle text input.
  *

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -16,6 +16,7 @@
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/NSView+ClipsToBounds.h"
 
 static NSString* const kTextInputChannel = @"flutter/textinput";
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -9,6 +9,7 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/NSView+ClipsToBounds.h"
 
 #import <OCMock/OCMock.h>
 #import "flutter/testing/testing.h"

--- a/shell/platform/darwin/macos/framework/Source/NSView+ClipsToBounds.h
+++ b/shell/platform/darwin/macos/framework/Source/NSView+ClipsToBounds.h
@@ -1,0 +1,10 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+
+@interface NSView (ClipsToBounds)
+// This property is available since macOS 10.9 but only declared in macOS 14 SDK.
+@property BOOL clipsToBounds API_AVAILABLE(macos(10.9));
+@end


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
