### PR TITLE
[ios]fix ios 16 auto correction highlight showing on top left corner

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1676,6 +1676,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
     }
   }
 
+  if (@available(iOS 17.0, *)) {
   NSUInteger first = start;
   if (end < start) {
     first = end;
@@ -1698,12 +1699,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
         !isLastSelectionRect && _selectionRects[i + 1].position > first;
     if (startsOnOrBeforeStartOfRange &&
         (endOfTextIsAfterStartOfRange || nextSelectionRectIsAfterStartOfRange)) {
-      // TODO(hellohaunlin): Remove iOS 17 check. The logic should also work for older versions.
-      if (@available(iOS 17, *)) {
-        startSelectionRect = _selectionRects[i].rect;
-      } else {
-        return _selectionRects[i].rect;
-      }
+      startSelectionRect = _selectionRects[i].rect;
     }
     if (!CGRectIsNull(startSelectionRect)) {
       minY = fmin(minY, CGRectGetMinY(_selectionRects[i].rect));
@@ -1729,6 +1725,10 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
     CGFloat minX = fmin(CGRectGetMinX(startSelectionRect), CGRectGetMinX(endSelectionRect));
     CGFloat maxX = fmax(CGRectGetMaxX(startSelectionRect), CGRectGetMaxX(endSelectionRect));
     return CGRectMake(minX, minY, maxX - minX, maxY - minY);
+  }
+  } else {
+    // Auto correction highlight on iOS 16 and older is rendered by Flutter.
+    return CGRectZero;
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1688,9 +1688,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   CGFloat minY = CGFLOAT_MAX;
   CGFloat maxY = CGFLOAT_MIN;
 
-  FlutterTextRange* textRange =
-      [FlutterTextRange rangeWithNSRange:fml::RangeForCharactersInRange(
-                                              self.text, NSMakeRange(0, self.text.length))];
+  FlutterTextRange* textRange = [FlutterTextRange
+      rangeWithNSRange:fml::RangeForCharactersInRange(self.text, NSMakeRange(0, self.text.length))];
   for (NSUInteger i = 0; i < [_selectionRects count]; i++) {
     BOOL startsOnOrBeforeStartOfRange = _selectionRects[i].position <= first;
     BOOL isLastSelectionRect = i + 1 == [_selectionRects count];
@@ -1699,12 +1698,14 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
         !isLastSelectionRect && _selectionRects[i + 1].position > first;
     if (startsOnOrBeforeStartOfRange &&
         (endOfTextIsAfterStartOfRange || nextSelectionRectIsAfterStartOfRange)) {
-      if (@available(iOS 17.0, *)) {
+      // TODO(hellohaunlin): Remove iOS 17 check. The logic should also work for older versions.
+      if (@available(iOS 17, *)) {
         startSelectionRect = _selectionRects[i].rect;
       } else {
-        // The iOS 17 system highlight does not repect the height returned by `firstRectForRange` API. 
-        // So we return CGRectZero to hide it. 
-        // However, for iPad scribble, at least 1 character's width is required for advanced gestures (e.g. insert a space with a vertical bar)
+        // The iOS 16 system highlight does not repect the height returned by `firstRectForRange`
+        // API (unlike iOS 17). So we return CGRectZero to hide it (unless if scribble is enabled).
+        // To support scribble's advanced gestures (e.g. insert a space with a vertical bar),
+        // at least 1 character's width is required.
         return [self isScribbleAvailable] ? _selectionRects[i].rect : CGRectZero;
       }
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1676,6 +1676,18 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
     }
   }
 
+  // The iOS 16 system highlight does not repect the height returned by `firstRectForRange`
+  // API (unlike iOS 17). So we return CGRectZero to hide it (unless if scribble is enabled).
+  // To support scribble's advanced gestures (e.g. insert a space with a vertical bar),
+  // at least 1 character's width is required.
+  if (@available(iOS 17, *)) {
+    // No-op
+  } else {
+    if (![self isScribbleAvailable]) {
+      return CGRectZero;
+    }
+  }
+
   NSUInteger first = start;
   if (end < start) {
     first = end;
@@ -1702,11 +1714,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
       if (@available(iOS 17, *)) {
         startSelectionRect = _selectionRects[i].rect;
       } else {
-        // The iOS 16 system highlight does not repect the height returned by `firstRectForRange`
-        // API (unlike iOS 17). So we return CGRectZero to hide it (unless if scribble is enabled).
-        // To support scribble's advanced gestures (e.g. insert a space with a vertical bar),
-        // at least 1 character's width is required.
-        return [self isScribbleAvailable] ? _selectionRects[i].rect : CGRectZero;
+        return _selectionRects[i].rect;
       }
     }
     if (!CGRectIsNull(startSelectionRect)) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1682,10 +1682,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   // at least 1 character's width is required.
   if (@available(iOS 17, *)) {
     // No-op
-  } else {
-    if (![self isScribbleAvailable]) {
-      return CGRectZero;
-    }
+  } else if (![self isScribbleAvailable]) {
+    return CGRectZero;
   }
 
   NSUInteger first = start;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1677,55 +1677,56 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   }
 
   if (@available(iOS 17.0, *)) {
-  NSUInteger first = start;
-  if (end < start) {
-    first = end;
-  }
-
-  CGRect startSelectionRect = CGRectNull;
-  CGRect endSelectionRect = CGRectNull;
-  // Selection rects from different langauges may have different minY/maxY.
-  // So we need to iterate through each rects to update minY/maxY.
-  CGFloat minY = CGFLOAT_MAX;
-  CGFloat maxY = CGFLOAT_MIN;
-
-  FlutterTextRange* textRange = [FlutterTextRange
-      rangeWithNSRange:fml::RangeForCharactersInRange(self.text, NSMakeRange(0, self.text.length))];
-  for (NSUInteger i = 0; i < [_selectionRects count]; i++) {
-    BOOL startsOnOrBeforeStartOfRange = _selectionRects[i].position <= first;
-    BOOL isLastSelectionRect = i + 1 == [_selectionRects count];
-    BOOL endOfTextIsAfterStartOfRange = isLastSelectionRect && textRange.range.length > first;
-    BOOL nextSelectionRectIsAfterStartOfRange =
-        !isLastSelectionRect && _selectionRects[i + 1].position > first;
-    if (startsOnOrBeforeStartOfRange &&
-        (endOfTextIsAfterStartOfRange || nextSelectionRectIsAfterStartOfRange)) {
-      startSelectionRect = _selectionRects[i].rect;
+    NSUInteger first = start;
+    if (end < start) {
+      first = end;
     }
-    if (!CGRectIsNull(startSelectionRect)) {
-      minY = fmin(minY, CGRectGetMinY(_selectionRects[i].rect));
-      maxY = fmax(maxY, CGRectGetMaxY(_selectionRects[i].rect));
-      BOOL endsOnOrAfterEndOfRange = _selectionRects[i].position >= end - 1;  // end is exclusive
-      BOOL nextSelectionRectIsOnNextLine =
-          !isLastSelectionRect &&
-          // Selection rects from different langauges in 2 lines may overlap with each other.
-          // A good approximation is to check if the center of next rect is below the bottom of
-          // current rect.
-          // TODO(hellohuanlin): Consider passing the line break info from framework.
-          CGRectGetMidY(_selectionRects[i + 1].rect) > CGRectGetMaxY(_selectionRects[i].rect);
-      if (endsOnOrAfterEndOfRange || isLastSelectionRect || nextSelectionRectIsOnNextLine) {
-        endSelectionRect = _selectionRects[i].rect;
-        break;
+
+    CGRect startSelectionRect = CGRectNull;
+    CGRect endSelectionRect = CGRectNull;
+    // Selection rects from different langauges may have different minY/maxY.
+    // So we need to iterate through each rects to update minY/maxY.
+    CGFloat minY = CGFLOAT_MAX;
+    CGFloat maxY = CGFLOAT_MIN;
+
+    FlutterTextRange* textRange =
+        [FlutterTextRange rangeWithNSRange:fml::RangeForCharactersInRange(
+                                               self.text, NSMakeRange(0, self.text.length))];
+    for (NSUInteger i = 0; i < [_selectionRects count]; i++) {
+      BOOL startsOnOrBeforeStartOfRange = _selectionRects[i].position <= first;
+      BOOL isLastSelectionRect = i + 1 == [_selectionRects count];
+      BOOL endOfTextIsAfterStartOfRange = isLastSelectionRect && textRange.range.length > first;
+      BOOL nextSelectionRectIsAfterStartOfRange =
+          !isLastSelectionRect && _selectionRects[i + 1].position > first;
+      if (startsOnOrBeforeStartOfRange &&
+          (endOfTextIsAfterStartOfRange || nextSelectionRectIsAfterStartOfRange)) {
+        startSelectionRect = _selectionRects[i].rect;
+      }
+      if (!CGRectIsNull(startSelectionRect)) {
+        minY = fmin(minY, CGRectGetMinY(_selectionRects[i].rect));
+        maxY = fmax(maxY, CGRectGetMaxY(_selectionRects[i].rect));
+        BOOL endsOnOrAfterEndOfRange = _selectionRects[i].position >= end - 1;  // end is exclusive
+        BOOL nextSelectionRectIsOnNextLine =
+            !isLastSelectionRect &&
+            // Selection rects from different langauges in 2 lines may overlap with each other.
+            // A good approximation is to check if the center of next rect is below the bottom of
+            // current rect.
+            // TODO(hellohuanlin): Consider passing the line break info from framework.
+            CGRectGetMidY(_selectionRects[i + 1].rect) > CGRectGetMaxY(_selectionRects[i].rect);
+        if (endsOnOrAfterEndOfRange || isLastSelectionRect || nextSelectionRectIsOnNextLine) {
+          endSelectionRect = _selectionRects[i].rect;
+          break;
+        }
       }
     }
-  }
-  if (CGRectIsNull(startSelectionRect) || CGRectIsNull(endSelectionRect)) {
-    return CGRectZero;
-  } else {
-    // fmin/fmax to support both LTR and RTL languages.
-    CGFloat minX = fmin(CGRectGetMinX(startSelectionRect), CGRectGetMinX(endSelectionRect));
-    CGFloat maxX = fmax(CGRectGetMaxX(startSelectionRect), CGRectGetMaxX(endSelectionRect));
-    return CGRectMake(minX, minY, maxX - minX, maxY - minY);
-  }
+    if (CGRectIsNull(startSelectionRect) || CGRectIsNull(endSelectionRect)) {
+      return CGRectZero;
+    } else {
+      // fmin/fmax to support both LTR and RTL languages.
+      CGFloat minX = fmin(CGRectGetMinX(startSelectionRect), CGRectGetMinX(endSelectionRect));
+      CGFloat maxX = fmax(CGRectGetMaxX(startSelectionRect), CGRectGetMaxX(endSelectionRect));
+      return CGRectMake(minX, minY, maxX - minX, maxY - minY);
+    }
   } else {
     // Auto correction highlight on iOS 16 and older is rendered by Flutter.
     return CGRectZero;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1578,7 +1578,8 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100), [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
+                                    [inputView firstRectForRange:multiRectRange]));
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1558,6 +1558,30 @@ FLUTTER_ASSERT_ARC
                                   [inputView firstRectForRange:range]));
 }
 
+- (void)testFirstRectForRangeReturnsNoneZeroRectWhenScribbleIsEnabled {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [inputView setTextInputState:@{@"text" : @"COMPOSING"}];
+
+  FlutterTextInputView* mockInputView = OCMPartialMock(inputView);
+  OCMStub([mockInputView isScribbleAvailable]).andReturn(YES);
+
+  [inputView setSelectionRects:@[
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(0, 0, 100, 100) position:0U],
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(100, 0, 100, 100) position:1U],
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(200, 0, 100, 100) position:2U],
+    [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(300, 0, 100, 100) position:3U],
+  ]];
+
+  FlutterTextRange* multiRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 3)];
+
+  if (@available(iOS 17, *)) {
+    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 300, 100),
+                                    [inputView firstRectForRange:multiRectRange]));
+  } else {
+    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100), [inputView firstRectForRange:multiRectRange]));
+  }
+}
+
 - (void)testFirstRectForRangeReturnsCorrectRectOnASingleLineLeftToRight {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
   [inputView setTextInputState:@{@"text" : @"COMPOSING"}];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1569,8 +1569,13 @@ FLUTTER_ASSERT_ARC
     [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(300, 0, 100, 100) position:3U],
   ]];
   FlutterTextRange* singleRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 1)];
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
+  if (@available(iOS 17, *)) {
+    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
                                   [inputView firstRectForRange:singleRectRange]));
+  } else {
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
+                                  [inputView firstRectForRange:singleRectRange]));
+  }
 
   FlutterTextRange* multiRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 3)];
 
@@ -1578,7 +1583,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 
@@ -1598,15 +1603,20 @@ FLUTTER_ASSERT_ARC
     [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(0, 0, 100, 100) position:3U],
   ]];
   FlutterTextRange* singleRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 1)];
+  if (@available(iOS 17, *)) {
   XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
                                   [inputView firstRectForRange:singleRectRange]));
+  } else {
+  XCTAssertTrue(CGRectEqualToRect(CGRectZero,
+                                  [inputView firstRectForRange:singleRectRange]));
+  }
 
   FlutterTextRange* multiRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 3)];
   if (@available(iOS 17, *)) {
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 
@@ -1630,8 +1640,13 @@ FLUTTER_ASSERT_ARC
     [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(300, 100, 100, 100) position:7U],
   ]];
   FlutterTextRange* singleRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 1)];
+  if (@available(iOS 17, *)) {
   XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
                                   [inputView firstRectForRange:singleRectRange]));
+  } else {
+  XCTAssertTrue(CGRectEqualToRect(CGRectZero,
+                                  [inputView firstRectForRange:singleRectRange]));
+  }
 
   FlutterTextRange* multiRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 4)];
 
@@ -1639,7 +1654,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 }
@@ -1659,15 +1674,20 @@ FLUTTER_ASSERT_ARC
     [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(0, 100, 100, 100) position:7U],
   ]];
   FlutterTextRange* singleRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 1)];
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
+   if (@available(iOS 17, *)) {
+ XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
                                   [inputView firstRectForRange:singleRectRange]));
+   } else {
+ XCTAssertTrue(CGRectEqualToRect(CGRectZero,
+                                  [inputView firstRectForRange:singleRectRange]));
+   }
 
   FlutterTextRange* multiRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 4)];
   if (@available(iOS 17, *)) {
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 }
@@ -1691,7 +1711,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, -10, 300, 120),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 10, 100, 80),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 }
@@ -1715,7 +1735,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, -10, 300, 120),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, -10, 100, 120),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 }
@@ -1739,7 +1759,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 }
@@ -1763,7 +1783,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 }
@@ -1787,7 +1807,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 400, 140),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 }
@@ -1811,7 +1831,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, 0, 400, 140),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectMake(300, 0, 100, 100),
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
                                     [inputView firstRectForRange:multiRectRange]));
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1571,10 +1571,9 @@ FLUTTER_ASSERT_ARC
   FlutterTextRange* singleRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 1)];
   if (@available(iOS 17, *)) {
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
-                                  [inputView firstRectForRange:singleRectRange]));
+                                    [inputView firstRectForRange:singleRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                  [inputView firstRectForRange:singleRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:singleRectRange]));
   }
 
   FlutterTextRange* multiRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 3)];
@@ -1583,8 +1582,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 
   [inputView setTextInputState:@{@"text" : @"COM"}];
@@ -1604,11 +1602,10 @@ FLUTTER_ASSERT_ARC
   ]];
   FlutterTextRange* singleRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 1)];
   if (@available(iOS 17, *)) {
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
-                                  [inputView firstRectForRange:singleRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
+                                    [inputView firstRectForRange:singleRectRange]));
   } else {
-  XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                  [inputView firstRectForRange:singleRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:singleRectRange]));
   }
 
   FlutterTextRange* multiRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 3)];
@@ -1616,8 +1613,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 
   [inputView setTextInputState:@{@"text" : @"COM"}];
@@ -1641,11 +1637,10 @@ FLUTTER_ASSERT_ARC
   ]];
   FlutterTextRange* singleRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 1)];
   if (@available(iOS 17, *)) {
-  XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
-                                  [inputView firstRectForRange:singleRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 100, 100),
+                                    [inputView firstRectForRange:singleRectRange]));
   } else {
-  XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                  [inputView firstRectForRange:singleRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:singleRectRange]));
   }
 
   FlutterTextRange* multiRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 4)];
@@ -1654,8 +1649,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 }
 
@@ -1674,21 +1668,19 @@ FLUTTER_ASSERT_ARC
     [FlutterTextSelectionRect selectionRectWithRect:CGRectMake(0, 100, 100, 100) position:7U],
   ]];
   FlutterTextRange* singleRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 1)];
-   if (@available(iOS 17, *)) {
- XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
-                                  [inputView firstRectForRange:singleRectRange]));
-   } else {
- XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                  [inputView firstRectForRange:singleRectRange]));
-   }
+  if (@available(iOS 17, *)) {
+    XCTAssertTrue(CGRectEqualToRect(CGRectMake(200, 0, 100, 100),
+                                    [inputView firstRectForRange:singleRectRange]));
+  } else {
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:singleRectRange]));
+  }
 
   FlutterTextRange* multiRectRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(1, 4)];
   if (@available(iOS 17, *)) {
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 }
 
@@ -1711,8 +1703,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, -10, 300, 120),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 }
 
@@ -1735,8 +1726,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, -10, 300, 120),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 }
 
@@ -1759,8 +1749,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 }
 
@@ -1783,8 +1772,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, 0, 300, 100),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 }
 
@@ -1807,8 +1795,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(100, 0, 400, 140),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 }
 
@@ -1831,8 +1818,7 @@ FLUTTER_ASSERT_ARC
     XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, 0, 400, 140),
                                     [inputView firstRectForRange:multiRectRange]));
   } else {
-    XCTAssertTrue(CGRectEqualToRect(CGRectZero,
-                                    [inputView firstRectForRange:multiRectRange]));
+    XCTAssertTrue(CGRectEqualToRect(CGRectZero, [inputView firstRectForRange:multiRectRange]));
   }
 }
 


### PR DESCRIPTION
This PR hides the system highlights in iOS 16 (except when scribble is enabled). 

Note that auto correction highlight is still drawn by flutter, so it still works. 

I don't think we need to CP this, since it's iOS 16 only, and iOS 17 is already out. 

## Why not use system highlight? 

Unlike iOS 17, the iOS 16 system highlight only respect the width provided by `firstRectForRange`, but not the height. I have audited all sizing related APIs in UITextInput (doc [here](https://developer.apple.com/documentation/uikit/uitextinput#1653155)), specifically, `firstRect(for:)`, `caretRect(for:)` and `selectionRects(for:)`, and they all return the correct height. 

## About scribble
The initial implementation of `firstRectForRange` (that returns the first selection rect) was introduced for the scribble feature on iPad (code [here](https://github.com/flutter/engine/commit/1ae721c0230e8e3f3618f7e9d301ad2133b2fd61#diff-4c7b102c0690b8ec5e2212b079f5d69fe3f816c84e47ce94bc7bc89312f39e40R1487-R1505)). 

It turns out that a non-zero rect is required for scribble's advanced feature to work (e.g. inserting a space with a vertical bar). So we can't apply this fix for scribble. 

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/136802

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
