### PR TITLE
[Impeller] Compute uniform string keys offline.

### DIFF
--- a/impeller/compiler/code_gen_template.h
+++ b/impeller/compiler/code_gen_template.h
@@ -226,15 +226,17 @@ static_assert(offsetof(Shader::{{def.name}}, {{member.name}}) == {{member.offset
 {% for buffer in buffers %}
 ShaderMetadata Shader::kMetadata{{camel_case(buffer.name)}} = {
   "{{buffer.name}}",    // name
+  "",                   // uniform_non_struct_name
   std::vector<ShaderStructMemberMetadata> {
     {% for member in buffer.type.members %}
       ShaderStructMemberMetadata {
-        {{ member.base_type }},      // type
-        "{{ member.name }}",         // name
-        {{ member.offset }},         // offset
-        {{ member.size }},           // size
-        {{ member.byte_length }},    // byte_length
-        {{ member.array_elements }}, // array_elements
+        {{ member.base_type }},             // type
+        "{{ member.name }}",                 // name
+        {{ member.offset }},                 // offset
+        {{ member.size }},                   // size
+        {{ member.byte_length }},            // byte_length
+        {{ member.array_elements }},         // array_elements
+        "{{ member.uniform_struct_name}}",     // uniform_struct_name
       },
     {% endfor %}
   } // members
@@ -244,6 +246,7 @@ ShaderMetadata Shader::kMetadata{{camel_case(buffer.name)}} = {
 {% for sampled_image in sampled_images %}
 ShaderMetadata Shader::kMetadata{{camel_case(sampled_image.name)}} = {
     "{{sampled_image.name}}",    // name
+    "{{sampled_image.uniform_non_struct_name}}", // uniform_non_struct_name
     std::vector<ShaderStructMemberMetadata> {}, // 0 members
 };
 {% endfor %}

--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -97,7 +97,7 @@ TEST_P(CompilerTest, BindingBaseForFragShader) {
   ASSERT_GT(frag_uniform_binding, vert_uniform_binding);
 }
 
-TEST_P(CompilerTest, UniformsHaveBindingAndSet) {
+TEST_P(CompilerTest, UniformsHaveBindingSetAndComputedName) {
   ASSERT_TRUE(CanCompileAndReflect("sample_with_binding.vert",
                                    SourceType::kVertexShader));
   ASSERT_TRUE(CanCompileAndReflect("sample.frag", SourceType::kFragmentShader));

--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -97,7 +97,7 @@ TEST_P(CompilerTest, BindingBaseForFragShader) {
   ASSERT_GT(frag_uniform_binding, vert_uniform_binding);
 }
 
-TEST_P(CompilerTest, UniformsHaveBindingSetAndComputedName) {
+TEST_P(CompilerTest, UniformsHaveBindingAndSet) {
   ASSERT_TRUE(CanCompileAndReflect("sample_with_binding.vert",
                                    SourceType::kVertexShader));
   ASSERT_TRUE(CanCompileAndReflect("sample.frag", SourceType::kFragmentShader));

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -124,7 +124,8 @@ class Reflector {
       const spirv_cross::SmallVector<spirv_cross::Resource>& resources) const;
 
   std::optional<nlohmann::json::object_t> ReflectType(
-      const spirv_cross::TypeID& type_id) const;
+      const spirv_cross::TypeID& type_id,
+      const std::string& struct_name) const;
 
   nlohmann::json::object_t EmitStructDefinition(
       std::optional<Reflector::StructDefinition> struc) const;

--- a/impeller/core/shader_types.h
+++ b/impeller/core/shader_types.h
@@ -71,10 +71,12 @@ struct ShaderStructMemberMetadata {
   size_t size;
   size_t byte_length;
   std::optional<size_t> array_elements;
+  std::string uniform_struct_name;
 };
 
 struct ShaderMetadata {
   std::string name;
+  std::string uniform_non_struct_name;
   std::vector<ShaderStructMemberMetadata> members;
 };
 

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -4,11 +4,9 @@
 
 #include "impeller/renderer/backend/gles/buffer_bindings_gles.h"
 
-#include <algorithm>
 #include <cstring>
 #include <vector>
 
-#include "impeller/base/config.h"
 #include "impeller/base/validation.h"
 #include "impeller/renderer/backend/gles/device_buffer_gles.h"
 #include "impeller/renderer/backend/gles/formats_gles.h"
@@ -59,25 +57,6 @@ static std::string NormalizeUniformKey(const std::string& key) {
     }
   }
   return result;
-}
-
-static std::string CreateUniformMemberKey(const std::string& struct_name,
-                                          const std::string& member,
-                                          bool is_array) {
-  std::string result;
-  result.reserve(struct_name.length() + member.length() + (is_array ? 4 : 1));
-  result += struct_name;
-  result += '.';
-  result += member;
-  if (is_array) {
-    result += "[0]";
-  }
-  return NormalizeUniformKey(result);
-}
-
-static std::string CreateUniformMemberKey(
-    const std::string& non_struct_member) {
-  return NormalizeUniformKey(non_struct_member);
 }
 
 bool BufferBindingsGLES::ReadUniformsBindings(const ProcTableGLES& gl,
@@ -203,8 +182,7 @@ bool BufferBindingsGLES::BindUniformBuffer(const ProcTableGLES& gl,
 
     size_t element_count = member.array_elements.value_or(1);
 
-    const auto member_key =
-        CreateUniformMemberKey(metadata->name, member.name, element_count > 1);
+    const auto member_key = member.uniform_struct_name;
     const auto location = uniform_locations_.find(member_key);
     if (location == uniform_locations_.end()) {
       // The list of uniform locations only contains "active" uniforms that are
@@ -306,8 +284,7 @@ bool BufferBindingsGLES::BindTextures(const ProcTableGLES& gl,
       return false;
     }
 
-    const auto uniform_key =
-        CreateUniformMemberKey(data.second.texture.GetMetadata()->name);
+    const auto uniform_key = data.second.texture.GetMetadata()->uniform_non_struct_name;
     auto uniform = uniform_locations_.find(uniform_key);
     if (uniform == uniform_locations_.end()) {
       VALIDATION_LOG << "Could not find uniform for key: " << uniform_key;

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -284,7 +284,8 @@ bool BufferBindingsGLES::BindTextures(const ProcTableGLES& gl,
       return false;
     }
 
-    const auto uniform_key = data.second.texture.GetMetadata()->uniform_non_struct_name;
+    const auto uniform_key =
+        data.second.texture.GetMetadata()->uniform_non_struct_name;
     auto uniform = uniform_locations_.find(uniform_key);
     if (uniform == uniform_locations_.end()) {
       VALIDATION_LOG << "Could not find uniform for key: " << uniform_key;


### PR DESCRIPTION
Creating the strings shows up in most profiles, we can do most of the work offline. Still not as efficient as it could be because we're still hashing the uniform locations. We should be able to cache the location data and avoid the repeated lookups, though I don't think that can be done offline.