### PR TITLE
[Windows] Set swap interval on raster thread after startup

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -350,12 +350,6 @@ void AngleSurfaceManager::SetVSyncEnabled(bool enabled) {
     LogEglError("Unable to update the swap interval");
     return;
   }
-
-  if (!ClearCurrent()) {
-    LogEglError(
-        "Unable to clear current surface after updating the swap interval");
-    return;
-  }
 }
 
 bool AngleSurfaceManager::GetDevice(ID3D11Device** device) {

--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -231,8 +231,7 @@ void AngleSurfaceManager::CleanUp() {
 
 bool AngleSurfaceManager::CreateSurface(WindowsRenderTarget* render_target,
                                         EGLint width,
-                                        EGLint height,
-                                        bool vsync_enabled) {
+                                        EGLint height) {
   if (!render_target || !initialize_succeeded_) {
     return false;
   }
@@ -255,13 +254,6 @@ bool AngleSurfaceManager::CreateSurface(WindowsRenderTarget* render_target,
   surface_width_ = width;
   surface_height_ = height;
   render_surface_ = surface;
-
-  if (!MakeCurrent()) {
-    LogEglError("Unable to make surface current to update the swap interval");
-    return false;
-  }
-
-  SetVSyncEnabled(vsync_enabled);
   return true;
 }
 
@@ -277,11 +269,13 @@ void AngleSurfaceManager::ResizeSurface(WindowsRenderTarget* render_target,
 
     ClearContext();
     DestroySurface();
-    if (!CreateSurface(render_target, width, height, vsync_enabled)) {
+    if (!CreateSurface(render_target, width, height)) {
       FML_LOG(ERROR)
           << "AngleSurfaceManager::ResizeSurface failed to create surface";
     }
   }
+
+  SetVSyncEnabled(vsync_enabled);
 }
 
 void AngleSurfaceManager::GetSurfaceDimensions(EGLint* width, EGLint* height) {
@@ -342,6 +336,11 @@ EGLSurface AngleSurfaceManager::CreateSurfaceFromHandle(
 }
 
 void AngleSurfaceManager::SetVSyncEnabled(bool enabled) {
+  if (!MakeCurrent()) {
+    LogEglError("Unable to make surface current to update the swap interval");
+    return;
+  }
+
   // OpenGL swap intervals can be used to prevent screen tearing.
   // If enabled, the raster thread blocks until the v-blank.
   // This is unnecessary if DWM composition is enabled.
@@ -349,6 +348,12 @@ void AngleSurfaceManager::SetVSyncEnabled(bool enabled) {
   // See: https://learn.microsoft.com/windows/win32/dwm/composition-ovw
   if (eglSwapInterval(egl_display_, enabled ? 1 : 0) != EGL_TRUE) {
     LogEglError("Unable to update the swap interval");
+    return;
+  }
+
+  if (!ClearCurrent()) {
+    LogEglError(
+        "Unable to clear current surface after updating the swap interval");
     return;
   }
 }

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -35,12 +35,9 @@ class AngleSurfaceManager {
   // associated with window, in the appropriate format for display.
   // Target represents the visual entity to bind to. Width and
   // height represent dimensions surface is created at.
-  //
-  // This binds |egl_context_| to the current thread.
   virtual bool CreateSurface(WindowsRenderTarget* render_target,
                              EGLint width,
-                             EGLint height,
-                             bool enable_vsync);
+                             EGLint height);
 
   // Resizes backing surface from current size to newly requested size
   // based on width and height for the specific case when width and height do
@@ -91,6 +88,11 @@ class AngleSurfaceManager {
 
   // If enabled, makes the current surface's buffer swaps block until the
   // v-blank.
+  //
+  // If disabled, allows one thread to swap multiple buffers per v-blank
+  // but can result in screen tearing if the system compositor is disabled.
+  //
+  // This makes the render surface current and then releases it.
   virtual void SetVSyncEnabled(bool enabled);
 
   // Gets the |ID3D11Device| chosen by ANGLE.

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -35,6 +35,9 @@ class AngleSurfaceManager {
   // associated with window, in the appropriate format for display.
   // Target represents the visual entity to bind to. Width and
   // height represent dimensions surface is created at.
+  //
+  // After the surface is created, |SetVSyncEnabled| should be called on a
+  // thread that can bind the |egl_context_|.
   virtual bool CreateSurface(WindowsRenderTarget* render_target,
                              EGLint width,
                              EGLint height);
@@ -65,7 +68,7 @@ class AngleSurfaceManager {
   virtual bool MakeCurrent();
 
   // Unbinds the current EGL context from the current thread.
-  bool ClearCurrent();
+  virtual bool ClearCurrent();
 
   // Clears the |egl_context_| draw and read surfaces.
   bool ClearContext();
@@ -92,7 +95,8 @@ class AngleSurfaceManager {
   // If disabled, allows one thread to swap multiple buffers per v-blank
   // but can result in screen tearing if the system compositor is disabled.
   //
-  // This makes the render surface current and then releases it.
+  // This binds |egl_context_| to the current thread and makes the render
+  // surface current.
   virtual void SetVSyncEnabled(bool enabled);
 
   // Gets the |ID3D11Device| chosen by ANGLE.

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -373,7 +373,7 @@ ui::AXPlatformNodeWin* FlutterWindow::GetAlert() {
   return alert_node_.get();
 }
 
-bool FlutterWindow::NeedsVSync() {
+bool FlutterWindow::NeedsVSync() const {
   // If the Desktop Window Manager composition is enabled,
   // the system itself synchronizes with v-sync.
   // See: https://learn.microsoft.com/windows/win32/dwm/composition-ovw

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -196,7 +196,7 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
   virtual ui::AXPlatformNodeWin* GetAlert() override;
 
   // |WindowBindingHandler|
-  virtual bool NeedsVSync() override;
+  virtual bool NeedsVSync() const override;
 
   // Called to obtain a pointer to the fragment root delegate.
   virtual ui::AXFragmentRootDelegateWin* GetAxFragmentRootDelegate();

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -685,7 +685,7 @@ bool FlutterWindowsEngine::MarkExternalTextureFrameAvailable(
               engine_, texture_id) == kSuccess);
 }
 
-bool FlutterWindowsEngine::PostRasterThreadTask(fml::closure callback) {
+bool FlutterWindowsEngine::PostRasterThreadTask(fml::closure callback) const {
   struct Captures {
     fml::closure callback;
   };

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -102,7 +102,7 @@ class FlutterWindowsEngine {
   bool Run(std::string_view entrypoint);
 
   // Returns true if the engine is currently running.
-  virtual bool running() { return engine_ != nullptr; }
+  virtual bool running() const { return engine_ != nullptr; }
 
   // Stops the engine. This invalidates the pointer returned by engine().
   //
@@ -141,7 +141,9 @@ class FlutterWindowsEngine {
 
   // The ANGLE surface manager object. If this is nullptr, then we are
   // rendering using software instead of OpenGL.
-  AngleSurfaceManager* surface_manager() { return surface_manager_.get(); }
+  AngleSurfaceManager* surface_manager() const {
+    return surface_manager_.get();
+  }
 
   WindowProcDelegateManager* window_proc_delegate_manager() {
     return window_proc_delegate_manager_.get();
@@ -201,7 +203,7 @@ class FlutterWindowsEngine {
   bool MarkExternalTextureFrameAvailable(int64_t texture_id);
 
   // Posts the given callback onto the raster thread.
-  virtual bool PostRasterThreadTask(fml::closure callback);
+  virtual bool PostRasterThreadTask(fml::closure callback) const;
 
   // Invoke on the embedder's vsync callback to schedule a frame.
   void OnVsync(intptr_t baton);

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -102,7 +102,7 @@ class FlutterWindowsEngine {
   bool Run(std::string_view entrypoint);
 
   // Returns true if the engine is currently running.
-  bool running() { return engine_ != nullptr; }
+  virtual bool running() { return engine_ != nullptr; }
 
   // Stops the engine. This invalidates the pointer returned by engine().
   //

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -25,10 +25,10 @@ constexpr std::chrono::milliseconds kWindowResizeTimeout{100};
 /// to be blocked until the frame with the right size has been rendered. It
 /// should be kept in-sync with how the engine deals with a new surface request
 /// as seen in `CreateOrUpdateSurface` in `GPUSurfaceGL`.
-static bool SurfaceWillUpdate(size_t cur_width,
-                              size_t cur_height,
-                              size_t target_width,
-                              size_t target_height) {
+bool SurfaceWillUpdate(size_t cur_width,
+                       size_t cur_height,
+                       size_t target_width,
+                       size_t target_height) {
   // TODO (https://github.com/flutter/flutter/issues/65061) : Avoid special
   // handling for zero dimensions.
   bool non_zero_target_dims = target_height > 0 && target_width > 0;
@@ -39,8 +39,8 @@ static bool SurfaceWillUpdate(size_t cur_width,
 
 /// Update the surface's swap interval to block until the v-blank iff
 /// the system compositor is disabled.
-static void UpdateVsync(FlutterWindowsEngine& engine,
-                        WindowBindingHandler& window) {
+void UpdateVsync(const FlutterWindowsEngine& engine,
+                 const WindowBindingHandler& window) {
   AngleSurfaceManager* surface_manager = engine.surface_manager();
   if (!surface_manager) {
     return;

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -1245,7 +1245,7 @@ TEST(FlutterWindowsViewTest, DisablesVSyncAtStartup) {
       .Times(1)
       .WillOnce(Return(true));
   EXPECT_CALL(*surface_manager.get(), SetVSyncEnabled(false)).Times(1);
-  EXPECT_CALL(*surface_manager.get(), ClearCurrent).Times(1);
+  EXPECT_CALL(*surface_manager.get(), ClearCurrent).WillOnce(Return(true));
 
   EXPECT_CALL(*engine.get(), Stop).Times(1);
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);
@@ -1278,7 +1278,7 @@ TEST(FlutterWindowsViewTest, EnablesVSyncAtStartup) {
       .Times(1)
       .WillOnce(Return(true));
   EXPECT_CALL(*surface_manager.get(), SetVSyncEnabled(true)).Times(1);
-  EXPECT_CALL(*surface_manager.get(), ClearCurrent).Times(1);
+  EXPECT_CALL(*surface_manager.get(), ClearCurrent).WillOnce(Return(true));
 
   EXPECT_CALL(*engine.get(), Stop).Times(1);
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);
@@ -1315,6 +1315,7 @@ TEST(FlutterWindowsViewTest, DisablesVSyncAfterStartup) {
         return true;
       });
   EXPECT_CALL(*surface_manager.get(), SetVSyncEnabled(true)).Times(1);
+  EXPECT_CALL(*surface_manager.get(), ClearCurrent).Times(0);
 
   EXPECT_CALL(*engine.get(), Stop).Times(1);
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);
@@ -1352,6 +1353,7 @@ TEST(FlutterWindowsViewTest, EnablesVSyncAfterStartup) {
         return true;
       });
   EXPECT_CALL(*surface_manager.get(), SetVSyncEnabled(true)).Times(1);
+  EXPECT_CALL(*surface_manager.get(), ClearCurrent).Times(0);
 
   EXPECT_CALL(*engine.get(), Stop).Times(1);
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);
@@ -1384,6 +1386,8 @@ TEST(FlutterWindowsViewTest, UpdatesVSyncOnDwmUpdates) {
   EXPECT_CALL(*window_binding_handler.get(), NeedsVSync)
       .WillOnce(Return(true))
       .WillOnce(Return(false));
+
+  EXPECT_CALL(*surface_manager.get(), ClearCurrent).Times(0);
 
   EngineModifier modifier(engine.get());
   FlutterWindowsView view(std::move(window_binding_handler));

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -110,9 +110,9 @@ class MockFlutterWindowsEngine : public FlutterWindowsEngine {
  public:
   MockFlutterWindowsEngine() : FlutterWindowsEngine(GetTestProject()) {}
 
-  MOCK_METHOD(bool, running, (), ());
+  MOCK_METHOD(bool, running, (), (const));
   MOCK_METHOD(bool, Stop, (), ());
-  MOCK_METHOD(bool, PostRasterThreadTask, (fml::closure), ());
+  MOCK_METHOD(bool, PostRasterThreadTask, (fml::closure), (const));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsEngine);

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -133,6 +133,7 @@ class MockAngleSurfaceManager : public AngleSurfaceManager {
   MOCK_METHOD(void, DestroySurface, (), (override));
 
   MOCK_METHOD(bool, MakeCurrent, (), (override));
+  MOCK_METHOD(bool, ClearCurrent, (), (override));
   MOCK_METHOD(void, SetVSyncEnabled, (bool), (override));
 
  private:
@@ -1244,6 +1245,7 @@ TEST(FlutterWindowsViewTest, DisablesVSyncAtStartup) {
       .Times(1)
       .WillOnce(Return(true));
   EXPECT_CALL(*surface_manager.get(), SetVSyncEnabled(false)).Times(1);
+  EXPECT_CALL(*surface_manager.get(), ClearCurrent).Times(1);
 
   EXPECT_CALL(*engine.get(), Stop).Times(1);
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);
@@ -1276,6 +1278,7 @@ TEST(FlutterWindowsViewTest, EnablesVSyncAtStartup) {
       .Times(1)
       .WillOnce(Return(true));
   EXPECT_CALL(*surface_manager.get(), SetVSyncEnabled(true)).Times(1);
+  EXPECT_CALL(*surface_manager.get(), ClearCurrent).Times(1);
 
   EXPECT_CALL(*engine.get(), Stop).Times(1);
   EXPECT_CALL(*surface_manager.get(), DestroySurface).Times(1);

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -40,7 +40,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD(PointerLocation, GetPrimaryPointerLocation, (), (override));
   MOCK_METHOD(AlertPlatformNodeDelegate*, GetAlertDelegate, (), (override));
   MOCK_METHOD(ui::AXPlatformNodeWin*, GetAlert, (), (override));
-  MOCK_METHOD(bool, NeedsVSync, (), (override));
+  MOCK_METHOD(bool, NeedsVSync, (), (const override));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowBindingHandler);

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -106,7 +106,7 @@ class WindowBindingHandler {
 
   // If true, rendering to the window should synchronize with the vsync
   // to prevent screen tearing.
-  virtual bool NeedsVSync() = 0;
+  virtual bool NeedsVSync() const = 0;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
The EGL context can only be used by a single thread at a time. Currently:

1. The platform thread uses the EGL context to configure the render surface when a `FlutterViewController` is created
2. The raster thread uses the EGL context to render

In a multi-view world, a `FlutterViewController` can be created in parallel to a rendering operation. This results in multiple threads attempting to use the EGL context in parallel, which can crash (see https://github.com/flutter/flutter/issues/137973).

This change configures the render surface on the raster thread if the raster thread exists (aka the engine is running).

Addresses https://github.com/flutter/flutter/issues/137973

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
