### PR TITLE
[Impeller] remove capability to read from onscreen.

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -333,16 +333,11 @@ bool EntityPass::Render(ContentContext& renderer,
       .coverage = Rect::MakeSize(root_render_target.GetRenderTargetSize()),
       .clip_depth = 0}};
 
-  bool supports_onscreen_backdrop_reads =
-      renderer.GetDeviceCapabilities().SupportsReadFromOnscreenTexture() &&
-      // If the backend doesn't have `SupportsReadFromResolve`, we need to flip
-      // between two textures when restoring a previous MSAA pass.
-      renderer.GetDeviceCapabilities().SupportsReadFromResolve();
   bool reads_from_onscreen_backdrop = GetTotalPassReads(renderer) > 0;
   // In this branch path, we need to render everything to an offscreen texture
   // and then blit the results onto the onscreen texture. If using this branch,
   // there's no need to set up a stencil attachment on the root render target.
-  if (!supports_onscreen_backdrop_reads && reads_from_onscreen_backdrop) {
+  if (reads_from_onscreen_backdrop) {
     auto offscreen_target =
         CreateRenderTarget(renderer, root_render_target.GetRenderTargetSize(),
                            GetClearColor(render_target.GetRenderTargetSize()));

--- a/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -169,10 +169,6 @@ bool CapabilitiesGLES::SupportsComputeSubgroups() const {
   return false;
 }
 
-bool CapabilitiesGLES::SupportsReadFromOnscreenTexture() const {
-  return false;
-}
-
 bool CapabilitiesGLES::SupportsReadFromResolve() const {
   return false;
 }

--- a/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/impeller/renderer/backend/gles/capabilities_gles.h
@@ -98,9 +98,6 @@ class CapabilitiesGLES final
   bool SupportsComputeSubgroups() const override;
 
   // |Capabilities|
-  bool SupportsReadFromOnscreenTexture() const override;
-
-  // |Capabilities|
   bool SupportsReadFromResolve() const override;
 
   // |Capabilities|

--- a/impeller/renderer/backend/gles/test/capabilities_unittests.cc
+++ b/impeller/renderer/backend/gles/test/capabilities_unittests.cc
@@ -22,7 +22,6 @@ TEST(CapabilitiesGLES, CanInitializeWithDefaults) {
   EXPECT_FALSE(capabilities->SupportsFramebufferFetch());
   EXPECT_FALSE(capabilities->SupportsCompute());
   EXPECT_FALSE(capabilities->SupportsComputeSubgroups());
-  EXPECT_FALSE(capabilities->SupportsReadFromOnscreenTexture());
   EXPECT_FALSE(capabilities->SupportsReadFromResolve());
   EXPECT_FALSE(capabilities->SupportsDecalSamplerAddressMode());
   EXPECT_FALSE(capabilities->SupportsDeviceTransientTextures());

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -66,7 +66,6 @@ static std::unique_ptr<Capabilities> InferMetalCapabilities(
       .SetSupportsCompute(true)
       .SetSupportsComputeSubgroups(DeviceSupportsComputeSubgroups(device))
       .SetSupportsReadFromResolve(true)
-      .SetSupportsReadFromOnscreenTexture(true)
       .SetSupportsDeviceTransientTextures(true)
       .Build();
 }

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -451,11 +451,6 @@ bool CapabilitiesVK::SupportsReadFromResolve() const {
   return false;
 }
 
-// |Capabilities|
-bool CapabilitiesVK::SupportsReadFromOnscreenTexture() const {
-  return false;
-}
-
 bool CapabilitiesVK::SupportsDecalSamplerAddressMode() const {
   return true;
 }

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -86,9 +86,6 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsReadFromResolve() const override;
 
   // |Capabilities|
-  bool SupportsReadFromOnscreenTexture() const override;
-
-  // |Capabilities|
   bool SupportsDecalSamplerAddressMode() const override;
 
   // |Capabilities|

--- a/impeller/renderer/capabilities.cc
+++ b/impeller/renderer/capabilities.cc
@@ -50,11 +50,6 @@ class StandardCapabilities final : public Capabilities {
   }
 
   // |Capabilities|
-  bool SupportsReadFromOnscreenTexture() const override {
-    return supports_read_from_onscreen_texture_;
-  }
-
-  // |Capabilities|
   bool SupportsReadFromResolve() const override {
     return supports_read_from_resolve_;
   }
@@ -91,7 +86,6 @@ class StandardCapabilities final : public Capabilities {
                        bool supports_framebuffer_fetch,
                        bool supports_compute,
                        bool supports_compute_subgroups,
-                       bool supports_read_from_onscreen_texture,
                        bool supports_read_from_resolve,
                        bool supports_decal_sampler_address_mode,
                        bool supports_device_transient_textures,
@@ -105,8 +99,6 @@ class StandardCapabilities final : public Capabilities {
         supports_framebuffer_fetch_(supports_framebuffer_fetch),
         supports_compute_(supports_compute),
         supports_compute_subgroups_(supports_compute_subgroups),
-        supports_read_from_onscreen_texture_(
-            supports_read_from_onscreen_texture),
         supports_read_from_resolve_(supports_read_from_resolve),
         supports_decal_sampler_address_mode_(
             supports_decal_sampler_address_mode),
@@ -124,7 +116,6 @@ class StandardCapabilities final : public Capabilities {
   bool supports_framebuffer_fetch_ = false;
   bool supports_compute_ = false;
   bool supports_compute_subgroups_ = false;
-  bool supports_read_from_onscreen_texture_ = false;
   bool supports_read_from_resolve_ = false;
   bool supports_decal_sampler_address_mode_ = false;
   bool supports_device_transient_textures_ = false;
@@ -180,18 +171,6 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsComputeSubgroups(
   return *this;
 }
 
-CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsReadFromOnscreenTexture(
-    bool read_from_onscreen_texture) {
-  supports_read_from_onscreen_texture_ = read_from_onscreen_texture;
-  return *this;
-}
-
-CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsReadFromResolve(
-    bool read_from_resolve) {
-  supports_read_from_resolve_ = read_from_resolve;
-  return *this;
-}
-
 CapabilitiesBuilder& CapabilitiesBuilder::SetDefaultColorFormat(
     PixelFormat value) {
   default_color_format_ = value;
@@ -207,6 +186,12 @@ CapabilitiesBuilder& CapabilitiesBuilder::SetDefaultStencilFormat(
 CapabilitiesBuilder& CapabilitiesBuilder::SetDefaultDepthStencilFormat(
     PixelFormat value) {
   default_depth_stencil_format_ = value;
+  return *this;
+}
+
+CapabilitiesBuilder& CapabilitiesBuilder::SetSupportsReadFromResolve(
+    bool read_from_resolve) {
+  supports_read_from_resolve_ = read_from_resolve;
   return *this;
 }
 
@@ -231,7 +216,6 @@ std::unique_ptr<Capabilities> CapabilitiesBuilder::Build() {
       supports_framebuffer_fetch_,                                        //
       supports_compute_,                                                  //
       supports_compute_subgroups_,                                        //
-      supports_read_from_onscreen_texture_,                               //
       supports_read_from_resolve_,                                        //
       supports_decal_sampler_address_mode_,                               //
       supports_device_transient_textures_,                                //

--- a/impeller/renderer/capabilities.h
+++ b/impeller/renderer/capabilities.h
@@ -64,10 +64,6 @@ class Capabilities {
   ///         command subgroups.
   virtual bool SupportsComputeSubgroups() const = 0;
 
-  /// @brief  Whether the context backend supports binding the on-screen surface
-  ///         texture for shader reading.
-  virtual bool SupportsReadFromOnscreenTexture() const = 0;
-
   /// @brief  Whether the context backend supports binding the current
   ///         `RenderPass` attachments. This is supported if the backend can
   ///         guarantee that attachment textures will not be mutated until the
@@ -136,8 +132,6 @@ class CapabilitiesBuilder {
 
   CapabilitiesBuilder& SetSupportsComputeSubgroups(bool value);
 
-  CapabilitiesBuilder& SetSupportsReadFromOnscreenTexture(bool value);
-
   CapabilitiesBuilder& SetSupportsReadFromResolve(bool value);
 
   CapabilitiesBuilder& SetDefaultColorFormat(PixelFormat value);
@@ -160,7 +154,6 @@ class CapabilitiesBuilder {
   bool supports_framebuffer_fetch_ = false;
   bool supports_compute_ = false;
   bool supports_compute_subgroups_ = false;
-  bool supports_read_from_onscreen_texture_ = false;
   bool supports_read_from_resolve_ = false;
   bool supports_decal_sampler_address_mode_ = false;
   bool supports_device_transient_textures_ = false;

--- a/impeller/renderer/capabilities_unittests.cc
+++ b/impeller/renderer/capabilities_unittests.cc
@@ -25,7 +25,6 @@ CAPABILITY_TEST(SupportsTextureToTextureBlits, false);
 CAPABILITY_TEST(SupportsFramebufferFetch, false);
 CAPABILITY_TEST(SupportsCompute, false);
 CAPABILITY_TEST(SupportsComputeSubgroups, false);
-CAPABILITY_TEST(SupportsReadFromOnscreenTexture, false);
 CAPABILITY_TEST(SupportsReadFromResolve, false);
 CAPABILITY_TEST(SupportsDecalSamplerAddressMode, false);
 CAPABILITY_TEST(SupportsDeviceTransientTextures, false);


### PR DESCRIPTION
As discovered by @knopp in https://github.com/flutter/flutter/issues/131567#issuecomment-1678210475, this is actually reducing performance substantially when there are multiple blurs. In the case of https://github.com/flutter/flutter/issues/132735 , removing this capbility improves GPU performance from 400ms per frame to ~100 ms per frame.

Fixes https://github.com/flutter/flutter/issues/131567#issuecomment-1678210475

-----

  | Macrobench | Example App
-- | -- | --
TOT | 250 | 450
W/Out OnScreen | 203-187 | 125-109
W/Out Onscreen and Resolve | 203 | 125


