### PR TITLE
[web] autofocus in new routes

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -102,4 +102,7 @@ class Checkable extends PrimaryRoleManager {
     removeAttribute('aria-disabled');
     removeAttribute('disabled');
   }
+
+  @override
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
 }

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -16,6 +16,39 @@ class Dialog extends PrimaryRoleManager {
     // names its own route an `aria-label` is used instead of `aria-describedby`.
     addFocusManagement();
     addLiveRegion();
+
+    // When a route/dialog shows up it is expected that the screen reader will
+    // focus on something inside it. There could be two possibilities:
+    //
+    // 1. The framework explicitly marked a node inside the dialog as focused
+    //    via the `isFocusabe` and `isFocused` flags. In this case, the node
+    //    will request focus directly and there's nothing to do on top of that.
+    // 2. No node inside the route takes focus explicitly. In this case, the
+    //    expectation is to look through all nodes in traversal order and focus
+    //    on the first one.
+    semanticsObject.owner.addOneTimePostUpdateCallback(() {
+      if (semanticsObject.owner.hasNodeRequestingFocus) {
+        // Case 1: a node requested explicit focus. Nothing extra to do.
+        return;
+      }
+
+      // Case 2: nothing requested explicit focus. Focus on the first descendant.
+      _setDefaultFocus();
+    });
+  }
+
+  void _setDefaultFocus() {
+    semanticsObject.visitDepthFirstInTraversalOrder((SemanticsObject node) {
+      final PrimaryRoleManager? roleManager = node.primaryRole;
+      if (roleManager == null) {
+        return true;
+      }
+
+      // If the node does not take focus (e.g. focusing on it does not make
+      // sense at all), depair not. Keep looking.
+      final bool didTakeFocus = roleManager.focusAsRouteDefault();
+      return !didTakeFocus;
+    });
   }
 
   @override
@@ -56,6 +89,13 @@ class Dialog extends PrimaryRoleManager {
       'aria-describedby',
       routeName.semanticsObject.element.id,
     );
+  }
+
+  @override
+  bool focusAsRouteDefault() {
+    // Dialogs are the ones that look inside themselves to find elements to
+    // focus one. It doesn't make sense to focus on the dialog itself.
+    return false;
   }
 }
 

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -21,7 +21,7 @@ class Dialog extends PrimaryRoleManager {
     // focus on something inside it. There could be two possibilities:
     //
     // 1. The framework explicitly marked a node inside the dialog as focused
-    //    via the `isFocusabe` and `isFocused` flags. In this case, the node
+    //    via the `isFocusable` and `isFocused` flags. In this case, the node
     //    will request focus directly and there's nothing to do on top of that.
     // 2. No node inside the route takes focus explicitly. In this case, the
     //    expectation is to look through all nodes in traversal order and focus
@@ -45,7 +45,7 @@ class Dialog extends PrimaryRoleManager {
       }
 
       // If the node does not take focus (e.g. focusing on it does not make
-      // sense at all), depair not. Keep looking.
+      // sense at all). Despair not. Keep looking.
       final bool didTakeFocus = roleManager.focusAsRouteDefault();
       return !didTakeFocus;
     });
@@ -94,7 +94,7 @@ class Dialog extends PrimaryRoleManager {
   @override
   bool focusAsRouteDefault() {
     // Dialogs are the ones that look inside themselves to find elements to
-    // focus one. It doesn't make sense to focus on the dialog itself.
+    // focus on. It doesn't make sense to focus on the dialog itself.
     return false;
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -34,8 +34,16 @@ class Focusable extends RoleManager {
 
   final AccessibilityFocusManager _focusManager;
 
+  /// Requests focus as a result of a route (e.g. dialog) deciding that the node
+  /// managed by this class should be focused by default when nothing requests
+  /// focus explicitly.
+  ///
+  /// This method of taking focus is different from the regular method of using
+  /// the [SemanticsObject.hasFocus] flag, as in this case the framework is not
+  /// explicitly request focus. Instead, the DOM element is being focus directly
+  /// programmatically, simulating the screen reader choosing a default element
+  /// to focus on.
   bool focusAsRouteDefault() {
-    print('>>> ${semanticsObject.id} is taking default route focus (label: ${semanticsObject.label})');
     owner.element.focus();
     return true;
   }
@@ -237,7 +245,6 @@ class AccessibilityFocusManager {
         return;
       }
 
-      print('>>> calling focus on ${target.element} id="${target.element.id}"');
       target.element.focus();
     });
   }

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -39,7 +39,7 @@ class Focusable extends RoleManager {
   /// focus explicitly.
   ///
   /// This method of taking focus is different from the regular method of using
-  /// the [SemanticsObject.hasFocus] flag, as in this case the framework is not
+  /// the [SemanticsObject.hasFocus] flag, as in this case the framework did not
   /// explicitly request focus. Instead, the DOM element is being focus directly
   /// programmatically, simulating the screen reader choosing a default element
   /// to focus on.

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -44,7 +44,7 @@ class Focusable extends RoleManager {
   /// programmatically, simulating the screen reader choosing a default element
   /// to focus on.
   ///
-  /// Returns `true` if the this role manager took the focus. Returns `false` if
+  /// Returns `true` if the role manager took the focus. Returns `false` if
   /// this role manager did not take the focus. The return value can be used to
   /// decide whether to stop searching for a node that should take focus.
   bool focusAsRouteDefault() {

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -43,6 +43,10 @@ class Focusable extends RoleManager {
   /// explicitly request focus. Instead, the DOM element is being focus directly
   /// programmatically, simulating the screen reader choosing a default element
   /// to focus on.
+  ///
+  /// Returns `true` if the this role manager took the focus. Returns `false` if
+  /// this role manager did not take the focus. The return value can be used to
+  /// decide whether to stop searching for a node that should take focus.
   bool focusAsRouteDefault() {
     owner.element.focus();
     return true;

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -34,6 +34,12 @@ class Focusable extends RoleManager {
 
   final AccessibilityFocusManager _focusManager;
 
+  bool focusAsRouteDefault() {
+    print('>>> ${semanticsObject.id} is taking default route focus (label: ${semanticsObject.label})');
+    owner.element.focus();
+    return true;
+  }
+
   @override
   void update() {
     if (semanticsObject.isFocusable) {
@@ -83,6 +89,14 @@ class AccessibilityFocusManager {
   final EngineSemanticsOwner _owner;
 
   _FocusTarget? _target;
+
+  // The last focus value set by this focus manager, used to prevent requesting
+  // focus on the same element repeatedly. Requesting focus on DOM elements is
+  // not an idempotent operation. If the element is already focused and focus is
+  // requested the browser will scroll to that element. However, scrolling is
+  // not this class' concern and so this class should avoid doing anything that
+  // would affect scrolling.
+  bool? _lastSetValue;
 
   /// Whether this focus manager is managing a focusable target.
   bool get isManaging => _target != null;
@@ -136,6 +150,7 @@ class AccessibilityFocusManager {
   void stopManaging() {
     final _FocusTarget? target = _target;
     _target = null;
+    _lastSetValue = null;
 
     if (target == null) {
       /// Nothing is being managed. Just return.
@@ -144,11 +159,6 @@ class AccessibilityFocusManager {
 
     target.element.removeEventListener('focus', target.domFocusListener);
     target.element.removeEventListener('blur', target.domBlurListener);
-
-    // Blur the element after removing listeners. If this method is being called
-    // it indicates that the framework already knows that this node should not
-    // have focus, and there's no need to notify it.
-    target.element.blur();
   }
 
   void _setFocusFromDom(bool acquireFocus) {
@@ -174,6 +184,10 @@ class AccessibilityFocusManager {
     final _FocusTarget? target = _target;
 
     if (target == null) {
+      // If this branch is being executed, there's a bug somewhere already, but
+      // it doesn't hurt to clean up old values anyway.
+      _lastSetValue = null;
+
       // Nothing is being managed right now.
       assert(() {
         printWarning(
@@ -182,6 +196,32 @@ class AccessibilityFocusManager {
         );
         return true;
       }());
+      return;
+    }
+
+    if (value == _lastSetValue) {
+      // The focus is being changed to a value that's already been requested in
+      // the past. Do nothing.
+      return;
+    }
+    _lastSetValue = value;
+
+    if (value) {
+      _owner.willRequestFocus();
+    } else {
+      // Do not blur elements. Instead let the element be blurred by requesting
+      // focus elsewhere. Blurring elements is a very error-prone thing to do,
+      // as it is subject to non-local effects. Let's say the framework decides
+      // that a semantics node is currently not focused. That would lead to
+      // changeFocus(false) to be called. However, what if this node is inside
+      // a dialog, and nothing else in the dialog is focused. The Flutter
+      // framework expects that the screen reader will focus on the first (in
+      // traversal order) focusable element inside the dialog and send a
+      // didGainAccessibilityFocus action. Screen readers on the web do not do
+      // that, and so the web engine has to implement this behavior directly. So
+      // the dialog will look for a focusable element and request focus on it,
+      // but now there may be a race between this method unsetting the focus and
+      // the dialog requesting focus on the same element.
       return;
     }
 
@@ -197,11 +237,8 @@ class AccessibilityFocusManager {
         return;
       }
 
-      if (value) {
-        target.element.focus();
-      } else {
-        target.element.blur();
-      }
+      print('>>> calling focus on ${target.element} id="${target.element.id}"');
+      target.element.focus();
     });
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/image.dart
+++ b/lib/web_ui/lib/src/engine/semantics/image.dart
@@ -23,6 +23,9 @@ class ImageRoleManager extends PrimaryRoleManager {
     addTappable();
   }
 
+  @override
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
+
   /// The element with role="img" and aria-label could block access to all
   /// children elements, therefore create an auxiliary element and  describe the
   /// image in that if the semantic object have child nodes.

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -59,6 +59,12 @@ class Incrementable extends PrimaryRoleManager {
     _focusManager.manage(semanticsObject.id, _element);
   }
 
+  @override
+  bool focusAsRouteDefault() {
+    _element.focus();
+    return true;
+  }
+
   /// The HTML element used to render semantics to the browser.
   final DomHTMLInputElement _element = createDomHTMLInputElement();
 

--- a/lib/web_ui/lib/src/engine/semantics/link.dart
+++ b/lib/web_ui/lib/src/engine/semantics/link.dart
@@ -18,4 +18,7 @@ class Link extends PrimaryRoleManager {
     element.style.display = 'block';
     return element;
   }
+
+  @override
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
 }

--- a/lib/web_ui/lib/src/engine/semantics/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/semantics/platform_view.dart
@@ -38,4 +38,13 @@ class PlatformViewRoleManager extends PrimaryRoleManager {
       removeAttribute('aria-owns');
     }
   }
+
+  @override
+  bool focusAsRouteDefault() {
+    // It's unclear how it's possible to auto-focus on something inside a
+    // platform view without knowing what's in it. If the framework adds API for
+    // focusing on platform view internals, this method will be able to do more,
+    // but for now there's nothing to focus on.
+    return false;
+  }
 }

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -241,5 +241,5 @@ class Scrollable extends PrimaryRoleManager {
   }
 
   @override
-  bool focusAsRouteDefault() => false;
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
 }

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -239,4 +239,7 @@ class Scrollable extends PrimaryRoleManager {
       _gestureModeListener = null;
     }
   }
+
+  @override
+  bool focusAsRouteDefault() => false;
 }

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -609,6 +609,10 @@ abstract class PrimaryRoleManager {
   /// focus. Not all elements that can take accessibility focus can also take
   /// input focus. For example, a plain text node cannot take input focus, but
   /// it can take accessibility focus.
+  ///
+  /// Returns `true` if the this role manager took the focus. Returns `false` if
+  /// this role manager did not take the focus. The return value can be used to
+  /// decide whether to stop searching for a node that should take focus.
   bool focusAsRouteDefault();
 }
 
@@ -2472,7 +2476,11 @@ AFTER: $description
     _oneTimePostUpdateCallbacks.clear();
   }
 
-  /// True, if any semantics node requested focus explicitly.
+  /// True, if any semantics node requested focus explicitly during the latest
+  /// semantics update.
+  ///
+  /// The default value is `false`, and it is reset back to `false` after the
+  /// semantics update at the end of [updateSemantics].
   ///
   /// Since focus can only be taken by no more than one element, the engine
   /// should not request focus for multiple elements. This flag helps resolve

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -519,9 +519,13 @@ abstract class PrimaryRoleManager {
 
   void removeEventListener(String type, DomEventListener? listener, [bool? useCapture]) => element.removeEventListener(type, listener, useCapture);
 
+  /// Convenience getter for the [Focusable] role manager, if any.
+  Focusable? get focusable => _focusable;
+  Focusable? _focusable;
+
   /// Adds generic focus management features.
   void addFocusManagement() {
-    addSecondaryRole(Focusable(semanticsObject, this));
+    addSecondaryRole(_focusable = Focusable(semanticsObject, this));
   }
 
   /// Adds generic live region features.
@@ -594,6 +598,18 @@ abstract class PrimaryRoleManager {
     removeAttribute('role');
     _isDisposed = true;
   }
+
+  /// Transfers the accessibility focus to the [element] managed by this role
+  /// manager as a result of this node taking focus by default.
+  ///
+  /// For example, when a dialog pops up it is expected that one of its child
+  /// nodes takes accessibility focus.
+  ///
+  /// Transferring accessibility focus is different from transferring input
+  /// focus. Not all elements that can take accessibility focus can also take
+  /// input focus. For example, a plain text node cannot take input focus, but
+  /// it can take accessibility focus.
+  bool focusAsRouteDefault();
 }
 
 /// A role used when a more specific role couldn't be assigned to the node.
@@ -638,6 +654,38 @@ final class GenericRole extends PrimaryRoleManager {
     } else {
       setAriaRole('text');
     }
+  }
+
+  @override
+  bool focusAsRouteDefault() {
+    // Case 1: current node has input focus. Let the input focus system decide
+    // default focusability.
+    if (semanticsObject.isFocusable) {
+      final Focusable? focusable = this.focusable;
+      if (focusable != null) {
+        return focusable.focusAsRouteDefault();
+      }
+    }
+
+    // Case 2: current node is not focusable, but just a container of other
+    // nodes or lacks a label. Do not focus on it and let the search continue.
+    if (semanticsObject.hasChildren || !semanticsObject.hasLabel) {
+      return false;
+    }
+
+    // Case 3: current node is visual/informational. Move just the
+    // accessibility focus.
+
+    // Plain text nodes should not be focusable via keyboard or mouse. They are
+    // only focusable for the purposes of focusing the screen reader. To achieve
+    // this the -1 value is used.
+    //
+    // See also:
+    //
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
+    element.tabIndex = -1;
+    element.focus();
+    return true;
   }
 }
 
@@ -1719,14 +1767,57 @@ class SemanticsObject {
     }
   }
 
-  /// Recursively visits the tree rooted at `this` node in depth-first fashion.
+  /// Recursively visits the tree rooted at `this` node in depth-first fashion
+  /// in render order.
   ///
   /// Calls the [callback] for `this` node, then for all of its descendants.
-  void visitDepthFirst(void Function(SemanticsObject) callback) {
+  void visitDepthFirstInRenderOrder(void Function(SemanticsObject) callback) {
     callback(this);
     _currentChildrenInRenderOrder?.forEach((SemanticsObject child) {
-      child.visitDepthFirst(callback);
+      child.visitDepthFirstInRenderOrder(callback);
     });
+  }
+
+  /// Recursively visits the tree rooted at `this` node in depth-first fashion
+  /// in traversal order.
+  ///
+  /// Calls the [callback] for `this` node, then for all of its descendants. If
+  /// the callback returns true, continues visiting descendants. Otherwise,
+  /// stops immediately after visiting the node that caused the callback to
+  /// return false.
+  void visitDepthFirstInTraversalOrder(bool Function(SemanticsObject) callback) {
+    _visitDepthFirstInTraversalOrder(callback);
+  }
+
+  bool _visitDepthFirstInTraversalOrder(bool Function(SemanticsObject) callback) {
+    final bool shouldContinueVisiting = callback(this);
+
+    if (!shouldContinueVisiting) {
+      return false;
+    }
+
+    final Int32List? childrenInTraversalOrder = _childrenInTraversalOrder;
+
+    if (childrenInTraversalOrder == null) {
+      return true;
+    }
+
+    for (final int childId in childrenInTraversalOrder) {
+      final SemanticsObject? child = owner._semanticsTree[childId];
+
+      assert(
+        child != null,
+        'visitDepthFirstInTraversalOrder must only be called after the node '
+        'tree has been established. However, child #$childId does not have its '
+        'SemanticsNode created at the time this method was called.',
+      );
+
+      if (!child!._visitDepthFirstInTraversalOrder(callback)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   @override
@@ -2170,7 +2261,7 @@ class EngineSemanticsOwner {
       // A detached node may or may not have some of its descendants reattached
       // elsewhere. Walk the descendant tree and find all descendants that were
       // reattached to a parent. Those descendants need to be removed.
-      detachmentRoot.visitDepthFirst((SemanticsObject node) {
+      detachmentRoot.visitDepthFirstInRenderOrder((SemanticsObject node) {
         final SemanticsObject? parent = _attachments[node.id];
         if (parent == null) {
           // Was not reparented and is removed permanently from the tree.
@@ -2202,6 +2293,7 @@ class EngineSemanticsOwner {
     } finally {
       _phase = SemanticsUpdatePhase.idle;
     }
+    _hasNodeRequestingFocus = false;
   }
 
   /// Returns the entire semantics tree for testing.
@@ -2235,7 +2327,7 @@ class EngineSemanticsOwner {
 
     final SemanticsObject? root = _semanticsTree[0];
     if (root != null) {
-      root.visitDepthFirst((SemanticsObject child) {
+      root.visitDepthFirstInRenderOrder((SemanticsObject child) {
         liveIds[child.id] = child._childrenInTraversalOrder?.toList() ?? const <int>[];
       });
     }
@@ -2378,6 +2470,23 @@ AFTER: $description
     _detachments.clear();
     _phase = SemanticsUpdatePhase.idle;
     _oneTimePostUpdateCallbacks.clear();
+  }
+
+  /// True, if any semantics node requested focus explicitly.
+  ///
+  /// Since focus can only be taken by no more than one element, the engine
+  /// should not request focus for multiple elements. This flag helps resolve
+  /// that.
+  bool get hasNodeRequestingFocus => _hasNodeRequestingFocus;
+  bool _hasNodeRequestingFocus = false;
+
+  /// Declares that a semantics node will explicitly request focus.
+  ///
+  /// This prevents others, [Dialog] in particular, from requesting autofocus,
+  /// as focus can only be taken by one element. Explicit focus has higher
+  /// precedence than autofocus.
+  void willRequestFocus() {
+    _hasNodeRequestingFocus = true;
   }
 }
 

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -610,7 +610,7 @@ abstract class PrimaryRoleManager {
   /// input focus. For example, a plain text node cannot take input focus, but
   /// it can take accessibility focus.
   ///
-  /// Returns `true` if the this role manager took the focus. Returns `false` if
+  /// Returns `true` if the role manager took the focus. Returns `false` if
   /// this role manager did not take the focus. The return value can be used to
   /// decide whether to stop searching for a node that should take focus.
   bool focusAsRouteDefault();

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -12,6 +12,9 @@ class Button extends PrimaryRoleManager {
   }
 
   @override
+  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
+
+  @override
   void update() {
     super.update();
 

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -226,6 +226,16 @@ class TextField extends PrimaryRoleManager {
     return editableElement!;
   }
 
+  @override
+  bool focusAsRouteDefault() {
+    final DomHTMLElement? editableElement = this.editableElement;
+    if (editableElement == null) {
+      return false;
+    }
+    editableElement.focus();
+    return true;
+  }
+
   /// Timer that times when to set the location of the input text.
   ///
   /// This is only used for iOS. In iOS, virtual keyboard shifts the screen.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/138371

When a new route pops up the expectation is that the screen reader focuses on something in the new route. Since routes typically result in DOM nodes being replaced, the current effect is that the screen reader simply unfocuses from the page, causing the user to have to refocus on back on the page and look for elements to interact with, which is a poor user experience. The current workaround is to use `autofocus`, but that doesn't scale as it's easy to forget, and if the route in question is maintained by a different person you may not even have enough control over it to set `autofocus` on anything. For example, this is the case with Flutter's default date picker. All you have is `showDatePicker` and there's no way to control the focus.

With this change the route (managed by the `Dialog` primary role) will check if a widget requested explicit focus (perhaps using `autofocus`), and if not, looks for the first descendant that a screen reader can focus on, and requests focus on it. The auto-focused element does not have to be literally focusable. For example, plain `Text` nodes do not have input focus (i.e. they are not `isFocusable`) but screen readers can still focus on them. If such an element is found, the web engine requests that the browser move focus to it programmatically (`element.focus()`), which causes the screen reader to move the a11y focus to it as well, but it sets `tabindex=-1` so the element is not focusable via keyboard or mouse.
