### PR TITLE
Fix async image loading issues in skwasm.

### DIFF
--- a/lib/web_ui/lib/src/engine/scene_view.dart
+++ b/lib/web_ui/lib/src/engine/scene_view.dart
@@ -16,17 +16,17 @@ abstract class PictureRenderer {
   FutureOr<DomImageBitmap> renderPicture(ScenePicture picture);
 }
 
-class SceneRender {
-  SceneRender(this.scene, this.completer) {
+class _SceneRender {
+  _SceneRender(this.scene, this._completer) {
     scene.beginRender();
   }
 
   final EngineScene scene;
-  final Completer<void> completer;
+  final Completer<void> _completer;
 
   void done() {
     scene.endRender();
-    completer.complete();
+    _completer.complete();
   }
 }
 
@@ -44,31 +44,31 @@ class EngineSceneView {
 
   List<SliceContainer> containers = <SliceContainer>[];
 
-  SceneRender? currentRender;
-  SceneRender? nextRender;
+  _SceneRender? _currentRender;
+  _SceneRender? _nextRender;
 
   Future<void> renderScene(EngineScene scene) {
-    if (currentRender != null) {
+    if (_currentRender != null) {
       // If a scene is already queued up, drop it and queue this one up instead
       // so that the scene view always displays the most recently requested scene.
-      nextRender?.done();
+      _nextRender?.done();
       final Completer<void> completer = Completer<void>();
-      nextRender = SceneRender(scene, completer);
+      _nextRender = _SceneRender(scene, completer);
       return completer.future;
     }
     final Completer<void> completer = Completer<void>();
-    currentRender = SceneRender(scene, completer);
+    _currentRender = _SceneRender(scene, completer);
     _kickRenderLoop();
     return completer.future;
   }
 
   Future<void> _kickRenderLoop() async {
-    final SceneRender current = currentRender!;
+    final _SceneRender current = _currentRender!;
     await _renderScene(current.scene);
     current.done();
-    currentRender = nextRender;
-    nextRender = null;
-    if (currentRender == null) {
+    _currentRender = _nextRender;
+    _nextRender = null;
+    if (_currentRender == null) {
       return;
     } else {
       return _kickRenderLoop();

--- a/lib/web_ui/lib/src/engine/scene_view.dart
+++ b/lib/web_ui/lib/src/engine/scene_view.dart
@@ -16,6 +16,20 @@ abstract class PictureRenderer {
   FutureOr<DomImageBitmap> renderPicture(ScenePicture picture);
 }
 
+class SceneRender {
+  SceneRender(this.scene, this.completer) {
+    scene.beginRender();
+  }
+
+  final EngineScene scene;
+  final Completer<void> completer;
+
+  void done() {
+    scene.endRender();
+    completer.complete();
+  }
+}
+
 // This class builds a DOM tree that composites an `EngineScene`.
 class EngineSceneView {
   factory EngineSceneView(PictureRenderer pictureRenderer) {
@@ -30,16 +44,38 @@ class EngineSceneView {
 
   List<SliceContainer> containers = <SliceContainer>[];
 
-  int queuedRenders = 0;
-  static const int kMaxQueuedRenders = 3;
+  SceneRender? currentRender;
+  SceneRender? nextRender;
 
-  Future<void> renderScene(EngineScene scene) async {
-    if (queuedRenders >= kMaxQueuedRenders) {
-      return;
+  Future<void> renderScene(EngineScene scene) {
+    if (currentRender != null) {
+      // If a scene is already queued up, drop it and queue this one up instead
+      // so that the scene view always displays the most recently requested scene.
+      nextRender?.done();
+      final Completer<void> completer = Completer<void>();
+      nextRender = SceneRender(scene, completer);
+      return completer.future;
     }
-    queuedRenders += 1;
+    final Completer<void> completer = Completer<void>();
+    currentRender = SceneRender(scene, completer);
+    _kickRenderLoop();
+    return completer.future;
+  }
 
-    scene.beginRender();
+  Future<void> _kickRenderLoop() async {
+    final SceneRender current = currentRender!;
+    await _renderScene(current.scene);
+    current.done();
+    currentRender = nextRender;
+    nextRender = null;
+    if (currentRender == null) {
+      return;
+    } else {
+      return _kickRenderLoop();
+    }
+  }
+
+  Future<void> _renderScene(EngineScene scene) async {
     final List<LayerSlice> slices = scene.rootLayer.slices;
     final Iterable<Future<DomImageBitmap?>> renderFutures = slices.map(
       (LayerSlice slice) async => switch (slice) {
@@ -113,9 +149,6 @@ class EngineSceneView {
       sceneElement.removeChild(currentElement);
       currentElement = sibling;
     }
-    scene.endRender();
-
-    queuedRenders -= 1;
   }
 }
 

--- a/lib/web_ui/skwasm/image.cpp
+++ b/lib/web_ui/skwasm/image.cpp
@@ -101,6 +101,10 @@ class TextureSourceImageGenerator : public GrExternalTextureGenerator {
 
     auto backendTexture = GrBackendTextures::MakeGL(
         fInfo.width(), fInfo.height(), mipmapped, glInfo);
+
+    // In order to bind the image source to the texture, makeTexture has changed
+    // which texture is "in focus" for the WebGL context.
+    GrAsDirectContext(context)->resetContext(kTextureBinding_GrGLBackendState);
     return std::make_unique<ExternalWebGLTexture>(
         backendTexture, glInfo.fID, emscripten_webgl_get_current_context());
   }

--- a/lib/web_ui/skwasm/library_skwasm_support.js
+++ b/lib/web_ui/skwasm/library_skwasm_support.js
@@ -27,6 +27,9 @@ mergeInto(LibraryManager.library, {
           return;
         }
         switch (skwasmMessage) {
+          case 'renderPicture':
+            _surface_renderPictureOnWorker(data.surface, data.picture, data.callbackId);
+            return;
           case 'onRenderComplete':
             _surface_onRenderComplete(data.surface, data.callbackId, data.imageBitmap);
             return;
@@ -50,6 +53,14 @@ mergeInto(LibraryManager.library, {
       } else {
         PThread.pthreads[threadId].addEventListener("message", eventListener);
       }
+    };
+    _skwasm_dispatchRenderPicture = function(threadId, surfaceHandle, pictureHandle, callbackId) {
+      PThread.pthreads[threadId].postMessage({
+        skwasmMessage: 'renderPicture',
+        surface: surfaceHandle,
+        picture: pictureHandle,
+        callbackId,
+      });
     };
     _skwasm_createOffscreenCanvas = function(width, height) {
       const canvas = new OffscreenCanvas(width, height);
@@ -114,6 +125,8 @@ mergeInto(LibraryManager.library, {
   skwasm_disposeAssociatedObjectOnThread__deps: ['$skwasm_support_setup'],
   skwasm_registerMessageListener: function() {},
   skwasm_registerMessageListener__deps: ['$skwasm_support_setup'],
+  skwasm_dispatchRenderPicture: function() {},
+  skwasm_dispatchRenderPicture__deps: ['$skwasm_support_setup'],
   skwasm_createOffscreenCanvas: function () {},
   skwasm_createOffscreenCanvas__deps: ['$skwasm_support_setup'],
   skwasm_resizeCanvas: function () {},

--- a/lib/web_ui/skwasm/skwasm_support.h
+++ b/lib/web_ui/skwasm/skwasm_support.h
@@ -4,6 +4,7 @@
 
 #include <emscripten/threading.h>
 #include <cinttypes>
+#include "third_party/skia/include/core/SkPicture.h"
 
 namespace Skwasm {
 class Surface;
@@ -19,6 +20,10 @@ extern SkwasmObject skwasm_getAssociatedObject(void* pointer);
 extern void skwasm_disposeAssociatedObjectOnThread(unsigned long threadId,
                                                    void* pointer);
 extern void skwasm_registerMessageListener(pthread_t threadId);
+extern void skwasm_dispatchRenderPicture(unsigned long threadId,
+                                         Skwasm::Surface* surface,
+                                         SkPicture* picture,
+                                         uint32_t callbackId);
 extern uint32_t skwasm_createOffscreenCanvas(int width, int height);
 extern void skwasm_resizeCanvas(uint32_t contextHandle, int width, int height);
 extern void skwasm_captureImageBitmap(Skwasm::Surface* surfaceHandle,

--- a/lib/web_ui/skwasm/surface.h
+++ b/lib/web_ui/skwasm/surface.h
@@ -70,13 +70,15 @@ class Surface {
   std::unique_ptr<TextureSourceWrapper> createTextureSourceWrapper(
       SkwasmObject textureSource);
 
+  // Worker thread
+  void renderPictureOnWorker(SkPicture* picture, uint32_t callbackId);
+
  private:
   void _runWorker();
   void _init();
   void _dispose();
   void _resizeCanvasToFit(int width, int height);
   void _recreateSurface();
-  void _renderPicture(const SkPicture* picture, uint32_t callbackId);
   void _rasterizeImage(SkImage* image,
                        ImageByteFormat format,
                        uint32_t callbackId);
@@ -99,9 +101,6 @@ class Surface {
   pthread_t _thread;
 
   static void fDispose(Surface* surface);
-  static void fRenderPicture(Surface* surface,
-                             SkPicture* picture,
-                             uint32_t callbackId);
   static void fOnRenderComplete(Surface* surface,
                                 uint32_t callbackId,
                                 SkwasmObject imageBitmap);

--- a/lib/web_ui/test/engine/scene_view_test.dart
+++ b/lib/web_ui/test/engine/scene_view_test.dart
@@ -25,7 +25,7 @@ class StubPictureRenderer implements PictureRenderer {
 
   @override
   Future<DomImageBitmap> renderPicture(ScenePicture picture) async {
-    lastRenderedPicture = picture;
+    renderedPictures.add(picture);
     final ui.Rect cullRect = picture.cullRect;
     final DomImageBitmap bitmap = (await createImageBitmap(
       scratchCanvasElement,
@@ -34,7 +34,7 @@ class StubPictureRenderer implements PictureRenderer {
     return bitmap;
   }
 
-  ScenePicture? lastRenderedPicture;
+  List<ScenePicture> renderedPictures = <ScenePicture>[];
 }
 
 void testMain() {
@@ -107,7 +107,7 @@ void testMain() {
     debugOverrideDevicePixelRatio(null);
   });
 
-  test('SceneView always renders most recent picture', () async {
+  test('SceneView always renders most recent picture and skips intermediate pictures', () async {
     final List<StubPicture> pictures = <StubPicture>[];
     final List<Future<void>> renderFutures = <Future<void>>[];
     for (int i = 1; i < 20; i++) {
@@ -124,6 +124,10 @@ void testMain() {
       renderFutures.add(sceneView.renderScene(scene));
     }
     await Future.wait(renderFutures);
-    expect(stubPictureRenderer.lastRenderedPicture, pictures.last);
+
+    // Should just render the first and last pictures and skip the one inbetween.
+    expect(stubPictureRenderer.renderedPictures.length, 2);
+    expect(stubPictureRenderer.renderedPictures.first, pictures.first);
+    expect(stubPictureRenderer.renderedPictures.last, pictures.last);
   });
 }


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/134045

There were a few different issues here:
* We need to do our own message passing for rendering pictures. The async methods provided by emscripten have their own queue that can drain synchronously, so basically it's not guaranteed to be FIFO with other messages sent to the web worker or main thread.
* When we drop frames, we should only drop intermediate frames, so that when the rendering flurry stops that the frame that is displayed is the last one that was actually requested.
* We need to reset the GL context after lazy image creation, otherwise skia's renderer gets into a bad state for that frame.