### PR TITLE
Bump minSdk to 19 for Android tests

### DIFF
--- a/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -238,7 +238,7 @@ public class LocalizationPluginTest {
   // Tests the legacy pre API 24 algorithm.
   @Test
   @Config(
-      minSdk = Build.VERSION_CODES.JELLY_BEAN,
+      minSdk = Build.VERSION_CODES.KITKAT,
       maxSdk = Build.VERSION_CODES.M,
       qualifiers = "es-rMX")
   public void computePlatformResolvedLocale_emptySupportedLocales_beforeAndroidN() {
@@ -252,7 +252,7 @@ public class LocalizationPluginTest {
   }
 
   @Test
-  @Config(minSdk = Build.VERSION_CODES.JELLY_BEAN, maxSdk = Build.VERSION_CODES.M, qualifiers = "")
+  @Config(minSdk = Build.VERSION_CODES.KITKAT, maxSdk = Build.VERSION_CODES.M, qualifiers = "")
   public void computePlatformResolvedLocale_selectFirstLocaleWhenNoUserSetting_beforeAndroidN() {
     FlutterJNI flutterJNI = new FlutterJNI();
     DartExecutor dartExecutor = mock(DartExecutor.class);
@@ -273,7 +273,7 @@ public class LocalizationPluginTest {
 
   @Test
   @Config(
-      minSdk = Build.VERSION_CODES.JELLY_BEAN,
+      minSdk = Build.VERSION_CODES.KITKAT,
       maxSdk = Build.VERSION_CODES.M,
       qualifiers = "fr-rCH")
   public void computePlatformResolvedLocale_selectFirstLocaleWhenNoExactMatch_beforeAndroidN() {
@@ -299,7 +299,7 @@ public class LocalizationPluginTest {
 
   @Test
   @Config(
-      minSdk = Build.VERSION_CODES.JELLY_BEAN,
+      minSdk = Build.VERSION_CODES.KITKAT,
       maxSdk = Build.VERSION_CODES.M,
       qualifiers = "it-rIT")
   public void computePlatformResolvedLocale_selectExactMatchLocale_beforeAndroidN() {
@@ -325,7 +325,7 @@ public class LocalizationPluginTest {
 
   @Test
   @Config(
-      minSdk = Build.VERSION_CODES.JELLY_BEAN,
+      minSdk = Build.VERSION_CODES.KITKAT,
       maxSdk = Build.VERSION_CODES.M,
       qualifiers = "fr-rCH")
   public void computePlatformResolvedLocale_selectOnlyLanguageLocale_beforeAndroidN() {
@@ -351,35 +351,35 @@ public class LocalizationPluginTest {
   }
 
   // Tests the legacy pre API 21 algorithm.
-  @Config(sdk = 16)
+  @Config(sdk = 19)
   @Test
   public void localeFromString_languageOnly() {
     Locale locale = LocalizationPlugin.localeFromString("en");
     assertEquals(locale, new Locale("en"));
   }
 
-  @Config(sdk = 16)
+  @Config(sdk = 19)
   @Test
   public void localeFromString_languageAndCountry() {
     Locale locale = LocalizationPlugin.localeFromString("en-US");
     assertEquals(locale, new Locale("en", "US"));
   }
 
-  @Config(sdk = 16)
+  @Config(sdk = 19)
   @Test
   public void localeFromString_languageCountryAndVariant() {
     Locale locale = LocalizationPlugin.localeFromString("zh-Hans-CN");
     assertEquals(locale, new Locale("zh", "CN", "Hans"));
   }
 
-  @Config(sdk = 16)
+  @Config(sdk = 19)
   @Test
   public void localeFromString_underscore() {
     Locale locale = LocalizationPlugin.localeFromString("zh_Hans_CN");
     assertEquals(locale, new Locale("zh", "CN", "Hans"));
   }
 
-  @Config(sdk = 16)
+  @Config(sdk = 19)
   @Test
   public void localeFromString_additionalVariantsAreIgnored() {
     Locale locale = LocalizationPlugin.localeFromString("de-DE-u-co-phonebk");

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -52,7 +52,7 @@ import org.robolectric.shadows.ShadowLooper;
 public class PlatformPluginTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();
 
-  @Config(sdk = 16)
+  @Config(sdk = 19)
   @Test
   public void itIgnoresNewHapticEventsOnOldAndroidPlatforms() {
     View fakeDecorView = mock(View.class);

--- a/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -4,7 +4,6 @@
 
 package io.flutter.plugin.platform;
 
-import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.R;
 import static org.junit.Assert.assertEquals;
@@ -28,7 +27,7 @@ import org.robolectric.annotation.Config;
 @TargetApi(P)
 public class SingleViewPresentationTest {
   @Test
-  @Config(minSdk = JELLY_BEAN_MR1, maxSdk = R)
+  @Config(minSdk = KITKAT, maxSdk = R)
   public void returnsOuterContextInputMethodManager() {
     // There's a bug in Android Q caused by the IMM being instanced per display.
     // https://github.com/flutter/flutter/issues/38375. We need the context returned by
@@ -59,7 +58,7 @@ public class SingleViewPresentationTest {
   }
 
   @Test
-  @Config(minSdk = JELLY_BEAN_MR1, maxSdk = R)
+  @Config(minSdk = KITKAT, maxSdk = R)
   public void returnsOuterContextInputMethodManager_createDisplayContext() {
     // The IMM should also persist across display contexts created from the base context.
 

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -35,7 +35,7 @@ android {
   compileSdkVersion 33
 
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 19
   }
 
   compileOptions {

--- a/testing/android_background_image/android/app/build.gradle
+++ b/testing/android_background_image/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
     }
     defaultConfig {
         applicationId 'dev.flutter.android_background_image'
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 33
         versionCode 1
         versionName '1.0'

--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
     }
     defaultConfig {
         applicationId 'dev.flutter.scenarios'
-        minSdkVersion 18
+        minSdkVersion 19
         targetSdkVersion 33
         versionCode 1
         versionName '1.0'


### PR DESCRIPTION
The latest Robolectric version, 4.11.x, removed the support for SDKs < 19 by following AndroidX strategy. Also following https://github.com/flutter/buildroot/pull/750.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
