### PR TITLE
[Impeller] Remove NOLINT on entity_pass.cc.

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// FLUTTER_NOLINT: https://github.com/flutter/flutter/issues/132129
-
 #include "impeller/entity/entity_pass.h"
 
 #include <memory>


### PR DESCRIPTION
We've had a few clang rolls since linting this file was causing timeouts. This PR removes the NOLINT to see if we still hit this issue on CI.

If the NOLINT needs to be added back, the linked issue should be updated to https://github.com/flutter/flutter/issues/132417.

Fixes https://github.com/flutter/flutter/issues/132417

@flar @gaaclarke @matanlurey 