### PR TITLE
[Impeller] Enable GLES MSAA only if the multisampled_render_to_texture2 extension is available

### DIFF
--- a/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -108,7 +108,7 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   }
 
   if (gl.GetDescription()->HasExtension(
-          "GL_EXT_multisampled_render_to_texture") &&
+          "GL_EXT_multisampled_render_to_texture2") &&
       // The current implementation of MSAA support in Impeller GLES requires
       // the use of glBlitFramebuffer, which is not available on all GLES
       // implementations. We can't use MSAA on these platforms yet.


### PR DESCRIPTION
The GLES MSAA implementation may need to call FramebufferTexture2DMultisampleEXT for the stencil attachment.

See https://github.com/flutter/flutter/issues/137252