### PR TITLE
Update vulkan_deps to ToT

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -288,7 +288,7 @@ deps = {
    Var('chromium_git') + '/external/github.com/google/shaderc' + '@' + '7ea834ecc59258a5c13c3d3e6fa0582bdde7c543',
 
   'src/third_party/vulkan-deps':
-   Var('chromium_git') + '/vulkan-deps' + '@' + '40b75117a60b11c42a1fb87bf14c0f49bcdb8b3d',
+   Var('chromium_git') + '/vulkan-deps' + '@' + '6fff5ad7622c15407b997ec7ca2a9ad35313e375',
 
   'src/flutter/third_party/flatbuffers':
    Var('chromium_git') + '/external/github.com/google/flatbuffers' + '@' + '0a80646371179f8a7a5c1f42c31ee1d44dcf6709',


### PR DESCRIPTION
Attempt to fix the ANGLE roller, which is currently failing due to the Vulkan headers missing an extension.