### PR TITLE
[macOS] Allocate textures as unique_ptr earlier

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
@@ -108,15 +108,14 @@ TEST_F(FlutterEmbedderExternalTextureTest, TestTextureResolution) {
     EXPECT_TRUE(w == width);
     EXPECT_TRUE(h == height);
 
-    FlutterMetalExternalTexture* texture = new FlutterMetalExternalTexture();
+    auto texture = std::make_unique<FlutterMetalExternalTexture>();
     texture->struct_size = sizeof(FlutterMetalExternalTexture);
     texture->num_textures = 1;
     texture->height = h;
     texture->width = w;
     texture->pixel_format = FlutterMetalExternalTexturePixelFormat::kRGBA;
     texture->textures = textures.data();
-
-    return std::unique_ptr<FlutterMetalExternalTexture>(texture);
+    return texture;
   };
 
   // Render the texture.
@@ -164,14 +163,13 @@ TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateExternalTexture) {
     EXPECT_TRUE(w == width);
     EXPECT_TRUE(h == height);
 
-    FlutterMetalExternalTexture* texture = new FlutterMetalExternalTexture();
-    [textureHolder populateTexture:texture];
+    auto texture = std::make_unique<FlutterMetalExternalTexture>();
+    [textureHolder populateTexture:texture.get()];
 
     EXPECT_TRUE(texture->num_textures == 1);
     EXPECT_TRUE(texture->textures != nullptr);
     EXPECT_TRUE(texture->pixel_format == FlutterMetalExternalTexturePixelFormat::kRGBA);
-
-    return std::unique_ptr<FlutterMetalExternalTexture>(texture);
+    return texture;
   };
 
   // Render the texture.
@@ -217,16 +215,15 @@ TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateExternalTextureYUVA) {
     EXPECT_TRUE(w == width);
     EXPECT_TRUE(h == height);
 
-    FlutterMetalExternalTexture* texture = new FlutterMetalExternalTexture();
-    [textureHolder populateTexture:texture];
+    auto texture = std::make_unique<FlutterMetalExternalTexture>();
+    [textureHolder populateTexture:texture.get()];
 
     EXPECT_TRUE(texture->num_textures == 2);
     EXPECT_TRUE(texture->textures != nullptr);
     EXPECT_TRUE(texture->pixel_format == FlutterMetalExternalTexturePixelFormat::kYUVA);
     EXPECT_TRUE(texture->yuv_color_space ==
                 FlutterMetalExternalTextureYUVColorSpace::kBT601LimitedRange);
-
-    return std::unique_ptr<FlutterMetalExternalTexture>(texture);
+    return texture;
   };
 
   // Render the texture.
@@ -272,16 +269,15 @@ TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateExternalTextureYUVA2) {
     EXPECT_TRUE(w == width);
     EXPECT_TRUE(h == height);
 
-    FlutterMetalExternalTexture* texture = new FlutterMetalExternalTexture();
-    [textureHolder populateTexture:texture];
+    auto texture = std::make_unique<FlutterMetalExternalTexture>();
+    [textureHolder populateTexture:texture.get()];
 
     EXPECT_TRUE(texture->num_textures == 2);
     EXPECT_TRUE(texture->textures != nullptr);
     EXPECT_TRUE(texture->pixel_format == FlutterMetalExternalTexturePixelFormat::kYUVA);
     EXPECT_TRUE(texture->yuv_color_space ==
                 FlutterMetalExternalTextureYUVColorSpace::kBT601FullRange);
-
-    return std::unique_ptr<FlutterMetalExternalTexture>(texture);
+    return texture;
   };
 
   // Render the texture.


### PR DESCRIPTION
This cleans up several places where instead of allocating a std::unique_ptr immediately, we were making allocations with the new operator, then later wrapping in a unique_ptr. The previous code was correct but there was no reason not to allocate a unique_ptr immediately.

This code makes no semantic changes; just applies a stylistic improvement that makes the code very slightly safer.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
