### PR TITLE
[DRAFT] Research setting accessibilityIdentifier/resource-id

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -922,6 +922,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       }
       if (content != null) {
         result.setContentDescription(content);
+        result.setViewIdResourceName(content.toString());
       }
     }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -96,6 +96,7 @@ void AccessibilityBridge::UpdateSemantics(
   for (const auto& entry : nodes) {
     const flutter::SemanticsNode& node = entry.second;
     SemanticsObject* object = GetOrCreateObject(node.id, nodes);
+    object.accessibilityIdentifier = [NSString stringWithUTF8String:node.label.c_str()];
     layoutChanged = layoutChanged || [object nodeWillCauseLayoutChange:&node];
     scrollOccured = scrollOccured || [object nodeWillCauseScroll:&node];
     needsAnnouncement = [object nodeShouldTriggerAnnouncement:&node];


### PR DESCRIPTION
Trying out if [#137735](https://github.com/flutter/flutter/issues/137735) is possible. Turns out it is!

When a Flutter app is built with engine from this PR, `accessibilityIdentifier` (iOS) and `resource-id` (Android) are filled with values of [`SemanticsProperties.label`](https://api.flutter.dev/flutter/semantics/SemanticsProperties/label.html). They appear in `uiautomator dump`, `idb`, `Accessibility Inspector.app` etc.