### PR TITLE
[macOS] Fail early when no a11y notification

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -105,10 +105,10 @@ TEST(AccessibilityBridgeMacTest, SendsAccessibilityCreateNotificationToWindowOfF
 
   bridge->OnAccessibilityEvent(targeted_event);
 
-  EXPECT_EQ(bridge->actual_notifications.size(), 1u);
-  EXPECT_EQ(
-      bridge->actual_notifications.find([NSAccessibilityCreatedNotification UTF8String])->second,
-      expectedTarget);
+  ASSERT_EQ(bridge->actual_notifications.size(), 1u);
+  auto target = bridge->actual_notifications.find([NSAccessibilityCreatedNotification UTF8String]);
+  ASSERT_NE(target, bridge->actual_notifications.end());
+  EXPECT_EQ(target->second, expectedTarget);
   [engine shutDownEngine];
 }
 


### PR DESCRIPTION
In the SendsAccessibilityCreateNotificationToWindowOfFlutterView test in AccessibilityBridgeMacTest, we look for an accessibility notification by name in a map stored in the test accessibility bridge. If there is no such notification, bail out immediately.

Previously we got a crash since we called `second` to retrieve the value associated with the map entry we find, without actually checking that we'd actually found an entry.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
