### PR TITLE
[Impeller] Disable raster stats service protocol.

### DIFF
--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -70,6 +70,8 @@ class LayerTree {
   /// When `Paint` is called, if leaf layer tracing is enabled, additional
   /// metadata around raterization of leaf layers is collected.
   ///
+  /// This is not supported in the Impeller backend.
+  ///
   /// See: `LayerSnapshotStore`
   void enable_leaf_layer_tracing(bool enable) {
     enable_leaf_layer_tracing_ = enable;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1972,6 +1972,13 @@ bool Shell::OnServiceProtocolRenderFrameWithRasterStats(
     rapidjson::Document* response) {
   FML_DCHECK(task_runners_.GetRasterTaskRunner()->RunsTasksOnCurrentThread());
 
+  // Impeller does not support this protocol method.
+  if (io_manager_->GetImpellerContext()) {
+    const char* error = "Raster status not supported on Impeller backend.";
+    ServiceProtocolFailureError(response, error);
+    return false;
+  }
+
   // TODO(dkwingsmt): This method only handles view #0, including the snapshot
   // and the frame size. We need to adapt this method to multi-view.
   // https://github.com/flutter/flutter/issues/131892


### PR DESCRIPTION
As far as I can tell, this functionality has _always_ been falling back to software rendering with Skia when Impeller was enabled. This is at best extremely misleading. Since I started putting Impeller specific objects in the display list it introduced crashes, and must be disabled.

Fixes https://github.com/flutter/flutter/issues/136847