### PR TITLE
[Impeller] Include cstdint everywhere that uint32_t is used.

### DIFF
--- a/impeller/base/allocation.h
+++ b/impeller/base/allocation.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <memory>
 

--- a/impeller/compiler/compiler.cc
+++ b/impeller/compiler/compiler.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/compiler/compiler.h"
 
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <optional>

--- a/impeller/compiler/compiler_backend.h
+++ b/impeller/compiler/compiler_backend.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <variant>
 

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 

--- a/impeller/compiler/runtime_stage_data.cc
+++ b/impeller/compiler/runtime_stage_data.cc
@@ -5,6 +5,7 @@
 #include "impeller/compiler/runtime_stage_data.h"
 
 #include <array>
+#include <cstdint>
 #include <optional>
 
 #include "inja/inja.hpp"

--- a/impeller/compiler/source_options.h
+++ b/impeller/compiler/source_options.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/impeller/compiler/spirv_compiler.h
+++ b/impeller/compiler/spirv_compiler.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "flutter/fml/macros.h"

--- a/impeller/compiler/spirv_sksl.h
+++ b/impeller/compiler/spirv_sksl.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <utility>
 #include <variant>

--- a/impeller/compiler/switches.h
+++ b/impeller/compiler/switches.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <memory>
 

--- a/impeller/compiler/uniform_sorter.cc
+++ b/impeller/compiler/uniform_sorter.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/compiler/uniform_sorter.h"
 
+#include <cstdint>
+
 namespace impeller {
 
 std::vector<spirv_cross::ID> SortUniforms(

--- a/impeller/core/shader_types.h
+++ b/impeller/core/shader_types.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <string_view>
 #include <vector>

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -4,14 +4,13 @@
 
 #pragma once
 
-#include <variant>
+#include <cstdint>
+
 #include "impeller/core/capture.h"
 #include "impeller/entity/contents/contents.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/matrix.h"
-#include "impeller/geometry/path.h"
 #include "impeller/geometry/rect.h"
-#include "impeller/image/decompressed_image.h"
 
 namespace impeller {
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "impeller/entity/entity_pass_target.h"
 #include "impeller/renderer/context.h"
 #include "impeller/renderer/render_pass.h"

--- a/impeller/geometry/color.h
+++ b/impeller/geometry/color.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstdlib>
 #include <ostream>
 #include <type_traits>

--- a/impeller/geometry/gradient.h
+++ b/impeller/geometry/gradient.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/impeller/geometry/point.h
+++ b/impeller/geometry/point.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <ostream>
 #include <string>
 #include <type_traits>

--- a/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "flutter/fml/macros.h"

--- a/impeller/renderer/backend/gles/gpu_tracer_gles.h
+++ b/impeller/renderer/backend/gles/gpu_tracer_gles.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <deque>
 #include <thread>
 

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/renderer/backend/gles/render_pass_gles.h"
 
+#include <cstdint>
+
 #include "GLES3/gl3.h"
 #include "flutter/fml/trace_event.h"
 #include "fml/closure.h"

--- a/impeller/renderer/backend/vulkan/allocator_vk.h
+++ b/impeller/renderer/backend/vulkan/allocator_vk.h
@@ -13,6 +13,7 @@
 #include "impeller/renderer/backend/vulkan/vk.h"
 
 #include <array>
+#include <cstdint>
 #include <memory>
 
 namespace impeller {

--- a/impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.cc
+++ b/impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.cc
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.h"
+
+#include <cstdint>
+
 #include "impeller/renderer/backend/vulkan/texture_source_vk.h"
 
 #ifdef FML_OS_ANDROID

--- a/impeller/renderer/backend/vulkan/blit_command_vk.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/renderer/backend/vulkan/blit_command_vk.h"
 
+#include <cstdint>
+
 #include "impeller/renderer/backend/vulkan/command_encoder_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
 

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string>

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <optional>
 

--- a/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/descriptor_pool_vk.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "flutter/fml/macros.h"
 #include "fml/status_or.h"
 #include "impeller/renderer/backend/vulkan/device_holder.h"

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "flutter/fml/macros.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"

--- a/impeller/renderer/backend/vulkan/pass_bindings_cache.h
+++ b/impeller/renderer/backend/vulkan/pass_bindings_cache.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 
 #include "flutter/impeller/renderer/backend/vulkan/vk.h"

--- a/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
@@ -5,6 +5,7 @@
 #include "impeller/renderer/backend/vulkan/pipeline_library_vk.h"
 
 #include <chrono>
+#include <cstdint>
 #include <optional>
 #include <sstream>
 

--- a/impeller/renderer/backend/vulkan/shader_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/shader_library_vk.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/renderer/backend/vulkan/shader_library_vk.h"
 
+#include <cstdint>
+
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <variant>
 

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -3,9 +3,12 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
+
+#include <cstdint>
 #include <cstring>
 #include <utility>
 #include <vector>
+
 #include "fml/macros.h"
 #include "fml/thread_local.h"
 #include "impeller/base/thread_safety.h"

--- a/impeller/renderer/backend/vulkan/vertex_descriptor_vk.cc
+++ b/impeller/renderer/backend/vulkan/vertex_descriptor_vk.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/renderer/backend/vulkan/vertex_descriptor_vk.h"
 
+#include <cstdint>
+
 namespace impeller {
 
 vk::Format ToVertexDescriptorFormat(const ShaderStageIOSlot& input) {

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>

--- a/impeller/renderer/compute_tessellator.cc
+++ b/impeller/renderer/compute_tessellator.cc
@@ -4,6 +4,8 @@
 
 #include "impeller/renderer/compute_tessellator.h"
 
+#include <cstdint>
+
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/path_polyline.comp.h"
 #include "impeller/renderer/pipeline_library.h"

--- a/impeller/renderer/pool.h
+++ b/impeller/renderer/pool.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 

--- a/impeller/scene/importer/vertices_builder.cc
+++ b/impeller/scene/importer/vertices_builder.cc
@@ -4,6 +4,7 @@
 
 #include "impeller/scene/importer/vertices_builder.h"
 
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <memory>

--- a/impeller/tessellator/c/tessellator.h
+++ b/impeller/tessellator/c/tessellator.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "impeller/geometry/path_builder.h"
 #include "impeller/tessellator/tessellator.h"
 


### PR DESCRIPTION
Sprinkle cstdint everywhere that it's used. Unblocks the next impeller-cmake bump.

Ran into include issues during the build for the most recent impeller-cmake bump: https://github.com/bdero/impeller-cmake/pull/20

Going to add an optional libcxx STL build to help avoid stuff like this later (in the AAOS action items).