### PR TITLE
[Impeller] Migrate unit tests to named Rect factories

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -193,16 +193,17 @@ void CanRenderTiledTexture(AiksTest* aiks_test,
   paint.color_source =
       ColorSource::MakeImage(texture, tile_mode, tile_mode, {}, local_matrix);
   paint.color = Color(1, 1, 1, 1);
-  canvas.DrawRect({0, 0, 600, 600}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
 
   // Should not change the image.
   constexpr auto stroke_width = 64;
   paint.style = Paint::Style::kStroke;
   paint.stroke_width = stroke_width;
   if (tile_mode == Entity::TileMode::kDecal) {
-    canvas.DrawRect({stroke_width, stroke_width, 600, 600}, paint);
+    canvas.DrawRect(Rect::MakeXYWH(stroke_width, stroke_width, 600, 600),
+                    paint);
   } else {
-    canvas.DrawRect({0, 0, 600, 600}, paint);
+    canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
   }
 
   // Should not change the image.
@@ -241,13 +242,12 @@ TEST_P(AiksTest, CanRenderImageRect) {
   Canvas canvas;
   Paint paint;
   auto image = std::make_shared<Image>(CreateTextureForFixture("kalimba.jpg"));
-  auto source_rect = Rect::MakeSize(Size(image->GetSize()));
+  Size image_half_size = Size(image->GetSize()) * 0.5;
 
   // Render the bottom right quarter of the source image in a stretched rect.
-  source_rect.size.width /= 2;
-  source_rect.size.height /= 2;
-  source_rect.origin.x += source_rect.size.width;
-  source_rect.origin.y += source_rect.size.height;
+  auto source_rect = Rect::MakeSize(image_half_size);
+  source_rect = source_rect.Shift(Point(image_half_size));
+
   canvas.DrawImageRect(image, source_rect, Rect::MakeXYWH(100, 100, 600, 600),
                        paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
@@ -380,7 +380,7 @@ TEST_P(AiksTest, ClipsUseCurrentTransform) {
 
     paint.color = colors[i % colors.size()];
     canvas.ClipPath(PathBuilder{}.AddCircle({0, 0}, 300).TakePath());
-    canvas.DrawRect(Rect(-300, -300, 600, 600), paint);
+    canvas.DrawRect(Rect::MakeXYWH(-300, -300, 600, 600), paint);
   }
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -418,7 +418,7 @@ void CanRenderLinearGradient(AiksTest* aiks_test, Entity::TileMode tile_mode) {
       {0, 0}, {200, 200}, std::move(colors), std::move(stops), tile_mode, {});
 
   paint.color = Color(1.0, 1.0, 1.0, 1.0);
-  canvas.DrawRect({0, 0, 600, 600}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 }  // namespace
@@ -456,7 +456,7 @@ TEST_P(AiksTest, CanRenderLinearGradientDecalWithColorFilter) {
                                               Color::Green().WithAlpha(0.25));
 
   paint.color = Color(1.0, 1.0, 1.0, 1.0);
-  canvas.DrawRect({0, 0, 600, 600}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -476,7 +476,7 @@ static void CanRenderLinearGradientWithDithering(AiksTest* aiks_test,
       {0, 0}, {800, 500}, std::move(colors), std::move(stops),
       Entity::TileMode::kClamp, {});
   paint.dither = use_dithering;
-  canvas.DrawRect({0, 0, 800, 500}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 800, 500), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -503,7 +503,7 @@ static void CanRenderRadialGradientWithDithering(AiksTest* aiks_test,
       {600, 600}, 600, std::move(colors), std::move(stops),
       Entity::TileMode::kClamp, {});
   paint.dither = use_dithering;
-  canvas.DrawRect({0, 0, 1200, 1200}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 1200, 1200), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -532,7 +532,7 @@ static void CanRenderSweepGradientWithDithering(AiksTest* aiks_test,
       std::move(stops), Entity::TileMode::kMirror, {});
   paint.dither = use_dithering;
 
-  canvas.DrawRect({0, 0, 600, 600}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -561,7 +561,7 @@ static void CanRenderConicalGradientWithDithering(AiksTest* aiks_test,
       Entity::TileMode::kMirror, {});
   paint.dither = use_dithering;
 
-  canvas.DrawRect({0, 0, 600, 600}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -589,7 +589,7 @@ void CanRenderLinearGradientWithOverlappingStops(AiksTest* aiks_test,
       {0, 0}, {500, 500}, std::move(colors), std::move(stops), tile_mode, {});
 
   paint.color = Color(1.0, 1.0, 1.0, 1.0);
-  canvas.DrawRect({0, 0, 500, 500}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 500, 500), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 }  // namespace
@@ -629,7 +629,7 @@ void CanRenderLinearGradientManyColors(AiksTest* aiks_test,
       {0, 0}, {200, 200}, std::move(colors), std::move(stops), tile_mode, {});
 
   paint.color = Color(1.0, 1.0, 1.0, 1.0);
-  canvas.DrawRect({0, 0, 600, 600}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
   canvas.Restore();
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -668,7 +668,7 @@ void CanRenderLinearGradientWayManyColors(AiksTest* aiks_test,
   paint.color_source = ColorSource::MakeLinearGradient(
       {0, 0}, {200, 200}, std::move(colors), std::move(stops), tile_mode, {});
 
-  canvas.DrawRect({0, 0, 600, 600}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 }  // namespace
@@ -723,7 +723,7 @@ TEST_P(AiksTest, CanRenderLinearGradientManyColorsUnevenStops) {
     paint.color_source = ColorSource::MakeLinearGradient(
         {0, 0}, {200, 200}, std::move(colors), std::move(stops), tile_mode, {});
 
-    canvas.DrawRect({0, 0, 600, 600}, paint);
+    canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
     return canvas.EndRecordingAsPicture();
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));
@@ -791,7 +791,7 @@ TEST_P(AiksTest, CanRenderRadialGradient) {
     paint.color_source = ColorSource::MakeRadialGradient(
         {100, 100}, 100, std::move(colors), std::move(stops), tile_mode, {});
 
-    canvas.DrawRect({0, 0, 600, 600}, paint);
+    canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
     return canvas.EndRecordingAsPicture();
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));
@@ -848,7 +848,7 @@ TEST_P(AiksTest, CanRenderRadialGradientManyColors) {
     paint.color_source = ColorSource::MakeRadialGradient(
         {100, 100}, 100, std::move(colors), std::move(stops), tile_mode, {});
 
-    canvas.DrawRect({0, 0, 600, 600}, paint);
+    canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
     return canvas.EndRecordingAsPicture();
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));
@@ -869,7 +869,7 @@ void CanRenderSweepGradient(AiksTest* aiks_test, Entity::TileMode tile_mode) {
       {100, 100}, Degrees(45), Degrees(135), std::move(colors),
       std::move(stops), tile_mode, {});
 
-  canvas.DrawRect({0, 0, 600, 600}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 }  // namespace
@@ -916,7 +916,7 @@ void CanRenderSweepGradientManyColors(AiksTest* aiks_test,
       {100, 100}, Degrees(45), Degrees(135), std::move(colors),
       std::move(stops), tile_mode, {});
 
-  canvas.DrawRect({0, 0, 600, 600}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
   ASSERT_TRUE(aiks_test->OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 }  // namespace
@@ -939,7 +939,7 @@ TEST_P(AiksTest, CanRenderConicalGradient) {
   Canvas canvas;
   Paint paint;
   paint.color = Color::White();
-  canvas.DrawRect({0, 0, size * 3, size * 3}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, size * 3, size * 3), paint);
   std::vector<Color> colors = {Color::MakeRGBA8(0xF4, 0x43, 0x36, 0xFF),
                                Color::MakeRGBA8(0xFF, 0xEB, 0x3B, 0xFF),
                                Color::MakeRGBA8(0x4c, 0xAF, 0x50, 0xFF),
@@ -970,7 +970,7 @@ TEST_P(AiksTest, CanRenderConicalGradient) {
         std::get<0>(array[i]), std::get<1>(array[i]), colors, stops,
         std::get<2>(array[i]), std::get<3>(array[i]), Entity::TileMode::kClamp,
         {});
-    canvas.DrawRect({0, 0, size, size}, paint);
+    canvas.DrawRect(Rect::MakeXYWH(0, 0, size, size), paint);
     canvas.Restore();
   }
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
@@ -1024,7 +1024,7 @@ TEST_P(AiksTest, CanRenderDifferentShapesWithSameColorSource) {
 
   canvas.Save();
   canvas.Translate({100, 100, 0});
-  canvas.DrawRect({0, 0, 200, 200}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 200, 200), paint);
   canvas.Restore();
 
   canvas.Save();
@@ -1038,9 +1038,9 @@ TEST_P(AiksTest, CanPictureConvertToImage) {
   Canvas recorder_canvas;
   Paint paint;
   paint.color = Color{0.9568, 0.2627, 0.2118, 1.0};
-  recorder_canvas.DrawRect({100.0, 100.0, 600, 600}, paint);
+  recorder_canvas.DrawRect(Rect::MakeXYWH(100.0, 100.0, 600, 600), paint);
   paint.color = Color{0.1294, 0.5882, 0.9529, 1.0};
-  recorder_canvas.DrawRect({200.0, 200.0, 600, 600}, paint);
+  recorder_canvas.DrawRect(Rect::MakeXYWH(200.0, 200.0, 600, 600), paint);
 
   Canvas canvas;
   AiksContext renderer(GetContext(), nullptr);
@@ -1068,13 +1068,13 @@ TEST_P(AiksTest, BlendModeShouldCoverWholeScreen) {
   canvas.SaveLayer(paint);
 
   paint.color = Color::White();
-  canvas.DrawRect({100, 100, 400, 400}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(100, 100, 400, 400), paint);
 
   paint.blend_mode = BlendMode::kSource;
   canvas.SaveLayer(paint);
 
   paint.color = Color::Blue();
-  canvas.DrawRect({200, 200, 200, 200}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(200, 200, 200, 200), paint);
 
   canvas.Restore();
   canvas.Restore();
@@ -1097,9 +1097,9 @@ TEST_P(AiksTest, CanRenderGroupOpacity) {
 
   canvas.SaveLayer(alpha);
 
-  canvas.DrawRect({000, 000, 100, 100}, red);
-  canvas.DrawRect({020, 020, 100, 100}, green);
-  canvas.DrawRect({040, 040, 100, 100}, blue);
+  canvas.DrawRect(Rect::MakeXYWH(000, 000, 100, 100), red);
+  canvas.DrawRect(Rect::MakeXYWH(020, 020, 100, 100), green);
+  canvas.DrawRect(Rect::MakeXYWH(040, 040, 100, 100), blue);
 
   canvas.Restore();
 
@@ -1137,9 +1137,9 @@ TEST_P(AiksTest, CoordinateConversionsAreCorrect) {
 
     canvas.SaveLayer(alpha);
 
-    canvas.DrawRect({000, 000, 100, 100}, red);
-    canvas.DrawRect({020, 020, 100, 100}, green);
-    canvas.DrawRect({040, 040, 100, 100}, blue);
+    canvas.DrawRect(Rect::MakeXYWH(000, 000, 100, 100), red);
+    canvas.DrawRect(Rect::MakeXYWH(020, 020, 100, 100), green);
+    canvas.DrawRect(Rect::MakeXYWH(040, 040, 100, 100), blue);
 
     canvas.Restore();
   }
@@ -1185,11 +1185,11 @@ TEST_P(AiksTest, CanPerformSaveLayerWithBounds) {
   Paint save;
   save.color = Color::Black();
 
-  canvas.SaveLayer(save, Rect{0, 0, 50, 50});
+  canvas.SaveLayer(save, Rect::MakeXYWH(0, 0, 50, 50));
 
-  canvas.DrawRect({0, 0, 100, 100}, red);
-  canvas.DrawRect({10, 10, 100, 100}, green);
-  canvas.DrawRect({20, 20, 100, 100}, blue);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 100, 100), red);
+  canvas.DrawRect(Rect::MakeXYWH(10, 10, 100, 100), green);
+  canvas.DrawRect(Rect::MakeXYWH(20, 20, 100, 100), blue);
 
   canvas.Restore();
 
@@ -1212,11 +1212,11 @@ TEST_P(AiksTest,
   Paint save;
   save.color = Color::Black().WithAlpha(0.5);
 
-  canvas.SaveLayer(save, Rect{0, 0, 100000, 100000});
+  canvas.SaveLayer(save, Rect::MakeXYWH(0, 0, 100000, 100000));
 
-  canvas.DrawRect({0, 0, 100, 100}, red);
-  canvas.DrawRect({10, 10, 100, 100}, green);
-  canvas.DrawRect({20, 20, 100, 100}, blue);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 100, 100), red);
+  canvas.DrawRect(Rect::MakeXYWH(10, 10, 100, 100), green);
+  canvas.DrawRect(Rect::MakeXYWH(20, 20, 100, 100), blue);
 
   canvas.Restore();
 
@@ -1235,8 +1235,9 @@ TEST_P(AiksTest, CanRenderRoundedRectWithNonUniformRadii) {
   radii.bottom_right = {50, 25};
   radii.bottom_left = {25, 50};
 
-  auto path =
-      PathBuilder{}.AddRoundedRect(Rect{100, 100, 500, 500}, radii).TakePath();
+  auto path = PathBuilder{}
+                  .AddRoundedRect(Rect::MakeXYWH(100, 100, 500, 500), radii)
+                  .TakePath();
 
   canvas.DrawPath(path, paint);
 
@@ -1251,7 +1252,7 @@ TEST_P(AiksTest, CanRenderStrokePathThatEndsAtSharpTurn) {
   paint.style = Paint::Style::kStroke;
   paint.stroke_width = 200;
 
-  Rect rect = {100, 100, 200, 200};
+  Rect rect = Rect::MakeXYWH(100, 100, 200, 200);
   PathBuilder builder;
   builder.AddArc(rect, Degrees(0), Degrees(90), false);
 
@@ -1288,7 +1289,7 @@ TEST_P(AiksTest, CanRenderDifferencePaths) {
   radii.bottom_right = {50, 25};
   radii.bottom_left = {25, 50};
 
-  builder.AddRoundedRect({100, 100, 200, 200}, radii);
+  builder.AddRoundedRect(Rect::MakeXYWH(100, 100, 200, 200), radii);
   builder.AddCircle({200, 200}, 50);
   auto path = builder.TakePath(FillType::kOdd);
 
@@ -1375,8 +1376,9 @@ bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
                             const std::string& font_fixture,
                             TextRenderOptions options = {}) {
   // Draw the baseline.
-  canvas.DrawRect({options.position.x - 50, options.position.y, 900, 10},
-                  Paint{.color = Color::Aqua().WithAlpha(0.25)});
+  canvas.DrawRect(
+      Rect::MakeXYWH(options.position.x - 50, options.position.y, 900, 10),
+      Paint{.color = Color::Aqua().WithAlpha(0.25)});
 
   // Mark the point at which the text is drawn.
   canvas.DrawCircle(options.position, 5.0,
@@ -1408,8 +1410,9 @@ bool RenderTextInCanvasSTB(const std::shared_ptr<Context>& context,
                            const std::string& font_fixture,
                            TextRenderOptions options = {}) {
   // Draw the baseline.
-  canvas.DrawRect({options.position.x - 50, options.position.y, 900, 10},
-                  Paint{.color = Color::Aqua().WithAlpha(0.25)});
+  canvas.DrawRect(
+      Rect::MakeXYWH(options.position.x - 50, options.position.y, 900, 10),
+      Paint{.color = Color::Aqua().WithAlpha(0.25)});
 
   // Mark the point at which the text is drawn.
   canvas.DrawCircle(options.position, 5.0,
@@ -2078,9 +2081,12 @@ TEST_P(AiksTest, CoverageOriginShouldBeAccountedForInSubpasses) {
 
     canvas.SaveLayer(alpha, bounds);
 
-    canvas.DrawRect({current, size}, Paint{.color = Color::Red()});
-    canvas.DrawRect({current += offset, size}, Paint{.color = Color::Green()});
-    canvas.DrawRect({current += offset, size}, Paint{.color = Color::Blue()});
+    canvas.DrawRect(Rect::MakeOriginSize(current, size),
+                    Paint{.color = Color::Red()});
+    canvas.DrawRect(Rect::MakeOriginSize(current += offset, size),
+                    Paint{.color = Color::Green()});
+    canvas.DrawRect(Rect::MakeOriginSize(current += offset, size),
+                    Paint{.color = Color::Blue()});
 
     canvas.Restore();
 
@@ -2127,7 +2133,7 @@ TEST_P(AiksTest, SaveLayerDrawsBehindSubsequentEntities) {
   Paint paint;
 
   paint.color = Color::Black();
-  Rect rect(25, 25, 25, 25);
+  Rect rect = Rect::MakeXYWH(25, 25, 25, 25);
   canvas.DrawRect(rect, paint);
 
   canvas.Translate({10, 10});
@@ -2148,7 +2154,7 @@ TEST_P(AiksTest, SaveLayerDrawsBehindSubsequentEntities) {
 TEST_P(AiksTest, SiblingSaveLayerBoundsAreRespected) {
   Canvas canvas;
   Paint paint;
-  Rect rect(0, 0, 1000, 1000);
+  Rect rect = Rect::MakeXYWH(0, 0, 1000, 1000);
 
   // Black, green, and red squares offset by [10, 10].
   {
@@ -2385,9 +2391,9 @@ TEST_P(AiksTest,
 
 TEST_P(AiksTest, DrawRectAbsorbsClears) {
   Canvas canvas;
-  canvas.DrawRect({0, 0, 300, 300},
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 300, 300),
                   {.color = Color::Red(), .blend_mode = BlendMode::kSource});
-  canvas.DrawRect({0, 0, 300, 300},
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 300, 300),
                   {.color = Color::CornflowerBlue().WithAlpha(0.75),
                    .blend_mode = BlendMode::kSourceOver});
 
@@ -2405,9 +2411,9 @@ TEST_P(AiksTest, DrawRectAbsorbsClears) {
 
 TEST_P(AiksTest, DrawRectAbsorbsClearsNegativeRRect) {
   Canvas canvas;
-  canvas.DrawRRect({0, 0, 300, 300}, 5.0,
+  canvas.DrawRRect(Rect::MakeXYWH(0, 0, 300, 300), 5.0,
                    {.color = Color::Red(), .blend_mode = BlendMode::kSource});
-  canvas.DrawRRect({0, 0, 300, 300}, 5.0,
+  canvas.DrawRRect(Rect::MakeXYWH(0, 0, 300, 300), 5.0,
                    {.color = Color::CornflowerBlue().WithAlpha(0.75),
                     .blend_mode = BlendMode::kSourceOver});
 
@@ -2428,7 +2434,7 @@ TEST_P(AiksTest, DrawRectAbsorbsClearsNegativeRotation) {
   canvas.Translate(Vector3(150.0, 150.0, 0.0));
   canvas.Rotate(Degrees(45.0));
   canvas.Translate(Vector3(-150.0, -150.0, 0.0));
-  canvas.DrawRect({0, 0, 300, 300},
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 300, 300),
                   {.color = Color::Red(), .blend_mode = BlendMode::kSource});
 
   std::shared_ptr<ContextSpy> spy = ContextSpy::Make();
@@ -2445,9 +2451,9 @@ TEST_P(AiksTest, DrawRectAbsorbsClearsNegativeRotation) {
 
 TEST_P(AiksTest, DrawRectAbsorbsClearsNegative) {
   Canvas canvas;
-  canvas.DrawRect({0, 0, 300, 300},
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 300, 300),
                   {.color = Color::Red(), .blend_mode = BlendMode::kSource});
-  canvas.DrawRect({0, 0, 300, 300},
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 300, 300),
                   {.color = Color::CornflowerBlue().WithAlpha(0.75),
                    .blend_mode = BlendMode::kSourceOver});
 
@@ -2464,9 +2470,9 @@ TEST_P(AiksTest, DrawRectAbsorbsClearsNegative) {
 }
 
 TEST_P(AiksTest, ClipRectElidesNoOpClips) {
-  Canvas canvas(Rect(0, 0, 100, 100));
-  canvas.ClipRect(Rect(0, 0, 100, 100));
-  canvas.ClipRect(Rect(-100, -100, 300, 300));
+  Canvas canvas(Rect::MakeXYWH(0, 0, 100, 100));
+  canvas.ClipRect(Rect::MakeXYWH(0, 0, 100, 100));
+  canvas.ClipRect(Rect::MakeXYWH(-100, -100, 300, 300));
   canvas.DrawPaint({.color = Color::Red(), .blend_mode = BlendMode::kSource});
   canvas.DrawPaint({.color = Color::CornflowerBlue().WithAlpha(0.75),
                     .blend_mode = BlendMode::kSourceOver});
@@ -2552,7 +2558,7 @@ TEST_P(AiksTest, ForegroundBlendSubpassCollapseOptimization) {
 
   canvas.Translate({500, 300, 0});
   canvas.Rotate(Radians(2 * kPi / 3));
-  canvas.DrawRect({100, 100, 200, 200}, {.color = Color::Blue()});
+  canvas.DrawRect(Rect::MakeXYWH(100, 100, 200, 200), {.color = Color::Blue()});
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -2573,7 +2579,7 @@ TEST_P(AiksTest, ColorMatrixFilterSubpassCollapseOptimization) {
 
   canvas.Translate({500, 300, 0});
   canvas.Rotate(Radians(2 * kPi / 3));
-  canvas.DrawRect({100, 100, 200, 200}, {.color = Color::Blue()});
+  canvas.DrawRect(Rect::MakeXYWH(100, 100, 200, 200), {.color = Color::Blue()});
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -2587,7 +2593,7 @@ TEST_P(AiksTest, LinearToSrgbFilterSubpassCollapseOptimization) {
 
   canvas.Translate({500, 300, 0});
   canvas.Rotate(Radians(2 * kPi / 3));
-  canvas.DrawRect({100, 100, 200, 200}, {.color = Color::Blue()});
+  canvas.DrawRect(Rect::MakeXYWH(100, 100, 200, 200), {.color = Color::Blue()});
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -2601,7 +2607,7 @@ TEST_P(AiksTest, SrgbToLinearFilterSubpassCollapseOptimization) {
 
   canvas.Translate({500, 300, 0});
   canvas.Rotate(Radians(2 * kPi / 3));
-  canvas.DrawRect({100, 100, 200, 200}, {.color = Color::Blue()});
+  canvas.DrawRect(Rect::MakeXYWH(100, 100, 200, 200), {.color = Color::Blue()});
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -2637,7 +2643,7 @@ static Picture BlendModeTest(BlendMode blend_mode,
         // pass.
         canvas.SaveLayer({.blend_mode = blend_mode});
         {  //
-          canvas.DrawRect({50, 50, 100, 100}, {.color = color});
+          canvas.DrawRect(Rect::MakeXYWH(50, 50, 100, 100), {.color = color});
         }
         canvas.Restore();
       }
@@ -2661,7 +2667,7 @@ static Picture BlendModeTest(BlendMode blend_mode,
   // canvas.DrawPaint({.color = destination_color});
   for (const auto& color : source_colors) {
     // Simply write the CPU blended color to the pass.
-    canvas.DrawRect({50, 50, 100, 100},
+    canvas.DrawRect(Rect::MakeXYWH(50, 50, 100, 100),
                     {.color = destination_color.Blend(color, blend_mode),
                      .blend_mode = BlendMode::kSourceOver});
     canvas.Translate(Vector2(100, 0));
@@ -2957,7 +2963,7 @@ TEST_P(AiksTest,
 
 TEST_P(AiksTest, TranslucentSaveLayerWithAdvancedBlendModeDrawsCorrectly) {
   Canvas canvas;
-  canvas.DrawRect({0, 0, 400, 400}, {.color = Color::Red()});
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 400, 400), {.color = Color::Red()});
   canvas.SaveLayer({
       .color = Color::Black().WithAlpha(0.5),
       .blend_mode = BlendMode::kLighten,
@@ -3200,9 +3206,9 @@ TEST_P(AiksTest, CanRenderClippedRuntimeEffects) {
 
   Canvas canvas;
   canvas.Save();
-  canvas.ClipRRect(Rect{0, 0, 400, 400}, 10.0,
+  canvas.ClipRRect(Rect::MakeXYWH(0, 0, 400, 400), 10.0,
                    Entity::ClipOperation::kIntersect);
-  canvas.DrawRect(Rect{0, 0, 400, 400}, paint);
+  canvas.DrawRect(Rect::MakeXYWH(0, 0, 400, 400), paint);
   canvas.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
@@ -3619,7 +3625,7 @@ TEST_P(AiksTest, PipelineBlendSingleParameter) {
   {
     canvas.Translate(Point(100, 100));
     canvas.DrawCircle(Point(200, 200), 200, {.color = Color::Blue()});
-    canvas.ClipRect(Rect(100, 100, 200, 200));
+    canvas.ClipRect(Rect::MakeXYWH(100, 100, 200, 200));
     canvas.DrawCircle(Point(200, 200), 200,
                       {
                           .color = Color::Green(),
@@ -3713,7 +3719,7 @@ TEST_P(AiksTest, ReleasesTextureOnTeardown) {
     Paint paint;
     paint.color_source = ColorSource::MakeImage(
         texture, Entity::TileMode::kClamp, Entity::TileMode::kClamp, {}, {});
-    canvas.DrawRect({0, 0, 600, 600}, paint);
+    canvas.DrawRect(Rect::MakeXYWH(0, 0, 600, 600), paint);
 
     ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
   }
@@ -3867,7 +3873,7 @@ TEST_P(AiksTest, BlurHasNoEdge) {
               .sigma = Sigma(47.6),
           },
   };
-  canvas.DrawRect(Rect{300, 300, 200, 200}, blur);
+  canvas.DrawRect(Rect::MakeXYWH(300, 300, 200, 200), blur);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -3875,7 +3881,7 @@ TEST_P(AiksTest, EmptySaveLayerIgnoresPaint) {
   Canvas canvas;
   canvas.Scale(GetContentScale());
   canvas.DrawPaint(Paint{.color = Color::Red()});
-  canvas.ClipRect({100, 100, 200, 200});
+  canvas.ClipRect(Rect::MakeXYWH(100, 100, 200, 200));
   canvas.SaveLayer(Paint{.color = Color::Blue()});
   canvas.Restore();
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
@@ -3886,7 +3892,7 @@ TEST_P(AiksTest, EmptySaveLayerRendersWithClear) {
   canvas.Scale(GetContentScale());
   auto image = std::make_shared<Image>(CreateTextureForFixture("airplane.jpg"));
   canvas.DrawImage(image, {10, 10}, {});
-  canvas.ClipRect({100, 100, 200, 200});
+  canvas.ClipRect(Rect::MakeXYWH(100, 100, 200, 200));
   canvas.SaveLayer(Paint{.blend_mode = BlendMode::kClear});
   canvas.Restore();
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));

--- a/impeller/aiks/canvas_unittests.cc
+++ b/impeller/aiks/canvas_unittests.cc
@@ -21,7 +21,7 @@ TEST(AiksCanvasTest, EmptyCullRect) {
 }
 
 TEST(AiksCanvasTest, InitialCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
 
   Canvas canvas(initial_cull);
 
@@ -30,8 +30,8 @@ TEST(AiksCanvasTest, InitialCullRect) {
 }
 
 TEST(AiksCanvasTest, TranslatedCullRect) {
-  Rect initial_cull(5, 5, 10, 10);
-  Rect translated_cull(0, 0, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect translated_cull = Rect::MakeXYWH(0, 0, 10, 10);
 
   Canvas canvas(initial_cull);
   canvas.Translate(Vector3(5, 5, 0));
@@ -41,8 +41,8 @@ TEST(AiksCanvasTest, TranslatedCullRect) {
 }
 
 TEST(AiksCanvasTest, ScaledCullRect) {
-  Rect initial_cull(5, 5, 10, 10);
-  Rect scaled_cull(10, 10, 20, 20);
+  Rect initial_cull = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect scaled_cull = Rect::MakeXYWH(10, 10, 20, 20);
 
   Canvas canvas(initial_cull);
   canvas.Scale(Vector2(0.5, 0.5));
@@ -52,7 +52,7 @@ TEST(AiksCanvasTest, ScaledCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipIntersectAgainstEmptyCullRect) {
-  Rect rect_clip(5, 5, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas;
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kIntersect);
@@ -62,7 +62,7 @@ TEST(AiksCanvasTest, RectClipIntersectAgainstEmptyCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipDiffAgainstEmptyCullRect) {
-  Rect rect_clip(5, 5, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas;
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
@@ -71,9 +71,9 @@ TEST(AiksCanvasTest, RectClipDiffAgainstEmptyCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipIntersectAgainstCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(5, 5, 10, 10);
-  Rect result_cull(5, 5, 5, 5);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(5, 5, 5, 5);
 
   Canvas canvas(initial_cull);
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kIntersect);
@@ -83,9 +83,9 @@ TEST(AiksCanvasTest, RectClipIntersectAgainstCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipDiffAgainstNonCoveredCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(5, 5, 10, 10);
-  Rect result_cull(0, 0, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(0, 0, 10, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
@@ -95,9 +95,9 @@ TEST(AiksCanvasTest, RectClipDiffAgainstNonCoveredCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipDiffAboveCullRect) {
-  Rect initial_cull(5, 5, 10, 10);
-  Rect rect_clip(0, 0, 20, 4);
-  Rect result_cull(5, 5, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(0, 0, 20, 4);
+  Rect result_cull = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
@@ -107,9 +107,9 @@ TEST(AiksCanvasTest, RectClipDiffAboveCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipDiffBelowCullRect) {
-  Rect initial_cull(5, 5, 10, 10);
-  Rect rect_clip(0, 16, 20, 4);
-  Rect result_cull(5, 5, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(0, 16, 20, 4);
+  Rect result_cull = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
@@ -119,9 +119,9 @@ TEST(AiksCanvasTest, RectClipDiffBelowCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipDiffLeftOfCullRect) {
-  Rect initial_cull(5, 5, 10, 10);
-  Rect rect_clip(0, 0, 4, 20);
-  Rect result_cull(5, 5, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(0, 0, 4, 20);
+  Rect result_cull = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
@@ -131,9 +131,9 @@ TEST(AiksCanvasTest, RectClipDiffLeftOfCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipDiffRightOfCullRect) {
-  Rect initial_cull(5, 5, 10, 10);
-  Rect rect_clip(16, 0, 4, 20);
-  Rect result_cull(5, 5, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(16, 0, 4, 20);
+  Rect result_cull = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
@@ -143,9 +143,9 @@ TEST(AiksCanvasTest, RectClipDiffRightOfCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipDiffAgainstVCoveredCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(5, 0, 10, 10);
-  Rect result_cull(0, 0, 5, 10);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 0, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(0, 0, 5, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
@@ -155,9 +155,9 @@ TEST(AiksCanvasTest, RectClipDiffAgainstVCoveredCullRect) {
 }
 
 TEST(AiksCanvasTest, RectClipDiffAgainstHCoveredCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(0, 5, 10, 10);
-  Rect result_cull(0, 0, 10, 5);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(0, 5, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(0, 0, 10, 5);
 
   Canvas canvas(initial_cull);
   canvas.ClipRect(rect_clip, Entity::ClipOperation::kDifference);
@@ -167,7 +167,7 @@ TEST(AiksCanvasTest, RectClipDiffAgainstHCoveredCullRect) {
 }
 
 TEST(AiksCanvasTest, RRectClipIntersectAgainstEmptyCullRect) {
-  Rect rect_clip(5, 5, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas;
   canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kIntersect);
@@ -177,7 +177,7 @@ TEST(AiksCanvasTest, RRectClipIntersectAgainstEmptyCullRect) {
 }
 
 TEST(AiksCanvasTest, RRectClipDiffAgainstEmptyCullRect) {
-  Rect rect_clip(5, 5, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas;
   canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
@@ -186,9 +186,9 @@ TEST(AiksCanvasTest, RRectClipDiffAgainstEmptyCullRect) {
 }
 
 TEST(AiksCanvasTest, RRectClipIntersectAgainstCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(5, 5, 10, 10);
-  Rect result_cull(5, 5, 5, 5);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(5, 5, 5, 5);
 
   Canvas canvas(initial_cull);
   canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kIntersect);
@@ -198,9 +198,9 @@ TEST(AiksCanvasTest, RRectClipIntersectAgainstCullRect) {
 }
 
 TEST(AiksCanvasTest, RRectClipDiffAgainstNonCoveredCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(5, 5, 10, 10);
-  Rect result_cull(0, 0, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(0, 0, 10, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
@@ -210,9 +210,9 @@ TEST(AiksCanvasTest, RRectClipDiffAgainstNonCoveredCullRect) {
 }
 
 TEST(AiksCanvasTest, RRectClipDiffAgainstVPartiallyCoveredCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(5, 0, 10, 10);
-  Rect result_cull(0, 0, 6, 10);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 0, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(0, 0, 6, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
@@ -222,9 +222,9 @@ TEST(AiksCanvasTest, RRectClipDiffAgainstVPartiallyCoveredCullRect) {
 }
 
 TEST(AiksCanvasTest, RRectClipDiffAgainstVFullyCoveredCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(5, -2, 10, 14);
-  Rect result_cull(0, 0, 5, 10);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, -2, 10, 14);
+  Rect result_cull = Rect::MakeXYWH(0, 0, 5, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
@@ -234,9 +234,9 @@ TEST(AiksCanvasTest, RRectClipDiffAgainstVFullyCoveredCullRect) {
 }
 
 TEST(AiksCanvasTest, RRectClipDiffAgainstHPartiallyCoveredCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(0, 5, 10, 10);
-  Rect result_cull(0, 0, 10, 6);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(0, 5, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(0, 0, 10, 6);
 
   Canvas canvas(initial_cull);
   canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
@@ -246,9 +246,9 @@ TEST(AiksCanvasTest, RRectClipDiffAgainstHPartiallyCoveredCullRect) {
 }
 
 TEST(AiksCanvasTest, RRectClipDiffAgainstHFullyCoveredCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
-  Rect rect_clip(-2, 5, 14, 10);
-  Rect result_cull(0, 0, 10, 5);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(-2, 5, 14, 10);
+  Rect result_cull = Rect::MakeXYWH(0, 0, 10, 5);
 
   Canvas canvas(initial_cull);
   canvas.ClipRRect(rect_clip, 1, Entity::ClipOperation::kDifference);
@@ -259,12 +259,12 @@ TEST(AiksCanvasTest, RRectClipDiffAgainstHFullyCoveredCullRect) {
 
 TEST(AiksCanvasTest, PathClipIntersectAgainstEmptyCullRect) {
   PathBuilder builder;
-  builder.AddRect({5, 5, 1, 1});
-  builder.AddRect({5, 14, 1, 1});
-  builder.AddRect({14, 5, 1, 1});
-  builder.AddRect({14, 14, 1, 1});
+  builder.AddRect(Rect::MakeXYWH(5, 5, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(5, 14, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(14, 5, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(14, 14, 1, 1));
   Path path = builder.TakePath();
-  Rect rect_clip(5, 5, 10, 10);
+  Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas;
   canvas.ClipPath(path, Entity::ClipOperation::kIntersect);
@@ -275,10 +275,10 @@ TEST(AiksCanvasTest, PathClipIntersectAgainstEmptyCullRect) {
 
 TEST(AiksCanvasTest, PathClipDiffAgainstEmptyCullRect) {
   PathBuilder builder;
-  builder.AddRect({5, 5, 1, 1});
-  builder.AddRect({5, 14, 1, 1});
-  builder.AddRect({14, 5, 1, 1});
-  builder.AddRect({14, 14, 1, 1});
+  builder.AddRect(Rect::MakeXYWH(5, 5, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(5, 14, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(14, 5, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(14, 14, 1, 1));
   Path path = builder.TakePath();
 
   Canvas canvas;
@@ -288,14 +288,14 @@ TEST(AiksCanvasTest, PathClipDiffAgainstEmptyCullRect) {
 }
 
 TEST(AiksCanvasTest, PathClipIntersectAgainstCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
   PathBuilder builder;
-  builder.AddRect({5, 5, 1, 1});
-  builder.AddRect({5, 14, 1, 1});
-  builder.AddRect({14, 5, 1, 1});
-  builder.AddRect({14, 14, 1, 1});
+  builder.AddRect(Rect::MakeXYWH(5, 5, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(5, 14, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(14, 5, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(14, 14, 1, 1));
   Path path = builder.TakePath();
-  Rect result_cull(5, 5, 5, 5);
+  Rect result_cull = Rect::MakeXYWH(5, 5, 5, 5);
 
   Canvas canvas(initial_cull);
   canvas.ClipPath(path, Entity::ClipOperation::kIntersect);
@@ -305,14 +305,14 @@ TEST(AiksCanvasTest, PathClipIntersectAgainstCullRect) {
 }
 
 TEST(AiksCanvasTest, PathClipDiffAgainstNonCoveredCullRect) {
-  Rect initial_cull(0, 0, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(0, 0, 10, 10);
   PathBuilder builder;
-  builder.AddRect({5, 5, 1, 1});
-  builder.AddRect({5, 14, 1, 1});
-  builder.AddRect({14, 5, 1, 1});
-  builder.AddRect({14, 14, 1, 1});
+  builder.AddRect(Rect::MakeXYWH(5, 5, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(5, 14, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(14, 5, 1, 1));
+  builder.AddRect(Rect::MakeXYWH(14, 14, 1, 1));
   Path path = builder.TakePath();
-  Rect result_cull(0, 0, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(0, 0, 10, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipPath(path, Entity::ClipOperation::kDifference);
@@ -322,12 +322,12 @@ TEST(AiksCanvasTest, PathClipDiffAgainstNonCoveredCullRect) {
 }
 
 TEST(AiksCanvasTest, PathClipDiffAgainstFullyCoveredCullRect) {
-  Rect initial_cull(5, 5, 10, 10);
+  Rect initial_cull = Rect::MakeXYWH(5, 5, 10, 10);
   PathBuilder builder;
-  builder.AddRect({0, 0, 100, 100});
+  builder.AddRect(Rect::MakeXYWH(0, 0, 100, 100));
   Path path = builder.TakePath();
   // Diff clip of Paths is ignored due to complexity
-  Rect result_cull(5, 5, 10, 10);
+  Rect result_cull = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas(initial_cull);
   canvas.ClipPath(path, Entity::ClipOperation::kDifference);

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -224,7 +224,7 @@ TEST_P(EntityTest, FilterCoverageRespectsCropRect) {
 
 TEST_P(EntityTest, CanDrawRect) {
   auto contents = std::make_shared<SolidColorContents>();
-  contents->SetGeometry(Geometry::MakeRect({100, 100, 100, 100}));
+  contents->SetGeometry(Geometry::MakeRect(Rect::MakeXYWH(100, 100, 100, 100)));
   contents->SetColor(Color::Red());
 
   Entity entity;
@@ -238,7 +238,7 @@ TEST_P(EntityTest, CanDrawRRect) {
   auto contents = std::make_shared<SolidColorContents>();
   auto path = PathBuilder{}
                   .SetConvexity(Convexity::kConvex)
-                  .AddRoundedRect({100, 100, 100, 100}, 10.0)
+                  .AddRoundedRect(Rect::MakeXYWH(100, 100, 100, 100), 10.0)
                   .TakePath();
   contents->SetGeometry(Geometry::MakeFillPath(path));
   contents->SetColor(Color::Red());
@@ -251,11 +251,11 @@ TEST_P(EntityTest, CanDrawRRect) {
 }
 
 TEST_P(EntityTest, GeometryBoundsAreTransformed) {
-  auto geometry = Geometry::MakeRect({100, 100, 100, 100});
+  auto geometry = Geometry::MakeRect(Rect::MakeXYWH(100, 100, 100, 100));
   auto transform = Matrix::MakeScale({2.0, 2.0, 2.0});
 
   ASSERT_RECT_NEAR(geometry->GetCoverage(transform).value(),
-                   Rect(200, 200, 200, 200));
+                   Rect::MakeXYWH(200, 200, 200, 200));
 }
 
 TEST_P(EntityTest, ThreeStrokesInOnePath) {
@@ -915,9 +915,10 @@ TEST_P(EntityTest, BlendingModeOptions) {
         Point(470, 190), Point(270, 390), 20, Color::White(), Color::White());
 
     bool result = true;
-    result = result && draw_rect(Rect(0, 0, pass.GetRenderTargetSize().width,
+    result = result &&
+             draw_rect(Rect::MakeXYWH(0, 0, pass.GetRenderTargetSize().width,
                                       pass.GetRenderTargetSize().height),
-                                 Color(), BlendMode::kClear);
+                       Color(), BlendMode::kClear);
     result = result && draw_rect(Rect::MakeLTRB(a.x, a.y, b.x, b.y), color1,
                                  BlendMode::kSourceOver);
     result = result && draw_rect(Rect::MakeLTRB(c.x, c.y, d.x, d.y), color2,
@@ -2482,7 +2483,7 @@ TEST_P(EntityTest, AdvancedBlendCoverageHintIsNotResetByEntityPass) {
   }
 
   auto contents = std::make_shared<SolidColorContents>();
-  contents->SetGeometry(Geometry::MakeRect({100, 100, 100, 100}));
+  contents->SetGeometry(Geometry::MakeRect(Rect::MakeXYWH(100, 100, 100, 100)));
   contents->SetColor(Color::Red());
 
   Entity entity;

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -670,17 +670,17 @@ TEST(GeometryTest, BoundingBoxCubic) {
       builder.AddCubicCurve({120, 160}, {25, 200}, {220, 260}, {220, 40})
           .TakePath();
   auto box = path.GetBoundingBox();
-  Rect expected(93.9101, 40, 126.09, 158.862);
+  Rect expected = Rect::MakeXYWH(93.9101, 40, 126.09, 158.862);
   ASSERT_TRUE(box.has_value());
   ASSERT_RECT_NEAR(box.value(), expected);
 }
 
 TEST(GeometryTest, BoundingBoxOfCompositePathIsCorrect) {
   PathBuilder builder;
-  builder.AddRoundedRect({{10, 10}, {300, 300}}, {50, 50, 50, 50});
+  builder.AddRoundedRect(Rect::MakeXYWH(10, 10, 300, 300), {50, 50, 50, 50});
   auto path = builder.TakePath();
   auto actual = path.GetBoundingBox();
-  Rect expected(10, 10, 300, 300);
+  Rect expected = Rect::MakeXYWH(10, 10, 300, 300);
   ASSERT_TRUE(actual.has_value());
   ASSERT_RECT_NEAR(actual.value(), expected);
 }
@@ -742,7 +742,7 @@ TEST(GeometryTest, CanConvertTTypesExplicitly) {
   }
 
   {
-    Rect r1(1.0, 2.0, 3.0, 4.0);
+    Rect r1 = Rect::MakeXYWH(1.0, 2.0, 3.0, 4.0);
     IRect r2 = static_cast<IRect>(r1);
     ASSERT_EQ(r2.origin.x, 1u);
     ASSERT_EQ(r2.origin.y, 2u);
@@ -1612,34 +1612,34 @@ TEST(GeometryTest, RectMakeSize) {
 
 TEST(GeometryTest, RectUnion) {
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(0, 0, 0, 0);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(0, 0, 0, 0);
     auto u = a.Union(b);
-    auto expected = Rect(0, 0, 200, 200);
+    auto expected = Rect::MakeXYWH(0, 0, 200, 200);
     ASSERT_RECT_NEAR(u, expected);
   }
 
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(10, 10, 0, 0);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(10, 10, 0, 0);
     auto u = a.Union(b);
-    auto expected = Rect(10, 10, 190, 190);
+    auto expected = Rect::MakeXYWH(10, 10, 190, 190);
     ASSERT_RECT_NEAR(u, expected);
   }
 
   {
-    Rect a(0, 0, 100, 100);
-    Rect b(10, 10, 100, 100);
+    Rect a = Rect::MakeXYWH(0, 0, 100, 100);
+    Rect b = Rect::MakeXYWH(10, 10, 100, 100);
     auto u = a.Union(b);
-    auto expected = Rect(0, 0, 110, 110);
+    auto expected = Rect::MakeXYWH(0, 0, 110, 110);
     ASSERT_RECT_NEAR(u, expected);
   }
 
   {
-    Rect a(0, 0, 100, 100);
-    Rect b(100, 100, 100, 100);
+    Rect a = Rect::MakeXYWH(0, 0, 100, 100);
+    Rect b = Rect::MakeXYWH(100, 100, 100, 100);
     auto u = a.Union(b);
-    auto expected = Rect(0, 0, 200, 200);
+    auto expected = Rect::MakeXYWH(0, 0, 200, 200);
     ASSERT_RECT_NEAR(u, expected);
   }
 }
@@ -1698,39 +1698,39 @@ TEST(GeometryTest, OptRectUnion) {
 
 TEST(GeometryTest, RectIntersection) {
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(0, 0, 0, 0);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(0, 0, 0, 0);
 
     auto u = a.Intersection(b);
     ASSERT_FALSE(u.has_value());
   }
 
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(10, 10, 0, 0);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(10, 10, 0, 0);
     auto u = a.Intersection(b);
     ASSERT_FALSE(u.has_value());
   }
 
   {
-    Rect a(0, 0, 100, 100);
-    Rect b(10, 10, 100, 100);
+    Rect a = Rect::MakeXYWH(0, 0, 100, 100);
+    Rect b = Rect::MakeXYWH(10, 10, 100, 100);
     auto u = a.Intersection(b);
     ASSERT_TRUE(u.has_value());
-    auto expected = Rect(10, 10, 90, 90);
+    auto expected = Rect::MakeXYWH(10, 10, 90, 90);
     ASSERT_RECT_NEAR(u.value(), expected);
   }
 
   {
-    Rect a(0, 0, 100, 100);
-    Rect b(100, 100, 100, 100);
+    Rect a = Rect::MakeXYWH(0, 0, 100, 100);
+    Rect b = Rect::MakeXYWH(100, 100, 100, 100);
     auto u = a.Intersection(b);
     ASSERT_FALSE(u.has_value());
   }
 
   {
     Rect a = Rect::MakeMaximum();
-    Rect b(10, 10, 300, 300);
+    Rect b = Rect::MakeXYWH(10, 10, 300, 300);
     auto u = a.Intersection(b);
     ASSERT_TRUE(u);
     ASSERT_RECT_NEAR(u.value(), b);
@@ -1799,32 +1799,32 @@ TEST(GeometryTest, OptRectIntersection) {
 
 TEST(GeometryTest, RectIntersectsWithRect) {
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(0, 0, 0, 0);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(0, 0, 0, 0);
     ASSERT_FALSE(a.IntersectsWithRect(b));
   }
 
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(10, 10, 0, 0);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(10, 10, 0, 0);
     ASSERT_FALSE(a.IntersectsWithRect(b));
   }
 
   {
-    Rect a(0, 0, 100, 100);
-    Rect b(10, 10, 100, 100);
+    Rect a = Rect::MakeXYWH(0, 0, 100, 100);
+    Rect b = Rect::MakeXYWH(10, 10, 100, 100);
     ASSERT_TRUE(a.IntersectsWithRect(b));
   }
 
   {
-    Rect a(0, 0, 100, 100);
-    Rect b(100, 100, 100, 100);
+    Rect a = Rect::MakeXYWH(0, 0, 100, 100);
+    Rect b = Rect::MakeXYWH(100, 100, 100, 100);
     ASSERT_FALSE(a.IntersectsWithRect(b));
   }
 
   {
     Rect a = Rect::MakeMaximum();
-    Rect b(10, 10, 100, 100);
+    Rect b = Rect::MakeXYWH(10, 10, 100, 100);
     ASSERT_TRUE(a.IntersectsWithRect(b));
   }
 
@@ -1838,8 +1838,8 @@ TEST(GeometryTest, RectIntersectsWithRect) {
 TEST(GeometryTest, RectCutout) {
   // No cutout.
   {
-    Rect a(0, 0, 100, 100);
-    Rect b(0, 0, 50, 50);
+    Rect a = Rect::MakeXYWH(0, 0, 100, 100);
+    Rect b = Rect::MakeXYWH(0, 0, 50, 50);
     auto u = a.Cutout(b);
     ASSERT_TRUE(u.has_value());
     ASSERT_RECT_NEAR(u.value(), a);
@@ -1847,8 +1847,8 @@ TEST(GeometryTest, RectCutout) {
 
   // Full cutout.
   {
-    Rect a(0, 0, 100, 100);
-    Rect b(-10, -10, 120, 120);
+    Rect a = Rect::MakeXYWH(0, 0, 100, 100);
+    Rect b = Rect::MakeXYWH(-10, -10, 120, 120);
     auto u = a.Cutout(b);
     ASSERT_FALSE(u.has_value());
   }
@@ -1897,23 +1897,23 @@ TEST(GeometryTest, RectCutout) {
 TEST(GeometryTest, RectContainsPoint) {
   {
     // Origin is inclusive
-    Rect r(100, 100, 100, 100);
+    Rect r = Rect::MakeXYWH(100, 100, 100, 100);
     Point p(100, 100);
     ASSERT_TRUE(r.Contains(p));
   }
   {
     // Size is exclusive
-    Rect r(100, 100, 100, 100);
+    Rect r = Rect::MakeXYWH(100, 100, 100, 100);
     Point p(200, 200);
     ASSERT_FALSE(r.Contains(p));
   }
   {
-    Rect r(100, 100, 100, 100);
+    Rect r = Rect::MakeXYWH(100, 100, 100, 100);
     Point p(99, 99);
     ASSERT_FALSE(r.Contains(p));
   }
   {
-    Rect r(100, 100, 100, 100);
+    Rect r = Rect::MakeXYWH(100, 100, 100, 100);
     Point p(199, 199);
     ASSERT_TRUE(r.Contains(p));
   }
@@ -1927,44 +1927,44 @@ TEST(GeometryTest, RectContainsPoint) {
 
 TEST(GeometryTest, RectContainsRect) {
   {
-    Rect a(100, 100, 100, 100);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
     ASSERT_TRUE(a.Contains(a));
   }
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(0, 0, 0, 0);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(0, 0, 0, 0);
     ASSERT_FALSE(a.Contains(b));
   }
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(150, 150, 20, 20);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(150, 150, 20, 20);
     ASSERT_TRUE(a.Contains(b));
   }
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(150, 150, 100, 100);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(150, 150, 100, 100);
     ASSERT_FALSE(a.Contains(b));
   }
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(50, 50, 100, 100);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(50, 50, 100, 100);
     ASSERT_FALSE(a.Contains(b));
   }
   {
-    Rect a(100, 100, 100, 100);
-    Rect b(0, 0, 300, 300);
+    Rect a = Rect::MakeXYWH(100, 100, 100, 100);
+    Rect b = Rect::MakeXYWH(0, 0, 300, 300);
     ASSERT_FALSE(a.Contains(b));
   }
   {
     Rect a = Rect::MakeMaximum();
-    Rect b(0, 0, 300, 300);
+    Rect b = Rect::MakeXYWH(0, 0, 300, 300);
     ASSERT_TRUE(a.Contains(b));
   }
 }
 
 TEST(GeometryTest, RectGetPoints) {
   {
-    Rect r(100, 200, 300, 400);
+    Rect r = Rect::MakeXYWH(100, 200, 300, 400);
     auto points = r.GetPoints();
     ASSERT_POINT_NEAR(points[0], Point(100, 200));
     ASSERT_POINT_NEAR(points[1], Point(400, 200));
@@ -1994,7 +1994,7 @@ TEST(GeometryTest, RectShift) {
 }
 
 TEST(GeometryTest, RectGetTransformedPoints) {
-  Rect r(100, 200, 300, 400);
+  Rect r = Rect::MakeXYWH(100, 200, 300, 400);
   auto points = r.GetTransformedPoints(Matrix::MakeTranslation({10, 20}));
   ASSERT_POINT_NEAR(points[0], Point(110, 220));
   ASSERT_POINT_NEAR(points[1], Point(410, 220));
@@ -2006,7 +2006,7 @@ TEST(GeometryTest, RectMakePointBounds) {
   {
     std::vector<Point> points{{1, 5}, {4, -1}, {0, 6}};
     Rect r = Rect::MakePointBounds(points.begin(), points.end()).value();
-    auto expected = Rect(0, -1, 4, 7);
+    auto expected = Rect::MakeXYWH(0, -1, 4, 7);
     ASSERT_RECT_NEAR(r, expected);
   }
   {
@@ -2046,14 +2046,14 @@ TEST(GeometryTest, RectExpand) {
 
 TEST(GeometryTest, RectGetPositive) {
   {
-    Rect r{100, 200, 300, 400};
+    Rect r = Rect::MakeXYWH(100, 200, 300, 400);
     auto actual = r.GetPositive();
     ASSERT_RECT_NEAR(r, actual);
   }
   {
-    Rect r{100, 200, -100, -100};
+    Rect r = Rect::MakeXYWH(100, 200, -100, -100);
     auto actual = r.GetPositive();
-    Rect expected(0, 100, 100, 100);
+    Rect expected = Rect::MakeXYWH(0, 100, 100, 100);
     ASSERT_RECT_NEAR(expected, actual);
   }
 }
@@ -2164,7 +2164,8 @@ TEST(GeometryTest, PathBuilderSetsCorrectContourPropertiesForAddCommands) {
   }
 
   {
-    Path path = PathBuilder{}.AddOval(Rect(100, 100, 100, 100)).TakePath();
+    Path path =
+        PathBuilder{}.AddOval(Rect::MakeXYWH(100, 100, 100, 100)).TakePath();
     ContourComponent contour;
     path.GetContourComponentAtIndex(0, contour);
     ASSERT_POINT_NEAR(contour.destination, Point(150, 100));
@@ -2172,7 +2173,8 @@ TEST(GeometryTest, PathBuilderSetsCorrectContourPropertiesForAddCommands) {
   }
 
   {
-    Path path = PathBuilder{}.AddRect(Rect(100, 100, 100, 100)).TakePath();
+    Path path =
+        PathBuilder{}.AddRect(Rect::MakeXYWH(100, 100, 100, 100)).TakePath();
     ContourComponent contour;
     path.GetContourComponentAtIndex(0, contour);
     ASSERT_POINT_NEAR(contour.destination, Point(100, 100));
@@ -2180,8 +2182,9 @@ TEST(GeometryTest, PathBuilderSetsCorrectContourPropertiesForAddCommands) {
   }
 
   {
-    Path path =
-        PathBuilder{}.AddRoundedRect(Rect(100, 100, 100, 100), 10).TakePath();
+    Path path = PathBuilder{}
+                    .AddRoundedRect(Rect::MakeXYWH(100, 100, 100, 100), 10)
+                    .TakePath();
     ContourComponent contour;
     path.GetContourComponentAtIndex(0, contour);
     ASSERT_POINT_NEAR(contour.destination, Point(110, 100));

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -30,10 +30,6 @@ struct TRect {
   constexpr TRect(TPoint<Type> origin, TSize<Type> size)
       : origin(origin), size(size) {}
 
-  constexpr TRect(const Type components[4])
-      : origin(components[0], components[1]),
-        size(components[2], components[3]) {}
-
   constexpr TRect(Type x, Type y, Type width, Type height)
       : origin(x, y), size(width, height) {}
 
@@ -46,6 +42,11 @@ struct TRect {
 
   constexpr static TRect MakeXYWH(Type x, Type y, Type width, Type height) {
     return TRect(x, y, width, height);
+  }
+
+  constexpr static TRect MakeOriginSize(const TPoint<Type>& origin,
+                                        const TSize<Type>& size) {
+    return TRect(origin, size);
   }
 
   template <class U>

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -11,7 +11,7 @@ namespace testing {
 
 TEST(RectTest, RectOriginSizeGetters) {
   {
-    Rect r{{10, 20}, {50, 40}};
+    Rect r = Rect::MakeOriginSize({10, 20}, {50, 40});
     ASSERT_EQ(r.GetOrigin(), Point(10, 20));
     ASSERT_EQ(r.GetSize(), Size(50, 40));
   }


### PR DESCRIPTION
This is a pre-requisite step to deleting the un-named Constructors for Rect and moving to named factories. The intention is both to improve code readability and so that the underlying storage information is not implied or exposed.

This PR only modifies the unit tests which will not affect actual running apps, but migrates >95% of the concrete Rect construction to the named factory methods. Use of these constructors in the rest of the code is very rare since most methods get their Rect instances from data they compute or are delivered from elsewhere. Those other instances will be eliminated more on a file by file basis to reduce the surface area of errors arising due to typos or porting mistakes.