### PR TITLE
Bump to Chrome 119.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -360,7 +360,7 @@ targets:
         {"download_emsdk": true}
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:118.0.5993.70"},
+          {"dependency": "chrome_and_driver", "version": "version:119.0.6045.9"},
           {"dependency": "curl", "version": "version:7.64.0"}
         ]
       framework: "true"

--- a/ci/builders/linux_web_engine.json
+++ b/ci/builders/linux_web_engine.json
@@ -355,7 +355,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -391,7 +391,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -427,7 +427,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -463,7 +463,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -499,7 +499,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -535,7 +535,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -571,7 +571,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -607,7 +607,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -823,7 +823,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -859,7 +859,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -895,7 +895,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -931,7 +931,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -967,7 +967,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1003,7 +1003,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1039,7 +1039,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1075,7 +1075,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1271,7 +1271,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1307,7 +1307,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1343,7 +1343,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1379,7 +1379,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1415,7 +1415,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1451,7 +1451,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1487,7 +1487,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [
@@ -1523,7 +1523,7 @@
         },
         {
           "dependency": "chrome_and_driver",
-          "version": "118.0.5993.70"
+          "version": "119.0.6045.9"
         }
       ],
       "tasks": [

--- a/lib/web_ui/dev/browser_lock.yaml
+++ b/lib/web_ui/dev/browser_lock.yaml
@@ -1,7 +1,7 @@
 # Please refer to the "Upgrade Browser Version" section in the README.md for
 # more details on how to update browser version numbers.
 chrome:
-  version: '118.0.5993.70'
+  version: '119.0.6045.9'
 
 firefox:
   version: '106.0'

--- a/lib/web_ui/dev/generate_builder_json.dart
+++ b/lib/web_ui/dev/generate_builder_json.dart
@@ -154,7 +154,7 @@ Iterable<dynamic> _getTestStepsForPlatform(
           if (suite.runConfig.browser == BrowserName.chrome)
             <String, dynamic>{
               'dependency': 'chrome_and_driver',
-              'version': '118.0.5993.70',
+              'version': '119.0.6045.9',
             },
           if (suite.runConfig.browser == BrowserName.firefox)
             <String, dynamic>{


### PR DESCRIPTION
Chrome 119 uses the WasmGC final encodings. Therefore, without compiler support, all wasm tests are expected to fail here. However, I am opening a draft to ensure the rest of the non-wasm tests pass and have no issues.