### PR TITLE
[Impeller] remove doc comment claiming Command objects are light weight.

### DIFF
--- a/impeller/core/formats.h
+++ b/impeller/core/formats.h
@@ -311,13 +311,13 @@ enum class TextureCoordinateSystem {
   kRenderToTexture,
 };
 
-enum class CullMode : uint8_t {
+enum class CullMode {
   kNone,
   kFrontFace,
   kBackFace,
 };
 
-enum class IndexType : uint8_t {
+enum class IndexType {
   kUnknown,
   k16bit,
   k32bit,

--- a/impeller/core/formats.h
+++ b/impeller/core/formats.h
@@ -311,13 +311,13 @@ enum class TextureCoordinateSystem {
   kRenderToTexture,
 };
 
-enum class CullMode {
+enum class CullMode : uint8_t {
   kNone,
   kFrontFace,
   kBackFace,
 };
 
-enum class IndexType {
+enum class IndexType : uint8_t {
   kUnknown,
   k16bit,
   k32bit,

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -92,9 +92,9 @@ struct Bindings {
 ///             * Specify any stage bindings.
 ///             * (Optional) Specify a debug label.
 ///
-///             Command are objects and can be created frequently and on demand. The resources referenced in commands
-///             views into buffers managed by other allocators and resource
-///             managers.
+///             Command are objects and can be created frequently and on demand.
+///             The resources referenced in commands views into buffers managed
+///             by other allocators and resource managers.
 ///
 struct Command : public ResourceBinder {
   //----------------------------------------------------------------------------

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -92,8 +92,7 @@ struct Bindings {
 ///             * Specify any stage bindings.
 ///             * (Optional) Specify a debug label.
 ///
-///             Command are very lightweight objects and can be created
-///             frequently and on demand. The resources referenced in commands
+///             Command are objects and can be created frequently and on demand. The resources referenced in commands
 ///             views into buffers managed by other allocators and resource
 ///             managers.
 ///


### PR DESCRIPTION
These are nearly 500 bytes, they're not lightweight by any stretch of the imagination.
