### PR TITLE
Fix `Platform.script` for flutter_tester

### DIFF
--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -526,6 +526,7 @@ int main(int argc, char* argv[]) {
     // it as a positional argument instead.
     settings.application_kernel_asset = command_line.positional_args()[0];
   }
+  settings.advisory_script_uri = settings.application_kernel_asset;
 
   if (settings.application_kernel_asset.empty()) {
     FML_LOG(ERROR) << "Dart kernel file not specified.";

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -38,6 +38,7 @@ tests = [
   "paragraph_test.dart",
   "path_test.dart",
   "picture_test.dart",
+  "platform_test.dart",
   "platform_view_test.dart",
   "plugin_utilities_test.dart",
   "semantics_test.dart",

--- a/testing/dart/platform_test.dart
+++ b/testing/dart/platform_test.dart
@@ -1,0 +1,14 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:litetest/litetest.dart';
+
+void main() {
+  test('Platform.script has right URI', () async {
+    // Platform.script should look like file:///path/to/engine/src/out/variant/gen/platform_test.dart.dill
+    expect(Platform.script.path, endsWith('gen/platform_test.dart.dill'));
+  });
+}


### PR DESCRIPTION
This addresses the problem in https://github.com/flutter/flutter/issues/12847 which changed slightly over time.

Today, `Platform.script` does not give an empty `file` URI, it gives something like `file://path/to/package/main.dart` _regardless of how the file is actually named_.

After this change, it will give the absolute path to the file being run under test.

So before this change, the new test would have a URI like

```
file:///Users/dnfield/src/flutter/engine/src/main.dart
```

And now it has

```
file:///Users/dnfield/src/flutter/engine/src/out/host_debug_unopt_arm64/gen/platform_test.dart.dill
```

This is going to be helpful in generating relative paths from the test file.