### PR TITLE
Prepare to move new folders into `third_party/` by adding a `.gitignore`.

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -391,6 +391,7 @@
 ../../../flutter/sky/tools/objcopy.py
 ../../../flutter/testing
 ../../../flutter/third_party/.clang-tidy
+../../../flutter/third_party/.gitignore
 ../../../flutter/third_party/accessibility/README.md
 ../../../flutter/third_party/accessibility/ax/ax_enum_util_unittest.cc
 ../../../flutter/third_party/accessibility/ax/ax_event_generator_unittest.cc

--- a/third_party/.gitignore
+++ b/third_party/.gitignore
@@ -1,0 +1,19 @@
+# Ignore everything by default, as these come from gclient/DEPS.
+# We'll explicitly include the folders we want to track.
+*
+
+# Include the .gitignore file itself and .clang-tidy.
+!.gitignore
+!.clang-tidy
+
+# Include folders that have hand-written code (not DEPS).
+!accessibility/
+!canvaskit/
+!ninja/
+!spring_animation/
+!test_shaders/
+!tonic/
+!txt/
+!web_locale_keymap/
+!web_test_fonts/
+!web_unicode/


### PR DESCRIPTION
As part of https://github.com/flutter/flutter/issues/67373, we'll be adding, for example `third_party/glfw`.

This PR will by default ignore folders, except for ones that have internal repo-sourced code (which are unlikely to change much, if at all during this transition).

_/cc @Hixie, @chinmaygarde FYI only_.