### PR TITLE
[Impeller] add async command submission for blit pass.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -164,7 +164,8 @@ TEST_P(AiksTest, CanRenderColorFilterWithInvertColorsDrawPaint) {
 namespace {
 bool GenerateMipmap(const std::shared_ptr<Context>& context,
                     std::shared_ptr<Texture> texture,
-                    std::string label) {
+                    std::string label,
+                    bool async_submit) {
   auto buffer = context->CreateCommandBuffer();
   if (!buffer) {
     return false;
@@ -174,18 +175,23 @@ bool GenerateMipmap(const std::shared_ptr<Context>& context,
     return false;
   }
   pass->GenerateMipmap(std::move(texture), std::move(label));
+  if (async_submit) {
+    return buffer->SubmitCommandsAsync(pass, context->GetResourceAllocator());
+  }
+
   pass->EncodeCommands(context->GetResourceAllocator());
   return buffer->SubmitCommands();
 }
 
 void CanRenderTiledTexture(AiksTest* aiks_test,
                            Entity::TileMode tile_mode,
+                           bool async_submit = false,
                            Matrix local_matrix = {}) {
   auto context = aiks_test->GetContext();
   ASSERT_TRUE(context);
   auto texture = aiks_test->CreateTextureForFixture("table_mountain_nx.png",
                                                     /*enable_mipmapping=*/true);
-  GenerateMipmap(context, texture, "table_mountain_nx");
+  GenerateMipmap(context, texture, "table_mountain_nx", async_submit);
   Canvas canvas;
   canvas.Scale(aiks_test->GetContentScale());
   canvas.Translate({100.0f, 100.0f, 0});
@@ -232,6 +238,10 @@ TEST_P(AiksTest, CanRenderTiledTextureClamp) {
   CanRenderTiledTexture(this, Entity::TileMode::kClamp);
 }
 
+TEST_P(AiksTest, CanRenderTiledTextureClampAsync) {
+  CanRenderTiledTexture(this, Entity::TileMode::kClamp, /*async_submit=*/true);
+}
+
 TEST_P(AiksTest, CanRenderTiledTextureRepeat) {
   CanRenderTiledTexture(this, Entity::TileMode::kRepeat);
 }
@@ -245,7 +255,7 @@ TEST_P(AiksTest, CanRenderTiledTextureDecal) {
 }
 
 TEST_P(AiksTest, CanRenderTiledTextureClampWithTranslate) {
-  CanRenderTiledTexture(this, Entity::TileMode::kClamp,
+  CanRenderTiledTexture(this, Entity::TileMode::kClamp, /*async_submit=*/false,
                         Matrix::MakeTranslation({172.f, 172.f, 0.f}));
 }
 

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -176,7 +176,7 @@ bool GenerateMipmap(const std::shared_ptr<Context>& context,
   }
   pass->GenerateMipmap(std::move(texture), std::move(label));
   if (async_submit) {
-    return buffer->SubmitCommandsAsync(pass, context->GetResourceAllocator());
+    return buffer->EncodeAndSubmit(pass, context->GetResourceAllocator());
   }
 
   pass->EncodeCommands(context->GetResourceAllocator());

--- a/impeller/aiks/testing/context_mock.h
+++ b/impeller/aiks/testing/context_mock.h
@@ -25,11 +25,6 @@ class CommandBufferMock : public CommandBuffer {
 
   MOCK_METHOD(void, SetLabel, (const std::string& label), (const, override));
 
-  MOCK_METHOD(bool,
-              SubmitCommandsAsync,
-              (std::shared_ptr<RenderPass> render_pass),
-              (override));
-
   MOCK_METHOD(std::shared_ptr<RenderPass>,
               OnCreateRenderPass,
               (RenderTarget render_target),

--- a/impeller/aiks/testing/context_spy.cc
+++ b/impeller/aiks/testing/context_spy.cc
@@ -63,12 +63,6 @@ std::shared_ptr<ContextMock> ContextSpy::MakeContext(
               return real_buffer->SetLabel(label);
             });
 
-        ON_CALL(*spy, SubmitCommandsAsync)
-            .WillByDefault([real_buffer](
-                               std::shared_ptr<RenderPass> render_pass) {
-              return real_buffer->SubmitCommandsAsync(std::move(render_pass));
-            });
-
         ON_CALL(*spy, OnCreateRenderPass)
             .WillByDefault(
                 [real_buffer, shared_this](const RenderTarget& render_target) {

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -430,7 +430,7 @@ std::shared_ptr<Texture> ContentContext::MakeSubpass(
     return nullptr;
   }
 
-  if (!sub_command_buffer->SubmitCommandsAsync(std::move(sub_renderpass))) {
+  if (!sub_command_buffer->EncodeAndSubmit(sub_renderpass)) {
     return nullptr;
   }
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -371,8 +371,8 @@ bool EntityPass::Render(ContentContext& renderer,
           offscreen_target.GetRenderTarget().GetRenderTargetTexture(),
           root_render_target.GetRenderTargetTexture());
 
-      if (!blit_pass->EncodeCommands(
-              renderer.GetContext()->GetResourceAllocator())) {
+      if (!command_buffer->SubmitCommandsAsync(
+              blit_pass, renderer.GetContext()->GetResourceAllocator())) {
         VALIDATION_LOG << "Failed to encode root pass blit command.";
         return false;
       }
@@ -399,14 +399,10 @@ bool EntityPass::Render(ContentContext& renderer,
         }
       }
 
-      if (!render_pass->EncodeCommands()) {
+      if (!command_buffer->SubmitCommandsAsync(render_pass)) {
         VALIDATION_LOG << "Failed to encode root pass command buffer.";
         return false;
       }
-    }
-    if (!command_buffer->SubmitCommands()) {
-      VALIDATION_LOG << "Failed to submit root pass command buffer.";
-      return false;
     }
 
     return true;

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -371,7 +371,7 @@ bool EntityPass::Render(ContentContext& renderer,
           offscreen_target.GetRenderTarget().GetRenderTargetTexture(),
           root_render_target.GetRenderTargetTexture());
 
-      if (!command_buffer->SubmitCommandsAsync(
+      if (!command_buffer->EncodeAndSubmit(
               blit_pass, renderer.GetContext()->GetResourceAllocator())) {
         VALIDATION_LOG << "Failed to encode root pass blit command.";
         return false;
@@ -399,7 +399,7 @@ bool EntityPass::Render(ContentContext& renderer,
         }
       }
 
-      if (!command_buffer->SubmitCommandsAsync(render_pass)) {
+      if (!command_buffer->EncodeAndSubmit(render_pass)) {
         VALIDATION_LOG << "Failed to encode root pass command buffer.";
         return false;
       }

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -54,7 +54,7 @@ bool InlinePassContext::EndPass() {
   }
 
   if (command_buffer_) {
-    if (!command_buffer_->SubmitCommandsAsync(std::move(pass_))) {
+    if (!command_buffer_->EncodeAndSubmit(pass_)) {
       VALIDATION_LOG
           << "Failed to encode and submit command buffer while ending "
              "render pass.";

--- a/impeller/renderer/backend/metal/command_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.h
@@ -7,6 +7,7 @@
 #include <Metal/Metal.h>
 
 #include "flutter/fml/macros.h"
+#include "impeller/core/allocator.h"
 #include "impeller/renderer/command_buffer.h"
 
 namespace impeller {
@@ -37,7 +38,13 @@ class CommandBufferMTL final : public CommandBuffer {
   void OnWaitUntilScheduled() override;
 
   // |CommandBuffer|
-  bool SubmitCommandsAsync(std::shared_ptr<RenderPass> render_pass) override;
+  bool SubmitCommandsAsync(
+      const std::shared_ptr<RenderPass>& render_pass) override;
+
+  // |CommandBuffer|
+  bool SubmitCommandsAsync(
+      const std::shared_ptr<BlitPass>& blit_ass,
+      const std::shared_ptr<Allocator>& allocator) override;
 
   // |CommandBuffer|
   std::shared_ptr<RenderPass> OnCreateRenderPass(RenderTarget target) override;

--- a/impeller/renderer/backend/metal/command_buffer_mtl.h
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.h
@@ -38,13 +38,11 @@ class CommandBufferMTL final : public CommandBuffer {
   void OnWaitUntilScheduled() override;
 
   // |CommandBuffer|
-  bool SubmitCommandsAsync(
-      const std::shared_ptr<RenderPass>& render_pass) override;
+  bool EncodeAndSubmit(const std::shared_ptr<RenderPass>& render_pass) override;
 
   // |CommandBuffer|
-  bool SubmitCommandsAsync(
-      const std::shared_ptr<BlitPass>& blit_ass,
-      const std::shared_ptr<Allocator>& allocator) override;
+  bool EncodeAndSubmit(const std::shared_ptr<BlitPass>& blit_ass,
+                       const std::shared_ptr<Allocator>& allocator) override;
 
   // |CommandBuffer|
   std::shared_ptr<RenderPass> OnCreateRenderPass(RenderTarget target) override;

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -184,7 +184,7 @@ bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
 }
 
 bool CommandBufferMTL::SubmitCommandsAsync(
-    std::shared_ptr<RenderPass> render_pass) {
+    const std::shared_ptr<RenderPass>& render_pass) {
   TRACE_EVENT0("impeller", "CommandBufferMTL::SubmitCommandsAsync");
   if (!IsValid() || !render_pass->IsValid()) {
     return false;
@@ -234,6 +234,34 @@ bool CommandBufferMTL::SubmitCommandsAsync(
         } else {
           VALIDATION_LOG << "Failed to encode command buffer";
         }
+      });
+  worker_task_runner->PostTask(task);
+  return true;
+}
+
+bool CommandBufferMTL::SubmitCommandsAsync(
+    const std::shared_ptr<BlitPass>& blit_pass,
+    const std::shared_ptr<Allocator>& allocator) {
+  if (!IsValid() || !blit_pass->IsValid()) {
+    return false;
+  }
+  auto context = context_.lock();
+  if (!context) {
+    return false;
+  }
+  [buffer_ enqueue];
+  auto buffer = buffer_;
+  buffer_ = nil;
+
+  auto worker_task_runner = ContextMTL::Cast(*context).GetWorkerTaskRunner();
+  auto task = fml::MakeCopyable(
+      [blit_pass, buffer, weak_context = context_, allocator]() {
+        auto context = weak_context.lock();
+        if (!blit_pass->EncodeCommands(allocator)) {
+          VALIDATION_LOG << "Failed to encode blit pass.";
+          return;
+        }
+        [buffer commit];
       });
   worker_task_runner->PostTask(task);
   return true;

--- a/impeller/renderer/backend/metal/command_buffer_mtl.mm
+++ b/impeller/renderer/backend/metal/command_buffer_mtl.mm
@@ -183,9 +183,9 @@ bool CommandBufferMTL::OnSubmitCommands(CompletionCallback callback) {
   return true;
 }
 
-bool CommandBufferMTL::SubmitCommandsAsync(
+bool CommandBufferMTL::EncodeAndSubmit(
     const std::shared_ptr<RenderPass>& render_pass) {
-  TRACE_EVENT0("impeller", "CommandBufferMTL::SubmitCommandsAsync");
+  TRACE_EVENT0("impeller", "CommandBufferMTL::EncodeAndSubmit");
   if (!IsValid() || !render_pass->IsValid()) {
     return false;
   }
@@ -239,7 +239,7 @@ bool CommandBufferMTL::SubmitCommandsAsync(
   return true;
 }
 
-bool CommandBufferMTL::SubmitCommandsAsync(
+bool CommandBufferMTL::EncodeAndSubmit(
     const std::shared_ptr<BlitPass>& blit_pass,
     const std::shared_ptr<Allocator>& allocator) {
   if (!IsValid() || !blit_pass->IsValid()) {

--- a/impeller/renderer/command_buffer.cc
+++ b/impeller/renderer/command_buffer.cc
@@ -37,14 +37,26 @@ void CommandBuffer::WaitUntilScheduled() {
 }
 
 bool CommandBuffer::SubmitCommandsAsync(
-    std::shared_ptr<RenderPass>
-        render_pass  // NOLINT(performance-unnecessary-value-param)
-) {
+    const std::shared_ptr<RenderPass>& render_pass) {
   TRACE_EVENT0("impeller", "CommandBuffer::SubmitCommandsAsync");
   if (!render_pass->IsValid() || !IsValid()) {
     return false;
   }
   if (!render_pass->EncodeCommands()) {
+    return false;
+  }
+
+  return SubmitCommands(nullptr);
+}
+
+bool CommandBuffer::SubmitCommandsAsync(
+    const std::shared_ptr<BlitPass>& blit_pass,
+    const std::shared_ptr<Allocator>& allocator) {
+  TRACE_EVENT0("impeller", "CommandBuffer::SubmitCommandsAsync");
+  if (!blit_pass->IsValid() || !IsValid()) {
+    return false;
+  }
+  if (!blit_pass->EncodeCommands(allocator)) {
     return false;
   }
 

--- a/impeller/renderer/command_buffer.cc
+++ b/impeller/renderer/command_buffer.cc
@@ -36,9 +36,9 @@ void CommandBuffer::WaitUntilScheduled() {
   return OnWaitUntilScheduled();
 }
 
-bool CommandBuffer::SubmitCommandsAsync(
+bool CommandBuffer::EncodeAndSubmit(
     const std::shared_ptr<RenderPass>& render_pass) {
-  TRACE_EVENT0("impeller", "CommandBuffer::SubmitCommandsAsync");
+  TRACE_EVENT0("impeller", "CommandBuffer::EncodeAndSubmit");
   if (!render_pass->IsValid() || !IsValid()) {
     return false;
   }
@@ -49,10 +49,10 @@ bool CommandBuffer::SubmitCommandsAsync(
   return SubmitCommands(nullptr);
 }
 
-bool CommandBuffer::SubmitCommandsAsync(
+bool CommandBuffer::EncodeAndSubmit(
     const std::shared_ptr<BlitPass>& blit_pass,
     const std::shared_ptr<Allocator>& allocator) {
-  TRACE_EVENT0("impeller", "CommandBuffer::SubmitCommandsAsync");
+  TRACE_EVENT0("impeller", "CommandBuffer::EncodeAndSubmit");
   if (!blit_pass->IsValid() || !IsValid()) {
     return false;
   }

--- a/impeller/renderer/command_buffer.h
+++ b/impeller/renderer/command_buffer.h
@@ -81,7 +81,19 @@ class CommandBuffer {
   ///             A command buffer may only be committed once.
   ///
   [[nodiscard]] virtual bool SubmitCommandsAsync(
-      std::shared_ptr<RenderPass> render_pass);
+      const std::shared_ptr<RenderPass>& render_pass);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Schedule the command encoded by blit passes within this
+  ///             command buffer on the GPU. The enqueing of this buffer is
+  ///             performed immediately but encoding is pushed to a worker
+  ///             thread if possible.
+  ///
+  ///             A command buffer may only be committed once.
+  ///
+  [[nodiscard]] virtual bool SubmitCommandsAsync(
+      const std::shared_ptr<BlitPass>& blit_pass,
+      const std::shared_ptr<Allocator>& allocator);
 
   //----------------------------------------------------------------------------
   /// @brief      Force execution of pending GPU commands.

--- a/impeller/renderer/command_buffer.h
+++ b/impeller/renderer/command_buffer.h
@@ -80,7 +80,7 @@ class CommandBuffer {
   ///
   ///             A command buffer may only be committed once.
   ///
-  [[nodiscard]] virtual bool SubmitCommandsAsync(
+  [[nodiscard]] virtual bool EncodeAndSubmit(
       const std::shared_ptr<RenderPass>& render_pass);
 
   //----------------------------------------------------------------------------
@@ -91,7 +91,7 @@ class CommandBuffer {
   ///
   ///             A command buffer may only be committed once.
   ///
-  [[nodiscard]] virtual bool SubmitCommandsAsync(
+  [[nodiscard]] virtual bool EncodeAndSubmit(
       const std::shared_ptr<BlitPass>& blit_pass,
       const std::shared_ptr<Allocator>& allocator);
 


### PR DESCRIPTION
This is a requirement for the "Remove Drawable Acquisition Latency" Change, but is otherwise a harmless improvement.

---

Submitting a command buffer causes the backend specific encoding logic to run. Metal is unique in that it is fairly easy to move this work into a background thread, allowing the engine to move onto creating the next command buffer. This improves throughput of the engine, at the cost of needing two slightly different APIs. Currently the GLES and Vulkan versions of this method still submit synchronously - for now that is out of scope as doing background work with those APIs has proved more challenging.

See also:
   * https://github.com/flutter/engine/pull/42028
   * https://github.com/flutter/flutter/issues/131698
   
Separately, as a requirement for the design in "Remove Drawable Acquisition Latency", we need to be able to defer drawable acquisition to this background thread. While this almost already works for render passes, it does not work for blit passes today. if the engine renders a backdrop filter, then the final command buffer submitted will be a blit pass that copies an offscreen onto the drawable. Therefore we need to add an async version of the blit submission, so that we have a hook to move the drawable acquisition onto a background thread for metal.

This hadn't been done until now because most blit cmd buffers have 1 or 2 cmds on them so the benefit of moving to a background thread is minimal.

Part of https://github.com/flutter/flutter/issues/138490
