### PR TITLE
[macOS] Wrap external texture tests in autorelease pool

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
@@ -14,7 +14,8 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterExternalTexture.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/embedder_external_texture_metal.h"
-#import "flutter/testing/testing.h"
+#include "flutter/testing/autoreleasepool_test.h"
+#include "flutter/testing/testing.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSamplingOptions.h"
@@ -66,7 +67,17 @@
 
 namespace flutter::testing {
 
-TEST(FlutterEmbedderExternalTextureUnittests, TestTextureResolution) {
+// AutoreleasePoolTest subclass that exists simply to provide more specific naming.
+class FlutterEmbedderExternalTextureTest : public AutoreleasePoolTest {
+ public:
+  FlutterEmbedderExternalTextureTest() = default;
+  ~FlutterEmbedderExternalTextureTest() = default;
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterEmbedderExternalTextureTest);
+};
+
+TEST_F(FlutterEmbedderExternalTextureTest, TestTextureResolution) {
   // Constants.
   const size_t width = 100;
   const size_t height = 100;
@@ -125,7 +136,7 @@ TEST(FlutterEmbedderExternalTextureUnittests, TestTextureResolution) {
   gpuSurface->makeImageSnapshot();
 }
 
-TEST(FlutterEmbedderExternalTextureUnittests, TestPopulateExternalTexture) {
+TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateExternalTexture) {
   // Constants.
   const size_t width = 100;
   const size_t height = 100;
@@ -178,7 +189,7 @@ TEST(FlutterEmbedderExternalTextureUnittests, TestPopulateExternalTexture) {
   gpuSurface->makeImageSnapshot();
 }
 
-TEST(FlutterEmbedderExternalTextureUnittests, TestPopulateExternalTextureYUVA) {
+TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateExternalTextureYUVA) {
   // Constants.
   const size_t width = 100;
   const size_t height = 100;
@@ -233,7 +244,7 @@ TEST(FlutterEmbedderExternalTextureUnittests, TestPopulateExternalTextureYUVA) {
   gpuSurface->makeImageSnapshot();
 }
 
-TEST(FlutterEmbedderExternalTextureUnittests, TestPopulateExternalTextureYUVA2) {
+TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateExternalTextureYUVA2) {
   // Constants.
   const size_t width = 100;
   const size_t height = 100;


### PR DESCRIPTION
Wraps all FlutterExternalTexture tests in an autorelease pool to ensure resources are cleaned up between tests.

Prior to this change, running these tests via:

    ../out/host_debug_unopt_arm64/flutter_desktop_darwin_unittests \
        --gtest_filter='FlutterEmbedderExternalTextureUnittests.*'

Resuling in a segfault:

    [ERROR:flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.mm(35)]
    Could not create Metal command queue.
    zsh: segmentation fault
    ../out/host_debug_unopt_arm64/flutter_desktop_darwin_unittests

Issue: https://github.com/flutter/flutter/issues/104789
Issue: https://github.com/flutter/flutter/issues/127441
Issue: https://github.com/flutter/flutter/issues/124840

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
