### PR TITLE
[Impeller] log specific framebuffer incomplete error.

### DIFF
--- a/impeller/renderer/backend/gles/BUILD.gn
+++ b/impeller/renderer/backend/gles/BUILD.gn
@@ -15,6 +15,7 @@ impeller_component("gles_unittests") {
   testonly = true
   sources = [
     "test/capabilities_unittests.cc",
+    "test/formats_gles_unittests.cc",
     "test/mock_gles.cc",
     "test/mock_gles.h",
     "test/mock_gles_unittests.cc",

--- a/impeller/renderer/backend/gles/formats_gles.cc
+++ b/impeller/renderer/backend/gles/formats_gles.cc
@@ -6,6 +6,21 @@
 
 namespace impeller {
 
-//
+std::string DebugToFramebufferError(int status) {
+  switch (status) {
+    case GL_FRAMEBUFFER_UNDEFINED:
+      return "GL_FRAMEBUFFER_UNDEFINED";
+    case GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT:
+      return "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
+    case GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT:
+      return "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT";
+    case GL_FRAMEBUFFER_UNSUPPORTED:
+      return "GL_FRAMEBUFFER_UNSUPPORTED";
+    case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:
+      return "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE";
+    default:
+      return "Unknown error code: " + std::to_string(status);
+  }
+}
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/formats_gles.h
+++ b/impeller/renderer/backend/gles/formats_gles.h
@@ -194,21 +194,6 @@ constexpr std::optional<GLenum> ToTextureTarget(TextureType type) {
   FML_UNREACHABLE();
 }
 
-std::string DebugToFramebufferError(int status) {
-  switch (status) {
-    case GL_FRAMEBUFFER_UNDEFINED:
-      return "GL_FRAMEBUFFER_UNDEFINED";
-    case GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT:
-      return "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
-    case GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT:
-      return "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT";
-    case GL_FRAMEBUFFER_UNSUPPORTED:
-      return "GL_FRAMEBUFFER_UNSUPPORTED";
-    case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:
-      return "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE";
-    default:
-      return "Unknown error code: " + std::to_string(status);
-  }
-}
+std::string DebugToFramebufferError(int status);
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/formats_gles.h
+++ b/impeller/renderer/backend/gles/formats_gles.h
@@ -194,4 +194,21 @@ constexpr std::optional<GLenum> ToTextureTarget(TextureType type) {
   FML_UNREACHABLE();
 }
 
+std::string DebugToFramebufferError(int status) {
+  switch (status) {
+    case GL_FRAMEBUFFER_UNDEFINED:
+      return "GL_FRAMEBUFFER_UNDEFINED";
+    case GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT:
+      return "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
+    case GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT:
+      return "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT";
+    case GL_FRAMEBUFFER_UNSUPPORTED:
+      return "GL_FRAMEBUFFER_UNSUPPORTED";
+    case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:
+      return "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE";
+    default:
+      return "Unknown error code: " + std::to_string(status);
+  }
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -193,8 +193,10 @@ struct RenderPassData {
       }
     }
 
-    if (gl.CheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-      VALIDATION_LOG << "Could not create a complete frambuffer.";
+    auto status = gl.CheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
+      VALIDATION_LOG << "Could not create a complete frambuffer: "
+                     << DebugToFramebufferError(status);
       return false;
     }
   }

--- a/impeller/renderer/backend/gles/test/formats_gles_unittests.cc
+++ b/impeller/renderer/backend/gles/test/formats_gles_unittests.cc
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gtest/gtest.h"
+#include "impeller/renderer/backend/gles/formats_gles.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(FormatsGLES, CanFormatFramebufferErrorMessage) {
+  ASSERT_EQ(DebugToFramebufferError(GL_FRAMEBUFFER_UNDEFINED),
+            "GL_FRAMEBUFFER_UNDEFINED");
+  ASSERT_EQ(DebugToFramebufferError(GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT),
+            "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT");
+  ASSERT_EQ(
+      DebugToFramebufferError(GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT),
+      "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT");
+  ASSERT_EQ(DebugToFramebufferError(GL_FRAMEBUFFER_UNSUPPORTED),
+            "GL_FRAMEBUFFER_UNSUPPORTED");
+  ASSERT_EQ(DebugToFramebufferError(GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE),
+            "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE");
+  ASSERT_EQ(DebugToFramebufferError(0), "Unknown error code: 0");
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
This is much easier to debug if we know the actual error code.
