### PR TITLE
Remove //third_party/khronos

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -291,9 +291,6 @@ deps = {
   'src/third_party/icu':
    Var('chromium_git') + '/chromium/deps/icu.git' + '@' + 'a622de35ac311c5ad390a7af80724634e5dc61ed',
 
-  'src/third_party/khronos':
-   Var('chromium_git') + '/chromium/src/third_party/khronos.git' + '@' + '676d544d2b8f48903b7da9fceffaa534a5613978',
-
    'src/flutter/third_party/gtest-parallel':
    Var('chromium_git') + '/external/github.com/google/gtest-parallel' + '@' + '38191e2733d7cbaeaef6a3f1a942ddeb38a2ad14',
 

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -2371,11 +2371,6 @@
 ../../../third_party/json/tools/serve_header/README.md
 ../../../third_party/json/tools/serve_header/requirements.txt
 ../../../third_party/json/tools/serve_header/serve_header.py
-../../../third_party/khronos/.git
-../../../third_party/khronos/DEPS
-../../../third_party/khronos/DIR_METADATA
-../../../third_party/khronos/OWNERS
-../../../third_party/khronos/README.chromium
 ../../../third_party/libcxx/.clang-format
 ../../../third_party/libcxx/.clang-tidy
 ../../../third_party/libcxx/.git


### PR DESCRIPTION
It was introduced for a Linux/GTK component in https://github.com/flutter/engine/pull/17634.  But it looks like that dependency was later removed.