### PR TITLE
[Impeller] OpenGLES: Ensure frag/vert textures are bound with unique texture units.

### DIFF
--- a/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -70,9 +70,10 @@ class BufferBindingsGLES {
                          Allocator& transients_allocator,
                          const BufferResource& buffer);
 
-  bool BindTextures(const ProcTableGLES& gl,
-                    const Bindings& bindings,
-                    ShaderStage stage);
+  std::optional<size_t> BindTextures(const ProcTableGLES& gl,
+                                     const Bindings& bindings,
+                                     ShaderStage stage,
+                                     size_t unit_start_index = 0);
 
   BufferBindingsGLES(const BufferBindingsGLES&) = delete;
 


### PR DESCRIPTION
The fragment shader texture bindings will smash into the texture units used for the vertex shader bindings if the vertex and fragment shaders both have textures.

Entities doesn't use any pipelines that tickle this case.