### PR TITLE
[Impeller] some tidying of entities.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -51,4 +51,4 @@ CheckOptions:
 #
 # Note this is because of our buildroot setup, so the full path of a lint is:
 # "../../flutter/impeller/core/runtime_types.h:1:1" as reported.
-HeaderFilterRegex: "(!third_party/)(!gen/).*/flutter/.*"
+HeaderFilterRegex: "[..\/]+\/flutter\/.*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -51,4 +51,4 @@ CheckOptions:
 #
 # Note this is because of our buildroot setup, so the full path of a lint is:
 # "../../flutter/impeller/core/runtime_types.h:1:1" as reported.
-HeaderFilterRegex: "[..\/]+\/flutter\/.*"
+HeaderFilterRegex: "(!third_party/)(!gen/).*/flutter/.*"

--- a/impeller/aiks/color_source.cc
+++ b/impeller/aiks/color_source.cc
@@ -63,8 +63,8 @@ ColorSource ColorSource::MakeLinearGradient(Point start_point,
 
     std::vector<Point> bounds{start_point, end_point};
     auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
-    if (intrinsic_size.has_value()) {
-      contents->SetColorSourceSize(intrinsic_size->GetSize());
+    if (!intrinsic_size.IsEmpty()) {
+      contents->SetColorSourceSize(intrinsic_size.GetSize());
     }
     return contents;
   };
@@ -97,8 +97,8 @@ ColorSource ColorSource::MakeConicalGradient(Point center,
     auto radius_pt = Point(radius, radius);
     std::vector<Point> bounds{center + radius_pt, center - radius_pt};
     auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
-    if (intrinsic_size.has_value()) {
-      contents->SetColorSourceSize(intrinsic_size->GetSize());
+    if (!intrinsic_size.IsEmpty()) {
+      contents->SetColorSourceSize(intrinsic_size.GetSize());
     }
     return contents;
   };
@@ -127,8 +127,8 @@ ColorSource ColorSource::MakeRadialGradient(Point center,
     auto radius_pt = Point(radius, radius);
     std::vector<Point> bounds{center + radius_pt, center - radius_pt};
     auto intrinsic_size = Rect::MakePointBounds(bounds.begin(), bounds.end());
-    if (intrinsic_size.has_value()) {
-      contents->SetColorSourceSize(intrinsic_size->GetSize());
+    if (!intrinsic_size.IsEmpty()) {
+      contents->SetColorSourceSize(intrinsic_size.GetSize());
     }
     return contents;
   };

--- a/impeller/core/vertex_buffer.h
+++ b/impeller/core/vertex_buffer.h
@@ -17,7 +17,7 @@ struct VertexBuffer {
   size_t vertex_count = 0u;
   IndexType index_type = IndexType::kUnknown;
 
-  constexpr operator bool() const {
+  constexpr explicit operator bool() const {
     return static_cast<bool>(vertex_buffer) &&
            (index_type == IndexType::kNone || static_cast<bool>(index_buffer));
   }

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -648,7 +648,7 @@ void DlDispatcher::scale(SkScalar sx, SkScalar sy) {
 
 // |flutter::DlOpReceiver|
 void DlDispatcher::rotate(SkScalar degrees) {
-  canvas_.Rotate(Degrees{degrees});
+  canvas_.Rotate(Radians{Degrees{degrees}});
 }
 
 // |flutter::DlOpReceiver|
@@ -846,8 +846,9 @@ void DlDispatcher::drawArc(const SkRect& oval_bounds,
                            SkScalar sweep_degrees,
                            bool use_center) {
   PathBuilder builder;
-  builder.AddArc(skia_conversions::ToRect(oval_bounds), Degrees(start_degrees),
-                 Degrees(sweep_degrees), use_center);
+  builder.AddArc(skia_conversions::ToRect(oval_bounds),
+                 Radians(Degrees(start_degrees)),
+                 Radians(Degrees(sweep_degrees)), use_center);
   canvas_.DrawPath(builder.TakePath(), paint_);
 }
 

--- a/impeller/geometry/color.h
+++ b/impeller/geometry/color.h
@@ -840,10 +840,10 @@ struct Color {
 
   static Color Random() {
     return {
-        static_cast<Scalar>((std::rand() % 255) / 255.0f),  //
-        static_cast<Scalar>((std::rand() % 255) / 255.0f),  //
-        static_cast<Scalar>((std::rand() % 255) / 255.0f),  //
-        1.0f                                                //
+        static_cast<Scalar>((arc4random() % 255) / 255.0f),  //
+        static_cast<Scalar>((arc4random() % 255) / 255.0f),  //
+        static_cast<Scalar>((arc4random() % 255) / 255.0f),  //
+        1.0f                                                 //
     };
   }
 

--- a/impeller/geometry/constants.h
+++ b/impeller/geometry/constants.h
@@ -10,16 +10,16 @@ namespace impeller {
 constexpr float kE = 2.7182818284590452354f;
 
 // log_2 e
-constexpr float kLog2_E = 1.4426950408889634074f;
+constexpr float kLog2E = 1.4426950408889634074f;
 
 // log_10 e
-constexpr float kLog10_E = 0.43429448190325182765f;
+constexpr float kLog10E = 0.43429448190325182765f;
 
 // log_e 2
-constexpr float klogE_2 = 0.69314718055994530942f;
+constexpr float kLogE2 = 0.69314718055994530942f;
 
 // log_e 10
-constexpr float klogE_10 = 2.30258509299404568402f;
+constexpr float kLogE10 = 2.30258509299404568402f;
 
 // pi
 constexpr float kPi = 3.14159265358979323846f;

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1977,14 +1977,14 @@ TEST(GeometryTest, RectGetTransformedPoints) {
 TEST(GeometryTest, RectMakePointBounds) {
   {
     std::vector<Point> points{{1, 5}, {4, -1}, {0, 6}};
-    Rect r = Rect::MakePointBounds(points.begin(), points.end()).value();
+    Rect r = Rect::MakePointBounds(points.begin(), points.end());
     auto expected = Rect::MakeXYWH(0, -1, 4, 7);
-    ASSERT_RECT_NEAR(r, expected);
+    EXPECT_RECT_NEAR(r, expected);
   }
   {
     std::vector<Point> points;
-    std::optional<Rect> r = Rect::MakePointBounds(points.begin(), points.end());
-    ASSERT_FALSE(r.has_value());
+    Rect r = Rect::MakePointBounds(points.begin(), points.end());
+    EXPECT_TRUE(r.IsEmpty());
   }
 }
 

--- a/impeller/geometry/half.h
+++ b/impeller/geometry/half.h
@@ -13,6 +13,8 @@
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/vector.h"
 
+// NOLINTBEGIN(google-explicit-constructor)
+
 #ifdef FML_OS_WIN
 using InternalHalf = uint16_t;
 #else
@@ -184,5 +186,7 @@ inline std::ostream& operator<<(std::ostream& out,
       << static_cast<impeller::Scalar>(p.w) << ")";
   return out;
 }
+
+// NOLINTEND(google-explicit-constructor)
 
 }  // namespace std

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -216,20 +216,20 @@ bool Path::GetContourComponentAtIndex(size_t index,
 
 Path::Polyline::Polyline(Path::Polyline::PointBufferPtr point_buffer,
                          Path::Polyline::ReclaimPointBufferCallback reclaim)
-    : points(std::move(point_buffer)), reclaim_points(std::move(reclaim)) {
+    : points(std::move(point_buffer)), reclaim_points_(std::move(reclaim)) {
   FML_DCHECK(points);
 }
 
 Path::Polyline::Polyline(Path::Polyline&& other) {
   points = std::move(other.points);
-  reclaim_points = std::move(other.reclaim_points);
+  reclaim_points_ = std::move(other.reclaim_points_);
   contours = std::move(other.contours);
 }
 
 Path::Polyline::~Polyline() {
-  if (reclaim_points) {
+  if (reclaim_points_) {
     points->clear();
-    reclaim_points(std::move(points));
+    reclaim_points_(std::move(points));
   }
 }
 

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -125,7 +125,7 @@ class Path {
         size_t contour_index) const;
 
    private:
-    ReclaimPointBufferCallback reclaim_points;
+    ReclaimPointBufferCallback reclaim_points_;
   };
 
   Path();

--- a/impeller/geometry/path_component.h
+++ b/impeller/geometry/path_component.h
@@ -102,7 +102,7 @@ struct CubicPathComponent {
 
   CubicPathComponent() {}
 
-  CubicPathComponent(const QuadraticPathComponent& q)
+  explicit CubicPathComponent(const QuadraticPathComponent& q)
       : p1(q.p1),
         cp1(q.p1 + (q.cp - q.p1) * (2.0 / 3.0)),
         cp2(q.p2 + (q.cp - q.p2) * (2.0 / 3.0)),
@@ -148,7 +148,7 @@ struct ContourComponent {
 
   ContourComponent() {}
 
-  ContourComponent(Point p, bool is_closed = false)
+  explicit ContourComponent(Point p, bool is_closed = false)
       : destination(p), is_closed(is_closed) {}
 
   bool operator==(const ContourComponent& other) const {

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -49,10 +49,10 @@ struct TRect {
   }
 
   template <typename PointIter>
-  constexpr static std::optional<TRect> MakePointBounds(const PointIter first,
-                                                        const PointIter last) {
+  constexpr static TRect MakePointBounds(const PointIter first,
+                                         const PointIter last) {
     if (first == last) {
-      return std::nullopt;
+      return TRect::MakeLTRB(0, 0, 0, 0);
     }
     auto left = first->x;
     auto top = first->y;
@@ -211,7 +211,7 @@ struct TRect {
   ///         rectangle.
   constexpr TRect TransformBounds(const Matrix& transform) const {
     auto points = GetTransformedPoints(transform);
-    return TRect::MakePointBounds(points.begin(), points.end()).value();
+    return TRect::MakePointBounds(points.begin(), points.end());
   }
 
   /// @brief  Constructs a Matrix that will map all points in the coordinate

--- a/impeller/geometry/scalar.h
+++ b/impeller/geometry/scalar.h
@@ -6,11 +6,12 @@
 
 #include <cfloat>
 #include <type_traits>
-#include <valarray>
 
 #include "impeller/geometry/constants.h"
 
 namespace impeller {
+
+// NOLINTBEGIN(google-explicit-constructor)
 
 using Scalar = float;
 
@@ -37,7 +38,7 @@ struct Radians {
 
   constexpr Radians() = default;
 
-  explicit constexpr Radians(Scalar p_radians) : radians(p_radians) {}
+  constexpr Radians(Scalar p_radians) : radians(p_radians) {}
 };
 
 struct Degrees {
@@ -51,5 +52,7 @@ struct Degrees {
     return Radians{degrees * kPi / 180.0f};
   };
 };
+
+// NOLINTEND(google-explicit-constructor)
 
 }  // namespace impeller

--- a/impeller/geometry/vector.h
+++ b/impeller/geometry/vector.h
@@ -14,6 +14,8 @@
 
 namespace impeller {
 
+// NOLINTBEGIN(google-explicit-constructor)
+
 struct Vector3 {
   union {
     struct {
@@ -323,5 +325,7 @@ inline std::ostream& operator<<(std::ostream& out, const impeller::Vector4& p) {
   out << "(" << p.x << ", " << p.y << ", " << p.z << ", " << p.w << ")";
   return out;
 }
+
+// NOLINTEND(google-explicit-constructor)
 
 }  // namespace std

--- a/impeller/image/compressed_image.h
+++ b/impeller/image/compressed_image.h
@@ -26,7 +26,7 @@ class CompressedImage {
  protected:
   const std::shared_ptr<const fml::Mapping> source_;
 
-  CompressedImage(std::shared_ptr<const fml::Mapping> allocation);
+  explicit CompressedImage(std::shared_ptr<const fml::Mapping> allocation);
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -99,13 +99,15 @@ class ContextMTL final : public Context,
 #endif  // IMPELLER_DEBUG
 
   // |Context|
-  void StoreTaskForGPU(std::function<void()> task) override;
+  void StoreTaskForGPU(const std::function<void()>& task) override;
 
  private:
   class SyncSwitchObserver : public fml::SyncSwitch::Observer {
    public:
-    SyncSwitchObserver(ContextMTL& parent);
+    explicit SyncSwitchObserver(ContextMTL& parent);
+
     virtual ~SyncSwitchObserver() = default;
+
     void OnSyncSwitchUpdate(bool new_value) override;
 
    private:

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -390,8 +390,8 @@ id<MTLCommandBuffer> ContextMTL::CreateMTLCommandBuffer(
   return buffer;
 }
 
-void ContextMTL::StoreTaskForGPU(std::function<void()> task) {
-  tasks_awaiting_gpu_.emplace_back(std::move(task));
+void ContextMTL::StoreTaskForGPU(const std::function<void()>& task) {
+  tasks_awaiting_gpu_.emplace_back(task);
   while (tasks_awaiting_gpu_.size() > kMaxTasksAwaitingGPU) {
     tasks_awaiting_gpu_.front()();
     tasks_awaiting_gpu_.pop_front();

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -195,7 +195,7 @@ class Context {
   /// Threadsafe.
   ///
   /// `task` will be executed on the platform thread.
-  virtual void StoreTaskForGPU(std::function<void()> task) {
+  virtual void StoreTaskForGPU(const std::function<void()>& task) {
     FML_CHECK(false && "not supported in this context");
   }
 

--- a/impeller/renderer/renderer.h
+++ b/impeller/renderer/renderer.h
@@ -24,8 +24,8 @@ class Renderer {
 
   using RenderCallback = std::function<bool(RenderTarget& render_target)>;
 
-  Renderer(std::shared_ptr<Context> context,
-           size_t max_frames_in_flight = kDefaultMaxFramesInFlight);
+  explicit Renderer(std::shared_ptr<Context> context,
+                    size_t max_frames_in_flight = kDefaultMaxFramesInFlight);
 
   ~Renderer();
 


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/134969

I turned off explict ctr lints for some geometry classes that would require large refactors. We can decide if we want to do that once we get the other lints enabled.

I don't think this is clean yet because the header lints are picking up all dependency header lints.
