### PR TITLE
[Impeller] Use triangle strips to dedupe rectangle vertices.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -192,6 +192,11 @@ ContentContext::ContentContext(
       .sample_count = SampleCount::kCount4,
       .color_attachment_pixel_format =
           context_->GetCapabilities()->GetDefaultColorFormat()};
+  auto options_trianglestrip = ContentContextOptions{
+      .sample_count = SampleCount::kCount4,
+      .primitive_type = PrimitiveType::kTriangleStrip,
+      .color_attachment_pixel_format =
+          context_->GetCapabilities()->GetDefaultColorFormat()};
 
 #ifdef IMPELLER_DEBUG
   checkerboard_pipelines_.CreateDefault(*context_, options);
@@ -212,56 +217,76 @@ ContentContext::ContentContext(
   }
 
   if (context_->GetCapabilities()->SupportsFramebufferFetch()) {
-    framebuffer_blend_color_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_colorburn_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_colordodge_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_darken_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_difference_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_exclusion_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_hardlight_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_hue_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_lighten_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_luminosity_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_multiply_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_overlay_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_saturation_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_screen_pipelines_.CreateDefault(*context_, options);
-    framebuffer_blend_softlight_pipelines_.CreateDefault(*context_, options);
+    framebuffer_blend_color_pipelines_.CreateDefault(*context_,
+                                                     options_trianglestrip);
+    framebuffer_blend_colorburn_pipelines_.CreateDefault(*context_,
+                                                         options_trianglestrip);
+    framebuffer_blend_colordodge_pipelines_.CreateDefault(
+        *context_, options_trianglestrip);
+    framebuffer_blend_darken_pipelines_.CreateDefault(*context_,
+                                                      options_trianglestrip);
+    framebuffer_blend_difference_pipelines_.CreateDefault(
+        *context_, options_trianglestrip);
+    framebuffer_blend_exclusion_pipelines_.CreateDefault(*context_,
+                                                         options_trianglestrip);
+    framebuffer_blend_hardlight_pipelines_.CreateDefault(*context_,
+                                                         options_trianglestrip);
+    framebuffer_blend_hue_pipelines_.CreateDefault(*context_,
+                                                   options_trianglestrip);
+    framebuffer_blend_lighten_pipelines_.CreateDefault(*context_,
+                                                       options_trianglestrip);
+    framebuffer_blend_luminosity_pipelines_.CreateDefault(
+        *context_, options_trianglestrip);
+    framebuffer_blend_multiply_pipelines_.CreateDefault(*context_,
+                                                        options_trianglestrip);
+    framebuffer_blend_overlay_pipelines_.CreateDefault(*context_,
+                                                       options_trianglestrip);
+    framebuffer_blend_saturation_pipelines_.CreateDefault(
+        *context_, options_trianglestrip);
+    framebuffer_blend_screen_pipelines_.CreateDefault(*context_,
+                                                      options_trianglestrip);
+    framebuffer_blend_softlight_pipelines_.CreateDefault(*context_,
+                                                         options_trianglestrip);
   }
 
-  blend_color_pipelines_.CreateDefault(*context_, options);
-  blend_colorburn_pipelines_.CreateDefault(*context_, options);
-  blend_colordodge_pipelines_.CreateDefault(*context_, options);
-  blend_darken_pipelines_.CreateDefault(*context_, options);
-  blend_difference_pipelines_.CreateDefault(*context_, options);
-  blend_exclusion_pipelines_.CreateDefault(*context_, options);
-  blend_hardlight_pipelines_.CreateDefault(*context_, options);
-  blend_hue_pipelines_.CreateDefault(*context_, options);
-  blend_lighten_pipelines_.CreateDefault(*context_, options);
-  blend_luminosity_pipelines_.CreateDefault(*context_, options);
-  blend_multiply_pipelines_.CreateDefault(*context_, options);
-  blend_overlay_pipelines_.CreateDefault(*context_, options);
-  blend_saturation_pipelines_.CreateDefault(*context_, options);
-  blend_screen_pipelines_.CreateDefault(*context_, options);
-  blend_softlight_pipelines_.CreateDefault(*context_, options);
+  blend_color_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_colorburn_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_colordodge_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_darken_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_difference_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_exclusion_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_hardlight_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_hue_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_lighten_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_luminosity_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_multiply_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_overlay_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_saturation_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_screen_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  blend_softlight_pipelines_.CreateDefault(*context_, options_trianglestrip);
 
-  rrect_blur_pipelines_.CreateDefault(*context_, options);
+  rrect_blur_pipelines_.CreateDefault(*context_, options_trianglestrip);
   texture_blend_pipelines_.CreateDefault(*context_, options);
   texture_pipelines_.CreateDefault(*context_, options);
   position_uv_pipelines_.CreateDefault(*context_, options);
   tiled_texture_pipelines_.CreateDefault(*context_, options);
-  gaussian_blur_noalpha_decal_pipelines_.CreateDefault(*context_, options);
-  gaussian_blur_noalpha_nodecal_pipelines_.CreateDefault(*context_, options);
-  border_mask_blur_pipelines_.CreateDefault(*context_, options);
-  morphology_filter_pipelines_.CreateDefault(*context_, options);
-  color_matrix_color_filter_pipelines_.CreateDefault(*context_, options);
-  linear_to_srgb_filter_pipelines_.CreateDefault(*context_, options);
-  srgb_to_linear_filter_pipelines_.CreateDefault(*context_, options);
+  gaussian_blur_noalpha_decal_pipelines_.CreateDefault(*context_,
+                                                       options_trianglestrip);
+  gaussian_blur_noalpha_nodecal_pipelines_.CreateDefault(*context_,
+                                                         options_trianglestrip);
+  border_mask_blur_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  morphology_filter_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  color_matrix_color_filter_pipelines_.CreateDefault(*context_,
+                                                     options_trianglestrip);
+  linear_to_srgb_filter_pipelines_.CreateDefault(*context_,
+                                                 options_trianglestrip);
+  srgb_to_linear_filter_pipelines_.CreateDefault(*context_,
+                                                 options_trianglestrip);
   glyph_atlas_pipelines_.CreateDefault(*context_, options);
   glyph_atlas_color_pipelines_.CreateDefault(*context_, options);
   geometry_color_pipelines_.CreateDefault(*context_, options);
-  yuv_to_rgb_filter_pipelines_.CreateDefault(*context_, options);
-  porter_duff_blend_pipelines_.CreateDefault(*context_, options);
+  yuv_to_rgb_filter_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  porter_duff_blend_pipelines_.CreateDefault(*context_, options_trianglestrip);
   // GLES only shader.
 #ifdef IMPELLER_ENABLE_OPENGLES
   if (GetContext()->GetBackendType() == Context::BackendType::kOpenGLES) {

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -164,6 +164,7 @@ static std::unique_ptr<PipelineT> CreateDefaultPipeline(
   const auto default_color_format =
       context.GetCapabilities()->GetDefaultColorFormat();
   ContentContextOptions{.sample_count = SampleCount::kCount4,
+                        .primitive_type = PrimitiveType::kTriangleStrip,
                         .color_attachment_pixel_format = default_color_format}
       .ApplyToPipelineDescriptor(*desc);
   return std::make_unique<PipelineT>(context, desc);

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -155,8 +155,8 @@ static std::optional<Entity> AdvancedBlend(
     vtx_builder.AddVertices({
         {Point(0, 0), dst_uvs[0], src_uvs[0]},
         {Point(size.width, 0), dst_uvs[1], src_uvs[1]},
-        {Point(size.width, size.height), dst_uvs[3], src_uvs[3]},
         {Point(0, size.height), dst_uvs[2], src_uvs[2]},
+        {Point(size.width, size.height), dst_uvs[3], src_uvs[3]},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
@@ -282,9 +282,9 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
     vtx_builder.AddVertices({
         {origin, dst_uvs[0], dst_uvs[0]},
         {Point(origin.x + size.width, origin.y), dst_uvs[1], dst_uvs[1]},
+        {Point(origin.x, origin.y + size.height), dst_uvs[2], dst_uvs[2]},
         {Point(origin.x + size.width, origin.y + size.height), dst_uvs[3],
          dst_uvs[3]},
-        {Point(origin.x, origin.y + size.height), dst_uvs[2], dst_uvs[2]},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
@@ -455,9 +455,9 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
     vtx_builder.AddVertices({
         {origin, dst_uvs[0], color},
         {Point(origin.x + size.width, origin.y), dst_uvs[1], color},
+        {Point(origin.x, origin.y + size.height), dst_uvs[2], color},
         {Point(origin.x + size.width, origin.y + size.height), dst_uvs[3],
          color},
-        {Point(origin.x, origin.y + size.height), dst_uvs[2], color},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
@@ -586,8 +586,8 @@ static std::optional<Entity> PipelineBlend(
       vtx_builder.AddVertices({
           {Point(0, 0), Point(0, 0)},
           {Point(size.width, 0), Point(1, 0)},
-          {Point(size.width, size.height), Point(1, 1)},
           {Point(0, size.height), Point(0, 1)},
+          {Point(size.width, size.height), Point(1, 1)},
       });
       auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
       cmd.BindVertices(vtx_buffer);

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -156,13 +156,12 @@ static std::optional<Entity> AdvancedBlend(
         {Point(0, 0), dst_uvs[0], src_uvs[0]},
         {Point(size.width, 0), dst_uvs[1], src_uvs[1]},
         {Point(size.width, size.height), dst_uvs[3], src_uvs[3]},
-        {Point(0, 0), dst_uvs[0], src_uvs[0]},
-        {Point(size.width, size.height), dst_uvs[3], src_uvs[3]},
         {Point(0, size.height), dst_uvs[2], src_uvs[2]},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
     auto options = OptionsFromPass(pass);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
     options.blend_mode = BlendMode::kSource;
     std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline =
         std::invoke(pipeline_proc, renderer, options);
@@ -285,9 +284,6 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
         {Point(origin.x + size.width, origin.y), dst_uvs[1], dst_uvs[1]},
         {Point(origin.x + size.width, origin.y + size.height), dst_uvs[3],
          dst_uvs[3]},
-        {origin, dst_uvs[0], dst_uvs[0]},
-        {Point(origin.x + size.width, origin.y + size.height), dst_uvs[3],
-         dst_uvs[3]},
         {Point(origin.x, origin.y + size.height), dst_uvs[2], dst_uvs[2]},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
@@ -298,6 +294,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
     cmd.BindVertices(vtx_buffer);
     cmd.stencil_reference = entity.GetClipDepth();
     auto options = OptionsFromPass(pass);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
 
     switch (blend_mode) {
       case BlendMode::kScreen:
@@ -460,9 +457,6 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
         {Point(origin.x + size.width, origin.y), dst_uvs[1], color},
         {Point(origin.x + size.width, origin.y + size.height), dst_uvs[3],
          color},
-        {origin, dst_uvs[0], color},
-        {Point(origin.x + size.width, origin.y + size.height), dst_uvs[3],
-         color},
         {Point(origin.x, origin.y + size.height), dst_uvs[2], color},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
@@ -473,6 +467,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
     cmd.BindVertices(vtx_buffer);
     cmd.stencil_reference = entity.GetClipDepth();
     auto options = OptionsFromPass(pass);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
     cmd.pipeline = renderer.GetPorterDuffBlendPipeline(options);
 
     FS::FragInfo frag_info;
@@ -571,6 +566,7 @@ static std::optional<Entity> PipelineBlend(
     DEBUG_COMMAND_INFO(cmd, SPrintF("Pipeline Blend Filter (%s)",
                                     BlendModeToString(blend_mode)));
     auto options = OptionsFromPass(pass);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
 
     auto add_blend_command = [&](std::optional<Snapshot> input) {
       if (!input.has_value()) {
@@ -590,8 +586,6 @@ static std::optional<Entity> PipelineBlend(
       vtx_builder.AddVertices({
           {Point(0, 0), Point(0, 0)},
           {Point(size.width, 0), Point(1, 0)},
-          {Point(size.width, size.height), Point(1, 1)},
-          {Point(0, 0), Point(0, 0)},
           {Point(size.width, size.height), Point(1, 1)},
           {Point(0, size.height), Point(0, 1)},
       });

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -96,11 +96,11 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
         {coverage.origin, input_uvs[0]},
         {{coverage.origin.x + coverage.size.width, coverage.origin.y},
          input_uvs[1]},
+        {{coverage.origin.x, coverage.origin.y + coverage.size.height},
+         input_uvs[2]},
         {{coverage.origin.x + coverage.size.width,
           coverage.origin.y + coverage.size.height},
          input_uvs[3]},
-        {{coverage.origin.x, coverage.origin.y + coverage.size.height},
-         input_uvs[2]},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -99,10 +99,6 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
         {{coverage.origin.x + coverage.size.width,
           coverage.origin.y + coverage.size.height},
          input_uvs[3]},
-        {coverage.origin, input_uvs[0]},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         input_uvs[3]},
         {{coverage.origin.x, coverage.origin.y + coverage.size.height},
          input_uvs[2]},
     });
@@ -111,6 +107,7 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     Command cmd;
     DEBUG_COMMAND_INFO(cmd, "Border Mask Blur Filter");
     auto options = OptionsFromPassAndEntity(pass, entity);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
 
     cmd.pipeline = renderer.GetBorderMaskBlurPipeline(options);
     cmd.BindVertices(vtx_buffer);

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -69,8 +69,8 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0)},
         {Point(1, 0)},
-        {Point(1, 1)},
         {Point(0, 1)},
+        {Point(1, 1)},
     });
     auto& host_buffer = pass.GetTransientsBuffer();
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -60,6 +60,7 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     cmd.stencil_reference = entity.GetClipDepth();
 
     auto options = OptionsFromPassAndEntity(pass, entity);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
     cmd.pipeline = renderer.GetColorMatrixColorFilterPipeline(options);
 
     auto size = input_snapshot->texture->GetSize();
@@ -68,8 +69,6 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0)},
         {Point(1, 0)},
-        {Point(1, 1)},
-        {Point(0, 0)},
         {Point(1, 1)},
         {Point(0, 1)},
     });

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -158,8 +158,6 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
         {Point(0, 0), input_uvs[0]},
         {Point(1, 0), input_uvs[1]},
         {Point(1, 1), input_uvs[3]},
-        {Point(0, 0), input_uvs[0]},
-        {Point(1, 1), input_uvs[3]},
         {Point(0, 1), input_uvs[2]},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
@@ -185,6 +183,7 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
     cmd.BindVertices(vtx_buffer);
 
     auto options = OptionsFromPass(pass);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
     options.blend_mode = BlendMode::kSource;
     auto input_descriptor = input_snapshot->sampler_descriptor;
     switch (tile_mode_) {

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -157,8 +157,8 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0), input_uvs[0]},
         {Point(1, 0), input_uvs[1]},
-        {Point(1, 1), input_uvs[3]},
         {Point(0, 1), input_uvs[2]},
+        {Point(1, 1), input_uvs[3]},
     });
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -50,6 +50,7 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     cmd.stencil_reference = entity.GetClipDepth();
 
     auto options = OptionsFromPassAndEntity(pass, entity);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
     cmd.pipeline = renderer.GetLinearToSrgbFilterPipeline(options);
 
     auto size = input_snapshot->texture->GetSize();
@@ -58,8 +59,6 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0)},
         {Point(1, 0)},
-        {Point(1, 1)},
-        {Point(0, 0)},
         {Point(1, 1)},
         {Point(0, 1)},
     });

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -59,8 +59,8 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0)},
         {Point(1, 0)},
-        {Point(1, 1)},
         {Point(0, 1)},
+        {Point(1, 1)},
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -81,8 +81,8 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0), input_uvs[0]},
         {Point(1, 0), input_uvs[1]},
-        {Point(1, 1), input_uvs[3]},
         {Point(0, 1), input_uvs[2]},
+        {Point(1, 1), input_uvs[3]},
     });
 
     auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -6,6 +6,7 @@
 
 #include <cmath>
 
+#include "impeller/core/formats.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/contents.h"
 #include "impeller/renderer/render_pass.h"
@@ -81,8 +82,6 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
         {Point(0, 0), input_uvs[0]},
         {Point(1, 0), input_uvs[1]},
         {Point(1, 1), input_uvs[3]},
-        {Point(0, 0), input_uvs[0]},
-        {Point(1, 1), input_uvs[3]},
         {Point(0, 1), input_uvs[2]},
     });
 
@@ -118,6 +117,7 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
     Command cmd;
     DEBUG_COMMAND_INFO(cmd, "Morphology Filter");
     auto options = OptionsFromPass(pass);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
     options.blend_mode = BlendMode::kSource;
     cmd.pipeline = renderer.GetMorphologyFilterPipeline(options);
     cmd.BindVertices(vtx_buffer);

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -59,8 +59,8 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0)},
         {Point(1, 0)},
-        {Point(1, 1)},
         {Point(0, 1)},
+        {Point(1, 1)},
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -50,6 +50,7 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     cmd.stencil_reference = entity.GetClipDepth();
 
     auto options = OptionsFromPassAndEntity(pass, entity);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
     cmd.pipeline = renderer.GetSrgbToLinearFilterPipeline(options);
 
     auto size = input_snapshot->texture->GetSize();
@@ -58,8 +59,6 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0)},
         {Point(1, 0)},
-        {Point(1, 1)},
-        {Point(0, 0)},
         {Point(1, 1)},
         {Point(0, 1)},
     });

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -87,8 +87,8 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0)},
         {Point(1, 0)},
-        {Point(1, 1)},
         {Point(0, 1)},
+        {Point(1, 1)},
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -78,6 +78,7 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     cmd.stencil_reference = entity.GetClipDepth();
 
     auto options = OptionsFromPassAndEntity(pass, entity);
+    options.primitive_type = PrimitiveType::kTriangleStrip;
     cmd.pipeline = renderer.GetYUVToRGBFilterPipeline(options);
 
     auto size = y_input_snapshot->texture->GetSize();
@@ -86,8 +87,6 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     vtx_builder.AddVertices({
         {Point(0, 0)},
         {Point(1, 0)},
-        {Point(1, 1)},
-        {Point(0, 0)},
         {Point(1, 1)},
         {Point(0, 1)},
     });

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -64,14 +64,13 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
       {Point(0, 0), Point(0, 0)},
       {Point(size.width, 0), Point(1, 0)},
       {Point(size.width, size.height), Point(1, 1)},
-      {Point(0, 0), Point(0, 0)},
-      {Point(size.width, size.height), Point(1, 1)},
       {Point(0, size.height), Point(0, 1)},
   });
   auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
   auto options = OptionsFromPass(pass);
   options.blend_mode = BlendMode::kSource;
+  options.primitive_type = PrimitiveType::kTriangleStrip;
 
   Command cmd;
   DEBUG_COMMAND_INFO(cmd, "Framebuffer Advanced Blend Filter");

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -63,8 +63,8 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
   vtx_builder.AddVertices({
       {Point(0, 0), Point(0, 0)},
       {Point(size.width, 0), Point(1, 0)},
-      {Point(size.width, size.height), Point(1, 1)},
       {Point(0, size.height), Point(0, 1)},
+      {Point(size.width, size.height), Point(1, 1)},
   });
   auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -80,8 +80,6 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
         {Point(left, top)},
         {Point(right, top)},
         {Point(left, bottom)},
-        {Point(left, bottom)},
-        {Point(right, top)},
         {Point(right, bottom)},
     });
   }
@@ -89,7 +87,7 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
   Command cmd;
   DEBUG_COMMAND_INFO(cmd, "RRect Shadow");
   ContentContextOptions opts = OptionsFromPassAndEntity(pass, entity);
-  opts.primitive_type = PrimitiveType::kTriangle;
+  opts.primitive_type = PrimitiveType::kTriangleStrip;
   Color color = color_;
   if (entity.GetBlendMode() == BlendMode::kClear) {
     opts.is_for_rrect_blur_clear = true;


### PR DESCRIPTION
Remove a couple of duplicate verts in a bunch of situations.

Pedantic improvements: "Brandon, why are you like this" edition.