### PR TITLE
[engine] request frame rate once per frame.

### DIFF
--- a/flow/stopwatch.cc
+++ b/flow/stopwatch.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/stopwatch.h"
+#include "fml/trace_event.h"
 
 namespace flutter {
 
@@ -57,7 +58,7 @@ size_t Stopwatch::GetCurrentSample() const {
 }
 
 double StopwatchVisualizer::UnitFrameInterval(double raster_time_ms) const {
-  return raster_time_ms / stopwatch_.GetFrameBudget().count();
+  return raster_time_ms / frame_budget_.count();
 }
 
 double StopwatchVisualizer::UnitHeight(double raster_time_ms,
@@ -88,6 +89,7 @@ fml::TimeDelta Stopwatch::AverageDelta() const {
 }
 
 fml::Milliseconds Stopwatch::GetFrameBudget() const {
+  TRACE_EVENT0("flutter", "Stopwatch::GetFrameBudget");
   return refresh_rate_updater_.GetFrameBudget();
 }
 

--- a/flow/stopwatch.cc
+++ b/flow/stopwatch.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/stopwatch.h"
-#include "fml/trace_event.h"
 
 namespace flutter {
 
@@ -89,7 +88,6 @@ fml::TimeDelta Stopwatch::AverageDelta() const {
 }
 
 fml::Milliseconds Stopwatch::GetFrameBudget() const {
-  TRACE_EVENT0("flutter", "Stopwatch::GetFrameBudget");
   return refresh_rate_updater_.GetFrameBudget();
 }
 

--- a/flow/stopwatch.h
+++ b/flow/stopwatch.h
@@ -93,7 +93,9 @@ class FixedRefreshRateStopwatch : public Stopwatch {
 class StopwatchVisualizer {
  public:
   explicit StopwatchVisualizer(const Stopwatch& stopwatch)
-      : stopwatch_(stopwatch) {}
+      : stopwatch_(stopwatch) {
+    frame_budget_ = stopwatch_.GetFrameBudget();
+  }
 
   virtual ~StopwatchVisualizer() = default;
 
@@ -112,7 +114,10 @@ class StopwatchVisualizer {
   /// @brief      Converts a raster time to a unit height.
   double UnitHeight(double time_ms, double max_height) const;
 
+  fml::Milliseconds GetFrameBudget() const { return frame_budget_; }
+
   const Stopwatch& stopwatch_;
+  fml::Milliseconds frame_budget_;
 };
 
 }  // namespace flutter

--- a/flow/stopwatch.h
+++ b/flow/stopwatch.h
@@ -94,6 +94,9 @@ class StopwatchVisualizer {
  public:
   explicit StopwatchVisualizer(const Stopwatch& stopwatch)
       : stopwatch_(stopwatch) {
+    // Looking up the frame budget from the stopwatch delegate class may call
+    // into JNI or make platform calls which are slow. This value is safe to
+    // cache since the StopwatchVisualizer is recreated on each frame.
     frame_budget_ = stopwatch_.GetFrameBudget();
   }
 

--- a/flow/stopwatch_dl.cc
+++ b/flow/stopwatch_dl.cc
@@ -30,7 +30,7 @@ void DlStopwatchVisualizer::Visualize(DlCanvas* canvas,
   auto const bottom = rect.bottom();
 
   // Scale the graph to show time frames up to those that are 3x the frame time.
-  auto const one_frame_ms = stopwatch_.GetFrameBudget().count();
+  auto const one_frame_ms = GetFrameBudget().count();
   auto const max_interval = one_frame_ms * 3.0;
   auto const max_unit_interval = UnitFrameInterval(max_interval);
   auto const sample_unit_width = (1.0 / kMaxSamples);

--- a/flow/stopwatch_sk.cc
+++ b/flow/stopwatch_sk.cc
@@ -47,7 +47,7 @@ void SkStopwatchVisualizer::InitVisualizeSurface(SkISize size) const {
 
   // Scale the graph to show frame times up to those that are 3 times the frame
   // time.
-  const double one_frame_ms = stopwatch_.GetFrameBudget().count();
+  const double one_frame_ms = GetFrameBudget().count();
   const double max_interval = one_frame_ms * 3.0;
   const double max_unit_interval = UnitFrameInterval(max_interval);
 
@@ -101,7 +101,7 @@ void SkStopwatchVisualizer::Visualize(DlCanvas* canvas,
 
   // Scale the graph to show frame times up to those that are 3 times the frame
   // time.
-  const double one_frame_ms = stopwatch_.GetFrameBudget().count();
+  const double one_frame_ms = GetFrameBudget().count();
   const double max_interval = one_frame_ms * 3.0;
   const double max_unit_interval = UnitFrameInterval(max_interval);
 


### PR DESCRIPTION
With the current stopwatch design, we request the frame rate multiple times per frame. On Android this calls into JNI which is pretty slow. If we cache the value at construction of the StopwatchVisualizer, then we will only compute it once per frame (because the StopwatchVisualizer is reconstructed each frame).

Fixes https://github.com/flutter/flutter/issues/137797

So the issue isn't that we're checking the fresh rate every frame, its that we were checking N times on each frame.
