### PR TITLE
Opt out `flutter/third_party/**` from clang-tidy checks explicitly.

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -389,6 +389,7 @@
 ../../../flutter/sky/tools/install_framework_headers.py
 ../../../flutter/sky/tools/objcopy.py
 ../../../flutter/testing
+../../../flutter/third_party/.clang-tidy
 ../../../flutter/third_party/accessibility/README.md
 ../../../flutter/third_party/accessibility/ax/ax_enum_util_unittest.cc
 ../../../flutter/third_party/accessibility/ax/ax_event_generator_unittest.cc

--- a/third_party/.clang-tidy
+++ b/third_party/.clang-tidy
@@ -1,0 +1,4 @@
+# Disable all checks in this folder.
+#
+# We cannot ask third_party code to conform to our lints.
+Checks: "-*"


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/134969.

/cc @zanderso