### PR TITLE
[Impeller] Add Rect::GetNormalizingTransform to handle UV coordinate conversion

### DIFF
--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -83,7 +83,7 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
   using VS = TextureFillVertexShader;
 
   auto uv_transform =
-      effect_transform * texture_coverage.GetNormalizingTransform();
+      texture_coverage.GetNormalizingTransform() * effect_transform;
 
   if (path_.GetFillType() == FillType::kNonZero &&  //
       path_.IsConvex()) {

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -82,6 +82,9 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
     RenderPass& pass) {
   using VS = TextureFillVertexShader;
 
+  auto uv_transform =
+      effect_transform * texture_coverage.GetNormalizingTransform();
+
   if (path_.GetFillType() == FillType::kNonZero &&  //
       path_.IsConvex()) {
     auto [points, indices] = TessellateConvex(
@@ -93,9 +96,7 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
     for (auto i = 0u; i < points.size(); i++) {
       VS::PerVertexData data;
       data.position = points[i];
-      data.texture_coords = effect_transform *
-                            (points[i] - texture_coverage.origin) /
-                            texture_coverage.size;
+      data.texture_coords = uv_transform * points[i];
       vertex_builder.AppendVertex(data);
     }
     for (auto i = 0u; i < indices.size(); i++) {
@@ -116,16 +117,14 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
   auto tesselation_result = renderer.GetTessellator()->Tessellate(
       path_.GetFillType(),
       path_.CreatePolyline(entity.GetTransformation().GetMaxBasisLength()),
-      [&vertex_builder, &texture_coverage, &effect_transform](
+      [&vertex_builder, &uv_transform](
           const float* vertices, size_t vertices_count, const uint16_t* indices,
           size_t indices_count) {
         for (auto i = 0u; i < vertices_count * 2; i += 2) {
           VS::PerVertexData data;
           Point vtx = {vertices[i], vertices[i + 1]};
           data.position = vtx;
-          data.texture_coords = effect_transform *
-                                (vtx - texture_coverage.origin) /
-                                texture_coverage.size;
+          data.texture_coords = uv_transform * vtx;
           vertex_builder.AppendVertex(data);
         }
         FML_DCHECK(vertex_builder.GetVertexCount() == vertices_count);

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -76,7 +76,7 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
   auto& host_buffer = pass.GetTransientsBuffer();
 
   auto uv_transform =
-      effect_transform * texture_coverage.GetNormalizingTransform();
+      texture_coverage.GetNormalizingTransform() * effect_transform;
   std::vector<Point> data(8);
   auto points = source_rect.GetPoints();
   for (auto i = 0u, j = 0u; i < 8; i += 2, j++) {

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -75,12 +75,13 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
                                         RenderPass& pass) {
   auto& host_buffer = pass.GetTransientsBuffer();
 
+  auto uv_transform =
+      effect_transform * texture_coverage.GetNormalizingTransform();
   std::vector<Point> data(8);
   auto points = source_rect.GetPoints();
   for (auto i = 0u, j = 0u; i < 8; i += 2, j++) {
     data[i] = points[j];
-    data[i + 1] = effect_transform * (points[j] - texture_coverage.origin) /
-                  texture_coverage.size;
+    data[i + 1] = uv_transform * points[j];
   }
 
   return GeometryResult{

--- a/impeller/entity/geometry/vertices_geometry.cc
+++ b/impeller/entity/geometry/vertices_geometry.cc
@@ -227,8 +227,8 @@ GeometryResult VerticesGeometry::GetPositionUVBuffer(
 
   auto index_count = indices_.size();
   auto vertex_count = vertices_.size();
-  auto size = texture_coverage.size;
-  auto origin = texture_coverage.origin;
+  auto uv_transform =
+      effect_transform * texture_coverage.GetNormalizingTransform();
   auto has_texture_coordinates = HasTextureCoordinates();
   std::vector<VS::PerVertexData> vertex_data(vertex_count);
   {
@@ -236,9 +236,7 @@ GeometryResult VerticesGeometry::GetPositionUVBuffer(
       auto vertex = vertices_[i];
       auto texture_coord =
           has_texture_coordinates ? texture_coordinates_[i] : vertices_[i];
-      auto uv =
-          effect_transform * Point((texture_coord.x - origin.x) / size.width,
-                                   (texture_coord.y - origin.y) / size.height);
+      auto uv = uv_transform * texture_coord;
       // From experimentation we need to clamp these values to < 1.0 or else
       // there can be flickering.
       vertex_data[i] = {

--- a/impeller/entity/geometry/vertices_geometry.cc
+++ b/impeller/entity/geometry/vertices_geometry.cc
@@ -228,7 +228,7 @@ GeometryResult VerticesGeometry::GetPositionUVBuffer(
   auto index_count = indices_.size();
   auto vertex_count = vertices_.size();
   auto uv_transform =
-      effect_transform * texture_coverage.GetNormalizingTransform();
+      texture_coverage.GetNormalizingTransform() * effect_transform;
   auto has_texture_coordinates = HasTextureCoordinates();
   std::vector<VS::PerVertexData> vertex_data(vertex_count);
   {

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -14,14 +14,14 @@ namespace testing {
 TEST(RectTest, RectOriginSizeGetters) {
   {
     Rect r = Rect::MakeOriginSize({10, 20}, {50, 40});
-    ASSERT_EQ(r.GetOrigin(), Point(10, 20));
-    ASSERT_EQ(r.GetSize(), Size(50, 40));
+    EXPECT_EQ(r.GetOrigin(), Point(10, 20));
+    EXPECT_EQ(r.GetSize(), Size(50, 40));
   }
 
   {
     Rect r = Rect::MakeLTRB(10, 20, 50, 40);
-    ASSERT_EQ(r.GetOrigin(), Point(10, 20));
-    ASSERT_EQ(r.GetSize(), Size(40, 20));
+    EXPECT_EQ(r.GetOrigin(), Point(10, 20));
+    EXPECT_EQ(r.GetSize(), Size(40, 20));
   }
 }
 
@@ -44,14 +44,152 @@ TEST(RectTest, RectMakeSize) {
     Size s(100, 200);
     IRect r = IRect::MakeSize(s);
     IRect expected = IRect::MakeLTRB(0, 0, 100, 200);
-    ASSERT_EQ(r, expected);
+    EXPECT_EQ(r, expected);
   }
 
   {
     ISize s(100, 200);
     IRect r = IRect::MakeSize(s);
     IRect expected = IRect::MakeLTRB(0, 0, 100, 200);
-    ASSERT_EQ(r, expected);
+    EXPECT_EQ(r, expected);
+  }
+}
+
+TEST(RectTest, RectGetNormalizingTransform) {
+  {
+    // Checks for expected matrix values
+
+    auto r = Rect::MakeXYWH(100, 200, 200, 400);
+
+    EXPECT_EQ(r.GetNormalizingTransform(),
+              Matrix::MakeScale({0.005, 0.0025, 1.0}) *
+                  Matrix::MakeTranslation({-100, -200}));
+  }
+
+  {
+    // Checks for expected transformation of points relative to the rect
+
+    auto r = Rect::MakeLTRB(300, 500, 400, 700);
+    auto m = r.GetNormalizingTransform();
+
+    // The 4 corners of the rect => (0, 0) to (1, 1)
+    EXPECT_EQ(m * Point(300, 500), Point(0, 0));
+    EXPECT_EQ(m * Point(400, 500), Point(1, 0));
+    EXPECT_EQ(m * Point(400, 700), Point(1, 1));
+    EXPECT_EQ(m * Point(300, 700), Point(0, 1));
+
+    // The center => (0.5, 0.5)
+    EXPECT_EQ(m * Point(350, 600), Point(0.5, 0.5));
+
+    // Outside the 4 corners => (-1, -1) to (2, 2)
+    EXPECT_EQ(m * Point(200, 300), Point(-1, -1));
+    EXPECT_EQ(m * Point(500, 300), Point(2, -1));
+    EXPECT_EQ(m * Point(500, 900), Point(2, 2));
+    EXPECT_EQ(m * Point(200, 900), Point(-1, 2));
+  }
+
+  {
+    // Checks for behavior with empty rects
+
+    auto zero = Matrix::MakeScale({0.0, 0.0, 1.0});
+
+    // Empty for width and/or height == 0
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, 0, 10).GetNormalizingTransform(), zero);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, 10, 0).GetNormalizingTransform(), zero);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, 0, 0).GetNormalizingTransform(), zero);
+
+    // Empty for width and/or height < 0
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, -1, 10).GetNormalizingTransform(), zero);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, 10, -1).GetNormalizingTransform(), zero);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, -1, -1).GetNormalizingTransform(), zero);
+  }
+
+  {
+    // Checks for behavior with non-finite rects
+
+    auto z = Matrix::MakeScale({0.0, 0.0, 1.0});
+    auto nan = std::numeric_limits<Scalar>::quiet_NaN();
+    auto inf = std::numeric_limits<Scalar>::infinity();
+
+    // Non-finite for width and/or height == nan
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, nan, 10).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, 10, nan).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, nan, nan).GetNormalizingTransform(), z);
+
+    // Non-finite for width and/or height == inf
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, inf, 10).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, 10, inf).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, inf, inf).GetNormalizingTransform(), z);
+
+    // Non-finite for width and/or height == -inf
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, -inf, 10).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, 10, -inf).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(10, 10, -inf, -inf).GetNormalizingTransform(), z);
+
+    // Non-finite for origin X and/or Y == nan
+    EXPECT_EQ(Rect::MakeXYWH(nan, 10, 10, 10).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(10, nan, 10, 10).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(nan, nan, 10, 10).GetNormalizingTransform(), z);
+
+    // Non-finite for origin X and/or Y == inf
+    EXPECT_EQ(Rect::MakeXYWH(inf, 10, 10, 10).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(10, inf, 10, 10).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(inf, inf, 10, 10).GetNormalizingTransform(), z);
+
+    // Non-finite for origin X and/or Y == -inf
+    EXPECT_EQ(Rect::MakeXYWH(-inf, 10, 10, 10).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(10, -inf, 10, 10).GetNormalizingTransform(), z);
+    EXPECT_EQ(Rect::MakeXYWH(-inf, -inf, 10, 10).GetNormalizingTransform(), z);
+  }
+}
+
+TEST(RectTest, IRectGetNormalizingTransform) {
+  {
+    // Checks for expected matrix values
+
+    auto r = IRect::MakeXYWH(100, 200, 200, 400);
+
+    EXPECT_EQ(r.GetNormalizingTransform(),
+              Matrix::MakeScale({0.005, 0.0025, 1.0}) *
+                  Matrix::MakeTranslation({-100, -200}));
+  }
+
+  {
+    // Checks for expected transformation of points relative to the rect
+
+    auto r = IRect::MakeLTRB(300, 500, 400, 700);
+    auto m = r.GetNormalizingTransform();
+
+    // The 4 corners of the rect => (0, 0) to (1, 1)
+    EXPECT_EQ(m * Point(300, 500), Point(0, 0));
+    EXPECT_EQ(m * Point(400, 500), Point(1, 0));
+    EXPECT_EQ(m * Point(400, 700), Point(1, 1));
+    EXPECT_EQ(m * Point(300, 700), Point(0, 1));
+
+    // The center => (0.5, 0.5)
+    EXPECT_EQ(m * Point(350, 600), Point(0.5, 0.5));
+
+    // Outside the 4 corners => (-1, -1) to (2, 2)
+    EXPECT_EQ(m * Point(200, 300), Point(-1, -1));
+    EXPECT_EQ(m * Point(500, 300), Point(2, -1));
+    EXPECT_EQ(m * Point(500, 900), Point(2, 2));
+    EXPECT_EQ(m * Point(200, 900), Point(-1, 2));
+  }
+
+  {
+    // Checks for behavior with empty rects
+
+    auto zero = Matrix::MakeScale({0.0, 0.0, 1.0});
+
+    // Empty for width and/or height == 0
+    EXPECT_EQ(IRect::MakeXYWH(10, 10, 0, 10).GetNormalizingTransform(), zero);
+    EXPECT_EQ(IRect::MakeXYWH(10, 10, 10, 0).GetNormalizingTransform(), zero);
+    EXPECT_EQ(IRect::MakeXYWH(10, 10, 0, 0).GetNormalizingTransform(), zero);
+
+    // Empty for width and/or height < 0
+    EXPECT_EQ(IRect::MakeXYWH(10, 10, -1, 10).GetNormalizingTransform(), zero);
+    EXPECT_EQ(IRect::MakeXYWH(10, 10, 10, -1).GetNormalizingTransform(), zero);
+    EXPECT_EQ(IRect::MakeXYWH(10, 10, -1, -1).GetNormalizingTransform(), zero);
   }
 }
 


### PR DESCRIPTION
Three places in the code were manually computing the UV coordinates relative to a texture coverage rectangle while also transforming the points. This change will make it easier both to compute the UV conversion matrix and also to consolidate it with the transform that was already being applied to streamline the total computations.