### PR TITLE
[Impeller] implement Canvas::DrawLine to tesselate lines directly

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -3124,6 +3124,8 @@ ORIGIN: ../../../flutter/impeller/entity/geometry/fill_path_geometry.cc + ../../
 ORIGIN: ../../../flutter/impeller/entity/geometry/fill_path_geometry.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/geometry/geometry.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/geometry/geometry.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/entity/geometry/line_geometry.cc + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/impeller/entity/geometry/line_geometry.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/geometry/point_field_geometry.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/geometry/point_field_geometry.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/impeller/entity/geometry/rect_geometry.cc + ../../../flutter/LICENSE
@@ -5881,6 +5883,8 @@ FILE: ../../../flutter/impeller/entity/geometry/fill_path_geometry.cc
 FILE: ../../../flutter/impeller/entity/geometry/fill_path_geometry.h
 FILE: ../../../flutter/impeller/entity/geometry/geometry.cc
 FILE: ../../../flutter/impeller/entity/geometry/geometry.h
+FILE: ../../../flutter/impeller/entity/geometry/line_geometry.cc
+FILE: ../../../flutter/impeller/entity/geometry/line_geometry.h
 FILE: ../../../flutter/impeller/entity/geometry/point_field_geometry.cc
 FILE: ../../../flutter/impeller/entity/geometry/point_field_geometry.h
 FILE: ../../../flutter/impeller/entity/geometry/rect_geometry.cc

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -226,6 +226,17 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
   return true;
 }
 
+void Canvas::DrawLine(const Point& p0, const Point& p1, const Paint& paint) {
+  Entity entity;
+  entity.SetTransformation(GetCurrentTransformation());
+  entity.SetClipDepth(GetClipDepth());
+  entity.SetBlendMode(paint.blend_mode);
+  entity.SetContents(paint.WithFilters(paint.CreateContentsForGeometry(
+      Geometry::MakeLine(p0, p1, paint.stroke_width, paint.stroke_cap))));
+
+  GetCurrentPass().AddEntity(entity);
+}
+
 void Canvas::DrawRect(Rect rect, const Paint& paint) {
   if (paint.style == Paint::Style::kStroke) {
     DrawPath(PathBuilder{}.AddRect(rect).TakePath(), paint);

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -227,6 +227,17 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
 }
 
 void Canvas::DrawLine(const Point& p0, const Point& p1, const Paint& paint) {
+  if (paint.stroke_cap == Cap::kRound) {
+    auto path = PathBuilder{}
+                    .AddLine((p0), (p1))
+                    .SetConvexity(Convexity::kConvex)
+                    .TakePath();
+    Paint stroke_paint = paint;
+    stroke_paint.style = Paint::Style::kStroke;
+    DrawPath(path, stroke_paint);
+    return;
+  }
+
   Entity entity;
   entity.SetTransformation(GetCurrentTransformation());
   entity.SetClipDepth(GetClipDepth());

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -103,6 +103,8 @@ class Canvas {
 
   void DrawPaint(const Paint& paint);
 
+  void DrawLine(const Point& p0, const Point& p1, const Paint& paint);
+
   void DrawRect(Rect rect, const Paint& paint);
 
   void DrawRRect(Rect rect, Point corner_radii, const Paint& paint);

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -759,14 +759,8 @@ void DlDispatcher::drawPaint() {
 
 // |flutter::DlOpReceiver|
 void DlDispatcher::drawLine(const SkPoint& p0, const SkPoint& p1) {
-  auto path =
-      PathBuilder{}
-          .AddLine(skia_conversions::ToPoint(p0), skia_conversions::ToPoint(p1))
-          .SetConvexity(Convexity::kConvex)
-          .TakePath();
-  Paint paint = paint_;
-  paint.style = Paint::Style::kStroke;
-  canvas_.DrawPath(path, paint);
+  canvas_.DrawLine(skia_conversions::ToPoint(p0), skia_conversions::ToPoint(p1),
+                   paint_);
 }
 
 // |flutter::DlOpReceiver|

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -873,8 +873,7 @@ void DlDispatcher::drawPoints(PointMode mode,
       for (uint32_t i = 1; i < count; i += 2) {
         Point p0 = skia_conversions::ToPoint(points[i - 1]);
         Point p1 = skia_conversions::ToPoint(points[i]);
-        auto path = PathBuilder{}.AddLine(p0, p1).TakePath();
-        canvas_.DrawPath(path, paint);
+        canvas_.DrawLine(p0, p1, paint);
       }
       break;
     case flutter::DlCanvas::PointMode::kPolygon:
@@ -882,8 +881,7 @@ void DlDispatcher::drawPoints(PointMode mode,
         Point p0 = skia_conversions::ToPoint(points[0]);
         for (uint32_t i = 1; i < count; i++) {
           Point p1 = skia_conversions::ToPoint(points[i]);
-          auto path = PathBuilder{}.AddLine(p0, p1).TakePath();
-          canvas_.DrawPath(path, paint);
+          canvas_.DrawLine(p0, p1, paint);
           p0 = p1;
         }
       }

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -194,6 +194,8 @@ impeller_component("entity") {
     "geometry/fill_path_geometry.h",
     "geometry/geometry.cc",
     "geometry/geometry.h",
+    "geometry/line_geometry.cc",
+    "geometry/line_geometry.h",
     "geometry/point_field_geometry.cc",
     "geometry/point_field_geometry.h",
     "geometry/rect_geometry.cc",

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -8,6 +8,7 @@
 
 #include "impeller/entity/geometry/cover_geometry.h"
 #include "impeller/entity/geometry/fill_path_geometry.h"
+#include "impeller/entity/geometry/line_geometry.h"
 #include "impeller/entity/geometry/point_field_geometry.h"
 #include "impeller/entity/geometry/rect_geometry.h"
 #include "impeller/entity/geometry/stroke_path_geometry.h"
@@ -142,6 +143,13 @@ std::unique_ptr<Geometry> Geometry::MakeCover() {
 
 std::unique_ptr<Geometry> Geometry::MakeRect(Rect rect) {
   return std::make_unique<RectGeometry>(rect);
+}
+
+std::unique_ptr<Geometry> Geometry::MakeLine(Point p0,
+                                             Point p1,
+                                             Scalar width,
+                                             Cap cap) {
+  return std::make_unique<LineGeometry>(p0, p1, width, cap);
 }
 
 bool Geometry::CoversArea(const Matrix& transform, const Rect& rect) const {

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -72,6 +72,11 @@ class Geometry {
 
   static std::unique_ptr<Geometry> MakeRect(Rect rect);
 
+  static std::unique_ptr<Geometry> MakeLine(Point p0,
+                                            Point p1,
+                                            Scalar width,
+                                            Cap cap);
+
   static std::unique_ptr<Geometry> MakePointField(std::vector<Point> points,
                                                   Scalar radius,
                                                   bool round);

--- a/impeller/entity/geometry/geometry_unittests.cc
+++ b/impeller/entity/geometry/geometry_unittests.cc
@@ -39,20 +39,26 @@ TEST(EntityGeometryTest, FillPathGeometryCoversAreaNoInnerRect) {
 TEST(EntityGeometryTest, LineGeometryCoverage) {
   {
     auto geometry = Geometry::MakeLine({10, 10}, {20, 10}, 2, Cap::kButt);
-    auto matrix = Matrix();
-    EXPECT_EQ(geometry->GetCoverage(matrix), Rect::MakeLTRB(10, 9, 20, 11));
+    EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(10, 9, 20, 11));
+    EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(10, 9, 20, 11)));
   }
 
   {
     auto geometry = Geometry::MakeLine({10, 10}, {20, 10}, 2, Cap::kSquare);
-    auto matrix = Matrix();
-    EXPECT_EQ(geometry->GetCoverage(matrix), Rect::MakeLTRB(9, 9, 21, 11));
+    EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(9, 9, 21, 11));
+    EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(9, 9, 21, 11)));
   }
 
   {
-    auto geometry = Geometry::MakeLine({10, 10}, {20, 10}, 2, Cap::kRound);
-    auto matrix = Matrix();
-    EXPECT_EQ(geometry->GetCoverage(matrix), Rect::MakeLTRB(9, 9, 21, 11));
+    auto geometry = Geometry::MakeLine({10, 10}, {10, 20}, 2, Cap::kButt);
+    EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(9, 10, 11, 20));
+    EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(9, 10, 11, 20)));
+  }
+
+  {
+    auto geometry = Geometry::MakeLine({10, 10}, {10, 20}, 2, Cap::kSquare);
+    EXPECT_EQ(geometry->GetCoverage({}), Rect::MakeLTRB(9, 9, 11, 21));
+    EXPECT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(9, 9, 11, 21)));
   }
 }
 

--- a/impeller/entity/geometry/geometry_unittests.cc
+++ b/impeller/entity/geometry/geometry_unittests.cc
@@ -36,5 +36,25 @@ TEST(EntityGeometryTest, FillPathGeometryCoversAreaNoInnerRect) {
   ASSERT_FALSE(geometry->CoversArea({}, Rect()));
 }
 
+TEST(EntityGeometryTest, LineGeometryCoverage) {
+  {
+    auto geometry = Geometry::MakeLine({10, 10}, {20, 10}, 2, Cap::kButt);
+    auto matrix = Matrix();
+    EXPECT_EQ(geometry->GetCoverage(matrix), Rect::MakeLTRB(10, 9, 20, 11));
+  }
+
+  {
+    auto geometry = Geometry::MakeLine({10, 10}, {20, 10}, 2, Cap::kSquare);
+    auto matrix = Matrix();
+    EXPECT_EQ(geometry->GetCoverage(matrix), Rect::MakeLTRB(9, 9, 21, 11));
+  }
+
+  {
+    auto geometry = Geometry::MakeLine({10, 10}, {20, 10}, 2, Cap::kRound);
+    auto matrix = Matrix();
+    EXPECT_EQ(geometry->GetCoverage(matrix), Rect::MakeLTRB(9, 9, 21, 11));
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -1,0 +1,107 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/entity/geometry/line_geometry.h"
+
+namespace impeller {
+
+LineGeometry::LineGeometry(Point p0, Point p1, Scalar width, Cap cap)
+    : p0_(p0), p1_(p1) {
+  Point along = (p1 - p0).Normalize();
+  if (width < 1) {
+    width = 1;
+  }
+  along *= width * 0.5f;
+  Point across = {along.y, -along.x};
+  switch (cap) {
+    case Cap::kButt:
+      corners_[0] = p0 - across;
+      corners_[1] = p1 - across;
+      corners_[2] = p0 + across;
+      corners_[3] = p1 + across;
+      break;
+
+    case Cap::kSquare:
+    case Cap::kRound:
+      corners_[0] = p0 - across - along;
+      corners_[1] = p1 - across + along;
+      corners_[2] = p0 + across - along;
+      corners_[3] = p1 + across + along;
+  }
+}
+
+LineGeometry::~LineGeometry() = default;
+
+GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
+                                               const Entity& entity,
+                                               RenderPass& pass) {
+  auto& host_buffer = pass.GetTransientsBuffer();
+  return GeometryResult{
+      .type = PrimitiveType::kTriangleStrip,
+      .vertex_buffer =
+          {
+              .vertex_buffer = host_buffer.Emplace(corners_, 8 * sizeof(float),
+                                                   alignof(float)),
+              .vertex_count = 4,
+              .index_type = IndexType::kNone,
+          },
+      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation(),
+      .prevent_overdraw = false,
+  };
+}
+
+// |Geometry|
+GeometryResult LineGeometry::GetPositionUVBuffer(Rect texture_coverage,
+                                                 Matrix effect_transform,
+                                                 const ContentContext& renderer,
+                                                 const Entity& entity,
+                                                 RenderPass& pass) {
+  auto& host_buffer = pass.GetTransientsBuffer();
+
+  auto uv_transform =
+      texture_coverage.GetNormalizingTransform() * effect_transform;
+  std::vector<Point> data(8);
+  for (auto i = 0u, j = 0u; i < 8; i += 2, j++) {
+    data[i] = corners_[j];
+    data[i + 1] = uv_transform * corners_[j];
+  }
+
+  return GeometryResult{
+      .type = PrimitiveType::kTriangleStrip,
+      .vertex_buffer =
+          {
+              .vertex_buffer = host_buffer.Emplace(
+                  data.data(), 16 * sizeof(float), alignof(float)),
+              .vertex_count = 4,
+              .index_type = IndexType::kNone,
+          },
+      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+                   entity.GetTransformation(),
+      .prevent_overdraw = false,
+  };
+}
+
+GeometryVertexType LineGeometry::GetVertexType() const {
+  return GeometryVertexType::kPosition;
+}
+
+std::optional<Rect> LineGeometry::GetCoverage(const Matrix& transform) const {
+  auto rect = Rect::MakePointBounds(std::begin(corners_), std::end(corners_));
+  return rect.has_value() ? rect->TransformBounds(transform) : rect;
+}
+
+bool LineGeometry::CoversArea(const Matrix& transform, const Rect& rect) const {
+  if (!transform.IsTranslationScaleOnly() || !IsAxisAlignedRect()) {
+    return false;
+  }
+  auto coverage = GetCoverage(transform);
+  return coverage.has_value() ? coverage->Contains(rect) : false;
+}
+
+bool LineGeometry::IsAxisAlignedRect() const {
+  return p0_.x == p1_.x || p0_.y == p1_.y;
+}
+
+}  // namespace impeller

--- a/impeller/entity/geometry/line_geometry.h
+++ b/impeller/entity/geometry/line_geometry.h
@@ -21,6 +21,24 @@ class LineGeometry : public Geometry {
   bool IsAxisAlignedRect() const override;
 
  private:
+  // Computes the 4 corners of a rectangle that defines the line and
+  // possibly extended endpoints which will be rendered under the given
+  // transform, and returns true if such a rectangle is defined.
+  //
+  // The coordinates will be generated in the original coordinate system
+  // of the line end points and the transform will only be used to determine
+  // the minimum line width.
+  //
+  // For kButt and kSquare end caps the ends should always be exteded as
+  // per that decoration, but for kRound caps the ends might be extended
+  // if the goal is to get a conservative bounds and might not be extended
+  // if the calling code is planning to draw the round caps on the ends.
+  //
+  // @return true if the transform and width were not degenerate
+  bool ComputeCorners(Point corners[4],
+                      const Matrix& transform,
+                      bool extend_endpoints) const;
+
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,
                                    const Entity& entity,
@@ -41,7 +59,8 @@ class LineGeometry : public Geometry {
 
   Point p0_;
   Point p1_;
-  Point corners_[4];
+  Scalar width_;
+  Cap cap_;
 
   LineGeometry(const LineGeometry&) = delete;
 

--- a/impeller/entity/geometry/line_geometry.h
+++ b/impeller/entity/geometry/line_geometry.h
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include "impeller/entity/geometry/geometry.h"
+
+namespace impeller {
+
+class LineGeometry : public Geometry {
+ public:
+  explicit LineGeometry(Point p0, Point p1, Scalar width, Cap cap);
+
+  ~LineGeometry();
+
+  // |Geometry|
+  bool CoversArea(const Matrix& transform, const Rect& rect) const override;
+
+  // |Geometry|
+  bool IsAxisAlignedRect() const override;
+
+ private:
+  // |Geometry|
+  GeometryResult GetPositionBuffer(const ContentContext& renderer,
+                                   const Entity& entity,
+                                   RenderPass& pass) override;
+
+  // |Geometry|
+  GeometryVertexType GetVertexType() const override;
+
+  // |Geometry|
+  std::optional<Rect> GetCoverage(const Matrix& transform) const override;
+
+  // |Geometry|
+  GeometryResult GetPositionUVBuffer(Rect texture_coverage,
+                                     Matrix effect_transform,
+                                     const ContentContext& renderer,
+                                     const Entity& entity,
+                                     RenderPass& pass) override;
+
+  Point p0_;
+  Point p1_;
+  Point corners_[4];
+
+  LineGeometry(const LineGeometry&) = delete;
+
+  LineGeometry& operator=(const LineGeometry&) = delete;
+};
+
+}  // namespace impeller


### PR DESCRIPTION
Impeller implements the DrawLine primitive as DrawPath on a path containing a single line. Benchmarks show that this can cost 30% overhead on apps that use a lot of DrawLine primitives. This PR creates a more direct Entity that can tesselate the geometry of a line directly.

The reduced overhead should help with https://github.com/flutter/flutter/issues/138004

The current code will back off to Path rendering for round caps. When the circle geometry work is finished (https://github.com/flutter/engine/pull/47845) we can come back and implement round caps using the code refactored in that PR.