### PR TITLE
wip: [macOS] Wrap FlutterTextInputPlugin tests in autorelase pool

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -12,6 +12,8 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/NSView+ClipsToBounds.h"
 
 #import <OCMock/OCMock.h>
+
+#import "flutter/testing/autoreleasepool_test.h"
 #import "flutter/testing/testing.h"
 
 @interface FlutterTextField (Testing)
@@ -1816,109 +1818,119 @@ FlutterEngine* CreateTestEngine() {
 }
 }  // namespace
 
-TEST(FlutterTextInputPluginTest, TestEmptyCompositionRange) {
+// AutoreleasePoolTest subclass that exists simply to provide more specific naming.
+class FlutterTextInputPluginTest : public AutoreleasePoolTest {
+ public:
+  FlutterTextInputPluginTest() = default;
+  ~FlutterTextInputPluginTest() = default;
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterTextInputPluginTest);
+};
+
+TEST_F(FlutterTextInputPluginTest, TestEmptyCompositionRange) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testEmptyCompositionRange]);
 }
 
-TEST(FlutterTextInputPluginTest, TestSetMarkedTextWithSelectionChange) {
+TEST_F(FlutterTextInputPluginTest, TestSetMarkedTextWithSelectionChange) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSetMarkedTextWithSelectionChange]);
 }
 
-TEST(FlutterTextInputPluginTest, TestSetMarkedTextWithReplacementRange) {
+TEST_F(FlutterTextInputPluginTest, TestSetMarkedTextWithReplacementRange) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSetMarkedTextWithReplacementRange]);
 }
 
-TEST(FlutterTextInputPluginTest, TestComposingRegionRemovedByFramework) {
+TEST_F(FlutterTextInputPluginTest, TestComposingRegionRemovedByFramework) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testComposingRegionRemovedByFramework]);
 }
 
-TEST(FlutterTextInputPluginTest, TestClearClientDuringComposing) {
+TEST_F(FlutterTextInputPluginTest, TestClearClientDuringComposing) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testClearClientDuringComposing]);
 }
 
-TEST(FlutterTextInputPluginTest, TestAutocompleteDisabledWhenAutofillNotSet) {
+TEST_F(FlutterTextInputPluginTest, TestAutocompleteDisabledWhenAutofillNotSet) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testAutocompleteDisabledWhenAutofillNotSet]);
 }
 
-TEST(FlutterTextInputPluginTest, TestAutocompleteEnabledWhenAutofillSet) {
+TEST_F(FlutterTextInputPluginTest, TestAutocompleteEnabledWhenAutofillSet) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testAutocompleteEnabledWhenAutofillSet]);
 }
 
-TEST(FlutterTextInputPluginTest, TestAutocompleteEnabledWhenAutofillSetNoHint) {
+TEST_F(FlutterTextInputPluginTest, TestAutocompleteEnabledWhenAutofillSetNoHint) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testAutocompleteEnabledWhenAutofillSetNoHint]);
 }
 
-TEST(FlutterTextInputPluginTest, TestAutocompleteDisabledWhenObscureTextSet) {
+TEST_F(FlutterTextInputPluginTest, TestAutocompleteDisabledWhenObscureTextSet) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testAutocompleteDisabledWhenObscureTextSet]);
 }
 
-TEST(FlutterTextInputPluginTest, TestAutocompleteDisabledWhenPasswordAutofillSet) {
+TEST_F(FlutterTextInputPluginTest, TestAutocompleteDisabledWhenPasswordAutofillSet) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testAutocompleteDisabledWhenPasswordAutofillSet]);
 }
 
-TEST(FlutterTextInputPluginTest, TestAutocompleteDisabledWhenAutofillGroupIncludesPassword) {
+TEST_F(FlutterTextInputPluginTest, TestAutocompleteDisabledWhenAutofillGroupIncludesPassword) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc]
       testAutocompleteDisabledWhenAutofillGroupIncludesPassword]);
 }
 
-TEST(FlutterTextInputPluginTest, TestFirstRectForCharacterRange) {
+TEST_F(FlutterTextInputPluginTest, TestFirstRectForCharacterRange) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testFirstRectForCharacterRange]);
 }
 
-TEST(FlutterTextInputPluginTest, TestFirstRectForCharacterRangeAtInfinity) {
+TEST_F(FlutterTextInputPluginTest, TestFirstRectForCharacterRangeAtInfinity) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testFirstRectForCharacterRangeAtInfinity]);
 }
 
-TEST(FlutterTextInputPluginTest, TestFirstRectForCharacterRangeWithEsotericAffineTransform) {
+TEST_F(FlutterTextInputPluginTest, TestFirstRectForCharacterRangeWithEsotericAffineTransform) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc]
       testFirstRectForCharacterRangeWithEsotericAffineTransform]);
 }
 
-TEST(FlutterTextInputPluginTest, TestSetEditingStateWithTextEditingDelta) {
+TEST_F(FlutterTextInputPluginTest, TestSetEditingStateWithTextEditingDelta) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSetEditingStateWithTextEditingDelta]);
 }
 
-TEST(FlutterTextInputPluginTest, TestOperationsThatTriggerDelta) {
+TEST_F(FlutterTextInputPluginTest, TestOperationsThatTriggerDelta) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testOperationsThatTriggerDelta]);
 }
 
-TEST(FlutterTextInputPluginTest, TestComposingWithDelta) {
+TEST_F(FlutterTextInputPluginTest, TestComposingWithDelta) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testComposingWithDelta]);
 }
 
-TEST(FlutterTextInputPluginTest, testComposingWithDeltasWhenSelectionIsActive) {
+TEST_F(FlutterTextInputPluginTest, testComposingWithDeltasWhenSelectionIsActive) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testComposingWithDeltasWhenSelectionIsActive]);
 }
 
-TEST(FlutterTextInputPluginTest, TestLocalTextAndSelectionUpdateAfterDelta) {
+TEST_F(FlutterTextInputPluginTest, TestLocalTextAndSelectionUpdateAfterDelta) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testLocalTextAndSelectionUpdateAfterDelta]);
 }
 
-TEST(FlutterTextInputPluginTest, TestPerformKeyEquivalent) {
+TEST_F(FlutterTextInputPluginTest, TestPerformKeyEquivalent) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testPerformKeyEquivalent]);
 }
 
-TEST(FlutterTextInputPluginTest, HandleArrowKeyWhenImePopoverIsActive) {
+TEST_F(FlutterTextInputPluginTest, HandleArrowKeyWhenImePopoverIsActive) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] handleArrowKeyWhenImePopoverIsActive]);
 }
 
-TEST(FlutterTextInputPluginTest, UnhandledKeyEquivalent) {
+TEST_F(FlutterTextInputPluginTest, UnhandledKeyEquivalent) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] unhandledKeyEquivalent]);
 }
 
-TEST(FlutterTextInputPluginTest, TestSelectorsAreForwardedToFramework) {
+TEST_F(FlutterTextInputPluginTest, TestSelectorsAreForwardedToFramework) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSelectorsAreForwardedToFramework]);
 }
 
-TEST(FlutterTextInputPluginTest, TestInsertNewLine) {
+TEST_F(FlutterTextInputPluginTest, TestInsertNewLine) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testInsertNewLine]);
 }
 
-TEST(FlutterTextInputPluginTest, TestSendActionDoNotInsertNewLine) {
+TEST_F(FlutterTextInputPluginTest, TestSendActionDoNotInsertNewLine) {
   ASSERT_TRUE([[FlutterInputPluginTestObjc alloc] testSendActionDoNotInsertNewLine]);
 }
 
-TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
+TEST_F(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
   FlutterEngine* engine = CreateTestEngine();
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
@@ -1983,7 +1995,7 @@ TEST(FlutterTextInputPluginTest, CanWorkWithFlutterTextField) {
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
 }
 
-TEST(FlutterTextInputPluginTest, CanNotBecomeResponderIfNoViewController) {
+TEST_F(FlutterTextInputPluginTest, CanNotBecomeResponderIfNoViewController) {
   FlutterEngine* engine = CreateTestEngine();
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
@@ -2017,7 +2029,7 @@ TEST(FlutterTextInputPluginTest, CanNotBecomeResponderIfNoViewController) {
   EXPECT_EQ([textField becomeFirstResponder], NO);
 }
 
-TEST(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
+TEST_F(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
   FlutterEngine* engine = CreateTestEngine();
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
@@ -2050,7 +2062,7 @@ TEST(FlutterTextInputPluginTest, IsAddedAndRemovedFromViewHierarchy) {
   ASSERT_FALSE(window.firstResponder == viewController.textInputPlugin);
 }
 
-TEST(FlutterTextInputPluginTest, FirstResponderIsCorrect) {
+TEST_F(FlutterTextInputPluginTest, FirstResponderIsCorrect) {
   FlutterEngine* engine = CreateTestEngine();
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
@@ -2085,7 +2097,7 @@ TEST(FlutterTextInputPluginTest, FirstResponderIsCorrect) {
   ASSERT_TRUE(window.firstResponder == viewController.flutterView);
 }
 
-TEST(FlutterTextInputPluginTest, HasZeroSizeAndClipsToBounds) {
+TEST_F(FlutterTextInputPluginTest, HasZeroSizeAndClipsToBounds) {
   id engineMock = flutter::testing::CreateMockFlutterEngine(@"");
   id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
   OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)


### PR DESCRIPTION
Wraps all FlutterTextInputPlugin tests in an autorelease pool to ensure resources are cleaned up between tests.

Prior to this change, running these tests via:

    ../out/host_debug_unopt_arm64/flutter_desktop_darwin_unittests \
        --gtest_repeat=1000 \
	--gtest_filter='FlutterTextInputPluginTest.TestFirstRectForCharacterRange'

Resuling in a test failure:

```
[ RUN      ] FlutterTextInputPluginTest.TestFirstRectForCharacterRange
2023-10-31 10:30:48.497112-0700 flutter_desktop_darwin_unittests[5304:4897209] Could not create Metal command queue.
2023-10-31 10:30:48.497761-0700 flutter_desktop_darwin_unittests[5304:4897209] Unable to create FlutterView; no MTLDevice or MTLCommandQueue available.
2023-10-31 10:30:48.520949-0700 flutter_desktop_darwin_unittests[5304:4897209] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Did not record an invocation in OCMStub/OCMExpect/OCMReject.
Possible causes are:
- The receiver is not a mock object.
- The selector conflicts with a selector implemented by OCMStubRecorder/OCMExpectationRecorder.'
*** First throw call stack:
(
        0   CoreFoundation                      0x000000018b1f6800 __exceptionPreprocess + 176
        1   libobjc.A.dylib                     0x000000018acedeb4 objc_exception_throw + 60
        2   CoreFoundation                      0x000000018b1f66f0 +[NSException exceptionWithName:reason:userInfo:] + 0
        3   flutter_desktop_darwin_unittests    0x00000001039318a0 +[OCMMacroState endStubMacro] + 272
        4   flutter_desktop_darwin_unittests    0x0000000100138858 -[FlutterInputPluginTestObjc testFirstRectForCharacterRange] + 1316
        5   flutter_desktop_darwin_unittests    0x0000000100152e04 _ZN7flutter7testing62FlutterTextInputPluginTest_TestFirstRectForCharacterRange_Test8TestBodyEv + 60
        6   flutter_d
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Did not record an invocation in OCMStub/OCMExpect/OCMReject.
Possible causes are:
- The receiver is not a mock object.
- The selector conflicts with a selector implemented by OCMStubRecorder/OCMExpectationRecorder.'
*** First throw call stack:
(
        0   CoreFoundation                      0x000000018b1f6800 __exceptionPreprocess + 176
        1   libobjc.A.dylib                     0x000000018acedeb4 objc_exception_throw + 60
        2   CoreFoundation                      0x000000018b1f66f0 +[NSException exceptionWithName:reason:userInfo:] + 0
        3   flutter_desktop_darwin_unittests    0x00000001039318a0 +[OCMMacroState endStubMacro] + 272
        4   flutter_desktop_darwin_unittests    0x0000000100138858 -[FlutterInputPluginTestObjc testFirstRectForCharacterRange] + 1316
```

Issue: https://github.com/flutter/flutter/issues/104789
Issue: https://github.com/flutter/flutter/issues/127441
Issue: https://github.com/flutter/flutter/issues/124840

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
