### PR TITLE
Fix race condition in Platform View Scenario tests

### DIFF
--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -1758,6 +1758,7 @@ class PlatformViewsWithClipsScrolling extends Scenario
 }
 
 final Map<String, int> _createdPlatformViews = <String, int> {};
+final Map<String, bool> _calledToBeCreatedPlatformViews = <String, bool> {};
 
 /// Adds the platform view to the scene.
 ///
@@ -1787,6 +1788,10 @@ void addPlatformView(
     );
     return;
   }
+  if (_calledToBeCreatedPlatformViews.containsKey(platformViewKey)) {
+    return;
+  }
+  _calledToBeCreatedPlatformViews[platformViewKey] = true;
 
   final bool usesAndroidHybridComposition = scenarioParams['use_android_view'] as bool? ?? false;
   final bool expectAndroidHybridCompositionFallback =


### PR DESCRIPTION
Fixes race condition in Platform View Scenario tests, see https://github.com/flutter/flutter/issues/126627 for description of issue.

Fixes https://github.com/flutter/flutter/issues/137547 and https://github.com/flutter/flutter/issues/126627.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
