### PR TITLE
[Impeller] Refactor CapabilitiesGLES into a Capabilties.

### DIFF
--- a/impeller/renderer/backend/gles/BUILD.gn
+++ b/impeller/renderer/backend/gles/BUILD.gn
@@ -17,6 +17,7 @@ impeller_component("gles_unittests") {
     "test/mock_gles.cc",
     "test/mock_gles.h",
     "test/mock_gles_unittests.cc",
+    "test/capabilities_unittests.cc",
   ]
   deps = [
     ":gles",

--- a/impeller/renderer/backend/gles/BUILD.gn
+++ b/impeller/renderer/backend/gles/BUILD.gn
@@ -14,10 +14,10 @@ config("gles_config") {
 impeller_component("gles_unittests") {
   testonly = true
   sources = [
+    "test/capabilities_unittests.cc",
     "test/mock_gles.cc",
     "test/mock_gles.h",
     "test/mock_gles_unittests.cc",
-    "test/capabilities_unittests.cc",
   ]
   deps = [
     ":gles",

--- a/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -103,4 +103,60 @@ size_t CapabilitiesGLES::GetMaxTextureUnits(ShaderStage stage) const {
   FML_UNREACHABLE();
 }
 
+bool CapabilitiesGLES::SupportsOffscreenMSAA() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsSSBO() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsBufferToTextureBlits() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsTextureToTextureBlits() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsFramebufferFetch() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsCompute() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsComputeSubgroups() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsReadFromOnscreenTexture() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsReadFromResolve() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsDecalSamplerAddressMode() const {
+  return false;
+}
+
+bool CapabilitiesGLES::SupportsDeviceTransientTextures() const {
+  return false;
+}
+
+PixelFormat CapabilitiesGLES::GetDefaultColorFormat() const {
+  return PixelFormat::kR8G8B8A8UNormInt;
+}
+
+PixelFormat CapabilitiesGLES::GetDefaultStencilFormat() const {
+  return PixelFormat::kS8UInt;
+}
+
+PixelFormat CapabilitiesGLES::GetDefaultDepthStencilFormat() const {
+  return PixelFormat::kD24UnormS8Uint;
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/impeller/renderer/backend/gles/capabilities_gles.h
@@ -6,16 +6,31 @@
 
 #include <cstddef>
 
-#include "flutter/fml/macros.h"
+#include "impeller/base/backend_cast.h"
 #include "impeller/core/shader_types.h"
 #include "impeller/geometry/size.h"
+#include "impeller/renderer/capabilities.h"
 
 namespace impeller {
 
 class ProcTableGLES;
 
-struct CapabilitiesGLES {
-  CapabilitiesGLES(const ProcTableGLES& gl);
+//------------------------------------------------------------------------------
+/// @brief      The Vulkan layers and extensions wrangler.
+///
+class CapabilitiesGLES final
+    : public Capabilities,
+      public BackendCast<CapabilitiesGLES, Capabilities> {
+ public:
+  explicit CapabilitiesGLES(const ProcTableGLES& gl);
+
+  CapabilitiesGLES(const CapabilitiesGLES&) = delete;
+
+  CapabilitiesGLES(CapabilitiesGLES&&) = delete;
+
+  CapabilitiesGLES& operator=(const CapabilitiesGLES&) = delete;
+
+  CapabilitiesGLES& operator=(CapabilitiesGLES&&) = delete;
 
   // Must be at least 8.
   size_t max_combined_texture_image_units = 8;
@@ -57,6 +72,48 @@ struct CapabilitiesGLES {
   size_t num_shader_binary_formats = 0;
 
   size_t GetMaxTextureUnits(ShaderStage stage) const;
+
+  // |Capabilities|
+  bool SupportsOffscreenMSAA() const override;
+
+  // |Capabilities|
+  bool SupportsSSBO() const override;
+
+  // |Capabilities|
+  bool SupportsBufferToTextureBlits() const override;
+
+  // |Capabilities|
+  bool SupportsTextureToTextureBlits() const override;
+
+  // |Capabilities|
+  bool SupportsFramebufferFetch() const override;
+
+  // |Capabilities|
+  bool SupportsCompute() const override;
+
+  // |Capabilities|
+  bool SupportsComputeSubgroups() const override;
+
+  // |Capabilities|
+  bool SupportsReadFromOnscreenTexture() const override;
+
+  // |Capabilities|
+  bool SupportsReadFromResolve() const override;
+
+  // |Capabilities|
+  bool SupportsDecalSamplerAddressMode() const override;
+
+  // |Capabilities|
+  bool SupportsDeviceTransientTextures() const override;
+
+  // |Capabilities|
+  PixelFormat GetDefaultColorFormat() const override;
+
+  // |Capabilities|
+  PixelFormat GetDefaultStencilFormat() const override;
+
+  // |Capabilities|
+  PixelFormat GetDefaultDepthStencilFormat() const override;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -6,6 +6,7 @@
 
 #include "impeller/base/config.h"
 #include "impeller/base/validation.h"
+#include "impeller/renderer/backend/gles/command_buffer_gles.h"
 
 namespace impeller {
 
@@ -58,26 +59,7 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
         std::shared_ptr<SamplerLibraryGLES>(new SamplerLibraryGLES());
   }
 
-  // Create the device capabilities.
-  {
-    device_capabilities_ =
-        CapabilitiesBuilder()
-            .SetSupportsOffscreenMSAA(false)
-            .SetSupportsSSBO(false)
-            .SetSupportsBufferToTextureBlits(false)
-            .SetSupportsTextureToTextureBlits(false)
-            .SetSupportsFramebufferFetch(false)
-            .SetDefaultColorFormat(PixelFormat::kR8G8B8A8UNormInt)
-            .SetDefaultStencilFormat(PixelFormat::kS8UInt)
-            .SetDefaultDepthStencilFormat(PixelFormat::kD24UnormS8Uint)
-            .SetSupportsCompute(false)
-            .SetSupportsComputeSubgroups(false)
-            .SetSupportsReadFromResolve(false)
-            .SetSupportsReadFromOnscreenTexture(false)
-            .SetSupportsDecalSamplerAddressMode(false)
-            .SetSupportsDeviceTransientTextures(false)
-            .Build();
-  }
+  { device_capabilities_ = reactor_->GetProcTable().GetCapabilities(); }
 
   is_valid_ = true;
 }

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -59,8 +59,7 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
         std::shared_ptr<SamplerLibraryGLES>(new SamplerLibraryGLES());
   }
 
-  { device_capabilities_ = reactor_->GetProcTable().GetCapabilities(); }
-
+  device_capabilities_ = reactor_->GetProcTable().GetCapabilities();
   is_valid_ = true;
 }
 

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -7,7 +7,7 @@
 #include "flutter/fml/macros.h"
 #include "impeller/base/backend_cast.h"
 #include "impeller/renderer/backend/gles/allocator_gles.h"
-#include "impeller/renderer/backend/gles/command_buffer_gles.h"
+#include "impeller/renderer/backend/gles/capabilities_gles.h"
 #include "impeller/renderer/backend/gles/pipeline_library_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/backend/gles/sampler_library_gles.h"
@@ -44,6 +44,9 @@ class ContextGLES final : public Context,
   std::shared_ptr<PipelineLibraryGLES> pipeline_library_;
   std::shared_ptr<SamplerLibraryGLES> sampler_library_;
   std::shared_ptr<AllocatorGLES> resource_allocator_;
+  // Note: This is stored separately from the ProcTableGLES CapabilitiesGLES
+  // in order to satisfy the Context::GetCapabilities signature which returns
+  // a reference.
   std::shared_ptr<const Capabilities> device_capabilities_;
   bool is_valid_ = false;
 

--- a/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -150,7 +150,8 @@ const DescriptionGLES* ProcTableGLES::GetDescription() const {
   return description_.get();
 }
 
-const std::shared_ptr<const CapabilitiesGLES>& ProcTableGLES::GetCapabilities() const {
+const std::shared_ptr<const CapabilitiesGLES>& ProcTableGLES::GetCapabilities()
+    const {
   return capabilities_;
 }
 

--- a/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -9,6 +9,8 @@
 #include "impeller/base/allocation.h"
 #include "impeller/base/comparable.h"
 #include "impeller/base/validation.h"
+#include "impeller/renderer/backend/gles/capabilities_gles.h"
+#include "impeller/renderer/capabilities.h"
 
 namespace impeller {
 
@@ -125,7 +127,7 @@ ProcTableGLES::ProcTableGLES(Resolver resolver) {
     DiscardFramebufferEXT.Reset();
   }
 
-  capabilities_ = std::make_unique<CapabilitiesGLES>(*this);
+  capabilities_ = std::make_shared<CapabilitiesGLES>(*this);
 
   is_valid_ = true;
 }
@@ -148,8 +150,8 @@ const DescriptionGLES* ProcTableGLES::GetDescription() const {
   return description_.get();
 }
 
-const CapabilitiesGLES* ProcTableGLES::GetCapabilities() const {
-  return capabilities_.get();
+const std::shared_ptr<const CapabilitiesGLES>& ProcTableGLES::GetCapabilities() const {
+  return capabilities_;
 }
 
 static const char* FramebufferStatusToString(GLenum status) {

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -229,7 +229,7 @@ class ProcTableGLES {
 
   const DescriptionGLES* GetDescription() const;
 
-  const CapabilitiesGLES* GetCapabilities() const;
+  const std::shared_ptr<const CapabilitiesGLES>& GetCapabilities() const;
 
   std::string DescribeCurrentFramebuffer() const;
 
@@ -248,7 +248,7 @@ class ProcTableGLES {
  private:
   bool is_valid_ = false;
   std::unique_ptr<DescriptionGLES> description_;
-  std::unique_ptr<CapabilitiesGLES> capabilities_;
+  std::shared_ptr<const CapabilitiesGLES> capabilities_;
   GLint debug_label_max_length_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ProcTableGLES);

--- a/impeller/renderer/backend/gles/test/capabilities_unittests.cc
+++ b/impeller/renderer/backend/gles/test/capabilities_unittests.cc
@@ -1,0 +1,38 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gtest/gtest.h"
+#include "impeller/renderer/backend/gles/proc_table_gles.h"
+#include "impeller/renderer/backend/gles/test/mock_gles.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(CapabilitiesGLES, CanInitializeWithDefaults) {
+  auto mock_gles = MockGLES::Init();
+
+  auto capabilities = mock_gles->GetProcTable().GetCapabilities();
+
+  EXPECT_FALSE(capabilities->SupportsOffscreenMSAA());
+  EXPECT_FALSE(capabilities->SupportsSSBO());
+  EXPECT_FALSE(capabilities->SupportsBufferToTextureBlits());
+  EXPECT_FALSE(capabilities->SupportsTextureToTextureBlits());
+  EXPECT_FALSE(capabilities->SupportsFramebufferFetch());
+  EXPECT_FALSE(capabilities->SupportsCompute());
+  EXPECT_FALSE(capabilities->SupportsComputeSubgroups());
+  EXPECT_FALSE(capabilities->SupportsReadFromOnscreenTexture());
+  EXPECT_FALSE(capabilities->SupportsReadFromResolve());
+  EXPECT_FALSE(capabilities->SupportsDecalSamplerAddressMode());
+  EXPECT_FALSE(capabilities->SupportsDeviceTransientTextures());
+
+  EXPECT_EQ(capabilities->GetDefaultColorFormat(),
+            PixelFormat::kR8G8B8A8UNormInt);
+  EXPECT_EQ(capabilities->GetDefaultStencilFormat(), PixelFormat::kS8UInt);
+  EXPECT_EQ(capabilities->GetDefaultDepthStencilFormat(),
+            PixelFormat::kD24UnormS8Uint);
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
From https://github.com/flutter/engine/pull/46585

For Framebuffer fetch and other changes we should refactor the CapabilitiesGLES into a regular capabilities.