### PR TITLE
Run tests on either macOS 12 or 13

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -53,7 +53,7 @@ platform_properties:
         ]
       device_type: none
       cpu: x86
-      os: Mac-12
+      os: Mac-12|Mac-13
       $flutter/osx_sdk : >-
         {
           "sdk_version": "14e300c"
@@ -448,7 +448,7 @@ targets:
           "sdk_version": "14e300c"
         }
     drone_dimensions:
-      - os=Mac-12
+      - os=Mac-12|Mac-13
 
   - name: Linux mac_unopt
     recipe: engine_v2/engine_v2
@@ -469,7 +469,7 @@ targets:
           "sdk_version": "14e300c"
         }
     drone_dimensions:
-      - os=Mac-12
+      - os=Mac-12|Mac-13
       - cpu=x86
 
   - name: Mac impeller-cmake-example

--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -14,7 +14,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -53,7 +53,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -93,7 +93,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -133,7 +133,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -172,7 +172,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -212,7 +212,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -3,7 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -24,7 +24,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -50,7 +50,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -82,7 +82,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -114,7 +114,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -146,7 +146,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -178,7 +178,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_clang_tidy_presubmit.json
+++ b/ci/builders/mac_clang_tidy_presubmit.json
@@ -3,7 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -24,7 +24,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -50,7 +50,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -82,7 +82,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -15,7 +15,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -79,7 +79,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -139,7 +139,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -208,7 +208,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -255,7 +255,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -299,7 +299,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_impeller_cmake_example.json
+++ b/ci/builders/mac_impeller_cmake_example.json
@@ -5,7 +5,7 @@
             "archives": [],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -3,7 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -26,7 +26,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -50,7 +50,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -74,7 +74,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -99,7 +99,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -124,7 +124,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -148,7 +148,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -173,7 +173,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -198,7 +198,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -224,7 +224,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -11,7 +11,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -71,7 +71,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -128,7 +128,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -177,7 +177,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -247,7 +247,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=arm64"
             ],
             "gclient_variables": {


### PR DESCRIPTION
In preparation for migrating our fleet to macOS 13, we're updating tests to run on either macOS 12 or macOS 13.

I have run all tests on macOS 13: https://docs.google.com/spreadsheets/d/1-KOSOSF7uVA4KuqSMn9xz3IIJW78u8SXLYK2OAfe_Qg/edit?usp=sharing&resourcekey=0-df8Bj5PRS1IPBccPDdvRCQ

Note: I'm leaving subtests of `Linux linux_web_engine` on Mac-12 since they're currently incompatible with MacOS 13.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
