### PR TITLE
[ios17][text_input]fix ios 17.0 keyboard freeze when switching languages (without relying on text affinity)

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -622,7 +622,9 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                           inDirection:(UITextDirection)direction {
   // TODO(hellohuanlin): remove iOS 17 check. The same logic should apply to older iOS version.
   if (@available(iOS 17.0, *)) {
-    // If querying the line from end of document in forward direction, report not found.
+    // According to the API doc if the text position is at a text-unit boundary, it is considered
+    // enclosed only if the next position in the given direction is entirely enclosed. Link:
+    // https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614464-rangeenclosingposition?language=objc
     FlutterTextPosition* flutterPosition = (FlutterTextPosition*)position;
     if (flutterPosition.index > _textInputView.text.length ||
         (flutterPosition.index == _textInputView.text.length &&

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -602,7 +602,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
     case UITextGranularityLine:
       // The default UITextInputStringTokenizer does not handle line granularity
       // correctly. We need to implement our own line tokenizer.
-      result = [self lineEnclosingPosition:position];
+      result = [self lineEnclosingPosition:position inDirection:direction];
       break;
     case UITextGranularityCharacter:
     case UITextGranularityWord:
@@ -618,8 +618,18 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   return result;
 }
 
-- (UITextRange*)lineEnclosingPosition:(UITextPosition*)position {
+- (UITextRange*)lineEnclosingPosition:(UITextPosition*)position
+                          inDirection:(UITextDirection)direction {
   // Gets the first line break position after the input position.
+
+  // If querying the line from end of document in forward direction, report not found.
+  // This is an undocumented behavior of the default `UITextInputStringTokenizer`.
+  FlutterTextPosition* flutterPosition = (FlutterTextPosition*)position;
+  if (flutterPosition.index >= _textInputView.text.length &&
+      direction == UITextStorageDirectionForward) {
+    return nil;
+  }
+
   NSString* textAfter = [_textInputView
       textInRange:[_textInputView textRangeFromPosition:position
                                              toPosition:[_textInputView endOfDocument]]];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -620,16 +620,18 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
 - (UITextRange*)lineEnclosingPosition:(UITextPosition*)position
                           inDirection:(UITextDirection)direction {
-  // Gets the first line break position after the input position.
-
-  // If querying the line from end of document in forward direction, report not found.
-  // This is an undocumented behavior of the default `UITextInputStringTokenizer`.
-  FlutterTextPosition* flutterPosition = (FlutterTextPosition*)position;
-  if (flutterPosition.index >= _textInputView.text.length &&
-      direction == UITextStorageDirectionForward) {
-    return nil;
+  // TODO(hellohuanlin): remove iOS 17 check. The same logic should apply to older iOS version.
+  if (@available(iOS 17.0, *)) {
+    // If querying the line from end of document in forward direction, report not found.
+    // This is an undocumented behavior of the default `UITextInputStringTokenizer`.
+    FlutterTextPosition* flutterPosition = (FlutterTextPosition*)position;
+    if (flutterPosition.index >= _textInputView.text.length &&
+        direction == UITextStorageDirectionForward) {
+      return nil;
+    }
   }
 
+  // Gets the first line break position after the input position.
   NSString* textAfter = [_textInputView
       textInRange:[_textInputView textRangeFromPosition:position
                                              toPosition:[_textInputView endOfDocument]]];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -623,10 +623,10 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   // TODO(hellohuanlin): remove iOS 17 check. The same logic should apply to older iOS version.
   if (@available(iOS 17.0, *)) {
     // If querying the line from end of document in forward direction, report not found.
-    // This is an undocumented behavior of the default `UITextInputStringTokenizer`.
     FlutterTextPosition* flutterPosition = (FlutterTextPosition*)position;
-    if (flutterPosition.index >= _textInputView.text.length &&
-        direction == UITextStorageDirectionForward) {
+    if (flutterPosition.index > _textInputView.text.length ||
+        (flutterPosition.index == _textInputView.text.length &&
+         direction == UITextStorageDirectionForward)) {
       return nil;
     }
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -2690,6 +2690,30 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(range.range.length, 20u);
 }
 
+- (void)testFlutterTokenizerLineEnclosingEndOfDocumentInBackwardDirectionShouldNotReturnNil {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [inputView insertText:@"0123456789\n012345"];
+  id<UITextInputTokenizer> tokenizer = [inputView tokenizer];
+
+  FlutterTextRange* range =
+      (FlutterTextRange*)[tokenizer rangeEnclosingPosition:[inputView endOfDocument]
+                                           withGranularity:UITextGranularityLine
+                                               inDirection:UITextStorageDirectionBackward];
+  XCTAssertEqual(range.range.location, 11u);
+  XCTAssertEqual(range.range.length, 6u);
+}
+
+- (void)testFlutterTokenizerLineEnclosingEndOfDocumentInForwardDirectionShouldReturnNil {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [inputView insertText:@"0123456789\n012345"];
+  id<UITextInputTokenizer> tokenizer = [inputView tokenizer];
+
+  UITextRange* range = [tokenizer rangeEnclosingPosition:[inputView endOfDocument]
+                                         withGranularity:UITextGranularityLine
+                                             inDirection:UITextStorageDirectionForward];
+  XCTAssertNil(range);
+}
+
 - (void)testFlutterTextInputPluginRetainsFlutterTextInputView {
   FlutterViewController* flutterViewController = [[FlutterViewController alloc] init];
   FlutterTextInputPlugin* myInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:engine];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -2720,6 +2720,24 @@ FLUTTER_ASSERT_ARC
   }
 }
 
+- (void)testFlutterTokenizerLineEnclosingOutOfRangePositionShouldReturnNilOnIOS17 {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
+  [inputView insertText:@"0123456789\n012345"];
+  id<UITextInputTokenizer> tokenizer = [inputView tokenizer];
+
+  FlutterTextPosition* position = [FlutterTextPosition positionWithIndex:100];
+  FlutterTextRange* range =
+      (FlutterTextRange*)[tokenizer rangeEnclosingPosition:position
+                                           withGranularity:UITextGranularityLine
+                                               inDirection:UITextStorageDirectionForward];
+  if (@available(iOS 17.0, *)) {
+    XCTAssertNil(range);
+  } else {
+    XCTAssertEqual(range.range.location, 0u);
+    XCTAssertEqual(range.range.length, 0u);
+  }
+}
+
 - (void)testFlutterTextInputPluginRetainsFlutterTextInputView {
   FlutterViewController* flutterViewController = [[FlutterViewController alloc] init];
   FlutterTextInputPlugin* myInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:engine];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -2703,15 +2703,21 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(range.range.length, 6u);
 }
 
-- (void)testFlutterTokenizerLineEnclosingEndOfDocumentInForwardDirectionShouldReturnNil {
+- (void)testFlutterTokenizerLineEnclosingEndOfDocumentInForwardDirectionShouldReturnNilOnIOS17 {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
   [inputView insertText:@"0123456789\n012345"];
   id<UITextInputTokenizer> tokenizer = [inputView tokenizer];
 
-  UITextRange* range = [tokenizer rangeEnclosingPosition:[inputView endOfDocument]
-                                         withGranularity:UITextGranularityLine
-                                             inDirection:UITextStorageDirectionForward];
-  XCTAssertNil(range);
+  FlutterTextRange* range =
+      (FlutterTextRange*)[tokenizer rangeEnclosingPosition:[inputView endOfDocument]
+                                           withGranularity:UITextGranularityLine
+                                               inDirection:UITextStorageDirectionForward];
+  if (@available(iOS 17.0, *)) {
+    XCTAssertNil(range);
+  } else {
+    XCTAssertEqual(range.range.location, 11u);
+    XCTAssertEqual(range.range.length, 6u);
+  }
 }
 
 - (void)testFlutterTextInputPluginRetainsFlutterTextInputView {


### PR DESCRIPTION
After close examination of the UIKit's default string tokenizer, when querying the line enclosing the end of doc position **in forward direction**, we should return nil (regardless whether the position is forward or backward affinity). 

This aligns with the [API doc](https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614464-rangeenclosingposition?language=objc): 

> If the text position is at a text-unit boundary, it is considered enclosed only if the next position in the given direction is entirely enclosed.

Will cherry pick this soon. Otherwise it will be less and less important as users upgrade to iOS 17.1. 

### Why my previous workaround also works? 

It turns out my previous workaround PR https://github.com/flutter/engine/pull/46591 works only because our misuse of text affinity in our text input. Specifically, when adding text affinity support, we only added it to `FlutterTextPosition`, but not `FlutterTextRange`. So when getting the beginning/end position from the range, we assign arbitrary affinities. 

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/engine/pull/46591

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
