### PR TITLE
[Impeller] remove image upload workarounds.

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -10,14 +10,13 @@
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/impeller/core/allocator.h"
-#include "flutter/impeller/core/texture.h"
 #include "flutter/impeller/display_list/dl_image_impeller.h"
 #include "flutter/impeller/renderer/command_buffer.h"
 #include "flutter/impeller/renderer/context.h"
-#include "flutter/lib/ui/painting/image_decoder_skia.h"
 #include "impeller/base/strings.h"
 #include "impeller/display_list/skia_conversions.h"
 #include "impeller/geometry/size.h"
+
 #include "third_party/skia/include/core/SkAlphaType.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
@@ -31,42 +30,6 @@
 #include "third_party/skia/include/core/SkSize.h"
 
 namespace flutter {
-
-class MallocDeviceBuffer : public impeller::DeviceBuffer {
- public:
-  explicit MallocDeviceBuffer(impeller::DeviceBufferDescriptor desc)
-      : impeller::DeviceBuffer(desc) {
-    data_ = static_cast<uint8_t*>(malloc(desc.size));
-  }
-
-  ~MallocDeviceBuffer() override { free(data_); }
-
-  bool SetLabel(const std::string& label) override { return true; }
-
-  bool SetLabel(const std::string& label, impeller::Range range) override {
-    return true;
-  }
-
-  uint8_t* OnGetContents() const override { return data_; }
-
-  bool OnCopyHostBuffer(const uint8_t* source,
-                        impeller::Range source_range,
-                        size_t offset) override {
-    memcpy(data_ + offset, source + source_range.offset, source_range.length);
-    return true;
-  }
-
- private:
-  uint8_t* data_;
-
-  FML_DISALLOW_COPY_AND_ASSIGN(MallocDeviceBuffer);
-};
-
-#ifdef FML_OS_ANDROID
-static constexpr bool kShouldUseMallocDeviceBuffer = true;
-#else
-static constexpr bool kShouldUseMallocDeviceBuffer = false;
-#endif  // FML_OS_ANDROID
 
 namespace {
 /**
@@ -522,8 +485,7 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
                                                  gpu_disabled_switch]() {
           sk_sp<DlImage> image;
           std::string decode_error;
-          if (!kShouldUseMallocDeviceBuffer &&
-              context->GetCapabilities()->SupportsBufferToTextureBlits()) {
+          if (context->GetCapabilities()->SupportsBufferToTextureBlits()) {
             std::tie(image, decode_error) = UploadTextureToPrivate(
                 context, bitmap_result.device_buffer, bitmap_result.image_info,
                 bitmap_result.sk_bitmap, gpu_disabled_switch);
@@ -567,9 +529,7 @@ bool ImpellerAllocator::allocPixelRef(SkBitmap* bitmap) {
                     (bitmap->width() * bitmap->bytesPerPixel());
 
   std::shared_ptr<impeller::DeviceBuffer> device_buffer =
-      kShouldUseMallocDeviceBuffer
-          ? std::make_shared<MallocDeviceBuffer>(descriptor)
-          : allocator_->CreateBuffer(descriptor);
+      allocator_->CreateBuffer(descriptor);
 
   struct ImpellerPixelRef final : public SkPixelRef {
     ImpellerPixelRef(int w, int h, void* s, size_t r)


### PR DESCRIPTION
Testing locally I cant see any impact from this. Its possible the problem this "fixed" was instead fixed by affinity changes and now its no longer necessary.


See https://github.com/flutter/engine/pull/43493 .