### PR TITLE
[Impeller] GPU Tracer for GLES.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2086,6 +2086,8 @@ ORIGIN: ../../../flutter/impeller/renderer/backend/gles/device_buffer_gles.h + .
 ORIGIN: ../../../flutter/impeller/renderer/backend/gles/formats_gles.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/gles/formats_gles.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/gles/gles.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/renderer/backend/gles/gpu_tracer_gles.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/renderer/backend/gles/gpu_tracer_gles.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/gles/handle_gles.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/gles/handle_gles.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/renderer/backend/gles/pipeline_gles.cc + ../../../flutter/LICENSE
@@ -4854,6 +4856,8 @@ FILE: ../../../flutter/impeller/renderer/backend/gles/device_buffer_gles.h
 FILE: ../../../flutter/impeller/renderer/backend/gles/formats_gles.cc
 FILE: ../../../flutter/impeller/renderer/backend/gles/formats_gles.h
 FILE: ../../../flutter/impeller/renderer/backend/gles/gles.h
+FILE: ../../../flutter/impeller/renderer/backend/gles/gpu_tracer_gles.cc
+FILE: ../../../flutter/impeller/renderer/backend/gles/gpu_tracer_gles.h
 FILE: ../../../flutter/impeller/renderer/backend/gles/handle_gles.cc
 FILE: ../../../flutter/impeller/renderer/backend/gles/handle_gles.h
 FILE: ../../../flutter/impeller/renderer/backend/gles/pipeline_gles.cc

--- a/common/settings.h
+++ b/common/settings.h
@@ -228,6 +228,10 @@ struct Settings {
   // must be available to the application.
   bool enable_vulkan_validation = false;
 
+  // Enable GPU tracing in GLES backends.
+  // Some devices claim to support the required APIs but crash on their usage.
+  bool enable_opengl_gpu_tracing = false;
+
   // Data set by platform-specific embedders for use in font initialization.
   uint32_t font_initialization_data = 0;
 

--- a/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -112,8 +112,8 @@ std::shared_ptr<Context> PlaygroundImplGLES::GetContext() const {
     return nullptr;
   }
 
-  auto context =
-      ContextGLES::Create(std::move(gl), ShaderLibraryMappingsForPlayground());
+  auto context = ContextGLES::Create(
+      std::move(gl), ShaderLibraryMappingsForPlayground(), true);
   if (!context) {
     FML_LOG(ERROR) << "Could not create context.";
     return nullptr;

--- a/impeller/renderer/backend/gles/BUILD.gn
+++ b/impeller/renderer/backend/gles/BUILD.gn
@@ -16,6 +16,7 @@ impeller_component("gles_unittests") {
   sources = [
     "test/capabilities_unittests.cc",
     "test/formats_gles_unittests.cc",
+    "test/gpu_tracer_gles_unittests.cc",
     "test/mock_gles.cc",
     "test/mock_gles.h",
     "test/mock_gles_unittests.cc",
@@ -43,7 +44,6 @@ impeller_component("gles") {
     "command_buffer_gles.cc",
     "command_buffer_gles.h",
     "context_gles.cc",
-    "context_gles.h",
     "context_gles.h",
     "description_gles.cc",
     "description_gles.h",

--- a/impeller/renderer/backend/gles/BUILD.gn
+++ b/impeller/renderer/backend/gles/BUILD.gn
@@ -44,6 +44,7 @@ impeller_component("gles") {
     "command_buffer_gles.h",
     "context_gles.cc",
     "context_gles.h",
+    "context_gles.h",
     "description_gles.cc",
     "description_gles.h",
     "device_buffer_gles.cc",
@@ -51,6 +52,8 @@ impeller_component("gles") {
     "formats_gles.cc",
     "formats_gles.h",
     "gles.h",
+    "gpu_tracer_gles.cc",
+    "gpu_tracer_gles.h",
     "handle_gles.cc",
     "handle_gles.h",
     "pipeline_gles.cc",
@@ -75,9 +78,6 @@ impeller_component("gles") {
     "surface_gles.h",
     "texture_gles.cc",
     "texture_gles.h",
-    "context_gles.h",
-    "gpu_tracer_gles.cc",
-    "gpu_tracer_gles.h",
   ]
 
   if (!is_android && !is_fuchsia) {

--- a/impeller/renderer/backend/gles/BUILD.gn
+++ b/impeller/renderer/backend/gles/BUILD.gn
@@ -75,6 +75,9 @@ impeller_component("gles") {
     "surface_gles.h",
     "texture_gles.cc",
     "texture_gles.h",
+    "context_gles.h",
+    "gpu_tracer_gles.cc",
+    "gpu_tracer_gles.h",
   ]
 
   if (!is_android && !is_fuchsia) {

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -63,7 +63,6 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
             device_capabilities_->SupportsDecalSamplerAddressMode()));
   }
 
-  gpu_tracer_ = std::make_shared<GPUTracerGLES>(reactor_->GetProcTable());
   is_valid_ = true;
 }
 

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/gles/context_gles.h"
+#include <memory>
 
 #include "impeller/base/config.h"
 #include "impeller/base/validation.h"
@@ -62,7 +63,7 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
         std::shared_ptr<SamplerLibraryGLES>(new SamplerLibraryGLES(
             device_capabilities_->SupportsDecalSamplerAddressMode()));
   }
-
+  gpu_tracer_ = std::make_shared<GPUTracerGLES>(GetReactor()->GetProcTable());
   is_valid_ = true;
 }
 

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -14,14 +14,16 @@ namespace impeller {
 
 std::shared_ptr<ContextGLES> ContextGLES::Create(
     std::unique_ptr<ProcTableGLES> gl,
-    const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries) {
+    const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
+    bool enable_gpu_tracing) {
   return std::shared_ptr<ContextGLES>(
-      new ContextGLES(std::move(gl), shader_libraries));
+      new ContextGLES(std::move(gl), shader_libraries, enable_gpu_tracing));
 }
 
-ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
-                         const std::vector<std::shared_ptr<fml::Mapping>>&
-                             shader_libraries_mappings) {
+ContextGLES::ContextGLES(
+    std::unique_ptr<ProcTableGLES> gl,
+    const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries_mappings,
+    bool enable_gpu_tracing) {
   reactor_ = std::make_shared<ReactorGLES>(std::move(gl));
   if (!reactor_->IsValid()) {
     VALIDATION_LOG << "Could not create valid reactor.";
@@ -63,7 +65,8 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
         std::shared_ptr<SamplerLibraryGLES>(new SamplerLibraryGLES(
             device_capabilities_->SupportsDecalSamplerAddressMode()));
   }
-  gpu_tracer_ = std::make_shared<GPUTracerGLES>(GetReactor()->GetProcTable());
+  gpu_tracer_ = std::make_shared<GPUTracerGLES>(GetReactor()->GetProcTable(),
+                                                enable_gpu_tracing);
   is_valid_ = true;
 }
 

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -7,6 +7,7 @@
 #include "impeller/base/config.h"
 #include "impeller/base/validation.h"
 #include "impeller/renderer/backend/gles/command_buffer_gles.h"
+#include "impeller/renderer/backend/gles/gpu_tracer_gles.h"
 
 namespace impeller {
 
@@ -62,6 +63,7 @@ ContextGLES::ContextGLES(std::unique_ptr<ProcTableGLES> gl,
             device_capabilities_->SupportsDecalSamplerAddressMode()));
   }
 
+  gpu_tracer_ = std::make_shared<GPUTracerGLES>(reactor_->GetProcTable());
   is_valid_ = true;
 }
 

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -42,14 +42,7 @@ class ContextGLES final : public Context,
   bool RemoveReactorWorker(ReactorGLES::WorkerID id);
 
   std::shared_ptr<GPUTracerGLES> GetGPUTracer() const {
-    FML_LOG(ERROR) << "Size: " << gpu_tracers_.size();
-    auto result = gpu_tracers_.find(std::this_thread::get_id());
-    if (result == gpu_tracers_.end()) {
-      return gpu_tracers_[std::this_thread::get_id()] =
-                 std::make_shared<GPUTracerGLES>(GetReactor()->GetProcTable());
-    } else {
-      return result->second;
-    }
+   return gpu_tracer_;
   }
 
  private:
@@ -58,8 +51,7 @@ class ContextGLES final : public Context,
   std::shared_ptr<PipelineLibraryGLES> pipeline_library_;
   std::shared_ptr<SamplerLibraryGLES> sampler_library_;
   std::shared_ptr<AllocatorGLES> resource_allocator_;
-  mutable std::unordered_map<std::thread::id, std::shared_ptr<GPUTracerGLES>>
-      gpu_tracers_;
+  std::shared_ptr<GPUTracerGLES> gpu_tracer_;
 
   // Note: This is stored separately from the ProcTableGLES CapabilitiesGLES
   // in order to satisfy the Context::GetCapabilities signature which returns

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -26,7 +26,8 @@ class ContextGLES final : public Context,
  public:
   static std::shared_ptr<ContextGLES> Create(
       std::unique_ptr<ProcTableGLES> gl,
-      const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries);
+      const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
+      bool enable_gpu_tracing);
 
   // |Context|
   ~ContextGLES() override;
@@ -59,7 +60,8 @@ class ContextGLES final : public Context,
 
   ContextGLES(
       std::unique_ptr<ProcTableGLES> gl,
-      const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries);
+      const std::vector<std::shared_ptr<fml::Mapping>>& shader_libraries,
+      bool enable_gpu_tracing);
 
   // |Context|
   std::string DescribeGpuModel() const override;

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -41,9 +41,7 @@ class ContextGLES final : public Context,
 
   bool RemoveReactorWorker(ReactorGLES::WorkerID id);
 
-  std::shared_ptr<GPUTracerGLES> GetGPUTracer() const {
-   return gpu_tracer_;
-  }
+  std::shared_ptr<GPUTracerGLES> GetGPUTracer() const { return gpu_tracer_; }
 
  private:
   ReactorGLES::Ref reactor_;

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -8,6 +8,7 @@
 #include "impeller/base/backend_cast.h"
 #include "impeller/renderer/backend/gles/allocator_gles.h"
 #include "impeller/renderer/backend/gles/capabilities_gles.h"
+#include "impeller/renderer/backend/gles/gpu_tracer_gles.h"
 #include "impeller/renderer/backend/gles/pipeline_library_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/backend/gles/sampler_library_gles.h"
@@ -38,12 +39,17 @@ class ContextGLES final : public Context,
 
   bool RemoveReactorWorker(ReactorGLES::WorkerID id);
 
+  std::shared_ptr<GPUTracerGLES> GetGPUTracer() const {
+    return gpu_tracer_;
+  }
+
  private:
   ReactorGLES::Ref reactor_;
   std::shared_ptr<ShaderLibraryGLES> shader_library_;
   std::shared_ptr<PipelineLibraryGLES> pipeline_library_;
   std::shared_ptr<SamplerLibraryGLES> sampler_library_;
   std::shared_ptr<AllocatorGLES> resource_allocator_;
+  std::shared_ptr<GPUTracerGLES> gpu_tracer_;
   // Note: This is stored separately from the ProcTableGLES CapabilitiesGLES
   // in order to satisfy the Context::GetCapabilities signature which returns
   // a reference.

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <thread>
+#include <unordered_map>
 #include "flutter/fml/macros.h"
 #include "impeller/base/backend_cast.h"
 #include "impeller/renderer/backend/gles/allocator_gles.h"
@@ -39,7 +41,16 @@ class ContextGLES final : public Context,
 
   bool RemoveReactorWorker(ReactorGLES::WorkerID id);
 
-  std::shared_ptr<GPUTracerGLES> GetGPUTracer() const { return gpu_tracer_; }
+  std::shared_ptr<GPUTracerGLES> GetGPUTracer() const {
+    FML_LOG(ERROR) << "Size: " << gpu_tracers_.size();
+    auto result = gpu_tracers_.find(std::this_thread::get_id());
+    if (result == gpu_tracers_.end()) {
+      return gpu_tracers_[std::this_thread::get_id()] =
+                 std::make_shared<GPUTracerGLES>(GetReactor()->GetProcTable());
+    } else {
+      return result->second;
+    }
+  }
 
  private:
   ReactorGLES::Ref reactor_;
@@ -47,7 +58,9 @@ class ContextGLES final : public Context,
   std::shared_ptr<PipelineLibraryGLES> pipeline_library_;
   std::shared_ptr<SamplerLibraryGLES> sampler_library_;
   std::shared_ptr<AllocatorGLES> resource_allocator_;
-  std::shared_ptr<GPUTracerGLES> gpu_tracer_;
+  mutable std::unordered_map<std::thread::id, std::shared_ptr<GPUTracerGLES>>
+      gpu_tracers_;
+
   // Note: This is stored separately from the ProcTableGLES CapabilitiesGLES
   // in order to satisfy the Context::GetCapabilities signature which returns
   // a reference.

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -39,9 +39,7 @@ class ContextGLES final : public Context,
 
   bool RemoveReactorWorker(ReactorGLES::WorkerID id);
 
-  std::shared_ptr<GPUTracerGLES> GetGPUTracer() const {
-    return gpu_tracer_;
-  }
+  std::shared_ptr<GPUTracerGLES> GetGPUTracer() const { return gpu_tracer_; }
 
  private:
   ReactorGLES::Ref reactor_;

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.cc
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.cc
@@ -32,7 +32,6 @@ void GPUTracerGLES::MarkFrameStart(const ProcTableGLES& gl) {
     return;
   }
 
-  FML_DCHECK(!active_frame_.has_value());
   active_frame_ = query;
   gl.BeginQueryEXT(GL_TIME_ELAPSED_EXT, query);
 }
@@ -75,7 +74,7 @@ void GPUTracerGLES::ProcessQueries(const ProcTableGLES& gl) {
 
 void GPUTracerGLES::MarkFrameEnd(const ProcTableGLES& gl) {
   if (!enabled_ || std::this_thread::get_id() != raster_thread_ ||
-      !active_frame_.has_value() || !active_frame_.has_value()) {
+      !active_frame_.has_value()) {
     return;
   }
 

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.cc
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.cc
@@ -1,0 +1,85 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/gles/gpu_tracer_gles.h"
+#include "GLES2/gl2ext.h"
+#include "impeller/renderer/backend/gles/context_gles.h"
+
+namespace impeller {
+
+static const constexpr char* kAngleTimerQuery = "GL_ANGLE_timer_query";
+static const constexpr char* kExtTimerQuery = "GL_EXT_timer_query";
+static const constexpr char* kExtDisjointTimerQuery =
+    "GL_EXT_disjoint_timer_query";
+
+GPUTracerGLES::GPUTracerGLES(const ProcTableGLES& gl) {
+#ifdef IMPELLER_DEBUG
+  auto desc = gl.GetDescription();
+  enabled_ = desc->HasExtension(kAngleTimerQuery) ||
+             desc->HasExtension(kExtTimerQuery) ||
+             desc->HasExtension(kExtDisjointTimerQuery);
+#endif  // IMPELLER_DEBUG
+}
+
+void GPUTracerGLES::MarkFrameStart(const ProcTableGLES& gl) {
+  if (!enabled_) {
+    return;
+  }
+  has_started_frame_ = true;
+  if (queries_.empty()) {
+    queries_ = std::vector<uint32_t>(32);
+    gl.GenQueriesEXT(32, queries_.data());
+  }
+
+  // At the beginning of a frame, check the status of all pending
+  // previous queries.
+  if (!pending_traces_.empty()) {
+    std::vector<uint32_t> pending_traces = pending_traces_;
+    pending_traces_.clear();
+
+    for (auto query : pending_traces) {
+      // First check if the query is complete without blocking
+      // on the result. Incomplete results are left in the pending
+      // trace vector and will not be checked again for another
+      // frame.
+      uint available = 0;
+      FML_LOG(ERROR) << "Checking: " << query;
+      gl.GetQueryObjectuivEXT(query, GL_QUERY_RESULT_AVAILABLE_EXT, &available);
+
+      if (available) {
+        // Return the timer resolution in nanoseconds.
+        uint64_t duration = 0;
+        gl.GetQueryObjectui64vEXT(query, GL_QUERY_RESULT, &duration);
+        auto gpu_ms = duration / 1000000.0;
+        FML_LOG(ERROR) << "gpu_ms: " << gpu_ms;
+      } else {
+        pending_traces_.push_back(query);
+      }
+    }
+  }
+
+  // Allocate a single query object for the start and end of the frame.
+  FML_CHECK(!active_frame_.has_value());
+  uint32_t query = queries_.back();
+  queries_.pop_back();
+  FML_CHECK(query != 0);
+  active_frame_ = query;
+  FML_LOG(ERROR) << "query: " << query;
+  gl.BeginQueryEXT(GL_TIME_ELAPSED_EXT, query);
+}
+
+void GPUTracerGLES::MarkFrameEnd(const ProcTableGLES& gl) {
+  if (!enabled_ || !active_frame_.has_value()) {
+    return;
+  }
+  auto query = active_frame_.value();
+  FML_LOG(ERROR) << "END " << query;
+  gl.EndQueryEXT(GL_TIME_ELAPSED_EXT);
+
+  pending_traces_.push_back(query);
+  active_frame_ = std::nullopt;
+  has_started_frame_ = false;
+}
+
+}  // namespace impeller

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.cc
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.cc
@@ -8,15 +8,16 @@
 
 namespace impeller {
 
-GPUTracerGLES::GPUTracerGLES(const ProcTableGLES& gl) {
+GPUTracerGLES::GPUTracerGLES(const ProcTableGLES& gl, bool enable_tracing) {
 #ifdef IMPELLER_DEBUG
   auto desc = gl.GetDescription();
-  enabled_ = desc->HasExtension("GL_EXT_disjoint_timer_query");
+  enabled_ =
+      enable_tracing && desc->HasExtension("GL_EXT_disjoint_timer_query");
 #endif  // IMPELLER_DEBUG
 }
 
 void GPUTracerGLES::MarkFrameStart(const ProcTableGLES& gl) {
-  if (!enabled_ || has_started_frame_ ||
+  if (!enabled_ || active_frame_.has_value() ||
       std::this_thread::get_id() != raster_thread_) {
     return;
   }
@@ -31,10 +32,7 @@ void GPUTracerGLES::MarkFrameStart(const ProcTableGLES& gl) {
     return;
   }
 
-  has_started_frame_ = true;
-
   FML_DCHECK(!active_frame_.has_value());
-  FML_DCHECK(query != 0);
   active_frame_ = query;
   gl.BeginQueryEXT(GL_TIME_ELAPSED_EXT, query);
 }
@@ -44,42 +42,41 @@ void GPUTracerGLES::RecordRasterThread() {
 }
 
 void GPUTracerGLES::ProcessQueries(const ProcTableGLES& gl) {
-  if (pending_traces_.empty()) {
-    return;
-  }
-
   // For reasons unknown to me, querying the state of more than
-  // on query object per frame causes crashes on a Pixel 6 pro.
+  // one query object per frame causes crashes on a Pixel 6 pro.
   // It does not crash on an S10.
-  auto latest_query = pending_traces_.front();
+  while (!pending_traces_.empty()) {
+    auto query = pending_traces_.front();
 
-  // First check if the query is complete without blocking
-  // on the result. Incomplete results are left in the pending
-  // trace vector and will not be checked again for another
-  // frame.
-  GLuint available = GL_FALSE;
-  gl.GetQueryObjectuivEXT(latest_query, GL_QUERY_RESULT_AVAILABLE_EXT,
-                          &available);
+    // First check if the query is complete without blocking
+    // on the result. Incomplete results are left in the pending
+    // trace vector and will not be checked again for another
+    // frame.
+    GLuint available = GL_FALSE;
+    gl.GetQueryObjectuivEXT(query, GL_QUERY_RESULT_AVAILABLE_EXT, &available);
 
-  if (available != GL_TRUE) {
-    return;
+    if (available != GL_TRUE) {
+      // If a query is not available, then all subsequent queries will be
+      // unavailable.
+      return;
+    }
+    // Return the timer resolution in nanoseconds.
+    uint64_t duration = 0;
+    gl.GetQueryObjectui64vEXT(query, GL_QUERY_RESULT_EXT, &duration);
+    auto gpu_ms = duration / 1000000.0;
+
+    FML_TRACE_COUNTER("flutter", "GPUTracer",
+                      reinterpret_cast<int64_t>(this),  // Trace Counter ID
+                      "FrameTimeMS", gpu_ms);
+    FML_LOG(ERROR) << gpu_ms;
+    gl.DeleteQueriesEXT(1, &query);
+    pending_traces_.pop_front();
   }
-  // Return the timer resolution in nanoseconds.
-  uint64_t duration = 0;
-  gl.GetQueryObjectui64vEXT(latest_query, GL_QUERY_RESULT_EXT, &duration);
-  auto gpu_ms = duration / 1000000.0;
-
-  FML_TRACE_COUNTER("flutter", "GPUTracer",
-                    reinterpret_cast<int64_t>(this),  // Trace Counter ID
-                    "FrameTimeMS", gpu_ms);
-
-  gl.DeleteQueriesEXT(1, &latest_query);
-  pending_traces_.pop_front();
 }
 
 void GPUTracerGLES::MarkFrameEnd(const ProcTableGLES& gl) {
   if (!enabled_ || std::this_thread::get_id() != raster_thread_ ||
-      !active_frame_.has_value() || !has_started_frame_) {
+      !active_frame_.has_value() || !active_frame_.has_value()) {
     return;
   }
 
@@ -88,7 +85,6 @@ void GPUTracerGLES::MarkFrameEnd(const ProcTableGLES& gl) {
 
   pending_traces_.push_back(query);
   active_frame_ = std::nullopt;
-  has_started_frame_ = false;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.cc
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.cc
@@ -68,7 +68,6 @@ void GPUTracerGLES::ProcessQueries(const ProcTableGLES& gl) {
     FML_TRACE_COUNTER("flutter", "GPUTracer",
                       reinterpret_cast<int64_t>(this),  // Trace Counter ID
                       "FrameTimeMS", gpu_ms);
-    FML_LOG(ERROR) << gpu_ms;
     gl.DeleteQueriesEXT(1, &query);
     pending_traces_.pop_front();
   }

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.h
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <thread>
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 
 namespace impeller {
@@ -14,16 +15,18 @@ class GPUTracerGLES {
 
   ~GPUTracerGLES() = default;
 
+  bool HasStartedFrame() const {
+    return has_started_frame_;
+  }
+
   void MarkFrameStart(const ProcTableGLES& gl);
 
   void MarkFrameEnd(const ProcTableGLES& gl);
 
-  bool HasStartedFrame() const { return has_started_frame_; }
-
  private:
-  std::vector<uint32_t> queries_;
   std::vector<uint32_t> pending_traces_;
   std::optional<uint32_t> active_frame_ = std::nullopt;
+  std::thread::id raster_thread_;
   bool has_started_frame_ = false;
 
   bool enabled_ = false;

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.h
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.h
@@ -17,6 +17,11 @@ namespace impeller {
 /// known to cause crashes. As a result, this functionality is disabled by
 /// default and can only be enabled in debug/profile mode via a specific opt-in
 /// flag that is exposed in the Android manifest.
+///
+/// To enable, add the following metadata to the application's Android manifest:
+///   <meta-data
+///       android:name="io.flutter.embedding.android.EnableOpenGLGPUTracing"
+///       android:value="false" />
 class GPUTracerGLES {
  public:
   GPUTracerGLES(const ProcTableGLES& gl, bool enable_tracing);

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.h
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <deque>
 #include <thread>
+
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 
 namespace impeller {
@@ -15,16 +17,20 @@ class GPUTracerGLES {
 
   ~GPUTracerGLES() = default;
 
-  bool HasStartedFrame() const {
-    return has_started_frame_;
-  }
+  /// @brief Record the thread id of the raster thread.
+  void RecordRasterThread();
 
+  /// @brief Record the start of a frame workload, if one hasn't already been
+  ///        started.
   void MarkFrameStart(const ProcTableGLES& gl);
 
+  /// @brief Record the end of a frame workload.
   void MarkFrameEnd(const ProcTableGLES& gl);
 
  private:
-  std::vector<uint32_t> pending_traces_;
+  void ProcessQueries(const ProcTableGLES& gl);
+
+  std::deque<uint32_t> pending_traces_;
   std::optional<uint32_t> active_frame_ = std::nullopt;
   std::thread::id raster_thread_;
   bool has_started_frame_ = false;

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.h
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.h
@@ -11,9 +11,15 @@
 
 namespace impeller {
 
+/// @brief Trace GPU execution times using GL_EXT_disjoint_timer_query on GLES.
+///
+/// Note: there are a substantial number of GPUs where usage of the this API is
+/// known to cause crashes. As a result, this functionality is disabled by
+/// default and can only be enabled in debug/profile mode via a specific opt-in
+/// flag that is exposed in the Android manifest.
 class GPUTracerGLES {
  public:
-  explicit GPUTracerGLES(const ProcTableGLES& gl);
+  GPUTracerGLES(const ProcTableGLES& gl, bool enable_tracing);
 
   ~GPUTracerGLES() = default;
 
@@ -33,7 +39,6 @@ class GPUTracerGLES {
   std::deque<uint32_t> pending_traces_;
   std::optional<uint32_t> active_frame_ = std::nullopt;
   std::thread::id raster_thread_;
-  bool has_started_frame_ = false;
 
   bool enabled_ = false;
 };

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.h
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.h
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "impeller/renderer/backend/gles/proc_table_gles.h"
+
+namespace impeller {
+
+class GPUTracerGLES {
+ public:
+  explicit GPUTracerGLES(const ProcTableGLES& gl);
+
+  ~GPUTracerGLES() = default;
+
+  void MarkFrameStart(const ProcTableGLES& gl);
+
+  void MarkFrameEnd(const ProcTableGLES& gl);
+
+  bool HasStartedFrame() const {
+    return has_started_frame_;
+  }
+
+ private:
+  std::vector<uint32_t> queries_;
+  std::vector<uint32_t> pending_traces_;
+  std::optional<uint32_t> active_frame_ = std::nullopt;
+  bool has_started_frame_ = false;
+
+  bool enabled_ = false;
+};
+
+}  // namespace impeller

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.h
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.h
@@ -18,9 +18,7 @@ class GPUTracerGLES {
 
   void MarkFrameEnd(const ProcTableGLES& gl);
 
-  bool HasStartedFrame() const {
-    return has_started_frame_;
-  }
+  bool HasStartedFrame() const { return has_started_frame_; }
 
  private:
   std::vector<uint32_t> queries_;

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -196,7 +196,16 @@ struct GLProc {
   PROC(PushDebugGroupKHR);                 \
   PROC(PopDebugGroupKHR);                  \
   PROC(ObjectLabelKHR);                    \
-  PROC(RenderbufferStorageMultisampleEXT);
+  PROC(RenderbufferStorageMultisampleEXT); \
+  PROC(GenQueriesEXT);                     \
+  PROC(DeleteQueriesEXT);                  \
+  PROC(IsQueryEXT);                        \
+  PROC(QueryCounterEXT);                   \
+  PROC(GetQueryObjectui64vEXT);            \
+  PROC(BeginQueryEXT);                     \
+  PROC(EndQueryEXT);                       \
+  PROC(GetQueryObjectuivEXT);              \
+  PROC(GetQueryObjectivEXT);
 
 enum class DebugResourceType {
   kTexture,

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -199,13 +199,10 @@ struct GLProc {
   PROC(RenderbufferStorageMultisampleEXT); \
   PROC(GenQueriesEXT);                     \
   PROC(DeleteQueriesEXT);                  \
-  PROC(IsQueryEXT);                        \
-  PROC(QueryCounterEXT);                   \
   PROC(GetQueryObjectui64vEXT);            \
   PROC(BeginQueryEXT);                     \
   PROC(EndQueryEXT);                       \
-  PROC(GetQueryObjectuivEXT);              \
-  PROC(GetQueryObjectivEXT);
+  PROC(GetQueryObjectuivEXT);
 
 enum class DebugResourceType {
   kTexture,

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -561,8 +561,8 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
   auto tracer = ContextGLES::Cast(context).GetGPUTracer();
   return reactor_->AddOperation([pass_data,
                                  allocator = context.GetResourceAllocator(),
-                                 render_pass = std::move(shared_this), tracer](
-                                    const auto& reactor) {
+                                 render_pass = std::move(shared_this),
+                                 tracer](const auto& reactor) {
     auto result = EncodeCommandsInReactor(*pass_data, allocator, reactor,
                                           render_pass->commands_, tracer);
     FML_CHECK(result) << "Must be able to encode GL commands without error.";

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -152,9 +152,9 @@ struct RenderPassData {
   }
 
   const auto& gl = reactor.GetProcTable();
-  if (!tracer->HasStartedFrame()) {
-    tracer->MarkFrameStart(gl);
-  }
+#ifdef IMPELLER_DEBUG
+  tracer->MarkFrameStart(gl);
+#endif // IMPELLER_DEBUG
 
   fml::ScopedCleanupClosure pop_pass_debug_marker(
       [&gl]() { gl.PopDebugGroup(); });
@@ -498,9 +498,11 @@ struct RenderPassData {
                              attachments.data()   // size
     );
   }
+#ifdef IMPELLER_DEBUG
   if (is_default_fbo) {
     tracer->MarkFrameEnd(gl);
   }
+#endif // IMPELLER_DEBUG
 
   return true;
 }

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -7,8 +7,10 @@
 #include "flutter/fml/trace_event.h"
 #include "fml/closure.h"
 #include "impeller/base/validation.h"
+#include "impeller/renderer/backend/gles/context_gles.h"
 #include "impeller/renderer/backend/gles/device_buffer_gles.h"
 #include "impeller/renderer/backend/gles/formats_gles.h"
+#include "impeller/renderer/backend/gles/gpu_tracer_gles.h"
 #include "impeller/renderer/backend/gles/pipeline_gles.h"
 #include "impeller/renderer/backend/gles/texture_gles.h"
 
@@ -141,7 +143,8 @@ struct RenderPassData {
     const RenderPassData& pass_data,
     const std::shared_ptr<Allocator>& transients_allocator,
     const ReactorGLES& reactor,
-    const std::vector<Command>& commands) {
+    const std::vector<Command>& commands,
+    const std::shared_ptr<GPUTracerGLES>& tracer) {
   TRACE_EVENT0("impeller", "RenderPassGLES::EncodeCommandsInReactor");
 
   if (commands.empty()) {
@@ -149,6 +152,9 @@ struct RenderPassData {
   }
 
   const auto& gl = reactor.GetProcTable();
+  if (!tracer->HasStartedFrame()) {
+    tracer->MarkFrameStart(gl);
+  }
 
   fml::ScopedCleanupClosure pop_pass_debug_marker(
       [&gl]() { gl.PopDebugGroup(); });
@@ -492,6 +498,9 @@ struct RenderPassData {
                              attachments.data()   // size
     );
   }
+  if (is_default_fbo) {
+    tracer->MarkFrameEnd(gl);
+  }
 
   return true;
 }
@@ -549,12 +558,13 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
   }
 
   std::shared_ptr<const RenderPassGLES> shared_this = shared_from_this();
+  auto tracer = ContextGLES::Cast(context).GetGPUTracer();
   return reactor_->AddOperation([pass_data,
                                  allocator = context.GetResourceAllocator(),
-                                 render_pass = std::move(shared_this)](
+                                 render_pass = std::move(shared_this), tracer](
                                     const auto& reactor) {
     auto result = EncodeCommandsInReactor(*pass_data, allocator, reactor,
-                                          render_pass->commands_);
+                                          render_pass->commands_, tracer);
     FML_CHECK(result) << "Must be able to encode GL commands without error.";
   });
 }

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -154,7 +154,7 @@ struct RenderPassData {
   const auto& gl = reactor.GetProcTable();
 #ifdef IMPELLER_DEBUG
   tracer->MarkFrameStart(gl);
-#endif // IMPELLER_DEBUG
+#endif  // IMPELLER_DEBUG
 
   fml::ScopedCleanupClosure pop_pass_debug_marker(
       [&gl]() { gl.PopDebugGroup(); });
@@ -502,7 +502,7 @@ struct RenderPassData {
   if (is_default_fbo) {
     tracer->MarkFrameEnd(gl);
   }
-#endif // IMPELLER_DEBUG
+#endif  // IMPELLER_DEBUG
 
   return true;
 }

--- a/impeller/renderer/backend/gles/surface_gles.cc
+++ b/impeller/renderer/backend/gles/surface_gles.cc
@@ -60,6 +60,10 @@ std::unique_ptr<Surface> SurfaceGLES::WrapFBO(
   render_target_desc.SetColorAttachment(color0, 0u);
   render_target_desc.SetStencilAttachment(stencil0);
 
+#ifdef IMPELLER_DEBUG
+  gl_context.GetGPUTracer()->RecordRasterThread();
+#endif  // IMPELLER_DEBUG
+
   return std::unique_ptr<SurfaceGLES>(
       new SurfaceGLES(std::move(swap_callback), render_target_desc));
 }

--- a/impeller/renderer/backend/gles/test/gpu_tracer_gles_unittests.cc
+++ b/impeller/renderer/backend/gles/test/gpu_tracer_gles_unittests.cc
@@ -17,7 +17,8 @@ TEST(GPUTracerGLES, CanFormatFramebufferErrorMessage) {
       reinterpret_cast<const unsigned char*>("GL_EXT_disjoint_timer_query"),  //
   };
   auto mock_gles = MockGLES::Init(extensions);
-  auto tracer = std::make_shared<GPUTracerGLES>(mock_gles->GetProcTable());
+  auto tracer =
+      std::make_shared<GPUTracerGLES>(mock_gles->GetProcTable(), true);
   tracer->RecordRasterThread();
   tracer->MarkFrameStart(mock_gles->GetProcTable());
   tracer->MarkFrameEnd(mock_gles->GetProcTable());

--- a/impeller/renderer/backend/gles/test/gpu_tracer_gles_unittests.cc
+++ b/impeller/renderer/backend/gles/test/gpu_tracer_gles_unittests.cc
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gtest/gtest.h"
+#include "impeller/renderer/backend/gles/gpu_tracer_gles.h"
+#include "impeller/renderer/backend/gles/test/mock_gles.h"
+
+namespace impeller {
+namespace testing {
+
+#ifdef IMPELLER_DEBUG
+TEST(GPUTracerGLES, CanFormatFramebufferErrorMessage) {
+  auto const extensions = std::vector<const unsigned char*>{
+      reinterpret_cast<const unsigned char*>("GL_KHR_debug"),                 //
+      reinterpret_cast<const unsigned char*>("GL_EXT_disjoint_timer_query"),  //
+  };
+  auto mock_gles = MockGLES::Init(extensions);
+  auto tracer = std::make_shared<GPUTracerGLES>(mock_gles->GetProcTable());
+  tracer->RecordRasterThread();
+  tracer->MarkFrameStart(mock_gles->GetProcTable());
+  tracer->MarkFrameEnd(mock_gles->GetProcTable());
+
+  auto calls = mock_gles->GetCapturedCalls();
+
+  std::vector<std::string> expected = {"glGenQueriesEXT", "glBeginQueryEXT",
+                                       "glEndQueryEXT"};
+  for (auto i = 0; i < 3; i++) {
+    EXPECT_EQ(calls[i], expected[i]);
+  }
+
+  // Begin second frame, which prompts the tracer to query the result
+  // from the previous frame.
+  tracer->MarkFrameStart(mock_gles->GetProcTable());
+
+  calls = mock_gles->GetCapturedCalls();
+  std::vector<std::string> expected_b = {"glGetQueryObjectuivEXT",
+                                         "glGetQueryObjectui64vEXT",
+                                         "glDeleteQueriesEXT"};
+  for (auto i = 0; i < 3; i++) {
+    EXPECT_EQ(calls[i], expected_b[i]);
+  }
+}
+
+#endif  // IMPELLER_DEBUG
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -112,6 +112,53 @@ void mockPushDebugGroupKHR(GLenum source,
 static_assert(CheckSameSignature<decltype(mockPushDebugGroupKHR),  //
                                  decltype(glPushDebugGroupKHR)>::value);
 
+void mockGenQueriesEXT(GLsizei n, GLuint* ids) {
+  RecordGLCall("glGenQueriesEXT");
+  for (auto i = 0; i < n; i++) {
+    ids[i] = i + 1;
+  }
+}
+
+static_assert(CheckSameSignature<decltype(mockGenQueriesEXT),  //
+                                 decltype(glGenQueriesEXT)>::value);
+
+void mockBeginQueryEXT(GLenum target, GLuint id) {
+  RecordGLCall("glBeginQueryEXT");
+}
+
+static_assert(CheckSameSignature<decltype(mockBeginQueryEXT),  //
+                                 decltype(glBeginQueryEXT)>::value);
+
+void mockEndQueryEXT(GLuint id) {
+  RecordGLCall("glEndQueryEXT");
+}
+
+static_assert(CheckSameSignature<decltype(mockEndQueryEXT),  //
+                                 decltype(glEndQueryEXT)>::value);
+
+void mockGetQueryObjectuivEXT(GLuint id, GLenum target, GLuint* result) {
+  RecordGLCall("glGetQueryObjectuivEXT");
+  *result = GL_TRUE;
+}
+
+static_assert(CheckSameSignature<decltype(mockGetQueryObjectuivEXT),  //
+                                 decltype(glGetQueryObjectuivEXT)>::value);
+
+void mockGetQueryObjectui64vEXT(GLuint id, GLenum target, GLuint64* result) {
+  RecordGLCall("glGetQueryObjectui64vEXT");
+  *result = 1000u;
+}
+
+static_assert(CheckSameSignature<decltype(mockGetQueryObjectui64vEXT),  //
+                                 decltype(glGetQueryObjectui64vEXT)>::value);
+
+void mockDeleteQueriesEXT(GLsizei size, const GLuint* queries) {
+  RecordGLCall("glDeleteQueriesEXT");
+}
+
+static_assert(CheckSameSignature<decltype(mockDeleteQueriesEXT),  //
+                                 decltype(glDeleteQueriesEXT)>::value);
+
 std::shared_ptr<MockGLES> MockGLES::Init(
     const std::optional<std::vector<const unsigned char*>>& extensions) {
   // If we cannot obtain a lock, MockGLES is already being used elsewhere.
@@ -136,6 +183,18 @@ const ProcTableGLES::Resolver kMockResolver = [](const char* name) {
     return reinterpret_cast<void*>(&mockGetIntegerv);
   } else if (strcmp(name, "glGetError") == 0) {
     return reinterpret_cast<void*>(&mockGetError);
+  } else if (strcmp(name, "glGenQueriesEXT") == 0) {
+    return reinterpret_cast<void*>(&mockGenQueriesEXT);
+  } else if (strcmp(name, "glBeginQueryEXT") == 0) {
+    return reinterpret_cast<void*>(&mockBeginQueryEXT);
+  } else if (strcmp(name, "glEndQueryEXT") == 0) {
+    return reinterpret_cast<void*>(&mockEndQueryEXT);
+  } else if (strcmp(name, "glDeleteQueriesEXT") == 0) {
+    return reinterpret_cast<void*>(&mockDeleteQueriesEXT);
+  } else if (strcmp(name, "glGetQueryObjectui64vEXT") == 0) {
+    return reinterpret_cast<void*>(mockGetQueryObjectui64vEXT);
+  } else if (strcmp(name, "glGetQueryObjectuivEXT") == 0) {
+    return reinterpret_cast<void*>(mockGetQueryObjectuivEXT);
   } else {
     return reinterpret_cast<void*>(&doNothing);
   }

--- a/impeller/renderer/backend/metal/gpu_tracer_mtl.h
+++ b/impeller/renderer/backend/metal/gpu_tracer_mtl.h
@@ -17,9 +17,8 @@ namespace impeller {
 class ContextMTL;
 
 /// @brief Approximate the GPU frame time by computing a difference between the
-/// smallest
-///        GPUStartTime and largest GPUEndTime for all cmd buffers submitted in
-///        a frame workload.
+///        smallest GPUStartTime and largest GPUEndTime for all command buffers
+///        submitted in a frame workload.
 class GPUTracerMTL : public std::enable_shared_from_this<GPUTracerMTL> {
  public:
   GPUTracerMTL() = default;
@@ -27,13 +26,11 @@ class GPUTracerMTL : public std::enable_shared_from_this<GPUTracerMTL> {
   ~GPUTracerMTL() = default;
 
   /// @brief Record that the current frame has ended. Any additional cmd buffers
-  /// will be
-  ///        attributed to the "next" frame.
+  ///        will be attributed to the "next" frame.
   void MarkFrameEnd();
 
   /// @brief Record the current cmd buffer GPU execution timestamps into an
-  /// aggregate
-  ///        frame workload metric.
+  ///        aggregate frame workload metric.
   void RecordCmdBuffer(id<MTLCommandBuffer> buffer);
 
  private:

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -477,6 +477,8 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
 
   settings.enable_vulkan_validation =
       command_line.HasOption(FlagForSwitch(Switch::EnableVulkanValidation));
+  settings.enable_opengl_gpu_tracing =
+      command_line.HasOption(FlagForSwitch(Switch::EnableOpenGLGPUTracing));
 
   settings.enable_embedder_api =
       command_line.HasOption(FlagForSwitch(Switch::EnableEmbedderAPI));

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -275,6 +275,10 @@ DEF_SWITCH(EnableVulkanValidation,
            "Enable loading Vulkan validation layers. The layers must be "
            "available to the application and loadable. On non-Vulkan backends, "
            "this flag does nothing.")
+DEF_SWITCH(EnableOpenGLGPUTracing,
+           "enable-opengl-gpu-tracing",
+           "Enable tracing of GPU execution time when using the Impeller "
+           "OpenGLES backend.")
 DEF_SWITCH(LeakVM,
            "leak-vm",
            "When the last shell shuts down, the shared VM is leaked by default "

--- a/shell/platform/android/android_context_gl_impeller.h
+++ b/shell/platform/android/android_context_gl_impeller.h
@@ -13,8 +13,8 @@ namespace flutter {
 
 class AndroidContextGLImpeller : public AndroidContext {
  public:
-  explicit AndroidContextGLImpeller(
-      std::unique_ptr<impeller::egl::Display> display);
+  AndroidContextGLImpeller(std::unique_ptr<impeller::egl::Display> display,
+                           bool enable_gpu_tracing);
 
   ~AndroidContextGLImpeller();
 

--- a/shell/platform/android/android_context_gl_impeller_unittests.cc
+++ b/shell/platform/android/android_context_gl_impeller_unittests.cc
@@ -45,7 +45,8 @@ TEST(AndroidContextGLImpeller, MSAAFirstAttempt) {
       .WillOnce(Return(ByMove(std::move(second_result))));
   ON_CALL(*display, ChooseConfig(_))
       .WillByDefault(Return(ByMove(std::unique_ptr<Config>())));
-  auto context = std::make_unique<AndroidContextGLImpeller>(std::move(display));
+  auto context =
+      std::make_unique<AndroidContextGLImpeller>(std::move(display), true);
   ASSERT_TRUE(context);
 }
 
@@ -76,7 +77,8 @@ TEST(AndroidContextGLImpeller, FallbackForEmulator) {
       .WillOnce(Return(ByMove(std::move(third_result))));
   ON_CALL(*display, ChooseConfig(_))
       .WillByDefault(Return(ByMove(std::unique_ptr<Config>())));
-  auto context = std::make_unique<AndroidContextGLImpeller>(std::move(display));
+  auto context =
+      std::make_unique<AndroidContextGLImpeller>(std::move(display), true);
   ASSERT_TRUE(context);
 }
 }  // namespace testing

--- a/shell/platform/android/android_context_vulkan_impeller.h
+++ b/shell/platform/android/android_context_vulkan_impeller.h
@@ -14,7 +14,7 @@ namespace flutter {
 
 class AndroidContextVulkanImpeller : public AndroidContext {
  public:
-  AndroidContextVulkanImpeller(bool enable_validation);
+  explicit AndroidContextVulkanImpeller(bool enable_validation);
 
   ~AndroidContextVulkanImpeller();
 

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -45,6 +45,8 @@ public class FlutterLoader {
       "io.flutter.embedding.android.EnableVulkanValidation";
   private static final String IMPELLER_BACKEND_META_DATA_KEY =
       "io.flutter.embedding.android.ImpellerBackend";
+  private static final String IMPELLER_OPENGL_GPU_TRACING_DATA_KEY =
+      "io.flutter.embedding.android.EnableOpenGLGPUTracing";
   private static final String DISABLE_IMAGE_READER_PLATFORM_VIEWS_KEY =
       "io.flutter.embedding.android.DisableImageReaderPlatformViews";
 
@@ -339,6 +341,9 @@ public class FlutterLoader {
         if (metaData.getBoolean(
             ENABLE_VULKAN_VALIDATION_META_DATA_KEY, areValidationLayersOnByDefault())) {
           shellArgs.add("--enable-vulkan-validation");
+        }
+        if (metaData.getBoolean(IMPELLER_OPENGL_GPU_TRACING_DATA_KEY, false)) {
+          shellArgs.add("--enable-opengl-gpu-tracing");
         }
         String backend = metaData.getString(IMPELLER_BACKEND_META_DATA_KEY);
         if (backend != null) {

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -70,7 +70,8 @@ static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
     uint8_t msaa_samples,
     bool enable_impeller,
     const std::optional<std::string>& impeller_backend,
-    bool enable_vulkan_validation) {
+    bool enable_vulkan_validation,
+    bool enable_opengl_gpu_tracing) {
   if (use_software_rendering) {
     return std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
   }
@@ -90,7 +91,8 @@ static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
     switch (backend) {
       case AndroidRenderingAPI::kOpenGLES:
         return std::make_unique<AndroidContextGLImpeller>(
-            std::make_unique<impeller::egl::Display>());
+            std::make_unique<impeller::egl::Display>(),
+            enable_opengl_gpu_tracing);
       case AndroidRenderingAPI::kVulkan:
         return std::make_unique<AndroidContextVulkanImpeller>(
             enable_vulkan_validation);
@@ -99,7 +101,8 @@ static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
             enable_vulkan_validation);
         if (!vulkan_backend->IsValid()) {
           return std::make_unique<AndroidContextGLImpeller>(
-              std::make_unique<impeller::egl::Display>());
+              std::make_unique<impeller::egl::Display>(),
+              enable_opengl_gpu_tracing);
         }
         return vulkan_backend;
       }
@@ -131,7 +134,9 @@ PlatformViewAndroid::PlatformViewAndroid(
               msaa_samples,
               delegate.OnPlatformViewGetSettings().enable_impeller,
               delegate.OnPlatformViewGetSettings().impeller_backend,
-              delegate.OnPlatformViewGetSettings().enable_vulkan_validation)) {}
+              delegate.OnPlatformViewGetSettings().enable_vulkan_validation,
+              delegate.OnPlatformViewGetSettings().enable_opengl_gpu_tracing)) {
+}
 
 PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,

--- a/shell/platform/embedder/embedder_surface_gl_impeller.cc
+++ b/shell/platform/embedder/embedder_surface_gl_impeller.cc
@@ -65,11 +65,12 @@ EmbedderSurfaceGLImpeller::EmbedderSurfaceGLImpeller(
   gl_dispatch_table_.gl_make_current_callback();
 
   std::vector<std::shared_ptr<fml::Mapping>> shader_mappings = {
-    std::make_shared<fml::NonOwnedMapping>(impeller_entity_shaders_gles_data,
-                                           impeller_entity_shaders_gles_length),
+      std::make_shared<fml::NonOwnedMapping>(
+          impeller_entity_shaders_gles_data,
+          impeller_entity_shaders_gles_length),
 #if IMPELLER_ENABLE_3D
-    std::make_shared<fml::NonOwnedMapping>(impeller_scene_shaders_gles_data,
-                                           impeller_scene_shaders_gles_length),
+      std::make_shared<fml::NonOwnedMapping>(
+          impeller_scene_shaders_gles_data, impeller_scene_shaders_gles_length),
 #endif  // IMPELLER_ENABLE_3D
   };
   auto gl = std::make_unique<impeller::ProcTableGLES>(
@@ -78,8 +79,8 @@ EmbedderSurfaceGLImpeller::EmbedderSurfaceGLImpeller(
     return;
   }
 
-  impeller_context_ =
-      impeller::ContextGLES::Create(std::move(gl), shader_mappings);
+  impeller_context_ = impeller::ContextGLES::Create(
+      std::move(gl), shader_mappings, /*enable_gpu_tracing=*/false);
 
   if (!impeller_context_) {
     FML_LOG(ERROR) << "Could not create Impeller context.";


### PR DESCRIPTION
Trace GPU execution time on GLES using GL_EXT_disjoint_timer_query. This requires a per-app opt in from the Android Manifest with the key `"io.flutter.embedding.android.EnableOpenGLGPUTracing` set to true.