### PR TITLE
[Impeller] Use a weak pointer factory in GPUSurfaceGLImpeller that supports the raster thread merger

### DIFF
--- a/shell/gpu/gpu_surface_gl_impeller.h
+++ b/shell/gpu/gpu_surface_gl_impeller.h
@@ -32,7 +32,7 @@ class GPUSurfaceGLImpeller final : public Surface {
   std::shared_ptr<impeller::Renderer> impeller_renderer_;
   std::shared_ptr<impeller::AiksContext> aiks_context_;
   bool is_valid_ = false;
-  fml::WeakPtrFactory<GPUSurfaceGLImpeller> weak_factory_;
+  fml::TaskRunnerAffineWeakPtrFactory<GPUSurfaceGLImpeller> weak_factory_;
 
   // |Surface|
   std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) override;


### PR DESCRIPTION
This is required for platform view scenarios that merge the raster task runner into the platform thread.