### PR TITLE
[CP][Impeller] Disable raster stats service protocol. (#47206)

### DIFF
--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -70,6 +70,8 @@ class LayerTree {
   /// When `Paint` is called, if leaf layer tracing is enabled, additional
   /// metadata around raterization of leaf layers is collected.
   ///
+  /// This is not supported in the Impeller backend.
+  ///
   /// See: `LayerSnapshotStore`
   void enable_leaf_layer_tracing(bool enable) {
     enable_leaf_layer_tracing_ = enable;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1968,6 +1968,13 @@ bool Shell::OnServiceProtocolRenderFrameWithRasterStats(
     rapidjson::Document* response) {
   FML_DCHECK(task_runners_.GetRasterTaskRunner()->RunsTasksOnCurrentThread());
 
+  // Impeller does not support this protocol method.
+  if (io_manager_->GetImpellerContext()) {
+    const char* error = "Raster status not supported on Impeller backend.";
+    ServiceProtocolFailureError(response, error);
+    return false;
+  }
+
   // TODO(dkwingsmt): This method only handles view #0, including the snapshot
   // and the frame size. We need to adapt this method to multi-view.
   // https://github.com/flutter/flutter/issues/131892

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2713,6 +2713,47 @@ TEST_F(ShellTest, OnServiceProtocolRenderFrameWithRasterStatsWorks) {
   DestroyShell(std::move(shell));
 }
 
+#if defined(FML_OS_MACOSX)
+TEST_F(ShellTest, OnServiceProtocolRenderFrameWithRasterStatsDisableImpeller) {
+  auto settings = CreateSettingsForFixture();
+  settings.enable_impeller = true;
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .platform_view_create_callback = ShellTestPlatformViewBuilder({
+          .rendering_backend =
+              ShellTestPlatformView::BackendType::kMetalBackend,
+      }),
+  });
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("scene_with_red_box");
+
+  RunEngine(shell.get(), std::move(configuration));
+  PumpOneFrame(shell.get());
+
+  ServiceProtocol::Handler::ServiceProtocolMap empty_params;
+  rapidjson::Document document;
+  OnServiceProtocol(
+      shell.get(), ServiceProtocolEnum::kRenderFrameWithRasterStats,
+      shell->GetTaskRunners().GetRasterTaskRunner(), empty_params, &document);
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  document.Accept(writer);
+  std::string actual_json = buffer.GetString();
+  std::string expected_json =
+      "{\"code\":-32000,\"message\":\"Raster status not supported on Impeller "
+      "backend.\"}";
+
+  ASSERT_EQ(actual_json, expected_json);
+
+  PlatformViewNotifyDestroyed(shell.get());
+  DestroyShell(std::move(shell));
+}
+#endif  // FML_OS_MACOSX
+
 // TODO(https://github.com/flutter/flutter/issues/100273): Disabled due to
 // flakiness.
 // TODO(https://github.com/flutter/flutter/issues/100299): Fix it when


### PR DESCRIPTION
As far as I can tell, this functionality has _always_ been falling back to software rendering with Skia when Impeller was enabled. This is at best extremely misleading. Since I started putting Impeller specific objects in the display list it introduced crashes, and must be disabled.

Fixes https://github.com/flutter/flutter/issues/136847
