### PR TITLE
Revert "[deps] Stop moving NDK folder inside Android SDK (#47454)"

### DIFF
--- a/tools/android_sdk/create_cipd_packages.sh
+++ b/tools/android_sdk/create_cipd_packages.sh
@@ -116,6 +116,10 @@ for platform in "${platforms[@]}"; do
   done
 
   # Special treatment for NDK to move to expected directory.
+  # Instead of the ndk being in `sdk/ndk/<major>.<minor>.<patch>/`, it will be
+  # in `ndk/`.
+  # This simplifies the build scripts, and enables version difference between
+  # the Dart and Flutter build while reusing the same build rules.
   mv $upload_dir/sdk/ndk $upload_dir/ndk-bundle
   ndk_sub_paths=`find $upload_dir/ndk-bundle -maxdepth 1 -type d`
   ndk_sub_paths_arr=($ndk_sub_paths)

--- a/tools/android_sdk/create_cipd_packages.sh
+++ b/tools/android_sdk/create_cipd_packages.sh
@@ -115,6 +115,13 @@ for platform in "${platforms[@]}"; do
     done
   done
 
+  # Special treatment for NDK to move to expected directory.
+  mv $upload_dir/sdk/ndk $upload_dir/ndk-bundle
+  ndk_sub_paths=`find $upload_dir/ndk-bundle -maxdepth 1 -type d`
+  ndk_sub_paths_arr=($ndk_sub_paths)
+  mv ${ndk_sub_paths_arr[1]} $upload_dir/ndk
+  rm -rf $upload_dir/ndk-bundle
+
   # Accept all licenses to ensure they are generated and uploaded.
   yes "y" | $sdkmanager_path --licenses --sdk_root=$sdk_root
   cp -r "$sdk_root/licenses" "$upload_dir/sdk"


### PR DESCRIPTION
Reverts

* https://github.com/flutter/engine/pull/47454

and adds documentation

The NDK folder shuffling in the DEPS is to simplify the build files and enable building with different NDK versions between Dart and Flutter while sharing the build files.

Closes: https://github.com/flutter/flutter/issues/136666

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
