### PR TITLE
Fix incorrect C++ return value of PictureRecorder::endRecording()

### DIFF
--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -26,13 +26,12 @@ namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, Picture);
 
-fml::RefPtr<Picture> Picture::Create(Dart_Handle dart_handle,
-                                     sk_sp<DisplayList> display_list) {
+void Picture::CreateAndAssociateWithDartWrapper(
+    Dart_Handle dart_handle,
+    sk_sp<DisplayList> display_list) {
   FML_DCHECK(display_list->isUIThreadSafe());
   auto canvas_picture = fml::MakeRefCounted<Picture>(std::move(display_list));
-
   canvas_picture->AssociateWithDartWrapper(dart_handle);
-  return canvas_picture;
 }
 
 Picture::Picture(sk_sp<DisplayList> display_list)

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -20,8 +20,9 @@ class Picture : public RefCountedDartWrappable<Picture> {
 
  public:
   ~Picture() override;
-  static fml::RefPtr<Picture> Create(Dart_Handle dart_handle,
-                                     sk_sp<DisplayList> display_list);
+  static void CreateAndAssociateWithDartWrapper(
+      Dart_Handle dart_handle,
+      sk_sp<DisplayList> display_list);
 
   sk_sp<DisplayList> display_list() const { return display_list_; }
 

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -31,9 +31,9 @@ sk_sp<DisplayListBuilder> PictureRecorder::BeginRecording(SkRect bounds) {
   return display_list_builder_;
 }
 
-fml::RefPtr<Picture> PictureRecorder::endRecording(Dart_Handle dart_picture) {
+void PictureRecorder::endRecording(Dart_Handle dart_picture) {
   if (!canvas_) {
-    return nullptr;
+    return;
   }
 
   fml::RefPtr<Picture> picture;
@@ -44,7 +44,6 @@ fml::RefPtr<Picture> PictureRecorder::endRecording(Dart_Handle dart_picture) {
   canvas_->Invalidate();
   canvas_ = nullptr;
   ClearDartWrapper();
-  return picture;
 }
 
 }  // namespace flutter

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -36,9 +36,8 @@ void PictureRecorder::endRecording(Dart_Handle dart_picture) {
     return;
   }
 
-  fml::RefPtr<Picture> picture;
-
-  picture = Picture::Create(dart_picture, display_list_builder_->Build());
+  Picture::CreateAndAssociateWithDartWrapper(dart_picture,
+                                             display_list_builder_->Build());
   display_list_builder_ = nullptr;
 
   canvas_->Invalidate();

--- a/lib/ui/painting/picture_recorder.h
+++ b/lib/ui/painting/picture_recorder.h
@@ -22,7 +22,7 @@ class PictureRecorder : public RefCountedDartWrappable<PictureRecorder> {
   ~PictureRecorder() override;
 
   sk_sp<DisplayListBuilder> BeginRecording(SkRect bounds);
-  fml::RefPtr<Picture> endRecording(Dart_Handle dart_picture);
+  void endRecording(Dart_Handle dart_picture);
 
   void set_canvas(fml::RefPtr<Canvas> canvas) { canvas_ = std::move(canvas); }
 


### PR DESCRIPTION
The Dart code has the following declaration:

```dart
  @Native<Void Function(Pointer<Void>, Handle)>(symbol: 'PictureRecorder::endRecording')
  external void _endRecording(_NativePicture outPicture);
```

=> Dart doesn't expect to get a return value, so C++ shouldn't return anything.