### PR TITLE
[Windows] Fix a11y node delegate lock lifetime

### DIFF
--- a/shell/platform/windows/flutter_platform_node_delegate_windows.cc
+++ b/shell/platform/windows/flutter_platform_node_delegate_windows.cc
@@ -62,9 +62,10 @@ gfx::NativeViewAccessible FlutterPlatformNodeDelegateWindows::HitTestSync(
   auto bridge = bridge_.lock();
   FML_DCHECK(bridge);
   for (const ui::AXNode* child : GetAXNode()->children()) {
-    std::shared_ptr<FlutterPlatformNodeDelegateWindows> win_delegate =
-        std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(
-            bridge->GetFlutterPlatformNodeDelegateFromID(child->id()).lock());
+    std::shared_ptr<FlutterPlatformNodeDelegate> delegate =
+        bridge->GetFlutterPlatformNodeDelegateFromID(child->id()).lock();
+    auto win_delegate =
+        std::static_pointer_cast<FlutterPlatformNodeDelegateWindows>(delegate);
     FML_DCHECK(win_delegate)
         << "No FlutterPlatformNodeDelegate found for node " << child->id();
     auto hit_view = win_delegate->HitTestSync(screen_physical_pixel_x,


### PR DESCRIPTION
When taking a std::shared_pointer from a weak pointer node delegate, we need to hold the shared pointer to get the ownership guarantee on the underlying object until after its last use. Previously, we never assigned to a local, thus the lifetime of the returned shared_ptr (and thus the lock on the underlying object) was zero.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
