### PR TITLE
[ios] introduce weak_nsobject

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -104,6 +104,7 @@
 ../../../flutter/fml/platform/darwin/scoped_nsobject_arc_unittests.mm
 ../../../flutter/fml/platform/darwin/scoped_nsobject_unittests.mm
 ../../../flutter/fml/platform/darwin/string_range_sanitization_unittests.mm
+../../../flutter/fml/platform/darwin/weak_nsobject_unittests.mm
 ../../../flutter/fml/platform/win/file_win_unittests.cc
 ../../../flutter/fml/platform/win/wstring_conversion_unittests.cc
 ../../../flutter/fml/raster_thread_merger_unittests.cc

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -104,6 +104,7 @@
 ../../../flutter/fml/platform/darwin/scoped_nsobject_arc_unittests.mm
 ../../../flutter/fml/platform/darwin/scoped_nsobject_unittests.mm
 ../../../flutter/fml/platform/darwin/string_range_sanitization_unittests.mm
+../../../flutter/fml/platform/darwin/weak_nsobject_arc_unittests.mm
 ../../../flutter/fml/platform/darwin/weak_nsobject_unittests.mm
 ../../../flutter/fml/platform/win/file_win_unittests.cc
 ../../../flutter/fml/platform/win/wstring_conversion_unittests.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -2799,6 +2799,8 @@ ORIGIN: ../../../flutter/fml/platform/darwin/scoped_policy.h + ../../../flutter/
 ORIGIN: ../../../flutter/fml/platform/darwin/scoped_typeref.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/fml/platform/darwin/string_range_sanitization.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/fml/platform/darwin/string_range_sanitization.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/fml/platform/darwin/weak_nsobject.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/fml/platform/darwin/weak_nsobject.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/fml/platform/fuchsia/message_loop_fuchsia.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/fml/platform/fuchsia/message_loop_fuchsia.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/fml/platform/fuchsia/paths_fuchsia.cc + ../../../flutter/LICENSE
@@ -5563,6 +5565,8 @@ FILE: ../../../flutter/fml/platform/darwin/scoped_policy.h
 FILE: ../../../flutter/fml/platform/darwin/scoped_typeref.h
 FILE: ../../../flutter/fml/platform/darwin/string_range_sanitization.h
 FILE: ../../../flutter/fml/platform/darwin/string_range_sanitization.mm
+FILE: ../../../flutter/fml/platform/darwin/weak_nsobject.h
+FILE: ../../../flutter/fml/platform/darwin/weak_nsobject.mm
 FILE: ../../../flutter/fml/platform/fuchsia/message_loop_fuchsia.cc
 FILE: ../../../flutter/fml/platform/fuchsia/message_loop_fuchsia.h
 FILE: ../../../flutter/fml/platform/fuchsia/paths_fuchsia.cc

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -169,6 +169,8 @@ source_set("fml") {
       "platform/darwin/scoped_typeref.h",
       "platform/darwin/string_range_sanitization.h",
       "platform/darwin/string_range_sanitization.mm",
+      "platform/darwin/weak_nsobject.h",
+      "platform/darwin/weak_nsobject.mm",
     ]
 
     frameworks = [ "Foundation.framework" ]
@@ -369,7 +371,10 @@ if (enable_unittests) {
     }
 
     if (is_mac || is_ios) {
-      sources += [ "platform/darwin/scoped_nsobject_unittests.mm" ]
+      sources += [
+        "platform/darwin/scoped_nsobject_unittests.mm",
+        "platform/darwin/weak_nsobject_unittests.mm",
+      ]
     }
 
     if (is_win) {

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -404,7 +404,10 @@ if (enable_unittests) {
     testonly = true
     if (is_mac || is_ios) {
       cflags_objcc = flutter_cflags_objc_arc
-      sources = [ "platform/darwin/scoped_nsobject_arc_unittests.mm" ]
+      sources = [
+        "platform/darwin/scoped_nsobject_arc_unittests.mm",
+        "platform/darwin/weak_nsobject_arc_unittests.mm",
+      ]
     }
 
     deps = [

--- a/fml/platform/darwin/weak_nsobject.h
+++ b/fml/platform/darwin/weak_nsobject.h
@@ -73,8 +73,7 @@ class WeakNSObjectFactory;
 // receives nullify() from the object's sentinel.
 class WeakContainer : public fml::RefCountedThreadSafe<WeakContainer> {
  public:
-  explicit WeakContainer(id object, debug::DebugThreadChecker checker)
-      : checker_(checker), object_(object) {}
+  explicit WeakContainer(id object, debug::DebugThreadChecker checker);
 
   id object() {
     CheckThreadSafety();
@@ -85,10 +84,10 @@ class WeakContainer : public fml::RefCountedThreadSafe<WeakContainer> {
 
  private:
   friend fml::RefCountedThreadSafe<WeakContainer>;
-  ~WeakContainer() {}
+  ~WeakContainer();
 
   debug::DebugThreadChecker checker_;
-  id object_;
+  __unsafe_unretained id object_;
 
   void CheckThreadSafety() const { FML_DCHECK_CREATION_THREAD_IS_CURRENT(checker_.checker); }
 };

--- a/fml/platform/darwin/weak_nsobject.h
+++ b/fml/platform/darwin/weak_nsobject.h
@@ -1,0 +1,287 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_PLATFORM_DARWIN_WEAK_NSOBJECT_H_
+#define FLUTTER_FML_PLATFORM_DARWIN_WEAK_NSOBJECT_H_
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+#include <stdlib.h>
+#include "flutter/fml/compiler_specific.h"
+#include "flutter/fml/logging.h"
+#include "flutter/fml/memory/ref_counted.h"
+#include "flutter/fml/memory/ref_ptr.h"
+#include "flutter/fml/memory/thread_checker.h"
+
+namespace debug {
+struct DebugThreadChecker {
+  FML_DECLARE_THREAD_CHECKER(checker);
+};
+}  // namespace debug
+
+// WeakNSObject<> is patterned after scoped_nsobject<>, but instead of
+// maintaining ownership of an NSObject subclass object, it will nil itself out
+// when the object is deallocated.
+//
+// WeakNSProtocol<> has the same behavior as WeakNSObject, but can be used
+// with protocols.
+//
+// Example usage (fml::WeakNSObject<T>):
+//   WeakNSObjectFactory factory([[Foo alloc] init]);
+//   WeakNSObject<Foo> weak_foo;  // No pointer
+//   weak_foo = factory.GetWeakNSObject() // Now a weak reference is kept.
+//   [weak_foo description];  // Returns [foo description].
+//   foo.reset();  // The reference is released.
+//   [weak_foo description];  // Returns nil, as weak_foo is pointing to nil.
+//
+//
+// Implementation wise a WeakNSObject keeps a reference to a refcounted
+// WeakContainer. There is one unique instance of a WeakContainer per watched
+// NSObject, this relationship is maintained via the ObjectiveC associated
+// object API, indirectly via an ObjectiveC CRBWeakNSProtocolSentinel class.
+//
+// Threading restrictions:
+// - Several WeakNSObject pointing to the same underlying object must all be
+//   created and dereferenced on the same thread;
+// - thread safety is enforced by the implementation, except:
+//     - it is allowed to destroy a WeakNSObject on any thread;
+// - the implementation assumes that the tracked object will be released on the
+//   same thread that the WeakNSObject is created on.
+//
+// fml specifics:
+// WeakNSObjects can only originate from a |WeakNSObjectFactory| (see below), though WeakNSObjects
+// are copyable and movable.
+//
+// WeakNSObjects are not in general thread-safe. They may only be *used* on
+// a single thread, namely the same thread as the "originating"
+// |WeakNSObjectFactory| (which can invalidate the WeakNSObjects that it
+// generates).
+namespace fml {
+
+// Forward declaration, so |WeakNSObject<NST>| can friend it.
+template <typename NST>
+class WeakNSObjectFactory;
+
+// WeakContainer keeps a weak pointer to an object and clears it when it
+// receives nullify() from the object's sentinel.
+class WeakContainer : public fml::RefCountedThreadSafe<WeakContainer> {
+ public:
+  explicit WeakContainer(id object, std::shared_ptr<debug::DebugThreadChecker> checker = nullptr)
+      : checker_(checker), object_(object) {}
+
+  id object() {
+    CheckThreadSafety();
+    return object_;
+  }
+
+  void nullify() {
+    CheckThreadSafety();
+    object_ = nil;
+  }
+
+ private:
+  friend fml::RefCountedThreadSafe<WeakContainer>;
+  ~WeakContainer() {}
+
+  std::shared_ptr<debug::DebugThreadChecker> checker_;
+  id object_;
+
+  void CheckThreadSafety() const {
+    if (!checker_) {
+      return;
+    }
+    FML_DCHECK_CREATION_THREAD_IS_CURRENT(checker_->checker);
+  }
+};
+
+}  // namespace fml
+
+// Sentinel for observing the object contained in the weak pointer. The object
+// will be deleted when the weak object is deleted and will notify its
+// container.
+@interface CRBWeakNSProtocolSentinel : NSObject
+// Return the only associated container for this object. There can be only one.
+// Will return null if object is nil .
++ (fml::RefPtr<fml::WeakContainer>)containerForObject:(id)object
+                                        threadChecker:
+                                            (std::shared_ptr<debug::DebugThreadChecker>)checker;
+@end
+
+namespace fml {
+
+// Base class for all WeakNSObject derivatives.
+template <typename NST>
+class WeakNSProtocol {
+ public:
+  WeakNSProtocol() = default;
+
+  WeakNSProtocol(const WeakNSProtocol<NST>& that) {
+    // A WeakNSProtocol object can be copied on one thread and used on
+    // another.
+    container_ = that.container_;
+  }
+
+  ~WeakNSProtocol() = default;
+
+  void reset() {
+    CheckThreadSafety();
+    container_ = [CRBWeakNSProtocolSentinel containerForObject:nil threadChecker:checker_];
+  }
+
+  NST get() const {
+    CheckThreadSafety();
+    if (!container_.get()) {
+      return nil;
+    }
+    return container_->object();
+  }
+
+  WeakNSProtocol& operator=(const WeakNSProtocol<NST>& that) {
+    // A WeakNSProtocol object can be copied on one thread and used on
+    // another.
+    container_ = that.container_;
+    return *this;
+  }
+
+  bool operator==(NST that) const {
+    CheckThreadSafety();
+    return get() == that;
+  }
+
+  bool operator!=(NST that) const {
+    CheckThreadSafety();
+    return get() != that;
+  }
+
+  operator NST() const {
+    CheckThreadSafety();
+    return get();
+  }
+
+ protected:
+  friend class WeakNSObjectFactory<NST>;
+
+  explicit WeakNSProtocol(std::shared_ptr<debug::DebugThreadChecker> checker, NST object = nil)
+      : checker_(checker) {
+    container_ = [CRBWeakNSProtocolSentinel containerForObject:object threadChecker:checker];
+  }
+
+  // Refecounted reference to the container tracking the ObjectiveC object this
+  // class encapsulates.
+  RefPtr<fml::WeakContainer> container_;
+  std::shared_ptr<debug::DebugThreadChecker> checker_;
+
+  void CheckThreadSafety() const {
+    if (!checker_) {
+      return;
+    }
+    FML_DCHECK_CREATION_THREAD_IS_CURRENT(checker_->checker);
+  }
+};
+
+// Free functions
+template <class NST>
+bool operator==(NST p1, const WeakNSProtocol<NST>& p2) {
+  return p1 == p2.get();
+}
+
+template <class NST>
+bool operator!=(NST p1, const WeakNSProtocol<NST>& p2) {
+  return p1 != p2.get();
+}
+
+template <typename NST>
+class WeakNSObject : public WeakNSProtocol<NST*> {
+ public:
+  WeakNSObject() = default;
+  WeakNSObject(const WeakNSObject<NST>& that) : WeakNSProtocol<NST*>(that) {}
+
+  WeakNSObject& operator=(const WeakNSObject<NST>& that) {
+    WeakNSProtocol<NST*>::operator=(that);
+    return *this;
+  }
+
+ private:
+  friend class WeakNSObjectFactory<NST>;
+
+  explicit WeakNSObject(std::shared_ptr<debug::DebugThreadChecker> checker, NST* object = nil)
+      : WeakNSProtocol<NST*>(checker, object) {}
+};
+
+// Specialization to make WeakNSObject<id> work.
+template <>
+class WeakNSObject<id> : public WeakNSProtocol<id> {
+ public:
+  WeakNSObject() = default;
+  WeakNSObject(const WeakNSObject<id>& that) : WeakNSProtocol<id>(that) {}
+
+  WeakNSObject& operator=(const WeakNSObject<id>& that) {
+    WeakNSProtocol<id>::operator=(that);
+    return *this;
+  }
+
+ private:
+  friend class WeakNSObjectFactory<id>;
+
+  explicit WeakNSObject(std::shared_ptr<debug::DebugThreadChecker> checker, id object = nil)
+      : WeakNSProtocol<id>(checker, object) {}
+};
+
+// Class that produces (valid) |WeakNSObject<NST>|s. Typically, this is used as a
+// member variable of |NST| (preferably the last one -- see below), and |NST|'s
+// methods control how WeakNSObjects to it are vended. This class is not
+// thread-safe, and should only be created, destroyed and used on a single
+// thread.
+//
+// Example:
+//
+// ```objc
+// @implementation Controller {
+//  std::unique_ptr<fml::WeakNSObjectFactory<Controller>> _weakFactory;
+// }
+//
+// - (instancetype)init {
+//   self = [super init];
+//   _weakFactory = std::make_unique<fml::WeakNSObjectFactory<Controller>>(self)
+// }
+
+// - (fml::WeakNSObject<Controller>) {
+//   return _weakFactory->GetWeakNSObject()
+// }
+//
+// @end
+// ```
+template <typename NST>
+class WeakNSObjectFactory {
+ public:
+  explicit WeakNSObjectFactory(NST* object) : object_(object) {
+    FML_DCHECK(object_);
+    checker_ = std::make_shared<debug::DebugThreadChecker>();
+  }
+
+  ~WeakNSObjectFactory() { CheckThreadSafety(); }
+
+  // Gets a new weak pointer, which will be valid until this object is
+  // destroyed.
+  WeakNSObject<NST> GetWeakNSObject() const { return WeakNSObject<NST>(checker_, object_); }
+
+ private:
+  NST* object_;
+
+  void CheckThreadSafety() const {
+    if (!checker_) {
+      return;
+    }
+    FML_DCHECK_CREATION_THREAD_IS_CURRENT(checker_->checker);
+  }
+
+  std::shared_ptr<debug::DebugThreadChecker> checker_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(WeakNSObjectFactory);
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_PLATFORM_DARWIN_WEAK_NSOBJECT_H_

--- a/fml/platform/darwin/weak_nsobject.mm
+++ b/fml/platform/darwin/weak_nsobject.mm
@@ -51,7 +51,7 @@ WeakContainer::~WeakContainer() {}
 }
 
 - (id)initWithContainer:(fml::RefPtr<fml::WeakContainer>)container {
-  FML_DCHECK(_container.get());
+  FML_DCHECK(container.get());
   self = [super init];
   if (self) {
     _container = container;

--- a/fml/platform/darwin/weak_nsobject.mm
+++ b/fml/platform/darwin/weak_nsobject.mm
@@ -25,8 +25,9 @@ char sentinelObserverKey_;
 + (fml::RefPtr<fml::WeakContainer>)containerForObject:(id)object
                                         threadChecker:
                                             (std::shared_ptr<debug::DebugThreadChecker>)checker {
-  if (object == nil)
+  if (object == nil) {
     return nullptr;
+  }
   // The autoreleasePool is needed here as the call to objc_getAssociatedObject
   // returns an autoreleased object which is better released sooner than later.
   fml::ScopedNSAutoreleasePool pool;

--- a/fml/platform/darwin/weak_nsobject.mm
+++ b/fml/platform/darwin/weak_nsobject.mm
@@ -62,7 +62,7 @@ WeakContainer::~WeakContainer() {}
 }
 
 - (void)dealloc {
-  self.container->nullify();
+  _container->nullify();
   [super dealloc];
 }
 

--- a/fml/platform/darwin/weak_nsobject.mm
+++ b/fml/platform/darwin/weak_nsobject.mm
@@ -29,8 +29,6 @@ WeakContainer::~WeakContainer() {}
 
 @implementation CRBWeakNSProtocolSentinel
 
-@synthesize container = container_;
-
 + (fml::RefPtr<fml::WeakContainer>)containerForObject:(id)object
                                         threadChecker:(debug::DebugThreadChecker)checker {
   if (object == nil) {
@@ -53,10 +51,10 @@ WeakContainer::~WeakContainer() {}
 }
 
 - (id)initWithContainer:(fml::RefPtr<fml::WeakContainer>)container {
-  FML_DCHECK(container.get());
+  FML_DCHECK(_container.get());
   self = [super init];
   if (self) {
-    container_ = container;
+    _container = container;
   }
   return self;
 }

--- a/fml/platform/darwin/weak_nsobject.mm
+++ b/fml/platform/darwin/weak_nsobject.mm
@@ -23,8 +23,7 @@ char sentinelObserverKey_;
 @synthesize container = container_;
 
 + (fml::RefPtr<fml::WeakContainer>)containerForObject:(id)object
-                                        threadChecker:
-                                            (std::shared_ptr<debug::DebugThreadChecker>)checker {
+                                        threadChecker:(debug::DebugThreadChecker)checker {
   if (object == nil) {
     return nullptr;
   }

--- a/fml/platform/darwin/weak_nsobject.mm
+++ b/fml/platform/darwin/weak_nsobject.mm
@@ -14,7 +14,7 @@ char sentinelObserverKey_;
 namespace fml {
 
 WeakContainer::WeakContainer(id object, debug::DebugThreadChecker checker)
-    : checker_(checker), object_(object) {}
+    : object_(object), checker_(checker) {}
 
 WeakContainer::~WeakContainer() {}
 

--- a/fml/platform/darwin/weak_nsobject.mm
+++ b/fml/platform/darwin/weak_nsobject.mm
@@ -1,0 +1,60 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/platform/darwin/weak_nsobject.h"
+#include "flutter/fml/platform/darwin/scoped_nsautorelease_pool.h"
+#include "flutter/fml/platform/darwin/scoped_nsobject.h"
+
+namespace {
+// The key needed by objc_setAssociatedObject.
+char sentinelObserverKey_;
+}  // namespace
+
+@interface CRBWeakNSProtocolSentinel ()
+// Container to notify on dealloc.
+@property(readonly, assign) fml::RefPtr<fml::WeakContainer> container;
+// Designed initializer.
+- (id)initWithContainer:(fml::RefPtr<fml::WeakContainer>)container;
+@end
+
+@implementation CRBWeakNSProtocolSentinel
+
+@synthesize container = container_;
+
++ (fml::RefPtr<fml::WeakContainer>)containerForObject:(id)object
+                                        threadChecker:
+                                            (std::shared_ptr<debug::DebugThreadChecker>)checker {
+  if (object == nil)
+    return nullptr;
+  // The autoreleasePool is needed here as the call to objc_getAssociatedObject
+  // returns an autoreleased object which is better released sooner than later.
+  fml::ScopedNSAutoreleasePool pool;
+  CRBWeakNSProtocolSentinel* sentinel = objc_getAssociatedObject(object, &sentinelObserverKey_);
+  if (!sentinel) {
+    fml::scoped_nsobject<CRBWeakNSProtocolSentinel> newSentinel([[CRBWeakNSProtocolSentinel alloc]
+        initWithContainer:AdoptRef(new fml::WeakContainer(object, checker))]);
+    sentinel = newSentinel;
+    objc_setAssociatedObject(object, &sentinelObserverKey_, sentinel, OBJC_ASSOCIATION_RETAIN);
+    // The retain count is 2. One retain is due to the alloc, the other to the
+    // association with the weak object.
+    FML_DCHECK(2u == [sentinel retainCount]);
+  }
+  return [sentinel container];
+}
+
+- (id)initWithContainer:(fml::RefPtr<fml::WeakContainer>)container {
+  FML_DCHECK(container.get());
+  self = [super init];
+  if (self) {
+    container_ = container;
+  }
+  return self;
+}
+
+- (void)dealloc {
+  self.container->nullify();
+  [super dealloc];
+}
+
+@end

--- a/fml/platform/darwin/weak_nsobject.mm
+++ b/fml/platform/darwin/weak_nsobject.mm
@@ -11,6 +11,15 @@ namespace {
 char sentinelObserverKey_;
 }  // namespace
 
+namespace fml {
+
+WeakContainer::WeakContainer(id object, debug::DebugThreadChecker checker)
+    : checker_(checker), object_(object) {}
+
+WeakContainer::~WeakContainer() {}
+
+}  // namespace fml
+
 @interface CRBWeakNSProtocolSentinel ()
 // Container to notify on dealloc.
 @property(readonly, assign) fml::RefPtr<fml::WeakContainer> container;

--- a/fml/platform/darwin/weak_nsobject_arc_unittests.mm
+++ b/fml/platform/darwin/weak_nsobject_arc_unittests.mm
@@ -1,0 +1,121 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/platform/darwin/scoped_nsobject.h"
+#include "flutter/fml/platform/darwin/weak_nsobject.h"
+#include "flutter/fml/task_runner.h"
+#include "flutter/fml/thread.h"
+#include "gtest/gtest.h"
+
+#if !defined(__has_feature) || !__has_feature(objc_arc)
+#error "This file requires ARC support."
+#endif
+
+namespace fml {
+namespace {
+
+TEST(WeakNSObjectTestARC, WeakNSObject) {
+  scoped_nsobject<NSObject> p1;
+  WeakNSObject<NSObject> w1;
+  @autoreleasepool {
+    p1.reset(([[NSObject alloc] init]));
+    WeakNSObjectFactory factory(p1.get());
+    w1 = factory.GetWeakNSObject();
+    EXPECT_TRUE(w1);
+    p1.reset();
+  }
+  EXPECT_FALSE(w1);
+}
+
+TEST(WeakNSObjectTestARC, MultipleWeakNSObject) {
+  scoped_nsobject<NSObject> p1;
+  WeakNSObject<NSObject> w1;
+  WeakNSObject<NSObject> w2;
+  @autoreleasepool {
+    p1.reset([[NSObject alloc] init]);
+    WeakNSObjectFactory factory(p1.get());
+    w1 = factory.GetWeakNSObject();
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    w2 = w1;
+    EXPECT_TRUE(w1);
+    EXPECT_TRUE(w2);
+    EXPECT_TRUE(w1.get() == w2.get());
+    p1.reset();
+  }
+  EXPECT_FALSE(w1);
+  EXPECT_FALSE(w2);
+}
+
+TEST(WeakNSObjectTestARC, WeakNSObjectDies) {
+  scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+  WeakNSObjectFactory factory(p1.get());
+  {
+    WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+    EXPECT_TRUE(w1);
+  }
+}
+
+TEST(WeakNSObjectTestARC, WeakNSObjectReset) {
+  scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+  WeakNSObjectFactory factory(p1.get());
+  WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+  EXPECT_TRUE(w1);
+  w1.reset();
+  EXPECT_FALSE(w1);
+  EXPECT_TRUE(p1);
+  EXPECT_TRUE([p1 description]);
+}
+
+TEST(WeakNSObjectTestARC, WeakNSObjectEmpty) {
+  scoped_nsobject<NSObject> p1;
+  WeakNSObject<NSObject> w1;
+  @autoreleasepool {
+    scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+    EXPECT_FALSE(w1);
+    WeakNSObjectFactory factory(p1.get());
+    w1 = factory.GetWeakNSObject();
+    EXPECT_TRUE(w1);
+    p1.reset();
+  }
+  EXPECT_FALSE(w1);
+}
+
+TEST(WeakNSObjectTestARC, WeakNSObjectCopy) {
+  scoped_nsobject<NSObject> p1;
+  WeakNSObject<NSObject> w1;
+  WeakNSObject<NSObject> w2;
+  @autoreleasepool {
+    scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+    WeakNSObjectFactory factory(p1.get());
+    w1 = factory.GetWeakNSObject();
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    w2 = w1;
+    EXPECT_TRUE(w1);
+    EXPECT_TRUE(w2);
+    p1.reset();
+  }
+  EXPECT_FALSE(w1);
+  EXPECT_FALSE(w2);
+}
+
+TEST(WeakNSObjectTestARC, WeakNSObjectAssignment) {
+  scoped_nsobject<NSObject> p1;
+  WeakNSObject<NSObject> w1;
+  WeakNSObject<NSObject> w2;
+  @autoreleasepool {
+    scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+    WeakNSObjectFactory factory(p1.get());
+    w1 = factory.GetWeakNSObject();
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    w2 = w1;
+    EXPECT_TRUE(w1);
+    EXPECT_TRUE(w2);
+    p1.reset();
+  }
+  EXPECT_FALSE(w1);
+  EXPECT_FALSE(w2);
+}
+}  // namespace
+}  // namespace fml

--- a/fml/platform/darwin/weak_nsobject_unittests.mm
+++ b/fml/platform/darwin/weak_nsobject_unittests.mm
@@ -1,0 +1,92 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/platform/darwin/scoped_nsobject.h"
+#include "flutter/fml/platform/darwin/weak_nsobject.h"
+#include "flutter/fml/task_runner.h"
+#include "flutter/fml/thread.h"
+#include "gtest/gtest.h"
+
+namespace fml {
+namespace {
+
+TEST(WeakNSObjectTest, WeakNSObject) {
+  scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+  WeakNSObjectFactory factory(p1.get());
+  WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+  EXPECT_TRUE(w1);
+  p1.reset();
+  EXPECT_FALSE(w1);
+}
+
+TEST(WeakNSObjectTest, MultipleWeakNSObject) {
+  scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+  WeakNSObjectFactory factory(p1.get());
+  WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+  WeakNSObject<NSObject> w2(w1);
+  EXPECT_TRUE(w1);
+  EXPECT_TRUE(w2);
+  EXPECT_TRUE(w1.get() == w2.get());
+  p1.reset();
+  EXPECT_FALSE(w1);
+  EXPECT_FALSE(w2);
+}
+
+TEST(WeakNSObjectTest, WeakNSObjectDies) {
+  scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+  WeakNSObjectFactory factory(p1.get());
+  {
+    WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+    EXPECT_TRUE(w1);
+  }
+}
+
+TEST(WeakNSObjectTest, WeakNSObjectReset) {
+  scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+  WeakNSObjectFactory factory(p1.get());
+  WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+  EXPECT_TRUE(w1);
+  w1.reset();
+  EXPECT_FALSE(w1);
+  EXPECT_TRUE(p1);
+  EXPECT_TRUE([p1 description]);
+}
+
+TEST(WeakNSObjectTest, WeakNSObjectEmpty) {
+  scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+  WeakNSObject<NSObject> w1;
+  EXPECT_FALSE(w1);
+  WeakNSObjectFactory factory(p1.get());
+  w1 = factory.GetWeakNSObject();
+  EXPECT_TRUE(w1);
+  p1.reset();
+  EXPECT_FALSE(w1);
+}
+
+TEST(WeakNSObjectTest, WeakNSObjectCopy) {
+  scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+  WeakNSObjectFactory factory(p1.get());
+  WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+  WeakNSObject<NSObject> w2(w1);
+  EXPECT_TRUE(w1);
+  EXPECT_TRUE(w2);
+  p1.reset();
+  EXPECT_FALSE(w1);
+  EXPECT_FALSE(w2);
+}
+
+TEST(WeakNSObjectTest, WeakNSObjectAssignment) {
+  scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
+  WeakNSObjectFactory factory(p1.get());
+  WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+  WeakNSObject<NSObject> w2 = w1;
+  EXPECT_TRUE(w1);
+  EXPECT_TRUE(w2);
+  p1.reset();
+  EXPECT_FALSE(w1);
+  EXPECT_FALSE(w2);
+}
+}  // namespace
+}  // namespace fml

--- a/fml/platform/darwin/weak_nsobject_unittests.mm
+++ b/fml/platform/darwin/weak_nsobject_unittests.mm
@@ -25,6 +25,7 @@ TEST(WeakNSObjectTest, MultipleWeakNSObject) {
   scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
   WeakNSObjectFactory factory(p1.get());
   WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   WeakNSObject<NSObject> w2(w1);
   EXPECT_TRUE(w1);
   EXPECT_TRUE(w2);
@@ -69,6 +70,7 @@ TEST(WeakNSObjectTest, WeakNSObjectCopy) {
   scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
   WeakNSObjectFactory factory(p1.get());
   WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   WeakNSObject<NSObject> w2(w1);
   EXPECT_TRUE(w1);
   EXPECT_TRUE(w2);
@@ -81,6 +83,7 @@ TEST(WeakNSObjectTest, WeakNSObjectAssignment) {
   scoped_nsobject<NSObject> p1([[NSObject alloc] init]);
   WeakNSObjectFactory factory(p1.get());
   WeakNSObject<NSObject> w1 = factory.GetWeakNSObject();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   WeakNSObject<NSObject> w2 = w1;
   EXPECT_TRUE(w1);
   EXPECT_TRUE(w2);

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -236,7 +236,6 @@ source_set("ios_test_flutter_mrc") {
   sources = [
     "framework/Source/FlutterEnginePlatformViewTest.mm",
     "framework/Source/FlutterEngineTest_mrc.mm",
-    "framework/Source/FlutterPlatformPluginTest.mm",
     "framework/Source/FlutterPlatformViewsTest.mm",
     "framework/Source/FlutterTouchInterceptingView_Test.h",
     "framework/Source/FlutterViewControllerTest_mrc.mm",
@@ -304,6 +303,7 @@ shared_library("ios_test_flutter") {
     "framework/Source/FlutterFakeKeyEvents.h",
     "framework/Source/FlutterFakeKeyEvents.mm",
     "framework/Source/FlutterKeyboardManagerTest.mm",
+    "framework/Source/FlutterPlatformPluginTest.mm",
     "framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm",
     "framework/Source/FlutterRestorationPluginTest.mm",
     "framework/Source/FlutterSpellCheckPluginTest.mm",

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -119,7 +119,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   NSString* _labelPrefix;
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory;
 
-  fml::WeakPtr<FlutterViewController> _viewController;
+  fml::WeakNSObject<FlutterViewController> _viewController;
   fml::scoped_nsobject<FlutterDartVMServicePublisher> _publisher;
 
   std::shared_ptr<flutter::FlutterPlatformViewsController> _platformViewsController;
@@ -424,8 +424,8 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
 - (void)setViewController:(FlutterViewController*)viewController {
   FML_DCHECK(self.iosPlatformView);
-  _viewController =
-      viewController ? [viewController getWeakPtr] : fml::WeakPtr<FlutterViewController>();
+  _viewController = viewController ? [viewController getWeakNSObject]
+                                   : fml::WeakNSObject<FlutterViewController>();
   self.iosPlatformView->SetOwnerViewController(_viewController);
   [self maybeSetupPlatformViewChannels];
   [self updateDisplays];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -11,6 +11,7 @@
 #include "flutter/common/constants.h"
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/platform/darwin/platform_version.h"
+#include "flutter/fml/platform/darwin/weak_nsobject.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/runtime/ptrace_check.h"
 #include "flutter/shell/common/engine.h"
@@ -116,7 +117,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::ThreadHost> _threadHost;
   std::unique_ptr<flutter::Shell> _shell;
   NSString* _labelPrefix;
-  std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory;
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory;
 
   fml::WeakPtr<FlutterViewController> _viewController;
   fml::scoped_nsobject<FlutterDartVMServicePublisher> _publisher;
@@ -189,7 +190,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   _allowHeadlessExecution = allowHeadlessExecution;
   _labelPrefix = [labelPrefix copy];
 
-  _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(self);
+  _weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(self);
 
   if (project == nil) {
     _dartProject.reset([[FlutterDartProject alloc] init]);
@@ -327,8 +328,8 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   return *_shell;
 }
 
-- (fml::WeakPtr<FlutterEngine>)getWeakPtr {
-  return _weakFactory->GetWeakPtr();
+- (fml::WeakNSObject<FlutterEngine>)getWeakNSObject {
+  return _weakFactory->GetWeakNSObject();
 }
 
 - (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics {
@@ -584,7 +585,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (void)setUpChannels {
   // This will be invoked once the shell is done setting up and the isolate ID
   // for the UI isolate is available.
-  fml::WeakPtr<FlutterEngine> weakSelf = [self getWeakPtr];
+  fml::WeakNSObject<FlutterEngine> weakSelf = [self getWeakNSObject];
   [_binaryMessenger setMessageHandlerOnChannel:@"flutter/isolate"
                           binaryMessageHandler:^(NSData* message, FlutterBinaryReply reply) {
                             if (weakSelf) {
@@ -674,7 +675,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
       [[FlutterUndoManagerPlugin alloc] initWithDelegate:self];
   _undoManagerPlugin.reset(undoManagerPlugin);
 
-  _platformPlugin.reset([[FlutterPlatformPlugin alloc] initWithEngine:[self getWeakPtr]]);
+  _platformPlugin.reset([[FlutterPlatformPlugin alloc] initWithEngine:[self getWeakNSObject]]);
 
   _restorationPlugin.reset([[FlutterRestorationPlugin alloc]
          initWithChannel:_restorationChannel.get()
@@ -719,7 +720,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
       [platformPlugin handleMethodCall:call result:result];
     }];
 
-    fml::WeakPtr<FlutterEngine> weakSelf = [self getWeakPtr];
+    fml::WeakNSObject<FlutterEngine> weakSelf = [self getWeakNSObject];
     [_platformViewsChannel.get()
         setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
           if (weakSelf) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.h
@@ -10,7 +10,6 @@
 #import <Foundation/NSObject.h>
 #import <UIKit/UIKit.h>
 
-#include "flutter/fml/memory/weak_ptr.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyPrimaryResponder.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeySecondaryResponder.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterUIPressProxy.h"

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.h"
-#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/platform/darwin/message_loop_darwin.h"
+#include "flutter/fml/platform/darwin/weak_nsobject.h"
 
 static constexpr CFTimeInterval kDistantFuture = 1.0e10;
 
@@ -29,7 +29,7 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
 @end
 
 @implementation FlutterKeyboardManager {
-  std::unique_ptr<fml::WeakPtrFactory<FlutterKeyboardManager>> _weakFactory;
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterKeyboardManager>> _weakFactory;
 }
 
 - (nonnull instancetype)init {
@@ -37,7 +37,7 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
   if (self != nil) {
     _primaryResponders = [[NSMutableArray alloc] init];
     _secondaryResponders = [[NSMutableArray alloc] init];
-    _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterKeyboardManager>>(self);
+    _weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterKeyboardManager>>(self);
   }
   return self;
 }
@@ -64,8 +64,8 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
   [super dealloc];
 }
 
-- (fml::WeakPtr<FlutterKeyboardManager>)getWeakPtr {
-  return _weakFactory->GetWeakPtr();
+- (fml::WeakNSObject<FlutterKeyboardManager>)getWeakNSObject {
+  return _weakFactory->GetWeakNSObject();
 }
 
 - (void)handlePress:(nonnull FlutterUIPressProxy*)press
@@ -89,7 +89,7 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
       // encounter.
       NSAssert([_primaryResponders count] >= 0, @"At least one primary responder must be added.");
 
-      __block auto weakSelf = [self getWeakPtr];
+      __block auto weakSelf = [self getWeakNSObject];
       __block NSUInteger unreplied = [self.primaryResponders count];
       __block BOOL anyHandled = false;
       FlutterAsyncKeyCallback replyCallback = ^(BOOL handled) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
@@ -5,14 +5,14 @@
 #ifndef SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMPLUGIN_H_
 #define SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMPLUGIN_H_
 
-#include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/fml/platform/darwin/weak_nsobject.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
 
 @interface FlutterPlatformPlugin : NSObject
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-- (instancetype)initWithEngine:(fml::WeakPtr<FlutterEngine>)engine NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithEngine:(fml::WeakNSObject<FlutterEngine>)engine NS_DESIGNATED_INITIALIZER;
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -72,12 +72,12 @@ static void SetStatusBarStyleForSharedApplication(UIStatusBarStyle style) {
 @end
 
 @implementation FlutterPlatformPlugin {
-  fml::WeakPtr<FlutterEngine> _engine;
+  fml::WeakNSObject<FlutterEngine> _engine;
   // Used to detect whether this device has live text input ability or not.
   UITextField* _textField;
 }
 
-- (instancetype)initWithEngine:(fml::WeakPtr<FlutterEngine>)engine {
+- (instancetype)initWithEngine:(fml::WeakNSObject<FlutterEngine>)engine {
   FML_DCHECK(engine) << "engine must be set";
   self = [super init];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -13,6 +13,8 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 
+FLUTTER_ASSERT_ARC
+
 @interface FlutterPlatformPluginTest : XCTestCase
 @end
 
@@ -34,7 +36,7 @@
   id mockApplication = OCMClassMock([UIApplication class]);
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
       std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   [engine runWithEntrypoint:nil];
@@ -43,7 +45,7 @@
       [self expectationWithDescription:@"Web search launched with escaped search term"];
 
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"SearchWeb.invoke"
@@ -68,7 +70,7 @@
   id mockApplication = OCMClassMock([UIApplication class]);
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
       std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   [engine runWithEntrypoint:nil];
@@ -77,7 +79,7 @@
       [self expectationWithDescription:@"Web search launched with non escaped search term"];
 
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"SearchWeb.invoke"
@@ -99,7 +101,7 @@
 }
 
 - (void)testLookUpCallInitiated {
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
       std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
@@ -107,12 +109,13 @@
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Look Up view controller presented"];
 
-  FlutterViewController* engineViewController =
-      [[[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil] autorelease];
+  FlutterViewController* engineViewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                      nibName:nil
+                                                                                       bundle:nil];
   FlutterViewController* mockEngineViewController = OCMPartialMock(engineViewController);
 
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"LookUp.invoke"
@@ -129,7 +132,7 @@
 }
 
 - (void)testShareScreenInvoked {
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
       std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
@@ -137,8 +140,9 @@
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Share view controller presented"];
 
-  FlutterViewController* engineViewController =
-      [[[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil] autorelease];
+  FlutterViewController* engineViewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                      nibName:nil
+                                                                                       bundle:nil];
   FlutterViewController* mockEngineViewController = OCMPartialMock(engineViewController);
   OCMStub([mockEngineViewController
       presentViewController:[OCMArg isKindOfClass:[UIActivityViewController class]]
@@ -146,7 +150,7 @@
                  completion:nil]);
 
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"Share.invoke"
@@ -164,11 +168,11 @@
 
 - (void)testClipboardHasCorrectStrings {
   [UIPasteboard generalPasteboard].string = nil;
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
       std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
 
   XCTestExpectation* setStringExpectation = [self expectationWithDescription:@"setString"];
   FlutterResult resultSet = ^(id result) {
@@ -203,11 +207,11 @@
 
 - (void)testClipboardSetDataToNullDoNotCrash {
   [UIPasteboard generalPasteboard].string = nil;
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
       std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
 
   XCTestExpectation* setStringExpectation = [self expectationWithDescription:@"setData"];
   FlutterResult resultSet = ^(id result) {
@@ -230,18 +234,18 @@
 }
 
 - (void)testPopSystemNavigator {
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
   FlutterViewController* flutterViewController =
       [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-  UINavigationController* navigationController = [[[UINavigationController alloc]
-      initWithRootViewController:flutterViewController] autorelease];
-  UITabBarController* tabBarController = [[[UITabBarController alloc] init] autorelease];
+  UINavigationController* navigationController =
+      [[UINavigationController alloc] initWithRootViewController:flutterViewController];
+  UITabBarController* tabBarController = [[UITabBarController alloc] init];
   tabBarController.viewControllers = @[ navigationController ];
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
       std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
 
   id navigationControllerMock = OCMPartialMock(navigationController);
   OCMStub([navigationControllerMock popViewControllerAnimated:YES]);
@@ -257,17 +261,16 @@
   OCMVerify([navigationControllerMock popViewControllerAnimated:YES]);
 
   [flutterViewController deregisterNotifications];
-  [flutterViewController release];
 }
 
 - (void)testWhetherDeviceHasLiveTextInputInvokeCorrectly {
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
       std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"isLiveTextInputAvailableInvoke"];
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
   FlutterMethodCall* methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"LiveText.isLiveTextInputAvailable"
@@ -286,7 +289,7 @@
       .andReturn(@YES);
   {
     // Enabling system UI overlays to update status bar.
-    FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+    FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
     [engine runWithEntrypoint:nil];
     FlutterViewController* flutterViewController =
         [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
@@ -323,11 +326,10 @@
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     [flutterViewController deregisterNotifications];
-    [flutterViewController release];
   }
   {
     // Enable system UI mode to update status bar.
-    FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
+    FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
     [engine runWithEntrypoint:nil];
     FlutterViewController* flutterViewController =
         [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
@@ -364,7 +366,6 @@
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     [flutterViewController deregisterNotifications];
-    [flutterViewController release];
   }
   [bundleMock stopMocking];
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -290,8 +290,8 @@
     [engine runWithEntrypoint:nil];
     FlutterViewController* flutterViewController =
         [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-    std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-        std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+    std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+        std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     // Update to hidden.
@@ -331,8 +331,8 @@
     [engine runWithEntrypoint:nil];
     FlutterViewController* flutterViewController =
         [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-    std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-        std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+    std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+        std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     // Update to hidden.

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -5,6 +5,7 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#import "flutter/fml/platform/darwin/weak_nsobject.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
@@ -34,15 +35,15 @@
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 
   FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
-  std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   [engine runWithEntrypoint:nil];
 
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"Web search launched with escaped search term"];
 
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakPtr()] autorelease];
+      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"SearchWeb.invoke"
@@ -68,15 +69,15 @@
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 
   FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
-  std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   [engine runWithEntrypoint:nil];
 
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"Web search launched with non escaped search term"];
 
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakPtr()] autorelease];
+      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"SearchWeb.invoke"
@@ -100,8 +101,8 @@
 - (void)testLookUpCallInitiated {
   FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
   [engine runWithEntrypoint:nil];
-  std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Look Up view controller presented"];
@@ -111,7 +112,7 @@
   FlutterViewController* mockEngineViewController = OCMPartialMock(engineViewController);
 
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakPtr()] autorelease];
+      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"LookUp.invoke"
@@ -130,8 +131,8 @@
 - (void)testShareScreenInvoked {
   FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
   [engine runWithEntrypoint:nil];
-  std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Share view controller presented"];
@@ -145,7 +146,7 @@
                  completion:nil]);
 
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakPtr()] autorelease];
+      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"Share.invoke"
@@ -164,10 +165,10 @@
 - (void)testClipboardHasCorrectStrings {
   [UIPasteboard generalPasteboard].string = nil;
   FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
-  std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakPtr()] autorelease];
+      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
 
   XCTestExpectation* setStringExpectation = [self expectationWithDescription:@"setString"];
   FlutterResult resultSet = ^(id result) {
@@ -203,10 +204,10 @@
 - (void)testClipboardSetDataToNullDoNotCrash {
   [UIPasteboard generalPasteboard].string = nil;
   FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
-  std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakPtr()] autorelease];
+      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
 
   XCTestExpectation* setStringExpectation = [self expectationWithDescription:@"setData"];
   FlutterResult resultSet = ^(id result) {
@@ -237,10 +238,10 @@
       initWithRootViewController:flutterViewController] autorelease];
   UITabBarController* tabBarController = [[[UITabBarController alloc] init] autorelease];
   tabBarController.viewControllers = @[ navigationController ];
-  std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakPtr()] autorelease];
+      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
 
   id navigationControllerMock = OCMPartialMock(navigationController);
   OCMStub([navigationControllerMock popViewControllerAnimated:YES]);
@@ -261,12 +262,12 @@
 
 - (void)testWhetherDeviceHasLiveTextInputInvokeCorrectly {
   FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"test" project:nil] autorelease];
-  std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakPtrFactory<FlutterEngine>>(engine);
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"isLiveTextInputAvailableInvoke"];
   FlutterPlatformPlugin* plugin =
-      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakPtr()] autorelease];
+      [[[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()] autorelease];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
   FlutterMethodCall* methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"LiveText.isLiveTextInputAvailable"

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -112,7 +112,7 @@ typedef struct MouseState {
 @end
 
 @implementation FlutterViewController {
-  std::unique_ptr<fml::WeakPtrFactory<FlutterViewController>> _weakFactory;
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterViewController>> _weakFactory;
   fml::scoped_nsobject<FlutterEngine> _engine;
 
   // We keep a separate reference to this and create it ahead of time because we want to be able to
@@ -171,7 +171,7 @@ typedef struct MouseState {
     _flutterView.reset([[FlutterView alloc] initWithDelegate:_engine
                                                       opaque:self.isViewOpaque
                                              enableWideGamut:engine.project.isWideGamutEnabled]);
-    _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(self);
+    _weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterViewController>>(self);
     _ongoingTouches.reset([[NSMutableSet alloc] init]);
 
     [self performCommonViewControllerInitialization];
@@ -232,7 +232,7 @@ typedef struct MouseState {
     project = [[[FlutterDartProject alloc] init] autorelease];
   }
   FlutterView.forceSoftwareRendering = project.settings.enable_software_rendering;
-  _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(self);
+  _weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterViewController>>(self);
   auto engine = fml::scoped_nsobject<FlutterEngine>{[[FlutterEngine alloc]
                 initWithName:@"io.flutter"
                      project:project
@@ -286,8 +286,8 @@ typedef struct MouseState {
   return _engine.get();
 }
 
-- (fml::WeakPtr<FlutterViewController>)getWeakPtr {
-  return _weakFactory->GetWeakPtr();
+- (fml::WeakNSObject<FlutterViewController>)getWeakNSObject {
+  return _weakFactory->GetWeakNSObject();
 }
 
 - (void)setUpNotificationCenterObservers {
@@ -617,7 +617,7 @@ static void SendFakeTouchEvent(UIScreen* screen,
   }
 
   // Start on the platform thread.
-  weakPlatformView->SetNextFrameCallback([weakSelf = [self getWeakPtr],
+  weakPlatformView->SetNextFrameCallback([weakSelf = [self getWeakNSObject],
                                           platformTaskRunner = [_engine.get() platformTaskRunner],
                                           rasterTaskRunner = [_engine.get() rasterTaskRunner]]() {
     FML_DCHECK(rasterTaskRunner->RunsTasksOnCurrentThread());
@@ -800,7 +800,7 @@ static void SendFakeTouchEvent(UIScreen* screen,
 
 - (void)addInternalPlugins {
   self.keyboardManager = [[[FlutterKeyboardManager alloc] init] autorelease];
-  fml::WeakPtr<FlutterViewController> weakSelf = [self getWeakPtr];
+  fml::WeakNSObject<FlutterViewController> weakSelf = [self getWeakNSObject];
   FlutterSendKeyEvent sendEvent =
       ^(const FlutterKeyEvent& event, FlutterKeyEventCallback callback, void* userData) {
         if (weakSelf) {
@@ -1702,7 +1702,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   // Invalidate old vsync client if old animation is not completed.
   [self invalidateKeyboardAnimationVSyncClient];
 
-  fml::WeakPtr<FlutterViewController> weakSelf = [self getWeakPtr];
+  fml::WeakNSObject<FlutterViewController> weakSelf = [self getWeakNSObject];
   FlutterKeyboardAnimationCallback keyboardAnimationCallback = ^(
       fml::TimePoint keyboardAnimationTargetTime) {
     if (!weakSelf) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -5,7 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERVIEWCONTROLLER_INTERNAL_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERVIEWCONTROLLER_INTERNAL_H_
 
-#include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/fml/platform/darwin/weak_nsobject.h"
+#include "flutter/fml/time/time_point.h"
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeySecondaryResponder.h"
@@ -51,7 +52,7 @@ typedef void (^FlutterKeyboardAnimationCallback)(fml::TimePoint);
  */
 @property(nonatomic, assign, readwrite) BOOL prefersStatusBarHidden;
 
-- (fml::WeakPtr<FlutterViewController>)getWeakPtr;
+- (fml::WeakNSObject<FlutterViewController>)getWeakNSObject;
 - (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
 - (FlutterRestorationPlugin*)restorationPlugin;
 // Send touches to the Flutter Engine while forcing the change type to be cancelled.

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -1979,8 +1979,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
   fml::AutoResetWaitableEvent latch;
   thread_task_runner->PostTask([&] {
     auto weakFactory =
-        std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(flutterViewController);
-    platform_view->SetOwnerViewController(weakFactory->GetWeakPtr());
+        std::make_unique<fml::WeakNSObjectFactory<FlutterViewController>>(flutterViewController);
+    platform_view->SetOwnerViewController(weakFactory->GetWeakNSObject());
     auto bridge =
         std::make_unique<flutter::AccessibilityBridge>(/*view=*/nil,
                                                        /*platform_view=*/platform_view.get(),
@@ -2067,9 +2067,9 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
         std::make_shared<flutter::FlutterPlatformViewsController>();
     OCMStub([mockFlutterViewController platformViewsController])
         .andReturn(flutterPlatformViewsController.get());
-    auto weakFactory =
-        std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(mockFlutterViewController);
-    platform_view->SetOwnerViewController(weakFactory->GetWeakPtr());
+    auto weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterViewController>>(
+        mockFlutterViewController);
+    platform_view->SetOwnerViewController(weakFactory->GetWeakNSObject());
 
     platform_view->SetSemanticsEnabled(true);
     XCTAssertNotEqual(test_delegate.set_semantics_enabled_calls, 0);

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -9,8 +9,8 @@
 
 #include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
-#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
+#include "flutter/fml/platform/darwin/weak_nsobject.h"
 #include "flutter/shell/common/platform_view.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
@@ -59,14 +59,14 @@ class PlatformViewIOS final : public PlatformView {
    * Returns the `FlutterViewController` currently attached to the `FlutterEngine` owning
    * this PlatformViewIOS.
    */
-  fml::WeakPtr<FlutterViewController> GetOwnerViewController() const;
+  fml::WeakNSObject<FlutterViewController> GetOwnerViewController() const;
 
   /**
    * Updates the `FlutterViewController` currently attached to the `FlutterEngine` owning
    * this PlatformViewIOS. This should be updated when the `FlutterEngine`
    * is given a new `FlutterViewController`.
    */
-  void SetOwnerViewController(const fml::WeakPtr<FlutterViewController>& owner_controller);
+  void SetOwnerViewController(const fml::WeakNSObject<FlutterViewController>& owner_controller);
 
   /**
    * Called one time per `FlutterViewController` when the `FlutterViewController`'s
@@ -133,7 +133,7 @@ class PlatformViewIOS final : public PlatformView {
     std::function<void(bool)> set_semantics_enabled_;
   };
 
-  fml::WeakPtr<FlutterViewController> owner_controller_;
+  fml::WeakNSObject<FlutterViewController> owner_controller_;
   // Since the `ios_surface_` is created on the platform thread but
   // used on the raster thread we need to protect it with a mutex.
   std::mutex ios_surface_mutex_;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -76,12 +76,12 @@ void PlatformViewIOS::HandlePlatformMessage(std::unique_ptr<flutter::PlatformMes
   platform_message_handler_->HandlePlatformMessage(std::move(message));
 }
 
-fml::WeakPtr<FlutterViewController> PlatformViewIOS::GetOwnerViewController() const {
+fml::WeakNSObject<FlutterViewController> PlatformViewIOS::GetOwnerViewController() const {
   return owner_controller_;
 }
 
 void PlatformViewIOS::SetOwnerViewController(
-    const fml::WeakPtr<FlutterViewController>& owner_controller) {
+    const fml::WeakNSObject<FlutterViewController>& owner_controller) {
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
   std::lock_guard<std::mutex> guard(ios_surface_mutex_);
   if (ios_surface_ || !owner_controller) {


### PR DESCRIPTION
Introduce weak_nsobject from chromium. 

There are some usages of weak_ptr wrapping Objective-C ids, weak_ptr is not really designed for ids and such usages are blocking the arc migration. 

This PR mostly copies the weak_nsobject from chromium, at the same hash that we copied the ARC/MRC compatible scoped_nsobject: https://chromium.googlesource.com/chromium/src/+/fd625125b8a6a3aceaf09993a5f74cfe5368b17f

To match how we used weak_ptr for those ids, I made some changes to the weak_nsobject:
- WeakNSObjects needs to be generated by a WeakNSObjectFactory. The WeakNSObjectFactory is owned by the objc class and acts as the generator of the WeakNSObjects. All the WeakNSObjects' derefing thread should be the same of the WeakNSObjectFactory's creation thread.
- chromuim's WeakNSObjects can be detached from the thread and re-attached to a new thread. To match our weak_ptr behavior, I changed WeakNSObjects to be only accessed from a single thread, the same as weak_ptr

This PR also moves the FlutterEngine to use WeakNSObject and updated related classes.

part of https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
