### PR TITLE
Run the binary size treemap script from the buildroot directory

### DIFF
--- a/ci/binary_size_treemap.sh
+++ b/ci/binary_size_treemap.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Run a tool that generates a treemap showing the contribution of each
+# component to the size of a binary.
+#
+# Usage:
+#   binary_size_treemap.sh [binary_path] [output_dir]
+
+set -e
+
+INPUT_PATH="$(cd $(dirname "$1"); pwd -P)/$(basename "$1")"
+DEST_DIR="$(cd $(dirname "$2"); pwd -P)/$(basename "$2")"
+CI_DIRECTORY=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd -P)
+ENGINE_BUILDROOT=$(cd "$CI_DIRECTORY/../.."; pwd -P)
+
+if [ "$(uname)" == "Darwin" ]; then
+  NDK_PLATFORM="darwin-x86_64"
+else
+  NDK_PLATFORM="linux-x86_64"
+fi
+ADDR2LINE="third_party/android_tools/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/$NDK_PLATFORM/bin/aarch64-linux-android-addr2line"
+
+# Run the binary size script from the buildroot directory so the treemap path
+# navigation will start from there.
+cd "$ENGINE_BUILDROOT"
+python3 third_party/dart/runtime/third_party/binary_size/src/run_binary_size_analysis.py --library "$INPUT_PATH" --destdir "$DEST_DIR" --addr2line-binary "$ADDR2LINE"

--- a/ci/builders/linux_android_aot_engine.json
+++ b/ci/builders/linux_android_aot_engine.json
@@ -114,15 +114,11 @@
             "tests": [
                 {
                     "name": "Generate treemap for android_release_arm64",
-                    "language": "python3",
-                    "script": "third_party/dart/runtime/third_party/binary_size/src/run_binary_size_analysis.py",
+                    "language": "bash",
+                    "script": "flutter/ci/binary_size_treemap.sh",
                     "parameters": [
-                        "--library",
                         "../../src/out/android_release_arm64/libflutter.so",
-                        "--destdir",
-                        "${FLUTTER_LOGS_DIR}",
-                        "--addr2line-binary",
-                        "../../src/third_party/android_tools/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-addr2line"
+                        "${FLUTTER_LOGS_DIR}"
                     ]
                 }
             ]


### PR DESCRIPTION
This will produce a treemap where navigation starts from the buildroot and the flutter and third_party source directories are shown as siblings.