### PR TITLE
[macOS] Bail out of tests if engine not running

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -122,7 +122,7 @@ namespace flutter::testing {
 TEST_F(FlutterEngineTest, CanLaunch) {
   FlutterEngine* engine = GetFlutterEngine();
   EXPECT_TRUE([engine runWithEntrypoint:@"main"]);
-  EXPECT_TRUE(engine.running);
+  ASSERT_TRUE(engine.running);
 }
 
 TEST_F(FlutterEngineTest, HasNonNullExecutableName) {
@@ -196,7 +196,7 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
   // Launch the test entrypoint.
   FlutterEngine* engine = GetFlutterEngine();
   EXPECT_TRUE([engine runWithEntrypoint:@"canLogToStdout"]);
-  EXPECT_TRUE(engine.running);
+  ASSERT_TRUE(engine.running);
 
   latch.Wait();
 
@@ -227,7 +227,7 @@ TEST_F(FlutterEngineTest, DISABLED_BackgroundIsBlack) {
 
   // Launch the test entrypoint.
   EXPECT_TRUE([engine runWithEntrypoint:@"backgroundTest"]);
-  EXPECT_TRUE(engine.running);
+  ASSERT_TRUE(engine.running);
 
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
@@ -257,7 +257,7 @@ TEST_F(FlutterEngineTest, DISABLED_CanOverrideBackgroundColor) {
 
   // Launch the test entrypoint.
   EXPECT_TRUE([engine runWithEntrypoint:@"backgroundTest"]);
-  EXPECT_TRUE(engine.running);
+  ASSERT_TRUE(engine.running);
 
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                                 nibName:nil
@@ -479,7 +479,7 @@ TEST_F(FlutterEngineTest, NativeCallbacks) {
 
   FlutterEngine* engine = GetFlutterEngine();
   EXPECT_TRUE([engine runWithEntrypoint:@"nativeCallback"]);
-  EXPECT_TRUE(engine.running);
+  ASSERT_TRUE(engine.running);
 
   latch.Wait();
   ASSERT_TRUE(latch_called);


### PR DESCRIPTION
In engine tests where we require a running engine to proceed with the test, immediately fail if the engine isn't running rather than carrying on with the test. In most cases, the fixture test proceeds to block the main thread on a latch until it's released from the UI thread, so this results in quicker test failures.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
