### PR TITLE
[web] Non-singleton implementation of ui.FlutterView

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -130,23 +130,20 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     EngineFlutterDisplay.instance,
   ];
 
+  /// Adds [view] to the platform dispatcher's registry of [views].
+  void registerView(EngineFlutterView view) {
+    viewData[view.viewId] = view;
+  }
+
   /// The current list of windows.
   @override
   Iterable<EngineFlutterView> get views => viewData.values;
   final Map<int, EngineFlutterView> viewData = <int, EngineFlutterView>{};
 
-  /// Returns the [FlutterView] with the provided ID if one exists, or null
+  /// Returns the [EngineFlutterView] with the provided ID if one exists, or null
   /// otherwise.
   @override
   EngineFlutterView? view({required int id}) => viewData[id];
-
-  /// A map of opaque platform window identifiers to window configurations.
-  ///
-  /// This should be considered a protected member, only to be used by
-  /// [PlatformDispatcher] subclasses.
-  Map<Object, ViewConfiguration> get windowConfigurations => _windowConfigurations;
-  final Map<Object, ViewConfiguration> _windowConfigurations =
-      <Object, ViewConfiguration>{};
 
   /// The [FlutterView] provided by the engine if the platform is unable to
   /// create windows, or, for backwards compatibility.

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -38,14 +38,22 @@ const int kImplicitViewId = 0;
 ///
 /// In addition to everything defined in [ui.FlutterView], this class adds
 /// a few web-specific properties.
-abstract mixin class EngineFlutterView implements ui.FlutterView {
+base class EngineFlutterView implements ui.FlutterView {
   factory EngineFlutterView(
     int viewId,
     EnginePlatformDispatcher platformDispatcher,
   ) = _EngineFlutterViewImpl;
 
+  EngineFlutterView._(
+    this.viewId,
+    this.platformDispatcher,
+  );
+
   @override
-  EnginePlatformDispatcher get platformDispatcher;
+  final int viewId;
+
+  @override
+  final EnginePlatformDispatcher platformDispatcher;
 
   final ViewConfiguration _viewConfiguration = const ViewConfiguration();
 
@@ -140,8 +148,11 @@ abstract mixin class EngineFlutterView implements ui.FlutterView {
   Stream<ui.Size?> get onResize => _dimensionsProvider.onResize;
 }
 
-class _EngineFlutterViewImpl extends ui.FlutterView with EngineFlutterView {
-  _EngineFlutterViewImpl(this.viewId, this.platformDispatcher) {
+final class _EngineFlutterViewImpl extends EngineFlutterView {
+  _EngineFlutterViewImpl(
+    int viewId,
+    EnginePlatformDispatcher platformDispatcher,
+  ) : super._(viewId, platformDispatcher) {
     platformDispatcher.registerView(this);
     registerHotRestartListener(() {
       // TODO(harryterkelsen): What should we do about this in multi-view?
@@ -149,17 +160,14 @@ class _EngineFlutterViewImpl extends ui.FlutterView with EngineFlutterView {
       _dimensionsProvider.close();
     });
   }
-
-  @override
-  final int viewId;
-
-  @override
-  final EnginePlatformDispatcher platformDispatcher;
 }
 
 /// The Web implementation of [ui.SingletonFlutterWindow].
-class EngineFlutterWindow extends ui.SingletonFlutterWindow with EngineFlutterView {
-  EngineFlutterWindow(this.viewId, this.platformDispatcher) {
+final class EngineFlutterWindow extends EngineFlutterView implements ui.SingletonFlutterWindow {
+  EngineFlutterWindow(
+    int viewId,
+    EnginePlatformDispatcher platformDispatcher,
+  ) : super._(viewId, platformDispatcher) {
     platformDispatcher.registerView(this);
     if (ui_web.isCustomUrlStrategySet) {
       _browserHistory = createHistoryForExistingState(ui_web.urlStrategy);
@@ -172,10 +180,159 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow with EngineFlutterVi
   }
 
   @override
-  final int viewId;
+  ui.VoidCallback? get onMetricsChanged => platformDispatcher.onMetricsChanged;
+  @override
+  set onMetricsChanged(ui.VoidCallback? callback) {
+    platformDispatcher.onMetricsChanged = callback;
+  }
 
   @override
-  final EnginePlatformDispatcher platformDispatcher;
+  ui.Locale get locale => platformDispatcher.locale;
+  @override
+  List<ui.Locale> get locales => platformDispatcher.locales;
+
+  @override
+  ui.Locale? computePlatformResolvedLocale(List<ui.Locale> supportedLocales) {
+    return platformDispatcher.computePlatformResolvedLocale(supportedLocales);
+  }
+
+  @override
+  ui.VoidCallback? get onLocaleChanged => platformDispatcher.onLocaleChanged;
+  @override
+  set onLocaleChanged(ui.VoidCallback? callback) {
+    platformDispatcher.onLocaleChanged = callback;
+  }
+
+  @override
+  String get initialLifecycleState => platformDispatcher.initialLifecycleState;
+
+  @override
+  double get textScaleFactor => platformDispatcher.textScaleFactor;
+
+  @override
+  bool get nativeSpellCheckServiceDefined => platformDispatcher.nativeSpellCheckServiceDefined;
+
+  @override
+  bool get brieflyShowPassword => platformDispatcher.brieflyShowPassword;
+
+  @override
+  bool get alwaysUse24HourFormat => platformDispatcher.alwaysUse24HourFormat;
+
+  @override
+  ui.VoidCallback? get onTextScaleFactorChanged => platformDispatcher.onTextScaleFactorChanged;
+  @override
+  set onTextScaleFactorChanged(ui.VoidCallback? callback) {
+    platformDispatcher.onTextScaleFactorChanged = callback;
+  }
+
+  @override
+  ui.Brightness get platformBrightness => platformDispatcher.platformBrightness;
+
+  @override
+  ui.VoidCallback? get onPlatformBrightnessChanged => platformDispatcher.onPlatformBrightnessChanged;
+  @override
+  set onPlatformBrightnessChanged(ui.VoidCallback? callback) {
+    platformDispatcher.onPlatformBrightnessChanged = callback;
+  }
+
+  @override
+  String? get systemFontFamily => platformDispatcher.systemFontFamily;
+
+  @override
+  ui.VoidCallback? get onSystemFontFamilyChanged => platformDispatcher.onSystemFontFamilyChanged;
+  @override
+  set onSystemFontFamilyChanged(ui.VoidCallback? callback) {
+    platformDispatcher.onSystemFontFamilyChanged = callback;
+  }
+
+  @override
+  ui.FrameCallback? get onBeginFrame => platformDispatcher.onBeginFrame;
+  @override
+  set onBeginFrame(ui.FrameCallback? callback) {
+    platformDispatcher.onBeginFrame = callback;
+  }
+
+  @override
+  ui.VoidCallback? get onDrawFrame => platformDispatcher.onDrawFrame;
+  @override
+  set onDrawFrame(ui.VoidCallback? callback) {
+    platformDispatcher.onDrawFrame = callback;
+  }
+
+  @override
+  ui.TimingsCallback? get onReportTimings => platformDispatcher.onReportTimings;
+  @override
+  set onReportTimings(ui.TimingsCallback? callback) {
+    platformDispatcher.onReportTimings = callback;
+  }
+
+  @override
+  ui.PointerDataPacketCallback? get onPointerDataPacket => platformDispatcher.onPointerDataPacket;
+  @override
+  set onPointerDataPacket(ui.PointerDataPacketCallback? callback) {
+    platformDispatcher.onPointerDataPacket = callback;
+  }
+
+  @override
+  ui.KeyDataCallback? get onKeyData => platformDispatcher.onKeyData;
+  @override
+  set onKeyData(ui.KeyDataCallback? callback) {
+    platformDispatcher.onKeyData = callback;
+  }
+
+  @override
+  String get defaultRouteName => platformDispatcher.defaultRouteName;
+
+  @override
+  void scheduleFrame() => platformDispatcher.scheduleFrame();
+
+  @override
+  bool get semanticsEnabled => platformDispatcher.semanticsEnabled;
+
+  @override
+  ui.VoidCallback? get onSemanticsEnabledChanged => platformDispatcher.onSemanticsEnabledChanged;
+  @override
+  set onSemanticsEnabledChanged(ui.VoidCallback? callback) {
+    platformDispatcher.onSemanticsEnabledChanged = callback;
+  }
+
+  @override
+  ui.FrameData get frameData => const ui.FrameData.webOnly();
+
+  @override
+  ui.VoidCallback? get onFrameDataChanged => null;
+  @override
+  set onFrameDataChanged(ui.VoidCallback? callback) {}
+
+  @override
+  ui.AccessibilityFeatures get accessibilityFeatures => platformDispatcher.accessibilityFeatures;
+
+  @override
+  ui.VoidCallback? get onAccessibilityFeaturesChanged =>
+      platformDispatcher.onAccessibilityFeaturesChanged;
+  @override
+  set onAccessibilityFeaturesChanged(ui.VoidCallback? callback) {
+    platformDispatcher.onAccessibilityFeaturesChanged = callback;
+  }
+
+  @override
+  void sendPlatformMessage(
+    String name,
+    ByteData? data,
+    ui.PlatformMessageResponseCallback? callback,
+  ) {
+    platformDispatcher.sendPlatformMessage(name, data, callback);
+  }
+
+  @override
+  ui.PlatformMessageCallback? get onPlatformMessage => platformDispatcher.onPlatformMessage;
+  @override
+  set onPlatformMessage(ui.PlatformMessageCallback? callback) {
+    platformDispatcher.onPlatformMessage = callback;
+  }
+
+  @override
+  void setIsolateDebugName(String name) => ui.PlatformDispatcher.instance.setIsolateDebugName(name);
 
   /// Handles the browser history integration to allow users to use the back
   /// button, etc.

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -29,118 +29,84 @@ abstract class FlutterView {
 }
 
 abstract class SingletonFlutterWindow extends FlutterView {
-  VoidCallback? get onMetricsChanged => platformDispatcher.onMetricsChanged;
-  set onMetricsChanged(VoidCallback? callback) {
-    platformDispatcher.onMetricsChanged = callback;
-  }
+  VoidCallback? get onMetricsChanged;
+  set onMetricsChanged(VoidCallback? callback);
 
-  Locale get locale => platformDispatcher.locale;
-  List<Locale> get locales => platformDispatcher.locales;
+  Locale get locale;
+  List<Locale> get locales;
 
-  Locale? computePlatformResolvedLocale(List<Locale> supportedLocales) {
-    return platformDispatcher.computePlatformResolvedLocale(supportedLocales);
-  }
+  Locale? computePlatformResolvedLocale(List<Locale> supportedLocales);
 
-  VoidCallback? get onLocaleChanged => platformDispatcher.onLocaleChanged;
-  set onLocaleChanged(VoidCallback? callback) {
-    platformDispatcher.onLocaleChanged = callback;
-  }
+  VoidCallback? get onLocaleChanged;
+  set onLocaleChanged(VoidCallback? callback);
 
-  String get initialLifecycleState => platformDispatcher.initialLifecycleState;
+  String get initialLifecycleState;
 
-  double get textScaleFactor => platformDispatcher.textScaleFactor;
+  double get textScaleFactor;
 
-  bool get nativeSpellCheckServiceDefined => platformDispatcher.nativeSpellCheckServiceDefined;
+  bool get nativeSpellCheckServiceDefined;
 
-  bool get brieflyShowPassword => platformDispatcher.brieflyShowPassword;
+  bool get brieflyShowPassword;
 
-  bool get alwaysUse24HourFormat => platformDispatcher.alwaysUse24HourFormat;
+  bool get alwaysUse24HourFormat;
 
-  VoidCallback? get onTextScaleFactorChanged => platformDispatcher.onTextScaleFactorChanged;
-  set onTextScaleFactorChanged(VoidCallback? callback) {
-    platformDispatcher.onTextScaleFactorChanged = callback;
-  }
+  VoidCallback? get onTextScaleFactorChanged;
+  set onTextScaleFactorChanged(VoidCallback? callback);
 
-  Brightness get platformBrightness => platformDispatcher.platformBrightness;
+  Brightness get platformBrightness;
 
-  VoidCallback? get onPlatformBrightnessChanged => platformDispatcher.onPlatformBrightnessChanged;
-  set onPlatformBrightnessChanged(VoidCallback? callback) {
-    platformDispatcher.onPlatformBrightnessChanged = callback;
-  }
+  VoidCallback? get onPlatformBrightnessChanged;
+  set onPlatformBrightnessChanged(VoidCallback? callback);
 
-  String? get systemFontFamily => platformDispatcher.systemFontFamily;
+  String? get systemFontFamily;
 
-  VoidCallback? get onSystemFontFamilyChanged => platformDispatcher.onSystemFontFamilyChanged;
-  set onSystemFontFamilyChanged(VoidCallback? callback) {
-    platformDispatcher.onSystemFontFamilyChanged = callback;
-  }
+  VoidCallback? get onSystemFontFamilyChanged;
+  set onSystemFontFamilyChanged(VoidCallback? callback);
 
-  FrameCallback? get onBeginFrame => platformDispatcher.onBeginFrame;
-  set onBeginFrame(FrameCallback? callback) {
-    platformDispatcher.onBeginFrame = callback;
-  }
+  FrameCallback? get onBeginFrame;
+  set onBeginFrame(FrameCallback? callback);
 
-  VoidCallback? get onDrawFrame => platformDispatcher.onDrawFrame;
-  set onDrawFrame(VoidCallback? callback) {
-    platformDispatcher.onDrawFrame = callback;
-  }
+  VoidCallback? get onDrawFrame;
+  set onDrawFrame(VoidCallback? callback);
 
-  TimingsCallback? get onReportTimings => platformDispatcher.onReportTimings;
-  set onReportTimings(TimingsCallback? callback) {
-    platformDispatcher.onReportTimings = callback;
-  }
+  TimingsCallback? get onReportTimings;
+  set onReportTimings(TimingsCallback? callback);
 
-  PointerDataPacketCallback? get onPointerDataPacket => platformDispatcher.onPointerDataPacket;
-  set onPointerDataPacket(PointerDataPacketCallback? callback) {
-    platformDispatcher.onPointerDataPacket = callback;
-  }
+  PointerDataPacketCallback? get onPointerDataPacket;
+  set onPointerDataPacket(PointerDataPacketCallback? callback);
 
-  KeyDataCallback? get onKeyData => platformDispatcher.onKeyData;
-  set onKeyData(KeyDataCallback? callback) {
-    platformDispatcher.onKeyData = callback;
-  }
+  KeyDataCallback? get onKeyData;
+  set onKeyData(KeyDataCallback? callback);
 
-  String get defaultRouteName => platformDispatcher.defaultRouteName;
+  String get defaultRouteName;
 
-  void scheduleFrame() => platformDispatcher.scheduleFrame();
+  void scheduleFrame();
 
-  @override
-  void render(Scene scene) => platformDispatcher.render(scene, this);
+  bool get semanticsEnabled;
 
-  bool get semanticsEnabled => platformDispatcher.semanticsEnabled;
+  VoidCallback? get onSemanticsEnabledChanged;
+  set onSemanticsEnabledChanged(VoidCallback? callback);
 
-  VoidCallback? get onSemanticsEnabledChanged => platformDispatcher.onSemanticsEnabledChanged;
-  set onSemanticsEnabledChanged(VoidCallback? callback) {
-    platformDispatcher.onSemanticsEnabledChanged = callback;
-  }
+  FrameData get frameData;
 
-  FrameData get frameData => const FrameData._();
+  VoidCallback? get onFrameDataChanged;
+  set onFrameDataChanged(VoidCallback? callback);
 
-  VoidCallback? get onFrameDataChanged => null;
-  set onFrameDataChanged(VoidCallback? callback) {}
+  AccessibilityFeatures get accessibilityFeatures;
 
-  AccessibilityFeatures get accessibilityFeatures => platformDispatcher.accessibilityFeatures;
-
-  VoidCallback? get onAccessibilityFeaturesChanged =>
-      platformDispatcher.onAccessibilityFeaturesChanged;
-  set onAccessibilityFeaturesChanged(VoidCallback? callback) {
-    platformDispatcher.onAccessibilityFeaturesChanged = callback;
-  }
+  VoidCallback? get onAccessibilityFeaturesChanged;
+  set onAccessibilityFeaturesChanged(VoidCallback? callback);
 
   void sendPlatformMessage(
     String name,
     ByteData? data,
     PlatformMessageResponseCallback? callback,
-  ) {
-    platformDispatcher.sendPlatformMessage(name, data, callback);
-  }
+  );
 
-  PlatformMessageCallback? get onPlatformMessage => platformDispatcher.onPlatformMessage;
-  set onPlatformMessage(PlatformMessageCallback? callback) {
-    platformDispatcher.onPlatformMessage = callback;
-  }
+  PlatformMessageCallback? get onPlatformMessage;
+  set onPlatformMessage(PlatformMessageCallback? callback);
 
-  void setIsolateDebugName(String name) => PlatformDispatcher.instance.setIsolateDebugName(name);
+  void setIsolateDebugName(String name);
 }
 
 abstract class AccessibilityFeatures {

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -169,8 +169,6 @@ abstract final class IsolateNameServer {
 SingletonFlutterWindow get window => engine.window;
 
 class FrameData {
-  const FrameData._();
-
   const FrameData.webOnly();
 
   int get frameNumber => -1;


### PR DESCRIPTION
- Provide a non-singleton implementation of `EngineFlutterView`.
- Move all common "view" logic into `EngineFlutterView`.
- Remove the unused `windowConfigurations` map from `EnginePlatformDispatcher`.