### PR TITLE
[Impeller] remove drawable latency (and partial repaint).

### DIFF
--- a/impeller/aiks/testing/context_mock.h
+++ b/impeller/aiks/testing/context_mock.h
@@ -27,7 +27,12 @@ class CommandBufferMock : public CommandBuffer {
 
   MOCK_METHOD(bool,
               SubmitCommandsAsync,
-              (std::shared_ptr<RenderPass> render_pass),
+              (const std::shared_ptr<RenderPass>& render_pass),
+              (override));
+
+  MOCK_METHOD(bool,
+              SubmitCommandsAsync,
+              (const std::shared_ptr<BlitPass>& render_pass, const std::shared_ptr<Allocator>& allocator),
               (override));
 
   MOCK_METHOD(std::shared_ptr<RenderPass>,

--- a/impeller/aiks/testing/context_mock.h
+++ b/impeller/aiks/testing/context_mock.h
@@ -32,7 +32,8 @@ class CommandBufferMock : public CommandBuffer {
 
   MOCK_METHOD(bool,
               SubmitCommandsAsync,
-              (const std::shared_ptr<BlitPass>& render_pass, const std::shared_ptr<Allocator>& allocator),
+              (const std::shared_ptr<BlitPass>& render_pass,
+               const std::shared_ptr<Allocator>& allocator),
               (override));
 
   MOCK_METHOD(std::shared_ptr<RenderPass>,

--- a/impeller/aiks/testing/context_spy.cc
+++ b/impeller/aiks/testing/context_spy.cc
@@ -63,12 +63,6 @@ std::shared_ptr<ContextMock> ContextSpy::MakeContext(
               return real_buffer->SetLabel(label);
             });
 
-        ON_CALL(*spy, SubmitCommandsAsync)
-            .WillByDefault([real_buffer](
-                               std::shared_ptr<RenderPass> render_pass) {
-              return real_buffer->SubmitCommandsAsync(std::move(render_pass));
-            });
-
         ON_CALL(*spy, OnCreateRenderPass)
             .WillByDefault(
                 [real_buffer, shared_this](const RenderTarget& render_target) {

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -371,9 +371,10 @@ bool EntityPass::Render(ContentContext& renderer,
           offscreen_target.GetRenderTarget().GetRenderTargetTexture(),
           root_render_target.GetRenderTargetTexture());
 
-      if (!blit_pass->EncodeCommands(
+      if (!command_buffer->SubmitCommandsAsync(
+              std::move(blit_pass),
               renderer.GetContext()->GetResourceAllocator())) {
-        VALIDATION_LOG << "Failed to encode root pass blit command.";
+        VALIDATION_LOG << "Failed to submit root pass command buffer.";
         return false;
       }
     } else {
@@ -399,14 +400,10 @@ bool EntityPass::Render(ContentContext& renderer,
         }
       }
 
-      if (!render_pass->EncodeCommands()) {
-        VALIDATION_LOG << "Failed to encode root pass command buffer.";
+      if (!command_buffer->SubmitCommandsAsync(std::move(render_pass))) {
+        VALIDATION_LOG << "Failed to submit root pass command buffer.";
         return false;
       }
-    }
-    if (!command_buffer->SubmitCommands()) {
-      VALIDATION_LOG << "Failed to submit root pass command buffer.";
-      return false;
     }
 
     return true;

--- a/impeller/playground/backend/metal/playground_impl_mtl.mm
+++ b/impeller/playground/backend/metal/playground_impl_mtl.mm
@@ -118,9 +118,10 @@ std::unique_ptr<Surface> PlaygroundImplMTL::AcquireSurfaceFrame(
   data_->metal_layer.drawableSize =
       CGSizeMake(layer_size.width * scale.x, layer_size.height * scale.y);
 
-  auto drawable =
-      SurfaceMTL::GetMetalDrawableAndValidate(context, data_->metal_layer);
-  return SurfaceMTL::MakeFromMetalLayerDrawable(context, drawable);
+  return nullptr;
+  // auto drawable =
+  //     SurfaceMTL::GetMetalDrawableAndValidate(context, data_->metal_layer);
+  // return SurfaceMTL::MakeFromMetalLayerDrawable(context, drawable);
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/command_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.h
@@ -37,7 +37,13 @@ class CommandBufferMTL final : public CommandBuffer {
   void OnWaitUntilScheduled() override;
 
   // |CommandBuffer|
-  bool SubmitCommandsAsync(std::shared_ptr<RenderPass> render_pass) override;
+  bool SubmitCommandsAsync(
+      const std::shared_ptr<RenderPass>& render_pass) override;
+
+  // |CommandBuffer|
+  bool SubmitCommandsAsync(
+      const std::shared_ptr<BlitPass>& blit_pass,
+      const std::shared_ptr<Allocator>& allocator) override;
 
   // |CommandBuffer|
   std::shared_ptr<RenderPass> OnCreateRenderPass(RenderTarget target) override;

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -90,7 +90,7 @@ ContextMTL::ContextMTL(
   // Worker task runner.
   {
     raster_message_loop_ = fml::ConcurrentMessageLoop::Create(
-        std::min(4u, std::thread::hardware_concurrency()));
+        std::min(1u, std::thread::hardware_concurrency()));
     raster_message_loop_->PostTaskToAllWorkers([]() {
       // See https://github.com/flutter/flutter/issues/65752
       // Intentionally opt out of QoS for raster task workloads.

--- a/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -24,6 +24,7 @@ class RenderPassMTL final : public RenderPass {
   MTLRenderPassDescriptor* desc_ = nil;
   std::string label_;
   bool is_valid_ = false;
+  bool deferred_drawable_ = false;
 
   RenderPassMTL(std::weak_ptr<const Context> context,
                 const RenderTarget& target,

--- a/impeller/renderer/backend/metal/surface_mtl.h
+++ b/impeller/renderer/backend/metal/surface_mtl.h
@@ -34,26 +34,28 @@ class SurfaceMTL final : public Surface {
   ///
   /// @return     A pointer to the wrapped surface or null.
   ///
-  static id<CAMetalDrawable> GetMetalDrawableAndValidate(
+  // static id<CAMetalDrawable> GetMetalDrawableAndValidate(
+  //     const std::shared_ptr<Context>& context,
+  //     CAMetalLayer* layer);
+
+  // static std::unique_ptr<SurfaceMTL> MakeFromMetalLayerDrawable(
+  //     const std::shared_ptr<Context>& context,
+  //     id<CAMetalDrawable> drawable,
+  //     std::optional<IRect> clip_rect = std::nullopt);
+
+  static std::unique_ptr<SurfaceMTL> MakeFromMetalLayer(
       const std::shared_ptr<Context>& context,
       CAMetalLayer* layer);
 
-  static std::unique_ptr<SurfaceMTL> MakeFromMetalLayerDrawable(
-      const std::shared_ptr<Context>& context,
-      id<CAMetalDrawable> drawable,
-      std::optional<IRect> clip_rect = std::nullopt);
-
-  static std::unique_ptr<SurfaceMTL> MakeFromTexture(
-      const std::shared_ptr<Context>& context,
-      id<MTLTexture> texture,
-      std::optional<IRect> clip_rect,
-      id<CAMetalDrawable> drawable = nil);
+  // static std::unique_ptr<SurfaceMTL> MakeFromTexture(
+  //     const std::shared_ptr<Context>& context,
+  //     id<MTLTexture> texture,
+  //     std::optional<IRect> clip_rect,
+  //     id<CAMetalDrawable> drawable = nil);
 #pragma GCC diagnostic pop
 
   // |Surface|
   ~SurfaceMTL() override;
-
-  id<MTLDrawable> drawable() const { return drawable_; }
 
   // Returns a Rect defining the area of the surface in device pixels
   IRect coverage() const;
@@ -64,22 +66,10 @@ class SurfaceMTL final : public Surface {
  private:
   std::weak_ptr<Context> context_;
   std::shared_ptr<Texture> resolve_texture_;
-  id<CAMetalDrawable> drawable_ = nil;
-  std::shared_ptr<Texture> source_texture_;
-  std::shared_ptr<Texture> destination_texture_;
-  bool requires_blit_ = false;
-  std::optional<IRect> clip_rect_;
-
-  static bool ShouldPerformPartialRepaint(std::optional<IRect> damage_rect);
 
   SurfaceMTL(const std::weak_ptr<Context>& context,
              const RenderTarget& target,
-             std::shared_ptr<Texture> resolve_texture,
-             id<CAMetalDrawable> drawable,
-             std::shared_ptr<Texture> source_texture,
-             std::shared_ptr<Texture> destination_texture,
-             bool requires_blit,
-             std::optional<IRect> clip_rect);
+             std::shared_ptr<Texture> resolve_texture);
 
   SurfaceMTL(const SurfaceMTL&) = delete;
 

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -18,50 +18,17 @@ namespace impeller {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunguarded-availability-new"
 
-id<CAMetalDrawable> SurfaceMTL::GetMetalDrawableAndValidate(
-    const std::shared_ptr<Context>& context,
-    CAMetalLayer* layer) {
-  TRACE_EVENT0("impeller", "SurfaceMTL::WrapCurrentMetalLayerDrawable");
-
-  if (context == nullptr || !context->IsValid() || layer == nil) {
-    return nullptr;
-  }
-
-  id<CAMetalDrawable> current_drawable = nil;
-  {
-    TRACE_EVENT0("impeller", "WaitForNextDrawable");
-    current_drawable = [layer nextDrawable];
-  }
-
-  if (!current_drawable) {
-    VALIDATION_LOG << "Could not acquire current drawable.";
-    return nullptr;
-  }
-  return current_drawable;
-}
-
 static std::optional<RenderTarget> WrapTextureWithRenderTarget(
     Allocator& allocator,
-    id<MTLTexture> texture,
-    bool requires_blit,
-    std::optional<IRect> clip_rect) {
+    CAMetalLayer* layer) {
   // compositor_context.cc will offset the rendering by the clip origin. Here we
   // shrink to the size of the clip. This has the same effect as clipping the
   // rendering but also creates smaller intermediate passes.
-  ISize root_size;
-  if (requires_blit) {
-    if (!clip_rect.has_value()) {
-      VALIDATION_LOG << "Missing clip rectangle.";
-      return std::nullopt;
-    }
-    root_size = ISize(clip_rect->size.width, clip_rect->size.height);
-  } else {
-    root_size = {static_cast<ISize::Type>(texture.width),
-                 static_cast<ISize::Type>(texture.height)};
-  }
+  ISize root_size = {static_cast<ISize::Type>(layer.drawableSize.width),
+                     static_cast<ISize::Type>(layer.drawableSize.height)};
 
   TextureDescriptor resolve_tex_desc;
-  resolve_tex_desc.format = FromMTLPixelFormat(texture.pixelFormat);
+  resolve_tex_desc.format = FromMTLPixelFormat(layer.pixelFormat);
   resolve_tex_desc.size = root_size;
   resolve_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget) |
                            static_cast<uint64_t>(TextureUsage::kShaderRead);
@@ -74,13 +41,8 @@ static std::optional<RenderTarget> WrapTextureWithRenderTarget(
   }
 
   // Create color resolve texture.
-  std::shared_ptr<Texture> resolve_tex;
-  if (requires_blit) {
-    resolve_tex_desc.compression_type = CompressionType::kLossy;
-    resolve_tex = allocator.CreateTexture(resolve_tex_desc);
-  } else {
-    resolve_tex = std::make_shared<TextureMTL>(resolve_tex_desc, texture);
-  }
+  std::shared_ptr<Texture> resolve_tex =
+      TextureMTL::Wrapper(resolve_tex_desc, layer);
 
   if (!resolve_tex) {
     VALIDATION_LOG << "Could not wrap resolve texture.";
@@ -116,102 +78,34 @@ static std::optional<RenderTarget> WrapTextureWithRenderTarget(
   return render_target_desc;
 }
 
-std::unique_ptr<SurfaceMTL> SurfaceMTL::MakeFromMetalLayerDrawable(
+std::unique_ptr<SurfaceMTL> SurfaceMTL::MakeFromMetalLayer(
     const std::shared_ptr<Context>& context,
-    id<CAMetalDrawable> drawable,
-    std::optional<IRect> clip_rect) {
-  return SurfaceMTL::MakeFromTexture(context, drawable.texture, clip_rect,
-                                     drawable);
-}
-
-std::unique_ptr<SurfaceMTL> SurfaceMTL::MakeFromTexture(
-    const std::shared_ptr<Context>& context,
-    id<MTLTexture> texture,
-    std::optional<IRect> clip_rect,
-    id<CAMetalDrawable> drawable) {
-  bool partial_repaint_blit_required = ShouldPerformPartialRepaint(clip_rect);
-
+    CAMetalLayer* layer) {
   // The returned render target is the texture that Impeller will render the
   // root pass to. If partial repaint is in use, this may be a new texture which
   // is smaller than the given MTLTexture.
   auto render_target =
-      WrapTextureWithRenderTarget(*context->GetResourceAllocator(), texture,
-                                  partial_repaint_blit_required, clip_rect);
+      WrapTextureWithRenderTarget(*context->GetResourceAllocator(), layer);
   if (!render_target) {
     return nullptr;
   }
 
-  // If partial repainting, set a "source" texture. The presence of a source
-  // texture and clip rect instructs the surface to blit this texture to the
-  // destination texture.
-  auto source_texture = partial_repaint_blit_required
-                            ? render_target->GetRenderTargetTexture()
-                            : nullptr;
-
-  // The final "destination" texture is the texture that will be presented. In
-  // this case, it's always the given drawable.
-  std::shared_ptr<Texture> destination_texture;
-  if (partial_repaint_blit_required) {
-    // If blitting for partial repaint, we need to wrap the drawable. Simply
-    // reuse the texture descriptor that was already formed for the new render
-    // target, but override the size with the drawable's size.
-    auto destination_descriptor =
-        render_target->GetRenderTargetTexture()->GetTextureDescriptor();
-    destination_descriptor.size = {static_cast<ISize::Type>(texture.width),
-                                   static_cast<ISize::Type>(texture.height)};
-    destination_texture = TextureMTL::Wrapper(destination_descriptor, texture);
-  } else {
-    // When not partial repaint blit is needed, the render target texture _is_
-    // the drawable texture.
-    destination_texture = render_target->GetRenderTargetTexture();
-  }
-
   return std::unique_ptr<SurfaceMTL>(new SurfaceMTL(
-      context,                                  // context
-      *render_target,                           // target
-      render_target->GetRenderTargetTexture(),  // resolve_texture
-      drawable,                                 // drawable
-      source_texture,                           // source_texture
-      destination_texture,                      // destination_texture
-      partial_repaint_blit_required,            // requires_blit
-      clip_rect                                 // clip_rect
+      context,                                 // context
+      *render_target,                          // target
+      render_target->GetRenderTargetTexture()  // resolve_texture
       ));
 }
 
 SurfaceMTL::SurfaceMTL(const std::weak_ptr<Context>& context,
                        const RenderTarget& target,
-                       std::shared_ptr<Texture> resolve_texture,
-                       id<CAMetalDrawable> drawable,
-                       std::shared_ptr<Texture> source_texture,
-                       std::shared_ptr<Texture> destination_texture,
-                       bool requires_blit,
-                       std::optional<IRect> clip_rect)
+                       std::shared_ptr<Texture> resolve_texture)
     : Surface(target),
       context_(context),
-      resolve_texture_(std::move(resolve_texture)),
-      drawable_(drawable),
-      source_texture_(std::move(source_texture)),
-      destination_texture_(std::move(destination_texture)),
-      requires_blit_(requires_blit),
-      clip_rect_(clip_rect) {}
+      resolve_texture_(std::move(resolve_texture)) {}
 
 // |Surface|
 SurfaceMTL::~SurfaceMTL() = default;
-
-bool SurfaceMTL::ShouldPerformPartialRepaint(std::optional<IRect> damage_rect) {
-  // compositor_context.cc will conditionally disable partial repaint if the
-  // damage region is large. If that happened, then a nullopt damage rect
-  // will be provided here.
-  if (!damage_rect.has_value()) {
-    return false;
-  }
-  // If the damage rect is 0 in at least one dimension, partial repaint isn't
-  // performed as we skip right to present.
-  if (damage_rect->size.width <= 0 || damage_rect->size.height <= 0) {
-    return false;
-  }
-  return true;
-}
 
 // |Surface|
 IRect SurfaceMTL::coverage() const {
@@ -225,48 +119,37 @@ bool SurfaceMTL::Present() const {
     return false;
   }
 
-  if (requires_blit_) {
-    if (!(source_texture_ && destination_texture_)) {
-      return false;
-    }
-
-    auto blit_command_buffer = context->CreateCommandBuffer();
-    if (!blit_command_buffer) {
-      return false;
-    }
-    auto blit_pass = blit_command_buffer->CreateBlitPass();
-    if (!clip_rect_.has_value()) {
-      VALIDATION_LOG << "Missing clip rectangle.";
-      return false;
-    }
-    blit_pass->AddCopy(source_texture_, destination_texture_, std::nullopt,
-                       clip_rect_->origin);
-    blit_pass->EncodeCommands(context->GetResourceAllocator());
-    if (!blit_command_buffer->SubmitCommands()) {
-      return false;
-    }
-  }
 #ifdef IMPELLER_DEBUG
   ContextMTL::Cast(context.get())->GetGPUTracer()->MarkFrameEnd();
-#endif  // IMPELLER_DEBUG
+#endif  // IMPELL
 
-  if (drawable_) {
-    id<MTLCommandBuffer> command_buffer =
-        ContextMTL::Cast(context.get())
-            ->CreateMTLCommandBuffer("Present Waiter Command Buffer");
-    // If the threads have been merged, or there is a pending frame capture,
-    // then block on cmd buffer scheduling to ensure that the
-    // transaction/capture work correctly.
-    if ([[NSThread currentThread] isMainThread] ||
-        [[MTLCaptureManager sharedCaptureManager] isCapturing]) {
-      TRACE_EVENT0("flutter", "waitUntilScheduled");
-      [command_buffer commit];
-      [command_buffer waitUntilScheduled];
-      [drawable_ present];
-    } else {
-      [command_buffer presentDrawable:drawable_];
-      [command_buffer commit];
-    }
+  id<MTLCommandBuffer> command_buffer =
+      ContextMTL::Cast(context.get())
+          ->CreateMTLCommandBuffer("Present Waiter Command Buffer");
+  // If the threads have been merged, or there is a pending frame capture,
+  // then block on cmd buffer scheduling to ensure that the
+  // transaction/capture work correctly.
+  if ([[NSThread currentThread] isMainThread] ||
+      [[MTLCaptureManager sharedCaptureManager] isCapturing]) {
+    TRACE_EVENT0("flutter", "waitUntilScheduled");
+    [command_buffer commit];
+    [command_buffer waitUntilScheduled];
+    TextureMTL::Cast(resolve_texture_.get())->WaitForNextDrawable();
+    auto drawable = TextureMTL::Cast(resolve_texture_.get())->GetDrawable();
+    [drawable present];
+  } else {
+    auto resolve_texture = resolve_texture_;
+    [command_buffer addScheduledHandler:^(id<MTLCommandBuffer> _Nonnull) {
+      FML_LOG(ERROR) << "Scheduled handled";
+      auto mtl_texture = TextureMTL::Cast(resolve_texture.get());
+      mtl_texture->WaitForNextDrawable();
+      auto drawable = mtl_texture->GetDrawable();
+      if (drawable) {
+        FML_LOG(ERROR) << "Present";
+        [drawable present];
+      }
+    }];
+    [command_buffer commit];
   }
 
   return true;

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -140,12 +140,10 @@ bool SurfaceMTL::Present() const {
   } else {
     auto resolve_texture = resolve_texture_;
     [command_buffer addScheduledHandler:^(id<MTLCommandBuffer> _Nonnull) {
-      FML_LOG(ERROR) << "Scheduled handled";
       auto mtl_texture = TextureMTL::Cast(resolve_texture.get());
       mtl_texture->WaitForNextDrawable();
       auto drawable = mtl_texture->GetDrawable();
       if (drawable) {
-        FML_LOG(ERROR) << "Present";
         [drawable present];
       }
     }];

--- a/impeller/renderer/backend/metal/texture_mtl.h
+++ b/impeller/renderer/backend/metal/texture_mtl.h
@@ -5,23 +5,25 @@
 #pragma once
 
 #include <Metal/Metal.h>
+#include <QuartzCore/QuartzCore.h>
 
 #include "flutter/fml/macros.h"
+#include "fml/synchronization/count_down_latch.h"
 #include "impeller/base/backend_cast.h"
 #include "impeller/core/texture.h"
 
 namespace impeller {
 
-class TextureMTL final : public Texture,
-                         public BackendCast<TextureMTL, Texture> {
+class TextureMTL : public Texture, public BackendCast<TextureMTL, Texture> {
  public:
   TextureMTL(TextureDescriptor desc,
              id<MTLTexture> texture,
-             bool wrapped = false);
+             bool wrapped = false,
+             CAMetalLayer* layer = nil);
 
   static std::shared_ptr<TextureMTL> Wrapper(
       TextureDescriptor desc,
-      id<MTLTexture> texture,
+      CAMetalLayer* layer,
       std::function<void()> deletion_proc = nullptr);
 
   // |Texture|
@@ -33,8 +35,21 @@ class TextureMTL final : public Texture,
 
   bool GenerateMipmap(id<MTLBlitCommandEncoder> encoder);
 
+  void WaitForNextDrawable() {
+    if (!is_wrapped_) {
+      return;
+    }
+    latch_->Wait();
+  }
+
+  id<CAMetalDrawable> GetDrawable() const { return drawable_; }
+
  private:
-  id<MTLTexture> texture_ = nullptr;
+  mutable id<MTLTexture> texture_ = nullptr;
+  CAMetalLayer* layer_ = nil;
+  mutable id<CAMetalDrawable> drawable_ = nil;
+  mutable std::shared_ptr<fml::CountDownLatch> latch_;
+
   bool is_valid_ = false;
   bool is_wrapped_ = false;
 

--- a/impeller/renderer/backend/metal/texture_mtl.mm
+++ b/impeller/renderer/backend/metal/texture_mtl.mm
@@ -112,13 +112,12 @@ ISize TextureMTL::GetSize() const {
 
 id<MTLTexture> TextureMTL::GetMTLTexture() const {
   if (is_wrapped_) {
-    TRACE_EVENT0("texture", "TextureMTL::GetMTLTexture");
+    TRACE_EVENT0("texture", "TextureMTL::WaitForNextDrawable");
     if (!texture_) {
       drawable_ = [layer_ nextDrawable];
       if (!drawable_) {
-        FML_LOG(ERROR) << "FAILED WAITING FOR DRAWABLE";
-      } else {
-        FML_LOG(ERROR) << "GOT DRAWABLE";
+        latch_->CountDown();
+        return nil;
       }
       texture_ = drawable_.texture;
       latch_->CountDown();

--- a/impeller/renderer/backend/metal/texture_wrapper_mtl.mm
+++ b/impeller/renderer/backend/metal/texture_wrapper_mtl.mm
@@ -14,9 +14,7 @@ namespace impeller {
 std::shared_ptr<Texture> WrapTextureMTL(TextureDescriptor desc,
                                         const void* mtl_texture,
                                         std::function<void()> deletion_proc) {
-  auto texture = (__bridge id<MTLTexture>)mtl_texture;
-  desc.format = FromMTLPixelFormat(texture.pixelFormat);
-  return TextureMTL::Wrapper(desc, texture, std::move(deletion_proc));
+  return nullptr;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/command_buffer.cc
+++ b/impeller/renderer/command_buffer.cc
@@ -5,6 +5,7 @@
 #include "impeller/renderer/command_buffer.h"
 
 #include "flutter/fml/trace_event.h"
+#include "impeller/core/allocator.h"
 #include "impeller/renderer/compute_pass.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
@@ -37,14 +38,26 @@ void CommandBuffer::WaitUntilScheduled() {
 }
 
 bool CommandBuffer::SubmitCommandsAsync(
-    std::shared_ptr<RenderPass>
-        render_pass  // NOLINT(performance-unnecessary-value-param)
-) {
+    const std::shared_ptr<RenderPass>& render_pass) {
   TRACE_EVENT0("impeller", "CommandBuffer::SubmitCommandsAsync");
   if (!render_pass->IsValid() || !IsValid()) {
     return false;
   }
   if (!render_pass->EncodeCommands()) {
+    return false;
+  }
+
+  return SubmitCommands(nullptr);
+}
+
+bool CommandBuffer::SubmitCommandsAsync(
+    const std::shared_ptr<BlitPass>& blit_pass,
+    const std::shared_ptr<Allocator>& allocator) {
+  TRACE_EVENT0("impeller", "CommandBuffer::SubmitCommandsAsync");
+  if (!blit_pass->IsValid() || !IsValid()) {
+    return false;
+  }
+  if (!blit_pass->EncodeCommands(allocator)) {
     return false;
   }
 

--- a/impeller/renderer/command_buffer.h
+++ b/impeller/renderer/command_buffer.h
@@ -81,7 +81,11 @@ class CommandBuffer {
   ///             A command buffer may only be committed once.
   ///
   [[nodiscard]] virtual bool SubmitCommandsAsync(
-      std::shared_ptr<RenderPass> render_pass);
+      const std::shared_ptr<RenderPass>& render_pass);
+
+  [[nodiscard]] virtual bool SubmitCommandsAsync(
+      const std::shared_ptr<BlitPass>& blit_pass,
+      const std::shared_ptr<Allocator>& allocator);
 
   //----------------------------------------------------------------------------
   /// @brief      Force execution of pending GPU commands.

--- a/shell/gpu/gpu_surface_metal_impeller.h
+++ b/shell/gpu/gpu_surface_metal_impeller.h
@@ -38,16 +38,11 @@ class IMPELLER_CA_METAL_LAYER_AVAILABLE GPUSurfaceMetalImpeller
   const MTLRenderTargetType render_target_type_;
   std::shared_ptr<impeller::Renderer> impeller_renderer_;
   std::shared_ptr<impeller::AiksContext> aiks_context_;
-  fml::scoped_nsprotocol<id<MTLTexture>> last_texture_;
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an
   // external view embedder may want to render to the root surface. This is a
   // hack to make avoid allocating resources for the root surface when an
   // external view embedder is present.
   bool render_to_surface_ = true;
-  bool disable_partial_repaint_ = false;
-  // Accumulated damage for each framebuffer; Key is address of underlying
-  // MTLTexture for each drawable
-  std::map<uintptr_t, SkIRect> damage_;
 
   // |Surface|
   std::unique_ptr<SurfaceFrame> AcquireFrame(

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -38,14 +38,7 @@ GPUSurfaceMetalImpeller::GPUSurfaceMetalImpeller(GPUSurfaceMetalDelegate* delega
       aiks_context_(
           std::make_shared<impeller::AiksContext>(impeller_renderer_ ? context : nullptr,
                                                   impeller::TypographerContextSkia::Make())),
-      render_to_surface_(render_to_surface) {
-  // If this preference is explicitly set, we allow for disabling partial repaint.
-  NSNumber* disablePartialRepaint =
-      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTDisablePartialRepaint"];
-  if (disablePartialRepaint != nil) {
-    disable_partial_repaint_ = disablePartialRepaint.boolValue;
-  }
-}
+      render_to_surface_(render_to_surface) {}
 
 GPUSurfaceMetalImpeller::~GPUSurfaceMetalImpeller() = default;
 
@@ -97,22 +90,11 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
 
   auto* mtl_layer = (CAMetalLayer*)layer;
 
-  auto drawable = impeller::SurfaceMTL::GetMetalDrawableAndValidate(
-      impeller_renderer_->GetContext(), mtl_layer);
-  if (!drawable) {
-    return nullptr;
-  }
-  if (Settings::kSurfaceDataAccessible) {
-    last_texture_.reset([drawable.texture retain]);
-  }
-
-  id<MTLTexture> last_texture = static_cast<id<MTLTexture>>(last_texture_);
   SurfaceFrame::SubmitCallback submit_callback =
       fml::MakeCopyable([this,                           //
                          renderer = impeller_renderer_,  //
                          aiks_context = aiks_context_,   //
-                         drawable,                       //
-                         last_texture                    //
+                         mtl_layer                       //
   ](SurfaceFrame& surface_frame, DlCanvas* canvas) mutable -> bool {
         if (!aiks_context) {
           return false;
@@ -124,34 +106,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
           return false;
         }
 
-        if (!disable_partial_repaint_) {
-          uintptr_t texture = reinterpret_cast<uintptr_t>(last_texture);
-
-          for (auto& entry : damage_) {
-            if (entry.first != texture) {
-              // Accumulate damage for other framebuffers
-              if (surface_frame.submit_info().frame_damage) {
-                entry.second.join(*surface_frame.submit_info().frame_damage);
-              }
-            }
-          }
-          // Reset accumulated damage for current framebuffer
-          damage_[texture] = SkIRect::MakeEmpty();
-        }
-
-        std::optional<impeller::IRect> clip_rect;
-        if (surface_frame.submit_info().buffer_damage.has_value()) {
-          auto buffer_damage = surface_frame.submit_info().buffer_damage;
-          clip_rect = impeller::IRect::MakeXYWH(buffer_damage->x(), buffer_damage->y(),
-                                                buffer_damage->width(), buffer_damage->height());
-        }
-
-        auto surface = impeller::SurfaceMTL::MakeFromMetalLayerDrawable(
-            impeller_renderer_->GetContext(), drawable, clip_rect);
-
-        if (clip_rect && (clip_rect->size.width == 0 || clip_rect->size.height == 0)) {
-          return surface->Present();
-        }
+        auto surface =
+            impeller::SurfaceMTL::MakeFromMetalLayer(impeller_renderer_->GetContext(), mtl_layer);
 
         impeller::IRect cull_rect = surface->coverage();
         SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.size.width, cull_rect.size.height);
@@ -168,18 +124,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
       });
 
   SurfaceFrame::FramebufferInfo framebuffer_info;
-  framebuffer_info.supports_readback = true;
-
-  if (!disable_partial_repaint_) {
-    // Provide accumulated damage to rasterizer (area in current framebuffer that lags behind
-    // front buffer)
-    uintptr_t texture = reinterpret_cast<uintptr_t>(drawable.texture);
-    auto i = damage_.find(texture);
-    if (i != damage_.end()) {
-      framebuffer_info.existing_damage = i->second;
-    }
-    framebuffer_info.supports_partial_repaint = true;
-  }
 
   return std::make_unique<SurfaceFrame>(nullptr,           // surface
                                         framebuffer_info,  // framebuffer info
@@ -200,17 +144,10 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromMTLTextur
     return nullptr;
   }
 
-  if (Settings::kSurfaceDataAccessible) {
-    last_texture_.reset([mtl_texture retain]);
-  }
-
   SurfaceFrame::SubmitCallback submit_callback =
-      fml::MakeCopyable([this,                           //
-                         renderer = impeller_renderer_,  //
-                         aiks_context = aiks_context_,   //
-                         texture_info,                   //
-                         mtl_texture,                    //
-                         delegate = delegate_            //
+      fml::MakeCopyable([                                   //
+                            renderer = impeller_renderer_,  //
+                            aiks_context = aiks_context_    //           //
   ](SurfaceFrame& surface_frame, DlCanvas* canvas) mutable -> bool {
         if (!aiks_context) {
           return false;
@@ -221,69 +158,34 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromMTLTextur
           FML_LOG(ERROR) << "Could not build display list for surface frame.";
           return false;
         }
+        return false;
 
-        if (!disable_partial_repaint_) {
-          uintptr_t texture_ptr = reinterpret_cast<uintptr_t>(mtl_texture);
+        // auto surface =
+        //     impeller::SurfaceMTL::MakeFromTexture(renderer->GetContext(), mtl_texture);
 
-          for (auto& entry : damage_) {
-            if (entry.first != texture_ptr) {
-              // Accumulate damage for other framebuffers
-              if (surface_frame.submit_info().frame_damage) {
-                entry.second.join(*surface_frame.submit_info().frame_damage);
-              }
-            }
-          }
-          // Reset accumulated damage for current framebuffer
-          damage_[texture_ptr] = SkIRect::MakeEmpty();
-        }
+        // impeller::IRect cull_rect = surface->coverage();
+        // SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.size.width, cull_rect.size.height);
+        // impeller::DlDispatcher impeller_dispatcher(cull_rect);
+        // display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
+        // auto picture = impeller_dispatcher.EndRecordingAsPicture();
 
-        std::optional<impeller::IRect> clip_rect;
-        if (surface_frame.submit_info().buffer_damage.has_value()) {
-          auto buffer_damage = surface_frame.submit_info().buffer_damage;
-          clip_rect = impeller::IRect::MakeXYWH(buffer_damage->x(), buffer_damage->y(),
-                                                buffer_damage->width(), buffer_damage->height());
-        }
+        // bool render_result =
+        //     renderer->Render(std::move(surface),
+        //                      fml::MakeCopyable([aiks_context, picture = std::move(picture)](
+        //                                            impeller::RenderTarget& render_target) -> bool
+        //                                            {
+        //                        return aiks_context->Render(picture, render_target);
+        //                      }));
+        // if (!render_result) {
+        //   FML_LOG(ERROR) << "Failed to render Impeller frame";
+        //   return false;
+        // }
 
-        auto surface =
-            impeller::SurfaceMTL::MakeFromTexture(renderer->GetContext(), mtl_texture, clip_rect);
-
-        if (clip_rect && (clip_rect->size.width == 0 || clip_rect->size.height == 0)) {
-          return surface->Present();
-        }
-
-        impeller::IRect cull_rect = surface->coverage();
-        SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.size.width, cull_rect.size.height);
-        impeller::DlDispatcher impeller_dispatcher(cull_rect);
-        display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
-        auto picture = impeller_dispatcher.EndRecordingAsPicture();
-
-        bool render_result =
-            renderer->Render(std::move(surface),
-                             fml::MakeCopyable([aiks_context, picture = std::move(picture)](
-                                                   impeller::RenderTarget& render_target) -> bool {
-                               return aiks_context->Render(picture, render_target);
-                             }));
-        if (!render_result) {
-          FML_LOG(ERROR) << "Failed to render Impeller frame";
-          return false;
-        }
-
-        return delegate->PresentTexture(texture_info);
+        // return delegate->PresentTexture(texture_info);
       });
 
   SurfaceFrame::FramebufferInfo framebuffer_info;
-  framebuffer_info.supports_readback = true;
-
-  if (!disable_partial_repaint_) {
-    // Provide accumulated damage to rasterizer (area in current framebuffer that lags behind
-    // front buffer)
-    uintptr_t texture = reinterpret_cast<uintptr_t>(mtl_texture);
-    auto i = damage_.find(texture);
-    if (i != damage_.end()) {
-      framebuffer_info.existing_damage = i->second;
-    }
-    framebuffer_info.supports_partial_repaint = true;
-  }
+  framebuffer_info.supports_readback = false;
 
   return std::make_unique<SurfaceFrame>(nullptr,           // surface
                                         framebuffer_info,  // framebuffer info
@@ -327,45 +229,7 @@ std::shared_ptr<impeller::AiksContext> GPUSurfaceMetalImpeller::GetAiksContext()
 }
 
 Surface::SurfaceData GPUSurfaceMetalImpeller::GetSurfaceData() const {
-  if (!(last_texture_ && [last_texture_ conformsToProtocol:@protocol(MTLTexture)])) {
-    return {};
-  }
-  id<MTLTexture> texture = last_texture_.get();
-  int bytesPerPixel = 0;
-  std::string pixel_format;
-  switch (texture.pixelFormat) {
-    case MTLPixelFormatBGR10_XR:
-      bytesPerPixel = 4;
-      pixel_format = "MTLPixelFormatBGR10_XR";
-      break;
-    case MTLPixelFormatBGRA10_XR:
-      bytesPerPixel = 8;
-      pixel_format = "MTLPixelFormatBGRA10_XR";
-      break;
-    case MTLPixelFormatBGRA8Unorm:
-      bytesPerPixel = 4;
-      pixel_format = "MTLPixelFormatBGRA8Unorm";
-      break;
-    case MTLPixelFormatRGBA16Float:
-      bytesPerPixel = 8;
-      pixel_format = "MTLPixelFormatRGBA16Float";
-      break;
-    default:
-      return {};
-  }
-
-  // Zero initialized so that errors are easier to find at the cost of
-  // performance.
-  sk_sp<SkData> result =
-      SkData::MakeZeroInitialized(texture.width * texture.height * bytesPerPixel);
-  [texture getBytes:result->writable_data()
-        bytesPerRow:texture.width * bytesPerPixel
-         fromRegion:MTLRegionMake2D(0, 0, texture.width, texture.height)
-        mipmapLevel:0];
-  return {
-      .pixel_format = pixel_format,
-      .data = result,
-  };
+  return {};
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -190,32 +190,6 @@ FLUTTER_ASSERT_ARC
   id<MTLTexture> uvTex = CVMetalTextureGetTexture(uvMetalTexture);
   CVBufferRelease(uvMetalTexture);
 
-  if (_enableImpeller) {
-    impeller::TextureDescriptor yDesc;
-    yDesc.storage_mode = impeller::StorageMode::kHostVisible;
-    yDesc.format = impeller::PixelFormat::kR8UNormInt;
-    yDesc.size = {textureSize.width(), textureSize.height()};
-    yDesc.mip_count = 1;
-    auto yTexture = impeller::TextureMTL::Wrapper(yDesc, yTex);
-    yTexture->SetCoordinateSystem(impeller::TextureCoordinateSystem::kUploadFromHost);
-
-    impeller::TextureDescriptor uvDesc;
-    uvDesc.storage_mode = impeller::StorageMode::kHostVisible;
-    uvDesc.format = impeller::PixelFormat::kR8G8UNormInt;
-    uvDesc.size = {textureSize.width() / 2, textureSize.height() / 2};
-    uvDesc.mip_count = 1;
-    auto uvTexture = impeller::TextureMTL::Wrapper(uvDesc, uvTex);
-    uvTexture->SetCoordinateSystem(impeller::TextureCoordinateSystem::kUploadFromHost);
-
-    impeller::YUVColorSpace yuvColorSpace =
-        _pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
-            ? impeller::YUVColorSpace::kBT601LimitedRange
-            : impeller::YUVColorSpace::kBT601FullRange;
-
-    return impeller::DlImageImpeller::MakeFromYUVTextures(context.aiks_context, yTexture, uvTexture,
-                                                          yuvColorSpace);
-  }
-
   SkYUVColorSpace colorSpace = _pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
                                    ? kRec601_Limited_SkYUVColorSpace
                                    : kJPEG_Full_SkYUVColorSpace;
@@ -256,17 +230,6 @@ FLUTTER_ASSERT_ARC
 
   id<MTLTexture> rgbaTex = CVMetalTextureGetTexture(metalTexture);
   CVBufferRelease(metalTexture);
-
-  if (_enableImpeller) {
-    impeller::TextureDescriptor desc;
-    desc.storage_mode = impeller::StorageMode::kHostVisible;
-    desc.format = impeller::PixelFormat::kB8G8R8A8UNormInt;
-    desc.size = {textureSize.width(), textureSize.height()};
-    desc.mip_count = 1;
-    auto texture = impeller::TextureMTL::Wrapper(desc, rgbaTex);
-    texture->SetCoordinateSystem(impeller::TextureCoordinateSystem::kUploadFromHost);
-    return impeller::DlImageImpeller::Make(texture);
-  }
 
   auto skImage = [FlutterDarwinExternalTextureSkImageWrapper wrapRGBATexture:rgbaTex
                                                                    grContext:context.gr_context


### PR DESCRIPTION
This is a quickly hacked together proof of concept of deferring drawable aquisition to the last possible second. This comes at the cost of removing partial repaint, as we can't tell which framebuffer we'll be given until we're done with all work.

lots of playground and embedder code was commented out - this isn't strictly necessary but reduced the scope of changes for experimentation.
