### PR TITLE
Lower the severity of a log message

### DIFF
--- a/shell/platform/android/image_external_texture.cc
+++ b/shell/platform/android/image_external_texture.cc
@@ -42,7 +42,7 @@ void ImageExternalTexture::Paint(PaintContext& context,
         flutter::DlCanvas::SrcRectConstraint::kStrict  // enforce edges
     );
   } else {
-    FML_LOG(ERROR) << "No DlImage available for ImageExternalTexture to paint.";
+    FML_LOG(INFO) << "No DlImage available for ImageExternalTexture to paint.";
   }
 }
 


### PR DESCRIPTION
This log message can print on the first frame of a platform view and is not an error.
