### PR TITLE
[macOS] Eliminate unused OCMock includes

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderTest.mm
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import <Foundation/Foundation.h>
-#import <OCMock/OCMock.h>
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.h"
 #include "flutter/shell/platform/embedder/test_utils/key_codes.g.h"

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -4,7 +4,6 @@
 
 #import <Cocoa/Cocoa.h>
 #import <Metal/Metal.h>
-#import <OCMock/OCMock.h>
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObjectTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObjectTest.mm
@@ -9,7 +9,6 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 
-#import <OCMock/OCMock.h>
 #import "flutter/testing/testing.h"
 
 namespace flutter::testing {

--- a/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizerTest.mm
@@ -4,7 +4,6 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.h"
 
-#import <OCMock/OCMock.h>
 #import "flutter/fml/synchronization/waitable_event.h"
 #import "flutter/testing/testing.h"
 


### PR DESCRIPTION
As part of the broader quest to reduce our dependence on OCMock in macOS embedder tests, this removes #includes of OCMock into files where OCMock is not actually used.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
