### PR TITLE
[Impeller] Fix framebuffer blend UVs.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1608,6 +1608,26 @@ TEST_P(AiksTest, DrawPaintWithAdvancedBlendOverFilter) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, DrawAdvancedBlendPartlyOffscreen) {
+  std::vector<Color> colors = {Color{0.9568, 0.2627, 0.2118, 1.0},
+                               Color{0.1294, 0.5882, 0.9529, 1.0}};
+  std::vector<Scalar> stops = {0.0, 1.0};
+
+  Paint paint = {
+      .color_source = ColorSource::MakeLinearGradient(
+          {0, 0}, {100, 100}, std::move(colors), std::move(stops),
+          Entity::TileMode::kRepeat, Matrix::MakeScale(Vector3(0.3, 0.3, 0.3))),
+      .blend_mode = BlendMode::kLighten,
+  };
+
+  Canvas canvas;
+  canvas.DrawPaint({.color = Color::Blue()});
+  canvas.Scale(Vector2(2, 2));
+  canvas.ClipRect(Rect::MakeLTRB(0, 0, 200, 200));
+  canvas.DrawCircle({100, 100}, 100, paint);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 #define BLEND_MODE_TUPLE(blend_mode) {#blend_mode, BlendMode::k##blend_mode},
 
 struct BlendModeSelection {

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -48,6 +48,7 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
       std::nullopt,                                // sampler_descriptor
       true,                                        // msaa_enabled
       "FramebufferBlendContents Snapshot");        // label
+
   if (!src_snapshot.has_value()) {
     return true;
   }
@@ -56,21 +57,16 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
     return true;
   }
   Rect src_coverage = coverage.value();
-  auto maybe_src_uvs = src_snapshot->GetCoverageUVs(src_coverage);
-  if (!maybe_src_uvs.has_value()) {
-    return true;
-  }
-  std::array<Point, 4> src_uvs = maybe_src_uvs.value();
 
   auto size = src_coverage.size;
   VertexBufferBuilder<VS::PerVertexData> vtx_builder;
   vtx_builder.AddVertices({
-      {Point(0, 0), src_uvs[0]},
-      {Point(size.width, 0), src_uvs[1]},
-      {Point(size.width, size.height), src_uvs[3]},
-      {Point(0, 0), src_uvs[0]},
-      {Point(size.width, size.height), src_uvs[3]},
-      {Point(0, size.height), src_uvs[2]},
+      {Point(0, 0), Point(0, 0)},
+      {Point(size.width, 0), Point(1, 0)},
+      {Point(size.width, size.height), Point(1, 1)},
+      {Point(0, 0), Point(0, 0)},
+      {Point(size.width, size.height), Point(1, 1)},
+      {Point(0, size.height), Point(0, 1)},
   });
   auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
@@ -147,8 +143,7 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
   FS::BindTextureSamplerSrc(cmd, src_snapshot->texture, src_sampler);
 
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation() *
-                   Matrix::MakeTranslation(src_coverage.origin);
+                   src_snapshot->transform;
   frame_info.src_y_coord_scale = src_snapshot->texture->GetYCoordScale();
   VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
 


### PR DESCRIPTION
Fixes b/303120488.

There's no need to use the `GetCoverageUVs` utility in this case. Correct usage here would require the geometry to match the coverage rectangle of the snapshot in pass space with no further transformations to the geometry.
We should just render the snapshot texture as-is with simple 0/1 UVs and the snapshot's transform.

Before:

https://github.com/flutter/engine/assets/919017/2908573e-b7cf-430f-9317-92c8aac6ade4

<img width="679" alt="Screenshot 2023-10-02 at 9 57 10 PM" src="https://github.com/flutter/engine/assets/919017/b1b5125f-681e-4f7c-925d-d286f55c2780">

After:

https://github.com/flutter/engine/assets/919017/74901c9d-cb26-43c8-b963-a28bffbd5a44

<img width="679" alt="Screenshot 2023-10-02 at 10 05 14 PM" src="https://github.com/flutter/engine/assets/919017/f55d2e8f-9730-47ce-ba0b-96581ab6e28b">
