### PR TITLE
[Windows] Refactor high contrast mode detection

### DIFF
--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -119,7 +119,7 @@ static uint64_t ConvertWinButtonToFlutterButton(UINT button) {
 FlutterWindow::FlutterWindow(
     int width,
     int height,
-    std::unique_ptr<WindowsProcTable> windows_proc_table,
+    std::shared_ptr<WindowsProcTable> windows_proc_table,
     std::unique_ptr<TextInputManager> text_input_manager)
     : binding_handler_delegate_(nullptr),
       touch_id_generator_(kMinTouchDeviceId, kMaxTouchDeviceId),
@@ -356,12 +356,7 @@ PointerLocation FlutterWindow::GetPrimaryPointerLocation() {
 }
 
 void FlutterWindow::OnThemeChange() {
-  binding_handler_delegate_->UpdateHighContrastEnabled(
-      GetHighContrastEnabled());
-}
-
-void FlutterWindow::SendInitialAccessibilityFeatures() {
-  OnThemeChange();
+  binding_handler_delegate_->OnHighContrastChanged();
 }
 
 ui::AXFragmentRootDelegateWin* FlutterWindow::GetAxFragmentRootDelegate() {
@@ -948,19 +943,6 @@ UINT FlutterWindow::GetCurrentHeight() {
 
 float FlutterWindow::GetScrollOffsetMultiplier() {
   return scroll_offset_multiplier_;
-}
-
-bool FlutterWindow::GetHighContrastEnabled() {
-  HIGHCONTRAST high_contrast = {.cbSize = sizeof(HIGHCONTRAST)};
-  // API call is only supported on Windows 8+
-  if (SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST),
-                            &high_contrast, 0)) {
-    return high_contrast.dwFlags & HCF_HIGHCONTRASTON;
-  } else {
-    FML_LOG(INFO) << "Failed to get status of high contrast feature,"
-                  << "support only for Windows 8 + ";
-    return false;
-  }
 }
 
 LRESULT FlutterWindow::Win32DefWindowProc(HWND hWnd,

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -38,7 +38,7 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
   // Create flutter Window for use as child window
   FlutterWindow(int width,
                 int height,
-                std::unique_ptr<WindowsProcTable> windows_proc_table = nullptr,
+                std::shared_ptr<WindowsProcTable> windows_proc_table = nullptr,
                 std::unique_ptr<TextInputManager> text_input_manager = nullptr);
 
   virtual ~FlutterWindow();
@@ -190,9 +190,6 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
   virtual void OnThemeChange();
 
   // |WindowBindingHandler|
-  virtual void SendInitialAccessibilityFeatures() override;
-
-  // |WindowBindingHandler|
   virtual AlertPlatformNodeDelegate* GetAlertDelegate() override;
 
   // |WindowBindingHandler|
@@ -280,9 +277,6 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
 
   // Returns the current pixel per scroll tick value.
   virtual float GetScrollOffsetMultiplier();
-
-  // Check if the high contrast feature is enabled on the OS
-  virtual bool GetHighContrastEnabled();
 
   // Delegate to a alert_node_ used to set the announcement text.
   std::unique_ptr<AlertPlatformNodeDelegate> alert_delegate_;
@@ -381,7 +375,7 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
 
   // Abstracts Windows APIs that may not be available on all supported versions
   // of Windows.
-  std::unique_ptr<WindowsProcTable> windows_proc_table_;
+  std::shared_ptr<WindowsProcTable> windows_proc_table_;
 
   // Manages IME state.
   std::unique_ptr<TextInputManager> text_input_manager_;

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -64,7 +64,6 @@ class MockFlutterWindow : public FlutterWindow {
               (override));
   MOCK_METHOD(void, OnSetCursor, (), (override));
   MOCK_METHOD(float, GetScrollOffsetMultiplier, (), (override));
-  MOCK_METHOD(bool, GetHighContrastEnabled, (), (override));
   MOCK_METHOD(float, GetDpiScale, (), (override));
   MOCK_METHOD(bool, IsVisible, (), (override));
   MOCK_METHOD(void, UpdateCursorRect, (const Rect&), (override));
@@ -290,8 +289,7 @@ TEST(FlutterWindowTest, OnThemeChange) {
   MockWindowBindingHandlerDelegate delegate;
   win32window.SetView(&delegate);
 
-  ON_CALL(win32window, GetHighContrastEnabled()).WillByDefault(Return(true));
-  EXPECT_CALL(delegate, UpdateHighContrastEnabled(true)).Times(1);
+  EXPECT_CALL(delegate, OnHighContrastChanged).Times(1);
 
   win32window.InjectWindowMessage(WM_THEMECHANGED, 0, 0);
 }
@@ -303,17 +301,6 @@ TEST(FlutterWindowTest, AccessibilityNodeWithoutView) {
   MockFlutterWindow win32window;
 
   EXPECT_EQ(win32window.GetNativeViewAccessible(), nullptr);
-}
-
-TEST(FlutterWindowTest, InitialAccessibilityFeatures) {
-  MockFlutterWindow win32window;
-  MockWindowBindingHandlerDelegate delegate;
-  win32window.SetView(&delegate);
-
-  ON_CALL(win32window, GetHighContrastEnabled()).WillByDefault(Return(true));
-  EXPECT_CALL(delegate, UpdateHighContrastEnabled(true)).Times(1);
-
-  win32window.SendInitialAccessibilityFeatures();
 }
 
 // Ensure that announcing the alert propagates the message to the alert node.

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -78,7 +78,9 @@ static void WindowsPlatformThreadPrioritySetter(
 class FlutterWindowsEngine {
  public:
   // Creates a new Flutter engine object configured to run |project|.
-  explicit FlutterWindowsEngine(const FlutterProjectBundle& project);
+  FlutterWindowsEngine(
+      const FlutterProjectBundle& project,
+      std::shared_ptr<WindowsProcTable> windows_proc_table = nullptr);
 
   virtual ~FlutterWindowsEngine();
 
@@ -215,11 +217,11 @@ class FlutterWindowsEngine {
   // Returns true if the semantics tree is enabled.
   bool semantics_enabled() const { return semantics_enabled_; }
 
-  // Update the high contrast feature state.
-  void UpdateHighContrastEnabled(bool enabled);
+  // Refresh accessibility features and send them to the engine.
+  void UpdateAccessibilityFeatures();
 
-  // Returns the flags for all currently enabled accessibility features
-  int EnabledAccessibilityFeatures() const;
+  // Refresh high contrast accessibility mode and notify the engine.
+  void UpdateHighContrastMode();
 
   // Returns true if the high contrast feature is enabled.
   bool high_contrast_enabled() const { return high_contrast_enabled_; }
@@ -239,9 +241,6 @@ class FlutterWindowsEngine {
 
   // Returns the executable name for this process or "Flutter" if unknown.
   std::string GetExecutableName() const;
-
-  // Updates accessibility, e.g. switch to high contrast mode
-  void UpdateAccessibilityFeatures(FlutterAccessibilityFeature flags);
 
   // Called when the application quits in response to a quit request.
   void OnQuit(std::optional<HWND> hwnd,
@@ -272,6 +271,10 @@ class FlutterWindowsEngine {
 
   WindowsLifecycleManager* lifecycle_manager() {
     return lifecycle_manager_.get();
+  }
+
+  std::shared_ptr<WindowsProcTable> windows_proc_table() {
+    return windows_proc_table_;
   }
 
  protected:
@@ -319,6 +322,9 @@ class FlutterWindowsEngine {
   // This requires that a view is attached to the engine.
   // Calling this method again resets the keyboard state.
   void InitializeKeyboard();
+
+  // Send the currently enabled accessibility features to the engine.
+  void SendAccessibilityFeatures();
 
   void HandleAccessibilityMessage(FlutterDesktopMessengerRef messenger,
                                   const FlutterDesktopMessage* message);
@@ -414,7 +420,7 @@ class FlutterWindowsEngine {
   // Handler for top level window messages.
   std::unique_ptr<WindowsLifecycleManager> lifecycle_manager_;
 
-  WindowsProcTable windows_proc_table_;
+  std::shared_ptr<WindowsProcTable> windows_proc_table_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsEngine);
 };

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -613,12 +613,8 @@ void FlutterWindowsView::DestroyRenderSurface() {
   }
 }
 
-void FlutterWindowsView::SendInitialAccessibilityFeatures() {
-  binding_handler_->SendInitialAccessibilityFeatures();
-}
-
-void FlutterWindowsView::UpdateHighContrastEnabled(bool enabled) {
-  engine_->UpdateHighContrastEnabled(enabled);
+void FlutterWindowsView::OnHighContrastChanged() {
+  engine_->UpdateHighContrastMode();
 }
 
 WindowsRenderTarget* FlutterWindowsView::GetRenderTarget() const {

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -82,14 +82,11 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   // Send initial bounds to embedder.  Must occur after engine has initialized.
   void SendInitialBounds();
 
-  // Send the initial accessibility features to the window
-  void SendInitialAccessibilityFeatures();
-
   // Set the text of the alert, and create it if it does not yet exist.
   void AnnounceAlert(const std::wstring& text);
 
   // |WindowBindingHandlerDelegate|
-  void UpdateHighContrastEnabled(bool enabled) override;
+  void OnHighContrastChanged() override;
 
   // Returns the frame buffer id for the engine to render to.
   uint32_t GetFrameBufferId(size_t width, size_t height);

--- a/shell/platform/windows/testing/flutter_windows_engine_builder.cc
+++ b/shell/platform/windows/testing/flutter_windows_engine_builder.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/windows/testing/flutter_windows_engine_builder.h"
 
 #include "flutter/fml/macros.h"
+#include "flutter/shell/platform/windows/windows_proc_table.h"
 
 namespace flutter {
 namespace testing {
@@ -14,8 +15,9 @@ class TestFlutterWindowsEngine : public FlutterWindowsEngine {
   TestFlutterWindowsEngine(
       const FlutterProjectBundle& project,
       KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state,
-      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan)
-      : FlutterWindowsEngine(project),
+      KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan,
+      std::shared_ptr<WindowsProcTable> windows_proc_table = nullptr)
+      : FlutterWindowsEngine(project, std::move(windows_proc_table)),
         get_key_state_(std::move(get_key_state)),
         map_vk_to_scan_(std::move(map_vk_to_scan)) {}
 
@@ -74,6 +76,11 @@ void FlutterWindowsEngineBuilder::SetCreateKeyboardHandlerCallbacks(
   map_vk_to_scan_ = std::move(map_vk_to_scan);
 }
 
+void FlutterWindowsEngineBuilder::SetWindowsProcTable(
+    std::shared_ptr<WindowsProcTable> windows_proc_table) {
+  windows_proc_table_ = std::move(windows_proc_table);
+}
+
 std::unique_ptr<FlutterWindowsEngine> FlutterWindowsEngineBuilder::Build() {
   std::vector<const char*> dart_args;
   dart_args.reserve(dart_entrypoint_arguments_.size());
@@ -93,8 +100,8 @@ std::unique_ptr<FlutterWindowsEngine> FlutterWindowsEngineBuilder::Build() {
   FlutterProjectBundle project(properties_);
   project.SetSwitches(switches_);
 
-  return std::make_unique<TestFlutterWindowsEngine>(project, get_key_state_,
-                                                    map_vk_to_scan_);
+  return std::make_unique<TestFlutterWindowsEngine>(
+      project, get_key_state_, map_vk_to_scan_, std::move(windows_proc_table_));
 }
 
 }  // namespace testing

--- a/shell/platform/windows/testing/flutter_windows_engine_builder.h
+++ b/shell/platform/windows/testing/flutter_windows_engine_builder.h
@@ -31,6 +31,9 @@ class FlutterWindowsEngineBuilder {
 
   void SetSwitches(std::vector<std::string> switches);
 
+  void SetWindowsProcTable(
+      std::shared_ptr<WindowsProcTable> windows_proc_table);
+
   std::unique_ptr<FlutterWindowsEngine> Build();
 
  private:
@@ -41,6 +44,7 @@ class FlutterWindowsEngineBuilder {
   std::vector<std::string> switches_;
   KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state_;
   KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan_;
+  std::shared_ptr<WindowsProcTable> windows_proc_table_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsEngineBuilder);
 };

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -38,7 +38,6 @@ class MockWindowBindingHandler : public WindowBindingHandler {
               (const void* allocation, size_t row_bytes, size_t height),
               (override));
   MOCK_METHOD(PointerLocation, GetPrimaryPointerLocation, (), (override));
-  MOCK_METHOD(void, SendInitialAccessibilityFeatures, (), (override));
   MOCK_METHOD(AlertPlatformNodeDelegate*, GetAlertDelegate, (), (override));
   MOCK_METHOD(ui::AXPlatformNodeWin*, GetAlert, (), (override));
   MOCK_METHOD(bool, NeedsVSync, (), (override));

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -68,7 +68,7 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
       (double, double, double, double, int, FlutterPointerDeviceKind, int32_t),
       (override));
   MOCK_METHOD(void, OnScrollInertiaCancel, (int32_t), (override));
-  MOCK_METHOD(void, UpdateHighContrastEnabled, (bool enabled), (override));
+  MOCK_METHOD(void, OnHighContrastChanged, (), (override));
 
   MOCK_METHOD(ui::AXFragmentRootDelegateWin*,
               GetAxFragmentRootDelegate,

--- a/shell/platform/windows/testing/mock_windows_proc_table.h
+++ b/shell/platform/windows/testing/mock_windows_proc_table.h
@@ -28,6 +28,8 @@ class MockWindowsProcTable : public WindowsProcTable {
               (DWORD, PULONG, PZZWSTR, PULONG),
               (const, override));
 
+  MOCK_METHOD(bool, GetHighContrastEnabled, (), (override));
+
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowsProcTable);
 };

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -98,9 +98,6 @@ class WindowBindingHandler {
   // coordinates.
   virtual PointerLocation GetPrimaryPointerLocation() = 0;
 
-  // Called to set the initial state of accessibility features
-  virtual void SendInitialAccessibilityFeatures() = 0;
-
   // Retrieve the delegate for the alert.
   virtual AlertPlatformNodeDelegate* GetAlertDelegate() = 0;
 

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -136,8 +136,8 @@ class WindowBindingHandlerDelegate {
   // Returns the root view accessibility node, or nullptr if none.
   virtual gfx::NativeViewAccessible GetNativeViewAccessible() = 0;
 
-  // Update the status of the high contrast feature
-  virtual void UpdateHighContrastEnabled(bool enabled) = 0;
+  // Update the status of the high contrast feature.
+  virtual void OnHighContrastChanged() = 0;
 
   // Obtain a pointer to the fragment root delegate.
   // This is required by UIA in order to obtain the fragment root that

--- a/shell/platform/windows/windows_proc_table.cc
+++ b/shell/platform/windows/windows_proc_table.cc
@@ -32,4 +32,14 @@ LRESULT WindowsProcTable::GetThreadPreferredUILanguages(DWORD flags,
   return ::GetThreadPreferredUILanguages(flags, count, languages, length);
 }
 
+bool WindowsProcTable::GetHighContrastEnabled() {
+  HIGHCONTRAST high_contrast = {.cbSize = sizeof(HIGHCONTRAST)};
+  if (!::SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST),
+                               &high_contrast, 0)) {
+    return false;
+  }
+
+  return high_contrast.dwFlags & HCF_HIGHCONTRASTON;
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/windows_proc_table.h
+++ b/shell/platform/windows/windows_proc_table.h
@@ -22,7 +22,7 @@ class WindowsProcTable {
   // Retrieves the pointer type for a specified pointer.
   //
   // Used to react differently to touch or pen inputs. Returns false on failure.
-  // Available in Windows 8 and newer, otherwise returns false.
+  // Available on Windows 8 and newer, otherwise returns false.
   virtual BOOL GetPointerType(UINT32 pointer_id,
                               POINTER_INPUT_TYPE* pointer_type);
 
@@ -34,6 +34,13 @@ class WindowsProcTable {
                                                 PULONG count,
                                                 PZZWSTR languages,
                                                 PULONG length) const;
+
+  // Get whether high contrast is enabled.
+  //
+  // Available on Windows 8 and newer, otherwise returns false.
+  // See
+  // https://learn.microsoft.com/windows/win32/winauto/high-contrast-parameter
+  virtual bool GetHighContrastEnabled();
 
  private:
   using GetPointerType_ = BOOL __stdcall(UINT32 pointerId,


### PR DESCRIPTION
This refactors how high contrast is implemented on Windows:

1. Added a test to verify accessibility features are updated when a view is created. This prevents staleness issues as the Windows embedder isn't notified of accessibility changes while in headless mode.
1. Moved high contrast mode detection to `WindowsProcTable` from `FlutterWindow` to remove engine to view to window plumbing.
1. `FlutterWindow` and `FlutterWindowsEngine` now share their `WindowsProcTable` (which is used for mocking and polyfilling win32 APIs) to reduce redundant dynamic loading.

This pull request contains no functional changes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
