### PR TITLE
Revert "[web] Ensure handled key event is not propagated to IME"

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -13,7 +13,6 @@ import 'browser_detection.dart';
 import 'dom.dart';
 import 'key_map.g.dart';
 import 'platform_dispatcher.dart';
-import 'raw_keyboard.dart';
 import 'semantics.dart';
 
 typedef _VoidCallback = void Function();
@@ -105,12 +104,9 @@ class KeyboardBinding {
     _addEventListener('keydown', (DomEvent domEvent) {
       final FlutterHtmlKeyboardEvent event = FlutterHtmlKeyboardEvent(domEvent as DomKeyboardEvent);
       _converter.handleEvent(event);
-      RawKeyboard.instance?.handleHtmlEvent(domEvent);
     });
-    _addEventListener('keyup', (DomEvent domEvent) {
-      final FlutterHtmlKeyboardEvent event = FlutterHtmlKeyboardEvent(domEvent as DomKeyboardEvent);
-      _converter.handleEvent(event);
-      RawKeyboard.instance?.handleHtmlEvent(domEvent);
+    _addEventListener('keyup', (DomEvent event) {
+      _converter.handleEvent(FlutterHtmlKeyboardEvent(event as DomKeyboardEvent));
     });
   }
 
@@ -213,7 +209,6 @@ class FlutterHtmlKeyboardEvent {
 
   bool getModifierState(String key) => _event.getModifierState(key);
   void preventDefault() => _event.preventDefault();
-  void stopPropagation() => _event.stopPropagation();
   bool get defaultPrevented => _event.defaultPrevented;
 }
 

--- a/lib/web_ui/test/common/keyboard_test_common.dart
+++ b/lib/web_ui/test/common/keyboard_test_common.dart
@@ -22,7 +22,6 @@ class MockKeyboardEvent implements FlutterHtmlKeyboardEvent {
     bool altGrKey = false,
     this.location = 0,
     this.onPreventDefault,
-    this.onStopPropagation,
   }) : modifierState =
         <String>{
           if (altKey) 'Alt',
@@ -84,12 +83,6 @@ class MockKeyboardEvent implements FlutterHtmlKeyboardEvent {
   @override
   bool get defaultPrevented => _defaultPrevented;
   bool _defaultPrevented = false;
-
-  @override
-  void stopPropagation() {
-    onStopPropagation?.call();
-  }
-  VoidCallback? onStopPropagation;
 
   static bool get lastDefaultPrevented => _lastEvent?.defaultPrevented ?? false;
   static MockKeyboardEvent? _lastEvent;

--- a/lib/web_ui/test/engine/raw_keyboard_test.dart
+++ b/lib/web_ui/test/engine/raw_keyboard_test.dart
@@ -52,10 +52,6 @@ void testMain() {
 
       DomKeyboardEvent event;
 
-      // Dispatch a keydown event first so that KeyboardBinding will recognize the keyup event.
-      // and will not set preventDefault on it.
-      event = dispatchKeyboardEvent('keydown', key: 'SomeKey', code: 'SomeCode', keyCode: 1);
-
       event = dispatchKeyboardEvent('keyup', key: 'SomeKey', code: 'SomeCode', keyCode: 1);
 
       expect(event.defaultPrevented, isFalse);

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -12,14 +12,12 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart' show flutterViewEmbedder;
 import 'package:ui/src/engine/browser_detection.dart';
 import 'package:ui/src/engine/dom.dart';
-import 'package:ui/src/engine/raw_keyboard.dart';
 import 'package:ui/src/engine/services.dart';
 import 'package:ui/src/engine/text_editing/autofill_hint.dart';
 import 'package:ui/src/engine/text_editing/input_type.dart';
 import 'package:ui/src/engine/text_editing/text_editing.dart';
 import 'package:ui/src/engine/util.dart';
 import 'package:ui/src/engine/vector_math.dart';
-import 'package:ui/ui.dart' as ui;
 
 import '../common/spy.dart';
 import '../common/test_initialization.dart';
@@ -370,52 +368,6 @@ Future<void> testMain() async {
         keyCode: _kReturnKeyCode,
       );
       expect(lastInputAction, 'TextInputAction.done');
-    });
-
-   test('handling keyboard event prevents triggering input action', () {
-      final ui.PlatformMessageCallback? savedCallback = ui.window.onPlatformMessage;
-
-      bool markTextEventHandled = false;
-      ui.window.onPlatformMessage = (String channel, ByteData? data,
-          ui.PlatformMessageResponseCallback? callback) {
-        final ByteData response = const JSONMessageCodec()
-            .encodeMessage(<String, dynamic>{'handled': markTextEventHandled})!;
-        callback!(response);
-      };
-      RawKeyboard.initialize();
-
-      final InputConfiguration config = InputConfiguration();
-      editingStrategy!.enable(
-        config,
-        onChange: trackEditingState,
-        onAction: trackInputAction,
-      );
-
-      // No input action so far.
-      expect(lastInputAction, isNull);
-
-      markTextEventHandled = true;
-      dispatchKeyboardEvent(
-        editingStrategy!.domElement!,
-        'keydown',
-        keyCode: _kReturnKeyCode,
-      );
-
-      // Input action prevented by platform message callback.
-      expect(lastInputAction, isNull);
-
-      markTextEventHandled = false;
-      dispatchKeyboardEvent(
-        editingStrategy!.domElement!,
-        'keydown',
-        keyCode: _kReturnKeyCode,
-      );
-
-      // Input action received.
-      expect(lastInputAction, 'TextInputAction.done');
-
-      ui.window.onPlatformMessage = savedCallback;
-      RawKeyboard.instance?.dispose();
     });
 
     test('Triggers input action in multi-line mode', () {

--- a/third_party/web_locale_keymap/lib/web_locale_keymap/locale_keymap.dart
+++ b/third_party/web_locale_keymap/lib/web_locale_keymap/locale_keymap.dart
@@ -41,9 +41,6 @@ class LocaleKeymap {
       return eventKeyCode;
     }
     if (result == null) {
-      if ((eventCode ?? '').isEmpty && (eventKey ?? '').isEmpty) {
-        return null;
-      }
       final int? heuristicResult = heuristicMapper(eventCode ?? '', eventKey ?? '');
       if (heuristicResult != null) {
         return heuristicResult;


### PR DESCRIPTION
Reverts flutter/engine#46829

Fixes https://github.com/flutter/flutter/issues/136857

Speculative fix for The builds breaking on the web text tests as seen here: https://github.com/flutter/flutter/runs/17840697842