### PR TITLE
[Impeller] Rect getters

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -137,6 +137,7 @@
 ../../../flutter/impeller/entity/contents/filters/inputs/filter_input_unittests.cc
 ../../../flutter/impeller/entity/entity_unittests.cc
 ../../../flutter/impeller/entity/geometry/geometry_unittests.cc
+../../../flutter/impeller/entity/geometry/rect_unittests.cc
 ../../../flutter/impeller/entity/render_target_cache_unittests.cc
 ../../../flutter/impeller/fixtures
 ../../../flutter/impeller/geometry/README.md

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -137,11 +137,11 @@
 ../../../flutter/impeller/entity/contents/filters/inputs/filter_input_unittests.cc
 ../../../flutter/impeller/entity/entity_unittests.cc
 ../../../flutter/impeller/entity/geometry/geometry_unittests.cc
-../../../flutter/impeller/entity/geometry/rect_unittests.cc
 ../../../flutter/impeller/entity/render_target_cache_unittests.cc
 ../../../flutter/impeller/fixtures
 ../../../flutter/impeller/geometry/README.md
 ../../../flutter/impeller/geometry/geometry_unittests.cc
+../../../flutter/impeller/geometry/rect_unittests.cc
 ../../../flutter/impeller/golden_tests/README.md
 ../../../flutter/impeller/golden_tests_harvester/.dart_tool
 ../../../flutter/impeller/golden_tests_harvester/.gitignore

--- a/impeller/geometry/BUILD.gn
+++ b/impeller/geometry/BUILD.gn
@@ -59,7 +59,11 @@ impeller_component("geometry_asserts") {
 
 impeller_component("geometry_unittests") {
   testonly = true
-  sources = [ "geometry_unittests.cc" ]
+  sources = [
+    "geometry_unittests.cc",
+    "rect_unittests.cc",
+  ]
+
   deps = [
     ":geometry",
     ":geometry_asserts",

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -134,6 +134,10 @@ struct TRect {
 
   constexpr bool IsMaximum() const { return *this == MakeMaximum(); }
 
+  constexpr TPoint<Type> GetOrigin() const { return origin; }
+
+  constexpr TSize<Type> GetSize() const { return size; }
+
   constexpr auto GetLeft() const {
     if (IsMaximum()) {
       return -std::numeric_limits<Type>::infinity();

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -134,8 +134,18 @@ struct TRect {
 
   constexpr bool IsMaximum() const { return *this == MakeMaximum(); }
 
+  /// @brief Returns the upper left corner of the rectangle as specified
+  ///        when it was constructed.
+  ///
+  ///        Note that unlike the |GetLeft|, |GetTop|, and |GetLeftTop|
+  ///        methods which will return values as if the rectangle had been
+  ///        "unswapped" by calling |GetPositive| on it, this method
+  ///        returns the raw origin values.
   constexpr TPoint<Type> GetOrigin() const { return origin; }
 
+  /// @brief Returns the size of the rectangle as specified when it was
+  ///        constructed and which may be negative in either width or
+  ///        height.
   constexpr TSize<Type> GetSize() const { return size; }
 
   constexpr auto GetLeft() const {

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include "flutter/impeller/geometry/rect.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(RectTest, RectOriginSizeGetters) {
+  {
+    Rect r{{10, 20}, {50, 40}};
+    ASSERT_EQ(r.GetOrigin(), Point(10, 20));
+    ASSERT_EQ(r.GetSize(), Size(50, 40));
+  }
+
+  {
+    Rect r = Rect::MakeLTRB(10, 20, 50, 40);
+    ASSERT_EQ(r.GetOrigin(), Point(10, 20));
+    ASSERT_EQ(r.GetSize(), Size(40, 20));
+  }
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
This is a precursor change that will allow us to migrate all of the Impeller sources off of accessing the `origin` and `size` fields in preparation for improving the implementation of `Rect`.

No code has been migrated to use the new fields yet, and so this code should be completely benign as is, but there will be a number of follow-on PRs that all share this PR as a pre-requisite and so it needs to be landed independently of any of the PRs that will modify code currently in use.