### PR TITLE
[ios17][text_input]fix chinese language switch freeze, and missing auto correction menu in iOS 17

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -533,17 +533,6 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   return self;
 }
 
-- (BOOL)isEqual:(nullable id)other {
-  if (self == other) {
-    return YES;
-  }
-  if (!other || ![other isKindOfClass:[FlutterTextPosition class]]) {
-    return NO;
-  }
-  FlutterTextPosition* otherPosition = (FlutterTextPosition*)other;
-  return _index == otherPosition.index && _affinity == otherPosition.affinity;
-}
-
 @end
 
 #pragma mark - FlutterTextRange
@@ -632,15 +621,14 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 - (UITextRange*)lineEnclosingPosition:(UITextPosition*)position {
   // TODO(hellohuanlin): Remove iOS 17 check. The same logic should apply to older versions too.
   if (@available(iOS 17.0, *)) {
-    // The end of document (with backward affinity) should not be part of any line, since end is
-    // exclusive. This is to fix 2 bugs:
-    // 1. Keyboard freezes when switching languages:
-    // https://github.com/flutter/flutter/issues/134716
-    // 2. Auto correction candidate menu does not show up in iOS 17:
-    // https://github.com/flutter/flutter/issues/132594
-    // The end of document with forward affinity should still return the last line, which is used
-    // by voice control's delete line command.
-    if ([position isEqual:[_textInputView endOfDocument]]) {
+    FlutterTextPosition* flutterPosition = (FlutterTextPosition*)position;
+    if (flutterPosition.index > _textInputView.text.length) {
+      return nil;
+    }
+    // end of document with forward affinity is still considered as part of the document, which is
+    // used by voice control's delete line command.
+    if (flutterPosition.index == _textInputView.text.length &&
+        flutterPosition.affinity == UITextStorageDirectionBackward) {
       return nil;
     }
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -2660,7 +2660,7 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(range.range.length, 20u);
 }
 
-- (void)testFlutterTokenizerEndOfDocumentLineRangeQuery {
+- (void)testFlutterTokenizerLineRangeQueryWithEndOfDocumentAndBackwardAffinity {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
   id<UITextInputTokenizer> tokenizer = [inputView tokenizer];
 
@@ -2681,9 +2681,15 @@ FLUTTER_ASSERT_ARC
     XCTAssertEqual(range.range.location, 12u);
     XCTAssertEqual(range.range.length, 12u);
   }
+}
 
-  // End of document with forward affinity should still be considered as part of the document.
-  // This is used by voice control's delete line command.
+- (void)testFlutterTokenizerLineRangeQueryWithEndOfDocumentAndForwardAffinity {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  id<UITextInputTokenizer> tokenizer = [inputView tokenizer];
+
+  NSString* text = @"Random text\nwith 2 lines";
+  [inputView insertText:text];
+
   FlutterTextPosition* endOfDocumentWithForwardAffinity =
       [FlutterTextPosition positionWithIndex:text.length affinity:UITextStorageDirectionForward];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -2660,6 +2660,41 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(range.range.length, 20u);
 }
 
+- (void)testFlutterTokenizerEndOfDocumentLineRangeQuery {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  id<UITextInputTokenizer> tokenizer = [inputView tokenizer];
+
+  NSString* text = @"Random text\nwith 2 lines";
+  [inputView insertText:text];
+
+  FlutterTextPosition* endOfDocumentWithBackwardAffinity =
+      [FlutterTextPosition positionWithIndex:text.length affinity:UITextStorageDirectionBackward];
+
+  FlutterTextRange* range =
+      (FlutterTextRange*)[tokenizer rangeEnclosingPosition:endOfDocumentWithBackwardAffinity
+                                           withGranularity:UITextGranularityLine
+                                               inDirection:UITextLayoutDirectionRight];
+
+  if (@available(iOS 17.0, *)) {
+    XCTAssertNil(range);
+  } else {
+    XCTAssertEqual(range.range.location, 12u);
+    XCTAssertEqual(range.range.length, 12u);
+  }
+
+  // End of document with forward affinity should still be considered as part of the document.
+  // This is used by voice control's delete line command.
+  FlutterTextPosition* endOfDocumentWithForwardAffinity =
+      [FlutterTextPosition positionWithIndex:text.length affinity:UITextStorageDirectionForward];
+
+  range = (FlutterTextRange*)[tokenizer rangeEnclosingPosition:endOfDocumentWithForwardAffinity
+                                               withGranularity:UITextGranularityLine
+                                                   inDirection:UITextLayoutDirectionRight];
+
+  XCTAssertEqual(range.range.location, 12u);
+  XCTAssertEqual(range.range.length, 12u);
+}
+
 - (void)testFlutterTextInputPluginRetainsFlutterTextInputView {
   FlutterViewController* flutterViewController = [[FlutterViewController alloc] init];
   FlutterTextInputPlugin* myInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:engine];


### PR DESCRIPTION
According to [Apple's API doc](https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614464-rangeenclosingposition?language=objc), the line range enclosing position should return `nil` if no such range. Since `endOfDocument` is exclusive, we should return `nil` when UIKit queries the line range enclosing it. 

Note that `endOfDocument` with forward affinity is still queried with "delete line" voice control command, which we should still return the range of the last line. 

It is unclear why iOS 17 starts to query this API, but both issues resolved seems to be related to auto-correction. 

More discussion can be found in [the design doc](https://docs.google.com/document/d/1sM3HMv-SQin39yX1aPUU7vtGv7Hcef1Quc3QhRXBl6A/edit?resourcekey=0-SFYD8vmOIkXiXCZvB1Wlcw#heading=h.3w4qkmom2rvs). 

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/134716 

Fixes https://github.com/flutter/flutter/issues/132594

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
