### PR TITLE
Revert "Add an AndroidManifest.xml flag to disable ImageReader backend Platform Views (#46430)"

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -218,9 +218,6 @@ struct Settings {
   bool enable_impeller = false;
 #endif
 
-  // Indicates if image reader backed platform views are disabled.
-  bool disable_image_reader_platform_views = false;
-
   // Requests a particular backend to be used (ex "opengles" or "vulkan")
   std::optional<std::string> impeller_backend;
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -455,17 +455,6 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   }
 
   {
-    std::string disable_image_reader_platform_views_value;
-    if (command_line.GetOptionValue(
-            FlagForSwitch(Switch::DisableImageReaderPlatformViews),
-            &disable_image_reader_platform_views_value)) {
-      settings.disable_image_reader_platform_views =
-          disable_image_reader_platform_views_value.empty() ||
-          "true" == disable_image_reader_platform_views_value;
-    }
-  }
-
-  {
     std::string impeller_backend_value;
     if (command_line.GetOptionValue(FlagForSwitch(Switch::ImpellerBackend),
                                     &impeller_backend_value)) {

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -284,9 +284,6 @@ DEF_SWITCH(LeakVM,
            "When the last shell shuts down, the shared VM is leaked by default "
            "(the leak_vm in VM settings is true). To clean up the leak VM, set "
            "this value to false.")
-DEF_SWITCH(DisableImageReaderPlatformViews,
-           "disable-image-reader-platform-views",
-           "Disables the use of ImageReader backed Platform Views on Android.")
 DEF_SWITCH(
     MsaaSamples,
     "msaa-samples",

--- a/shell/common/switches_unittests.cc
+++ b/shell/common/switches_unittests.cc
@@ -123,25 +123,6 @@ TEST(SwitchesTest, NoEnableImpeller) {
   }
 }
 
-TEST(SwitchesTest, DisableImageReaderPlatformViews) {
-  {
-    // enable
-    fml::CommandLine command_line = fml::CommandLineFromInitializerList(
-        {"command", "--disable-image-reader-platform-views"});
-    EXPECT_TRUE(command_line.HasOption("disable-image-reader-platform-views"));
-    Settings settings = SettingsFromCommandLine(command_line);
-    EXPECT_EQ(settings.disable_image_reader_platform_views, true);
-  }
-  {
-    // disable
-    fml::CommandLine command_line = fml::CommandLineFromInitializerList(
-        {"command", "--disable-image-reader-platform-views=false"});
-    EXPECT_TRUE(command_line.HasOption("disable-image-reader-platform-views"));
-    Settings settings = SettingsFromCommandLine(command_line);
-    EXPECT_EQ(settings.disable_image_reader_platform_views, false);
-  }
-}
-
 }  // namespace testing
 }  // namespace flutter
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -371,8 +371,6 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
     this.renderer = new FlutterRenderer(flutterJNI);
 
     this.platformViewsController = platformViewsController;
-    this.platformViewsController.setDisableImageReaderPlatformViews(
-        flutterJNI.getDisableImageReaderPlatformViews());
     this.platformViewsController.onAttachedToJNI();
 
     this.pluginRegistry =

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -237,17 +237,6 @@ public class FlutterJNI {
     return nativeGetIsSoftwareRenderingEnabled();
   }
 
-  private native boolean nativeGetDisableImageReaderPlatformViews();
-
-  /**
-   * Checks launch settings for whether image reader platform views are disabled.
-   *
-   * <p>The value is the same per program.
-   */
-  @UiThread
-  public boolean getDisableImageReaderPlatformViews() {
-    return nativeGetDisableImageReaderPlatformViews();
-  }
   /**
    * VM Service URI for the VM instance.
    *

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
@@ -20,7 +20,6 @@ import java.util.*;
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class FlutterShellArgs {
-  private static final String TAG = "FlutterShellArgs";
   public static final String ARG_KEY_TRACE_STARTUP = "trace-startup";
   public static final String ARG_TRACE_STARTUP = "--trace-startup";
   public static final String ARG_KEY_START_PAUSED = "start-paused";
@@ -39,10 +38,6 @@ public class FlutterShellArgs {
   public static final String ARG_SKIA_DETERMINISTIC_RENDERING = "--skia-deterministic-rendering";
   public static final String ARG_KEY_TRACE_SKIA = "trace-skia";
   public static final String ARG_TRACE_SKIA = "--trace-skia";
-  public static final String ARG_KEY_DISABLE_IMAGE_READER_PLATFORM_VIEWS =
-      "disable-image-reader-platform-views";
-  public static final String ARG_DISABLE_IMAGE_READER_PLATFORM_VIEWS =
-      "--disable-image-reader-platform-views";
   public static final String ARG_KEY_TRACE_SKIA_ALLOWLIST = "trace-skia-allowlist";
   public static final String ARG_TRACE_SKIA_ALLOWLIST = "--trace-skia-allowlist=";
   public static final String ARG_KEY_TRACE_SYSTRACE = "trace-systrace";
@@ -132,9 +127,6 @@ public class FlutterShellArgs {
     }
     if (intent.getBooleanExtra(ARG_KEY_ENABLE_IMPELLER, false)) {
       args.add(ARG_ENABLE_IMPELLER);
-    }
-    if (intent.getBooleanExtra(ARG_KEY_DISABLE_IMAGE_READER_PLATFORM_VIEWS, false)) {
-      args.add(ARG_DISABLE_IMAGE_READER_PLATFORM_VIEWS);
     }
     if (intent.getBooleanExtra(ARG_KEY_ENABLE_VULKAN_VALIDATION, false)) {
       args.add(ARG_ENABLE_VULKAN_VALIDATION);

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -47,8 +47,6 @@ public class FlutterLoader {
       "io.flutter.embedding.android.ImpellerBackend";
   private static final String IMPELLER_OPENGL_GPU_TRACING_DATA_KEY =
       "io.flutter.embedding.android.EnableOpenGLGPUTracing";
-  private static final String DISABLE_IMAGE_READER_PLATFORM_VIEWS_KEY =
-      "io.flutter.embedding.android.DisableImageReaderPlatformViews";
 
   /**
    * Set whether leave or clean up the VM after the last shell shuts down. It can be set from app's
@@ -334,9 +332,6 @@ public class FlutterLoader {
       if (metaData != null) {
         if (metaData.getBoolean(ENABLE_IMPELLER_META_DATA_KEY, false)) {
           shellArgs.add("--enable-impeller");
-        }
-        if (metaData.getBoolean(DISABLE_IMAGE_READER_PLATFORM_VIEWS_KEY, false)) {
-          shellArgs.add("--disable-image-reader-platform-views");
         }
         if (metaData.getBoolean(
             ENABLE_VULKAN_VALIDATION_META_DATA_KEY, areValidationLayersOnByDefault())) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -13,6 +13,8 @@ import android.content.MutableContextWrapper;
 import android.os.Build;
 import android.util.SparseArray;
 import android.view.MotionEvent;
+import android.view.MotionEvent.PointerCoords;
+import android.view.MotionEvent.PointerProperties;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
@@ -774,10 +776,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    */
   public void setSoftwareRendering(boolean useSoftwareRendering) {
     usesSoftwareRendering = useSoftwareRendering;
-  }
-
-  public void setDisableImageReaderPlatformViews(boolean disableImageReaderPlatformViews) {
-    enableHardwareBufferRenderingTarget = !disableImageReaderPlatformViews;
   }
 
   /**

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -483,11 +483,6 @@ static jboolean GetIsSoftwareRendering(JNIEnv* env, jobject jcaller) {
   return FlutterMain::Get().GetSettings().enable_software_rendering;
 }
 
-static jboolean GetDisableImageReaderPlatformViews(JNIEnv* env,
-                                                   jobject jcaller) {
-  return FlutterMain::Get().GetSettings().disable_image_reader_platform_views;
-}
-
 static void RegisterTexture(JNIEnv* env,
                             jobject jcaller,
                             jlong shell_holder,
@@ -782,11 +777,6 @@ bool RegisterApi(JNIEnv* env) {
           .name = "nativeGetIsSoftwareRenderingEnabled",
           .signature = "()Z",
           .fnPtr = reinterpret_cast<void*>(&GetIsSoftwareRendering),
-      },
-      {
-          .name = "nativeGetDisableImageReaderPlatformViews",
-          .signature = "()Z",
-          .fnPtr = reinterpret_cast<void*>(&GetDisableImageReaderPlatformViews),
       },
       {
           .name = "nativeRegisterTexture",


### PR DESCRIPTION
This reverts commit 87c3bf12b1ab51a70afe564589f828ec1758feeb. It is no longer needed as we have resolved the flickering issue in the ImageReader backend.