### PR TITLE
[Impeller] Remove use of FML_DISALLOW_<FOO> macros in Impeller.

### DIFF
--- a/impeller/aiks/aiks_context.h
+++ b/impeller/aiks/aiks_context.h
@@ -46,7 +46,9 @@ class AiksContext {
   std::unique_ptr<ContentContext> content_context_;
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AiksContext);
+  AiksContext(const AiksContext&) = delete;
+
+  AiksContext& operator=(const AiksContext&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/aiks/aiks_playground.h
+++ b/impeller/aiks/aiks_playground.h
@@ -35,7 +35,9 @@ class AiksPlayground : public PlaygroundTest {
   std::shared_ptr<TypographerContext> typographer_context_;
   AiksInspector inspector_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AiksPlayground);
+  AiksPlayground(const AiksPlayground&) = delete;
+
+  AiksPlayground& operator=(const AiksPlayground&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/aiks/aiks_playground_inspector.h
+++ b/impeller/aiks/aiks_playground_inspector.h
@@ -42,7 +42,9 @@ class AiksInspector {
   CaptureElement* selected_element_ = nullptr;
   std::optional<Picture> last_picture_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AiksInspector);
+  AiksInspector(const AiksInspector&) = delete;
+
+  AiksInspector& operator=(const AiksInspector&) = delete;
 };
 
 };  // namespace impeller

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -189,7 +189,9 @@ class Canvas {
                                Scalar corner_radius,
                                const Paint& paint);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Canvas);
+  Canvas(const Canvas&) = delete;
+
+  Canvas& operator=(const Canvas&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/aiks/image.h
+++ b/impeller/aiks/image.h
@@ -24,7 +24,9 @@ class Image {
  private:
   const std::shared_ptr<Texture> texture_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Image);
+  Image(const Image&) = delete;
+
+  Image& operator=(const Image&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/aiks/paint_pass_delegate.h
+++ b/impeller/aiks/paint_pass_delegate.h
@@ -40,7 +40,9 @@ class PaintPassDelegate final : public EntityPassDelegate {
  private:
   const Paint paint_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PaintPassDelegate);
+  PaintPassDelegate(const PaintPassDelegate&) = delete;
+
+  PaintPassDelegate& operator=(const PaintPassDelegate&) = delete;
 };
 
 /// A delegate that attempts to forward opacity from a save layer to
@@ -74,7 +76,10 @@ class OpacityPeepholePassDelegate final : public EntityPassDelegate {
  private:
   const Paint paint_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(OpacityPeepholePassDelegate);
+  OpacityPeepholePassDelegate(const OpacityPeepholePassDelegate&) = delete;
+
+  OpacityPeepholePassDelegate& operator=(const OpacityPeepholePassDelegate&) =
+      delete;
 };
 
 }  // namespace impeller

--- a/impeller/archivist/archive.h
+++ b/impeller/archivist/archive.h
@@ -68,7 +68,9 @@ class Archive {
                             const UnarchiveStep& stepper,
                             PrimaryKey primary_key = std::nullopt);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Archive);
+  Archive(const Archive&) = delete;
+
+  Archive& operator=(const Archive&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/archivist/archive_class_registration.h
+++ b/impeller/archivist/archive_class_registration.h
@@ -43,7 +43,9 @@ class ArchiveClassRegistration {
   MemberColumnMap column_map_;
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ArchiveClassRegistration);
+  ArchiveClassRegistration(const ArchiveClassRegistration&) = delete;
+
+  ArchiveClassRegistration& operator=(const ArchiveClassRegistration&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/archivist/archive_database.cc
+++ b/impeller/archivist/archive_database.cc
@@ -47,7 +47,9 @@ struct ArchiveDatabase::Handle {
  private:
   ::sqlite3* handle_ = nullptr;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Handle);
+  Handle(const Handle&) = delete;
+
+  Handle& operator=(const Handle&) = delete;
 };
 
 ArchiveDatabase::ArchiveDatabase(const std::string& filename)

--- a/impeller/archivist/archive_database.h
+++ b/impeller/archivist/archive_database.h
@@ -48,7 +48,9 @@ class ArchiveDatabase {
 
   ArchiveStatement CreateStatement(const std::string& statementString) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ArchiveDatabase);
+  ArchiveDatabase(const ArchiveDatabase&) = delete;
+
+  ArchiveDatabase& operator=(const ArchiveDatabase&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/archivist/archive_location.h
+++ b/impeller/archivist/archive_location.h
@@ -166,7 +166,9 @@ class ArchiveLocation {
             const ArchiveDef& otherDef,
             Archivable& other);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ArchiveLocation);
+  ArchiveLocation(const ArchiveLocation&) = delete;
+
+  ArchiveLocation& operator=(const ArchiveLocation&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/archivist/archive_statement.cc
+++ b/impeller/archivist/archive_statement.cc
@@ -41,7 +41,9 @@ struct ArchiveStatement::Handle {
  private:
   ::sqlite3_stmt* handle_ = nullptr;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Handle);
+  Handle(const Handle&) = delete;
+
+  Handle& operator=(const Handle&) = delete;
 };
 
 ArchiveStatement::ArchiveStatement(void* db, const std::string& statememt)

--- a/impeller/archivist/archive_statement.h
+++ b/impeller/archivist/archive_statement.h
@@ -90,7 +90,9 @@ class ArchiveStatement {
 
   bool ColumnIntegral(size_t index, int64_t& item);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ArchiveStatement);
+  ArchiveStatement(const ArchiveStatement&) = delete;
+
+  ArchiveStatement& operator=(const ArchiveStatement&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/archivist/archive_transaction.h
+++ b/impeller/archivist/archive_transaction.h
@@ -43,7 +43,9 @@ class ArchiveTransaction {
                      ArchiveStatement& endStatement,
                      ArchiveStatement& rollbackStatement);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ArchiveTransaction);
+  ArchiveTransaction(const ArchiveTransaction&) = delete;
+
+  ArchiveTransaction& operator=(const ArchiveTransaction&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/archivist/archive_vector.h
+++ b/impeller/archivist/archive_vector.h
@@ -30,7 +30,9 @@ class ArchiveVector : public Archivable {
 
   ArchiveVector(std::vector<int64_t> keys);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ArchiveVector);
+  ArchiveVector(const ArchiveVector&) = delete;
+
+  ArchiveVector& operator=(const ArchiveVector&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/archivist/archivist_fixture.h
+++ b/impeller/archivist/archivist_fixture.h
@@ -29,7 +29,9 @@ class ArchivistFixture : public ::testing::Test {
 
   void DeleteArchiveFile() const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ArchivistFixture);
+  ArchivistFixture(const ArchivistFixture&) = delete;
+
+  ArchivistFixture& operator=(const ArchivistFixture&) = delete;
 };
 
 }  // namespace testing

--- a/impeller/archivist/archivist_unittests.cc
+++ b/impeller/archivist/archivist_unittests.cc
@@ -47,7 +47,9 @@ class Sample : public Archivable {
   uint64_t some_data_;
   PrimaryKey name_ = ++LastSample;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Sample);
+  Sample(const Sample&) = delete;
+
+  Sample& operator=(const Sample&) = delete;
 };
 
 const ArchiveDef Sample::kArchiveDefinition = {
@@ -95,7 +97,9 @@ class SampleWithVector : public Archivable {
 
  private:
   std::vector<Sample> samples_;
-  FML_DISALLOW_COPY_AND_ASSIGN(SampleWithVector);
+  SampleWithVector(const SampleWithVector&) = delete;
+
+  SampleWithVector& operator=(const SampleWithVector&) = delete;
 };
 
 const ArchiveDef SampleWithVector::kArchiveDefinition = {

--- a/impeller/base/allocation.h
+++ b/impeller/base/allocation.h
@@ -37,7 +37,9 @@ class Allocation {
 
   [[nodiscard]] bool ReserveNPOT(size_t reserved);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Allocation);
+  Allocation(const Allocation&) = delete;
+
+  Allocation& operator=(const Allocation&) = delete;
 };
 
 std::shared_ptr<fml::Mapping> CreateMappingWithCopy(const uint8_t* contents,

--- a/impeller/base/thread.h
+++ b/impeller/base/thread.h
@@ -27,7 +27,13 @@ class IPLR_CAPABILITY("mutex") Mutex {
  private:
   std::mutex mutex_;
 
-  FML_DISALLOW_COPY_ASSIGN_AND_MOVE(Mutex);
+  Mutex(const Mutex&) = delete;
+
+  Mutex(Mutex&&) = delete;
+
+  Mutex& operator=(const Mutex&) = delete;
+
+  Mutex& operator=(Mutex&&) = delete;
 };
 
 class IPLR_CAPABILITY("mutex") RWMutex {
@@ -48,7 +54,13 @@ class IPLR_CAPABILITY("mutex") RWMutex {
  private:
   std::unique_ptr<fml::SharedMutex> mutex_;
 
-  FML_DISALLOW_COPY_ASSIGN_AND_MOVE(RWMutex);
+  RWMutex(const RWMutex&) = delete;
+
+  RWMutex(RWMutex&&) = delete;
+
+  RWMutex& operator=(const RWMutex&) = delete;
+
+  RWMutex& operator=(RWMutex&&) = delete;
 };
 
 class IPLR_SCOPED_CAPABILITY Lock {
@@ -62,7 +74,13 @@ class IPLR_SCOPED_CAPABILITY Lock {
  private:
   Mutex& mutex_;
 
-  FML_DISALLOW_COPY_ASSIGN_AND_MOVE(Lock);
+  Lock(const Lock&) = delete;
+
+  Lock(Lock&&) = delete;
+
+  Lock& operator=(const Lock&) = delete;
+
+  Lock& operator=(Lock&&) = delete;
 };
 
 class IPLR_SCOPED_CAPABILITY ReaderLock {
@@ -77,7 +95,13 @@ class IPLR_SCOPED_CAPABILITY ReaderLock {
  private:
   RWMutex& mutex_;
 
-  FML_DISALLOW_COPY_ASSIGN_AND_MOVE(ReaderLock);
+  ReaderLock(const ReaderLock&) = delete;
+
+  ReaderLock(ReaderLock&&) = delete;
+
+  ReaderLock& operator=(const ReaderLock&) = delete;
+
+  ReaderLock& operator=(ReaderLock&&) = delete;
 };
 
 class IPLR_SCOPED_CAPABILITY WriterLock {
@@ -91,7 +115,13 @@ class IPLR_SCOPED_CAPABILITY WriterLock {
  private:
   RWMutex& mutex_;
 
-  FML_DISALLOW_COPY_ASSIGN_AND_MOVE(WriterLock);
+  WriterLock(const WriterLock&) = delete;
+
+  WriterLock(WriterLock&&) = delete;
+
+  WriterLock& operator=(const WriterLock&) = delete;
+
+  WriterLock& operator=(WriterLock&&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/base/validation.h
+++ b/impeller/base/validation.h
@@ -27,7 +27,13 @@ class ValidationLog {
  private:
   std::ostringstream stream_;
 
-  FML_DISALLOW_COPY_ASSIGN_AND_MOVE(ValidationLog);
+  ValidationLog(const ValidationLog&) = delete;
+
+  ValidationLog(ValidationLog&&) = delete;
+
+  ValidationLog& operator=(const ValidationLog&) = delete;
+
+  ValidationLog& operator=(ValidationLog&&) = delete;
 };
 
 void ImpellerValidationBreak(const char* message);
@@ -39,7 +45,9 @@ struct ScopedValidationDisable {
 
   ~ScopedValidationDisable();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ScopedValidationDisable);
+  ScopedValidationDisable(const ScopedValidationDisable&) = delete;
+
+  ScopedValidationDisable& operator=(const ScopedValidationDisable&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/compiler/compiler.h
+++ b/impeller/compiler/compiler.h
@@ -57,7 +57,9 @@ class Compiler {
 
   std::string GetDependencyNames(const std::string& separator) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Compiler);
+  Compiler(const Compiler&) = delete;
+
+  Compiler& operator=(const Compiler&) = delete;
 };
 
 }  // namespace compiler

--- a/impeller/compiler/compiler_test.h
+++ b/impeller/compiler/compiler_test.h
@@ -33,7 +33,9 @@ class CompilerTest : public ::testing::TestWithParam<TargetPlatform> {
  private:
   fml::UniqueFD intermediates_directory_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CompilerTest);
+  CompilerTest(const CompilerTest&) = delete;
+
+  CompilerTest& operator=(const CompilerTest&) = delete;
 };
 
 }  // namespace testing

--- a/impeller/compiler/includer.h
+++ b/impeller/compiler/includer.h
@@ -52,7 +52,9 @@ class Includer final : public shaderc::CompileOptions::IncluderInterface {
   std::unique_ptr<fml::FileMapping> FindFirstMapping(
       const char* requested_source);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Includer);
+  Includer(const Includer&) = delete;
+
+  Includer& operator=(const Includer&) = delete;
 };
 
 }  // namespace compiler

--- a/impeller/compiler/logger.h
+++ b/impeller/compiler/logger.h
@@ -31,7 +31,9 @@ class AutoLogger {
  private:
   std::stringstream& logger_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AutoLogger);
+  AutoLogger(const AutoLogger&) = delete;
+
+  AutoLogger& operator=(const AutoLogger&) = delete;
 };
 
 #define COMPILER_ERROR(stream) \

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -169,7 +169,9 @@ class Reflector {
     return compiler_->type_struct_member_array_stride(struct_type, index);
   };
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Reflector);
+  Reflector(const Reflector&) = delete;
+
+  Reflector& operator=(const Reflector&) = delete;
 };
 
 }  // namespace compiler

--- a/impeller/compiler/runtime_stage_data.h
+++ b/impeller/compiler/runtime_stage_data.h
@@ -51,7 +51,9 @@ class RuntimeStageData {
   std::shared_ptr<fml::Mapping> shader_;
   std::shared_ptr<fml::Mapping> sksl_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RuntimeStageData);
+  RuntimeStageData(const RuntimeStageData&) = delete;
+
+  RuntimeStageData& operator=(const RuntimeStageData&) = delete;
 };
 
 }  // namespace compiler

--- a/impeller/compiler/spirv_compiler.cc
+++ b/impeller/compiler/spirv_compiler.cc
@@ -268,7 +268,9 @@ class UniqueIncluder final : public shaderc::CompileOptions::IncluderInterface {
     FML_CHECK(includer_);
   }
 
-  FML_DISALLOW_COPY_AND_ASSIGN(UniqueIncluder);
+  UniqueIncluder(const UniqueIncluder&) = delete;
+
+  UniqueIncluder& operator=(const UniqueIncluder&) = delete;
 };
 
 shaderc::CompileOptions SPIRVCompilerOptions::BuildShadercOptions() const {

--- a/impeller/compiler/spirv_compiler.h
+++ b/impeller/compiler/spirv_compiler.h
@@ -68,7 +68,9 @@ class SPIRVCompiler {
 
   std::string GetSourcePrefix() const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SPIRVCompiler);
+  SPIRVCompiler(const SPIRVCompiler&) = delete;
+
+  SPIRVCompiler& operator=(const SPIRVCompiler&) = delete;
 };
 
 }  // namespace compiler

--- a/impeller/core/allocator.h
+++ b/impeller/core/allocator.h
@@ -61,7 +61,9 @@ class Allocator {
       const TextureDescriptor& desc) = 0;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(Allocator);
+  Allocator(const Allocator&) = delete;
+
+  Allocator& operator=(const Allocator&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/core/capture.h
+++ b/impeller/core/capture.h
@@ -188,7 +188,9 @@ class CapturePlaybackList {
   size_t cursor_ = 0;
   std::vector<std::shared_ptr<Type>> values_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CapturePlaybackList);
+  CapturePlaybackList(const CapturePlaybackList&) = delete;
+
+  CapturePlaybackList& operator=(const CapturePlaybackList&) = delete;
 };
 
 /// A document of capture data, containing a list of properties and a list
@@ -206,7 +208,9 @@ struct CaptureElement final : public CaptureCursorListElement<CaptureElement> {
  private:
   explicit CaptureElement(const std::string& label);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CaptureElement);
+  CaptureElement(const CaptureElement&) = delete;
+
+  CaptureElement& operator=(const CaptureElement&) = delete;
 };
 
 #ifdef IMPELLER_ENABLE_CAPTURE

--- a/impeller/core/device_buffer.h
+++ b/impeller/core/device_buffer.h
@@ -55,7 +55,9 @@ class DeviceBuffer : public Buffer,
                                 size_t offset) = 0;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(DeviceBuffer);
+  DeviceBuffer(const DeviceBuffer&) = delete;
+
+  DeviceBuffer& operator=(const DeviceBuffer&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/core/host_buffer.h
+++ b/impeller/core/host_buffer.h
@@ -134,7 +134,9 @@ class HostBuffer final : public std::enable_shared_from_this<HostBuffer>,
 
   HostBuffer();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(HostBuffer);
+  HostBuffer(const HostBuffer&) = delete;
+
+  HostBuffer& operator=(const HostBuffer&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/core/sampler.h
+++ b/impeller/core/sampler.h
@@ -23,7 +23,9 @@ class Sampler {
   explicit Sampler(SamplerDescriptor desc);
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(Sampler);
+  Sampler(const Sampler&) = delete;
+
+  Sampler& operator=(const Sampler&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/core/texture.h
+++ b/impeller/core/texture.h
@@ -68,7 +68,9 @@ class Texture {
 
   bool IsSliceValid(size_t slice) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Texture);
+  Texture(const Texture&) = delete;
+
+  Texture& operator=(const Texture&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -229,7 +229,9 @@ class DlDispatcher final : public flutter::DlOpReceiver {
   CanvasType canvas_;
   Matrix initial_matrix_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DlDispatcher);
+  DlDispatcher(const DlDispatcher&) = delete;
+
+  DlDispatcher& operator=(const DlDispatcher&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/display_list/dl_image_impeller.h
+++ b/impeller/display_list/dl_image_impeller.h
@@ -58,7 +58,9 @@ class DlImageImpeller final : public flutter::DlImage {
   explicit DlImageImpeller(std::shared_ptr<Texture> texture,
                            OwningContext owning_context = OwningContext::kIO);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DlImageImpeller);
+  DlImageImpeller(const DlImageImpeller&) = delete;
+
+  DlImageImpeller& operator=(const DlImageImpeller&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/display_list/dl_playground.h
+++ b/impeller/display_list/dl_playground.h
@@ -32,7 +32,9 @@ class DlPlayground : public PlaygroundTest {
   SkFont CreateTestFont();
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(DlPlayground);
+  DlPlayground(const DlPlayground&) = delete;
+
+  DlPlayground& operator=(const DlPlayground&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/anonymous_contents.h
+++ b/impeller/entity/contents/anonymous_contents.h
@@ -34,7 +34,9 @@ class AnonymousContents final : public Contents {
 
   AnonymousContents(RenderProc render_proc, CoverageProc coverage_proc);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AnonymousContents);
+  AnonymousContents(const AnonymousContents&) = delete;
+
+  AnonymousContents& operator=(const AnonymousContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/atlas_contents.h
+++ b/impeller/entity/contents/atlas_contents.h
@@ -87,7 +87,9 @@ class AtlasContents final : public Contents {
   SamplerDescriptor sampler_descriptor_ = {};
   mutable std::optional<Rect> bounding_box_cache_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AtlasContents);
+  AtlasContents(const AtlasContents&) = delete;
+
+  AtlasContents& operator=(const AtlasContents&) = delete;
 };
 
 class AtlasTextureContents final : public Contents {
@@ -122,7 +124,9 @@ class AtlasTextureContents final : public Contents {
   bool use_destination_ = false;
   std::shared_ptr<SubAtlasResult> subatlas_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AtlasTextureContents);
+  AtlasTextureContents(const AtlasTextureContents&) = delete;
+
+  AtlasTextureContents& operator=(const AtlasTextureContents&) = delete;
 };
 
 class AtlasColorContents final : public Contents {
@@ -151,7 +155,9 @@ class AtlasColorContents final : public Contents {
   Rect coverage_;
   std::shared_ptr<SubAtlasResult> subatlas_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AtlasColorContents);
+  AtlasColorContents(const AtlasColorContents&) = delete;
+
+  AtlasColorContents& operator=(const AtlasColorContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/checkerboard_contents.h
+++ b/impeller/entity/contents/checkerboard_contents.h
@@ -35,7 +35,9 @@ class CheckerboardContents final : public Contents {
   Color color_ = Color::Red().WithAlpha(0.25);
   Scalar square_size_ = 12;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CheckerboardContents);
+  CheckerboardContents(const CheckerboardContents&) = delete;
+
+  CheckerboardContents& operator=(const CheckerboardContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/clip_contents.h
+++ b/impeller/entity/contents/clip_contents.h
@@ -51,7 +51,9 @@ class ClipContents final : public Contents {
   std::unique_ptr<Geometry> geometry_;
   Entity::ClipOperation clip_op_ = Entity::ClipOperation::kIntersect;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ClipContents);
+  ClipContents(const ClipContents&) = delete;
+
+  ClipContents& operator=(const ClipContents&) = delete;
 };
 
 class ClipRestoreContents final : public Contents {
@@ -92,7 +94,9 @@ class ClipRestoreContents final : public Contents {
  private:
   std::optional<Rect> restore_coverage_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ClipRestoreContents);
+  ClipRestoreContents(const ClipRestoreContents&) = delete;
+
+  ClipRestoreContents& operator=(const ClipRestoreContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -107,7 +107,9 @@ class ColorSourceContents : public Contents {
   Scalar opacity_ = 1.0;
   Scalar inherited_opacity_ = 1.0;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ColorSourceContents);
+  ColorSourceContents(const ColorSourceContents&) = delete;
+
+  ColorSourceContents& operator=(const ColorSourceContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/conical_gradient_contents.h
+++ b/impeller/entity/contents/conical_gradient_contents.h
@@ -64,7 +64,9 @@ class ConicalGradientContents final : public ColorSourceContents {
   std::optional<Point> focus_;
   Scalar focus_radius_ = 0.0f;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ConicalGradientContents);
+  ConicalGradientContents(const ConicalGradientContents&) = delete;
+
+  ConicalGradientContents& operator=(const ConicalGradientContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -772,7 +772,9 @@ class ContentContext {
                        ContentContextOptions::Equal>
         pipelines_;
 
-    FML_DISALLOW_COPY_AND_ASSIGN(Variants);
+    Variants(const Variants&) = delete;
+
+    Variants& operator=(const Variants&) = delete;
   };
 
   // These are mutable because while the prototypes are created eagerly, any
@@ -920,7 +922,9 @@ class ContentContext {
   std::shared_ptr<RenderTargetAllocator> render_target_cache_;
   bool wireframe_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ContentContext);
+  ContentContext(const ContentContext&) = delete;
+
+  ContentContext& operator=(const ContentContext&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -195,7 +195,9 @@ class Contents {
   std::optional<Rect> coverage_hint_;
   std::optional<Size> color_source_size_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Contents);
+  Contents(const Contents&) = delete;
+
+  Contents& operator=(const Contents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/blend_filter_contents.h
+++ b/impeller/entity/contents/filters/blend_filter_contents.h
@@ -95,7 +95,9 @@ class BlendFilterContents : public ColorFilterContents {
   AdvancedBlendProc advanced_blend_proc_;
   std::optional<Color> foreground_color_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(BlendFilterContents);
+  BlendFilterContents(const BlendFilterContents&) = delete;
+
+  BlendFilterContents& operator=(const BlendFilterContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.h
@@ -44,7 +44,10 @@ class BorderMaskBlurFilterContents final : public FilterContents {
   bool inner_blur_factor_ = true;
   bool outer_blur_factor_ = true;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(BorderMaskBlurFilterContents);
+  BorderMaskBlurFilterContents(const BorderMaskBlurFilterContents&) = delete;
+
+  BorderMaskBlurFilterContents& operator=(const BorderMaskBlurFilterContents&) =
+      delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/color_filter_contents.h
+++ b/impeller/entity/contents/filters/color_filter_contents.h
@@ -48,7 +48,9 @@ class ColorFilterContents : public FilterContents {
   AbsorbOpacity absorb_opacity_ = AbsorbOpacity::kNo;
   std::optional<Scalar> alpha_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ColorFilterContents);
+  ColorFilterContents(const ColorFilterContents&) = delete;
+
+  ColorFilterContents& operator=(const ColorFilterContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.h
@@ -34,7 +34,10 @@ class ColorMatrixFilterContents final : public ColorFilterContents {
 
   ColorMatrix matrix_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ColorMatrixFilterContents);
+  ColorMatrixFilterContents(const ColorMatrixFilterContents&) = delete;
+
+  ColorMatrixFilterContents& operator=(const ColorMatrixFilterContents&) =
+      delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -179,7 +179,9 @@ class FilterContents : public Contents {
   FilterInput::Vector inputs_;
   Matrix effect_transform_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(FilterContents);
+  FilterContents(const FilterContents&) = delete;
+
+  FilterContents& operator=(const FilterContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -51,7 +51,11 @@ class DirectionalGaussianBlurFilterContents final : public FilterContents {
   Entity::TileMode tile_mode_ = Entity::TileMode::kDecal;
   bool is_second_pass_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DirectionalGaussianBlurFilterContents);
+  DirectionalGaussianBlurFilterContents(
+      const DirectionalGaussianBlurFilterContents&) = delete;
+
+  DirectionalGaussianBlurFilterContents& operator=(
+      const DirectionalGaussianBlurFilterContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.h
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.h
@@ -25,7 +25,10 @@ class LinearToSrgbFilterContents final : public ColorFilterContents {
       const Rect& coverage,
       const std::optional<Rect>& coverage_hint) const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(LinearToSrgbFilterContents);
+  LinearToSrgbFilterContents(const LinearToSrgbFilterContents&) = delete;
+
+  LinearToSrgbFilterContents& operator=(const LinearToSrgbFilterContents&) =
+      delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/local_matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/local_matrix_filter_contents.h
@@ -32,7 +32,10 @@ class LocalMatrixFilterContents final : public FilterContents {
 
   Matrix matrix_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(LocalMatrixFilterContents);
+  LocalMatrixFilterContents(const LocalMatrixFilterContents&) = delete;
+
+  LocalMatrixFilterContents& operator=(const LocalMatrixFilterContents&) =
+      delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/matrix_filter_contents.h
+++ b/impeller/entity/contents/filters/matrix_filter_contents.h
@@ -45,7 +45,9 @@ class MatrixFilterContents final : public FilterContents {
   SamplerDescriptor sampler_descriptor_ = {};
   Entity::RenderingMode rendering_mode_ = Entity::RenderingMode::kDirect;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(MatrixFilterContents);
+  MatrixFilterContents(const MatrixFilterContents&) = delete;
+
+  MatrixFilterContents& operator=(const MatrixFilterContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/morphology_filter_contents.h
+++ b/impeller/entity/contents/filters/morphology_filter_contents.h
@@ -43,7 +43,11 @@ class DirectionalMorphologyFilterContents final : public FilterContents {
   Vector2 direction_;
   MorphType morph_type_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DirectionalMorphologyFilterContents);
+  DirectionalMorphologyFilterContents(
+      const DirectionalMorphologyFilterContents&) = delete;
+
+  DirectionalMorphologyFilterContents& operator=(
+      const DirectionalMorphologyFilterContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.h
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.h
@@ -25,7 +25,10 @@ class SrgbToLinearFilterContents final : public ColorFilterContents {
       const Rect& coverage,
       const std::optional<Rect>& coverage_hint) const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SrgbToLinearFilterContents);
+  SrgbToLinearFilterContents(const SrgbToLinearFilterContents&) = delete;
+
+  SrgbToLinearFilterContents& operator=(const SrgbToLinearFilterContents&) =
+      delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.h
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.h
@@ -28,7 +28,9 @@ class YUVToRGBFilterContents final : public FilterContents {
 
   YUVColorSpace yuv_color_space_ = YUVColorSpace::kBT601LimitedRange;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(YUVToRGBFilterContents);
+  YUVToRGBFilterContents(const YUVToRGBFilterContents&) = delete;
+
+  YUVToRGBFilterContents& operator=(const YUVToRGBFilterContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/framebuffer_blend_contents.h
+++ b/impeller/entity/contents/framebuffer_blend_contents.h
@@ -37,7 +37,9 @@ class FramebufferBlendContents final : public ColorSourceContents {
   BlendMode blend_mode_;
   std::shared_ptr<Contents> child_contents_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(FramebufferBlendContents);
+  FramebufferBlendContents(const FramebufferBlendContents&) = delete;
+
+  FramebufferBlendContents& operator=(const FramebufferBlendContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/linear_gradient_contents.h
+++ b/impeller/entity/contents/linear_gradient_contents.h
@@ -65,7 +65,9 @@ class LinearGradientContents final : public ColorSourceContents {
   Entity::TileMode tile_mode_;
   Color decal_border_color_ = Color::BlackTransparent();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(LinearGradientContents);
+  LinearGradientContents(const LinearGradientContents&) = delete;
+
+  LinearGradientContents& operator=(const LinearGradientContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/radial_gradient_contents.h
+++ b/impeller/entity/contents/radial_gradient_contents.h
@@ -63,7 +63,9 @@ class RadialGradientContents final : public ColorSourceContents {
   Entity::TileMode tile_mode_;
   Color decal_border_color_ = Color::BlackTransparent();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RadialGradientContents);
+  RadialGradientContents(const RadialGradientContents&) = delete;
+
+  RadialGradientContents& operator=(const RadialGradientContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -58,7 +58,9 @@ class SolidColorContents final : public ColorSourceContents {
  private:
   Color color_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SolidColorContents);
+  SolidColorContents(const SolidColorContents&) = delete;
+
+  SolidColorContents& operator=(const SolidColorContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/solid_rrect_blur_contents.h
+++ b/impeller/entity/contents/solid_rrect_blur_contents.h
@@ -54,7 +54,9 @@ class SolidRRectBlurContents final : public Contents {
 
   Color color_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SolidRRectBlurContents);
+  SolidRRectBlurContents(const SolidRRectBlurContents&) = delete;
+
+  SolidRRectBlurContents& operator=(const SolidRRectBlurContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/sweep_gradient_contents.h
+++ b/impeller/entity/contents/sweep_gradient_contents.h
@@ -66,7 +66,9 @@ class SweepGradientContents final : public ColorSourceContents {
   Entity::TileMode tile_mode_;
   Color decal_border_color_ = Color::BlackTransparent();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SweepGradientContents);
+  SweepGradientContents(const SweepGradientContents&) = delete;
+
+  SweepGradientContents& operator=(const SweepGradientContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -67,7 +67,9 @@ class TextContents final : public Contents {
       GlyphAtlas::Type type,
       const std::shared_ptr<LazyGlyphAtlas>& lazy_atlas) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TextContents);
+  TextContents(const TextContents&) = delete;
+
+  TextContents& operator=(const TextContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/texture_contents.h
+++ b/impeller/entity/contents/texture_contents.h
@@ -88,7 +88,9 @@ class TextureContents final : public Contents {
   Scalar inherited_opacity_ = 1.0f;
   bool defer_applying_opacity_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TextureContents);
+  TextureContents(const TextureContents&) = delete;
+
+  TextureContents& operator=(const TextureContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/tiled_texture_contents.h
+++ b/impeller/entity/contents/tiled_texture_contents.h
@@ -76,7 +76,9 @@ class TiledTextureContents final : public ColorSourceContents {
   Entity::TileMode y_tile_mode_ = Entity::TileMode::kClamp;
   ColorFilterProc color_filter_ = nullptr;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TiledTextureContents);
+  TiledTextureContents(const TiledTextureContents&) = delete;
+
+  TiledTextureContents& operator=(const TiledTextureContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/vertices_contents.h
+++ b/impeller/entity/contents/vertices_contents.h
@@ -52,7 +52,9 @@ class VerticesContents final : public Contents {
   BlendMode blend_mode_ = BlendMode::kSource;
   std::shared_ptr<Contents> src_contents_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(VerticesContents);
+  VerticesContents(const VerticesContents&) = delete;
+
+  VerticesContents& operator=(const VerticesContents&) = delete;
 };
 
 class VerticesColorContents final : public Contents {
@@ -75,7 +77,9 @@ class VerticesColorContents final : public Contents {
   const VerticesContents& parent_;
   Scalar alpha_ = 1.0;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(VerticesColorContents);
+  VerticesColorContents(const VerticesColorContents&) = delete;
+
+  VerticesColorContents& operator=(const VerticesColorContents&) = delete;
 };
 
 class VerticesUVContents final : public Contents {
@@ -98,7 +102,9 @@ class VerticesUVContents final : public Contents {
   const VerticesContents& parent_;
   Scalar alpha_ = 1.0;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(VerticesUVContents);
+  VerticesUVContents(const VerticesUVContents&) = delete;
+
+  VerticesUVContents& operator=(const VerticesUVContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -299,7 +299,9 @@ class EntityPass {
   std::shared_ptr<EntityPassDelegate> delegate_ =
       EntityPassDelegate::MakeDefault();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(EntityPass);
+  EntityPass(const EntityPass&) = delete;
+
+  EntityPass& operator=(const EntityPass&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/entity_pass_delegate.cc
+++ b/impeller/entity/entity_pass_delegate.cc
@@ -42,7 +42,10 @@ class DefaultEntityPassDelegate final : public EntityPassDelegate {
   }
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(DefaultEntityPassDelegate);
+  DefaultEntityPassDelegate(const DefaultEntityPassDelegate&) = delete;
+
+  DefaultEntityPassDelegate& operator=(const DefaultEntityPassDelegate&) =
+      delete;
 };
 
 std::unique_ptr<EntityPassDelegate> EntityPassDelegate::MakeDefault() {

--- a/impeller/entity/entity_pass_delegate.h
+++ b/impeller/entity/entity_pass_delegate.h
@@ -39,7 +39,9 @@ class EntityPassDelegate {
       const Matrix& effect_transform) const = 0;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(EntityPassDelegate);
+  EntityPassDelegate(const EntityPassDelegate&) = delete;
+
+  EntityPassDelegate& operator=(const EntityPassDelegate&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/entity_pass_target.h
+++ b/impeller/entity/entity_pass_target.h
@@ -37,7 +37,7 @@ class EntityPassTarget {
 
   friend InlinePassContext;
 
-  FML_DISALLOW_ASSIGN(EntityPassTarget);
+  EntityPassTarget& operator=(const EntityPassTarget&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/entity_playground.h
+++ b/impeller/entity/entity_playground.h
@@ -35,7 +35,9 @@ class EntityPlayground : public PlaygroundTest {
  private:
   std::shared_ptr<TypographerContext> typographer_context_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(EntityPlayground);
+  EntityPlayground(const EntityPlayground&) = delete;
+
+  EntityPlayground& operator=(const EntityPlayground&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/geometry/cover_geometry.h
+++ b/impeller/entity/geometry/cover_geometry.h
@@ -38,7 +38,9 @@ class CoverGeometry : public Geometry {
                                      const Entity& entity,
                                      RenderPass& pass) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CoverGeometry);
+  CoverGeometry(const CoverGeometry&) = delete;
+
+  CoverGeometry& operator=(const CoverGeometry&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/geometry/fill_path_geometry.h
+++ b/impeller/entity/geometry/fill_path_geometry.h
@@ -44,7 +44,9 @@ class FillPathGeometry : public Geometry {
   Path path_;
   std::optional<Rect> inner_rect_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(FillPathGeometry);
+  FillPathGeometry(const FillPathGeometry&) = delete;
+
+  FillPathGeometry& operator=(const FillPathGeometry&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/geometry/point_field_geometry.h
+++ b/impeller/entity/geometry/point_field_geometry.h
@@ -51,7 +51,9 @@ class PointFieldGeometry : public Geometry {
   Scalar radius_;
   bool round_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PointFieldGeometry);
+  PointFieldGeometry(const PointFieldGeometry&) = delete;
+
+  PointFieldGeometry& operator=(const PointFieldGeometry&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/geometry/rect_geometry.h
+++ b/impeller/entity/geometry/rect_geometry.h
@@ -38,7 +38,9 @@ class RectGeometry : public Geometry {
 
   Rect rect_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RectGeometry);
+  RectGeometry(const RectGeometry&) = delete;
+
+  RectGeometry& operator=(const RectGeometry&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/geometry/stroke_path_geometry.h
+++ b/impeller/entity/geometry/stroke_path_geometry.h
@@ -88,7 +88,9 @@ class StrokePathGeometry : public Geometry {
   Cap stroke_cap_;
   Join stroke_join_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(StrokePathGeometry);
+  StrokePathGeometry(const StrokePathGeometry&) = delete;
+
+  StrokePathGeometry& operator=(const StrokePathGeometry&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -44,7 +44,9 @@ class InlinePassContext {
   // Whether this context is collapsed into a parent entity pass.
   bool is_collapsed_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(InlinePassContext);
+  InlinePassContext(const InlinePassContext&) = delete;
+
+  InlinePassContext& operator=(const InlinePassContext&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/render_target_cache.h
+++ b/impeller/entity/render_target_cache.h
@@ -39,7 +39,9 @@ class RenderTargetCache : public RenderTargetAllocator {
 
   std::vector<TextureData> texture_data_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RenderTargetCache);
+  RenderTargetCache(const RenderTargetCache&) = delete;
+
+  RenderTargetCache& operator=(const RenderTargetCache&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/golden_tests/golden_digest.h
+++ b/impeller/golden_tests/golden_digest.h
@@ -32,7 +32,9 @@ class GoldenDigest {
   bool Write(WorkingDirectory* working_directory);
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(GoldenDigest);
+  GoldenDigest(const GoldenDigest&) = delete;
+
+  GoldenDigest& operator=(const GoldenDigest&) = delete;
   GoldenDigest();
   struct Entry {
     std::string test_name;

--- a/impeller/golden_tests/golden_playground_test.h
+++ b/impeller/golden_tests/golden_playground_test.h
@@ -73,7 +73,9 @@ class GoldenPlaygroundTest
   // This is only a shared_ptr so it can work with a forward declared type.
   std::shared_ptr<GoldenPlaygroundTestImpl> pimpl_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(GoldenPlaygroundTest);
+  GoldenPlaygroundTest(const GoldenPlaygroundTest&) = delete;
+
+  GoldenPlaygroundTest& operator=(const GoldenPlaygroundTest&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/golden_tests/metal_screenshot.h
+++ b/impeller/golden_tests/metal_screenshot.h
@@ -31,7 +31,9 @@ class MetalScreenshot {
  private:
   friend class MetalScreenshotter;
   explicit MetalScreenshot(CGImageRef cgImage);
-  FML_DISALLOW_COPY_AND_ASSIGN(MetalScreenshot);
+  MetalScreenshot(const MetalScreenshot&) = delete;
+
+  MetalScreenshot& operator=(const MetalScreenshot&) = delete;
   CGImageRef cg_image_;
   CFDataRef pixel_data_;
 };

--- a/impeller/golden_tests/working_directory.h
+++ b/impeller/golden_tests/working_directory.h
@@ -24,7 +24,9 @@ class WorkingDirectory {
   const std::string& GetPath() const { return path_; }
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(WorkingDirectory);
+  WorkingDirectory(const WorkingDirectory&) = delete;
+
+  WorkingDirectory& operator=(const WorkingDirectory&) = delete;
   WorkingDirectory();
   static WorkingDirectory* instance_;
   std::string path_;

--- a/impeller/image/backends/skia/compressed_image_skia.h
+++ b/impeller/image/backends/skia/compressed_image_skia.h
@@ -22,7 +22,9 @@ class CompressedImageSkia final : public CompressedImage {
   DecompressedImage Decode() const override;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(CompressedImageSkia);
+  CompressedImageSkia(const CompressedImageSkia&) = delete;
+
+  CompressedImageSkia& operator=(const CompressedImageSkia&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -41,7 +41,9 @@ class PlaygroundImplGLES::ReactorWorker final : public ReactorGLES::Worker {
   mutable RWMutex mutex_;
   std::map<std::thread::id, bool> reactions_allowed_ IPLR_GUARDED_BY(mutex_);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ReactorWorker);
+  ReactorWorker(const ReactorWorker&) = delete;
+
+  ReactorWorker& operator=(const ReactorWorker&) = delete;
 };
 
 void PlaygroundImplGLES::DestroyWindowHandle(WindowHandle handle) {

--- a/impeller/playground/backend/gles/playground_impl_gles.h
+++ b/impeller/playground/backend/gles/playground_impl_gles.h
@@ -33,7 +33,9 @@ class PlaygroundImplGLES final : public PlaygroundImpl {
   std::unique_ptr<Surface> AcquireSurfaceFrame(
       std::shared_ptr<Context> context) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PlaygroundImplGLES);
+  PlaygroundImplGLES(const PlaygroundImplGLES&) = delete;
+
+  PlaygroundImplGLES& operator=(const PlaygroundImplGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/playground/backend/metal/playground_impl_mtl.h
+++ b/impeller/playground/backend/metal/playground_impl_mtl.h
@@ -42,7 +42,9 @@ class PlaygroundImplMTL final : public PlaygroundImpl {
   std::unique_ptr<Surface> AcquireSurfaceFrame(
       std::shared_ptr<Context> context) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PlaygroundImplMTL);
+  PlaygroundImplMTL(const PlaygroundImplMTL&) = delete;
+
+  PlaygroundImplMTL& operator=(const PlaygroundImplMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/playground/backend/vulkan/playground_impl_vk.h
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.h
@@ -34,7 +34,9 @@ class PlaygroundImplVK final : public PlaygroundImpl {
   std::unique_ptr<Surface> AcquireSurfaceFrame(
       std::shared_ptr<Context> context) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PlaygroundImplVK);
+  PlaygroundImplVK(const PlaygroundImplVK&) = delete;
+
+  PlaygroundImplVK& operator=(const PlaygroundImplVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/playground/compute_playground_test.h
+++ b/impeller/playground/compute_playground_test.h
@@ -52,7 +52,9 @@ class ComputePlaygroundTest
  private:
   fml::TimeDelta start_time_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ComputePlaygroundTest);
+  ComputePlaygroundTest(const ComputePlaygroundTest&) = delete;
+
+  ComputePlaygroundTest& operator=(const ComputePlaygroundTest&) = delete;
 };
 
 #define INSTANTIATE_COMPUTE_SUITE(playground)                              \

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -107,7 +107,9 @@ class Playground {
 
   void SetCursorPosition(Point pos);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Playground);
+  Playground(const Playground&) = delete;
+
+  Playground& operator=(const Playground&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/playground/playground_impl.h
+++ b/impeller/playground/playground_impl.h
@@ -38,7 +38,9 @@ class PlaygroundImpl {
   explicit PlaygroundImpl(PlaygroundSwitches switches);
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(PlaygroundImpl);
+  PlaygroundImpl(const PlaygroundImpl&) = delete;
+
+  PlaygroundImpl& operator=(const PlaygroundImpl&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/playground/playground_test.h
+++ b/impeller/playground/playground_test.h
@@ -50,7 +50,9 @@ class PlaygroundTest : public Playground,
   fml::ScopedNSAutoreleasePool autorelease_pool_;
 #endif
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PlaygroundTest);
+  PlaygroundTest(const PlaygroundTest&) = delete;
+
+  PlaygroundTest& operator=(const PlaygroundTest&) = delete;
 };
 
 #define INSTANTIATE_PLAYGROUND_SUITE(playground)                            \

--- a/impeller/renderer/backend/gles/allocator_gles.h
+++ b/impeller/renderer/backend/gles/allocator_gles.h
@@ -37,7 +37,9 @@ class AllocatorGLES final : public Allocator {
   // |Allocator|
   ISize GetMaxTextureSizeSupported() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AllocatorGLES);
+  AllocatorGLES(const AllocatorGLES&) = delete;
+
+  AllocatorGLES& operator=(const AllocatorGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/blit_pass_gles.h
+++ b/impeller/renderer/backend/gles/blit_pass_gles.h
@@ -66,7 +66,9 @@ class BlitPassGLES final : public BlitPass,
   bool OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                std::string label) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(BlitPassGLES);
+  BlitPassGLES(const BlitPassGLES&) = delete;
+
+  BlitPassGLES& operator=(const BlitPassGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -65,7 +65,9 @@ class BufferBindingsGLES {
                     const Bindings& bindings,
                     ShaderStage stage) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(BufferBindingsGLES);
+  BufferBindingsGLES(const BufferBindingsGLES&) = delete;
+
+  BufferBindingsGLES& operator=(const BufferBindingsGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/command_buffer_gles.h
+++ b/impeller/renderer/backend/gles/command_buffer_gles.h
@@ -46,7 +46,9 @@ class CommandBufferGLES final : public CommandBuffer {
   // |CommandBuffer|
   std::shared_ptr<ComputePass> OnCreateComputePass() override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CommandBufferGLES);
+  CommandBufferGLES(const CommandBufferGLES&) = delete;
+
+  CommandBufferGLES& operator=(const CommandBufferGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -90,7 +90,9 @@ class ContextGLES final : public Context,
   // |Context|
   void Shutdown() override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ContextGLES);
+  ContextGLES(const ContextGLES&) = delete;
+
+  ContextGLES& operator=(const ContextGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/description_gles.h
+++ b/impeller/renderer/backend/gles/description_gles.h
@@ -42,7 +42,9 @@ class DescriptionGLES {
   std::set<std::string> extensions_;
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DescriptionGLES);
+  DescriptionGLES(const DescriptionGLES&) = delete;
+
+  DescriptionGLES& operator=(const DescriptionGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -58,7 +58,9 @@ class DeviceBufferGLES final
   // |DeviceBuffer|
   bool SetLabel(const std::string& label, Range range) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DeviceBufferGLES);
+  DeviceBufferGLES(const DeviceBufferGLES&) = delete;
+
+  DeviceBufferGLES& operator=(const DeviceBufferGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/pipeline_gles.h
+++ b/impeller/renderer/backend/gles/pipeline_gles.h
@@ -48,7 +48,9 @@ class PipelineGLES final
                std::weak_ptr<PipelineLibrary> library,
                const PipelineDescriptor& desc);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PipelineGLES);
+  PipelineGLES(const PipelineGLES&) = delete;
+
+  PipelineGLES& operator=(const PipelineGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/pipeline_library_gles.h
+++ b/impeller/renderer/backend/gles/pipeline_library_gles.h
@@ -40,7 +40,9 @@ class PipelineLibraryGLES final : public PipelineLibrary {
   void RemovePipelinesWithEntryPoint(
       std::shared_ptr<const ShaderFunction> function) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PipelineLibraryGLES);
+  PipelineLibraryGLES(const PipelineLibraryGLES&) = delete;
+
+  PipelineLibraryGLES& operator=(const PipelineLibraryGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -258,7 +258,9 @@ class ProcTableGLES {
   std::shared_ptr<const CapabilitiesGLES> capabilities_;
   GLint debug_label_max_length_ = 0;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ProcTableGLES);
+  ProcTableGLES(const ProcTableGLES&) = delete;
+
+  ProcTableGLES& operator=(const ProcTableGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/reactor_gles.h
+++ b/impeller/renderer/backend/gles/reactor_gles.h
@@ -265,7 +265,9 @@ class ReactorGLES {
 
   void SetupDebugGroups();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ReactorGLES);
+  ReactorGLES(const ReactorGLES&) = delete;
+
+  ReactorGLES& operator=(const ReactorGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/render_pass_gles.h
+++ b/impeller/renderer/backend/gles/render_pass_gles.h
@@ -39,7 +39,9 @@ class RenderPassGLES final
   // |RenderPass|
   bool OnEncodeCommands(const Context& context) const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RenderPassGLES);
+  RenderPassGLES(const RenderPassGLES&) = delete;
+
+  RenderPassGLES& operator=(const RenderPassGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/sampler_gles.h
+++ b/impeller/renderer/backend/gles/sampler_gles.h
@@ -30,7 +30,9 @@ class SamplerGLES final : public Sampler,
   // |Sampler|
   bool IsValid() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SamplerGLES);
+  SamplerGLES(const SamplerGLES&) = delete;
+
+  SamplerGLES& operator=(const SamplerGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/sampler_library_gles.h
+++ b/impeller/renderer/backend/gles/sampler_library_gles.h
@@ -29,7 +29,9 @@ class SamplerLibraryGLES final : public SamplerLibrary {
 
   bool supports_decal_sampler_address_mode_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SamplerLibraryGLES);
+  SamplerLibraryGLES(const SamplerLibraryGLES&) = delete;
+
+  SamplerLibraryGLES& operator=(const SamplerLibraryGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/shader_function_gles.h
+++ b/impeller/renderer/backend/gles/shader_function_gles.h
@@ -34,7 +34,9 @@ class ShaderFunctionGLES final
                      std::string name,
                      std::shared_ptr<const fml::Mapping> mapping);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderFunctionGLES);
+  ShaderFunctionGLES(const ShaderFunctionGLES&) = delete;
+
+  ShaderFunctionGLES& operator=(const ShaderFunctionGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/shader_library_gles.h
+++ b/impeller/renderer/backend/gles/shader_library_gles.h
@@ -46,7 +46,9 @@ class ShaderLibraryGLES final : public ShaderLibrary {
   // |ShaderLibrary|
   void UnregisterFunction(std::string name, ShaderStage stage) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderLibraryGLES);
+  ShaderLibraryGLES(const ShaderLibraryGLES&) = delete;
+
+  ShaderLibraryGLES& operator=(const ShaderLibraryGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/surface_gles.h
+++ b/impeller/renderer/backend/gles/surface_gles.h
@@ -36,7 +36,9 @@ class SurfaceGLES final : public Surface {
   // |Surface|
   bool Present() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SurfaceGLES);
+  SurfaceGLES(const SurfaceGLES&) = delete;
+
+  SurfaceGLES& operator=(const SurfaceGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/impeller/renderer/backend/gles/test/mock_gles.h
@@ -53,7 +53,9 @@ class MockGLES final {
   const ProcTableGLES proc_table_;
   std::vector<std::string> captured_calls_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(MockGLES);
+  MockGLES(const MockGLES&) = delete;
+
+  MockGLES& operator=(const MockGLES&) = delete;
 };
 
 }  // namespace testing

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -89,7 +89,9 @@ class TextureGLES final : public Texture,
 
   void InitializeContentsIfNecessary() const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TextureGLES);
+  TextureGLES(const TextureGLES&) = delete;
+
+  TextureGLES& operator=(const TextureGLES&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/allocator_mtl.h
+++ b/impeller/renderer/backend/metal/allocator_mtl.h
@@ -47,7 +47,9 @@ class AllocatorMTL final : public Allocator {
   // |Allocator|
   ISize GetMaxTextureSizeSupported() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AllocatorMTL);
+  AllocatorMTL(const AllocatorMTL&) = delete;
+
+  AllocatorMTL& operator=(const AllocatorMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/blit_pass_mtl.h
+++ b/impeller/renderer/backend/metal/blit_pass_mtl.h
@@ -62,7 +62,9 @@ class BlitPassMTL final : public BlitPass {
   bool OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                std::string label) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(BlitPassMTL);
+  BlitPassMTL(const BlitPassMTL&) = delete;
+
+  BlitPassMTL& operator=(const BlitPassMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/command_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.h
@@ -48,7 +48,9 @@ class CommandBufferMTL final : public CommandBuffer {
   // |CommandBuffer|
   std::shared_ptr<ComputePass> OnCreateComputePass() override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CommandBufferMTL);
+  CommandBufferMTL(const CommandBufferMTL&) = delete;
+
+  CommandBufferMTL& operator=(const CommandBufferMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/compute_pass_mtl.h
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.h
@@ -42,7 +42,9 @@ class ComputePassMTL final : public ComputePass {
                       const ISize& grid_size,
                       const ISize& thread_group_size) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ComputePassMTL);
+  ComputePassMTL(const ComputePassMTL&) = delete;
+
+  ComputePassMTL& operator=(const ComputePassMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/compute_pipeline_mtl.h
+++ b/impeller/renderer/backend/metal/compute_pipeline_mtl.h
@@ -35,7 +35,9 @@ class ComputePipelineMTL final
   // |Pipeline|
   bool IsValid() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ComputePipelineMTL);
+  ComputePipelineMTL(const ComputePipelineMTL&) = delete;
+
+  ComputePipelineMTL& operator=(const ComputePipelineMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -139,7 +139,9 @@ class ContextMTL final : public Context,
 
   void FlushTasksAwaitingGPU();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ContextMTL);
+  ContextMTL(const ContextMTL&) = delete;
+
+  ContextMTL& operator=(const ContextMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/device_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/device_buffer_mtl.h
@@ -51,7 +51,9 @@ class DeviceBufferMTL final : public DeviceBuffer,
   // |DeviceBuffer|
   bool SetLabel(const std::string& label, Range range) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DeviceBufferMTL);
+  DeviceBufferMTL(const DeviceBufferMTL&) = delete;
+
+  DeviceBufferMTL& operator=(const DeviceBufferMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/pipeline_library_mtl.h
+++ b/impeller/renderer/backend/metal/pipeline_library_mtl.h
@@ -44,7 +44,9 @@ class PipelineLibraryMTL final : public PipelineLibrary {
   void RemovePipelinesWithEntryPoint(
       std::shared_ptr<const ShaderFunction> function) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PipelineLibraryMTL);
+  PipelineLibraryMTL(const PipelineLibraryMTL&) = delete;
+
+  PipelineLibraryMTL& operator=(const PipelineLibraryMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/pipeline_mtl.h
+++ b/impeller/renderer/backend/metal/pipeline_mtl.h
@@ -38,7 +38,9 @@ class PipelineMTL final
   // |Pipeline|
   bool IsValid() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PipelineMTL);
+  PipelineMTL(const PipelineMTL&) = delete;
+
+  PipelineMTL& operator=(const PipelineMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -41,7 +41,9 @@ class RenderPassMTL final : public RenderPass {
   bool EncodeCommands(const std::shared_ptr<Allocator>& transients_allocator,
                       id<MTLRenderCommandEncoder> pass) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RenderPassMTL);
+  RenderPassMTL(const RenderPassMTL&) = delete;
+
+  RenderPassMTL& operator=(const RenderPassMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/sampler_library_mtl.h
+++ b/impeller/renderer/backend/metal/sampler_library_mtl.h
@@ -35,7 +35,9 @@ class SamplerLibraryMTL final
   std::shared_ptr<const Sampler> GetSampler(
       SamplerDescriptor descriptor) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SamplerLibraryMTL);
+  SamplerLibraryMTL(const SamplerLibraryMTL&) = delete;
+
+  SamplerLibraryMTL& operator=(const SamplerLibraryMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/sampler_mtl.h
+++ b/impeller/renderer/backend/metal/sampler_mtl.h
@@ -34,7 +34,9 @@ class SamplerMTL final : public Sampler,
   // |Sampler|
   bool IsValid() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SamplerMTL);
+  SamplerMTL(const SamplerMTL&) = delete;
+
+  SamplerMTL& operator=(const SamplerMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/shader_function_mtl.h
+++ b/impeller/renderer/backend/metal/shader_function_mtl.h
@@ -31,7 +31,9 @@ class ShaderFunctionMTL final
                     std::string name,
                     ShaderStage stage);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderFunctionMTL);
+  ShaderFunctionMTL(const ShaderFunctionMTL&) = delete;
+
+  ShaderFunctionMTL& operator=(const ShaderFunctionMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/shader_library_mtl.h
+++ b/impeller/renderer/backend/metal/shader_library_mtl.h
@@ -58,7 +58,9 @@ class ShaderLibraryMTL final : public ShaderLibrary {
 
   void RegisterLibrary(id<MTLLibrary> library);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderLibraryMTL);
+  ShaderLibraryMTL(const ShaderLibraryMTL&) = delete;
+
+  ShaderLibraryMTL& operator=(const ShaderLibraryMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/surface_mtl.h
+++ b/impeller/renderer/backend/metal/surface_mtl.h
@@ -81,7 +81,9 @@ class SurfaceMTL final : public Surface {
              bool requires_blit,
              std::optional<IRect> clip_rect);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SurfaceMTL);
+  SurfaceMTL(const SurfaceMTL&) = delete;
+
+  SurfaceMTL& operator=(const SurfaceMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/texture_mtl.h
+++ b/impeller/renderer/backend/metal/texture_mtl.h
@@ -56,7 +56,9 @@ class TextureMTL final : public Texture,
   // |Texture|
   ISize GetSize() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TextureMTL);
+  TextureMTL(const TextureMTL&) = delete;
+
+  TextureMTL& operator=(const TextureMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/vertex_descriptor_mtl.h
+++ b/impeller/renderer/backend/metal/vertex_descriptor_mtl.h
@@ -29,7 +29,9 @@ class VertexDescriptorMTL {
  private:
   MTLVertexDescriptor* descriptor_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(VertexDescriptorMTL);
+  VertexDescriptorMTL(const VertexDescriptorMTL&) = delete;
+
+  VertexDescriptorMTL& operator=(const VertexDescriptorMTL&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -379,13 +379,17 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
       std::swap(image_view, o.image_view);
     }
 
-    FML_DISALLOW_COPY_AND_ASSIGN(ImageResource);
+    ImageResource(const ImageResource&) = delete;
+
+    ImageResource& operator=(const ImageResource&) = delete;
   };
 
   UniqueResourceVKT<ImageResource> resource_;
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AllocatedTextureSourceVK);
+  AllocatedTextureSourceVK(const AllocatedTextureSourceVK&) = delete;
+
+  AllocatedTextureSourceVK& operator=(const AllocatedTextureSourceVK&) = delete;
 };
 
 // |Allocator|

--- a/impeller/renderer/backend/vulkan/allocator_vk.h
+++ b/impeller/renderer/backend/vulkan/allocator_vk.h
@@ -61,7 +61,9 @@ class AllocatorVK final : public Allocator {
   // |Allocator|
   ISize GetMaxTextureSizeSupported() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AllocatorVK);
+  AllocatorVK(const AllocatorVK&) = delete;
+
+  AllocatorVK& operator=(const AllocatorVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.h
+++ b/impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.h
@@ -47,7 +47,11 @@ class AndroidHardwareBufferTextureSourceVK final : public TextureSourceVK {
 
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AndroidHardwareBufferTextureSourceVK);
+  AndroidHardwareBufferTextureSourceVK(
+      const AndroidHardwareBufferTextureSourceVK&) = delete;
+
+  AndroidHardwareBufferTextureSourceVK& operator=(
+      const AndroidHardwareBufferTextureSourceVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/blit_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/blit_pass_vk.h
@@ -61,7 +61,9 @@ class BlitPassVK final : public BlitPass {
   bool OnGenerateMipmapCommand(std::shared_ptr<Texture> texture,
                                std::string label) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(BlitPassVK);
+  BlitPassVK(const BlitPassVK&) = delete;
+
+  BlitPassVK& operator=(const BlitPassVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -115,7 +115,9 @@ class CapabilitiesVK final : public Capabilities,
 
   bool HasLayer(const std::string& layer) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CapabilitiesVK);
+  CapabilitiesVK(const CapabilitiesVK&) = delete;
+
+  CapabilitiesVK& operator=(const CapabilitiesVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/command_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.h
@@ -55,7 +55,9 @@ class CommandBufferVK final
   // |CommandBuffer|
   std::shared_ptr<ComputePass> OnCreateComputePass() override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CommandBufferVK);
+  CommandBufferVK(const CommandBufferVK&) = delete;
+
+  CommandBufferVK& operator=(const CommandBufferVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -94,7 +94,9 @@ class TrackedObjectsVK {
   std::unique_ptr<GPUProbe> probe_;
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TrackedObjectsVK);
+  TrackedObjectsVK(const TrackedObjectsVK&) = delete;
+
+  TrackedObjectsVK& operator=(const TrackedObjectsVK&) = delete;
 };
 
 CommandEncoderFactoryVK::CommandEncoderFactoryVK(

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -40,7 +40,9 @@ class CommandEncoderFactoryVK {
   std::weak_ptr<const ContextVK> context_;
   std::optional<std::string> label_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CommandEncoderFactoryVK);
+  CommandEncoderFactoryVK(const CommandEncoderFactoryVK&) = delete;
+
+  CommandEncoderFactoryVK& operator=(const CommandEncoderFactoryVK&) = delete;
 };
 
 class CommandEncoderVK {
@@ -95,7 +97,9 @@ class CommandEncoderVK {
 
   void Reset();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CommandEncoderVK);
+  CommandEncoderVK(const CommandEncoderVK&) = delete;
+
+  CommandEncoderVK& operator=(const CommandEncoderVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -46,7 +46,9 @@ class BackgroundCommandPoolVK final {
   }
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(BackgroundCommandPoolVK);
+  BackgroundCommandPoolVK(const BackgroundCommandPoolVK&) = delete;
+
+  BackgroundCommandPoolVK& operator=(const BackgroundCommandPoolVK&) = delete;
 
   vk::UniqueCommandPool pool_;
 

--- a/impeller/renderer/backend/vulkan/command_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.h
@@ -57,7 +57,9 @@ class CommandPoolVK final {
   void Destroy();
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(CommandPoolVK);
+  CommandPoolVK(const CommandPoolVK&) = delete;
+
+  CommandPoolVK& operator=(const CommandPoolVK&) = delete;
 
   Mutex pool_mutex_;
   vk::UniqueCommandPool pool_ IPLR_GUARDED_BY(pool_mutex_);
@@ -138,7 +140,9 @@ class CommandPoolRecyclerVK final
   /// @returns    Returns a |std::nullopt| if a pool was not available.
   std::optional<vk::UniqueCommandPool> Reuse();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CommandPoolRecyclerVK);
+  CommandPoolRecyclerVK(const CommandPoolRecyclerVK&) = delete;
+
+  CommandPoolRecyclerVK& operator=(const CommandPoolRecyclerVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/compute_pipeline_vk.h
+++ b/impeller/renderer/backend/vulkan/compute_pipeline_vk.h
@@ -47,7 +47,9 @@ class ComputePipelineVK final
   // |Pipeline|
   bool IsValid() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ComputePipelineVK);
+  ComputePipelineVK(const ComputePipelineVK&) = delete;
+
+  ComputePipelineVK& operator=(const ComputePipelineVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -204,7 +204,9 @@ class ContextVK final : public Context,
   std::unique_ptr<CommandEncoderFactoryVK> CreateGraphicsCommandEncoderFactory()
       const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ContextVK);
+  ContextVK(const ContextVK&) = delete;
+
+  ContextVK& operator=(const ContextVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/debug_report_vk.h
+++ b/impeller/renderer/backend/vulkan/debug_report_vk.h
@@ -38,7 +38,9 @@ class DebugReportVK {
       const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
       void* user_data);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DebugReportVK);
+  DebugReportVK(const DebugReportVK&) = delete;
+
+  DebugReportVK& operator=(const DebugReportVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
@@ -37,7 +37,9 @@ class DescriptorPoolVK {
   std::weak_ptr<const DeviceHolder> device_holder_;
   vk::UniqueDescriptorPool pool_ = {};
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DescriptorPoolVK);
+  DescriptorPoolVK(const DescriptorPoolVK&) = delete;
+
+  DescriptorPoolVK& operator=(const DescriptorPoolVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.h
@@ -46,7 +46,9 @@ class DeviceBufferVK final : public DeviceBuffer,
       std::swap(o.info, info);
     }
 
-    FML_DISALLOW_COPY_AND_ASSIGN(BufferResource);
+    BufferResource(const BufferResource&) = delete;
+
+    BufferResource& operator=(const BufferResource&) = delete;
   };
 
   std::weak_ptr<Context> context_;
@@ -66,7 +68,9 @@ class DeviceBufferVK final : public DeviceBuffer,
   // |DeviceBuffer|
   bool SetLabel(const std::string& label, Range range) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(DeviceBufferVK);
+  DeviceBufferVK(const DeviceBufferVK&) = delete;
+
+  DeviceBufferVK& operator=(const DeviceBufferVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -43,7 +43,13 @@ class WaitSetEntry {
       : fence_(std::move(p_fence)),
         callback_(fml::ScopedCleanupClosure{p_callback}) {}
 
-  FML_DISALLOW_COPY_ASSIGN_AND_MOVE(WaitSetEntry);
+  WaitSetEntry(const WaitSetEntry&) = delete;
+
+  WaitSetEntry(WaitSetEntry&&) = delete;
+
+  WaitSetEntry& operator=(const WaitSetEntry&) = delete;
+
+  WaitSetEntry& operator=(WaitSetEntry&&) = delete;
 };
 
 FenceWaiterVK::FenceWaiterVK(std::weak_ptr<DeviceHolder> device_holder)

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.h
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.h
@@ -50,7 +50,9 @@ class FenceWaiterVK {
   bool Wait();
   void WaitUntilEmpty();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(FenceWaiterVK);
+  FenceWaiterVK(const FenceWaiterVK&) = delete;
+
+  FenceWaiterVK& operator=(const FenceWaiterVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
+++ b/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
@@ -42,7 +42,9 @@ class PipelineCacheVK {
 
   std::shared_ptr<fml::Mapping> CopyPipelineCacheData() const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PipelineCacheVK);
+  PipelineCacheVK(const PipelineCacheVK&) = delete;
+
+  PipelineCacheVK& operator=(const PipelineCacheVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/pipeline_library_vk.h
+++ b/impeller/renderer/backend/vulkan/pipeline_library_vk.h
@@ -73,7 +73,9 @@ class PipelineLibraryVK final
 
   void PersistPipelineCacheToDisk();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PipelineLibraryVK);
+  PipelineLibraryVK(const PipelineLibraryVK&) = delete;
+
+  PipelineLibraryVK& operator=(const PipelineLibraryVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/pipeline_vk.h
+++ b/impeller/renderer/backend/vulkan/pipeline_vk.h
@@ -50,7 +50,9 @@ class PipelineVK final
   // |Pipeline|
   bool IsValid() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(PipelineVK);
+  PipelineVK(const PipelineVK&) = delete;
+
+  PipelineVK& operator=(const PipelineVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/queue_vk.h
+++ b/impeller/renderer/backend/vulkan/queue_vk.h
@@ -47,7 +47,9 @@ class QueueVK {
   const QueueIndexVK index_;
   const vk::Queue queue_ IPLR_GUARDED_BY(queue_mutex_);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(QueueVK);
+  QueueVK(const QueueVK&) = delete;
+
+  QueueVK& operator=(const QueueVK&) = delete;
 };
 
 //------------------------------------------------------------------------------

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -49,7 +49,9 @@ class RenderPassVK final : public RenderPass {
       const ContextVK& context,
       const vk::RenderPass& pass) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RenderPassVK);
+  RenderPassVK(const RenderPassVK&) = delete;
+
+  RenderPassVK& operator=(const RenderPassVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/resource_manager_vk.h
+++ b/impeller/renderer/backend/vulkan/resource_manager_vk.h
@@ -96,7 +96,9 @@ class ResourceManagerVK final
   /// collected when the resource manager is collected.
   void Terminate();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ResourceManagerVK);
+  ResourceManagerVK(const ResourceManagerVK&) = delete;
+
+  ResourceManagerVK& operator=(const ResourceManagerVK&) = delete;
 };
 
 //------------------------------------------------------------------------------
@@ -127,7 +129,9 @@ class ResourceVKT : public ResourceVK {
 
   ResourceType resource_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ResourceVKT);
+  ResourceVKT(const ResourceVKT&) = delete;
+
+  ResourceVKT& operator=(const ResourceVKT&) = delete;
 };
 
 //------------------------------------------------------------------------------
@@ -198,7 +202,9 @@ class UniqueResourceVKT final {
   std::weak_ptr<ResourceManagerVK> resource_manager_;
   std::unique_ptr<ResourceVKT<ResourceType>> resource_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(UniqueResourceVKT);
+  UniqueResourceVKT(const UniqueResourceVKT&) = delete;
+
+  UniqueResourceVKT& operator=(const UniqueResourceVKT&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/sampler_library_vk.h
+++ b/impeller/renderer/backend/vulkan/sampler_library_vk.h
@@ -33,7 +33,9 @@ class SamplerLibraryVK final
   std::shared_ptr<const Sampler> GetSampler(
       SamplerDescriptor descriptor) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SamplerLibraryVK);
+  SamplerLibraryVK(const SamplerLibraryVK&) = delete;
+
+  SamplerLibraryVK& operator=(const SamplerLibraryVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/sampler_vk.h
+++ b/impeller/renderer/backend/vulkan/sampler_vk.h
@@ -34,7 +34,9 @@ class SamplerVK final : public Sampler, public BackendCast<SamplerVK, Sampler> {
   // |Sampler|
   bool IsValid() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SamplerVK);
+  SamplerVK(const SamplerVK&) = delete;
+
+  SamplerVK& operator=(const SamplerVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/shader_function_vk.h
+++ b/impeller/renderer/backend/vulkan/shader_function_vk.h
@@ -34,7 +34,9 @@ class ShaderFunctionVK final
                    ShaderStage stage,
                    vk::UniqueShaderModule module);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderFunctionVK);
+  ShaderFunctionVK(const ShaderFunctionVK&) = delete;
+
+  ShaderFunctionVK& operator=(const ShaderFunctionVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/shader_library_vk.h
+++ b/impeller/renderer/backend/vulkan/shader_library_vk.h
@@ -51,7 +51,9 @@ class ShaderLibraryVK final : public ShaderLibrary {
   // |ShaderLibrary|
   void UnregisterFunction(std::string name, ShaderStage stage) override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderLibraryVK);
+  ShaderLibraryVK(const ShaderLibraryVK&) = delete;
+
+  ShaderLibraryVK& operator=(const ShaderLibraryVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/shared_object_vk.h
+++ b/impeller/renderer/backend/vulkan/shared_object_vk.h
@@ -32,7 +32,9 @@ class SharedObjectVKT : public SharedObjectVK {
  private:
   UniqueResource resource_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SharedObjectVKT);
+  SharedObjectVKT(const SharedObjectVKT&) = delete;
+
+  SharedObjectVKT& operator=(const SharedObjectVKT&) = delete;
 };
 
 template <class T>

--- a/impeller/renderer/backend/vulkan/surface_vk.h
+++ b/impeller/renderer/backend/vulkan/surface_vk.h
@@ -33,7 +33,9 @@ class SurfaceVK final : public Surface {
   // |Surface|
   bool Present() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SurfaceVK);
+  SurfaceVK(const SurfaceVK&) = delete;
+
+  SurfaceVK& operator=(const SurfaceVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/swapchain_image_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain_image_vk.h
@@ -45,7 +45,9 @@ class SwapchainImageVK final : public TextureSourceVK {
   std::shared_ptr<Texture> msaa_tex_;
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SwapchainImageVK);
+  SwapchainImageVK(const SwapchainImageVK&) = delete;
+
+  SwapchainImageVK& operator=(const SwapchainImageVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
@@ -82,7 +82,9 @@ class SwapchainImplVK final
 
   void WaitIdle() const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SwapchainImplVK);
+  SwapchainImplVK(const SwapchainImplVK&) = delete;
+
+  SwapchainImplVK& operator=(const SwapchainImplVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/swapchain_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain_vk.h
@@ -40,7 +40,9 @@ class SwapchainVK {
 
   explicit SwapchainVK(std::shared_ptr<SwapchainImplVK> impl);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SwapchainVK);
+  SwapchainVK(const SwapchainVK&) = delete;
+
+  SwapchainVK& operator=(const SwapchainVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -70,7 +70,9 @@ class MockDevice final {
   }
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(MockDevice);
+  MockDevice(const MockDevice&) = delete;
+
+  MockDevice& operator=(const MockDevice&) = delete;
 
   Mutex called_functions_mutex_;
   std::shared_ptr<std::vector<std::string>> called_functions_

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -49,7 +49,9 @@ class MockFence final {
  private:
   std::atomic<vk::Result> result_ = vk::Result::eSuccess;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(MockFence);
+  MockFence(const MockFence&) = delete;
+
+  MockFence& operator=(const MockFence&) = delete;
 };
 
 class MockVulkanContextBuilder {

--- a/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/impeller/renderer/backend/vulkan/texture_vk.h
@@ -59,7 +59,9 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
   // |Texture|
   ISize GetSize() const override;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TextureVK);
+  TextureVK(const TextureVK&) = delete;
+
+  TextureVK& operator=(const TextureVK&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/blit_pass.h
+++ b/impeller/renderer/blit_pass.h
@@ -157,7 +157,9 @@ class BlitPass {
                                        std::string label) = 0;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(BlitPass);
+  BlitPass(const BlitPass&) = delete;
+
+  BlitPass& operator=(const BlitPass&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/capabilities.cc
+++ b/impeller/renderer/capabilities.cc
@@ -129,7 +129,9 @@ class StandardCapabilities final : public Capabilities {
   PixelFormat default_stencil_format_ = PixelFormat::kUnknown;
   PixelFormat default_depth_stencil_format_ = PixelFormat::kUnknown;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(StandardCapabilities);
+  StandardCapabilities(const StandardCapabilities&) = delete;
+
+  StandardCapabilities& operator=(const StandardCapabilities&) = delete;
 };
 
 CapabilitiesBuilder::CapabilitiesBuilder() = default;

--- a/impeller/renderer/capabilities.h
+++ b/impeller/renderer/capabilities.h
@@ -106,7 +106,9 @@ class Capabilities {
  protected:
   Capabilities();
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Capabilities);
+  Capabilities(const Capabilities&) = delete;
+
+  Capabilities& operator=(const Capabilities&) = delete;
 };
 
 class CapabilitiesBuilder {
@@ -161,7 +163,9 @@ class CapabilitiesBuilder {
   std::optional<PixelFormat> default_stencil_format_ = std::nullopt;
   std::optional<PixelFormat> default_depth_stencil_format_ = std::nullopt;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CapabilitiesBuilder);
+  CapabilitiesBuilder(const CapabilitiesBuilder&) = delete;
+
+  CapabilitiesBuilder& operator=(const CapabilitiesBuilder&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/command_buffer.h
+++ b/impeller/renderer/command_buffer.h
@@ -130,7 +130,9 @@ class CommandBuffer {
   virtual std::shared_ptr<ComputePass> OnCreateComputePass() = 0;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(CommandBuffer);
+  CommandBuffer(const CommandBuffer&) = delete;
+
+  CommandBuffer& operator=(const CommandBuffer&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/compute_pass.h
+++ b/impeller/renderer/compute_pass.h
@@ -74,7 +74,9 @@ class ComputePass {
   ISize grid_size_ = ISize(32, 32);
   ISize thread_group_size_ = ISize(32, 32);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ComputePass);
+  ComputePass(const ComputePass&) = delete;
+
+  ComputePass& operator=(const ComputePass&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/compute_tessellator.h
+++ b/impeller/renderer/compute_tessellator.h
@@ -78,7 +78,9 @@ class ComputeTessellator {
   Scalar cubic_accuracy_ = kDefaultCurveTolerance;
   Scalar quad_tolerance_ = .1f;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ComputeTessellator);
+  ComputeTessellator(const ComputeTessellator&) = delete;
+
+  ComputeTessellator& operator=(const ComputeTessellator&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -205,7 +205,9 @@ class Context {
  private:
   mutable Pool<HostBuffer> host_buffer_pool_ = Pool<HostBuffer>(1'000'000);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Context);
+  Context(const Context&) = delete;
+
+  Context& operator=(const Context&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/pipeline.h
+++ b/impeller/renderer/pipeline.h
@@ -70,7 +70,9 @@ class Pipeline {
   const std::weak_ptr<PipelineLibrary> library_;
   const T desc_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Pipeline);
+  Pipeline(const Pipeline&) = delete;
+
+  Pipeline& operator=(const Pipeline&) = delete;
 };
 
 extern template class Pipeline<PipelineDescriptor>;
@@ -123,7 +125,9 @@ class RenderPipelineT {
   std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline_;
   bool did_wait_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RenderPipelineT);
+  RenderPipelineT(const RenderPipelineT&) = delete;
+
+  RenderPipelineT& operator=(const RenderPipelineT&) = delete;
 };
 
 template <class ComputeShader_>
@@ -161,7 +165,9 @@ class ComputePipelineT {
   std::shared_ptr<Pipeline<ComputePipelineDescriptor>> pipeline_;
   bool did_wait_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ComputePipelineT);
+  ComputePipelineT(const ComputePipelineT&) = delete;
+
+  ComputePipelineT& operator=(const ComputePipelineT&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/pipeline_library.h
+++ b/impeller/renderer/pipeline_library.h
@@ -51,7 +51,9 @@ class PipelineLibrary : public std::enable_shared_from_this<PipelineLibrary> {
   PipelineLibrary();
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(PipelineLibrary);
+  PipelineLibrary(const PipelineLibrary&) = delete;
+
+  PipelineLibrary& operator=(const PipelineLibrary&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -79,7 +79,9 @@ class RenderPass {
   virtual bool OnEncodeCommands(const Context& context) const = 0;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(RenderPass);
+  RenderPass(const RenderPass&) = delete;
+
+  RenderPass& operator=(const RenderPass&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/renderer.h
+++ b/impeller/renderer/renderer.h
@@ -41,7 +41,9 @@ class Renderer {
   std::shared_ptr<Context> context_;
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Renderer);
+  Renderer(const Renderer&) = delete;
+
+  Renderer& operator=(const Renderer&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/sampler_library.h
+++ b/impeller/renderer/sampler_library.h
@@ -22,7 +22,9 @@ class SamplerLibrary {
   SamplerLibrary();
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(SamplerLibrary);
+  SamplerLibrary(const SamplerLibrary&) = delete;
+
+  SamplerLibrary& operator=(const SamplerLibrary&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/shader_function.h
+++ b/impeller/renderer/shader_function.h
@@ -34,7 +34,9 @@ class ShaderFunction : public Comparable<ShaderFunction> {
   std::string name_;
   ShaderStage stage_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderFunction);
+  ShaderFunction(const ShaderFunction&) = delete;
+
+  ShaderFunction& operator=(const ShaderFunction&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/shader_library.h
+++ b/impeller/renderer/shader_library.h
@@ -39,7 +39,9 @@ class ShaderLibrary : public std::enable_shared_from_this<ShaderLibrary> {
   ShaderLibrary();
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderLibrary);
+  ShaderLibrary(const ShaderLibrary&) = delete;
+
+  ShaderLibrary& operator=(const ShaderLibrary&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/surface.h
+++ b/impeller/renderer/surface.h
@@ -36,7 +36,9 @@ class Surface {
 
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Surface);
+  Surface(const Surface&) = delete;
+
+  Surface& operator=(const Surface&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/vertex_descriptor.h
+++ b/impeller/renderer/vertex_descriptor.h
@@ -69,7 +69,9 @@ class VertexDescriptor final : public Comparable<VertexDescriptor> {
   std::vector<ShaderStageBufferLayout> layouts_;
   std::vector<DescriptorSetLayout> desc_set_layouts_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(VertexDescriptor);
+  VertexDescriptor(const VertexDescriptor&) = delete;
+
+  VertexDescriptor& operator=(const VertexDescriptor&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/runtime_stage/runtime_stage.h
+++ b/impeller/runtime_stage/runtime_stage.h
@@ -50,7 +50,9 @@ class RuntimeStage {
   bool is_valid_ = false;
   bool is_dirty_ = true;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RuntimeStage);
+  RuntimeStage(const RuntimeStage&) = delete;
+
+  RuntimeStage& operator=(const RuntimeStage&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/runtime_stage/runtime_stage_playground.h
+++ b/impeller/runtime_stage/runtime_stage_playground.h
@@ -19,7 +19,9 @@ class RuntimeStagePlayground : public PlaygroundTest {
   bool RegisterStage(const RuntimeStage& stage);
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(RuntimeStagePlayground);
+  RuntimeStagePlayground(const RuntimeStagePlayground&) = delete;
+
+  RuntimeStagePlayground& operator=(const RuntimeStagePlayground&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/scene/animation/animation.h
+++ b/impeller/scene/animation/animation.h
@@ -70,7 +70,9 @@ class Animation final {
   std::vector<Channel> channels_;
   SecondsF end_time_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Animation);
+  Animation(const Animation&) = delete;
+
+  Animation& operator=(const Animation&) = delete;
 };
 
 }  // namespace scene

--- a/impeller/scene/animation/animation_clip.h
+++ b/impeller/scene/animation/animation_clip.h
@@ -83,7 +83,9 @@ class AnimationClip final {
   bool playing_ = false;
   bool loop_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AnimationClip);
+  AnimationClip(const AnimationClip&) = delete;
+
+  AnimationClip& operator=(const AnimationClip&) = delete;
 
   friend AnimationPlayer;
 };

--- a/impeller/scene/animation/animation_player.h
+++ b/impeller/scene/animation/animation_player.h
@@ -45,7 +45,9 @@ class AnimationPlayer final {
 
   std::optional<TimePoint> previous_time_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(AnimationPlayer);
+  AnimationPlayer(const AnimationPlayer&) = delete;
+
+  AnimationPlayer& operator=(const AnimationPlayer&) = delete;
 };
 
 }  // namespace scene

--- a/impeller/scene/animation/property_resolver.h
+++ b/impeller/scene/animation/property_resolver.h
@@ -87,7 +87,10 @@ class TranslationTimelineResolver final : public TimelineResolver {
 
   std::vector<Vector3> values_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TranslationTimelineResolver);
+  TranslationTimelineResolver(const TranslationTimelineResolver&) = delete;
+
+  TranslationTimelineResolver& operator=(const TranslationTimelineResolver&) =
+      delete;
 
   friend PropertyResolver;
 };
@@ -106,7 +109,9 @@ class RotationTimelineResolver final : public TimelineResolver {
 
   std::vector<Quaternion> values_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(RotationTimelineResolver);
+  RotationTimelineResolver(const RotationTimelineResolver&) = delete;
+
+  RotationTimelineResolver& operator=(const RotationTimelineResolver&) = delete;
 
   friend PropertyResolver;
 };
@@ -125,7 +130,9 @@ class ScaleTimelineResolver final : public TimelineResolver {
 
   std::vector<Vector3> values_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ScaleTimelineResolver);
+  ScaleTimelineResolver(const ScaleTimelineResolver&) = delete;
+
+  ScaleTimelineResolver& operator=(const ScaleTimelineResolver&) = delete;
 
   friend PropertyResolver;
 };

--- a/impeller/scene/geometry.h
+++ b/impeller/scene/geometry.h
@@ -72,7 +72,9 @@ class CuboidGeometry final : public Geometry {
  private:
   Vector3 size_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(CuboidGeometry);
+  CuboidGeometry(const CuboidGeometry&) = delete;
+
+  CuboidGeometry& operator=(const CuboidGeometry&) = delete;
 };
 
 class UnskinnedVertexBufferGeometry final : public Geometry {
@@ -98,7 +100,10 @@ class UnskinnedVertexBufferGeometry final : public Geometry {
  private:
   VertexBuffer vertex_buffer_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(UnskinnedVertexBufferGeometry);
+  UnskinnedVertexBufferGeometry(const UnskinnedVertexBufferGeometry&) = delete;
+
+  UnskinnedVertexBufferGeometry& operator=(
+      const UnskinnedVertexBufferGeometry&) = delete;
 };
 
 class SkinnedVertexBufferGeometry final : public Geometry {
@@ -128,7 +133,10 @@ class SkinnedVertexBufferGeometry final : public Geometry {
   VertexBuffer vertex_buffer_;
   std::shared_ptr<Texture> joints_texture_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SkinnedVertexBufferGeometry);
+  SkinnedVertexBufferGeometry(const SkinnedVertexBufferGeometry&) = delete;
+
+  SkinnedVertexBufferGeometry& operator=(const SkinnedVertexBufferGeometry&) =
+      delete;
 };
 
 }  // namespace scene

--- a/impeller/scene/importer/vertices_builder.h
+++ b/impeller/scene/importer/vertices_builder.h
@@ -91,7 +91,9 @@ class VerticesBuilder {
                   VerticesBuilder::AttributeProperties>
       kAttributeTypes;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(VerticesBuilder);
+  VerticesBuilder(const VerticesBuilder&) = delete;
+
+  VerticesBuilder& operator=(const VerticesBuilder&) = delete;
 };
 
 //------------------------------------------------------------------------------
@@ -125,7 +127,9 @@ class UnskinnedVerticesBuilder final : public VerticesBuilder {
  private:
   std::vector<Vertex> vertices_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(UnskinnedVerticesBuilder);
+  UnskinnedVerticesBuilder(const UnskinnedVerticesBuilder&) = delete;
+
+  UnskinnedVerticesBuilder& operator=(const UnskinnedVerticesBuilder&) = delete;
 };
 
 //------------------------------------------------------------------------------
@@ -157,7 +161,9 @@ class SkinnedVerticesBuilder final : public VerticesBuilder {
  private:
   std::vector<Vertex> vertices_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SkinnedVerticesBuilder);
+  SkinnedVerticesBuilder(const SkinnedVerticesBuilder&) = delete;
+
+  SkinnedVerticesBuilder& operator=(const SkinnedVerticesBuilder&) = delete;
 };
 
 }  // namespace importer

--- a/impeller/scene/mesh.h
+++ b/impeller/scene/mesh.h
@@ -40,7 +40,9 @@ class Mesh final {
  private:
   std::vector<Primitive> primitives_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Mesh);
+  Mesh(const Mesh&) = delete;
+
+  Mesh& operator=(const Mesh&) = delete;
 };
 
 }  // namespace scene

--- a/impeller/scene/node.h
+++ b/impeller/scene/node.h
@@ -128,7 +128,9 @@ class Node final {
 
   std::unique_ptr<Skin> skin_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Node);
+  Node(const Node&) = delete;
+
+  Node& operator=(const Node&) = delete;
 
   friend Scene;
 };

--- a/impeller/scene/scene.h
+++ b/impeller/scene/scene.h
@@ -36,7 +36,9 @@ class Scene {
   std::shared_ptr<SceneContext> scene_context_;
   Node root_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Scene);
+  Scene(const Scene&) = delete;
+
+  Scene& operator=(const Scene&) = delete;
 };
 
 }  // namespace scene

--- a/impeller/scene/scene_context.h
+++ b/impeller/scene/scene_context.h
@@ -127,7 +127,9 @@ class SceneContext {
   // Available for the lifetime of the scene context
   std::shared_ptr<Texture> placeholder_texture_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SceneContext);
+  SceneContext(const SceneContext&) = delete;
+
+  SceneContext& operator=(const SceneContext&) = delete;
 };
 
 }  // namespace scene

--- a/impeller/scene/scene_encoder.h
+++ b/impeller/scene/scene_encoder.h
@@ -42,7 +42,9 @@ class SceneEncoder {
 
   friend Scene;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(SceneEncoder);
+  SceneEncoder(const SceneEncoder&) = delete;
+
+  SceneEncoder& operator=(const SceneEncoder&) = delete;
 };
 
 }  // namespace scene

--- a/impeller/scene/skin.h
+++ b/impeller/scene/skin.h
@@ -35,7 +35,9 @@ class Skin final {
   std::vector<std::shared_ptr<Node>> joints_;
   std::vector<Matrix> inverse_bind_matrices_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Skin);
+  Skin(const Skin&) = delete;
+
+  Skin& operator=(const Skin&) = delete;
 };
 
 }  // namespace scene

--- a/impeller/shader_archive/multi_arch_shader_archive.h
+++ b/impeller/shader_archive/multi_arch_shader_archive.h
@@ -38,7 +38,9 @@ class MultiArchShaderArchive {
       backend_mappings_;
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(MultiArchShaderArchive);
+  MultiArchShaderArchive(const MultiArchShaderArchive&) = delete;
+
+  MultiArchShaderArchive& operator=(const MultiArchShaderArchive&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/shader_archive/multi_arch_shader_archive_writer.h
+++ b/impeller/shader_archive/multi_arch_shader_archive_writer.h
@@ -28,7 +28,10 @@ class MultiArchShaderArchiveWriter {
   std::map<ArchiveRenderingBackend, std::shared_ptr<const fml::Mapping>>
       archives_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(MultiArchShaderArchiveWriter);
+  MultiArchShaderArchiveWriter(const MultiArchShaderArchiveWriter&) = delete;
+
+  MultiArchShaderArchiveWriter& operator=(const MultiArchShaderArchiveWriter&) =
+      delete;
 };
 
 }  // namespace impeller

--- a/impeller/shader_archive/shader_archive.h
+++ b/impeller/shader_archive/shader_archive.h
@@ -69,7 +69,9 @@ class ShaderArchive {
 
   explicit ShaderArchive(std::shared_ptr<const fml::Mapping> payload);
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderArchive);
+  ShaderArchive(const ShaderArchive&) = delete;
+
+  ShaderArchive& operator=(const ShaderArchive&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/shader_archive/shader_archive_writer.h
+++ b/impeller/shader_archive/shader_archive_writer.h
@@ -37,7 +37,9 @@ class ShaderArchiveWriter {
 
   std::vector<ShaderDescription> shader_descriptions_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(ShaderArchiveWriter);
+  ShaderArchiveWriter(const ShaderArchiveWriter&) = delete;
+
+  ShaderArchiveWriter& operator=(const ShaderArchiveWriter&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/tessellator/tessellator.h
+++ b/impeller/tessellator/tessellator.h
@@ -74,7 +74,9 @@ class Tessellator {
  private:
   CTessellator c_tessellator_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Tessellator);
+  Tessellator(const Tessellator&) = delete;
+
+  Tessellator& operator=(const Tessellator&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/toolkit/egl/config.h
+++ b/impeller/toolkit/egl/config.h
@@ -67,7 +67,9 @@ class Config {
   const ConfigDescriptor desc_;
   EGLConfig config_ = nullptr;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Config);
+  Config(const Config&) = delete;
+
+  Config& operator=(const Config&) = delete;
 };
 
 }  // namespace egl

--- a/impeller/toolkit/egl/context.h
+++ b/impeller/toolkit/egl/context.h
@@ -49,7 +49,9 @@ class Context {
 
   void DispatchLifecyleEvent(LifecycleEvent event) const;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Context);
+  Context(const Context&) = delete;
+
+  Context& operator=(const Context&) = delete;
 };
 
 }  // namespace egl

--- a/impeller/toolkit/egl/display.h
+++ b/impeller/toolkit/egl/display.h
@@ -40,7 +40,9 @@ class Display {
  private:
   EGLDisplay display_ = EGL_NO_DISPLAY;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Display);
+  Display(const Display&) = delete;
+
+  Display& operator=(const Display&) = delete;
 };
 
 }  // namespace egl

--- a/impeller/toolkit/egl/surface.h
+++ b/impeller/toolkit/egl/surface.h
@@ -26,7 +26,9 @@ class Surface {
   EGLDisplay display_ = EGL_NO_DISPLAY;
   EGLSurface surface_ = EGL_NO_SURFACE;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(Surface);
+  Surface(const Surface&) = delete;
+
+  Surface& operator=(const Surface&) = delete;
 };
 
 }  // namespace egl

--- a/impeller/typographer/backends/skia/glyph_atlas_context_skia.h
+++ b/impeller/typographer/backends/skia/glyph_atlas_context_skia.h
@@ -31,7 +31,9 @@ class GlyphAtlasContextSkia
  private:
   std::shared_ptr<SkBitmap> bitmap_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(GlyphAtlasContextSkia);
+  GlyphAtlasContextSkia(const GlyphAtlasContextSkia&) = delete;
+
+  GlyphAtlasContextSkia& operator=(const GlyphAtlasContextSkia&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/typographer/backends/skia/typeface_skia.h
+++ b/impeller/typographer/backends/skia/typeface_skia.h
@@ -33,7 +33,9 @@ class TypefaceSkia final : public Typeface,
  private:
   sk_sp<SkTypeface> typeface_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TypefaceSkia);
+  TypefaceSkia(const TypefaceSkia&) = delete;
+
+  TypefaceSkia& operator=(const TypefaceSkia&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/typographer/backends/skia/typographer_context_skia.h
+++ b/impeller/typographer/backends/skia/typographer_context_skia.h
@@ -28,7 +28,9 @@ class TypographerContextSkia : public TypographerContext {
       const FontGlyphMap& font_glyph_map) const override;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(TypographerContextSkia);
+  TypographerContextSkia(const TypographerContextSkia&) = delete;
+
+  TypographerContextSkia& operator=(const TypographerContextSkia&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/typographer/backends/stb/glyph_atlas_context_stb.h
+++ b/impeller/typographer/backends/stb/glyph_atlas_context_stb.h
@@ -53,7 +53,9 @@ class GlyphAtlasContextSTB
  private:
   std::shared_ptr<BitmapSTB> bitmap_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(GlyphAtlasContextSTB);
+  GlyphAtlasContextSTB(const GlyphAtlasContextSTB&) = delete;
+
+  GlyphAtlasContextSTB& operator=(const GlyphAtlasContextSTB&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/typographer/backends/stb/typeface_stb.h
+++ b/impeller/typographer/backends/stb/typeface_stb.h
@@ -40,7 +40,9 @@ class TypefaceSTB final : public Typeface,
   std::unique_ptr<stbtt_fontinfo> font_info_;
   bool is_valid_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TypefaceSTB);
+  TypefaceSTB(const TypefaceSTB&) = delete;
+
+  TypefaceSTB& operator=(const TypefaceSTB&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/typographer/backends/stb/typographer_context_stb.h
+++ b/impeller/typographer/backends/stb/typographer_context_stb.h
@@ -30,7 +30,9 @@ class TypographerContextSTB : public TypographerContext {
       const FontGlyphMap& font_glyph_map) const override;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(TypographerContextSTB);
+  TypographerContextSTB(const TypographerContextSTB&) = delete;
+
+  TypographerContextSTB& operator=(const TypographerContextSTB&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/typographer/glyph_atlas.h
+++ b/impeller/typographer/glyph_atlas.h
@@ -133,7 +133,9 @@ class GlyphAtlas {
 
   std::unordered_map<ScaledFont, FontGlyphAtlas> font_atlas_map_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(GlyphAtlas);
+  GlyphAtlas(const GlyphAtlas&) = delete;
+
+  GlyphAtlas& operator=(const GlyphAtlas&) = delete;
 };
 
 //------------------------------------------------------------------------------
@@ -169,7 +171,9 @@ class GlyphAtlasContext {
   ISize atlas_size_;
   std::shared_ptr<RectanglePacker> rect_packer_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(GlyphAtlasContext);
+  GlyphAtlasContext(const GlyphAtlasContext&) = delete;
+
+  GlyphAtlasContext& operator=(const GlyphAtlasContext&) = delete;
 };
 
 //------------------------------------------------------------------------------
@@ -194,7 +198,9 @@ class FontGlyphAtlas {
   friend class GlyphAtlas;
   std::unordered_map<Glyph, Rect> positions_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(FontGlyphAtlas);
+  FontGlyphAtlas(const FontGlyphAtlas&) = delete;
+
+  FontGlyphAtlas& operator=(const FontGlyphAtlas&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/typographer/lazy_glyph_atlas.h
+++ b/impeller/typographer/lazy_glyph_atlas.h
@@ -39,7 +39,9 @@ class LazyGlyphAtlas {
   mutable std::unordered_map<GlyphAtlas::Type, std::shared_ptr<GlyphAtlas>>
       atlas_map_;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(LazyGlyphAtlas);
+  LazyGlyphAtlas(const LazyGlyphAtlas&) = delete;
+
+  LazyGlyphAtlas& operator=(const LazyGlyphAtlas&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/typographer/typeface.h
+++ b/impeller/typographer/typeface.h
@@ -25,7 +25,9 @@ class Typeface : public Comparable<Typeface> {
   virtual bool IsValid() const = 0;
 
  private:
-  FML_DISALLOW_COPY_AND_ASSIGN(Typeface);
+  Typeface(const Typeface&) = delete;
+
+  Typeface& operator=(const Typeface&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/typographer/typographer_context.h
+++ b/impeller/typographer/typographer_context.h
@@ -47,7 +47,9 @@ class TypographerContext {
  private:
   bool is_valid_ = false;
 
-  FML_DISALLOW_COPY_AND_ASSIGN(TypographerContext);
+  TypographerContext(const TypographerContext&) = delete;
+
+  TypographerContext& operator=(const TypographerContext&) = delete;
 };
 
 }  // namespace impeller


### PR DESCRIPTION
Really not convinced this is easier to read but maybe I just need to get used to it. Besides, good to just stick to the style guide uniformly.

Followup from https://github.com/flutter/engine/pull/47278#discussion_r1371971876

Can do this for the rest of the engine and remove the macros if this is fine.