### PR TITLE
Fix forward declare and some deprecated enums

### DIFF
--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -10,14 +10,15 @@
 #include "flutter/shell/common/context_options.h"
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLDirectContext.h"
 #include "third_party/skia/include/gpu/gl/GrGLInterface.h"
+#include "third_party/skia/include/gpu/gl/GrGLTypes.h"
 
 namespace flutter {
 
 sk_sp<GrDirectContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
-    GrBackend backend,
+    GrBackendApi backend,
     const sk_sp<const GrGLInterface>& gl_interface) {
 #if SK_GL
-  if (backend != GrBackend::kOpenGL_GrBackend) {
+  if (backend != GrBackendApi::kOpenGL) {
     return nullptr;
   }
 

--- a/shell/common/shell_io_manager.h
+++ b/shell/common/shell_io_manager.h
@@ -12,6 +12,9 @@
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/lib/ui/io_manager.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
+
+struct GrGLInterface;
 
 namespace flutter {
 
@@ -21,7 +24,7 @@ class ShellIOManager final : public IOManager {
   // supply to the IOManager. The platforms may create the context themselves if
   // they so desire.
   static sk_sp<GrDirectContext> CreateCompatibleResourceLoadingContext(
-      GrBackend backend,
+      GrBackendApi backend,
       const sk_sp<const GrGLInterface>& gl_interface);
 
   ShellIOManager(

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -386,7 +386,7 @@ sk_sp<GrDirectContext> PlatformViewAndroid::CreateResourceContext() const {
     // the OpenGL surface will be able to make a resource context current. If
     // this changes, this assumption breaks. Handle the same.
     resource_context = ShellIOManager::CreateCompatibleResourceLoadingContext(
-        GrBackend::kOpenGL_GrBackend,
+        GrBackendApi::kOpenGL,
         GPUSurfaceGLDelegate::GetDefaultPlatformGLInterface());
   } else {
     FML_DLOG(ERROR) << "Could not make the resource context current.";

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -107,7 +107,7 @@ sk_sp<GrDirectContext> EmbedderSurfaceGL::CreateResourceContext() const {
   auto callback = gl_dispatch_table_.gl_make_resource_current_callback;
   if (callback && callback()) {
     if (auto context = ShellIOManager::CreateCompatibleResourceLoadingContext(
-            GrBackend::kOpenGL_GrBackend, GetGLInterface())) {
+            GrBackendApi::kOpenGL, GetGLInterface())) {
       return context;
     } else {
       FML_LOG(ERROR)


### PR DESCRIPTION
There was a compile error when trying to roll in http://review.skia.org/764970, and this addresses that.

While I was here, I noticed some uses of the old-named `GrBackend` enum and updated it to the non-deprecated enum class.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
