### PR TITLE
Include updated locations for dart third_party components into license ignore-list.

### DIFF
--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 69d986a7b2275b798b574b6aea2c1b78
+Signature: 08abde25a4755bd5d629c7a646fb4c99
 

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 08abde25a4755bd5d629c7a646fb4c99
+Signature: 4b8678841cc9a099770862d08fb15c47
 

--- a/tools/licenses/lib/paths.dart
+++ b/tools/licenses/lib/paths.dart
@@ -96,11 +96,13 @@ final Set<String> skippedPaths = <String>{
   r'third_party/dart/pkg', // packages that don't become part of the binary (e.g. the analyzer)
   r'third_party/dart/runtime/bin/ffi_test',
   r'third_party/dart/runtime/docs',
-  r'third_party/dart/runtime/third_party/binary_size', // not linked in either
-  r'third_party/dart/runtime/third_party/d3', // Siva says "that is the charting library used by the binary size tool"
+  r'third_party/dart/runtime/third_party/binary_size', // not linked in either - todo: remove as a dup
+  r'third_party/dart/runtime/third_party/d3', // Siva says "that is the charting library used by the binary size tool" - todo: remove as a dup
   r'third_party/dart/runtime/vm/service',
   r'third_party/dart/sdk/lib/html/doc',
+  r'third_party/dart/third_party/binary_size', // not linked in
   r'third_party/dart/third_party/binaryen', // not linked in
+  r'third_party/dart/third_party/d3', // Siva says "that is the charting library used by the binary size tool"
   r'third_party/dart/third_party/d8', // testing tool for dart2js
   r'third_party/dart/third_party/devtools', // not linked in
   r'third_party/dart/third_party/firefox_jsshell', // testing tool for dart2js

--- a/tools/licenses/lib/paths.dart
+++ b/tools/licenses/lib/paths.dart
@@ -96,8 +96,10 @@ final Set<String> skippedPaths = <String>{
   r'third_party/dart/pkg', // packages that don't become part of the binary (e.g. the analyzer)
   r'third_party/dart/runtime/bin/ffi_test',
   r'third_party/dart/runtime/docs',
-  r'third_party/dart/runtime/third_party/binary_size', // not linked in either - todo: remove as a dup
-  r'third_party/dart/runtime/third_party/d3', // Siva says "that is the charting library used by the binary size tool" - todo: remove as a dup
+  // TODO(aam): remove as a dup
+  r'third_party/dart/runtime/third_party/binary_size',
+  // TODO(aam): remove as a dup
+  r'third_party/dart/runtime/third_party/d3',
   r'third_party/dart/runtime/vm/service',
   r'third_party/dart/sdk/lib/html/doc',
   r'third_party/dart/third_party/binary_size', // not linked in


### PR DESCRIPTION
Incoming dart roll with https://dart.googlesource.com/sdk/+/4d308f39115a2969fb9908055b37a93969d4fc8d moves `runtime/third_parry` in dart to `third_party`, so license script ignore-list have to be updated to accommodate new location.

Once the roll lands, old locations should be cleaned up from the ignore-list.