### PR TITLE
Reland "Remove Fuchsia Mac SDK from DEPS"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -946,16 +946,6 @@ deps = {
 
   # Get the SDK from https://chrome-infra-packages.appspot.com/p/fuchsia/sdk/core at the 'latest' tag
   # Get the toolchain from https://chrome-infra-packages.appspot.com/p/fuchsia/clang at the 'goma' tag
-   'src/fuchsia/sdk/mac': {
-     'packages': [
-       {
-        'package': 'fuchsia/sdk/core/mac-amd64',
-        'version': 'CssR5Ci8l8Wn47xEJSW2TxuUVmr2DpJ1FX-kTlrIW9wC'
-       }
-     ],
-     'condition': 'host_os == "mac" and not download_fuchsia_sdk',
-     'dep_type': 'cipd',
-   },
    'src/fuchsia/sdk/linux': {
      'packages': [
        {


### PR DESCRIPTION
Reverted as it broke the engine->flutter autoroller as it included this file. It was removed in https://skia-review.googlesource.com/c/skia-autoroll-internal-config/+/775817 and can now be removed from the engine.

https://github.com/flutter/flutter/issues/138087

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
