### PR TITLE
Add missing source file

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -90,6 +90,7 @@ template("embedder_source_set") {
       "embedder_thread_host.cc",
       "embedder_thread_host.h",
       "pixel_formats.cc",
+      "pixel_formats.h",
       "platform_view_embedder.cc",
       "platform_view_embedder.h",
       "vsync_waiter_embedder.cc",


### PR DESCRIPTION
Maybe I'm missing something here. It seems like we include this file below:

https://github.com/flutter/engine/blob/c9c9684e03a3e1f745cbd4f8de762f42aa01ae77/shell/platform/embedder/pixel_formats.cc#L5

But it isn't mentioned in the gn file. Not sure how it is actually working today.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
