### PR TITLE
Use GdkEvent methods to access values, direct access is removed in GTK4.

### DIFF
--- a/shell/platform/linux/fl_key_event.cc
+++ b/shell/platform/linux/fl_key_event.cc
@@ -9,21 +9,27 @@ static void dispose_origin_from_gdk_event(gpointer origin) {
   gdk_event_free(reinterpret_cast<GdkEvent*>(origin));
 }
 
-FlKeyEvent* fl_key_event_new_from_gdk_event(GdkEvent* raw_event) {
-  g_return_val_if_fail(raw_event != nullptr, nullptr);
-  GdkEventKey* event = reinterpret_cast<GdkEventKey*>(raw_event);
-  GdkEventType type = event->type;
+FlKeyEvent* fl_key_event_new_from_gdk_event(GdkEvent* event) {
+  g_return_val_if_fail(event != nullptr, nullptr);
+  GdkEventType type = gdk_event_get_event_type(event);
   g_return_val_if_fail(type == GDK_KEY_PRESS || type == GDK_KEY_RELEASE,
                        nullptr);
   FlKeyEvent* result = g_new(FlKeyEvent, 1);
 
-  result->time = event->time;
+  guint16 keycode = 0;
+  gdk_event_get_keycode(event, &keycode);
+  guint keyval = 0;
+  gdk_event_get_keyval(event, &keyval);
+  GdkModifierType state = static_cast<GdkModifierType>(0);
+  gdk_event_get_state(event, &state);
+
+  result->time = gdk_event_get_time(event);
   result->is_press = type == GDK_KEY_PRESS;
-  result->keycode = event->hardware_keycode;
-  result->keyval = event->keyval;
-  result->state = event->state;
-  result->string = g_strdup(event->string);
-  result->group = event->group;
+  result->keycode = keycode;
+  result->keyval = keyval;
+  result->state = state;
+  result->string = g_strdup(event->key.string);
+  result->group = event->key.group;
   result->origin = event;
   result->dispose_origin = dispose_origin_from_gdk_event;
 

--- a/shell/platform/linux/fl_scrolling_manager.cc
+++ b/shell/platform/linux/fl_scrolling_manager.cc
@@ -65,20 +65,31 @@ void fl_scrolling_manager_set_last_mouse_position(FlScrollingManager* self,
 }
 
 void fl_scrolling_manager_handle_scroll_event(FlScrollingManager* self,
-                                              GdkEventScroll* event,
+                                              GdkEventScroll* scroll_event,
                                               gint scale_factor) {
+  GdkEvent* event = reinterpret_cast<GdkEvent*>(scroll_event);
+
+  guint event_time = gdk_event_get_time(event);
+  gdouble event_x = 0.0, event_y = 0.0;
+  gdk_event_get_coords(event, &event_x, &event_y);
   gdouble scroll_delta_x = 0.0, scroll_delta_y = 0.0;
-  if (event->direction == GDK_SCROLL_SMOOTH) {
-    scroll_delta_x = event->delta_x;
-    scroll_delta_y = event->delta_y;
-  } else if (event->direction == GDK_SCROLL_UP) {
-    scroll_delta_y = -1;
-  } else if (event->direction == GDK_SCROLL_DOWN) {
-    scroll_delta_y = 1;
-  } else if (event->direction == GDK_SCROLL_LEFT) {
-    scroll_delta_x = -1;
-  } else if (event->direction == GDK_SCROLL_RIGHT) {
-    scroll_delta_x = 1;
+  GdkScrollDirection event_direction = GDK_SCROLL_SMOOTH;
+  if (gdk_event_get_scroll_direction(event, &event_direction)) {
+    if (event_direction == GDK_SCROLL_UP) {
+      scroll_delta_x = 0;
+      scroll_delta_y = -1;
+    } else if (event_direction == GDK_SCROLL_DOWN) {
+      scroll_delta_x = 0;
+      scroll_delta_y = 1;
+    } else if (event_direction == GDK_SCROLL_LEFT) {
+      scroll_delta_x = -1;
+      scroll_delta_y = 0;
+    } else if (event_direction == GDK_SCROLL_RIGHT) {
+      scroll_delta_x = 1;
+      scroll_delta_y = 0;
+    }
+  } else {
+    gdk_event_get_scroll_deltas(event, &scroll_delta_x, &scroll_delta_y);
   }
 
   // The multiplier is taken from the Chromium source
@@ -87,14 +98,14 @@ void fl_scrolling_manager_handle_scroll_event(FlScrollingManager* self,
   scroll_delta_x *= kScrollOffsetMultiplier * scale_factor;
   scroll_delta_y *= kScrollOffsetMultiplier * scale_factor;
 
-  if (gdk_device_get_source(gdk_event_get_source_device(
-          reinterpret_cast<GdkEvent*>(event))) == GDK_SOURCE_TOUCHPAD) {
+  if (gdk_device_get_source(gdk_event_get_source_device(event)) ==
+      GDK_SOURCE_TOUCHPAD) {
     scroll_delta_x *= -1;
     scroll_delta_y *= -1;
-    if (event->is_stop) {
+    if (gdk_event_is_scroll_stop_event(event)) {
       fl_scrolling_view_delegate_send_pointer_pan_zoom_event(
-          self->view_delegate, event->time * kMicrosecondsPerMillisecond,
-          event->x * scale_factor, event->y * scale_factor, kPanZoomEnd,
+          self->view_delegate, event_time * kMicrosecondsPerMillisecond,
+          event_x * scale_factor, event_y * scale_factor, kPanZoomEnd,
           self->pan_x, self->pan_y, 0, 0);
       self->pan_started = FALSE;
     } else {
@@ -102,28 +113,28 @@ void fl_scrolling_manager_handle_scroll_event(FlScrollingManager* self,
         self->pan_x = 0;
         self->pan_y = 0;
         fl_scrolling_view_delegate_send_pointer_pan_zoom_event(
-            self->view_delegate, event->time * kMicrosecondsPerMillisecond,
-            event->x * scale_factor, event->y * scale_factor, kPanZoomStart, 0,
-            0, 0, 0);
+            self->view_delegate, event_time * kMicrosecondsPerMillisecond,
+            event_x * scale_factor, event_y * scale_factor, kPanZoomStart, 0, 0,
+            0, 0);
         self->pan_started = TRUE;
       }
       self->pan_x += scroll_delta_x;
       self->pan_y += scroll_delta_y;
       fl_scrolling_view_delegate_send_pointer_pan_zoom_event(
-          self->view_delegate, event->time * kMicrosecondsPerMillisecond,
-          event->x * scale_factor, event->y * scale_factor, kPanZoomUpdate,
+          self->view_delegate, event_time * kMicrosecondsPerMillisecond,
+          event_x * scale_factor, event_y * scale_factor, kPanZoomUpdate,
           self->pan_x, self->pan_y, 1, 0);
     }
   } else {
-    self->last_x = event->x * scale_factor;
-    self->last_y = event->y * scale_factor;
+    self->last_x = event_x * scale_factor;
+    self->last_y = event_y * scale_factor;
     fl_scrolling_view_delegate_send_mouse_pointer_event(
         self->view_delegate,
         FlutterPointerPhase::kMove /* arbitrary value, phase will be ignored as
                                       this is a discrete scroll event */
         ,
-        event->time * kMicrosecondsPerMillisecond, event->x * scale_factor,
-        event->y * scale_factor, scroll_delta_x, scroll_delta_y, 0);
+        event_time * kMicrosecondsPerMillisecond, event_x * scale_factor,
+        event_y * scale_factor, scroll_delta_x, scroll_delta_y, 0);
   }
 }
 

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -125,9 +125,18 @@ static void init_scrolling(FlView* self) {
 }
 
 // Converts a GDK button event into a Flutter event and sends it to the engine.
-static gboolean send_pointer_button_event(FlView* self, GdkEventButton* event) {
+static gboolean send_pointer_button_event(FlView* self, GdkEvent* event) {
+  guint event_time = gdk_event_get_time(event);
+  GdkEventType event_type = gdk_event_get_event_type(event);
+  GdkModifierType event_state = static_cast<GdkModifierType>(0);
+  gdk_event_get_state(event, &event_state);
+  guint event_button = 0;
+  gdk_event_get_button(event, &event_button);
+  gdouble event_x = 0.0, event_y = 0.0;
+  gdk_event_get_coords(event, &event_x, &event_y);
+
   int64_t button;
-  switch (event->button) {
+  switch (event_button) {
     case 1:
       button = kFlutterPointerButtonMousePrimary;
       break;
@@ -142,7 +151,7 @@ static gboolean send_pointer_button_event(FlView* self, GdkEventButton* event) {
   }
   int old_button_state = self->button_state;
   FlutterPointerPhase phase = kMove;
-  if (event->type == GDK_BUTTON_PRESS) {
+  if (event_type == GDK_BUTTON_PRESS) {
     // Drop the event if Flutter already thinks the button is down.
     if ((self->button_state & button) != 0) {
       return FALSE;
@@ -150,7 +159,7 @@ static gboolean send_pointer_button_event(FlView* self, GdkEventButton* event) {
     self->button_state ^= button;
 
     phase = old_button_state == 0 ? kDown : kMove;
-  } else if (event->type == GDK_BUTTON_RELEASE) {
+  } else if (event_type == GDK_BUTTON_RELEASE) {
     // Drop the event if Flutter already thinks the button is up.
     if ((self->button_state & button) == 0) {
       return FALSE;
@@ -165,15 +174,13 @@ static gboolean send_pointer_button_event(FlView* self, GdkEventButton* event) {
   }
 
   gint scale_factor = gtk_widget_get_scale_factor(GTK_WIDGET(self));
-  fl_scrolling_manager_set_last_mouse_position(self->scrolling_manager,
-                                               event->x * scale_factor,
-                                               event->y * scale_factor);
+  fl_scrolling_manager_set_last_mouse_position(
+      self->scrolling_manager, event_x * scale_factor, event_y * scale_factor);
   fl_keyboard_manager_sync_modifier_if_needed(self->keyboard_manager,
-                                              event->state, event->time);
+                                              event_state, event_time);
   fl_engine_send_mouse_pointer_event(
-      self->engine, phase, event->time * kMicrosecondsPerMillisecond,
-      event->x * scale_factor, event->y * scale_factor, 0, 0,
-      self->button_state);
+      self->engine, phase, event_time * kMicrosecondsPerMillisecond,
+      event_x * scale_factor, event_y * scale_factor, 0, 0, self->button_state);
 
   return TRUE;
 }
@@ -286,8 +293,9 @@ static void fl_view_keyboard_delegate_iface_init(
                                std::unique_ptr<FlKeyEvent> in_event) {
     FlKeyEvent* event = in_event.release();
     GdkEvent* gdk_event = reinterpret_cast<GdkEvent*>(event->origin);
-    GdkEventType type = gdk_event->type;
-    g_return_if_fail(type == GDK_KEY_PRESS || type == GDK_KEY_RELEASE);
+    GdkEventType event_type = gdk_event_get_event_type(gdk_event);
+    g_return_if_fail(event_type == GDK_KEY_PRESS ||
+                     event_type == GDK_KEY_RELEASE);
     gdk_event_put(gdk_event);
     fl_key_event_dispose(event);
   };
@@ -352,23 +360,27 @@ static void fl_view_text_input_delegate_iface_init(
 
 // Signal handler for GtkWidget::button-press-event
 static gboolean button_press_event_cb(GtkWidget* widget,
-                                      GdkEventButton* event,
+                                      GdkEventButton* button_event,
                                       FlView* self) {
+  GdkEvent* event = reinterpret_cast<GdkEvent*>(button_event);
+
   // Flutter doesn't handle double and triple click events.
-  if (event->type == GDK_DOUBLE_BUTTON_PRESS ||
-      event->type == GDK_TRIPLE_BUTTON_PRESS) {
+  GdkEventType event_type = gdk_event_get_event_type(event);
+  if (event_type == GDK_DOUBLE_BUTTON_PRESS ||
+      event_type == GDK_TRIPLE_BUTTON_PRESS) {
     return FALSE;
   }
 
-  check_pointer_inside(self, reinterpret_cast<GdkEvent*>(event));
+  check_pointer_inside(self, event);
 
   return send_pointer_button_event(self, event);
 }
 
 // Signal handler for GtkWidget::button-release-event
 static gboolean button_release_event_cb(GtkWidget* widget,
-                                        GdkEventButton* event,
+                                        GdkEventButton* button_event,
                                         FlView* self) {
+  GdkEvent* event = reinterpret_cast<GdkEvent*>(button_event);
   return send_pointer_button_event(self, event);
 }
 
@@ -387,44 +399,60 @@ static gboolean scroll_event_cb(GtkWidget* widget,
 
 // Signal handler for GtkWidget::motion-notify-event
 static gboolean motion_notify_event_cb(GtkWidget* widget,
-                                       GdkEventMotion* event,
+                                       GdkEventMotion* motion_event,
                                        FlView* self) {
+  GdkEvent* event = reinterpret_cast<GdkEvent*>(motion_event);
+
   if (self->engine == nullptr) {
     return FALSE;
   }
 
-  check_pointer_inside(self, reinterpret_cast<GdkEvent*>(event));
+  guint event_time = gdk_event_get_time(event);
+  GdkModifierType event_state = static_cast<GdkModifierType>(0);
+  gdk_event_get_state(event, &event_state);
+  gdouble event_x = 0.0, event_y = 0.0;
+  gdk_event_get_coords(event, &event_x, &event_y);
+
+  check_pointer_inside(self, event);
 
   gint scale_factor = gtk_widget_get_scale_factor(GTK_WIDGET(self));
 
   fl_keyboard_manager_sync_modifier_if_needed(self->keyboard_manager,
-                                              event->state, event->time);
+                                              event_state, event_time);
   fl_engine_send_mouse_pointer_event(
       self->engine, self->button_state != 0 ? kMove : kHover,
-      event->time * kMicrosecondsPerMillisecond, event->x * scale_factor,
-      event->y * scale_factor, 0, 0, self->button_state);
+      event_time * kMicrosecondsPerMillisecond, event_x * scale_factor,
+      event_y * scale_factor, 0, 0, self->button_state);
 
   return TRUE;
 }
 
 // Signal handler for GtkWidget::enter-notify-event
 static gboolean enter_notify_event_cb(GtkWidget* widget,
-                                      GdkEventCrossing* event,
+                                      GdkEventCrossing* crossing_event,
                                       FlView* self) {
+  GdkEvent* event = reinterpret_cast<GdkEvent*>(crossing_event);
+
   if (self->engine == nullptr) {
     return FALSE;
   }
 
-  check_pointer_inside(self, reinterpret_cast<GdkEvent*>(event));
+  check_pointer_inside(self, event);
 
   return TRUE;
 }
 
 // Signal handler for GtkWidget::leave-notify-event
 static gboolean leave_notify_event_cb(GtkWidget* widget,
-                                      GdkEventCrossing* event,
+                                      GdkEventCrossing* crossing_event,
                                       FlView* self) {
-  if (event->mode != GDK_CROSSING_NORMAL) {
+  GdkEvent* event = reinterpret_cast<GdkEvent*>(crossing_event);
+
+  guint event_time = gdk_event_get_time(event);
+  gdouble event_x = 0.0, event_y = 0.0;
+  gdk_event_get_coords(event, &event_x, &event_y);
+
+  if (crossing_event->mode != GDK_CROSSING_NORMAL) {
     return FALSE;
   }
 
@@ -438,8 +466,8 @@ static gboolean leave_notify_event_cb(GtkWidget* widget,
   if (self->pointer_inside && self->button_state == 0) {
     gint scale_factor = gtk_widget_get_scale_factor(GTK_WIDGET(self));
     fl_engine_send_mouse_pointer_event(
-        self->engine, kRemove, event->time * kMicrosecondsPerMillisecond,
-        event->x * scale_factor, event->y * scale_factor, 0, 0,
+        self->engine, kRemove, event_time * kMicrosecondsPerMillisecond,
+        event_x * scale_factor, event_y * scale_factor, 0, 0,
         self->button_state);
     self->pointer_inside = FALSE;
   }


### PR DESCRIPTION
This should have no effect on the current implementation, and will be one less thing needed when we migrate to GTK4.
