### PR TITLE
Remove implements of JS types on @staticInterop classes

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -250,7 +250,7 @@ extension CanvasKitExtension on CanvasKit {
     DomImageBitmap imageBitmap,
     bool hasPremultipliedAlpha,
   ) => _MakeLazyImageFromTextureSource3(
-    imageBitmap,
+    imageBitmap as JSObject,
     0.toJS,
     hasPremultipliedAlpha.toJS,
   );

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -116,14 +116,14 @@ class Surface {
 
     DomImageBitmap bitmap;
     if (Surface.offscreenCanvasSupported) {
-      bitmap = (await createImageBitmap(_offscreenCanvas!, (
+      bitmap = (await createImageBitmap(_offscreenCanvas! as JSObject, (
         x: 0,
         y: _pixelHeight - frameSize.height.toInt(),
         width: frameSize.width.toInt(),
         height: frameSize.height.toInt(),
       )).toDart)! as DomImageBitmap;
     } else {
-      bitmap = (await createImageBitmap(_canvasElement!, (
+      bitmap = (await createImageBitmap(_canvasElement! as JSObject, (
         x: 0,
         y: _pixelHeight - frameSize.height.toInt(),
         width: frameSize.width.toInt(),

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -344,7 +344,7 @@ external DomHTMLDocument get domDocument;
 
 @JS()
 @staticInterop
-class DomEventTarget implements JSObject {}
+class DomEventTarget {}
 
 extension DomEventTargetExtension on DomEventTarget {
   @JS('addEventListener')
@@ -1157,7 +1157,7 @@ extension WebGLContextExtension on WebGLContext {
 
 @JS()
 @staticInterop
-abstract class DomCanvasImageSource implements JSObject {}
+abstract class DomCanvasImageSource {}
 
 @JS()
 @staticInterop
@@ -1453,7 +1453,7 @@ extension DomImageDataExtension on DomImageData {
 
 @JS('ImageBitmap')
 @staticInterop
-class DomImageBitmap implements JSObject {}
+class DomImageBitmap {}
 
 extension DomImageBitmapExtension on DomImageBitmap {
   external JSNumber get width;
@@ -1831,7 +1831,7 @@ class HttpFetchError implements Exception {
 
 @JS()
 @staticInterop
-class DomResponse implements JSObject {}
+class DomResponse {}
 
 extension DomResponseExtension on DomResponse {
   @JS('status')
@@ -1868,7 +1868,7 @@ extension DomHeadersExtension on DomHeaders {
 
 @JS()
 @staticInterop
-class _DomReadableStream implements JSObject {}
+class _DomReadableStream {}
 
 extension _DomReadableStreamExtension on _DomReadableStream {
   external _DomStreamReader getReader();

--- a/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_loader.dart
@@ -57,8 +57,8 @@ abstract class FlutterEngineInitializer{
     required InitializeEngineFn initializeEngine,
     required ImmediateRunAppFn autoStart,
   }) => FlutterEngineInitializer._(
-      initializeEngine: (([JsFlutterConfiguration? config]) => futureToPromise(initializeEngine(config))).toJS,
-      autoStart: (() => futureToPromise(autoStart())).toJS,
+      initializeEngine: (([JsFlutterConfiguration? config]) => futureToPromise(initializeEngine(config) as Future<JSObject>)).toJS,
+      autoStart: (() => futureToPromise(autoStart() as Future<JSObject>)).toJS,
     );
   external factory FlutterEngineInitializer._({
     required JSFunction initializeEngine,
@@ -73,9 +73,9 @@ abstract class FlutterEngineInitializer{
 @JS()
 @anonymous
 @staticInterop
-abstract class FlutterAppRunner implements JSObject {
+abstract class FlutterAppRunner {
   factory FlutterAppRunner({required RunAppFn runApp,}) => FlutterAppRunner._(
-    runApp: (([RunAppFnParameters? args]) => futureToPromise(runApp(args))).toJS
+    runApp: (([RunAppFnParameters? args]) => futureToPromise(runApp(args) as Future<JSObject>)).toJS
   );
 
   /// Runs a flutter app
@@ -101,7 +101,7 @@ typedef RunAppFn = Future<FlutterApp> Function([RunAppFnParameters?]);
 @JS()
 @anonymous
 @staticInterop
-abstract class FlutterApp implements JSObject {
+abstract class FlutterApp {
   /// Cleans a Flutter app
   external factory FlutterApp();
 }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/codecs.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/codecs.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:js_interop';
+
 import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
@@ -19,7 +21,7 @@ class SkwasmImageDecoder extends BrowserImageDecoder {
     final int height = frame.codedHeight.toInt();
     final SkwasmSurface surface = (renderer as SkwasmRenderer).surface;
     return SkwasmImage(imageCreateFromTextureSource(
-      frame,
+      frame as JSObject,
       width,
       height,
       surface.handle,

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -391,7 +391,7 @@ class SkwasmRenderer implements Renderer {
     }
     final SkwasmImageDecoder decoder = SkwasmImageDecoder(
       contentType: contentType,
-      dataSource: response.body,
+      dataSource: response.body as JSObject,
       debugSource: uri.toString(),
     );
     await decoder.initialize();
@@ -452,7 +452,7 @@ class SkwasmRenderer implements Renderer {
   @override
   ui.Image createImageFromImageBitmap(DomImageBitmap imageSource) {
     return SkwasmImage(imageCreateFromTextureSource(
-      imageSource,
+      imageSource as JSObject,
       imageSource.width.toDartInt,
       imageSource.height.toDartInt,
       surface.handle,

--- a/lib/web_ui/lib/src/engine/view_embedder/hot_restart_cache_handler.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/hot_restart_cache_handler.dart
@@ -53,7 +53,7 @@ class HotRestartCacheHandler {
   /// Registers a [DomElement] to be removed after hot-restart.
   @visibleForTesting
   void registerElement(DomElement element) {
-    _jsHotRestartStore!.push(element);
+    _jsHotRestartStore!.push(element as JSObject);
   }
 }
 

--- a/lib/web_ui/test/engine/scene_view_test.dart
+++ b/lib/web_ui/test/engine/scene_view_test.dart
@@ -27,7 +27,7 @@ class StubPictureRenderer implements PictureRenderer {
     renderedPictures.add(picture);
     final ui.Rect cullRect = picture.cullRect;
     final DomImageBitmap bitmap = (await createImageBitmap(
-      scratchCanvasElement,
+      scratchCanvasElement as JSObject,
       (x: 0, y: 0, width: cullRect.width.toInt(), height: cullRect.height.toInt())
     ).toDart)! as DomImageBitmap;
     return bitmap;

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -318,7 +318,7 @@ Future<void> testMain() async {
       image.src = url;
       await completer.future;
 
-      final DomImageBitmap bitmap = (await createImageBitmap(image).toDart)! as DomImageBitmap;
+      final DomImageBitmap bitmap = (await createImageBitmap(image as JSObject).toDart)! as DomImageBitmap;
 
       expect(bitmap.width.toDartInt, 150);
       expect(bitmap.height.toDartInt, 150);


### PR DESCRIPTION
JS types are going to become extension types and as such, @staticInterop types cannot implement these types. When we migrate these classes to extension types, we can add back the subtyping.

Enables https://github.com/dart-lang/sdk/issues/52687.
