### PR TITLE
[macOS] Reuse NSWindow instance across unit tests

### DIFF
--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -211,6 +211,7 @@ executable("flutter_desktop_darwin_unittests") {
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/platform/embedder:embedder_test_utils",
     "//flutter/testing",
+    "//flutter/testing:autoreleasepool_test",
     "//flutter/testing:dart",
     "//flutter/testing:skia",
     "//flutter/testing:testing_lib",

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -124,6 +124,19 @@ source_set("fixture_test") {
   }
 }
 
+if (is_mac || is_ios) {
+  source_set("autoreleasepool_test") {
+    testonly = true
+
+    sources = [ "autoreleasepool_test.h" ]
+
+    deps = [
+      "//flutter/fml",
+      "//third_party/googletest:gtest",
+    ]
+  }
+}
+
 if (enable_unittests && shell_enable_vulkan) {
   source_set("vulkan") {
     testonly = true

--- a/testing/autoreleasepool_test.h
+++ b/testing/autoreleasepool_test.h
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_TESTING_AUTORELEASEPOOL_TEST_H_
+#define FLUTTER_TESTING_AUTORELEASEPOOL_TEST_H_
+
+#include "flutter/fml/platform/darwin/scoped_nsautorelease_pool.h"
+
+#include "gtest/gtest.h"
+
+namespace flutter::testing {
+
+// GoogleTest mixin that runs the test within the scope of an NSAutoReleasePool.
+//
+// This can be mixed into test fixture classes that also inherit from gtest's
+// ::testing::Test base class.
+class AutoreleasePoolTestMixin {
+ public:
+  AutoreleasePoolTestMixin() = default;
+  ~AutoreleasePoolTestMixin() = default;
+
+ private:
+  fml::ScopedNSAutoreleasePool autorelease_pool_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AutoreleasePoolTestMixin);
+};
+
+// GoogleTest fixture that runs the test within the scope of an
+// NSAutoReleasePool.
+class AutoreleasePoolTest : public ::testing::Test,
+                            public AutoreleasePoolTestMixin {
+ public:
+  AutoreleasePoolTest() = default;
+  ~AutoreleasePoolTest() = default;
+
+ private:
+  fml::ScopedNSAutoreleasePool autorelease_pool_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AutoreleasePoolTest);
+};
+
+}  // namespace flutter::testing
+
+#endif  // FLUTTER_TESTING_AUTORELEASEPOOL_TEST_H_


### PR DESCRIPTION
Adds a gtest test fixture mixin and convenience class that instantiates an NSAutoreleasePool at the beginning of each test and flushes it at the end; this allows Objective-C tests using ARC to free  allocations at the end of each test.

Adds a subclass for the macOS accessibility bridge tests that instantiates and re-uses an NSWindow* across any tests that use it. This is because instantiating, closing, and immediately collecting an NSWindow results in a crash.

Prior to this patch, tests started failing (on my machine) around the 855th iteration, and issued the following warning on the 101st iteration:

```
2023-10-26 13:02:45.390829-0700 flutter_desktop_darwin_unittests[40837:1509026] [Window] WARNING: NSWindow has detected an excessive live window count of 101. Window 0x1423 of class 'NSWindow' created after passing the threshold of 100. This window is not necessarily the cause, and this warning will only be shown once per window class. (
  0   AppKit                              0x0000000192820d28 -[NSWindow _setWindowNumber:] + 684
  1   AppKit                              0x00000001933050e4 _NXCreateWindow + 284
  2   AppKit                              0x0000000192901ae0 -[NSWindow _commonAwake] + 672
  3   AppKit                              0x000000019281ff00 -[NSWindow _commonInitFrame:styleMask:backing:defer:] + 972
  4   AppKit                              0x000000019281f798 -[NSWindow _initContent:styleMask:backing:defer:contentView:] + 796
  5   AppKit                              0x000000019281f470 -[NSWindow initWithContentRect:styleMask:backing:defer:] + 48
  6   flutter_desktop_darwin_unittests    0x0000000100001e3c _ZN7flutter7testing89AccessibilityBridgeMacTest_SendsAccessibilityCreateNotificationToWindowOfFlutterView_Test8TestBodyEv + 328
```

See: http://www.openradar.me/FB13291861

Issue: https://github.com/flutter/flutter/issues/104789
Issue: https://github.com/flutter/flutter/issues/127441
Issue: https://github.com/flutter/flutter/issues/124840

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
