### PR TITLE
[Impeller] Remove Rect field accesses from aiks subdirectory

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -326,8 +326,11 @@ void Canvas::ClipRRect(const Rect& rect,
                   .SetBounds(rect)
                   .TakePath();
 
-  std::optional<Rect> inner_rect = (corner_radius * 2 < rect.size.width &&
-                                    corner_radius * 2 < rect.size.height)
+  auto size = rect.GetSize();
+  // Does the rounded rect have a flat part on the top/bottom or left/right?
+  bool flat_on_TB = corner_radius * 2 < size.width;
+  bool flat_on_LR = corner_radius * 2 < size.height;
+  std::optional<Rect> inner_rect = (flat_on_LR && flat_on_TB)
                                        ? rect.Expand(-corner_radius)
                                        : std::make_optional<Rect>();
   auto geometry = Geometry::MakeFillPath(path, inner_rect);
@@ -353,12 +356,12 @@ void Canvas::ClipRRect(const Rect& rect,
         // without involving the curved corners
         // Since this is a subtract operation, we can subtract each
         // rectangle piece individually without fear of interference.
-        if (corner_radius * 2 < rect.size.width) {
+        if (flat_on_TB) {
           SubtractCulling(Rect::MakeLTRB(
               rect.GetLeft() + corner_radius, rect.GetTop(),
               rect.GetRight() - corner_radius, rect.GetBottom()));
         }
-        if (corner_radius * 2 < rect.size.height) {
+        if (flat_on_LR) {
           SubtractCulling(Rect::MakeLTRB(
               rect.GetLeft(), rect.GetTop() + corner_radius,  //
               rect.GetRight(), rect.GetBottom() - corner_radius));
@@ -479,8 +482,7 @@ void Canvas::DrawImage(const std::shared_ptr<Image>& image,
   }
 
   const auto source = Rect::MakeSize(image->GetSize());
-  const auto dest =
-      Rect::MakeXYWH(offset.x, offset.y, source.size.width, source.size.height);
+  const auto dest = source.Shift(offset);
 
   DrawImageRect(image, source, dest, paint, std::move(sampler));
 }
@@ -490,7 +492,7 @@ void Canvas::DrawImageRect(const std::shared_ptr<Image>& image,
                            Rect dest,
                            const Paint& paint,
                            SamplerDescriptor sampler) {
-  if (!image || source.size.IsEmpty() || dest.size.IsEmpty()) {
+  if (!image || source.IsEmpty() || dest.IsEmpty()) {
     return;
   }
 

--- a/impeller/aiks/color_source.cc
+++ b/impeller/aiks/color_source.cc
@@ -64,7 +64,7 @@ ColorSource ColorSource::MakeLinearGradient(Point start_point,
     std::vector<Point> bounds{start_point, end_point};
     auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
     if (intrinsic_size.has_value()) {
-      contents->SetColorSourceSize(intrinsic_size->size);
+      contents->SetColorSourceSize(intrinsic_size->GetSize());
     }
     return contents;
   };
@@ -98,7 +98,7 @@ ColorSource ColorSource::MakeConicalGradient(Point center,
     std::vector<Point> bounds{center + radius_pt, center - radius_pt};
     auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
     if (intrinsic_size.has_value()) {
-      contents->SetColorSourceSize(intrinsic_size->size);
+      contents->SetColorSourceSize(intrinsic_size->GetSize());
     }
     return contents;
   };
@@ -128,7 +128,7 @@ ColorSource ColorSource::MakeRadialGradient(Point center,
     std::vector<Point> bounds{center + radius_pt, center - radius_pt};
     auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
     if (intrinsic_size.has_value()) {
-      contents->SetColorSourceSize(intrinsic_size->size);
+      contents->SetColorSourceSize(intrinsic_size->GetSize());
     }
     return contents;
   };

--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -20,12 +20,12 @@ std::optional<Snapshot> Picture::Snapshot(AiksContext& context) {
     return std::nullopt;
   }
 
-  const auto translate = Matrix::MakeTranslation(-coverage.value().origin);
+  const auto translate = Matrix::MakeTranslation(-coverage->GetOrigin());
   auto texture =
-      RenderToTexture(context, ISize(coverage.value().size), translate);
+      RenderToTexture(context, ISize(coverage->GetSize()), translate);
   return impeller::Snapshot{
       .texture = std::move(texture),
-      .transform = Matrix::MakeTranslation(coverage.value().origin)};
+      .transform = Matrix::MakeTranslation(coverage->GetOrigin())};
 }
 
 std::shared_ptr<Image> Picture::ToImage(AiksContext& context,


### PR DESCRIPTION
These changes move any code in `impeller/aiks` that accessed the internal fields of `Rect` to using either the appropriate convenience methods for the operation or the getters for those properties.

This is a simple code refactoring and should be covered by existing tests. 