### PR TITLE
[testing] Extract StreamCapture test utility

### DIFF
--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -25,6 +25,8 @@ source_set("testing_lib") {
     "mock_canvas.h",
     "post_task_sync.cc",
     "post_task_sync.h",
+    "stream_capture.cc",
+    "stream_capture.h",
     "test_args.cc",
     "test_args.h",
     "test_timeout_listener.cc",

--- a/testing/stream_capture.cc
+++ b/testing/stream_capture.cc
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/stream_capture.h"
+
+namespace flutter {
+namespace testing {
+
+StreamCapture::StreamCapture(std::ostream* ostream)
+    : ostream_(ostream), old_buffer_(ostream_->rdbuf()) {
+  ostream_->rdbuf(buffer_.rdbuf());
+}
+
+StreamCapture::~StreamCapture() {
+  Stop();
+}
+
+void StreamCapture::Stop() {
+  if (old_buffer_) {
+    ostream_->rdbuf(old_buffer_);
+    old_buffer_ = nullptr;
+  }
+}
+
+std::string StreamCapture::GetOutput() const {
+  return buffer_.str();
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/testing/stream_capture.h
+++ b/testing/stream_capture.h
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_TESTING_STREAM_CAPTURE_H_
+#define FLUTTER_TESTING_STREAM_CAPTURE_H_
+
+#include <ostream>
+#include <sstream>
+#include <string>
+
+namespace flutter {
+namespace testing {
+
+// Temporarily replaces the specified stream's output buffer to capture output.
+//
+// Example:
+// StreamCapture captured_stdout(&std::cout);
+// ... code that writest to std::cout ...
+// std::string output = captured_stdout.GetCapturedOutput();
+class StreamCapture {
+ public:
+  // Begins capturing output to the specified stream.
+  StreamCapture(std::ostream* ostream);
+
+  // Stops capturing output to the specified stream, and restores the original
+  // output buffer, if |Stop| has not already been called.
+  ~StreamCapture();
+
+  // Stops capturing output to the specified stream, and restores the original
+  // output buffer.
+  void Stop();
+
+  // Returns any output written to the captured stream between construction and
+  // the first call to |Stop|, if any, or now.
+  std::string GetOutput() const;
+
+ private:
+  std::ostream* ostream_;
+  std::stringstream buffer_;
+  std::streambuf* old_buffer_;
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_TESTING_STREAM_CAPTURE_H_


### PR DESCRIPTION
Factors out an RAII-based class that can be used to capture std::cout, std::cerr, or technically any other std::ostream, though that's unlikely to be useful.

This makes the logic reusable but more importantly, ensures the capture is cleaned up at the end of the test.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
