### PR TITLE
[Impeller] Deprecate the exposed Rect fields

### DIFF
--- a/impeller/geometry/geometry_asserts.h
+++ b/impeller/geometry/geometry_asserts.h
@@ -52,10 +52,10 @@ inline ::testing::AssertionResult QuaternionNear(impeller::Quaternion a,
 }
 
 inline ::testing::AssertionResult RectNear(impeller::Rect a, impeller::Rect b) {
-  auto equal = NumberNear(a.origin.x, b.origin.x) &&
-               NumberNear(a.origin.y, b.origin.y) &&
-               NumberNear(a.size.width, b.size.width) &&
-               NumberNear(a.size.height, b.size.height);
+  auto equal = NumberNear(a.GetOrigin().x, b.GetOrigin().x) &&
+               NumberNear(a.GetOrigin().y, b.GetOrigin().y) &&
+               NumberNear(a.GetSize().width, b.GetSize().width) &&
+               NumberNear(a.GetSize().height, b.GetSize().height);
 
   return equal ? ::testing::AssertionSuccess()
                : ::testing::AssertionFailure() << "Rects are not equal.";

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -744,10 +744,10 @@ TEST(GeometryTest, CanConvertTTypesExplicitly) {
   {
     Rect r1 = Rect::MakeXYWH(1.0, 2.0, 3.0, 4.0);
     IRect r2 = static_cast<IRect>(r1);
-    ASSERT_EQ(r2.origin.x, 1u);
-    ASSERT_EQ(r2.origin.y, 2u);
-    ASSERT_EQ(r2.size.width, 3u);
-    ASSERT_EQ(r2.size.height, 4u);
+    ASSERT_EQ(r2.GetOrigin().x, 1u);
+    ASSERT_EQ(r2.GetOrigin().y, 2u);
+    ASSERT_EQ(r2.GetSize().width, 3u);
+    ASSERT_EQ(r2.GetSize().height, 4u);
   }
 }
 

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -20,7 +20,9 @@ template <class T>
 struct TRect {
   using Type = T;
 
+  /// DEPRECATED: Use |GetOrigin|
   TPoint<Type> origin;
+  /// DEPRECATED: Use |GetSize|
   TSize<Type> size;
 
   constexpr TRect() : origin({0, 0}), size({0, 0}) {}


### PR DESCRIPTION
The exposed Rect fields prevent future optimizations which will depend on changing the internal storage format.