### PR TITLE
WIP - [Windows] Expose channel buffers 'resize' and 'overflow' control commands

### DIFF
--- a/shell/platform/common/client_wrapper/basic_message_channel_unittests.cc
+++ b/shell/platform/common/client_wrapper/basic_message_channel_unittests.cc
@@ -28,6 +28,10 @@ class TestBinaryMessenger : public BinaryMessenger {
     last_message_handler_ = handler;
   }
 
+  void Resize(const std::string& channel, int64_t newSize) override {}
+
+  void SetWarnsOnOverflow(const std::string& channel, bool warns) override {}
+
   std::string last_message_handler_channel() {
     return last_message_handler_channel_;
   }

--- a/shell/platform/common/client_wrapper/binary_messenger_impl.h
+++ b/shell/platform/common/client_wrapper/binary_messenger_impl.h
@@ -36,6 +36,12 @@ class BinaryMessengerImpl : public BinaryMessenger {
   void SetMessageHandler(const std::string& channel,
                          BinaryMessageHandler handler) override;
 
+  // |flutter::BinaryMessenger|
+  void Resize(const std::string& channel, int64_t newSize) override;
+
+  // |flutter::BinaryMessenger|
+  void SetWarnsOnOverflow(const std::string& channel, bool warns) override;
+
  private:
   // Handle for interacting with the C API.
   FlutterDesktopMessengerRef messenger_;

--- a/shell/platform/common/client_wrapper/core_implementations.cc
+++ b/shell/platform/common/client_wrapper/core_implementations.cc
@@ -127,6 +127,15 @@ void BinaryMessengerImpl::SetMessageHandler(const std::string& channel,
                                      ForwardToHandler, message_handler);
 }
 
+void BinaryMessengerImpl::Resize(const std::string& channel, int64_t newSize) {
+  FlutterDesktopMessengerResize(messenger_, channel.c_str(), newSize);
+}
+
+void BinaryMessengerImpl::SetWarnsOnOverflow(const std::string& channel,
+                                             bool warns) {
+  // TODO(bleroux).
+}
+
 // ========== engine_method_result.h ==========
 
 namespace internal {

--- a/shell/platform/common/client_wrapper/event_channel_unittests.cc
+++ b/shell/platform/common/client_wrapper/event_channel_unittests.cc
@@ -29,6 +29,10 @@ class TestBinaryMessenger : public BinaryMessenger {
     last_message_handler_ = handler;
   }
 
+  void Resize(const std::string& channel, int64_t newSize) override {}
+
+  void SetWarnsOnOverflow(const std::string& channel, bool warns) override {}
+
   std::string last_message_handler_channel() {
     return last_message_handler_channel_;
   }

--- a/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h
+++ b/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h
@@ -45,6 +45,19 @@ class BinaryMessenger {
   // existing handler.
   virtual void SetMessageHandler(const std::string& channel,
                                  BinaryMessageHandler handler) = 0;
+
+  // Adjusts the number of messages that will get buffered when sending messages
+  // to channels that aren't fully set up yet. For example, the engine isn't
+  // running yet or the channel's message handler isn't set up on the Dart side
+  // yet.
+  virtual void Resize(const std::string& channel, int64_t newSize) = 0;
+
+  // Defines whether the channel should show warning messages when discarding
+  // messages due to overflow.
+  //
+  // When |warns| is false, the channel is expected to overflow and warning
+  // messages will not be shown.
+  virtual void SetWarnsOnOverflow(const std::string& channel, bool warns) = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/common/client_wrapper/method_channel_unittests.cc
+++ b/shell/platform/common/client_wrapper/method_channel_unittests.cc
@@ -32,6 +32,10 @@ class TestBinaryMessenger : public BinaryMessenger {
     last_message_handler_ = handler;
   }
 
+  void Resize(const std::string& channel, int64_t newSize) override {}
+
+  void SetWarnsOnOverflow(const std::string& channel, bool warns) override {}
+
   bool send_called() { return send_called_; }
 
   BinaryReply last_reply_handler() { return last_reply_handler_; }

--- a/shell/platform/common/client_wrapper/testing/stub_flutter_api.cc
+++ b/shell/platform/common/client_wrapper/testing/stub_flutter_api.cc
@@ -159,3 +159,7 @@ bool FlutterDesktopTextureRegistrarMarkExternalTextureFrameAvailable(
   }
   return result;
 }
+
+void FlutterDesktopMessengerResize(FlutterDesktopMessengerRef messenger,
+                                   const char* channel,
+                                   int64_t newSize) {}

--- a/shell/platform/common/public/flutter_messenger.h
+++ b/shell/platform/common/public/flutter_messenger.h
@@ -137,6 +137,11 @@ FlutterDesktopMessengerLock(FlutterDesktopMessengerRef messenger);
 FLUTTER_EXPORT void FlutterDesktopMessengerUnlock(
     FlutterDesktopMessengerRef messenger);
 
+FLUTTER_EXPORT void FlutterDesktopMessengerResize(
+    FlutterDesktopMessengerRef messenger,
+    const char* channel,
+    int64_t newSize);
+
 #if defined(__cplusplus)
 }  // extern "C"
 #endif

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -224,6 +224,10 @@ void FlutterDesktopMessengerUnlock(FlutterDesktopMessengerRef messenger) {
   messenger->GetMutex().unlock();
 }
 
+void FlutterDesktopMessengerResize(FlutterDesktopMessengerRef messenger,
+                                   const char* channel,
+                                   int64_t newSize) {}
+
 // Retrieves state bag for the window in question from the GLFWWindow.
 static FlutterDesktopWindowControllerState* GetWindowController(
     GLFWwindow* window) {

--- a/shell/platform/windows/testing/test_binary_messenger.h
+++ b/shell/platform/windows/testing/test_binary_messenger.h
@@ -64,6 +64,10 @@ class TestBinaryMessenger : public BinaryMessenger {
     }
   }
 
+  void Resize(const std::string& channel, int64_t newSize) override {}
+
+  void SetWarnsOnOverflow(const std::string& channel, bool warns) override {}
+
  private:
   // Handler to call for SendMessage.
   SendHandler send_handler_;


### PR DESCRIPTION
## Description

This PR is a WIP PR to add two helper functions to invoke the 'resize' and 'overflow' commands exposed by the control channel.
See:

https://github.com/flutter/engine/blob/93e8901490e78c7ba7e319cce4470d9c6478c6dc/lib/ui/channel_buffers.dart#L302-L309

## Related Issue

Windows implementation for https://github.com/flutter/flutter/issues/132386

## Tests

To do