### PR TITLE
[Impeller] Switch from transient stencil-only to depth+stencil buffer.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3557,6 +3557,8 @@ TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
       .WillRepeatedly(::testing::Return(false));
   FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultColorFormat);
   FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultStencilFormat);
+  FLT_FORWARD(mock_capabilities, old_capabilities,
+              GetDefaultDepthStencilFormat);
   FLT_FORWARD(mock_capabilities, old_capabilities, SupportsOffscreenMSAA);
   FLT_FORWARD(mock_capabilities, old_capabilities,
               SupportsImplicitResolvingMSAA);

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -423,7 +423,8 @@ bool EntityPass::Render(ContentContext& renderer,
   // If a root stencil was provided by the caller, then verify that it has a
   // configuration which can be used to render this pass.
   auto stencil_attachment = root_render_target.GetStencilAttachment();
-  if (stencil_attachment.has_value()) {
+  auto depth_attachment = root_render_target.GetDepthAttachment();
+  if (stencil_attachment.has_value() && depth_attachment.has_value()) {
     auto stencil_texture = stencil_attachment->texture;
     if (!stencil_texture) {
       VALIDATION_LOG << "The root RenderTarget must have a stencil texture.";

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -442,7 +442,7 @@ bool EntityPass::Render(ContentContext& renderer,
   // Setup a new root stencil with an optimal configuration if one wasn't
   // provided by the caller.
   else {
-    root_render_target.SetupStencilAttachment(
+    root_render_target.SetupDepthStencilAttachments(
         *renderer.GetContext(), *renderer.GetRenderTargetCache(),
         color0.texture->GetSize(),
         renderer.GetContext()->GetCapabilities()->SupportsOffscreenMSAA(),

--- a/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -41,7 +41,7 @@ static std::optional<GLuint> ConfigureFBO(
   gl.BindFramebuffer(fbo_type, fbo);
 
   if (!TextureGLES::Cast(*texture).SetAsFramebufferAttachment(
-          fbo_type, TextureGLES::AttachmentPoint::kColor0)) {
+          fbo_type, TextureGLES::AttachmentType::kColor0)) {
     VALIDATION_LOG << "Could not attach texture to framebuffer.";
     DeleteFBO(gl, fbo, fbo_type);
     return std::nullopt;

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -186,20 +186,20 @@ struct RenderPassData {
 
     if (auto color = TextureGLES::Cast(pass_data.color_attachment.get())) {
       if (!color->SetAsFramebufferAttachment(
-              GL_FRAMEBUFFER, TextureGLES::AttachmentPoint::kColor0)) {
+              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kColor0)) {
         return false;
       }
     }
 
     if (auto depth = TextureGLES::Cast(pass_data.depth_attachment.get())) {
       if (!depth->SetAsFramebufferAttachment(
-              GL_FRAMEBUFFER, TextureGLES::AttachmentPoint::kDepth)) {
+              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kDepth)) {
         return false;
       }
     }
     if (auto stencil = TextureGLES::Cast(pass_data.stencil_attachment.get())) {
       if (!stencil->SetAsFramebufferAttachment(
-              GL_FRAMEBUFFER, TextureGLES::AttachmentPoint::kStencil)) {
+              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kStencil)) {
         return false;
       }
     }

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -41,13 +41,14 @@ class TextureGLES final : public Texture,
 
   [[nodiscard]] bool GenerateMipmap();
 
-  enum class AttachmentPoint {
+  enum class AttachmentType {
     kColor0,
     kDepth,
     kStencil,
   };
-  [[nodiscard]] bool SetAsFramebufferAttachment(GLenum target,
-                                                AttachmentPoint point) const;
+  [[nodiscard]] bool SetAsFramebufferAttachment(
+      GLenum target,
+      AttachmentType attachment_type) const;
 
   Type GetType() const;
 

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -255,8 +255,8 @@ RenderTarget RenderTarget::CreateOffscreen(
   target.SetColorAttachment(color0, 0u);
 
   if (stencil_attachment_config.has_value()) {
-    target.SetupStencilAttachment(context, allocator, size, false, label,
-                                  stencil_attachment_config.value());
+    target.SetupDepthStencilAttachments(context, allocator, size, false, label,
+                                        stencil_attachment_config.value());
   } else {
     target.SetStencilAttachment(std::nullopt);
   }
@@ -347,8 +347,8 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   // Create MSAA stencil texture.
 
   if (stencil_attachment_config.has_value()) {
-    target.SetupStencilAttachment(context, allocator, size, true, label,
-                                  stencil_attachment_config.value());
+    target.SetupDepthStencilAttachments(context, allocator, size, true, label,
+                                        stencil_attachment_config.value());
   } else {
     target.SetStencilAttachment(std::nullopt);
   }
@@ -356,34 +356,47 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   return target;
 }
 
-void RenderTarget::SetupStencilAttachment(
+void RenderTarget::SetupDepthStencilAttachments(
     const Context& context,
     RenderTargetAllocator& allocator,
     ISize size,
     bool msaa,
     const std::string& label,
     AttachmentConfig stencil_attachment_config) {
-  TextureDescriptor stencil_tex0;
-  stencil_tex0.storage_mode = stencil_attachment_config.storage_mode;
+  TextureDescriptor depth_stencil_texture_desc;
+  depth_stencil_texture_desc.storage_mode =
+      stencil_attachment_config.storage_mode;
   if (msaa) {
-    stencil_tex0.type = TextureType::kTexture2DMultisample;
-    stencil_tex0.sample_count = SampleCount::kCount4;
+    depth_stencil_texture_desc.type = TextureType::kTexture2DMultisample;
+    depth_stencil_texture_desc.sample_count = SampleCount::kCount4;
   }
-  stencil_tex0.format = context.GetCapabilities()->GetDefaultStencilFormat();
-  stencil_tex0.size = size;
-  stencil_tex0.usage =
+  depth_stencil_texture_desc.format =
+      context.GetCapabilities()->GetDefaultDepthStencilFormat();
+  depth_stencil_texture_desc.size = size;
+  depth_stencil_texture_desc.usage =
       static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+
+  auto depth_stencil_texture =
+      allocator.CreateTexture(depth_stencil_texture_desc);
+  if (!depth_stencil_texture) {
+    return;  // Error messages are handled by `Allocator::CreateTexture`.
+  }
+
+  DepthAttachment depth0;
+  depth0.load_action = stencil_attachment_config.load_action;
+  depth0.store_action = stencil_attachment_config.store_action;
+  depth0.clear_depth = 0u;
+  depth0.texture = depth_stencil_texture;
 
   StencilAttachment stencil0;
   stencil0.load_action = stencil_attachment_config.load_action;
   stencil0.store_action = stencil_attachment_config.store_action;
   stencil0.clear_stencil = 0u;
-  stencil0.texture = allocator.CreateTexture(stencil_tex0);
+  stencil0.texture = depth_stencil_texture;
 
-  if (!stencil0.texture) {
-    return;  // Error messages are handled by `Allocator::CreateTexture`.
-  }
-  stencil0.texture->SetLabel(SPrintF("%s Stencil Texture", label.c_str()));
+  stencil0.texture->SetLabel(
+      SPrintF("%s Depth+Stencil Texture", label.c_str()));
+  SetDepthAttachment(std::move(depth0));
   SetStencilAttachment(std::move(stencil0));
 }
 
@@ -401,6 +414,9 @@ size_t RenderTarget::GetTotalAttachmentCount() const {
     count++;
   }
   if (stencil_.has_value()) {
+    count++;
+  }
+  if (depth_.has_value()) {
     count++;
   }
   return count;

--- a/impeller/renderer/render_target.h
+++ b/impeller/renderer/render_target.h
@@ -109,13 +109,13 @@ class RenderTarget final {
 
   bool IsValid() const;
 
-  void SetupStencilAttachment(const Context& context,
-                              RenderTargetAllocator& allocator,
-                              ISize size,
-                              bool msaa,
-                              const std::string& label = "Offscreen",
-                              AttachmentConfig stencil_attachment_config =
-                                  kDefaultStencilAttachmentConfig);
+  void SetupDepthStencilAttachments(const Context& context,
+                                    RenderTargetAllocator& allocator,
+                                    ISize size,
+                                    bool msaa,
+                                    const std::string& label = "Offscreen",
+                                    AttachmentConfig stencil_attachment_config =
+                                        kDefaultStencilAttachmentConfig);
 
   SampleCount GetSampleCount() const;
 

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -1161,9 +1161,9 @@ TEST_P(RendererTest, StencilMask) {
       stencil_config.storage_mode = StorageMode::kHostVisible;
       auto render_target_allocator =
           RenderTargetAllocator(context->GetResourceAllocator());
-      render_target.SetupStencilAttachment(*context, render_target_allocator,
-                                           render_target.GetRenderTargetSize(),
-                                           true, "stencil", stencil_config);
+      render_target.SetupDepthStencilAttachments(
+          *context, render_target_allocator,
+          render_target.GetRenderTargetSize(), true, "stencil", stencil_config);
       // Fill the stencil buffer with an checkerboard pattern.
       const auto target_width = render_target.GetRenderTargetSize().width;
       const auto target_height = render_target.GetRenderTargetSize().height;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -1289,6 +1289,20 @@ TEST_P(RendererTest, CanLookupRenderTargetProperties) {
             render_target.GetRenderTargetSize());
 }
 
+TEST_P(RendererTest,
+       RenderTargetCreateOffscreenMSAASetsDefaultDepthStencilFormat) {
+  auto context = GetContext();
+  auto render_target_cache = std::make_shared<RenderTargetAllocator>(
+      GetContext()->GetResourceAllocator());
+
+  RenderTarget render_target = RenderTarget::CreateOffscreenMSAA(
+      *context, *render_target_cache, {100, 100}, /*mip_count=*/1);
+  EXPECT_EQ(render_target.GetDepthAttachment()
+                ->texture->GetTextureDescriptor()
+                .format,
+            GetContext()->GetCapabilities()->GetDefaultDepthStencilFormat());
+}
+
 }  // namespace testing
 }  // namespace impeller
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/138460.

In preparation for [draw order optimization](https://github.com/flutter/flutter/issues/114402) and [StC](https://github.com/flutter/flutter/issues/123671).

Use a transient depth+stencil texture instead of a stencil-only texture. Doing this in isolation to detect/weed out any HAL bugs with handling the attachment.