### PR TITLE
[flutter release cp] Use x86 machines for ios builds. (#46726)

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -3,8 +3,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "mac_model=Macmini8,1",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",
@@ -26,7 +26,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",
@@ -49,7 +50,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",
@@ -72,7 +74,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",
@@ -96,7 +99,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",
@@ -120,8 +124,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "mac_model=Macmini8,1",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",
@@ -144,7 +148,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",
@@ -168,7 +173,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",
@@ -192,7 +198,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",
@@ -217,7 +224,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12"
+                "os=Mac-12",
+                "cpu=x86"
             ],
             "gn": [
                 "--ios",


### PR DESCRIPTION
This is to workaround rosetta not being installed in dart-internal machines and to unblock beta releases.

Bug: https://github.com/flutter/flutter/issues/136219