### PR TITLE
Make `fml/...` compatible with `.clang_tidy`.

### DIFF
--- a/fml/memory/ref_counted_internal.h
+++ b/fml/memory/ref_counted_internal.h
@@ -87,8 +87,7 @@ inline RefCountedThreadSafeBase::RefCountedThreadSafeBase()
     : ref_count_(1u)
 #ifndef NDEBUG
       ,
-      adoption_required_(true),
-      destruction_started_(false)
+      adoption_required_(true)
 #endif
 {
 }

--- a/fml/memory/weak_ptr_internal.h
+++ b/fml/memory/weak_ptr_internal.h
@@ -30,7 +30,7 @@ class WeakPtrFlag : public fml::RefCountedThreadSafe<WeakPtrFlag> {
   void Invalidate();
 
  private:
-  bool is_valid_;
+  bool is_valid_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(WeakPtrFlag);
 };

--- a/fml/message_loop_task_queues.h
+++ b/fml/message_loop_task_queues.h
@@ -155,7 +155,7 @@ class MessageLoopTaskQueues {
   mutable std::mutex queue_mutex_;
   std::map<TaskQueueId, std::unique_ptr<TaskQueueEntry>> queue_entries_;
 
-  size_t task_queue_id_counter_;
+  size_t task_queue_id_counter_ = 0;
 
   std::atomic_int order_;
 

--- a/fml/platform/android/message_loop_android.h
+++ b/fml/platform/android/message_loop_android.h
@@ -29,7 +29,7 @@ class MessageLoopAndroid : public MessageLoopImpl {
  private:
   fml::UniqueObject<ALooper*, UniqueLooperTraits> looper_;
   fml::UniqueFD timer_fd_;
-  bool running_;
+  bool running_ = false;
 
   MessageLoopAndroid();
 

--- a/fml/shared_thread_merger.h
+++ b/fml/shared_thread_merger.h
@@ -59,7 +59,7 @@ class SharedThreadMerger
   fml::TaskQueueId subsumed_;
   fml::MessageLoopTaskQueues* task_queues_;
   std::mutex mutex_;
-  bool enabled_;
+  bool enabled_ = false;
 
   /// The |MergeWithLease| or |ExtendLeaseTo| method will record the caller
   /// into this lease_term_by_caller_ map, |UnMergeNowIfLastOne|

--- a/fml/synchronization/semaphore.cc
+++ b/fml/synchronization/semaphore.cc
@@ -170,24 +170,24 @@ class PlatformSemaphore {
 
 namespace fml {
 
-Semaphore::Semaphore(uint32_t count) : _impl(new PlatformSemaphore(count)) {}
+Semaphore::Semaphore(uint32_t count) : impl_(new PlatformSemaphore(count)) {}
 
 Semaphore::~Semaphore() = default;
 
 bool Semaphore::IsValid() const {
-  return _impl->IsValid();
+  return impl_->IsValid();
 }
 
 bool Semaphore::Wait() {
-  return _impl->Wait();
+  return impl_->Wait();
 }
 
 bool Semaphore::TryWait() {
-  return _impl->TryWait();
+  return impl_->TryWait();
 }
 
 void Semaphore::Signal() {
-  return _impl->Signal();
+  return impl_->Signal();
 }
 
 }  // namespace fml

--- a/fml/synchronization/semaphore.h
+++ b/fml/synchronization/semaphore.h
@@ -78,7 +78,7 @@ class Semaphore {
   void Signal();
 
  private:
-  std::unique_ptr<PlatformSemaphore> _impl;
+  std::unique_ptr<PlatformSemaphore> impl_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Semaphore);
 };


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/134969.

All changes were made automatically (i.e. with `--fix`).