### PR TITLE
Fix FFI-based tonic layer to use proper C++ static_cast<>()s

### DIFF
--- a/third_party/tonic/dart_args.h
+++ b/third_party/tonic/dart_args.h
@@ -356,11 +356,11 @@ struct FfiDispatcher<C, Return (C::*)(Args...), method> {
 
   // Static C entry-point with Dart FFI signature.
   static FfiReturn Call(
-      C* receiver,
+      DartWrappable* receiver,
       typename DartConverter<typename std::remove_const<
           typename std::remove_reference<Args>::type>::type>::FfiType... args) {
     // Call C++ method on receiver, forwarding converted native arguments.
-    return DartConverter<Return>::ToFfi((receiver->*method)(
+    return DartConverter<Return>::ToFfi((static_cast<C*>(receiver)->*method)(
         DartConverter<typename std::remove_const<typename std::remove_reference<
             Args>::type>::type>::FromFfi(args)...));
   }
@@ -408,11 +408,11 @@ struct FfiDispatcher<C, Return (C::*)(Args...) const, method> {
 
   // Static C entry-point with Dart FFI signature.
   static FfiReturn Call(
-      C* receiver,
+      DartWrappable* receiver,
       typename DartConverter<typename std::remove_const<
           typename std::remove_reference<Args>::type>::type>::FfiType... args) {
     // Call C++ method on receiver, forwarding converted native arguments.
-    return DartConverter<Return>::ToFfi((receiver->*method)(
+    return DartConverter<Return>::ToFfi((static_cast<C*>(receiver)->*method)(
         DartConverter<typename std::remove_const<typename std::remove_reference<
             Args>::type>::type>::FromFfi(args)...));
   }
@@ -501,11 +501,11 @@ struct FfiDispatcher<C, void (C::*)(Args...), method> {
 
   // Static C entry-point with Dart FFI signature.
   static void Call(
-      C* receiver,
+      DartWrappable* receiver,
       typename DartConverter<typename std::remove_const<
           typename std::remove_reference<Args>::type>::type>::FfiType... args) {
     // Call C++ method on receiver, forwarding converted native arguments.
-    (receiver->*method)(
+    (static_cast<C*>(receiver)->*method)(
         DartConverter<typename std::remove_const<typename std::remove_reference<
             Args>::type>::type>::FromFfi(args)...);
   }

--- a/third_party/tonic/dart_wrappable.h
+++ b/third_party/tonic/dart_wrappable.h
@@ -93,7 +93,7 @@ struct DartConverter<
     T*,
     typename std::enable_if<
         std::is_convertible<T*, const DartWrappable*>::value>::type> {
-  using FfiType = T*;
+  using FfiType = DartWrappable*;
   static constexpr const char* kFfiRepresentation = "Pointer";
   static constexpr const char* kDartRepresentation = "Pointer";
   static constexpr bool kAllowedInLeafCall = true;
@@ -145,7 +145,7 @@ struct DartConverter<
         DartConverterWrappable::FromArguments(args, index, exception));
   }
 
-  static T* FromFfi(FfiType val) { return val; }
+  static T* FromFfi(FfiType val) { return static_cast<T*>(val); }
   static FfiType ToFfi(T* val) { return val; }
   static const char* GetFfiRepresentation() { return kFfiRepresentation; }
   static const char* GetDartRepresentation() { return kDartRepresentation; }


### PR DESCRIPTION
Flutter makes use of C++ multiple inheritence in it's C++ classes that have corresponding Dart objects attached. An example is e.g.
```
  class Canvas : public RefCountedDartWrappable<Canvas>, DisplayListOpFlags { }

  template <typename T>
  class RefCountedDartWrappable : public fml::RefCountedThreadSafe<T>,
                                  public tonic::DartWrappable { }
```
When a C++ class has multiple base classes, the C++ compiler has the liberty to decide the order in which they get layed out in memory. (It doesn't necessarily follow declaration order, in fact it has a preference for having classes with
vtables before classes without vtables.)

Two casts to consider (with multiple inheritance in mind):

* upcasts: Those are done by C++ automatically but can modify the actual address (i.e. pointer value)

* downcasts: Those have to be done with `static_cast<>()`, which can also modify the address (i.e. pointer value) - using `reinterpret_cast<>()` is incorrect (as it doesn't modify the address)

Now the Dart objects that refer to C++ objects have a native field in them. The value of that field is a `tonic::DartWrappable*`. That means whenever we convert between the C++ object pointer (e.g. `flutter::Canvas*`) and the value of the native field (`tonic::Wrappable*`) the actual address / pointer may need modification.

There were bugs in the C FFI based tonic layer: Pointer values coming from Dart (via C FFI) are `dart::Wrappable*` and not pointers to subtypes.

=> For methods we type the first parameter in tonic trampolines as
    `dart::Wrappable*` and `static_cast<Class*>()` that value

=> Similarly for arguments, the parameter has to be typed as
    `dart::Wrappable*` and `static_cast<Class*>()` that value

How did it ever work? Well it happens to be that the C++ compiler decided to layout `tonic::DartWrappable` before
`fml::RefCountedThreadSafe`, making the `tonic::DartWrappable*` and the `flutter::Canvas*` (and other classes) have the same pointer value.

=> This worked due to implementation choice of C++ compiler.
=> This breaks immediately if one decided to add another base class (with virtual methods) to `RefCountedDartWrappable`
