### PR TITLE
[Impeller] fix drawVertices dest fast path to apply alpha.

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -136,6 +136,8 @@
 ../../../flutter/impeller/docs
 ../../../flutter/impeller/entity/contents/checkerboard_contents_unittests.cc
 ../../../flutter/impeller/entity/contents/filters/inputs/filter_input_unittests.cc
+../../../flutter/impeller/entity/contents/test
+../../../flutter/impeller/entity/contents/vertices_contents_unittests.cc
 ../../../flutter/impeller/entity/entity_unittests.cc
 ../../../flutter/impeller/entity/geometry/geometry_unittests.cc
 ../../../flutter/impeller/entity/render_target_cache_unittests.cc

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -264,12 +264,24 @@ impeller_component("entity") {
   deps = [ "//flutter/fml" ]
 }
 
+impeller_component("entity_test_helpers") {
+  testonly = true
+
+  sources = [
+    "contents/test/contents_test_helpers.cc",
+    "contents/test/contents_test_helpers.h",
+  ]
+
+  deps = [ ":entity" ]
+}
+
 impeller_component("entity_unittests") {
   testonly = true
 
   sources = [
     "contents/checkerboard_contents_unittests.cc",
     "contents/filters/inputs/filter_input_unittests.cc",
+    "contents/vertices_contents_unittests.cc",
     "entity_playground.cc",
     "entity_playground.h",
     "entity_unittests.cc",
@@ -278,6 +290,7 @@ impeller_component("entity_unittests") {
 
   deps = [
     ":entity",
+    ":entity_test_helpers",
     "../geometry:geometry_asserts",
     "../playground:playground_test",
     "//flutter/impeller/typographer/backends/skia:typographer_skia_backend",

--- a/impeller/entity/contents/test/contents_test_helpers.cc
+++ b/impeller/entity/contents/test/contents_test_helpers.cc
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/contents/test/contents_test_helpers.h"
+
+namespace impeller {
+
+//
+
+}

--- a/impeller/entity/contents/test/contents_test_helpers.h
+++ b/impeller/entity/contents/test/contents_test_helpers.h
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "impeller/renderer/command.h"
+
+namespace impeller {
+
+/// @brief Retrieve the [VertInfo] struct data from the provided [command].
+template <typename T>
+typename T::VertInfo* GetVertInfo(const Command& command) {
+  auto resource = command.vertex_bindings.buffers.find(0u);
+  if (resource == command.vertex_bindings.buffers.end()) {
+    return nullptr;
+  }
+
+  auto data = (resource->second.view.resource.contents +
+               resource->second.view.resource.range.offset);
+  return reinterpret_cast<typename T::VertInfo*>(data);
+}
+
+/// @brief Retrieve the [FragInfo] struct data from the provided [command].
+template <typename T>
+typename T::FragInfo* GetFragInfo(const Command& command) {
+  auto resource = command.fragment_bindings.buffers.find(0u);
+  if (resource == command.fragment_bindings.buffers.end()) {
+    return nullptr;
+  }
+
+  auto data = (resource->second.view.resource.contents +
+               resource->second.view.resource.range.offset);
+  return reinterpret_cast<typename T::FragInfo*>(data);
+}
+
+}  // namespace impeller

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -4,12 +4,8 @@
 
 #include "vertices_contents.h"
 
-#include "impeller/core/formats.h"
-#include "impeller/core/vertex_buffer.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/filters/color_filter_contents.h"
-#include "impeller/entity/contents/filters/filter_contents.h"
-#include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/position_color.vert.h"
 #include "impeller/entity/vertices.frag.h"
 #include "impeller/geometry/color.h"
@@ -73,6 +69,7 @@ bool VerticesContents::Render(const ContentContext& renderer,
 
   std::shared_ptr<Contents> contents;
   if (blend_mode_ == BlendMode::kDestination) {
+    dst_contents->SetAlpha(alpha_);
     contents = dst_contents;
   } else {
     auto color_filter_contents = ColorFilterContents::MakeBlend(

--- a/impeller/entity/contents/vertices_contents_unittests.cc
+++ b/impeller/entity/contents/vertices_contents_unittests.cc
@@ -1,0 +1,78 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <memory>
+#include <optional>
+
+#include "gtest/gtest.h"
+
+#include "impeller/entity/contents/contents.h"
+#include "impeller/entity/contents/solid_color_contents.h"
+#include "impeller/entity/contents/test/contents_test_helpers.h"
+#include "impeller/entity/contents/vertices_contents.h"
+#include "impeller/entity/entity.h"
+#include "impeller/entity/entity_playground.h"
+#include "impeller/entity/vertices.frag.h"
+#include "impeller/geometry/path_builder.h"
+#include "impeller/renderer/render_target.h"
+
+namespace impeller {
+namespace testing {
+
+using EntityTest = EntityPlayground;
+INSTANTIATE_PLAYGROUND_SUITE(EntityTest);
+
+std::shared_ptr<VerticesGeometry> CreateColorVertices(
+    const std::vector<Point>& vertices,
+    const std::vector<Color>& colors) {
+  auto bounds = Rect::MakePointBounds(vertices.begin(), vertices.end());
+  std::vector<uint16_t> indices = {};
+  for (auto i = 0u; i < vertices.size(); i++) {
+    indices.emplace_back(i);
+  }
+  std::vector<Point> texture_coordinates = {};
+
+  return std::make_shared<VerticesGeometry>(
+      vertices, indices, texture_coordinates, colors,
+      bounds.value_or(Rect::MakeLTRB(0, 0, 0, 0)),
+      VerticesGeometry::VertexMode::kTriangles);
+}
+
+// Verifies that the destination blend fast path still sets an alpha value.
+TEST_P(EntityTest, RendersDstPerColorWithAlpha) {
+  using FS = GeometryColorPipeline::FragmentShader;
+
+  auto contents = std::make_shared<VerticesContents>();
+  auto vertices = CreateColorVertices(
+      {{0, 0}, {100, 0}, {0, 100}, {100, 0}, {0, 100}, {100, 100}},
+      {Color::Red(), Color::Red(), Color::Red(), Color::Red(), Color::Red(),
+       Color::Red()});
+  auto src_contents = SolidColorContents::Make(
+      PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath(),
+      Color::Red());
+
+  contents->SetGeometry(vertices);
+  contents->SetAlpha(0.5);
+  contents->SetBlendMode(BlendMode::kDestination);
+  contents->SetSourceContents(std::move(src_contents));
+
+  auto content_context = GetContentContext();
+  auto buffer = content_context->GetContext()->CreateCommandBuffer();
+  auto render_target = RenderTarget::CreateOffscreenMSAA(
+      *content_context->GetContext(),
+      *GetContentContext()->GetRenderTargetCache(), {100, 100});
+  auto render_pass = buffer->CreateRenderPass(render_target);
+  Entity entity;
+
+  ASSERT_TRUE(render_pass->GetCommands().empty());
+  ASSERT_TRUE(contents->Render(*content_context, entity, *render_pass));
+
+  const auto& cmd = render_pass->GetCommands()[0];
+  auto* frag_uniforms = GetFragInfo<FS>(cmd);
+
+  ASSERT_EQ(frag_uniforms->alpha, 0.5);
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118914

When drawing vertices with a destination blend mode, we need to make sure to forward any alpha component. I introduced some test helpers to allow verification of recorded cmds without goldens.
