### PR TITLE
[Impeller] Add FilterContents::GetSourceCoverage to enable filtered saveLayer clipping.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2760,6 +2760,36 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorAndImageFilterDrawsCorrectly) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, ImageFilteredSaveLayerWithUnboundedContents) {
+  Canvas canvas;
+
+  auto texture = CreateTextureForFixture("airplane.jpg");
+  auto blur_filter = ImageFilter::MakeBlur(Sigma{5.0}, Sigma{5.0},
+                                           FilterContents::BlurStyle::kNormal,
+                                           Entity::TileMode::kClamp);
+  auto image_source = ColorSource::MakeImage(texture, Entity::TileMode::kRepeat,
+                                             Entity::TileMode::kRepeat, {}, {});
+
+  canvas.SaveLayer({.image_filter = blur_filter},
+                   Rect::MakeLTRB(100, 100, 200, 200));
+
+  canvas.DrawPaint({.color_source = image_source});
+
+  Paint blue = {.color = Color::Blue()};
+  Paint green = {.color = Color::Green()};
+
+  canvas.DrawRect(Rect::MakeLTRB(125, 125, 175, 175), blue);
+
+  canvas.DrawRect(Rect::MakeLTRB(125, 50, 175, 98), green);
+  canvas.DrawRect(Rect::MakeLTRB(202, 125, 250, 175), green);
+  canvas.DrawRect(Rect::MakeLTRB(125, 202, 175, 250), green);
+  canvas.DrawRect(Rect::MakeLTRB(50, 125, 98, 175), green);
+
+  canvas.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, TranslucentSaveLayerImageDrawsCorrectly) {
   Canvas canvas;
 

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2762,43 +2762,96 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorAndImageFilterDrawsCorrectly) {
 
 TEST_P(AiksTest, ImageFilteredSaveLayerWithUnboundedContents) {
   Canvas canvas;
+  canvas.Scale(GetContentScale());
 
-  auto blur_filter = ImageFilter::MakeBlur(Sigma{10.0}, Sigma{10.0},
-                                           FilterContents::BlurStyle::kNormal,
-                                           Entity::TileMode::kDecal);
+  auto test = [&canvas](const std::shared_ptr<ImageFilter>& filter) {
+    auto DrawLine = [&canvas](const Point& p0, const Point& p1,
+                              const Paint& p) {
+      auto path = PathBuilder{}
+                      .AddLine(p0, p1)
+                      .SetConvexity(Convexity::kConvex)
+                      .TakePath();
+      Paint paint = p;
+      paint.style = Paint::Style::kStroke;
+      canvas.DrawPath(path, paint);
+    };
+    // Registration marks for the edge of the SaveLayer
+    DrawLine(Point(75, 100), Point(225, 100), {.color = Color::White()});
+    DrawLine(Point(75, 200), Point(225, 200), {.color = Color::White()});
+    DrawLine(Point(100, 75), Point(100, 225), {.color = Color::White()});
+    DrawLine(Point(200, 75), Point(200, 225), {.color = Color::White()});
 
-  auto DrawLine = [&canvas](const Point& p0, const Point& p1, const Paint& p) {
-    auto path = PathBuilder{}
-                    .AddLine(p0, p1)
-                    .SetConvexity(Convexity::kConvex)
-                    .TakePath();
-    Paint paint = p;
-    paint.style = Paint::Style::kStroke;
-    canvas.DrawPath(path, paint);
+    canvas.SaveLayer({.image_filter = filter},
+                     Rect::MakeLTRB(100, 100, 200, 200));
+    {
+      // DrawPaint to verify correct behavior when the contents are unbounded.
+      canvas.DrawPaint({.color = Color::Yellow()});
+
+      // Contrasting rectangle to see interior blurring
+      canvas.DrawRect(Rect::MakeLTRB(125, 125, 175, 175),
+                      {.color = Color::Blue()});
+    }
+    canvas.Restore();
   };
-  // Registration marks for the edge of the SaveLayer
-  DrawLine(Point(75, 100), Point(225, 100), {.color = Color::White()});
-  DrawLine(Point(75, 200), Point(225, 200), {.color = Color::White()});
-  DrawLine(Point(100, 75), Point(100, 225), {.color = Color::White()});
-  DrawLine(Point(200, 75), Point(200, 225), {.color = Color::White()});
 
-  canvas.SaveLayer({.image_filter = blur_filter},
-                   Rect::MakeLTRB(100, 100, 200, 200));
-  {
-    // DrawPaint to verify correct behavior when the contents are unbounded.
-    canvas.DrawPaint({.color = Color::Yellow()});
+  test(ImageFilter::MakeBlur(Sigma{10.0}, Sigma{10.0},
+                             FilterContents::BlurStyle::kNormal,
+                             Entity::TileMode::kDecal));
 
-    // Contrasting rectangle to see interior blurring
-    canvas.DrawRect(Rect::MakeLTRB(125, 125, 175, 175),
-                    {.color = Color::Blue()});
-  }
-  canvas.Restore();
+  canvas.Translate({200.0, 0.0});
+
+  test(ImageFilter::MakeDilate(Radius{10.0}, Radius{10.0}));
+
+  canvas.Translate({200.0, 0.0});
+
+  test(ImageFilter::MakeErode(Radius{10.0}, Radius{10.0}));
+
+  canvas.Translate({-400.0, 200.0});
+
+  auto rotate_filter =
+      ImageFilter::MakeMatrix(Matrix::MakeTranslation({150, 150}) *
+                                  Matrix::MakeRotationZ(Degrees{10.0}) *
+                                  Matrix::MakeTranslation({-150, -150}),
+                              SamplerDescriptor{});
+  test(rotate_filter);
+
+  canvas.Translate({200.0, 0.0});
+
+  auto rgb_swap_filter = ImageFilter::MakeFromColorFilter(
+      *ColorFilter::MakeMatrix({.array = {
+                                    0, 1, 0, 0, 0,  //
+                                    0, 0, 1, 0, 0,  //
+                                    1, 0, 0, 0, 0,  //
+                                    0, 0, 0, 1, 0   //
+                                }}));
+  test(rgb_swap_filter);
+
+  canvas.Translate({200.0, 0.0});
+
+  test(ImageFilter::MakeCompose(*rotate_filter, *rgb_swap_filter));
+
+  canvas.Translate({-400.0, 200.0});
+
+  test(ImageFilter::MakeLocalMatrix(Matrix::MakeTranslation({25.0, 25.0}),
+                                    *rotate_filter));
+
+  canvas.Translate({200.0, 0.0});
+
+  test(ImageFilter::MakeLocalMatrix(Matrix::MakeTranslation({25.0, 25.0}),
+                                    *rgb_swap_filter));
+
+  canvas.Translate({200.0, 0.0});
+
+  test(ImageFilter::MakeLocalMatrix(
+      Matrix::MakeTranslation({25.0, 25.0}),
+      *ImageFilter::MakeCompose(*rotate_filter, *rgb_swap_filter)));
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
 TEST_P(AiksTest, ImageFilteredUnboundedSaveLayerWithUnboundedContents) {
   Canvas canvas;
+  canvas.Scale(GetContentScale());
 
   auto blur_filter = ImageFilter::MakeBlur(Sigma{10.0}, Sigma{10.0},
                                            FilterContents::BlurStyle::kNormal,

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -169,4 +169,15 @@ std::optional<Rect> BorderMaskBlurFilterContents::GetFilterCoverage(
               Size(extent.x, extent.y));
 }
 
+std::optional<Rect> BorderMaskBlurFilterContents::GetFilterSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  auto transformed_blur_vector =
+      effect_transform.TransformDirection(Vector2(Radius{sigma_x_}.radius, 0))
+          .Abs() +
+      effect_transform.TransformDirection(Vector2(0, Radius{sigma_y_}.radius))
+          .Abs();
+  return output_limit.Expand(transformed_blur_vector);
+}
+
 }  // namespace impeller

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
@@ -27,6 +27,11 @@ class BorderMaskBlurFilterContents final : public FilterContents {
       const Entity& entity,
       const Matrix& effect_transform) const override;
 
+  // |FilterContents|
+  std::optional<Rect> GetFilterSourceCoverage(
+      const Matrix& effect_transform,
+      const Rect& output_limit) const override;
+
  private:
   // |FilterContents|
   std::optional<Entity> RenderFilter(

--- a/impeller/entity/contents/filters/color_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_filter_contents.cc
@@ -99,4 +99,10 @@ std::optional<Scalar> ColorFilterContents::GetAlpha() const {
   return alpha_;
 }
 
+std::optional<Rect> ColorFilterContents::GetFilterSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  return output_limit;
+}
+
 }  // namespace impeller

--- a/impeller/entity/contents/filters/color_filter_contents.h
+++ b/impeller/entity/contents/filters/color_filter_contents.h
@@ -44,6 +44,11 @@ class ColorFilterContents : public FilterContents {
 
   std::optional<Scalar> GetAlpha() const;
 
+  // |FilterContents|
+  std::optional<Rect> GetFilterSourceCoverage(
+      const Matrix& effect_transform,
+      const Rect& output_limit) const override;
+
  private:
   AbsorbOpacity absorb_opacity_ = AbsorbOpacity::kNo;
   std::optional<Scalar> alpha_;

--- a/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.cc
@@ -273,6 +273,17 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
       entity.GetBlendMode(), entity.GetClipDepth());
 }
 
+std::optional<Rect>
+DirectionalGaussianBlurFilterContents::GetFilterSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  auto transform = effect_transform.Basis();
+  auto transformed_blur_vector =
+      transform.TransformDirection(blur_direction_ * Radius{blur_sigma_}.radius)
+          .Abs();
+  return output_limit.Expand(transformed_blur_vector);
+}
+
 std::optional<Rect> DirectionalGaussianBlurFilterContents::GetFilterCoverage(
     const FilterInput::Vector& inputs,
     const Entity& entity,

--- a/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.h
@@ -70,6 +70,11 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
   void SetIsSecondPass(bool is_second_pass);
 
   // |FilterContents|
+  std::optional<Rect> GetFilterSourceCoverage(
+      const Matrix& effect_transform,
+      const Rect& output_limit) const override;
+
+  // |FilterContents|
   std::optional<Rect> GetFilterCoverage(
       const FilterInput::Vector& inputs,
       const Entity& entity,

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -229,6 +229,28 @@ std::optional<Rect> FilterContents::GetFilterCoverage(
   return result;
 }
 
+std::optional<Rect> FilterContents::GetSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  auto filter_input_coverage =
+      GetFilterSourceCoverage(effect_transform_, output_limit);
+
+  if (!filter_input_coverage.has_value()) {
+    return std::nullopt;
+  }
+
+  std::optional<Rect> inputs_coverage;
+  for (auto input : inputs_) {
+    auto input_coverage = input->GetSourceCoverage(
+        effect_transform, filter_input_coverage.value());
+    if (!input_coverage.has_value()) {
+      return std::nullopt;
+    }
+    inputs_coverage = Union(inputs_coverage, input_coverage.value());
+  }
+  return inputs_coverage;
+}
+
 std::optional<Entity> FilterContents::GetEntity(
     const ContentContext& renderer,
     const Entity& entity,

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -132,6 +132,20 @@ class FilterContents : public Contents {
   // |Contents|
   const FilterContents* AsFilter() const override;
 
+  /// @brief Determines the coverage of source pixels that will be needed
+  ///        to apply this filter under the given transform and produce
+  ///        results anywhere within the indicated coverage limit.
+  ///
+  ///        This is useful for subpass rendering scenarios where a filter
+  ///        will be applied to the output of the subpass and we need to
+  ///        determine how large of a render target to allocate in order
+  ///        to collect all pixels that might affect the supplied output
+  ///        coverage limit. While we might clip the rendering of the subpass,
+  ///        we want to avoid clipping out any pixels that contribute to
+  ///        the output limit via the filtering operation.
+  std::optional<Rect> GetSourceCoverage(const Matrix& effect_transform,
+                                        const Rect& output_limit) const;
+
   virtual Matrix GetLocalTransform(const Matrix& parent_transform) const;
 
   Matrix GetTransform(const Matrix& parent_transform) const;
@@ -168,6 +182,10 @@ class FilterContents : public Contents {
       const FilterInput::Vector& inputs,
       const Entity& entity,
       const Matrix& effect_transform) const;
+
+  virtual std::optional<Rect> GetFilterSourceCoverage(
+      const Matrix& effect_transform,
+      const Rect& output_limit) const = 0;
 
   /// @brief  Converts zero or more filter inputs into a render instruction.
   virtual std::optional<Entity> RenderFilter(

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
@@ -43,6 +43,12 @@ std::optional<Rect> FilterContentsFilterInput::GetCoverage(
   return filter_->GetCoverage(entity);
 }
 
+std::optional<Rect> FilterContentsFilterInput::GetSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  return filter_->GetSourceCoverage(effect_transform, output_limit);
+}
+
 Matrix FilterContentsFilterInput::GetLocalTransform(
     const Entity& entity) const {
   return filter_->GetLocalTransform(entity.GetTransformation());

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.h
@@ -26,6 +26,11 @@ class FilterContentsFilterInput final : public FilterInput {
   std::optional<Rect> GetCoverage(const Entity& entity) const override;
 
   // |FilterInput|
+  std::optional<Rect> GetSourceCoverage(
+      const Matrix& effect_transform,
+      const Rect& output_limit) const override;
+
+  // |FilterInput|
   Matrix GetLocalTransform(const Entity& entity) const override;
 
   // |FilterInput|

--- a/impeller/entity/contents/filters/inputs/filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_input.cc
@@ -66,6 +66,12 @@ std::optional<Rect> FilterInput::GetLocalCoverage(const Entity& entity) const {
   return GetCoverage(local_entity);
 }
 
+std::optional<Rect> FilterInput::GetSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  return output_limit;
+}
+
 Matrix FilterInput::GetTransform(const Entity& entity) const {
   return entity.GetTransformation() * GetLocalTransform(entity);
 }

--- a/impeller/entity/contents/filters/inputs/filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_input.h
@@ -56,6 +56,9 @@ class FilterInput {
 
   virtual std::optional<Rect> GetCoverage(const Entity& entity) const = 0;
 
+  virtual std::optional<Rect> GetSourceCoverage(const Matrix& effect_transform,
+                                                const Rect& output_limit) const;
+
   /// @brief  Get the local transform of this filter input. This transform is
   ///         relative to the `Entity` transform space.
   virtual Matrix GetLocalTransform(const Entity& entity) const;

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.cc
@@ -19,6 +19,17 @@ Matrix LocalMatrixFilterContents::GetLocalTransform(
   return matrix_;
 }
 
+std::optional<Rect> LocalMatrixFilterContents::GetFilterSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  auto matrix = matrix_.Basis();
+  if (matrix.GetDeterminant() == 0.0) {
+    return std::nullopt;
+  }
+  auto inverse = matrix.Invert();
+  return output_limit.TransformBounds(inverse);
+}
+
 std::optional<Entity> LocalMatrixFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.h
@@ -20,6 +20,11 @@ class LocalMatrixFilterContents final : public FilterContents {
   // |FilterContents|
   Matrix GetLocalTransform(const Matrix& parent_transform) const override;
 
+  // |FilterContents|
+  std::optional<Rect> GetFilterSourceCoverage(
+      const Matrix& effect_transform,
+      const Rect& output_limit) const override;
+
  private:
   // |FilterContents|
   std::optional<Entity> RenderFilter(

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -68,6 +68,17 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
                               entity.GetClipDepth());
 }
 
+std::optional<Rect> MatrixFilterContents::GetFilterSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  auto matrix = matrix_.Basis();
+  if (matrix.GetDeterminant() == 0.0) {
+    return std::nullopt;
+  }
+  auto inverse = matrix.Invert();
+  return output_limit.TransformBounds(inverse);
+}
+
 std::optional<Rect> MatrixFilterContents::GetFilterCoverage(
     const FilterInput::Vector& inputs,
     const Entity& entity,

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -71,11 +71,10 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
 std::optional<Rect> MatrixFilterContents::GetFilterSourceCoverage(
     const Matrix& effect_transform,
     const Rect& output_limit) const {
-  auto matrix = matrix_.Basis();
-  if (matrix.GetDeterminant() == 0.0) {
-    return std::nullopt;
-  }
-  auto inverse = matrix.Invert();
+  auto transform = effect_transform *          //
+                   matrix_ *                   //
+                   effect_transform.Invert();  //
+  auto inverse = transform.Invert();
   return output_limit.TransformBounds(inverse);
 }
 

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -74,6 +74,9 @@ std::optional<Rect> MatrixFilterContents::GetFilterSourceCoverage(
   auto transform = effect_transform *          //
                    matrix_ *                   //
                    effect_transform.Invert();  //
+  if (transform.GetDeterminant() == 0.0) {
+    return std::nullopt;
+  }
   auto inverse = transform.Invert();
   return output_limit.TransformBounds(inverse);
 }

--- a/impeller/entity/contents/filters/matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/matrix_filter_contents.h
@@ -41,6 +41,11 @@ class MatrixFilterContents final : public FilterContents {
       const Rect& coverage,
       const std::optional<Rect>& coverage_hint) const override;
 
+  // |FilterContents|
+  std::optional<Rect> GetFilterSourceCoverage(
+      const Matrix& effect_transform,
+      const Rect& output_limit) const override;
+
   Matrix matrix_;
   SamplerDescriptor sampler_descriptor_ = {};
   Entity::RenderingMode rendering_mode_ = Entity::RenderingMode::kDirect;

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -192,4 +192,18 @@ std::optional<Rect> DirectionalMorphologyFilterContents::GetFilterCoverage(
   return Rect(origin, Size(size.x, size.y));
 }
 
+std::optional<Rect>
+DirectionalMorphologyFilterContents::GetFilterSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  auto transformed_vector =
+      effect_transform.TransformDirection(direction_ * radius_.radius).Abs();
+  switch (morph_type_) {
+    case FilterContents::MorphType::kDilate:
+      return output_limit.Expand(-transformed_vector);
+    case FilterContents::MorphType::kErode:
+      return output_limit.Expand(transformed_vector);
+  }
+}
+
 }  // namespace impeller

--- a/impeller/entity/contents/filters/morphology_filter_contents.h
+++ b/impeller/entity/contents/filters/morphology_filter_contents.h
@@ -29,6 +29,11 @@ class DirectionalMorphologyFilterContents final : public FilterContents {
       const Entity& entity,
       const Matrix& effect_transform) const override;
 
+  // |FilterContents|
+  std::optional<Rect> GetFilterSourceCoverage(
+      const Matrix& effect_transform,
+      const Rect& output_limit) const override;
+
  private:
   // |FilterContents|
   std::optional<Entity> RenderFilter(

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -137,4 +137,10 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
   return sub_entity;
 }
 
+std::optional<Rect> YUVToRGBFilterContents::GetFilterSourceCoverage(
+    const Matrix& effect_transform,
+    const Rect& output_limit) const {
+  return output_limit;
+}
+
 }  // namespace impeller

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.h
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.h
@@ -26,6 +26,11 @@ class YUVToRGBFilterContents final : public FilterContents {
       const Rect& coverage,
       const std::optional<Rect>& coverage_hint) const override;
 
+  // |FilterContents|
+  std::optional<Rect> GetFilterSourceCoverage(
+      const Matrix& effect_transform,
+      const Rect& output_limit) const override;
+
   YUVColorSpace yuv_color_space_ = YUVColorSpace::kBT601LimitedRange;
 
   YUVToRGBFilterContents(const YUVToRGBFilterContents&) = delete;

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -195,7 +195,10 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
   // If the subpass has an image filter, then its coverage space may deviate
   // from the parent pass and make intersecting with the pass coverage limit
   // unsafe.
-  coverage_limit = image_filter ? std::nullopt : coverage_limit;
+  if (image_filter && coverage_limit.has_value()) {
+    coverage_limit = image_filter->GetSourceCoverage(subpass.xformation_,
+                                                     coverage_limit.value());
+  }
 
   auto entities_coverage = subpass.GetElementsCoverage(coverage_limit);
   // The entities don't cover anything. There is nothing to do.

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -192,12 +192,6 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
   std::shared_ptr<FilterContents> image_filter =
       subpass.delegate_->WithImageFilter(Rect(), subpass.xformation_);
 
-  if (subpass.bounds_limit_.has_value()) {
-    auto user_bounds_coverage =
-        subpass.bounds_limit_->TransformBounds(subpass.xformation_);
-    coverage_limit = Intersection(user_bounds_coverage, coverage_limit);
-  }
-
   // If the subpass has an image filter, then its coverage space may deviate
   // from the parent pass and make intersecting with the pass coverage limit
   // unsafe.
@@ -207,8 +201,17 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
   }
 
   auto entities_coverage = subpass.GetElementsCoverage(coverage_limit);
+  // The entities don't cover anything. There is nothing to do.
+  if (!entities_coverage.has_value()) {
+    return std::nullopt;
+  }
 
-  return entities_coverage;
+  if (!subpass.bounds_limit_.has_value()) {
+    return entities_coverage;
+  }
+  auto user_bounds_coverage =
+      subpass.bounds_limit_->TransformBounds(subpass.xformation_);
+  return entities_coverage->Intersection(user_bounds_coverage);
 }
 
 EntityPass* EntityPass::GetSuperpass() const {

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -192,6 +192,12 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
   std::shared_ptr<FilterContents> image_filter =
       subpass.delegate_->WithImageFilter(Rect(), subpass.xformation_);
 
+  if (subpass.bounds_limit_.has_value()) {
+    auto user_bounds_coverage =
+        subpass.bounds_limit_->TransformBounds(subpass.xformation_);
+    coverage_limit = Intersection(user_bounds_coverage, coverage_limit);
+  }
+
   // If the subpass has an image filter, then its coverage space may deviate
   // from the parent pass and make intersecting with the pass coverage limit
   // unsafe.
@@ -201,17 +207,8 @@ std::optional<Rect> EntityPass::GetSubpassCoverage(
   }
 
   auto entities_coverage = subpass.GetElementsCoverage(coverage_limit);
-  // The entities don't cover anything. There is nothing to do.
-  if (!entities_coverage.has_value()) {
-    return std::nullopt;
-  }
 
-  if (!subpass.bounds_limit_.has_value()) {
-    return entities_coverage;
-  }
-  auto user_bounds_coverage =
-      subpass.bounds_limit_->TransformBounds(subpass.xformation_);
-  return entities_coverage->Intersection(user_bounds_coverage);
+  return entities_coverage;
 }
 
 EntityPass* EntityPass::GetSuperpass() const {

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -616,6 +616,8 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       return EntityPass::EntityResult::Skip();
     }
 
+    subpass_coverage = RoundOut(subpass_coverage.value());
+
     auto subpass_size = ISize(subpass_coverage->size);
     if (subpass_size.IsEmpty()) {
       capture.CreateChild("Subpass Entity (Skipped: Empty subpass coverage B)");

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -2114,6 +2114,17 @@ TEST(GeometryTest, RectProject) {
   }
 }
 
+TEST(GeometryTest, RectRoundOut) {
+  {
+    auto r = Rect::MakeLTRB(-100, -100, 100, 100);
+    ASSERT_EQ(RoundOut(r), r);
+  }
+  {
+    auto r = Rect::MakeLTRB(-100.1, -100.1, 100.1, 100.1);
+    ASSERT_EQ(RoundOut(r), Rect::MakeLTRB(-101, -101, 101, 101));
+  }
+}
+
 TEST(GeometryTest, CubicPathComponentPolylineDoesNotIncludePointOne) {
   CubicPathComponent component({10, 10}, {20, 35}, {35, 20}, {40, 40});
   auto polyline = component.CreatePolyline(1.0f);

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1644,6 +1644,58 @@ TEST(GeometryTest, RectUnion) {
   }
 }
 
+TEST(GeometryTest, OptRectUnion) {
+  Rect a = Rect::MakeLTRB(0, 0, 100, 100);
+  Rect b = Rect::MakeLTRB(100, 100, 200, 200);
+  Rect c = Rect::MakeLTRB(100, 0, 200, 100);
+
+  // NullOpt, NullOpt
+  EXPECT_FALSE(Union(std::nullopt, std::nullopt).has_value());
+  EXPECT_EQ(Union(std::nullopt, std::nullopt), std::nullopt);
+
+  auto test1 = [](const Rect& r) {
+    // Rect, NullOpt
+    EXPECT_TRUE(Union(r, std::nullopt).has_value());
+    EXPECT_EQ(Union(r, std::nullopt).value(), r);
+
+    // OptRect, NullOpt
+    EXPECT_TRUE(Union(std::optional(r), std::nullopt).has_value());
+    EXPECT_EQ(Union(std::optional(r), std::nullopt).value(), r);
+
+    // NullOpt, Rect
+    EXPECT_TRUE(Union(std::nullopt, r).has_value());
+    EXPECT_EQ(Union(std::nullopt, r).value(), r);
+
+    // NullOpt, OptRect
+    EXPECT_TRUE(Union(std::nullopt, std::optional(r)).has_value());
+    EXPECT_EQ(Union(std::nullopt, std::optional(r)).value(), r);
+  };
+
+  test1(a);
+  test1(b);
+  test1(c);
+
+  auto test2 = [](const Rect& a, const Rect& b, const Rect& u) {
+    ASSERT_EQ(a.Union(b), u);
+
+    // Rect, OptRect
+    EXPECT_TRUE(Union(a, std::optional(b)).has_value());
+    EXPECT_EQ(Union(a, std::optional(b)).value(), u);
+
+    // OptRect, Rect
+    EXPECT_TRUE(Union(std::optional(a), b).has_value());
+    EXPECT_EQ(Union(std::optional(a), b).value(), u);
+
+    // OptRect, OptRect
+    EXPECT_TRUE(Union(std::optional(a), std::optional(b)).has_value());
+    EXPECT_EQ(Union(std::optional(a), std::optional(b)).value(), u);
+  };
+
+  test2(a, b, Rect::MakeLTRB(0, 0, 200, 200));
+  test2(a, c, Rect::MakeLTRB(0, 0, 200, 100));
+  test2(b, c, Rect::MakeLTRB(100, 0, 200, 200));
+}
+
 TEST(GeometryTest, RectIntersection) {
   {
     Rect a(100, 100, 100, 100);
@@ -1691,6 +1743,58 @@ TEST(GeometryTest, RectIntersection) {
     ASSERT_TRUE(u);
     ASSERT_EQ(u, Rect::MakeMaximum());
   }
+}
+
+TEST(GeometryTest, OptRectIntersection) {
+  Rect a = Rect::MakeLTRB(0, 0, 110, 110);
+  Rect b = Rect::MakeLTRB(100, 100, 200, 200);
+  Rect c = Rect::MakeLTRB(100, 0, 200, 110);
+
+  // NullOpt, NullOpt
+  EXPECT_FALSE(Intersection(std::nullopt, std::nullopt).has_value());
+  EXPECT_EQ(Intersection(std::nullopt, std::nullopt), std::nullopt);
+
+  auto test1 = [](const Rect& r) {
+    // Rect, NullOpt
+    EXPECT_TRUE(Intersection(r, std::nullopt).has_value());
+    EXPECT_EQ(Intersection(r, std::nullopt).value(), r);
+
+    // OptRect, NullOpt
+    EXPECT_TRUE(Intersection(std::optional(r), std::nullopt).has_value());
+    EXPECT_EQ(Intersection(std::optional(r), std::nullopt).value(), r);
+
+    // NullOpt, Rect
+    EXPECT_TRUE(Intersection(std::nullopt, r).has_value());
+    EXPECT_EQ(Intersection(std::nullopt, r).value(), r);
+
+    // NullOpt, OptRect
+    EXPECT_TRUE(Intersection(std::nullopt, std::optional(r)).has_value());
+    EXPECT_EQ(Intersection(std::nullopt, std::optional(r)).value(), r);
+  };
+
+  test1(a);
+  test1(b);
+  test1(c);
+
+  auto test2 = [](const Rect& a, const Rect& b, const Rect& i) {
+    ASSERT_EQ(a.Intersection(b), i);
+
+    // Rect, OptRect
+    EXPECT_TRUE(Intersection(a, std::optional(b)).has_value());
+    EXPECT_EQ(Intersection(a, std::optional(b)).value(), i);
+
+    // OptRect, Rect
+    EXPECT_TRUE(Intersection(std::optional(a), b).has_value());
+    EXPECT_EQ(Intersection(std::optional(a), b).value(), i);
+
+    // OptRect, OptRect
+    EXPECT_TRUE(Intersection(std::optional(a), std::optional(b)).has_value());
+    EXPECT_EQ(Intersection(std::optional(a), std::optional(b)).value(), i);
+  };
+
+  test2(a, b, Rect::MakeLTRB(100, 100, 110, 110));
+  test2(a, c, Rect::MakeLTRB(100, 0, 110, 110));
+  test2(b, c, Rect::MakeLTRB(100, 100, 200, 110));
 }
 
 TEST(GeometryTest, RectIntersectsWithRect) {

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -315,31 +315,34 @@ struct TRect {
 using Rect = TRect<Scalar>;
 using IRect = TRect<int64_t>;
 
-constexpr std::optional<Rect> Union(const Rect& a,
-                                    const std::optional<Rect> b) {
-  if (!b.has_value()) {
-    return a;
-  }
-  return a.Union(b.value());
+constexpr inline std::optional<Rect> Union(const Rect& a,
+                                           const std::optional<Rect> b) {
+  return b.has_value() ? a.Union(b.value()) : a;
 }
 
-constexpr std::optional<Rect> Union(const std::optional<Rect> a,
-                                    const Rect& b) {
-  if (!a.has_value()) {
-    return b;
-  }
-  return a.value().Union(b);
+constexpr inline std::optional<Rect> Union(const std::optional<Rect> a,
+                                           const Rect& b) {
+  return Union(b, a);
 }
 
-constexpr std::optional<Rect> Union(const std::optional<Rect> a,
-                                    const std::optional<Rect> b) {
-  if (!a.has_value()) {
-    return b;
-  }
-  if (!b.has_value()) {
-    return a;
-  }
-  return a.value().Union(b.value());
+constexpr inline std::optional<Rect> Union(const std::optional<Rect> a,
+                                           const std::optional<Rect> b) {
+  return a.has_value() ? Union(a.value(), b) : b;
+}
+
+constexpr inline std::optional<Rect> Intersection(const Rect& a,
+                                                  const std::optional<Rect> b) {
+  return b.has_value() ? a.Intersection(b.value()) : a;
+}
+
+constexpr inline std::optional<Rect> Intersection(const std::optional<Rect> a,
+                                                  const Rect& b) {
+  return Intersection(b, a);
+}
+
+constexpr inline std::optional<Rect> Intersection(const std::optional<Rect> a,
+                                                  const std::optional<Rect> b) {
+  return a.has_value() ? Intersection(a.value(), b) : b;
 }
 
 }  // namespace impeller

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -315,6 +315,11 @@ struct TRect {
 using Rect = TRect<Scalar>;
 using IRect = TRect<int64_t>;
 
+constexpr inline Rect RoundOut(const Rect& r) {
+  return Rect::MakeLTRB(floor(r.GetLeft()), floor(r.GetTop()),
+                        ceil(r.GetRight()), ceil(r.GetBottom()));
+}
+
 constexpr inline std::optional<Rect> Union(const Rect& a,
                                            const std::optional<Rect> b) {
   return b.has_value() ? a.Union(b.value()) : a;

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -292,6 +292,15 @@ struct TRect {
                  size.height + amount * 2);
   }
 
+  /// @brief  Returns a rectangle with expanded edges in all directions.
+  ///         Negative expansion results in shrinking.
+  constexpr TRect<T> Expand(TPoint<T> amount) const {
+    return TRect(origin.x - amount.x,        //
+                 origin.y - amount.y,        //
+                 size.width + amount.x * 2,  //
+                 size.height + amount.y * 2);
+  }
+
   /// @brief  Returns a new rectangle that represents the projection of the
   ///         source rectangle onto this rectangle. In other words, the source
   ///         rectangle is redefined in terms of the corrdinate space of this
@@ -305,6 +314,33 @@ struct TRect {
 
 using Rect = TRect<Scalar>;
 using IRect = TRect<int64_t>;
+
+constexpr std::optional<Rect> Union(const Rect& a,
+                                    const std::optional<Rect> b) {
+  if (!b.has_value()) {
+    return a;
+  }
+  return a.Union(b.value());
+}
+
+constexpr std::optional<Rect> Union(const std::optional<Rect> a,
+                                    const Rect& b) {
+  if (!a.has_value()) {
+    return b;
+  }
+  return a.value().Union(b);
+}
+
+constexpr std::optional<Rect> Union(const std::optional<Rect> a,
+                                    const std::optional<Rect> b) {
+  if (!a.has_value()) {
+    return b;
+  }
+  if (!b.has_value()) {
+    return a;
+  }
+  return a.value().Union(b.value());
+}
 
 }  // namespace impeller
 


### PR DESCRIPTION
The new method allows a caller to ask for the coverage of the input pixels required to produce an output that spans a given area. This allows the code to clip a saveLayer that has an image filter applied to it.