### PR TITLE
[Impeller] Create a global Vulkan instance in PlaygroundImplVK to prevent SwiftShader from being unloaded after a test completes

### DIFF
--- a/impeller/playground/backend/vulkan/playground_impl_vk.h
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.h
@@ -24,6 +24,10 @@ class PlaygroundImplVK final : public PlaygroundImpl {
   using UniqueHandle = std::unique_ptr<void, decltype(&DestroyWindowHandle)>;
   UniqueHandle handle_;
 
+  // A global Vulkan instance which ensures that the Vulkan library will remain
+  // loaded throughout the lifetime of the process.
+  static vk::UniqueInstance global_instance_;
+
   // |PlaygroundImpl|
   std::shared_ptr<Context> GetContext() const override;
 
@@ -37,6 +41,8 @@ class PlaygroundImplVK final : public PlaygroundImpl {
   PlaygroundImplVK(const PlaygroundImplVK&) = delete;
 
   PlaygroundImplVK& operator=(const PlaygroundImplVK&) = delete;
+
+  static void InitGlobalVulkanInstance();
 };
 
 }  // namespace impeller


### PR DESCRIPTION
Libcxx is leaking a thread-local storage key each time SwiftShader is loaded and unloaded.  If a test's Vulkan instance is the only one in the process, then SwiftShader will be unloaded after the test ends.  If many Vulkan playground tests run in a suite, then eventually the leak will cause the process to exceed its limit of TLS keys and the suite will fail.

The process can ensure that SwiftShader remains loaded by holding another Vulkan instance that persists across all tests in the suite.

Fixes https://github.com/flutter/flutter/issues/138028