### PR TITLE
Allow Image backed platform view rendering target on Android >= 29 again

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
@@ -12,7 +12,7 @@ import android.view.Surface;
 import io.flutter.Log;
 import io.flutter.view.TextureRegistry.ImageTextureEntry;
 
-@TargetApi(33)
+@TargetApi(29)
 public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTarget {
   private ImageTextureEntry textureEntry;
   private ImageReader reader;
@@ -72,18 +72,33 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
     return reader;
   }
 
+  @TargetApi(29)
+  protected ImageReader createImageReader29() {
+    final ImageReader reader =
+        ImageReader.newInstance(
+            bufferWidth,
+            bufferHeight,
+            ImageFormat.PRIVATE,
+            MAX_IMAGES,
+            HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
+    reader.setOnImageAvailableListener(this.onImageAvailableListener, onImageAvailableHandler);
+    return reader;
+  }
+
   protected ImageReader createImageReader() {
     if (Build.VERSION.SDK_INT >= 33) {
       return createImageReader33();
+    } else if (Build.VERSION.SDK_INT >= 29) {
+      return createImageReader29();
     }
     throw new UnsupportedOperationException(
-        "ImageReaderPlatformViewRenderTarget requires API version 33+");
+        "ImageReaderPlatformViewRenderTarget requires API version 29+");
   }
 
   public ImageReaderPlatformViewRenderTarget(ImageTextureEntry textureEntry) {
-    if (Build.VERSION.SDK_INT < 33) {
+    if (Build.VERSION.SDK_INT < 29) {
       throw new UnsupportedOperationException(
-          "ImageReaderPlatformViewRenderTarget requires API version 33+");
+          "ImageReaderPlatformViewRenderTarget requires API version 29+");
     }
     this.textureEntry = textureEntry;
   }

--- a/shell/platform/android/test/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTargetTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTargetTest.java
@@ -1,0 +1,105 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugin.platform;
+
+import static android.os.Looper.getMainLooper;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.media.Image;
+import android.view.View;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.flutter.view.TextureRegistry.ImageTextureEntry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@TargetApi(29)
+@RunWith(AndroidJUnit4.class)
+public class ImageReaderPlatformViewRenderTargetTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
+
+  class TestImageTextureEntry implements ImageTextureEntry {
+    private Image lastPushedImage;
+
+    public long id() {
+      return 1;
+    }
+
+    public void release() {
+      if (this.lastPushedImage != null) {
+        this.lastPushedImage.close();
+      }
+    }
+
+    public void pushImage(Image image) {
+      if (this.lastPushedImage != null) {
+        this.lastPushedImage.close();
+      }
+      this.lastPushedImage = image;
+    }
+
+    public Image acquireLatestImage() {
+      Image r = this.lastPushedImage;
+      this.lastPushedImage = null;
+      return r;
+    }
+  }
+
+  @Test
+  public void viewDraw_writesToBuffer() {
+    final TestImageTextureEntry textureEntry = new TestImageTextureEntry();
+    final ImageReaderPlatformViewRenderTarget renderTarget =
+        new ImageReaderPlatformViewRenderTarget(textureEntry);
+    // Custom view.
+    final View platformView =
+        new View(ctx) {
+          @Override
+          public void draw(Canvas canvas) {
+            super.draw(canvas);
+            canvas.drawColor(Color.RED);
+          }
+        };
+    final int size = 100;
+    platformView.measure(size, size);
+    platformView.layout(0, 0, size, size);
+    renderTarget.resize(size, size);
+
+    // We don't have an image in the texture entry.
+    assertNull(textureEntry.acquireLatestImage());
+
+    // Start rendering a frame.
+    final Canvas targetCanvas = renderTarget.lockHardwareCanvas();
+    assertNotNull(targetCanvas);
+
+    try {
+      // Fill the render target with transparent pixels. This is needed for platform views that
+      // expect a transparent background.
+      targetCanvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+      // Override the canvas that this subtree of views will use to draw.
+      platformView.draw(targetCanvas);
+    } finally {
+      // Finish rendering a frame.
+      renderTarget.unlockCanvasAndPost(targetCanvas);
+    }
+
+    // Pump the UI thread task loop. This is needed so that the OnImageAvailable callback
+    // gets invoked (resulting in textureEntry.pushImage being invoked).
+    shadowOf(getMainLooper()).idle();
+
+    // An image was pushed into the texture entry and it has the correct dimensions.
+    Image pushedImage = textureEntry.acquireLatestImage();
+    assertNotNull(pushedImage);
+    assertEquals(pushedImage.getWidth(), size);
+    assertEquals(pushedImage.getHeight(), size);
+  }
+}

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugin.platform;
 
 import static android.view.WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS;

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewWrapperTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugin.platform;
 
 import static android.view.View.OnFocusChangeListener;

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugin.platform;
 
 import static android.os.Looper.getMainLooper;

--- a/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugin.platform;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;

--- a/shell/platform/android/test/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTargetTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTargetTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugin.platform;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
- Refactor the fence waiting code to only wait on Android >= 33.
- Log a warning message once per image rendering target on Android >= 29 && < 33.
- Add a simple unit test of ImageReaderPlatformViewRenderTargets.