### PR TITLE
[Windows] Reduce warnings produced by unit tests

### DIFF
--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -65,7 +65,7 @@ class AngleSurfaceManager {
 
   // Binds |egl_context_| to the current rendering thread and to the draw and
   // read surfaces returning a boolean result reflecting success.
-  bool MakeCurrent();
+  virtual bool MakeCurrent();
 
   // Unbinds the current EGL context from the current thread.
   bool ClearCurrent();

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -313,7 +313,7 @@ TEST(FlutterWindowTest, AlertNode) {
   std::unique_ptr<MockFlutterWindow> win32window =
       std::make_unique<MockFlutterWindow>();
   EXPECT_CALL(*win32window.get(), GetAxFragmentRootDelegate())
-      .WillOnce(Return(nullptr));
+      .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(*win32window.get(), OnWindowStateEvent).Times(AnyNumber());
   MockFlutterWindowsView view(std::move(win32window));
   std::wstring message = L"Test alert";

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -12,6 +12,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::AnyNumber;
 using testing::Invoke;
 using testing::Return;
 
@@ -133,8 +134,7 @@ TEST(FlutterWindowTest, OnBitmapSurfaceUpdated) {
 // when the DPI scale is 100% (96 DPI).
 TEST(FlutterWindowTest, OnCursorRectUpdatedRegularDPI) {
   MockFlutterWindow win32window;
-  ON_CALL(win32window, GetDpiScale()).WillByDefault(Return(1.0));
-  EXPECT_CALL(win32window, GetDpiScale()).Times(1);
+  EXPECT_CALL(win32window, GetDpiScale()).WillOnce(Return(1.0));
 
   Rect cursor_rect(Point(10, 20), Size(30, 40));
   EXPECT_CALL(win32window, UpdateCursorRect(cursor_rect)).Times(1);
@@ -147,8 +147,7 @@ TEST(FlutterWindowTest, OnCursorRectUpdatedRegularDPI) {
 // when the DPI scale is 150% (144 DPI).
 TEST(FlutterWindowTest, OnCursorRectUpdatedHighDPI) {
   MockFlutterWindow win32window;
-  ON_CALL(win32window, GetDpiScale()).WillByDefault(Return(1.5));
-  EXPECT_CALL(win32window, GetDpiScale()).Times(1);
+  EXPECT_CALL(win32window, GetDpiScale()).WillOnce(Return(1.5));
 
   Rect expected_cursor_rect(Point(15, 30), Size(45, 60));
   EXPECT_CALL(win32window, UpdateCursorRect(expected_cursor_rect)).Times(1);
@@ -160,7 +159,9 @@ TEST(FlutterWindowTest, OnCursorRectUpdatedHighDPI) {
 TEST(FlutterWindowTest, OnPointerStarSendsDeviceType) {
   FlutterWindow win32window(100, 100);
   MockWindowBindingHandlerDelegate delegate;
+  EXPECT_CALL(delegate, OnWindowStateEvent).Times(AnyNumber());
   win32window.SetView(&delegate);
+
   // Move
   EXPECT_CALL(delegate,
               OnPointerMove(10.0, 10.0, kFlutterPointerDeviceKindMouse,
@@ -259,6 +260,7 @@ TEST(FlutterWindowTest, OnPointerStarSendsDeviceType) {
 TEST(FlutterWindowTest, OnScrollCallsGetScrollOffsetMultiplier) {
   MockFlutterWindow win32window;
   MockWindowBindingHandlerDelegate delegate;
+  EXPECT_CALL(win32window, OnWindowStateEvent).Times(AnyNumber());
   win32window.SetView(&delegate);
 
   ON_CALL(win32window, GetScrollOffsetMultiplier())
@@ -277,6 +279,7 @@ TEST(FlutterWindowTest, OnScrollCallsGetScrollOffsetMultiplier) {
 TEST(FlutterWindowTest, OnWindowRepaint) {
   MockFlutterWindow win32window;
   MockWindowBindingHandlerDelegate delegate;
+  EXPECT_CALL(win32window, OnWindowStateEvent).Times(AnyNumber());
   win32window.SetView(&delegate);
 
   EXPECT_CALL(delegate, OnWindowRepaint()).Times(1);
@@ -287,6 +290,7 @@ TEST(FlutterWindowTest, OnWindowRepaint) {
 TEST(FlutterWindowTest, OnThemeChange) {
   MockFlutterWindow win32window;
   MockWindowBindingHandlerDelegate delegate;
+  EXPECT_CALL(win32window, OnWindowStateEvent).Times(AnyNumber());
   win32window.SetView(&delegate);
 
   EXPECT_CALL(delegate, OnHighContrastChanged).Times(1);
@@ -308,9 +312,9 @@ TEST(FlutterWindowTest, AccessibilityNodeWithoutView) {
 TEST(FlutterWindowTest, AlertNode) {
   std::unique_ptr<MockFlutterWindow> win32window =
       std::make_unique<MockFlutterWindow>();
-  ON_CALL(*win32window, GetPlatformWindow()).WillByDefault(Return(nullptr));
-  ON_CALL(*win32window, GetAxFragmentRootDelegate())
-      .WillByDefault(Return(nullptr));
+  EXPECT_CALL(*win32window.get(), GetAxFragmentRootDelegate())
+      .WillOnce(Return(nullptr));
+  EXPECT_CALL(*win32window.get(), OnWindowStateEvent).Times(AnyNumber());
   MockFlutterWindowsView view(std::move(win32window));
   std::wstring message = L"Test alert";
   EXPECT_CALL(view, NotifyWinEventWrapper(_, ax::mojom::Event::kAlert))
@@ -337,21 +341,22 @@ TEST(FlutterWindowTest, AlertNode) {
 
 TEST(FlutterWindowTest, LifecycleFocusMessages) {
   MockFlutterWindow win32window;
-  ON_CALL(win32window, GetPlatformWindow).WillByDefault([]() {
-    return reinterpret_cast<HWND>(1);
-  });
+  EXPECT_CALL(win32window, GetPlatformWindow)
+      .WillRepeatedly(Return(reinterpret_cast<HWND>(1)));
   MockWindowBindingHandlerDelegate delegate;
-  win32window.SetView(&delegate);
 
   WindowStateEvent last_event;
-  ON_CALL(delegate, OnWindowStateEvent)
-      .WillByDefault([&last_event](HWND hwnd, WindowStateEvent event) {
+  EXPECT_CALL(delegate, OnWindowStateEvent)
+      .WillRepeatedly([&last_event](HWND hwnd, WindowStateEvent event) {
         last_event = event;
       });
-  ON_CALL(win32window, OnWindowStateEvent)
-      .WillByDefault([&](WindowStateEvent event) {
+  EXPECT_CALL(win32window, OnWindowStateEvent)
+      .WillRepeatedly([&](WindowStateEvent event) {
         win32window.FlutterWindow::OnWindowStateEvent(event);
       });
+  EXPECT_CALL(win32window, OnResize).Times(AnyNumber());
+
+  win32window.SetView(&delegate);
 
   win32window.InjectWindowMessage(WM_SIZE, 0, 0);
   EXPECT_EQ(last_event, WindowStateEvent::kHide);
@@ -368,13 +373,13 @@ TEST(FlutterWindowTest, LifecycleFocusMessages) {
 
 TEST(FlutterWindowTest, CachedLifecycleMessage) {
   MockFlutterWindow win32window;
-  ON_CALL(win32window, GetPlatformWindow).WillByDefault([]() {
-    return reinterpret_cast<HWND>(1);
-  });
-  ON_CALL(win32window, OnWindowStateEvent)
-      .WillByDefault([&](WindowStateEvent event) {
+  EXPECT_CALL(win32window, GetPlatformWindow)
+      .WillRepeatedly(Return(reinterpret_cast<HWND>(1)));
+  EXPECT_CALL(win32window, OnWindowStateEvent)
+      .WillRepeatedly([&](WindowStateEvent event) {
         win32window.FlutterWindow::OnWindowStateEvent(event);
       });
+  EXPECT_CALL(win32window, OnResize).Times(1);
 
   // Restore
   win32window.InjectWindowMessage(WM_SIZE, 0, MAKEWORD(1, 1));
@@ -385,8 +390,8 @@ TEST(FlutterWindowTest, CachedLifecycleMessage) {
   MockWindowBindingHandlerDelegate delegate;
   bool focused = false;
   bool restored = false;
-  ON_CALL(delegate, OnWindowStateEvent)
-      .WillByDefault([&](HWND hwnd, WindowStateEvent event) {
+  EXPECT_CALL(delegate, OnWindowStateEvent)
+      .WillRepeatedly([&](HWND hwnd, WindowStateEvent event) {
         if (event == WindowStateEvent::kFocus) {
           focused = true;
         } else if (event == WindowStateEvent::kShow) {
@@ -403,18 +408,19 @@ TEST(FlutterWindowTest, PosthumousWindowMessage) {
   MockWindowBindingHandlerDelegate delegate;
   int msg_count = 0;
   HWND hwnd;
-  ON_CALL(delegate, OnWindowStateEvent)
-      .WillByDefault([&](HWND hwnd, WindowStateEvent event) { msg_count++; });
+  EXPECT_CALL(delegate, OnWindowStateEvent)
+      .WillRepeatedly([&](HWND hwnd, WindowStateEvent event) { msg_count++; });
 
   {
     MockFlutterWindow win32window(false);
-    ON_CALL(win32window, GetPlatformWindow).WillByDefault([&]() {
+    EXPECT_CALL(win32window, GetPlatformWindow).WillRepeatedly([&]() {
       return win32window.FlutterWindow::GetPlatformWindow();
     });
-    ON_CALL(win32window, OnWindowStateEvent)
-        .WillByDefault([&](WindowStateEvent event) {
+    EXPECT_CALL(win32window, OnWindowStateEvent)
+        .WillRepeatedly([&](WindowStateEvent event) {
           win32window.FlutterWindow::OnWindowStateEvent(event);
         });
+    EXPECT_CALL(win32window, OnResize).Times(AnyNumber());
     win32window.SetView(&delegate);
     win32window.InitializeChild("Title", 1, 1);
     hwnd = win32window.GetPlatformWindow();

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -641,7 +641,7 @@ TEST_F(FlutterWindowsEngineTest, AlertPlatformMessage) {
   ui::AXPlatformNodeDelegateBase parent_delegate;
   AlertPlatformNodeDelegate delegate(parent_delegate);
   EXPECT_CALL(*window_binding_handler, GetAlertDelegate)
-      .WillOnce(Return(&delegate));
+      .WillRepeatedly(Return(&delegate));
   MockFlutterWindowsView view(std::move(window_binding_handler));
   view.SetEngine(engine.get());
 
@@ -717,7 +717,7 @@ TEST_F(FlutterWindowsEngineTest, TestExit) {
                             std::optional<WPARAM> wparam,
                             std::optional<LPARAM> lparam,
                             UINT exit_code) { finished = exit_code == 0; });
-  EXPECT_CALL(*handler, IsLastWindowOfProcess).WillOnce(Return(true));
+  EXPECT_CALL(*handler, IsLastWindowOfProcess).WillRepeatedly(Return(true));
   modifier.SetLifecycleManager(std::move(handler));
 
   engine->lifecycle_manager()->BeginProcessingExit();
@@ -749,7 +749,7 @@ TEST_F(FlutterWindowsEngineTest, TestExitCancel) {
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
   EXPECT_CALL(*handler, SetLifecycleState(AppLifecycleState::kResumed));
-  EXPECT_CALL(*handler, IsLastWindowOfProcess).WillOnce(Return(true));
+  EXPECT_CALL(*handler, IsLastWindowOfProcess).WillRepeatedly(Return(true));
   EXPECT_CALL(*handler, Quit).Times(0);
   modifier.SetLifecycleManager(std::move(handler));
   engine->lifecycle_manager()->BeginProcessingExit();

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -909,10 +909,7 @@ TEST_F(FlutterWindowsEngineTest, EnableApplicationLifecycle) {
   EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
-  ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([]() {
-    return false;
-  });
-  EXPECT_CALL(*handler, IsLastWindowOfProcess).Times(1);
+  EXPECT_CALL(*handler, IsLastWindowOfProcess).WillOnce(Return(false));
   modifier.SetLifecycleManager(std::move(handler));
   engine->lifecycle_manager()->BeginProcessingExit();
 
@@ -932,10 +929,7 @@ TEST_F(FlutterWindowsEngineTest, ApplicationLifecycleExternalWindow) {
   EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
-  ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([]() {
-    return false;
-  });
-  EXPECT_CALL(*handler, IsLastWindowOfProcess).Times(1);
+  EXPECT_CALL(*handler, IsLastWindowOfProcess).WillOnce(Return(false));
   modifier.SetLifecycleManager(std::move(handler));
   engine->lifecycle_manager()->BeginProcessingExit();
 

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -640,9 +640,8 @@ TEST_F(FlutterWindowsEngineTest, AlertPlatformMessage) {
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   ui::AXPlatformNodeDelegateBase parent_delegate;
   AlertPlatformNodeDelegate delegate(parent_delegate);
-  ON_CALL(*window_binding_handler, GetAlertDelegate).WillByDefault([&delegate] {
-    return &delegate;
-  });
+  EXPECT_CALL(*window_binding_handler, GetAlertDelegate)
+      .WillOnce(Return(&delegate));
   MockFlutterWindowsView view(std::move(window_binding_handler));
   view.SetEngine(engine.get());
 
@@ -660,9 +659,9 @@ TEST_F(FlutterWindowsEngineTest, AlertPlatformMessage) {
       });
 
   bool did_call = false;
-  ON_CALL(view, NotifyWinEventWrapper)
-      .WillByDefault([&did_call](ui::AXPlatformNodeWin* node,
-                                 ax::mojom::Event event) { did_call = true; });
+  EXPECT_CALL(view, NotifyWinEventWrapper)
+      .WillOnce([&did_call](ui::AXPlatformNodeWin* node,
+                            ax::mojom::Event event) { did_call = true; });
 
   engine->UpdateSemanticsEnabled(true);
   engine->Run();
@@ -712,13 +711,13 @@ TEST_F(FlutterWindowsEngineTest, TestExit) {
   EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
-  ON_CALL(*handler, Quit)
-      .WillByDefault(
-          [&finished](std::optional<HWND> hwnd, std::optional<WPARAM> wparam,
-                      std::optional<LPARAM> lparam,
-                      UINT exit_code) { finished = exit_code == 0; });
-  ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([]() { return true; });
-  EXPECT_CALL(*handler, Quit).Times(1);
+  EXPECT_CALL(*handler, SetLifecycleState(AppLifecycleState::kResumed));
+  EXPECT_CALL(*handler, Quit)
+      .WillOnce([&finished](std::optional<HWND> hwnd,
+                            std::optional<WPARAM> wparam,
+                            std::optional<LPARAM> lparam,
+                            UINT exit_code) { finished = exit_code == 0; });
+  EXPECT_CALL(*handler, IsLastWindowOfProcess).WillOnce(Return(true));
   modifier.SetLifecycleManager(std::move(handler));
 
   engine->lifecycle_manager()->BeginProcessingExit();
@@ -738,7 +737,6 @@ TEST_F(FlutterWindowsEngineTest, TestExit) {
 TEST_F(FlutterWindowsEngineTest, TestExitCancel) {
   FlutterWindowsEngineBuilder builder{GetContext()};
   builder.SetDartEntrypoint("exitTestCancel");
-  bool finished = false;
   bool did_call = false;
 
   auto engine = builder.Build();
@@ -750,12 +748,8 @@ TEST_F(FlutterWindowsEngineTest, TestExitCancel) {
   EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
-  ON_CALL(*handler, Quit)
-      .WillByDefault([&finished](std::optional<HWND> hwnd,
-                                 std::optional<WPARAM> wparam,
-                                 std::optional<LPARAM> lparam,
-                                 UINT exit_code) { finished = true; });
-  ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([]() { return true; });
+  EXPECT_CALL(*handler, SetLifecycleState(AppLifecycleState::kResumed));
+  EXPECT_CALL(*handler, IsLastWindowOfProcess).WillOnce(Return(true));
   EXPECT_CALL(*handler, Quit).Times(0);
   modifier.SetLifecycleManager(std::move(handler));
   engine->lifecycle_manager()->BeginProcessingExit();
@@ -783,10 +777,11 @@ TEST_F(FlutterWindowsEngineTest, TestExitCancel) {
   while (!did_call) {
     engine->task_runner()->ProcessTasks();
   }
-
-  EXPECT_FALSE(finished);
 }
 
+// TODO(loicsharma): This test is passing incorrectly on the first
+// WM_CLOSE message when instead it should pass on the second WM_CLOSE message.
+// https://github.com/flutter/flutter/issues/137963
 TEST_F(FlutterWindowsEngineTest, TestExitSecondCloseMessage) {
   FlutterWindowsEngineBuilder builder{GetContext()};
   builder.SetDartEntrypoint("exitTestExit");
@@ -801,18 +796,18 @@ TEST_F(FlutterWindowsEngineTest, TestExitSecondCloseMessage) {
   EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
-  auto& handler_obj = *handler;
-  ON_CALL(handler_obj, IsLastWindowOfProcess).WillByDefault([]() {
-    return true;
-  });
-  ON_CALL(handler_obj, Quit)
-      .WillByDefault(
-          [&handler_obj](std::optional<HWND> hwnd, std::optional<WPARAM> wparam,
+  EXPECT_CALL(*handler, SetLifecycleState(AppLifecycleState::kResumed));
+  // TODO(loicsharma): These should be `EXPECT_CALL`s
+  // https://github.com/flutter/flutter/issues/137963
+  ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault(Return(true));
+  ON_CALL(*handler, Quit)
+      .WillByDefault([handler_ptr = handler.get()](
+                         std::optional<HWND> hwnd, std::optional<WPARAM> wparam,
                          std::optional<LPARAM> lparam, UINT exit_code) {
-            handler_obj.WindowsLifecycleManager::Quit(hwnd, wparam, lparam,
-                                                      exit_code);
-          });
-  ON_CALL(handler_obj, DispatchMessage)
+        handler_ptr->WindowsLifecycleManager::Quit(hwnd, wparam, lparam,
+                                                   exit_code);
+      });
+  ON_CALL(*handler, DispatchMessage)
       .WillByDefault(
           [&engine](HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
             engine->window_proc_delegate_manager()->OnTopLevelWindowProc(
@@ -863,7 +858,8 @@ TEST_F(FlutterWindowsEngineTest, TestExitCloseMultiWindow) {
   EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
-  ON_CALL(*handler, IsLastWindowOfProcess).WillByDefault([&finished]() {
+  EXPECT_CALL(*handler, SetLifecycleState(AppLifecycleState::kResumed));
+  EXPECT_CALL(*handler, IsLastWindowOfProcess).WillOnce([&finished]() {
     finished = true;
     return false;
   });
@@ -1065,8 +1061,8 @@ TEST_F(FlutterWindowsEngineTest, EnableLifecycleState) {
   EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
-  ON_CALL(*handler, SetLifecycleState)
-      .WillByDefault([handler_ptr = handler.get()](AppLifecycleState state) {
+  EXPECT_CALL(*handler, SetLifecycleState)
+      .WillRepeatedly([handler_ptr = handler.get()](AppLifecycleState state) {
         handler_ptr->WindowsLifecycleManager::SetLifecycleState(state);
       });
   modifier.SetLifecycleManager(std::move(handler));
@@ -1118,8 +1114,8 @@ TEST_F(FlutterWindowsEngineTest, LifecycleStateToFrom) {
   EngineModifier modifier(engine.get());
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
-  ON_CALL(*handler, SetLifecycleState)
-      .WillByDefault([handler_ptr = handler.get()](AppLifecycleState state) {
+  EXPECT_CALL(*handler, SetLifecycleState)
+      .WillRepeatedly([handler_ptr = handler.get()](AppLifecycleState state) {
         handler_ptr->WindowsLifecycleManager::SetLifecycleState(state);
       });
   handler->begin_processing_callback = [&]() { enabled_lifecycle = true; };
@@ -1167,6 +1163,7 @@ TEST_F(FlutterWindowsEngineTest, ChannelListenedTo) {
 
   bool lifecycle_began = false;
   auto handler = std::make_unique<MockWindowsLifecycleManager>(engine.get());
+  EXPECT_CALL(*handler, SetLifecycleState).Times(1);
   handler->begin_processing_callback = [&]() { lifecycle_began = true; };
   modifier.SetLifecycleManager(std::move(handler));
 

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -131,6 +131,7 @@ class MockAngleSurfaceManager : public AngleSurfaceManager {
               (override));
   MOCK_METHOD(void, DestroySurface, (), (override));
 
+  MOCK_METHOD(bool, MakeCurrent, (), (override));
   MOCK_METHOD(void, SetVSyncEnabled, (bool), (override));
 
  private:
@@ -1302,7 +1303,9 @@ TEST(FlutterWindowsViewTest, UpdatesVSyncOnDwmUpdates) {
   FlutterWindowsView view(std::move(window_binding_handler));
 
   InSequence s;
+  EXPECT_CALL(*surface_manager.get(), MakeCurrent).WillOnce(Return(true));
   EXPECT_CALL(*surface_manager.get(), SetVSyncEnabled(true)).Times(1);
+  EXPECT_CALL(*surface_manager.get(), MakeCurrent).WillOnce(Return(true));
   EXPECT_CALL(*surface_manager.get(), SetVSyncEnabled(false)).Times(1);
 
   EXPECT_CALL(*engine.get(), Stop).Times(1);

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -25,8 +25,8 @@ TEST(SystemUtils, GetPreferredLanguageInfo) {
 
 TEST(SystemUtils, GetPreferredLanguages) {
   MockWindowsProcTable proc_table;
-  ON_CALL(proc_table, GetThreadPreferredUILanguages)
-      .WillByDefault(
+  EXPECT_CALL(proc_table, GetThreadPreferredUILanguages)
+      .WillRepeatedly(
           [](DWORD flags, PULONG count, PZZWSTR languages, PULONG size) {
             // Languages string ends in a double-null.
             static const wchar_t lang[] = L"en-US\0";


### PR DESCRIPTION
This PR contains no functional changes but improves existing unit tests to reduce the number of warnings output when the tests are ran:

1. Replaced `ON_CALL` with `EXPECT_CALL` for expected method calls
2. Added some missing mocks

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
