### PR TITLE
[Impeller] increased padding for blurs

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3687,5 +3687,21 @@ TEST_P(AiksTest, ClearColorOptimizationWhenSubpassIsBiggerThanParentPass) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, BlurHasNoEdge) {
+  Canvas canvas;
+  canvas.Scale(GetContentScale());
+  canvas.DrawPaint({});
+  Paint blur = {
+      .color = Color::Green(),
+      .mask_blur_descriptor =
+          Paint::MaskBlurDescriptor{
+              .style = FilterContents::BlurStyle::kNormal,
+              .sigma = Sigma(47.6),
+          },
+  };
+  canvas.DrawRect(Rect{300, 300, 200, 200}, blur);
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -16,6 +16,13 @@
 
 namespace impeller {
 
+namespace {
+// Generous padding to avoid bugs.
+Scalar PadForSigma(Scalar sigma) {
+  return sigma * 4.0;
+}
+}  // namespace
+
 SolidRRectBlurContents::SolidRRectBlurContents() = default;
 
 SolidRRectBlurContents::~SolidRRectBlurContents() = default;
@@ -44,7 +51,7 @@ std::optional<Rect> SolidRRectBlurContents::GetCoverage(
     return std::nullopt;
   }
 
-  Scalar radius = sigma_.sigma * 2;
+  Scalar radius = PadForSigma(sigma_.sigma);
 
   auto ltrb = rect_->GetLTRB();
   Rect bounds = Rect::MakeLTRB(ltrb[0] - radius, ltrb[1] - radius,
@@ -68,7 +75,7 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
   auto blur_sigma = std::min(sigma_.sigma, 250.0f);
   // Increase quality by make the radius a bit bigger than the typical
   // sigma->radius conversion we use for slower blurs.
-  auto blur_radius = blur_sigma * 2;
+  auto blur_radius = PadForSigma(blur_sigma);
   auto positive_rect = rect_->GetPositive();
   {
     auto left = -blur_radius;

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -17,7 +17,8 @@
 namespace impeller {
 
 namespace {
-// Generous padding to avoid bugs.
+// Generous padding to make sure blurs with large sigmas are fully visible.
+// Used to expand the geometry around the rrect.
 Scalar PadForSigma(Scalar sigma) {
   return sigma * 4.0;
 }
@@ -73,7 +74,7 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
 
   // Clamp the max kernel width/height to 1000.
   auto blur_sigma = std::min(sigma_.sigma, 250.0f);
-  // Increase quality by make the radius a bit bigger than the typical
+  // Increase quality by making the radius a bit bigger than the typical
   // sigma->radius conversion we use for slower blurs.
   auto blur_radius = PadForSigma(blur_sigma);
   auto positive_rect = rect_->GetPositive();


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/119974

This duplicates the math found in skia at https://skia.googlesource.com/skia/+/cf2131f85d57f938472e50b6643c3c2348709a55/gm/blurrect.cpp#484

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
