### PR TITLE
Fix for undefined `uint8_t` seen on Clang-15+GCC13

### DIFF
--- a/fml/base32.cc
+++ b/fml/base32.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/fml/base32.h"
 
+#include <cstdint>  // uint8_t
 #include <limits>
 #include <string>
 

--- a/fml/hex_codec.cc
+++ b/fml/hex_codec.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/fml/base32.h"
 
+#include <cstdint>  // uint8_t
 #include <string>
 
 namespace fml {


### PR DESCRIPTION
This PR is to address an issue we're seeing compiling flutter+impeller in certain configurations. Specifically:

1. Compiling with `clang-15`
2. using the GCC 13 backend to provide headers and cstdlib.

Via the `clang-15` version flag:

```
clang-15 -v
Debian clang version 15.0.7
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/11
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/12
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/13
Selected GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/13
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Candidate multilib: x32;@mx32
Selected multilib: .;@m64
```

We were building using the gcc 12 backend for a while, but picked up an update that forced us to 13, and then saw this issue.

The issue is seen as `uint8_t` being undefined as in the following partial messages:

```
hex_codec.cc:18:5: error: unknown type name 'uint8_t'
base32.cc:29:32: error: unknown type name 'uint8_t'
```

I'm not sure this is the cleanest fix, or if it might be better handled by adding some compile time switches, but I wanted to provide this to start conversation.

I'm also hoping to get a better idea of tests run against a PR. If there's any I should run manually we can discuss that here.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
