### PR TITLE
[Impeller] Simplify convex tessellation

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -29,6 +29,7 @@
 #include "impeller/geometry/constants.h"
 #include "impeller/geometry/geometry_asserts.h"
 #include "impeller/geometry/matrix.h"
+#include "impeller/geometry/path.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/golden_tests/golden_playground_test.h"
 #include "impeller/playground/widgets.h"
@@ -3488,6 +3489,19 @@ TEST_P(AiksTest, CanCanvasDrawPictureWithAdvancedBlend) {
   canvas.DrawPaint({.color = Color::Black()});
   canvas.DrawCircle(Point::MakeXY(150, 150), 25, {.color = Color::Red()});
   canvas.DrawPicture(picture);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, CanDrawMultiContourConvexPath) {
+  PathBuilder builder = {};
+  for (auto i = 0; i < 10; i++) {
+    builder.AddCircle(Point(100 + 10 * i, 100 + 10 * i), 100);
+  }
+  builder.SetConvexity(Convexity::kConvex);
+
+  Canvas canvas;
+  canvas.DrawPath(builder.TakePath(), {.color = Color::Red().WithAlpha(0.4)});
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -27,8 +27,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
 
     vertex_buffer.vertex_buffer = host_buffer.Emplace(
         points.data(), points.size() * sizeof(Point), alignof(Point));
-    vertex_buffer.index_buffer = {},
-    vertex_buffer.vertex_count = points.size();
+    vertex_buffer.index_buffer = {}, vertex_buffer.vertex_count = points.size();
     vertex_buffer.index_type = IndexType::kNone;
 
     return GeometryResult{

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -22,18 +22,17 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
 
   if (path_.GetFillType() == FillType::kNonZero &&  //
       path_.IsConvex()) {
-    auto [points, indices] = renderer.GetTessellator()->TessellateConvex(
+    auto points = renderer.GetTessellator()->TessellateConvex(
         path_, entity.GetTransformation().GetMaxBasisLength());
 
     vertex_buffer.vertex_buffer = host_buffer.Emplace(
         points.data(), points.size() * sizeof(Point), alignof(Point));
-    vertex_buffer.index_buffer = host_buffer.Emplace(
-        indices.data(), indices.size() * sizeof(uint16_t), alignof(uint16_t));
-    vertex_buffer.vertex_count = indices.size();
-    vertex_buffer.index_type = IndexType::k16bit;
+    vertex_buffer.index_buffer = {},
+    vertex_buffer.vertex_count = points.size();
+    vertex_buffer.index_type = IndexType::kNone;
 
     return GeometryResult{
-        .type = PrimitiveType::kTriangle,
+        .type = PrimitiveType::kTriangleStrip,
         .vertex_buffer = vertex_buffer,
         .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
                      entity.GetTransformation(),
@@ -86,24 +85,20 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
 
   if (path_.GetFillType() == FillType::kNonZero &&  //
       path_.IsConvex()) {
-    auto [points, indices] = renderer.GetTessellator()->TessellateConvex(
+    auto points = renderer.GetTessellator()->TessellateConvex(
         path_, entity.GetTransformation().GetMaxBasisLength());
 
     VertexBufferBuilder<VS::PerVertexData> vertex_builder;
     vertex_builder.Reserve(points.size());
-    vertex_builder.ReserveIndices(indices.size());
     for (auto i = 0u; i < points.size(); i++) {
       VS::PerVertexData data;
       data.position = points[i];
       data.texture_coords = uv_transform * points[i];
       vertex_builder.AppendVertex(data);
     }
-    for (auto i = 0u; i < indices.size(); i++) {
-      vertex_builder.AppendIndex(indices[i]);
-    }
 
     return GeometryResult{
-        .type = PrimitiveType::kTriangle,
+        .type = PrimitiveType::kTriangleStrip,
         .vertex_buffer =
             vertex_builder.CreateVertexBuffer(pass.GetTransientsBuffer()),
         .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/geometry/geometry_benchmarks.cc
+++ b/impeller/geometry/geometry_benchmarks.cc
@@ -74,9 +74,9 @@ static void BM_Convex(benchmark::State& state, Args&&... args) {
   auto points = std::make_unique<std::vector<Point>>();
   points->reserve(2048);
   while (state.KeepRunning()) {
-    auto [points, index] = tess.TessellateConvex(path, 1.0f);
-    single_point_count = index.size();
-    point_count += index.size();
+    auto points = tess.TessellateConvex(path, 1.0f);
+    single_point_count = points.size();
+    point_count += points.size();
   }
   state.counters["SinglePointCount"] = single_point_count;
   state.counters["TotalPointCount"] = point_count;

--- a/impeller/geometry/geometry_benchmarks.cc
+++ b/impeller/geometry/geometry_benchmarks.cc
@@ -92,8 +92,8 @@ namespace {
 
 Path CreateRRect() {
   return PathBuilder{}
-    .AddRoundedRect(Rect::MakeLTRB(0, 0, 400, 400), 16)
-    .TakePath();
+      .AddRoundedRect(Rect::MakeLTRB(0, 0, 400, 400), 16)
+      .TakePath();
 }
 
 Path CreateCubic() {

--- a/impeller/geometry/geometry_benchmarks.cc
+++ b/impeller/geometry/geometry_benchmarks.cc
@@ -16,6 +16,8 @@ namespace {
 Path CreateCubic();
 /// Similar to the path above, but with all cubics replaced by quadratics.
 Path CreateQuadratic();
+/// Create a rounded rect.
+Path CreateRRect();
 }  // namespace
 
 static Tessellator tess;
@@ -62,12 +64,38 @@ static void BM_Polyline(benchmark::State& state, Args&&... args) {
   state.counters["TotalPointCount"] = point_count;
 }
 
+template <class... Args>
+static void BM_Convex(benchmark::State& state, Args&&... args) {
+  auto args_tuple = std::make_tuple(std::move(args)...);
+  auto path = std::get<Path>(args_tuple);
+
+  size_t point_count = 0u;
+  size_t single_point_count = 0u;
+  auto points = std::make_unique<std::vector<Point>>();
+  points->reserve(2048);
+  while (state.KeepRunning()) {
+    auto [points, index] = tess.TessellateConvex(path, 1.0f);
+    single_point_count = index.size();
+    point_count += index.size();
+  }
+  state.counters["SinglePointCount"] = single_point_count;
+  state.counters["TotalPointCount"] = point_count;
+}
+
 BENCHMARK_CAPTURE(BM_Polyline, cubic_polyline, CreateCubic(), false);
 BENCHMARK_CAPTURE(BM_Polyline, cubic_polyline_tess, CreateCubic(), true);
 BENCHMARK_CAPTURE(BM_Polyline, quad_polyline, CreateQuadratic(), false);
 BENCHMARK_CAPTURE(BM_Polyline, quad_polyline_tess, CreateQuadratic(), true);
+BENCHMARK_CAPTURE(BM_Convex, rrect_convex, CreateRRect(), true);
 
 namespace {
+
+Path CreateRRect() {
+  return PathBuilder{}
+    .AddRoundedRect(Rect::MakeLTRB(0, 0, 400, 400), 16)
+    .TakePath();
+}
+
 Path CreateCubic() {
   return PathBuilder{}
       .MoveTo({359.934, 96.6335})

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -4,8 +4,8 @@
 
 #include "impeller/tessellator/tessellator.h"
 
-#include "third_party/libtess2/Include/tesselator.h"
 #include "flutter/fml/logging.h"
+#include "third_party/libtess2/Include/tesselator.h"
 
 namespace impeller {
 
@@ -243,7 +243,8 @@ std::vector<Point> Tessellator::TessellateConvex(const Path& path,
                             point_buffer_ = std::move(point_buffer);
                           });
 
-  output.reserve(polyline.points->size() + (4 * (polyline.contours.size() - 1)));
+  output.reserve(polyline.points->size() +
+                 (4 * (polyline.contours.size() - 1)));
   for (auto j = 0u; j < polyline.contours.size(); j++) {
     auto [start, end] = polyline.GetContourPointBounds(j);
     auto origin = polyline.GetPoint(start);

--- a/impeller/tessellator/tessellator.h
+++ b/impeller/tessellator/tessellator.h
@@ -84,10 +84,9 @@ class Tessellator {
   ///                        Matrix::GetMaxBasisLength of the CTM applied to the
   ///                        path for rendering.
   ///
-  /// @return A point vector containing the vertices and a vector of indices
-  ///         into the point vector.
+  /// @return A point vector containing the vertices in triangle strip format.
   ///
-  std::pair<std::vector<Point>, std::vector<uint16_t>> TessellateConvex(
+  std::vector<Point> TessellateConvex(
       const Path& path,
       Scalar tolerance);
 

--- a/impeller/tessellator/tessellator.h
+++ b/impeller/tessellator/tessellator.h
@@ -86,9 +86,7 @@ class Tessellator {
   ///
   /// @return A point vector containing the vertices in triangle strip format.
   ///
-  std::vector<Point> TessellateConvex(
-      const Path& path,
-      Scalar tolerance);
+  std::vector<Point> TessellateConvex(const Path& path, Scalar tolerance);
 
  private:
   /// Used for polyline generation.

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -129,20 +129,18 @@ TEST(TessellatorTest, TessellateConvex) {
   {
     Tessellator t;
     // Sanity check simple rectangle.
-    auto [pts, indices] = t.TessellateConvex(
+    auto pts = t.TessellateConvex(
         PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 10, 10)).TakePath(), 1.0);
 
     std::vector<Point> expected = {
         {0, 0}, {10, 0}, {10, 10}, {0, 10},  //
     };
-    std::vector<uint16_t> expected_indices = {0, 1, 2, 0, 2, 3};
     ASSERT_EQ(pts, expected);
-    ASSERT_EQ(indices, expected_indices);
   }
 
   {
     Tessellator t;
-    auto [pts, indices] =
+    auto pts =
         t.TessellateConvex(PathBuilder{}
                                .AddRect(Rect::MakeLTRB(0, 0, 10, 10))
                                .AddRect(Rect::MakeLTRB(20, 20, 30, 30))
@@ -153,10 +151,7 @@ TEST(TessellatorTest, TessellateConvex) {
         {0, 0},   {10, 0},  {10, 10}, {0, 10},  //
         {20, 20}, {30, 20}, {30, 30}, {20, 30}  //
     };
-    std::vector<uint16_t> expected_indices = {0, 1, 2, 0, 2, 3,
-                                              0, 6, 7, 0, 7, 8};
     ASSERT_EQ(pts, expected);
-    ASSERT_EQ(indices, expected_indices);
   }
 }
 

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -133,25 +133,25 @@ TEST(TessellatorTest, TessellateConvex) {
         PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 10, 10)).TakePath(), 1.0);
 
     std::vector<Point> expected = {
-        {0, 0}, {10, 0}, {10, 10}, {0, 10},  //
+        {0, 0}, {10, 0}, {0, 10}, {10, 10},  //
     };
-    ASSERT_EQ(pts, expected);
+    EXPECT_EQ(pts, expected);
   }
 
   {
     Tessellator t;
-    auto pts =
-        t.TessellateConvex(PathBuilder{}
-                               .AddRect(Rect::MakeLTRB(0, 0, 10, 10))
-                               .AddRect(Rect::MakeLTRB(20, 20, 30, 30))
-                               .TakePath(),
-                           1.0);
+    auto pts = t.TessellateConvex(PathBuilder{}
+                                      .AddRect(Rect::MakeLTRB(0, 0, 10, 10))
+                                      .AddRect(Rect::MakeLTRB(20, 20, 30, 30))
+                                      .TakePath(),
+                                  1.0);
 
     std::vector<Point> expected = {
-        {0, 0},   {10, 0},  {10, 10}, {0, 10},  //
-        {20, 20}, {30, 20}, {30, 30}, {20, 30}  //
+        {0, 0},   {10, 0},  {0, 10},  {10, 10},  //
+        {10, 10}, {20, 20}, {20, 20}, {30, 20},  //
+        {30, 20}, {20, 30}, {30, 30}             //
     };
-    ASSERT_EQ(pts, expected);
+    EXPECT_EQ(pts, expected);
   }
 }
 


### PR DESCRIPTION
Removes usage of index buffer and adds zig-zagging triangle strip. Could also be adapted emplace directly into host buffer.
