### PR TITLE
[Impeller] Adjust advanced blend construction to avoid moto g4 crash.

### DIFF
--- a/impeller/entity/shaders/blending/advanced_blend.frag
+++ b/impeller/entity/shaders/blending/advanced_blend.frag
@@ -35,8 +35,6 @@ f16vec4 Sample(f16sampler2D texture_sampler, vec2 texture_coords) {
   return IPHalfSampleDecal(texture_sampler, texture_coords);
 }
 
-AdvancedBlend(blend_type);
-
 void main() {
   f16vec4 dst_sample = Sample(texture_sampler_dst,  // sampler
                               v_dst_texture_coords  // texture coordinates
@@ -51,7 +49,7 @@ void main() {
                              ) *
                           blend_info.src_input_alpha;
 
-  f16vec3 blend_result = Blend(dst.rgb, src.rgb);
+  f16vec3 blend_result = AdvancedBlend(dst.rgb, src.rgb, blend_type);
   f16vec4 blended = mix(src, f16vec4(blend_result, dst.a), dst.a);
   frag_color = mix(dst_sample, blended, src.a);
 }

--- a/impeller/entity/shaders/blending/blend_select.glsl
+++ b/impeller/entity/shaders/blending/blend_select.glsl
@@ -22,39 +22,51 @@
 // kColor,
 // kLuminosity,
 // Note, this isn't a switch as GLSL ES 1.0 does not support them.
-#define AdvancedBlend(blend_type)           \
-  f16vec3 Blend(f16vec3 dst, f16vec3 src) { \
-    if (blend_type == 0) {                  \
-      return IPBlendScreen(dst, src);       \
-    } else if (blend_type == 1) {           \
-      return IPBlendOverlay(dst, src);      \
-    } else if (blend_type == 2) {           \
-      return IPBlendDarken(dst, src);       \
-    } else if (blend_type == 3) {           \
-      return IPBlendLighten(dst, src);      \
-    } else if (blend_type == 4) {           \
-      return IPBlendColorDodge(dst, src);   \
-    } else if (blend_type == 5) {           \
-      return IPBlendColorBurn(dst, src);    \
-    } else if (blend_type == 6) {           \
-      return IPBlendHardLight(dst, src);    \
-    } else if (blend_type == 7) {           \
-      return IPBlendSoftLight(dst, src);    \
-    } else if (blend_type == 8) {           \
-      return IPBlendDifference(dst, src);   \
-    } else if (blend_type == 9) {           \
-      return IPBlendExclusion(dst, src);    \
-    } else if (blend_type == 10) {          \
-      return IPBlendMultiply(dst, src);     \
-    } else if (blend_type == 11) {          \
-      return IPBlendHue(dst, src);          \
-    } else if (blend_type == 12) {          \
-      return IPBlendSaturation(dst, src);   \
-    } else if (blend_type == 13) {          \
-      return IPBlendColor(dst, src);        \
-    } else if (blend_type == 14) {          \
-      return IPBlendLuminosity(dst, src);   \
-    } else {                                \
-      return f16vec3(0.0hf);                \
-    }                                       \
+f16vec3 AdvancedBlend(f16vec3 dst, f16vec3 src, int blend_type) {
+  if (blend_type == 0) {
+    return IPBlendScreen(dst, src);
   }
+  if (blend_type == 1) {
+    return IPBlendOverlay(dst, src);
+  }
+  if (blend_type == 2) {
+    return IPBlendDarken(dst, src);
+  }
+  if (blend_type == 3) {
+    return IPBlendLighten(dst, src);
+  }
+  if (blend_type == 4) {
+    return IPBlendColorDodge(dst, src);
+  }
+  if (blend_type == 5) {
+    return IPBlendColorBurn(dst, src);
+  }
+  if (blend_type == 6) {
+    return IPBlendHardLight(dst, src);
+  }
+  if (blend_type == 7) {
+    return IPBlendSoftLight(dst, src);
+  }
+  if (blend_type == 8) {
+    return IPBlendDifference(dst, src);
+  }
+  if (blend_type == 9) {
+    return IPBlendExclusion(dst, src);
+  }
+  if (blend_type == 10) {
+    return IPBlendMultiply(dst, src);
+  }
+  if (blend_type == 11) {
+    return IPBlendHue(dst, src);
+  }
+  if (blend_type == 12) {
+    return IPBlendSaturation(dst, src);
+  }
+  if (blend_type == 13) {
+    return IPBlendColor(dst, src);
+  }
+  if (blend_type == 14) {
+    return IPBlendLuminosity(dst, src);
+  }
+  return f16vec3(0.0hf);
+}

--- a/impeller/entity/shaders/blending/framebuffer_blend.frag
+++ b/impeller/entity/shaders/blending/framebuffer_blend.frag
@@ -39,8 +39,6 @@ vec4 Sample(sampler2D texture_sampler, vec2 texture_coords) {
   return IPSampleDecal(texture_sampler, texture_coords);
 }
 
-AdvancedBlend(blend_type);
-
 void main() {
   f16vec4 dst = f16vec4(ReadDestination());
   f16vec4 src = f16vec4(Sample(texture_sampler_src,  // sampler
@@ -48,7 +46,7 @@ void main() {
                                )) *
                 frag_info.src_input_alpha;
 
-  f16vec3 blend_result = Blend(dst.rgb, src.rgb);
+  f16vec3 blend_result = AdvancedBlend(dst.rgb, src.rgb, blend_type);
   f16vec4 blended = mix(src, f16vec4(blend_result, dst.a), dst.a);
   frag_color = vec4(mix(dst, blended, src.a));
 }


### PR DESCRIPTION
Re-arrange how the advanced blend shaders are constructed to simplify the shader slightly, avoid moto g4 driver crash.


Fixes https://github.com/flutter/flutter/issues/137816

This is tested, but the test is in the framework repo for reasons.