### PR TITLE
[Impeller] Track clip coverage per-pass when not collapsing.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3639,7 +3639,26 @@ TEST_P(AiksTest, MatrixImageFilterDoesntCullWhenTranslatedFromOffscreen) {
       .image_filter = std::make_shared<MatrixImageFilter>(
           Matrix::MakeTranslation({300, 0}), SamplerDescriptor{}),
   });
-  canvas.DrawCircle({-300, 0}, 100, {.color = Color::White()});
+  canvas.DrawCircle({-300, 0}, 100, {.color = Color::Green()});
+  canvas.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+// Render a white circle at the top left corner of the screen.
+TEST_P(AiksTest,
+       MatrixImageFilterDoesntCullWhenScaledAndTranslatedFromOffscreen) {
+  Canvas canvas;
+  canvas.Scale(GetContentScale());
+  canvas.Translate({100, 100});
+  // Draw a circle in a SaveLayer at -300, but move it back on-screen with a
+  // +300 translation applied by a SaveLayer image filter.
+  canvas.SaveLayer({
+      .image_filter = std::make_shared<MatrixImageFilter>(
+          Matrix::MakeTranslation({300, 0}) * Matrix::MakeScale({2, 2, 2}),
+          SamplerDescriptor{}),
+  });
+  canvas.DrawCircle({-150, 0}, 50, {.color = Color::Green()});
   canvas.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3619,15 +3619,27 @@ TEST_P(AiksTest, MatrixImageFilterMagnify) {
   canvas.Translate({600, -200});
   canvas.SaveLayer({
       .image_filter = std::make_shared<MatrixImageFilter>(
-          Matrix{
-              2, 0, 0, 0,  //
-              0, 2, 0, 0,  //
-              0, 0, 2, 0,  //
-              0, 0, 0, 1   //
-          },
-          SamplerDescriptor{}),
+          Matrix::MakeScale({2, 2, 2}), SamplerDescriptor{}),
   });
-  canvas.DrawImage(image, {0, 0}, Paint{.color = Color(1.0, 1.0, 1.0, 0.5)});
+  canvas.DrawImage(image, {0, 0},
+                   Paint{.color = Color::White().WithAlpha(0.5)});
+  canvas.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+// Render a white circle at the top left corner of the screen.
+TEST_P(AiksTest, MatrixImageFilterDoesntCullWhenTranslatedFromOffscreen) {
+  Canvas canvas;
+  canvas.Scale(GetContentScale());
+  canvas.Translate({100, 100});
+  // Draw a circle in a SaveLayer at -300, but move it back on-screen with a
+  // +300 translation applied by a SaveLayer image filter.
+  canvas.SaveLayer({
+      .image_filter = std::make_shared<MatrixImageFilter>(
+          Matrix::MakeTranslation({300, 0}), SamplerDescriptor{}),
+  });
+  canvas.DrawCircle({-300, 0}, 100, {.color = Color::White()});
   canvas.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -45,7 +45,7 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
   // scaled up, then translations applied by the matrix should be magnified
   // accordingly.
   //
-  // To accomplish this, we sandwitch the filter's matrix within the CTM in both
+  // To accomplish this, we sandwich the filter's matrix within the CTM in both
   // cases. But notice that for the subpass backdrop filter case, we use the
   // "effect transform" instead of the Entity's transform!
   //

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -641,9 +641,9 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
 
     // Start non-collapsed subpasses with a fresh clip coverage stack limited by
     // the subpass coverage. This is important because image filters applied to
-    // save layers may transform the subpass texture after its rendered, causing
-    // parent clip coverage to get misaligned with the actual area that the
-    // subpass will affect in the parent pass.
+    // save layers may transform the subpass texture after it's rendered,
+    // causing parent clip coverage to get misaligned with the actual area that
+    // the subpass will affect in the parent pass.
     ClipCoverageStack subpass_clip_coverage_stack = {ClipCoverageLayer{
         .coverage = subpass_coverage, .clip_depth = subpass->clip_depth_}};
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -198,12 +198,10 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
   std::shared_ptr<FilterContents> image_filter =
       subpass.delegate_->WithImageFilter(Rect(), subpass.xformation_);
 
-  // If the filter graph transforms the basis of the subpass, then its space
-  // has deviated too much from the parent pass to safely intersect with the
-  // pass coverage limit.
-  coverage_limit =
-      (image_filter && !image_filter->IsTranslationOnly() ? std::nullopt
-                                                          : coverage_limit);
+  // If the subpass has an image filter, then its coverage space may deviate
+  // from the parent pass and make intersecting with the pass coverage limit
+  // unsafe.
+  coverage_limit = image_filter ? std::nullopt : coverage_limit;
 
   auto entities_coverage = subpass.GetElementsCoverage(coverage_limit);
   // The entities don't cover anything. There is nothing to do.
@@ -641,6 +639,14 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     auto subpass_capture = capture.CreateChild("EntityPass");
     subpass_capture.AddRect("Coverage", *subpass_coverage, {.readonly = true});
 
+    // Start non-collapsed subpasses with a fresh clip coverage stack limited by
+    // the subpass coverage. This is important because image filters applied to
+    // save layers may transform the subpass texture after its rendered, causing
+    // parent clip coverage to get misaligned with the actual area that the
+    // subpass will affect in the parent pass.
+    ClipCoverageStack subpass_clip_coverage_stack = {ClipCoverageLayer{
+        .coverage = subpass_coverage, .clip_depth = subpass->clip_depth_}};
+
     // Stencil textures aren't shared between EntityPasses (as much of the
     // time they are transient).
     if (!subpass->OnRender(
@@ -652,7 +658,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
             subpass_coverage->origin -
                 global_pass_position,         // local_pass_position
             ++pass_depth,                     // pass_depth
-            clip_coverage_stack,              // clip_coverage_stack
+            subpass_clip_coverage_stack,      // clip_coverage_stack
             subpass->clip_depth_,             // clip_depth_floor
             subpass_backdrop_filter_contents  // backdrop_filter_contents
             )) {

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -142,7 +142,16 @@ class EntityPass {
   void SetEnableOffscreenCheckerboard(bool enabled);
 
   //----------------------------------------------------------------------------
-  /// @brief  Get the coverage of an unfiltered subpass.
+  /// @brief  Computes the coverage of a given subpass. This is used to
+  ///         determine the texture size of a given subpass before it's rendered
+  ///         to and passed through the subpass ImageFilter, if any.
+  ///
+  /// @param[in]  subpass         The EntityPass for which to compute
+  ///                             pre-filteredcoverage.
+  /// @param[in]  coverage_limit  Confines coverage to a specified area. This
+  ///                             hint is used to trim coverage to the root
+  ///                             framebuffer area. `std::nullopt` means no
+  ///                             coverage.
   ///
   std::optional<Rect> GetSubpassCoverage(
       const EntityPass& subpass,

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -150,8 +150,13 @@ class EntityPass {
   ///                             pre-filteredcoverage.
   /// @param[in]  coverage_limit  Confines coverage to a specified area. This
   ///                             hint is used to trim coverage to the root
-  ///                             framebuffer area. `std::nullopt` means no
-  ///                             coverage.
+  ///                             framebuffer area. `std::nullopt` means there
+  ///                             is no limit.
+  ///
+  /// @return  The screen space pixel area that the subpass contents will render
+  ///          into, prior to being transformed by the subpass ImageFilter, if
+  ///          any. `std::nullopt` means rendering the subpass will have no
+  ///          effect on the color attachment.
   ///
   std::optional<Rect> GetSubpassCoverage(
       const EntityPass& subpass,


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/135916.

Big credits to @gaaclarke for the repros and investigation around this.

Moves back to tracking clip coverage per-pass when not collapsing. This is especially important for SaveLayers with MatrixImageFilters, which can transform the rendered layer texture and thereby move elements inside or outside of existing parent clips.

This should have little to no performance impact, since we should already be generating correct minimal subpass textures based on correct subpass coverage computation.

Before:
<img width="679" alt="Screenshot 2023-10-05 at 1 25 29 PM" src="https://github.com/flutter/engine/assets/919017/fe63808a-6353-4969-8225-120fd5ee0949">

https://github.com/flutter/engine/assets/919017/9284f055-bee1-40cd-8b7e-f478b00d01da


After:
<img width="679" alt="Screenshot 2023-10-05 at 1 24 17 PM" src="https://github.com/flutter/engine/assets/919017/066b1e25-9611-4e14-a383-cc3a866dbe36">

https://github.com/flutter/engine/assets/919017/0fbd1f96-8920-472c-bb0e-4414187fc72d

