### PR TITLE
[Impeller] Guard calls to extension proc DebugMessageControlKHR.

### DIFF
--- a/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/impeller/renderer/backend/gles/reactor_gles.cc
@@ -257,12 +257,14 @@ bool ReactorGLES::FlushOps() {
 
 void ReactorGLES::SetupDebugGroups() {
   // Setup of a default active debug group: Filter everything in.
-  proc_table_->DebugMessageControlKHR(GL_DONT_CARE,  // source
-                                      GL_DONT_CARE,  // type
-                                      GL_DONT_CARE,  // severity
-                                      0,             // count
-                                      nullptr,       // ids
-                                      GL_TRUE);      // enabled
+  if (proc_table_->DebugMessageControlKHR.IsAvailable()) {
+    proc_table_->DebugMessageControlKHR(GL_DONT_CARE,  // source
+                                        GL_DONT_CARE,  // type
+                                        GL_DONT_CARE,  // severity
+                                        0,             // count
+                                        nullptr,       // ids
+                                        GL_TRUE);      // enabled
+  }
 }
 
 void ReactorGLES::SetDebugLabel(const HandleGLES& handle, std::string label) {


### PR DESCRIPTION
Quick fix to unblock the `impeller-cmake-example` build. Calls to ES3 and extension procs need to be guarded.