### PR TITLE
[macOS] Fix AccessibilityBridge lifetime in tests

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -71,8 +71,8 @@ TEST(AccessibilityBridgeMacTest, SendsAccessibilityCreateNotificationToWindowOfF
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.
   engine.semanticsEnabled = YES;
-  auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
-      viewController.accessibilityBridge.lock());
+  std::shared_ptr<AccessibilityBridgeMac> bridge = viewController.accessibilityBridge.lock();
+  auto spy_bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(bridge);
   FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
@@ -103,12 +103,12 @@ TEST(AccessibilityBridgeMacTest, SendsAccessibilityCreateNotificationToWindowOfF
                                                  ax::mojom::EventFrom::kNone, intent);
   ui::AXEventGenerator::TargetedEvent targeted_event(&ax_node, event_params);
 
-  bridge->OnAccessibilityEvent(targeted_event);
+  spy_bridge->OnAccessibilityEvent(targeted_event);
 
-  EXPECT_EQ(bridge->actual_notifications.size(), 1u);
-  EXPECT_EQ(
-      bridge->actual_notifications.find([NSAccessibilityCreatedNotification UTF8String])->second,
-      expectedTarget);
+  EXPECT_EQ(spy_bridge->actual_notifications.size(), 1u);
+  EXPECT_EQ(spy_bridge->actual_notifications.find([NSAccessibilityCreatedNotification UTF8String])
+                ->second,
+            expectedTarget);
   [engine shutDownEngine];
 }
 
@@ -132,8 +132,8 @@ TEST(AccessibilityBridgeMacTest, NonZeroRootNodeId) {
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.
   engine.semanticsEnabled = YES;
-  auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
-      viewController.accessibilityBridge.lock());
+  std::shared_ptr<AccessibilityBridgeMac> bridge = viewController.accessibilityBridge.lock();
+  auto spy_bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(bridge);
 
   FlutterSemanticsNode2 node1;
   std::vector<int32_t> node1_children{2};
@@ -196,8 +196,8 @@ TEST(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhenH
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.
   engine.semanticsEnabled = YES;
-  auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
-      viewController.accessibilityBridge.lock());
+  std::shared_ptr<AccessibilityBridgeMac> bridge = viewController.accessibilityBridge.lock();
+  auto spy_bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(bridge);
   FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
@@ -228,10 +228,10 @@ TEST(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhenH
                                                  ax::mojom::EventFrom::kNone, intent);
   ui::AXEventGenerator::TargetedEvent targeted_event(&ax_node, event_params);
 
-  bridge->OnAccessibilityEvent(targeted_event);
+  spy_bridge->OnAccessibilityEvent(targeted_event);
 
   // Does not send any notification if the engine is headless.
-  EXPECT_EQ(bridge->actual_notifications.size(), 0u);
+  EXPECT_EQ(spy_bridge->actual_notifications.size(), 0u);
   [engine shutDownEngine];
 }
 
@@ -243,8 +243,8 @@ TEST(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhenN
   // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
   // can query semantics information from.
   engine.semanticsEnabled = YES;
-  auto bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(
-      viewController.accessibilityBridge.lock());
+  std::shared_ptr<AccessibilityBridgeMac> bridge = viewController.accessibilityBridge.lock();
+  auto spy_bridge = std::static_pointer_cast<AccessibilityBridgeMacSpy>(bridge);
   FlutterSemanticsNode2 root;
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
@@ -275,10 +275,10 @@ TEST(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhenN
                                                  ax::mojom::EventFrom::kNone, intent);
   ui::AXEventGenerator::TargetedEvent targeted_event(&ax_node, event_params);
 
-  bridge->OnAccessibilityEvent(targeted_event);
+  spy_bridge->OnAccessibilityEvent(targeted_event);
 
   // Does not send any notification if the flutter view is not attached to a NSWindow.
-  EXPECT_EQ(bridge->actual_notifications.size(), 0u);
+  EXPECT_EQ(spy_bridge->actual_notifications.size(), 0u);
   [engine shutDownEngine];
 }
 


### PR DESCRIPTION
Fixes object lifetime race conditions in macOS accessibility unit tests. In several accessibility tests, we take a lock on the view controller's accessibility bridge weak pointer, then cast from
AccessibilityBridgeMac to the AccessibilityBridgeMacSpy subclass used in the test.

The ownership guarantee on the object pointed to by the weak pointer is good only for the lifetime of the std::shared_ptr returned from the lock() call which, because it's never assigned to a local, is never actually held.

We now hold on to the returned std::shared_ptr for the duration of the test, and cast to a new spy_bridge object for when we need to access specific test methods.

Fixes a subset of crashes in flutter_desktop_darwin_unittests.

The previous crash can be reproduced by running:

    flutter_desktop_darwin_unittests --gtest_shuffle --gtest_repeat=1000

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
