### PR TITLE
[Impeller] testing disabling framebuffer fetch.

### DIFF
--- a/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -153,7 +153,7 @@ bool CapabilitiesGLES::SupportsTextureToTextureBlits() const {
 }
 
 bool CapabilitiesGLES::SupportsFramebufferFetch() const {
-  return supports_framebuffer_fetch_;
+  return false;
 }
 
 bool CapabilitiesGLES::SupportsCompute() const {


### PR DESCRIPTION
We want to see the impact of advanced blend with MSAA and no framebuffer fetch:

https://flutter-flutter-perf.skia.org/e/?queries=device_type%3DPixel_7_Pro%26sub_result%3D90th_percentile_frame_rasterizer_time_millis%26sub_result%3D99th_percentile_frame_rasterizer_time_millis%26sub_result%3Daverage_frame_rasterizer_time_millis%26sub_result%3Dworst_frame_rasterizer_time_millis%26test%3Danimated_advanced_blend_perf__timeline_summary%26test%3Danimated_advanced_blend_perf_opengles__timeline_summary&selected=commit%3D37615%26name%3D%252Carch%253Dintel%252Cbranch%253Dmaster%252Cconfig%253Ddefault%252Cdevice_type%253DPixel_7_Pro%252Cdevice_version%253Dnone%252Chost_type%253Dlinux%252Csub_result%253Daverage_frame_rasterizer_time_millis%252Ctest%253Danimated_advanced_blend_perf__timeline_summary%252C


