### PR TITLE
Refactor `PlatformViewAndroid::Register*Texture`

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -38,6 +38,10 @@ source_set("image_generator") {
   ]
 }
 
+test_fixtures("android_shell_fixtures") {
+  fixtures = []
+}
+
 executable("flutter_shell_native_unittests") {
   visibility = [ "*" ]
   testonly = true
@@ -46,11 +50,11 @@ executable("flutter_shell_native_unittests") {
     "android_context_gl_unittests.cc",
     "android_shell_holder_unittests.cc",
     "apk_asset_provider_unittests.cc",
-    "flutter_shell_native_unittests.cc",
     "platform_view_android_unittests.cc",
   ]
   public_configs = [ "//flutter:config" ]
   deps = [
+    ":android_shell_fixtures",
     ":flutter_shell_native_src",
     "//flutter/shell/platform/android/jni:jni_mock",
     "//flutter/testing",

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -47,11 +47,13 @@ executable("flutter_shell_native_unittests") {
     "android_shell_holder_unittests.cc",
     "apk_asset_provider_unittests.cc",
     "flutter_shell_native_unittests.cc",
+    "platform_view_android_unittests.cc",
   ]
   public_configs = [ "//flutter:config" ]
   deps = [
     ":flutter_shell_native_src",
     "//flutter/shell/platform/android/jni:jni_mock",
+    "//flutter/testing",
     "//third_party/googletest:gmock",
     "//third_party/googletest:gtest",
   ]

--- a/shell/platform/android/flutter_shell_native_unittests.cc
+++ b/shell/platform/android/flutter_shell_native_unittests.cc
@@ -1,6 +1,0 @@
-#include "gtest/gtest.h"
-
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -72,6 +72,7 @@ static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
     const std::optional<std::string>& impeller_backend,
     bool enable_vulkan_validation,
     bool enable_opengl_gpu_tracing) {
+  FML_LOG(ERROR) << "CreateAndroidContext";
   if (use_software_rendering) {
     return std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
   }

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -19,6 +19,9 @@
 #include "flutter/shell/platform/android/android_surface_software.h"
 #include "flutter/shell/platform/android/image_external_texture_gl.h"
 #include "flutter/shell/platform/android/surface_texture_external_texture_gl.h"
+#include "fml/logging.h"
+#include "impeller/base/config.h"
+#include "impeller/renderer/backend/gles/context_gles.h"
 #if IMPELLER_ENABLE_VULKAN  // b/258506856 for why this is behind an if
 #include "flutter/shell/platform/android/android_surface_vulkan_impeller.h"
 #include "flutter/shell/platform/android/image_external_texture_vk.h"
@@ -307,49 +310,112 @@ void PlatformViewAndroid::UpdateSemantics(
 void PlatformViewAndroid::RegisterExternalTexture(
     int64_t texture_id,
     const fml::jni::ScopedJavaGlobalRef<jobject>& surface_texture) {
-  if (android_context_->RenderingApi() == AndroidRenderingAPI::kOpenGLES) {
-    if (android_context_->GetImpellerContext()) {
-      // Impeller GLES.
-      RegisterTexture(std::make_shared<SurfaceTextureExternalTextureImpellerGL>(
-          std::static_pointer_cast<impeller::ContextGLES>(
-              android_context_->GetImpellerContext()),
-          texture_id, surface_texture, jni_facade_));
-    } else {
-      // Legacy GL.
-      RegisterTexture(std::make_shared<SurfaceTextureExternalTextureGL>(
-          texture_id, surface_texture, jni_facade_));
+  std::shared_ptr<flutter::Texture> texture;
+
+  // TODO(https://github.com/flutter/flutter/issues/137798): Refactor.
+  if (auto const impeller = android_context_->GetImpellerContext()) {
+    switch (android_context_->RenderingApi()) {
+      case AndroidRenderingAPI::kOpenGLES:
+        impeller::ContextGLES::Cast(*impeller);
+        texture = std::make_shared<SurfaceTextureExternalTextureImpellerGL>(
+            /*context=*/std::static_pointer_cast<impeller::ContextGLES>(
+                impeller),
+            /*id=*/texture_id,
+            /*surface_texture=*/surface_texture,
+            /*jni_facade=*/jni_facade_);
+        return;
+      case AndroidRenderingAPI::kVulkan:
+        // TODO(https://github.com/flutter/flutter/issues/137639).
+        IMPELLER_UNIMPLEMENTED;
+        break;
+      case AndroidRenderingAPI::kAutoselect:
+        // Autoselect should have been resolved to GLES or Vulkan by now.
+        [[fallthrough]];
+      case AndroidRenderingAPI::kSoftware:
+        // Impeller does not have a software backend.
+        FML_UNREACHABLE();
+        break;
     }
-  } else {
-    FML_LOG(INFO) << "Attempted to use a SurfaceTextureExternalTexture with an "
-                     "unsupported rendering API.";
   }
+
+  // Skia backend always uses GLES, so fail on anything else.
+  switch (android_context_->RenderingApi()) {
+    case AndroidRenderingAPI::kOpenGLES:
+      texture = std::make_shared<SurfaceTextureExternalTextureGL>(
+          /*id=*/texture_id,
+          /*surface_texture=*/surface_texture,
+          /*jni_facade=*/jni_facade_);
+      return;
+    case AndroidRenderingAPI::kSoftware:
+      FML_LOG(INFO) << "Attempted to use a SurfaceTexture texture with a "
+                       "software rendering API. Nothing will be rendered.";
+      return;
+    case AndroidRenderingAPI::kVulkan:
+      [[fallthrough]];
+    case AndroidRenderingAPI::kAutoselect:
+      FML_UNREACHABLE();
+  }
+
+  FML_DCHECK(texture) << "Expected a texture to be created.";
+  RegisterTexture(texture);
 }
 
 void PlatformViewAndroid::RegisterImageTexture(
     int64_t texture_id,
     const fml::jni::ScopedJavaGlobalRef<jobject>& image_texture_entry) {
-  if (android_context_->RenderingApi() == AndroidRenderingAPI::kOpenGLES) {
-    if (android_context_->GetImpellerContext()) {
-      // Impeller GLES.
-      RegisterTexture(std::make_shared<ImageExternalTextureGLImpeller>(
-          std::static_pointer_cast<impeller::ContextGLES>(
-              android_context_->GetImpellerContext()),
-          texture_id, image_texture_entry, jni_facade_));
-    } else {
-      // Legacy GL.
-      RegisterTexture(std::make_shared<ImageExternalTextureGLSkia>(
-          std::static_pointer_cast<AndroidContextGLSkia>(android_context_),
-          texture_id, image_texture_entry, jni_facade_));
+  std::shared_ptr<flutter::Texture> texture;
+
+  // TODO(https://github.com/flutter/flutter/issues/137798): Refactor.
+  if (auto const impeller = android_context_->GetImpellerContext()) {
+    switch (android_context_->RenderingApi()) {
+      case AndroidRenderingAPI::kOpenGLES:
+        texture = std::make_shared<ImageExternalTextureGLImpeller>(
+            /*context=*/std::static_pointer_cast<impeller::ContextGLES>(
+                impeller),
+            /*id=*/texture_id,
+            /*hardware_buffer_texture_entry=*/image_texture_entry,
+            /*jni_facade=*/jni_facade_);
+        return;
+      case AndroidRenderingAPI::kVulkan:
+        texture = std::make_shared<ImageExternalTextureVK>(
+            /*context=*/std::static_pointer_cast<impeller::ContextVK>(impeller),
+            /*id=*/texture_id,
+            /*hardware_buffer_texture_entry=*/image_texture_entry,
+            /*jni_facade=*/jni_facade_);
+        break;
+      case AndroidRenderingAPI::kAutoselect:
+        // Autoselect should have been resolved to GLES or Vulkan by now.
+        [[fallthrough]];
+      case AndroidRenderingAPI::kSoftware:
+        // Impeller does not have a software backend.
+        FML_UNREACHABLE();
+        break;
     }
-  } else if (android_context_->RenderingApi() == AndroidRenderingAPI::kVulkan) {
-    RegisterTexture(std::make_shared<ImageExternalTextureVK>(
-        std::static_pointer_cast<impeller::ContextVK>(
-            android_context_->GetImpellerContext()),
-        texture_id, image_texture_entry, jni_facade_));
-  } else {
-    FML_LOG(INFO) << "Attempted to use a HardwareBuffer texture with an "
-                     "unsupported rendering API.";
   }
+
+  switch (android_context_->RenderingApi()) {
+    case AndroidRenderingAPI::kOpenGLES:
+      texture = std::make_shared<ImageExternalTextureGLSkia>(
+          /*context=*/std::static_pointer_cast<AndroidContextGLSkia>(
+              android_context_),
+          /*id=*/texture_id,
+          /*hardware_buffer_texture_entry=*/image_texture_entry,
+          /*jni_facade=*/jni_facade_);
+      return;
+    case AndroidRenderingAPI::kVulkan:
+      [[fallthrough]];
+    case AndroidRenderingAPI::kAutoselect:
+      // Skia backend always uses GLES, so fail on anything else.
+      FML_UNREACHABLE();
+      break;
+    case AndroidRenderingAPI::kSoftware:
+      FML_LOG(INFO) << "Attempted to use a HardwareBuffer with a software "
+                    << "rendering API. Nothing will be rendered.";
+      return;
+  }
+
+  FML_DCHECK(texture) << "Expected a texture to be created.";
+  RegisterTexture(texture);
 }
 
 // |PlatformView|

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -313,7 +313,6 @@ void PlatformViewAndroid::RegisterExternalTexture(
   if (auto const impeller = android_context_->GetImpellerContext()) {
     switch (android_context_->RenderingApi()) {
       case AndroidRenderingAPI::kOpenGLES:
-        impeller::ContextGLES::Cast(*impeller);
         texture = std::make_shared<SurfaceTextureExternalTextureImpellerGL>(
             /*context=*/std::static_pointer_cast<impeller::ContextGLES>(
                 impeller),

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -19,9 +19,6 @@
 #include "flutter/shell/platform/android/android_surface_software.h"
 #include "flutter/shell/platform/android/image_external_texture_gl.h"
 #include "flutter/shell/platform/android/surface_texture_external_texture_gl.h"
-#include "fml/logging.h"
-#include "impeller/base/config.h"
-#include "impeller/renderer/backend/gles/context_gles.h"
 #if IMPELLER_ENABLE_VULKAN  // b/258506856 for why this is behind an if
 #include "flutter/shell/platform/android/android_surface_vulkan_impeller.h"
 #include "flutter/shell/platform/android/image_external_texture_vk.h"

--- a/shell/platform/android/platform_view_android_unittests.cc
+++ b/shell/platform/android/platform_view_android_unittests.cc
@@ -1,0 +1,134 @@
+#include "flutter/common/task_runners.h"
+#include "flutter/shell/common/platform_view.h"
+#include "flutter/shell/platform/android/context/android_context.h"
+#include "flutter/shell/platform/android/jni/jni_mock.h"
+#include "flutter/shell/platform/android/platform_view_android.h"
+#include "flutter/testing/testing.h"
+#include "flutter/testing/thread_test.h"
+
+#include "gmock/gmock.h"  // IWYU pragma: keep
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+namespace {
+
+class MockDelegate final : public ::flutter::PlatformView::Delegate {
+ public:
+  MOCK_METHOD(void,
+              OnPlatformViewCreated,
+              (std::unique_ptr<Surface> surface),
+              (override));
+
+  MOCK_METHOD(void, OnPlatformViewDestroyed, (), (override));
+
+  MOCK_METHOD(void, OnPlatformViewScheduleFrame, (), (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewSetNextFrameCallback,
+              (const fml::closure& closure),
+              (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewSetViewportMetrics,
+              (int64_t view_id, const ViewportMetrics& metrics),
+              (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewDispatchPlatformMessage,
+              (std::unique_ptr<PlatformMessage> message),
+              (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewDispatchPointerDataPacket,
+              (std::unique_ptr<PointerDataPacket> packet),
+              (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewDispatchSemanticsAction,
+              (int32_t node_id,
+               SemanticsAction action,
+               fml::MallocMapping args),
+              (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewSetSemanticsEnabled,
+              (bool enabled),
+              (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewSetAccessibilityFeatures,
+              (int32_t flags),
+              (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewRegisterTexture,
+              (std::shared_ptr<Texture> texture),
+              (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewUnregisterTexture,
+              (int64_t texture_id),
+              (override));
+
+  MOCK_METHOD(void,
+              OnPlatformViewMarkTextureFrameAvailable,
+              (int64_t texture_id),
+              (override));
+
+  MOCK_METHOD(void,
+              LoadDartDeferredLibrary,
+              (intptr_t loading_unit_id,
+               std::unique_ptr<const fml::Mapping> snapshot_data,
+               std::unique_ptr<const fml::Mapping> snapshot_instructions),
+              (override));
+
+  MOCK_METHOD(void,
+              LoadDartDeferredLibraryError,
+              (intptr_t loading_unit_id,
+               const std::string error_message,
+               bool transient),
+              (override));
+
+  MOCK_METHOD(void,
+              UpdateAssetResolverByType,
+              (std::unique_ptr<AssetResolver> updated_asset_resolver,
+               AssetResolver::AssetResolverType type),
+              (override));
+
+  MOCK_METHOD(const Settings&,
+              OnPlatformViewGetSettings,
+              (),
+              (const, override));
+};
+
+class AndroidPlatformViewTest : public ThreadTest {
+ public:
+  MockDelegate& Delegate() { return *delegate_; }
+
+  std::shared_ptr<PlatformViewAndroid> Init(AndroidRenderingAPI api) {
+    return std::make_shared<PlatformViewAndroid>(
+        Delegate(),
+        TaskRunners(/*label=*/GetCurrentTestName(),
+                    /*platform=*/GetCurrentTaskRunner(),
+                    /*raster=*/CreateNewThread("raster"),
+                    /*ui=*/CreateNewThread("ui"),
+                    /*io=*/CreateNewThread("io")),
+        std::make_shared<JNIMock>(), std::make_shared<AndroidContext>(api));
+  }
+
+ private:
+  // A mocked delegate to use for testing.
+  std::shared_ptr<MockDelegate> delegate_ = std::make_shared<MockDelegate>();
+};
+
+}  // namespace
+
+TEST_F(AndroidPlatformViewTest, Create) {
+  MockDelegate();
+  Init(AndroidRenderingAPI::kVulkan);
+}
+
+}  // namespace testing
+}  // namespace flutter


### PR DESCRIPTION
Partial work towards https://github.com/flutter/flutter/issues/137639.

This is mostly to help me understand how it works today, and to clarify if I understand the branching correctly (filed https://github.com/flutter/flutter/issues/137798 to refactor this further after completion).

If you're leaning "this seems good", I could also use some advice on how to write a test for this. One option is mocking `PlatformView::Delegate`. I could try using a real android environment as well, assuming it's possible to set it up in such a way that I can assert that "given X backend, Y texture is produced".