### PR TITLE
[Windows] Introduce FlutterWindowsViewController

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -3919,6 +3919,7 @@ ORIGIN: ../../../flutter/shell/platform/windows/flutter_windows_texture_registra
 ORIGIN: ../../../flutter/shell/platform/windows/flutter_windows_texture_registrar.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/windows/flutter_windows_view.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/windows/flutter_windows_view.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/windows/flutter_windows_view_controller.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/windows/keyboard_handler_base.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/windows/keyboard_key_channel_handler.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/windows/keyboard_key_channel_handler.h + ../../../flutter/LICENSE
@@ -6717,6 +6718,7 @@ FILE: ../../../flutter/shell/platform/windows/flutter_windows_texture_registrar.
 FILE: ../../../flutter/shell/platform/windows/flutter_windows_texture_registrar.h
 FILE: ../../../flutter/shell/platform/windows/flutter_windows_view.cc
 FILE: ../../../flutter/shell/platform/windows/flutter_windows_view.h
+FILE: ../../../flutter/shell/platform/windows/flutter_windows_view_controller.h
 FILE: ../../../flutter/shell/platform/windows/keyboard_handler_base.h
 FILE: ../../../flutter/shell/platform/windows/keyboard_key_channel_handler.cc
 FILE: ../../../flutter/shell/platform/windows/keyboard_key_channel_handler.h

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -69,6 +69,7 @@ source_set("flutter_windows_source") {
     "flutter_windows_texture_registrar.h",
     "flutter_windows_view.cc",
     "flutter_windows_view.h",
+    "flutter_windows_view_controller.h",
     "keyboard_handler_base.h",
     "keyboard_key_channel_handler.cc",
     "keyboard_key_channel_handler.h",

--- a/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -186,10 +186,11 @@ std::shared_ptr<AccessibilityBridgeWindowsSpy> GetAccessibilityBridgeSpy(
 void ExpectWinEventFromAXEvent(int32_t node_id,
                                ui::AXEventGenerator::Event ax_event,
                                ax::mojom::Event expected_event) {
+  auto engine = GetTestEngine();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsViewSpy view(std::move(window_binding_handler));
-  view.SetEngine(GetTestEngine());
+  view.SetEngine(engine.get());
   view.OnUpdateSemanticsEnabled(true);
 
   auto bridge = GetAccessibilityBridgeSpy(view);
@@ -206,10 +207,11 @@ void ExpectWinEventFromAXEventOnFocusNode(int32_t node_id,
                                           ui::AXEventGenerator::Event ax_event,
                                           ax::mojom::Event expected_event,
                                           int32_t focus_id) {
+  auto engine = GetTestEngine();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsViewSpy view(std::move(window_binding_handler));
-  view.SetEngine(GetTestEngine());
+  view.SetEngine(engine.get());
   view.OnUpdateSemanticsEnabled(true);
 
   auto bridge = GetAccessibilityBridgeSpy(view);
@@ -231,10 +233,11 @@ void ExpectWinEventFromAXEventOnFocusNode(int32_t node_id,
 }  // namespace
 
 TEST(AccessibilityBridgeWindows, GetParent) {
+  auto engine = GetTestEngine();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsViewSpy view(std::move(window_binding_handler));
-  view.SetEngine(GetTestEngine());
+  view.SetEngine(engine.get());
   view.OnUpdateSemanticsEnabled(true);
 
   auto bridge = view.accessibility_bridge().lock();
@@ -247,10 +250,11 @@ TEST(AccessibilityBridgeWindows, GetParent) {
 }
 
 TEST(AccessibilityBridgeWindows, GetParentOnRootRetunsNullptr) {
+  auto engine = GetTestEngine();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsViewSpy view(std::move(window_binding_handler));
-  view.SetEngine(GetTestEngine());
+  view.SetEngine(engine.get());
   view.OnUpdateSemanticsEnabled(true);
 
   auto bridge = view.accessibility_bridge().lock();
@@ -261,10 +265,11 @@ TEST(AccessibilityBridgeWindows, GetParentOnRootRetunsNullptr) {
 }
 
 TEST(AccessibilityBridgeWindows, DispatchAccessibilityAction) {
+  auto engine = GetTestEngine();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsViewSpy view(std::move(window_binding_handler));
-  view.SetEngine(GetTestEngine());
+  view.SetEngine(engine.get());
   view.OnUpdateSemanticsEnabled(true);
 
   auto bridge = view.accessibility_bridge().lock();
@@ -297,10 +302,11 @@ TEST(AccessibilityBridgeWindows, OnAccessibilityEventChildrenChanged) {
 }
 
 TEST(AccessibilityBridgeWindows, OnAccessibilityEventFocusChanged) {
+  auto engine = GetTestEngine();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsViewSpy view(std::move(window_binding_handler));
-  view.SetEngine(GetTestEngine());
+  view.SetEngine(engine.get());
   view.OnUpdateSemanticsEnabled(true);
 
   auto bridge = GetAccessibilityBridgeSpy(view);

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -620,6 +620,7 @@ TEST_F(FlutterWindowsEngineTest, AlertPlatformMessage) {
   FlutterWindowsEngineBuilder builder{GetContext()};
   builder.SetDartEntrypoint("alertPlatformChannel");
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   ui::AXPlatformNodeDelegateBase parent_delegate;
@@ -628,10 +629,9 @@ TEST_F(FlutterWindowsEngineTest, AlertPlatformMessage) {
     return &delegate;
   });
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
 
   auto binary_messenger =
@@ -688,15 +688,15 @@ TEST_F(FlutterWindowsEngineTest, TestExit) {
   builder.SetDartEntrypoint("exitTestExit");
   bool finished = false;
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   ON_CALL(*handler, Quit)
       .WillByDefault(
           [&finished](std::optional<HWND> hwnd, std::optional<WPARAM> wparam,
@@ -726,15 +726,15 @@ TEST_F(FlutterWindowsEngineTest, TestExitCancel) {
   bool finished = false;
   bool did_call = false;
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   ON_CALL(*handler, Quit)
       .WillByDefault([&finished](std::optional<HWND> hwnd,
                                  std::optional<WPARAM> wparam,
@@ -777,15 +777,15 @@ TEST_F(FlutterWindowsEngineTest, TestExitSecondCloseMessage) {
   builder.SetDartEntrypoint("exitTestExit");
   bool second_close = false;
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   auto& handler_obj = *handler;
   ON_CALL(handler_obj, IsLastWindowOfProcess).WillByDefault([]() {
     return true;
@@ -839,15 +839,15 @@ TEST_F(FlutterWindowsEngineTest, TestExitCloseMultiWindow) {
   builder.SetDartEntrypoint("exitTestExit");
   bool finished = false;
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([&finished]() {
     finished = true;
     return false;
@@ -870,15 +870,15 @@ TEST_F(FlutterWindowsEngineTest, TestExitCloseMultiWindow) {
 TEST_F(FlutterWindowsEngineTest, LifecycleManagerDisabledByDefault) {
   FlutterWindowsEngineBuilder builder{GetContext()};
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   EXPECT_CALL(*handler, IsLastWindowOfProcess).Times(0);
   modifier.SetLifecycleManager(std::move(handler));
 
@@ -889,15 +889,15 @@ TEST_F(FlutterWindowsEngineTest, LifecycleManagerDisabledByDefault) {
 TEST_F(FlutterWindowsEngineTest, EnableApplicationLifecycle) {
   FlutterWindowsEngineBuilder builder{GetContext()};
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([]() {
     return false;
   });
@@ -912,15 +912,15 @@ TEST_F(FlutterWindowsEngineTest, EnableApplicationLifecycle) {
 TEST_F(FlutterWindowsEngineTest, ApplicationLifecycleExternalWindow) {
   FlutterWindowsEngineBuilder builder{GetContext()};
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([]() {
     return false;
   });
@@ -934,15 +934,15 @@ TEST_F(FlutterWindowsEngineTest, ApplicationLifecycleExternalWindow) {
 TEST_F(FlutterWindowsEngineTest, AppStartsInResumedState) {
   FlutterWindowsEngineBuilder builder{GetContext()};
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   EXPECT_CALL(*handler, SetLifecycleState(AppLifecycleState::kResumed))
       .Times(1);
   modifier.SetLifecycleManager(std::move(handler));
@@ -952,13 +952,13 @@ TEST_F(FlutterWindowsEngineTest, AppStartsInResumedState) {
 TEST_F(FlutterWindowsEngineTest, LifecycleStateTransition) {
   FlutterWindowsEngineBuilder builder{GetContext()};
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   engine->Run();
 
@@ -981,13 +981,13 @@ TEST_F(FlutterWindowsEngineTest, LifecycleStateTransition) {
 TEST_F(FlutterWindowsEngineTest, ExternalWindowMessage) {
   FlutterWindowsEngineBuilder builder{GetContext()};
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   // Sets lifecycle state to resumed.
   engine->Run();
@@ -1007,14 +1007,14 @@ TEST_F(FlutterWindowsEngineTest, InnerWindowHidden) {
   HWND outer = reinterpret_cast<HWND>(1);
   HWND inner = reinterpret_cast<HWND>(2);
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
   ON_CALL(view, GetPlatformWindow).WillByDefault([=]() { return inner; });
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   // Sets lifecycle state to resumed.
   engine->Run();
@@ -1041,15 +1041,15 @@ TEST_F(FlutterWindowsEngineTest, EnableLifecycleState) {
   builder.SetDartEntrypoint("enableLifecycleTest");
   bool finished = false;
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   ON_CALL(*handler, SetLifecycleState)
       .WillByDefault([handler_ptr = handler.get()](AppLifecycleState state) {
         handler_ptr->WindowsLifecycleManager::SetLifecycleState(state);
@@ -1094,15 +1094,15 @@ TEST_F(FlutterWindowsEngineTest, LifecycleStateToFrom) {
   bool enabled_lifecycle = false;
   bool dart_responded = false;
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
+  view.SetEngine(engine.get());
 
-  EngineModifier modifier(engine);
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   ON_CALL(*handler, SetLifecycleState)
       .WillByDefault([handler_ptr = handler.get()](AppLifecycleState state) {
         handler_ptr->WindowsLifecycleManager::SetLifecycleState(state);
@@ -1141,16 +1141,17 @@ TEST_F(FlutterWindowsEngineTest, ChannelListenedTo) {
   FlutterWindowsEngineBuilder builder{GetContext()};
   builder.SetDartEntrypoint("enableLifecycleToFrom");
 
+  auto engine = builder.Build();
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(builder.Build());
-  FlutterWindowsEngine* engine = view.GetEngine();
-  EngineModifier modifier(engine);
+  view.SetEngine(engine.get());
+
+  EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
 
   bool lifecycle_began = false;
-  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine);
+  auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   handler->begin_processing_callback = [&]() { lifecycle_began = true; };
   modifier.SetLifecycleManager(std::move(handler));
 

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -58,9 +58,11 @@ FlutterWindowsView::~FlutterWindowsView() {
   DestroyRenderSurface();
 }
 
-void FlutterWindowsView::SetEngine(
-    std::unique_ptr<FlutterWindowsEngine> engine) {
-  engine_ = std::move(engine);
+void FlutterWindowsView::SetEngine(FlutterWindowsEngine* engine) {
+  FML_DCHECK(engine_ == nullptr);
+  FML_DCHECK(engine != nullptr);
+
+  engine_ = engine;
 
   engine_->SetView(this);
 
@@ -628,7 +630,7 @@ PlatformWindow FlutterWindowsView::GetPlatformWindow() const {
 }
 
 FlutterWindowsEngine* FlutterWindowsView::GetEngine() {
-  return engine_.get();
+  return engine_;
 }
 
 void FlutterWindowsView::AnnounceAlert(const std::wstring& text) {

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -46,7 +46,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
 
   // Configures the window instance with an instance of a running Flutter
   // engine.
-  void SetEngine(std::unique_ptr<FlutterWindowsEngine> engine);
+  void SetEngine(FlutterWindowsEngine* engine);
 
   // Creates rendering surface for Flutter engine to draw into.
   // Should be called before calling FlutterEngineRun using this view.
@@ -364,7 +364,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   std::unique_ptr<WindowsRenderTarget> render_target_;
 
   // The engine associated with this view.
-  std::unique_ptr<FlutterWindowsEngine> engine_;
+  FlutterWindowsEngine* engine_ = nullptr;
 
   // Keeps track of pointer states in relation to the window.
   std::unordered_map<int32_t, std::unique_ptr<PointerState>> pointer_states_;

--- a/shell/platform/windows/flutter_windows_view_controller.h
+++ b/shell/platform/windows/flutter_windows_view_controller.h
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_VIEW_CONTROLLER_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_VIEW_CONTROLLER_H_
+
+#include <memory>
+
+#include "flutter_windows_engine.h"
+#include "flutter_windows_view.h"
+
+namespace flutter {
+
+/// Controls a view that displays Flutter content.
+class FlutterWindowsViewController {
+ public:
+  FlutterWindowsViewController(std::unique_ptr<FlutterWindowsEngine> engine,
+                               std::unique_ptr<FlutterWindowsView> view)
+      : engine_(std::move(engine)), view_(std::move(view)) {}
+
+  FlutterWindowsEngine* engine() { return engine_.get(); }
+  FlutterWindowsView* view() { return view_.get(); }
+
+ private:
+  std::unique_ptr<FlutterWindowsEngine> engine_;
+  std::unique_ptr<FlutterWindowsView> view_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_VIEW_CONTROLLER_H_

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -152,7 +152,7 @@ TEST(FlutterWindowsViewTest, SubMenuExpandedState) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
@@ -262,7 +262,7 @@ TEST(FlutterWindowsViewTest, Shutdown) {
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);
 
   modifier.SetSurfaceManager(surface_manager.release());
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 }
 
 TEST(FlutterWindowsViewTest, KeySequence) {
@@ -273,7 +273,7 @@ TEST(FlutterWindowsViewTest, KeySequence) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   view.OnKey(kVirtualKeyA, kScanCodeKeyA, WM_KEYDOWN, 'a', false, false,
              [](bool handled) {});
@@ -301,7 +301,7 @@ TEST(FlutterWindowsViewTest, EnableSemantics) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   view.OnUpdateSemanticsEnabled(true);
   EXPECT_TRUE(semantics_enabled);
@@ -318,7 +318,7 @@ TEST(FlutterWindowsViewTest, AddSemanticsNodeUpdate) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
@@ -417,7 +417,7 @@ TEST(FlutterWindowsViewTest, AddSemanticsNodeUpdateWithChildren) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
@@ -615,7 +615,7 @@ TEST(FlutterWindowsViewTest, NonZeroSemanticsRoot) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
@@ -747,7 +747,7 @@ TEST(FlutterWindowsViewTest, AccessibilityHitTesting) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
@@ -845,7 +845,7 @@ TEST(FlutterWindowsViewTest, WindowResizeTests) {
 
   FlutterWindowsView view(std::move(window_binding_handler));
   modifier.SetSurfaceManager(surface_manager.release());
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   fml::AutoResetWaitableEvent metrics_sent_latch;
   modifier.embedder_api().SendWindowMetricsEvent = MOCK_ENGINE_PROC(
@@ -877,7 +877,7 @@ TEST(FlutterWindowsViewTest, WindowRepaintTests) {
   EngineModifier modifier(engine.get());
 
   FlutterWindowsView view(std::make_unique<flutter::FlutterWindow>(100, 100));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
   view.CreateRenderSurface();
 
   bool schedule_frame_called = false;
@@ -908,7 +908,7 @@ TEST(FlutterWindowsViewTest, CheckboxNativeState) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
@@ -1054,7 +1054,7 @@ TEST(FlutterWindowsViewTest, SwitchNativeState) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
@@ -1171,7 +1171,7 @@ TEST(FlutterWindowsViewTest, TooltipNodeData) {
   auto window_binding_handler =
       std::make_unique<NiceMock<MockWindowBindingHandler>>();
   FlutterWindowsView view(std::move(window_binding_handler));
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   // Enable semantics to instantiate accessibility bridge.
   view.OnUpdateSemanticsEnabled(true);
@@ -1242,7 +1242,7 @@ TEST(FlutterWindowsViewTest, DisablesVSync) {
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);
 
   modifier.SetSurfaceManager(surface_manager.release());
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   view.CreateRenderSurface();
 }
@@ -1271,7 +1271,7 @@ TEST(FlutterWindowsViewTest, EnablesVSync) {
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);
 
   modifier.SetSurfaceManager(surface_manager.release());
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   view.CreateRenderSurface();
 }
@@ -1309,7 +1309,7 @@ TEST(FlutterWindowsViewTest, UpdatesVSyncOnDwmUpdates) {
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);
 
   modifier.SetSurfaceManager(surface_manager.release());
-  view.SetEngine(std::move(engine));
+  view.SetEngine(engine.get());
 
   view.GetEngine()->OnDwmCompositionChanged();
   view.GetEngine()->OnDwmCompositionChanged();

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -370,14 +370,12 @@ class KeyboardTester {
   explicit KeyboardTester(WindowsTestContext& context)
       : callback_handler_(RespondValue(false)),
         map_virtual_key_layout_(LayoutDefault) {
-    std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine(context);
-
-    engine_ = engine.get();
+    engine_ = GetTestEngine(context);
     view_ = std::make_unique<TestFlutterWindowsView>(
         // The WindowBindingHandler is used for window size and such, and
         // doesn't affect keyboard.
         std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>());
-    view_->SetEngine(std::move(engine));
+    view_->SetEngine(engine_.get());
     window_ = std::make_unique<MockKeyboardManagerDelegate>(
         view_.get(), [this](UINT virtual_key) -> SHORT {
           return map_virtual_key_layout_(virtual_key, MAPVK_VK_TO_CHAR);
@@ -388,7 +386,7 @@ class KeyboardTester {
   MockKeyboardManagerDelegate& GetWindow() { return *window_; }
 
   // Reset the keyboard by invoking the engine restart handler.
-  void ResetKeyboard() { EngineModifier{engine_}.Restart(); }
+  void ResetKeyboard() { EngineModifier{engine_.get()}.Restart(); }
 
   // Set all events to be handled (true) or unhandled (false).
   void Responding(bool response) { callback_handler_ = RespondValue(response); }
@@ -454,7 +452,7 @@ class KeyboardTester {
   }
 
  private:
-  FlutterWindowsEngine* engine_;
+  std::unique_ptr<FlutterWindowsEngine> engine_;
   std::unique_ptr<TestFlutterWindowsView> view_;
   std::unique_ptr<MockKeyboardManagerDelegate> window_;
   MockKeyResponseController::EmbedderCallbackHandler callback_handler_;

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -21,8 +21,8 @@ extern "C" {
 typedef void (*VoidCallback)(void* /* user data */);
 
 // Opaque reference to a Flutter window controller.
-typedef struct FlutterDesktopViewControllerState*
-    FlutterDesktopViewControllerRef;
+struct FlutterDesktopViewController;
+typedef struct FlutterDesktopViewController* FlutterDesktopViewControllerRef;
 
 // Opaque reference to a Flutter window.
 struct FlutterDesktopView;

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -20,7 +20,7 @@ extern "C" {
 
 typedef void (*VoidCallback)(void* /* user data */);
 
-// Opaque reference to a Flutter window controller.
+// Opaque reference to a Flutter view controller.
 struct FlutterDesktopViewController;
 typedef struct FlutterDesktopViewController* FlutterDesktopViewControllerRef;
 

--- a/shell/platform/windows/testing/windows_test_config_builder.h
+++ b/shell/platform/windows/testing/windows_test_config_builder.h
@@ -31,14 +31,14 @@ using EnginePtr = std::unique_ptr<FlutterDesktopEngine, EngineDeleter>;
 // Deleter for FlutterViewControllerRef objects.
 struct ViewControllerDeleter {
   typedef FlutterDesktopViewControllerRef pointer;
-  void operator()(FlutterDesktopViewControllerRef engine) {
-    FlutterDesktopViewControllerDestroy(engine);
+  void operator()(FlutterDesktopViewControllerRef controller) {
+    FlutterDesktopViewControllerDestroy(controller);
   }
 };
 
 // Unique pointer wrapper for FlutterDesktopViewControllerRef.
 using ViewControllerPtr =
-    std::unique_ptr<FlutterDesktopViewControllerState, ViewControllerDeleter>;
+    std::unique_ptr<FlutterDesktopViewController, ViewControllerDeleter>;
 
 // Test configuration builder for WindowsTests.
 //

--- a/shell/platform/windows/window_state.h
+++ b/shell/platform/windows/window_state.h
@@ -19,13 +19,6 @@ struct FlutterWindowsEngine;
 struct FlutterWindowsView;
 }  // namespace flutter
 
-// Wrapper to distinguish the view controller ref from the view ref given out
-// in the C API.
-struct FlutterDesktopViewControllerState {
-  // The view that backs this state object.
-  std::unique_ptr<flutter::FlutterWindowsView> view;
-};
-
 // Wrapper to distinguish the plugin registrar ref from the engine ref given out
 // in the C API.
 struct FlutterDesktopPluginRegistrar {

--- a/shell/platform/windows/window_state.h
+++ b/shell/platform/windows/window_state.h
@@ -16,7 +16,6 @@
 
 namespace flutter {
 struct FlutterWindowsEngine;
-struct FlutterWindowsView;
 }  // namespace flutter
 
 // Wrapper to distinguish the plugin registrar ref from the engine ref given out


### PR DESCRIPTION
This change begins the migration to the Windows embedder's new ownership model:

1. Renames `FlutterDesktopViewControllerState` to `FlutterWindowsViewController`
2. Moves ownership of the `FlutterWindowsEngine` from the `FlutterWindowsView` to the `FlutterWindowsViewController`

For more information, refer to: [flutter.dev/go/windows-multi-view-ownership-updates](https://flutter.dev/go/windows-multi-view-ownership-updates)

Part of https://github.com/flutter/flutter/issues/137267

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
