### PR TITLE
Use --timeline_recorder=systrace instead of --systrace_timeline

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -95,9 +95,8 @@ static const char* kDartEndlessTraceBufferArgs[]{
     "--timeline_recorder=endless",
 };
 
-// This is the same as --timeline_recorder=systrace.
 static const char* kDartSystraceTraceBufferArgs[] = {
-    "--systrace_timeline",
+    "--timeline_recorder=systrace",
 };
 
 static std::string DartFileRecorderArgs(const std::string& path) {

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -41,7 +41,7 @@ namespace {
 const char* kDartVMArgs[] = {
     // clang-format off
 
-    "--systrace_timeline",
+    "--timeline_recorder=systrace",
     "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM",
 
 #if defined(AOT_RUNTIME)


### PR DESCRIPTION
`--systrace_timeline` is redundant and makes the `getFlagList` VM Service RPC not return `timeline_recorder=systrace` (https://github.com/flutter/devtools/issues/6524#issuecomment-1760090526), so we would like to deprecate and remove it.