### PR TITLE
[Impeller] Avoid invalid GL depth calls on macOS desktop.

### DIFF
--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -207,7 +207,12 @@ struct RenderPassData {
                 pass_data.clear_color.alpha   // alpha
   );
   if (pass_data.depth_attachment) {
+    // TODO(bdero): Desktop GL for Apple requires glClearDepth. glClearDepthf
+    //              throws GL_INVALID_OPERATION.
+    //              https://github.com/flutter/flutter/issues/136322
+#if !FML_OS_MACOSX
     gl.ClearDepthf(pass_data.clear_depth);
+#endif
   }
   if (pass_data.stencil_attachment) {
     gl.ClearStencil(pass_data.clear_stencil);
@@ -303,7 +308,12 @@ struct RenderPassData {
                 viewport.rect.size.height       // height
     );
     if (pass_data.depth_attachment) {
+      // TODO(bdero): Desktop GL for Apple requires glDepthRange. glDepthRangef
+      //              throws GL_INVALID_OPERATION.
+      //              https://github.com/flutter/flutter/issues/136322
+#if !FML_OS_MACOSX
       gl.DepthRangef(viewport.depth_range.z_near, viewport.depth_range.z_far);
+#endif
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
The macOS desktop driver doesn't support ES profiles, and `glClearDepthf` + `glDepthRangef` are throwing `GL_INVALID_OPERATION` and doing nothing. Noticed this while updating impeller-cmake past @matanlurey's recent changes to make `GL_INVALID_OPERATION` fatal. Impeller-cmake-example uses a depth buffer, whereas Impeller's 2D renderer currently does not.

Added a follow-up bug to make these calls work on macOS desktop: https://github.com/flutter/flutter/issues/136322.
Both Impeller Scene and the impeller-cmake-example currently just rely on the default state for clearing depth.