### PR TITLE
[Impeller] remove giant closure in EntityPass.

### DIFF
--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -9,15 +9,12 @@
 #include <optional>
 #include <vector>
 
-#include "flutter/fml/macros.h"
-#include "impeller/core/texture.h"
 #include "impeller/entity/contents/contents.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/entity.h"
 #include "impeller/entity/entity_pass_delegate.h"
 #include "impeller/entity/inline_pass_context.h"
 #include "impeller/renderer/render_target.h"
-#include "impeller/typographer/lazy_glyph_atlas.h"
 
 namespace impeller {
 
@@ -188,6 +185,14 @@ class EntityPass {
     static EntityResult Failure() { return {{}, kFailure}; }
     static EntityResult Skip() { return {{}, kSkip}; }
   };
+
+  bool RenderElement(Entity& element_entity,
+                     size_t clip_depth_floor,
+                     InlinePassContext& pass_context,
+                     int32_t pass_depth,
+                     ContentContext& renderer,
+                     ClipCoverageStack& clip_coverage_stack,
+                     Point global_pass_position) const;
 
   EntityResult GetEntityForElement(const EntityPass::Element& element,
                                    ContentContext& renderer,


### PR DESCRIPTION
I find it difficult to track what parts of this method are part of the closure and which aren't. Lets hoist this data into a private method and remove some unused imports.