### PR TITLE
[Impeller] Rework Vulkan GPUTracker to decorate existing cmd buffers.

### DIFF
--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -15,6 +15,7 @@ impeller_component("vulkan_unittests") {
     "fence_waiter_vk_unittests.cc",
     "pass_bindings_cache_unittests.cc",
     "resource_manager_vk_unittests.cc",
+    "test/gpu_tracer_unittests.cc",
     "test/mock_vulkan.cc",
     "test/mock_vulkan.h",
     "test/mock_vulkan_unittests.cc",

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -134,10 +134,8 @@ std::shared_ptr<CommandEncoderVK> CommandEncoderFactoryVK::Create() {
     context_vk.SetDebugName(tracked_objects->GetCommandBuffer(),
                             label_.value());
   }
-#ifdef IMPELLER_DEBUG
   context->GetGPUTracer()->RecordCmdBufferStart(
       tracked_objects->GetCommandBuffer());
-#endif  // IMPELLER_DEBUG
 
   return std::make_shared<CommandEncoderVK>(
       context_vk.GetDeviceHolder(), tracked_objects, queue,
@@ -185,10 +183,7 @@ bool CommandEncoderVK::Submit(SubmitCallback callback) {
 
   auto command_buffer = GetCommandBuffer();
 
-  size_t end_frame = 0u;
-#ifdef IMPELLER_DEBUG
-  end_frame = gpu_tracer_->RecordCmdBufferEnd(command_buffer);
-#endif  // IMPELLER_DEBUG
+  size_t end_frame = gpu_tracer_->RecordCmdBufferEnd(command_buffer);
 
   auto status = command_buffer.end();
   if (status != vk::Result::eSuccess) {

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -183,7 +183,7 @@ bool CommandEncoderVK::Submit(SubmitCallback callback) {
 
   auto command_buffer = GetCommandBuffer();
 
-  size_t end_frame = gpu_tracer_->RecordCmdBufferEnd(command_buffer);
+  auto end_frame = gpu_tracer_->RecordCmdBufferEnd(command_buffer);
 
   auto status = command_buffer.end();
   if (status != vk::Result::eSuccess) {
@@ -222,7 +222,9 @@ bool CommandEncoderVK::Submit(SubmitCallback callback) {
       std::move(fence),
       [callback, tracked_objects = std::move(tracked_objects_), gpu_tracer,
        end_frame] {
-        gpu_tracer->OnFenceComplete(end_frame, true);
+        if (end_frame.has_value()) {
+          gpu_tracer->OnFenceComplete(end_frame, true);
+        }
         if (callback) {
           callback(true);
         }

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -7,6 +7,7 @@
 #include "flutter/fml/closure.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/fence_waiter_vk.h"
+#include "impeller/renderer/backend/vulkan/gpu_tracer_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
 
 namespace impeller {
@@ -133,21 +134,27 @@ std::shared_ptr<CommandEncoderVK> CommandEncoderFactoryVK::Create() {
     context_vk.SetDebugName(tracked_objects->GetCommandBuffer(),
                             label_.value());
   }
+#ifdef IMPELLER_DEBUG
+  context->GetGPUTracer()->RecordCmdBufferStart(
+      tracked_objects->GetCommandBuffer());
+#endif  // IMPELLER_DEBUG
 
-  return std::make_shared<CommandEncoderVK>(context_vk.GetDeviceHolder(),
-                                            tracked_objects, queue,
-                                            context_vk.GetFenceWaiter());
+  return std::make_shared<CommandEncoderVK>(
+      context_vk.GetDeviceHolder(), tracked_objects, queue,
+      context_vk.GetFenceWaiter(), context->GetGPUTracer());
 }
 
 CommandEncoderVK::CommandEncoderVK(
     std::weak_ptr<const DeviceHolder> device_holder,
     std::shared_ptr<TrackedObjectsVK> tracked_objects,
     const std::shared_ptr<QueueVK>& queue,
-    std::shared_ptr<FenceWaiterVK> fence_waiter)
+    std::shared_ptr<FenceWaiterVK> fence_waiter,
+    const std::shared_ptr<GPUTracerVK>& gpu_tracer)
     : device_holder_(std::move(device_holder)),
       tracked_objects_(std::move(tracked_objects)),
       queue_(queue),
-      fence_waiter_(std::move(fence_waiter)) {}
+      fence_waiter_(std::move(fence_waiter)),
+      gpu_tracer_(gpu_tracer) {}
 
 CommandEncoderVK::~CommandEncoderVK() = default;
 
@@ -178,18 +185,26 @@ bool CommandEncoderVK::Submit(SubmitCallback callback) {
 
   auto command_buffer = GetCommandBuffer();
 
+  size_t end_frame = 0u;
+#ifdef IMPELLER_DEBUG
+  end_frame = gpu_tracer_->RecordCmdBufferEnd(command_buffer);
+#endif  // IMPELLER_DEBUG
+
   auto status = command_buffer.end();
   if (status != vk::Result::eSuccess) {
+    gpu_tracer_->OnFenceComplete(end_frame);
     VALIDATION_LOG << "Failed to end command buffer: " << vk::to_string(status);
     return false;
   }
   std::shared_ptr<const DeviceHolder> strong_device = device_holder_.lock();
   if (!strong_device) {
+    gpu_tracer_->OnFenceComplete(end_frame);
     VALIDATION_LOG << "Device lost.";
     return false;
   }
   auto [fence_result, fence] = strong_device->GetDevice().createFenceUnique({});
   if (fence_result != vk::Result::eSuccess) {
+    gpu_tracer_->OnFenceComplete(end_frame);
     VALIDATION_LOG << "Failed to create fence: " << vk::to_string(fence_result);
     return false;
   }
@@ -199,6 +214,7 @@ bool CommandEncoderVK::Submit(SubmitCallback callback) {
   submit_info.setCommandBuffers(buffers);
   status = queue_->Submit(submit_info, *fence);
   if (status != vk::Result::eSuccess) {
+    gpu_tracer_->OnFenceComplete(end_frame);
     VALIDATION_LOG << "Failed to submit queue: " << vk::to_string(status);
     return false;
   }
@@ -206,9 +222,12 @@ bool CommandEncoderVK::Submit(SubmitCallback callback) {
   // Submit will proceed, call callback with true when it is done and do not
   // call when `reset` is collected.
   fail_callback = false;
+  auto gpu_tracer = gpu_tracer_;
   return fence_waiter_->AddFence(
       std::move(fence),
-      [callback, tracked_objects = std::move(tracked_objects_)] {
+      [callback, tracked_objects = std::move(tracked_objects_), gpu_tracer,
+       end_frame] {
+        gpu_tracer->OnFenceComplete(end_frame);
         if (callback) {
           callback(true);
         }

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -29,7 +29,8 @@ class FenceWaiterVK;
 
 class CommandEncoderFactoryVK {
  public:
-  CommandEncoderFactoryVK(const std::weak_ptr<const ContextVK>& context);
+  explicit CommandEncoderFactoryVK(
+      const std::weak_ptr<const ContextVK>& context);
 
   std::shared_ptr<CommandEncoderVK> Create();
 
@@ -50,7 +51,8 @@ class CommandEncoderVK {
   CommandEncoderVK(std::weak_ptr<const DeviceHolder> device_holder,
                    std::shared_ptr<TrackedObjectsVK> tracked_objects,
                    const std::shared_ptr<QueueVK>& queue,
-                   std::shared_ptr<FenceWaiterVK> fence_waiter);
+                   std::shared_ptr<FenceWaiterVK> fence_waiter,
+                   const std::shared_ptr<GPUTracerVK>& gpu_tracer);
 
   ~CommandEncoderVK();
 
@@ -89,6 +91,7 @@ class CommandEncoderVK {
   std::shared_ptr<TrackedObjectsVK> tracked_objects_;
   std::shared_ptr<QueueVK> queue_;
   const std::shared_ptr<FenceWaiterVK> fence_waiter_;
+  std::shared_ptr<GPUTracerVK> gpu_tracer_;
   bool is_valid_ = true;
 
   void Reset();

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -433,7 +433,7 @@ void ContextVK::Setup(Settings settings) {
 
   // Create the GPU Tracer later because it depends on state from
   // the ContextVK.
-  gpu_tracer_ = std::make_shared<GPUTracerVK>(weak_from_this());
+  gpu_tracer_ = std::make_shared<GPUTracerVK>(GetDeviceHolder());
 
   //----------------------------------------------------------------------------
   /// Label all the relevant objects. This happens after setup so that the

--- a/impeller/renderer/backend/vulkan/gpu_tracer_vk.cc
+++ b/impeller/renderer/backend/vulkan/gpu_tracer_vk.cc
@@ -63,9 +63,9 @@ void GPUTracerVK::MarkFrameEnd() {
   in_frame_ = false;
 }
 
-
 void GPUTracerVK::RecordCmdBufferStart(const vk::CommandBuffer& buffer) {
-  if (!enabled_ || std::this_thread::get_id() != raster_thread_id_ || !in_frame_) {
+  if (!enabled_ || std::this_thread::get_id() != raster_thread_id_ ||
+      !in_frame_) {
     return;
   }
   Lock lock(trace_state_mutex_);
@@ -102,8 +102,10 @@ void GPUTracerVK::RecordCmdBufferStart(const vk::CommandBuffer& buffer) {
   state.current_index += 1;
 }
 
-std::optional<size_t> GPUTracerVK::RecordCmdBufferEnd(const vk::CommandBuffer& buffer) {
-  if (!enabled_ || std::this_thread::get_id() != raster_thread_id_ || !in_frame_) {
+std::optional<size_t> GPUTracerVK::RecordCmdBufferEnd(
+    const vk::CommandBuffer& buffer) {
+  if (!enabled_ || std::this_thread::get_id() != raster_thread_id_ ||
+      !in_frame_) {
     return std::nullopt;
   }
   Lock lock(trace_state_mutex_);
@@ -120,7 +122,8 @@ std::optional<size_t> GPUTracerVK::RecordCmdBufferEnd(const vk::CommandBuffer& b
   return current_state_;
 }
 
-void GPUTracerVK::OnFenceComplete(std::optional<size_t> maybe_frame_index, bool success) {
+void GPUTracerVK::OnFenceComplete(std::optional<size_t> maybe_frame_index,
+                                  bool success) {
   if (!enabled_ || !maybe_frame_index.has_value()) {
     return;
   }

--- a/impeller/renderer/backend/vulkan/gpu_tracer_vk.cc
+++ b/impeller/renderer/backend/vulkan/gpu_tracer_vk.cc
@@ -30,6 +30,10 @@ GPUTracerVK::GPUTracerVK(const std::shared_ptr<DeviceHolder>& device_holder)
 #endif
 }
 
+bool GPUTracerVK::IsValid() const {
+  return valid_;
+}
+
 void GPUTracerVK::MarkFrameStart() {
   in_frame_ = true;
 }

--- a/impeller/renderer/backend/vulkan/gpu_tracer_vk.cc
+++ b/impeller/renderer/backend/vulkan/gpu_tracer_vk.cc
@@ -35,6 +35,9 @@ void GPUTracerVK::MarkFrameStart() {
 }
 
 void GPUTracerVK::MarkFrameEnd() {
+  if (!valid_) {
+    return;
+  }
   Lock lock(trace_state_mutex_);
   current_state_ = (current_state_ + 1) % 16;
 

--- a/impeller/renderer/backend/vulkan/gpu_tracer_vk.h
+++ b/impeller/renderer/backend/vulkan/gpu_tracer_vk.h
@@ -29,7 +29,7 @@ class GPUTracerVK {
   size_t RecordCmdBufferEnd(const vk::CommandBuffer& buffer);
 
   /// @brief Signal that the cmd buffer is completed.
-  void OnFenceComplete(size_t frame_index);
+  void OnFenceComplete(size_t frame_index, bool success);
 
   /// @brief Signal the start of a frame workload.
   ///
@@ -48,6 +48,7 @@ class GPUTracerVK {
   struct GPUTraceState {
     size_t current_index = 0;
     size_t pending_buffers = 0;
+    bool contains_failure = false;
     vk::UniqueQueryPool query_pool;
   };
 

--- a/impeller/renderer/backend/vulkan/gpu_tracer_vk.h
+++ b/impeller/renderer/backend/vulkan/gpu_tracer_vk.h
@@ -40,6 +40,8 @@ class GPUTracerVK {
   /// @brief Signal the end of a frame workload.
   void MarkFrameEnd();
 
+  bool IsValid() const;
+
  private:
   const std::shared_ptr<DeviceHolder> device_holder_;
 

--- a/impeller/renderer/backend/vulkan/gpu_tracer_vk.h
+++ b/impeller/renderer/backend/vulkan/gpu_tracer_vk.h
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <memory>
+#include <thread>
 
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/device_holder.h"
@@ -73,6 +74,10 @@ class GPUTracerVK {
   // actually renders a frame. Without the in_frame_ guard, the GPU frame time
   // would include this 30ms gap during which the engine was idle.
   bool in_frame_ = false;
+
+  // Track the raster thread id to avoid recording mipmap/image cmd buffers
+  // that are not guaranteed to start/end according to frame boundaries.
+  std::thread::id raster_thread_id_;
   bool enabled_ = false;
 };
 

--- a/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
+++ b/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
@@ -23,7 +23,7 @@ TEST(GPUTracerVK, CanTraceCmdBuffer) {
 
   auto cmd_buffer = context->CreateCommandBuffer();
   auto vk_cmd_buffer = CommandBufferVK::Cast(cmd_buffer.get());
-  auto blit_ass = cmd_buffer->CreateBlitPass();
+  auto blit_pass = cmd_buffer->CreateBlitPass();
 
   tracer->MarkFrameStart();
   tracer->RecordCmdBufferStart(vk_cmd_buffer->GetEncoder()->GetCommandBuffer());
@@ -54,7 +54,7 @@ TEST(GPUTracerVK, DoesNotTraceOutsideOfFrameWorkload) {
 
   auto cmd_buffer = context->CreateCommandBuffer();
   auto vk_cmd_buffer = CommandBufferVK::Cast(cmd_buffer.get());
-  auto blit_ass = cmd_buffer->CreateBlitPass();
+  auto blit_pass = cmd_buffer->CreateBlitPass();
 
   tracer->RecordCmdBufferStart(vk_cmd_buffer->GetEncoder()->GetCommandBuffer());
   auto frame_id = tracer->RecordCmdBufferEnd(
@@ -76,6 +76,35 @@ TEST(GPUTracerVK, DoesNotTraceOutsideOfFrameWorkload) {
   ASSERT_TRUE(std::find(called->begin(), called->end(),
                         "vkGetQueryPoolResults") == called->end());
 }
+
+TEST(GPUTracerVK, DoesNotTraceOtherTheads) {
+  auto const context = MockVulkanContextBuilder().Build();
+
+  auto tracer = std::make_shared<GPUTracerVK>(context->GetDeviceHolder());
+
+  ASSERT_TRUE(tracer->IsEnabled());
+
+  tracer->MarkFrameStart();
+
+  // Record the cmd buffer on another thread to simulate a mipmap cmd buffer.
+  std::thread image_upload_thread([&context]() {
+    auto cmd_buffer = context->CreateCommandBuffer();
+    auto vk_cmd_buffer = CommandBufferVK::Cast(cmd_buffer.get());
+    auto blit_pass = cmd_buffer->CreateBlitPass();
+    if (!cmd_buffer->SubmitCommands()) {
+      VALIDATION_LOG << "Failed to submit commands";
+    }
+  });
+
+  image_upload_thread.join();
+
+  auto called = GetMockVulkanFunctions(context->GetDevice());
+
+  ASSERT_NE(called, nullptr);
+  ASSERT_TRUE(std::find(called->begin(), called->end(), "vkCreateQueryPool") ==
+              called->end());
+}
+
 #endif  // IMPELLER_DEBUG
 
 }  // namespace testing

--- a/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
+++ b/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
@@ -9,13 +9,11 @@
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/gpu_tracer_vk.h"
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
-#include "impeller/renderer/command_buffer.h"
-#include "impeller/renderer/render_target.h"
-#include "vulkan/vulkan_enums.hpp"
 
 namespace impeller {
 namespace testing {
 
+#ifdef IMPELLER_DEBUG
 TEST(GPUTrackerVK, CanTraceCmdBuffer) {
   auto const context = MockVulkanContextBuilder().Build();
 
@@ -37,6 +35,7 @@ TEST(GPUTrackerVK, CanTraceCmdBuffer) {
 
   tracer->OnFenceComplete(frame_id);
 }
+#endif  // IMPELLER_DEBUG
 
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
+++ b/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
@@ -33,7 +33,7 @@ TEST(GPUTrackerVK, CanTraceCmdBuffer) {
 
   ASSERT_EQ(frame_id, 0u);
 
-  tracer->OnFenceComplete(frame_id);
+  tracer->OnFenceComplete(frame_id, true);
 }
 #endif  // IMPELLER_DEBUG
 

--- a/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
+++ b/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gtest/gtest.h"
+#include "impeller/renderer//backend/vulkan/command_encoder_vk.h"
+#include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
+#include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/gpu_tracer_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
+#include "impeller/renderer/command_buffer.h"
+#include "impeller/renderer/render_target.h"
+#include "vulkan/vulkan_enums.hpp"
+
+namespace impeller {
+namespace testing {
+
+TEST(GPUTrackerVK, CanTraceCmdBuffer) {
+  auto const context = MockVulkanContextBuilder().Build();
+
+  auto tracer = std::make_shared<GPUTracerVK>(context->GetDeviceHolder());
+
+  ASSERT_TRUE(tracer->IsValid());
+
+  auto cmd_buffer = context->CreateCommandBuffer();
+  auto vk_cmd_buffer = CommandBufferVK::Cast(cmd_buffer.get());
+  auto blit_ass = cmd_buffer->CreateBlitPass();
+
+  tracer->MarkFrameStart();
+  tracer->RecordCmdBufferStart(vk_cmd_buffer->GetEncoder()->GetCommandBuffer());
+  auto frame_id = tracer->RecordCmdBufferEnd(
+      vk_cmd_buffer->GetEncoder()->GetCommandBuffer());
+  tracer->MarkFrameEnd();
+
+  ASSERT_EQ(frame_id, 0u);
+
+  tracer->OnFenceComplete(frame_id);
+}
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -505,6 +505,32 @@ VkResult vkCreateQueryPool(VkDevice device,
                            const VkAllocationCallbacks* pAllocator,
                            VkQueryPool* pQueryPool) {
   *pQueryPool = reinterpret_cast<VkQueryPool>(new MockQueryPool());
+  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  mock_device->AddCalledFunction("vkCreateQueryPool");
+  return VK_SUCCESS;
+}
+
+VkResult vkGetQueryPoolResults(VkDevice device,
+                               VkQueryPool queryPool,
+                               uint32_t firstQuery,
+                               uint32_t queryCount,
+                               size_t dataSize,
+                               void* pData,
+                               VkDeviceSize stride,
+                               VkQueryResultFlags flags) {
+  MockDevice* mock_device = reinterpret_cast<MockDevice*>(device);
+  if (dataSize == sizeof(uint32_t)) {
+    uint32_t* data = static_cast<uint32_t*>(pData);
+    for (auto i = firstQuery; i < queryCount; i++) {
+      data[0] = i;
+    }
+  } else if (dataSize == sizeof(int64_t)) {
+    uint64_t* data = static_cast<uint64_t*>(pData);
+    for (auto i = firstQuery; i < queryCount; i++) {
+      data[0] = i;
+    }
+  }
+  mock_device->AddCalledFunction("vkGetQueryPoolResults");
   return VK_SUCCESS;
 }
 
@@ -610,6 +636,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return (PFN_vkVoidFunction)vkSetDebugUtilsObjectNameEXT;
   } else if (strcmp("vkCreateQueryPool", pName) == 0) {
     return (PFN_vkVoidFunction)vkCreateQueryPool;
+  } else if (strcmp("vkGetQueryPoolResults", pName) == 0) {
+    return (PFN_vkVoidFunction)vkGetQueryPoolResults;
   }
   return noop;
 }


### PR DESCRIPTION
Switches the GPU tracing implementation to work more like the metal version, where we decorate individual cmd buffers with start/end time queries and then min/max the final result. Hopefully this stabilizes the values on CI
