### PR TITLE
[Impeller] some clang tidies in impeller

### DIFF
--- a/impeller/geometry/constants.h
+++ b/impeller/geometry/constants.h
@@ -10,16 +10,16 @@ namespace impeller {
 constexpr float kE = 2.7182818284590452354f;
 
 // log_2 e
-constexpr float kLog2_E = 1.4426950408889634074f;
+constexpr float kLog2E = 1.4426950408889634074f;
 
 // log_10 e
-constexpr float kLog10_E = 0.43429448190325182765f;
+constexpr float kLog10E = 0.43429448190325182765f;
 
 // log_e 2
-constexpr float klogE_2 = 0.69314718055994530942f;
+constexpr float kLogE2 = 0.69314718055994530942f;
 
 // log_e 10
-constexpr float klogE_10 = 2.30258509299404568402f;
+constexpr float kLogE10 = 2.30258509299404568402f;
 
 // pi
 constexpr float kPi = 3.14159265358979323846f;

--- a/impeller/geometry/half.h
+++ b/impeller/geometry/half.h
@@ -13,6 +13,8 @@
 #include "impeller/geometry/scalar.h"
 #include "impeller/geometry/vector.h"
 
+// NOLINTBEGIN(google-explicit-constructor)
+
 #ifdef FML_OS_WIN
 using InternalHalf = uint16_t;
 #else
@@ -184,5 +186,7 @@ inline std::ostream& operator<<(std::ostream& out,
       << static_cast<impeller::Scalar>(p.w) << ")";
   return out;
 }
+
+// NOLINTEND(google-explicit-constructor)
 
 }  // namespace std

--- a/impeller/geometry/scalar.h
+++ b/impeller/geometry/scalar.h
@@ -12,6 +12,8 @@
 
 namespace impeller {
 
+// NOLINTBEGIN(google-explicit-constructor)
+
 using Scalar = float;
 
 template <class T, class = std::enable_if_t<std::is_arithmetic_v<T>>>
@@ -51,5 +53,7 @@ struct Degrees {
     return Radians{degrees * kPi / 180.0f};
   };
 };
+
+// NOLINTEND(google-explicit-constructor)
 
 }  // namespace impeller

--- a/impeller/geometry/vector.h
+++ b/impeller/geometry/vector.h
@@ -14,6 +14,8 @@
 
 namespace impeller {
 
+// NOLINTBEGIN(google-explicit-constructor)
+
 struct Vector3 {
   union {
     struct {
@@ -323,5 +325,7 @@ inline std::ostream& operator<<(std::ostream& out, const impeller::Vector4& p) {
   out << "(" << p.x << ", " << p.y << ", " << p.z << ", " << p.w << ")";
   return out;
 }
+
+// NOLINTEND(google-explicit-constructor)
 
 }  // namespace std

--- a/impeller/image/compressed_image.h
+++ b/impeller/image/compressed_image.h
@@ -26,7 +26,7 @@ class CompressedImage {
  protected:
   const std::shared_ptr<const fml::Mapping> source_;
 
-  CompressedImage(std::shared_ptr<const fml::Mapping> allocation);
+  explicit CompressedImage(std::shared_ptr<const fml::Mapping> allocation);
 };
 
 }  // namespace impeller


### PR DESCRIPTION
Usage of Scalar/Vector/Half types is desgned around implicit conversions today: we don't specifically convert to the correct generated header types, since that will depend on the target platform. Instead we rely on implicit conversions to handle this - any mistake there would still lead to a compilation error.
