### PR TITLE
[Impeller] Guard execution of ReactorGLES operations with a mutex

### DIFF
--- a/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/impeller/renderer/backend/gles/reactor_gles.cc
@@ -159,6 +159,10 @@ bool ReactorGLES::React() {
   }
   TRACE_EVENT0("impeller", "ReactorGLES::React");
   while (HasPendingOperations()) {
+    // Both the raster thread and the IO thread can flush queued operations.
+    // Ensure that execution of the ops is serialized.
+    Lock execution_lock(ops_execution_mutex_);
+
     if (!ReactOnce()) {
       return false;
     }

--- a/impeller/renderer/backend/gles/reactor_gles.h
+++ b/impeller/renderer/backend/gles/reactor_gles.h
@@ -69,6 +69,7 @@ class ReactorGLES {
 
   std::unique_ptr<ProcTableGLES> proc_table_;
 
+  Mutex ops_execution_mutex_;
   mutable Mutex ops_mutex_;
   std::vector<Operation> ops_ IPLR_GUARDED_BY(ops_mutex_);
 
@@ -88,7 +89,7 @@ class ReactorGLES {
   bool can_set_debug_labels_ = false;
   bool is_valid_ = false;
 
-  bool ReactOnce();
+  bool ReactOnce() IPLR_REQUIRES(ops_execution_mutex_);
 
   bool HasPendingOperations() const;
 


### PR DESCRIPTION
Both the raster and IO threads can flush the ops queue.  The reactor must ensure that execution of queued ops is serialized.

Fixes https://github.com/flutter/flutter/issues/135524