### PR TITLE
Fix high FPS screen flicker of Platform Views when using ImageReaderPlatformViewRenderTarget

### DIFF
--- a/shell/platform/android/hardware_buffer_external_texture_gl.h
+++ b/shell/platform/android/hardware_buffer_external_texture_gl.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_ANDROID_HARDWARE_BUFFER_EXTERNAL_TEXTURE_GL_H_
 #define FLUTTER_SHELL_PLATFORM_ANDROID_HARDWARE_BUFFER_EXTERNAL_TEXTURE_GL_H_
 
+#include "flutter/fml/platform/android/scoped_java_ref.h"
 #include "flutter/shell/platform/android/hardware_buffer_external_texture.h"
 
 #include "flutter/impeller/renderer/backend/gles/context_gles.h"
@@ -15,51 +16,76 @@
 #include "flutter/impeller/toolkit/gles/texture.h"
 
 #include "flutter/shell/platform/android/android_context_gl_skia.h"
+#include "flutter/shell/platform/android/ndk_helpers.h"
 
 namespace flutter {
 
 class HardwareBufferExternalTextureGL : public HardwareBufferExternalTexture {
  public:
   HardwareBufferExternalTextureGL(
-      const std::shared_ptr<AndroidContextGLSkia>& context,
       int64_t id,
-      const fml::jni::ScopedJavaGlobalRef<jobject>&
-          hardware_buffer_texture_entry,
+      const fml::jni::ScopedJavaGlobalRef<jobject>& image_textury_entry,
       const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade);
 
-  ~HardwareBufferExternalTextureGL() override;
-
- private:
-  void ProcessFrame(PaintContext& context, const SkRect& bounds) override;
+ protected:
+  void Attach(PaintContext& context) override;
   void Detach() override;
 
-  impeller::UniqueEGLImageKHR image_;
-  impeller::UniqueGLTexture texture_;
+  // Returns true if a new image was acquired and android_image_ and egl_image_
+  // were updated.
+  bool MaybeSwapImages();
+  impeller::UniqueEGLImageKHR CreateEGLImage(AHardwareBuffer* buffer);
+
+  fml::jni::ScopedJavaGlobalRef<jobject> android_image_;
+  impeller::UniqueEGLImageKHR egl_image_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(HardwareBufferExternalTextureGL);
 };
 
-class HardwareBufferExternalTextureImpellerGL
-    : public HardwareBufferExternalTexture {
+class HardwareBufferExternalTextureGLSkia
+    : public HardwareBufferExternalTextureGL {
  public:
-  HardwareBufferExternalTextureImpellerGL(
+  HardwareBufferExternalTextureGLSkia(
+      const std::shared_ptr<AndroidContextGLSkia>& context,
+      int64_t id,
+      const fml::jni::ScopedJavaGlobalRef<jobject>& image_textury_entry,
+      const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade);
+
+ private:
+  void Attach(PaintContext& context) override;
+  void Detach() override;
+  void ProcessFrame(PaintContext& context, const SkRect& bounds) override;
+
+  void BindImageToTexture(const impeller::UniqueEGLImageKHR& image, GLuint tex);
+  sk_sp<flutter::DlImage> CreateDlImage(PaintContext& context,
+                                        const SkRect& bounds);
+
+  impeller::UniqueGLTexture texture_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(HardwareBufferExternalTextureGLSkia);
+};
+
+class HardwareBufferExternalTextureGLImpeller
+    : public HardwareBufferExternalTextureGL {
+ public:
+  HardwareBufferExternalTextureGLImpeller(
       const std::shared_ptr<impeller::ContextGLES>& context,
       int64_t id,
       const fml::jni::ScopedJavaGlobalRef<jobject>&
           hardware_buffer_texture_entry,
       const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade);
 
-  ~HardwareBufferExternalTextureImpellerGL() override;
-
  private:
+  void Attach(PaintContext& context) override;
   void ProcessFrame(PaintContext& context, const SkRect& bounds) override;
   void Detach() override;
 
+  sk_sp<flutter::DlImage> CreateDlImage(PaintContext& context,
+                                        const SkRect& bounds);
+
   const std::shared_ptr<impeller::ContextGLES> impeller_context_;
 
-  impeller::UniqueEGLImageKHR egl_image_;
-
-  FML_DISALLOW_COPY_AND_ASSIGN(HardwareBufferExternalTextureImpellerGL);
+  FML_DISALLOW_COPY_AND_ASSIGN(HardwareBufferExternalTextureGLImpeller);
 };
 
 }  // namespace flutter

--- a/shell/platform/android/hardware_buffer_external_texture_vk.h
+++ b/shell/platform/android/hardware_buffer_external_texture_vk.h
@@ -26,10 +26,13 @@ class HardwareBufferExternalTextureVK : public HardwareBufferExternalTexture {
   ~HardwareBufferExternalTextureVK() override;
 
  private:
+  void Attach(PaintContext& context) override;
   void ProcessFrame(PaintContext& context, const SkRect& bounds) override;
   void Detach() override;
 
   const std::shared_ptr<impeller::ContextVK> impeller_context_;
+
+  fml::jni::ScopedJavaGlobalRef<jobject> android_image_;
 };
 
 }  // namespace flutter

--- a/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
@@ -19,7 +19,7 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
   private int bufferWidth = 0;
   private int bufferHeight = 0;
   private static final String TAG = "ImageReaderPlatformViewRenderTarget";
-  private static final int MAX_IMAGES = 3;
+  private static final int MAX_IMAGES = 4;
 
   private void closeReader() {
     if (this.reader != null) {
@@ -40,7 +40,7 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
           try {
             image = reader.acquireLatestImage();
           } catch (IllegalStateException e) {
-            Log.e(TAG, "New image available but it could not be acquired: " + e.toString());
+            Log.e(TAG, "onImageAvailable acquireLatestImage failed: " + e.toString());
           }
           if (image == null) {
             return;

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -147,7 +147,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   // Whether software rendering is used.
   private boolean usesSoftwareRendering = false;
 
-  private static boolean enableHardwareBufferRenderingTarget = false;
+  private static boolean enableHardwareBufferRenderingTarget = true;
 
   private final PlatformViewsChannel.PlatformViewsHandler channelHandler =
       new PlatformViewsChannel.PlatformViewsHandler() {
@@ -181,12 +181,14 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           }
           if (textureRegistry == null) {
             throw new IllegalStateException(
-                "Texture registry is null. This means that platform views controller was detached, view id: "
+                "Texture registry is null. This means that platform views controller was detached,"
+                    + " view id: "
                     + viewId);
           }
           if (flutterView == null) {
             throw new IllegalStateException(
-                "Flutter view is null. This means the platform views controller doesn't have an attached view, view id: "
+                "Flutter view is null. This means the platform views controller doesn't have an"
+                    + " attached view, view id: "
                     + viewId);
           }
 
@@ -195,7 +197,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           final View embeddedView = platformView.getView();
           if (embeddedView.getParent() != null) {
             throw new IllegalStateException(
-                "The Android view returned from PlatformView#getView() was already added to a parent view.");
+                "The Android view returned from PlatformView#getView() was already added to a"
+                    + " parent view.");
           }
 
           // The newer Texture Layer Hybrid Composition mode isn't suppported if any of the
@@ -1098,7 +1101,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     }
     if (embeddedView.getParent() != null) {
       throw new IllegalStateException(
-          "The Android view returned from PlatformView#getView() was already added to a parent view.");
+          "The Android view returned from PlatformView#getView() was already added to a parent"
+              + " view.");
     }
     final FlutterMutatorView parentView =
         new FlutterMutatorView(

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -324,13 +324,13 @@ void PlatformViewAndroid::RegisterImageTexture(
   if (android_context_->RenderingApi() == AndroidRenderingAPI::kOpenGLES) {
     if (android_context_->GetImpellerContext()) {
       // Impeller GLES.
-      RegisterTexture(std::make_shared<HardwareBufferExternalTextureImpellerGL>(
+      RegisterTexture(std::make_shared<HardwareBufferExternalTextureGLImpeller>(
           std::static_pointer_cast<impeller::ContextGLES>(
               android_context_->GetImpellerContext()),
           texture_id, image_texture_entry, jni_facade_));
     } else {
       // Legacy GL.
-      RegisterTexture(std::make_shared<HardwareBufferExternalTextureGL>(
+      RegisterTexture(std::make_shared<HardwareBufferExternalTextureGLSkia>(
           std::static_pointer_cast<AndroidContextGLSkia>(android_context_),
           texture_id, image_texture_entry, jni_facade_));
     }


### PR DESCRIPTION
The root bug (b/300627634) was that we were holding onto HardwareBuffers after the owning Image was closed. This CL refactors the C++ code to properly hold a reference to the Image until it is safe to dispose of.

This CL also refactors the Impeller GL and Skia GL code paths to share more code.