### PR TITLE
[web] JSConfig: Add multiViewEnabled value.

### DIFF
--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -287,6 +287,16 @@ class FlutterConfiguration {
   /// to render, or `null` if the user hasn't specified anything.
   DomElement? get hostElement => _configuration?.hostElement;
 
+  /// Sets Flutter Web in "multi-view" mode.
+  ///
+  /// Multi-view mode allows apps to:
+  ///
+  ///  * Start without a `hostElement`.
+  ///  * Add/remove views (`hostElements`) from JS while the application is running.
+  ///  * ...
+  ///  * PROFIT?
+  bool get multiViewEnabled => _configuration?.multiViewEnabled ?? false;
+
   /// Returns a `nonce` to allowlist the inline styles that Flutter web needs.
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce
@@ -341,6 +351,10 @@ extension JsFlutterConfigurationExtension on JsFlutterConfiguration {
   bool? get debugShowSemanticsNodes => _debugShowSemanticsNodes?.toDart;
 
   external DomElement? get hostElement;
+
+  @JS('multiViewEnabled')
+  external JSBoolean? get _multiViewEnabled;
+  bool? get multiViewEnabled => _multiViewEnabled?.toDart;
 
   @JS('nonce')
   external JSString? get _nonce;

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -267,17 +267,6 @@ class FlutterConfiguration {
     'FLUTTER_WEB_CANVASKIT_FORCE_CPU_ONLY',
   );
 
-  /// This is deprecated. The CanvasKit renderer will only ever create one
-  /// WebGL context, obviating the problem this configuration was meant to
-  /// solve originally.
-  @Deprecated('Setting canvasKitMaximumSurfaces has no effect')
-  int get canvasKitMaximumSurfaces =>
-      _configuration?.canvasKitMaximumSurfaces?.toInt() ?? _defaultCanvasKitMaximumSurfaces;
-  static const int _defaultCanvasKitMaximumSurfaces = int.fromEnvironment(
-    'FLUTTER_WEB_MAXIMUM_SURFACES',
-    defaultValue: 8,
-  );
-
   /// Set this flag to `true` to cause the engine to visualize the semantics tree
   /// on the screen for debugging.
   ///
@@ -346,10 +335,6 @@ extension JsFlutterConfigurationExtension on JsFlutterConfiguration {
   @JS('canvasKitForceCpuOnly')
   external JSBoolean? get _canvasKitForceCpuOnly;
   bool? get canvasKitForceCpuOnly => _canvasKitForceCpuOnly?.toDart;
-
-  @JS('canvasKitMaximumSurfaces')
-  external JSNumber? get _canvasKitMaximumSurfaces;
-  double? get canvasKitMaximumSurfaces => _canvasKitMaximumSurfaces?.toDartDouble;
 
   @JS('debugShowSemanticsNodes')
   external JSBoolean? get _debugShowSemanticsNodes;

--- a/lib/web_ui/test/canvaskit/initialization/stores_config_test.dart
+++ b/lib/web_ui/test/canvaskit/initialization/stores_config_test.dart
@@ -15,11 +15,19 @@ void testMain() {
   group('initializeEngineServices', () {
     test('stores user configuration', () async {
       final JsFlutterConfiguration config = JsFlutterConfiguration();
+      // `canvasKitBaseUrl` is required for the test to actually run.
+      js_util.setProperty(config, 'canvasKitBaseUrl', '/canvaskit/');
+      // A property under test, that we'll try to read later.
       js_util.setProperty(config, 'nonce', 'some_nonce');
-      // Set a non-existing property to verify our js-interop doesn't crash.
+      // A non-existing property to verify our js-interop doesn't crash.
       js_util.setProperty(config, 'canvasKitMaximumSurfaces', 32.0);
+
       // Remove window.flutterConfiguration (if it's there)
       js_util.setProperty(domWindow, 'flutterConfiguration', null);
+
+      // TODO(web): Replace the above nullification by the following assertion
+      // when wasm and JS tests initialize their config the same way:
+      // assert(js_util.getProperty<Object?>(domWindow, 'flutterConfiguration') == null);
 
       await initializeEngineServices(jsConfiguration: config);
 

--- a/lib/web_ui/test/canvaskit/initialization/stores_config_test.dart
+++ b/lib/web_ui/test/canvaskit/initialization/stores_config_test.dart
@@ -15,12 +15,15 @@ void testMain() {
   group('initializeEngineServices', () {
     test('stores user configuration', () async {
       final JsFlutterConfiguration config = JsFlutterConfiguration();
+      js_util.setProperty(config, 'nonce', 'some_nonce');
+      // Set a non-existing property to verify our js-interop doesn't crash.
       js_util.setProperty(config, 'canvasKitMaximumSurfaces', 32.0);
-      js_util.setProperty(config, 'canvasKitBaseUrl', '/canvaskit/');
+      // Remove window.flutterConfiguration (if it's there)
       js_util.setProperty(domWindow, 'flutterConfiguration', null);
+
       await initializeEngineServices(jsConfiguration: config);
 
-      expect(configuration.canvasKitMaximumSurfaces, 32);
+      expect(configuration.nonce, 'some_nonce');
     });
   });
 }

--- a/lib/web_ui/test/engine/configuration_test.dart
+++ b/lib/web_ui/test/engine/configuration_test.dart
@@ -73,63 +73,80 @@ void testMain() {
     });
   });
 
-  group('CanvasKit config', () {
-    test('default canvasKitVariant', () {
-      final FlutterConfiguration config = FlutterConfiguration();
-
-      expect(config.canvasKitVariant, CanvasKitVariant.auto);
-    });
-
-    test('default canvasKitVariant when it is undefined', () {
-      final FlutterConfiguration config = FlutterConfiguration();
-      config.setUserConfiguration(
-        // With an empty map, the canvasKitVariant is undefined in JS.
+  group('Default configuration values', () {
+    late FlutterConfiguration defaultConfig;
+    setUp(() {
+      defaultConfig = FlutterConfiguration();
+      defaultConfig.setUserConfiguration(
         js_util.jsify(<String, Object?>{}) as JsFlutterConfiguration,
       );
-
-      expect(config.canvasKitVariant, CanvasKitVariant.auto);
     });
 
-    test('validates canvasKitVariant', () {
-      final FlutterConfiguration config = FlutterConfiguration();
-
-      config.setUserConfiguration(
-        js_util.jsify(<String, Object?>{'canvasKitVariant': 'foo'}) as JsFlutterConfiguration,
-      );
-      expect(() => config.canvasKitVariant, throwsArgumentError);
-
-      config.setUserConfiguration(
-        js_util.jsify(<String, Object?>{'canvasKitVariant': 'auto'}) as JsFlutterConfiguration,
-      );
-      expect(config.canvasKitVariant, CanvasKitVariant.auto);
-
-      config.setUserConfiguration(
-        js_util.jsify(<String, Object?>{'canvasKitVariant': 'full'}) as JsFlutterConfiguration,
-      );
-      expect(config.canvasKitVariant, CanvasKitVariant.full);
-
-      config.setUserConfiguration(
-        js_util.jsify(<String, Object?>{'canvasKitVariant': 'chromium'}) as JsFlutterConfiguration,
-      );
-      expect(config.canvasKitVariant, CanvasKitVariant.chromium);
+    test('canvasKitVariant', () {
+      expect(defaultConfig.canvasKitVariant, CanvasKitVariant.auto);
     });
+
+    test('useColorEmoji', () {
+      expect(defaultConfig.useColorEmoji, isFalse);
+    });
+
+    test('multiViewEnabled', () {
+      expect(defaultConfig.multiViewEnabled, isFalse);
+    });
+
   });
 
-  group('useColorEmoji', () {
-    test('defaults to false', () {
-      final FlutterConfiguration config = FlutterConfiguration();
-      config.setUserConfiguration(
-        js_util.jsify(<String, Object?>{}) as JsFlutterConfiguration,
-      );
-      expect(config.useColorEmoji, isFalse);
+  group('setUserConfiguration (values)', () {
+    group('canvasKitVariant', () {
+      test('value undefined - defaults to "auto"', () {
+        final FlutterConfiguration config = FlutterConfiguration();
+        config.setUserConfiguration(
+          // With an empty map, the canvasKitVariant is undefined in JS.
+          js_util.jsify(<String, Object?>{}) as JsFlutterConfiguration,
+        );
+
+        expect(config.canvasKitVariant, CanvasKitVariant.auto);
+      });
+
+      test('value - converts to CanvasKitVariant enum (or throw)', () {
+        final FlutterConfiguration config = FlutterConfiguration();
+
+        config.setUserConfiguration(
+          js_util.jsify(<String, Object?>{'canvasKitVariant': 'foo'}) as JsFlutterConfiguration,
+        );
+        expect(() => config.canvasKitVariant, throwsArgumentError);
+
+        config.setUserConfiguration(
+          js_util.jsify(<String, Object?>{'canvasKitVariant': 'auto'}) as JsFlutterConfiguration,
+        );
+        expect(config.canvasKitVariant, CanvasKitVariant.auto);
+
+        config.setUserConfiguration(
+          js_util.jsify(<String, Object?>{'canvasKitVariant': 'full'}) as JsFlutterConfiguration,
+        );
+        expect(config.canvasKitVariant, CanvasKitVariant.full);
+
+        config.setUserConfiguration(
+          js_util.jsify(<String, Object?>{'canvasKitVariant': 'chromium'}) as JsFlutterConfiguration,
+        );
+        expect(config.canvasKitVariant, CanvasKitVariant.chromium);
+      });
     });
 
-    test('can be set to true', () {
+    test('useColorEmoji', () {
       final FlutterConfiguration config = FlutterConfiguration();
       config.setUserConfiguration(
         js_util.jsify(<String, Object?>{'useColorEmoji': true}) as JsFlutterConfiguration,
       );
       expect(config.useColorEmoji, isTrue);
+    });
+
+    test('multiViewEnabled', () {
+      final FlutterConfiguration config = FlutterConfiguration();
+      config.setUserConfiguration(
+        js_util.jsify(<String, Object?>{'multiViewEnabled': true}) as JsFlutterConfiguration,
+      );
+      expect(config.multiViewEnabled, isTrue);
     });
   });
 }

--- a/lib/web_ui/test/engine/configuration_test.dart
+++ b/lib/web_ui/test/engine/configuration_test.dart
@@ -22,16 +22,16 @@ void testMain() {
     test('initializes with null', () async {
       final FlutterConfiguration config = FlutterConfiguration.legacy(null);
 
-      expect(config.canvasKitMaximumSurfaces, 8); // _defaultCanvasKitMaximumSurfaces
+      expect(config.canvasKitBaseUrl, 'canvaskit/'); // _defaultCanvasKitBaseUrl
     });
 
     test('legacy constructor initializes with a Js Object', () async {
       final FlutterConfiguration config = FlutterConfiguration.legacy(
         js_util.jsify(<String, Object?>{
-          'canvasKitMaximumSurfaces': 16,
+          'canvasKitBaseUrl': 'some_other_url/',
         }) as JsFlutterConfiguration);
 
-      expect(config.canvasKitMaximumSurfaces, 16);
+      expect(config.canvasKitBaseUrl, 'some_other_url/');
     });
   });
 
@@ -39,13 +39,13 @@ void testMain() {
     test('throws assertion error if already initialized from JS', () async {
       final FlutterConfiguration config = FlutterConfiguration.legacy(
         js_util.jsify(<String, Object?>{
-          'canvasKitMaximumSurfaces': 12,
+          'canvasKitBaseUrl': 'some_other_url/',
         }) as JsFlutterConfiguration);
 
       expect(() {
         config.setUserConfiguration(
           js_util.jsify(<String, Object?>{
-            'canvasKitMaximumSurfaces': 16,
+            'canvasKitBaseUrl': 'yet_another_url/',
           }) as JsFlutterConfiguration);
       }, throwsAssertionError);
     });
@@ -55,10 +55,21 @@ void testMain() {
 
       config.setUserConfiguration(
         js_util.jsify(<String, Object?>{
-          'canvasKitMaximumSurfaces': 16,
+          'canvasKitBaseUrl': 'one_more_url/',
         }) as JsFlutterConfiguration);
 
-      expect(config.canvasKitMaximumSurfaces, 16);
+      expect(config.canvasKitBaseUrl, 'one_more_url/');
+    });
+
+    test('can receive non-existing properties without crashing', () async {
+      final FlutterConfiguration config = FlutterConfiguration.legacy(null);
+
+      expect(() {
+        config.setUserConfiguration(
+          js_util.jsify(<String, Object?>{
+            'canvasKitMaximumSurfaces': 32.0,
+          }) as JsFlutterConfiguration);
+      }, returnsNormally);
     });
   });
 


### PR DESCRIPTION
This change:

* Adds a boolean to `multiViewEnabled` (defaults to `false`).
* Removes unused `canvasKitMaximumSurfaces` value.

Part of: https://github.com/flutter/flutter/issues/137377

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
