### PR TITLE
[Impeller] made window size parametric in playground/golden tests

### DIFF
--- a/impeller/golden_tests/golden_playground_test.h
+++ b/impeller/golden_tests/golden_playground_test.h
@@ -57,6 +57,9 @@ class GoldenPlaygroundTest
 
   ISize GetWindowSize() const;
 
+ protected:
+  void SetWindowSize(ISize size);
+
  private:
 #if FML_OS_MACOSX
   // This must be placed first so that the autorelease pool is not destroyed

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -193,4 +193,8 @@ ISize GoldenPlaygroundTest::GetWindowSize() const {
   return pimpl_->window_size;
 }
 
+void GoldenPlaygroundTest::GoldenPlaygroundTest::SetWindowSize(ISize size) {
+  pimpl_->window_size = size;
+}
+
 }  // namespace impeller

--- a/impeller/golden_tests/golden_playground_test_stub.cc
+++ b/impeller/golden_tests/golden_playground_test_stub.cc
@@ -64,4 +64,6 @@ ISize GoldenPlaygroundTest::GetWindowSize() const {
   return ISize();
 }
 
+void GoldenPlaygroundTest::SetWindowSize(ISize size) {}
+
 }  // namespace impeller

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -92,6 +92,8 @@ class Playground {
 
   virtual bool ShouldKeepRendering() const;
 
+  void SetWindowSize(ISize size);
+
  private:
   struct GLFWInitializer;
 
@@ -104,8 +106,6 @@ class Playground {
   ISize window_size_ = ISize{1024, 768};
 
   void SetCursorPosition(Point pos);
-
-  void SetWindowSize(ISize size);
 
   FML_DISALLOW_COPY_AND_ASSIGN(Playground);
 };


### PR DESCRIPTION
In https://github.com/flutter/flutter/issues/136058#issuecomment-1751507094 it was seen that some bugs manifest only with viewports of certain sizes.  This allows writers of tests to adjust the window size for playgrounds and golden image tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
