### PR TITLE
Dynamic view sizing [dart:ui]

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1479,7 +1479,7 @@ class _ViewConfiguration {
   /// The pixel density of the output surface.
   final double devicePixelRatio;
 
-  /// The size requested for the view in logical pixels.
+  /// The size requested for the view in physical pixels.
   final Size size;
 
   /// The number of physical pixels on each side of the display rectangle into
@@ -1980,6 +1980,75 @@ class ViewPadding {
   'This feature was deprecated after v3.8.0-14.0.pre.',
 )
 typedef WindowPadding = ViewPadding;
+
+/// Immutable layout constraints for [FlutterView]s.
+///
+/// Similar to [BoxConstraints], a [Size] respects a [ViewConstraints] if, and
+/// only if, all of the following relations hold:
+///
+/// * [minWidth] <= [Size.width] <= [maxWidth]
+/// * [minHeight] <= [Size.height] <= [maxHeight]
+///
+/// The constraints themselves must satisfy these relations:
+///
+/// * 0.0 <= [minWidth] <= [maxWidth] <= [double.infinity]
+/// * 0.0 <= [minHeight] <= [maxHeight] <= [double.infinity]
+///
+/// For each constraint, [double.infinity] is a legal value.
+///
+/// For a generic class that represents these kind of constraints, see the
+/// [BoxConstraints] class.
+class ViewConstraints {
+  /// Creates view constraints with the given constraints.
+  const ViewConstraints({
+    this.minWidth = 0.0,
+    this.maxWidth = double.infinity,
+    this.minHeight = 0.0,
+    this.maxHeight = double.infinity,
+  });
+
+  /// Creates view constraints that is respected only by the given size.
+  ViewConstraints.tight(Size size)
+    : minWidth = size.width,
+      maxWidth = size.width,
+      minHeight = size.height,
+      maxHeight = size.height;
+
+  /// The minimum width that satisfies the constraints.
+  final double minWidth;
+
+  /// The maximum width that satisfies the constraints.
+  ///
+  /// Might be [double.infinity].
+  final double maxWidth;
+
+  /// The minimum height that satisfies the constraints.
+  final double minHeight;
+
+  /// The maximum height that satisfies the constraints.
+  ///
+  /// Might be [double.infinity].
+  final double maxHeight;
+
+  /// Whether the given size satisfies the constraints.
+  bool isSatisfiedBy(Size size) {
+    return (minWidth <= size.width) && (size.width <= maxWidth) &&
+           (minHeight <= size.height) && (size.height <= maxHeight);
+  }
+
+  /// Whether there is exactly one size that satisfies the constraints.
+  bool get isTight => minWidth >= maxWidth && minHeight >= maxHeight;
+
+  /// Scales each constraint parameter by the inverse of the given factor.
+  BoxConstraints operator/(double factor) {
+    return BoxConstraints(
+      minWidth: minWidth / factor,
+      maxWidth: maxWidth / factor,
+      minHeight: minHeight / factor,
+      maxHeight: maxHeight / factor,
+    );
+  }
+}
 
 /// Area of the display that may be obstructed by a hardware feature.
 ///

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -2066,6 +2066,26 @@ class ViewConstraints {
 
   @override
   int get hashCode => Object.hash(minWidth, maxWidth, minHeight, maxHeight);
+
+  @override
+  String toString() {
+    if (minWidth == double.infinity && minHeight == double.infinity) {
+      return 'ViewConstraints(biggest)';
+    }
+    if (minWidth == 0 && maxWidth == double.infinity &&
+        minHeight == 0 && maxHeight == double.infinity) {
+      return 'ViewConstraints(unconstrained)';
+    }
+    String describe(double min, double max, String dim) {
+      if (min == max) {
+        return '$dim=${min.toStringAsFixed(1)}';
+      }
+      return '${min.toStringAsFixed(1)}<=$dim<=${max.toStringAsFixed(1)}';
+    }
+    final String width = describe(minWidth, maxWidth, 'w');
+    final String height = describe(minHeight, maxHeight, 'h');
+    return 'ViewConstraints($width, $height)';
+  }
 }
 
 /// Area of the display that may be obstructed by a hardware feature.

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -2040,8 +2040,8 @@ class ViewConstraints {
   bool get isTight => minWidth >= maxWidth && minHeight >= maxHeight;
 
   /// Scales each constraint parameter by the inverse of the given factor.
-  BoxConstraints operator/(double factor) {
-    return BoxConstraints(
+  ViewConstraints operator/(double factor) {
+    return ViewConstraints(
       minWidth: minWidth / factor,
       maxWidth: maxWidth / factor,
       minHeight: minHeight / factor,

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -2048,6 +2048,24 @@ class ViewConstraints {
       maxHeight: maxHeight / factor,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is ViewConstraints
+        && other.minWidth == minWidth
+        && other.maxWidth == maxWidth
+        && other.minHeight == minHeight
+        && other.maxHeight == maxHeight;
+  }
+
+  @override
+  int get hashCode => Object.hash(minWidth, maxWidth, minHeight, maxHeight);
 }
 
 /// Area of the display that may be obstructed by a hardware feature.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -358,8 +358,12 @@ class FlutterView {
   /// then obtain a [Scene] object, which you can display to the user via this
   /// [render] function.
   ///
-  /// If the view is configured with loose [physicalConstraints] a `size`
-  /// satisfying those constraints must be provided.
+  /// If the view is configured with loose [physicalConstraints] (i.e.
+  /// [ViewConstraints.isTight] returns false) a `size` satisfying those
+  /// constraints must be provided. This method does not check that the provided
+  /// `size` actually meets the constraints (this should be done in a heigher
+  /// level), but an illegal `size` may result in undefined rendering behavior.
+  /// If no `size` is provided, [physicalSize] is used instead.
   ///
   /// See also:
   ///
@@ -368,7 +372,6 @@ class FlutterView {
   /// * [RendererBinding], the Flutter framework class which manages layout and
   ///   painting.
   void render(Scene scene, {Size? size}) {
-    assert((size != null && physicalConstraints.isSatisfiedBy(size)) || (size == null && physicalConstraints.isTight));
     // Duplicated calls or calls outside of onBeginFrame/onDrawFrame (indicated
     // by _renderedViews being null) are ignored. See _renderedViews.
     // TODO(dkwingsmt): We should change this skip into an assertion.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -373,13 +373,11 @@ class FlutterView {
     // https://github.com/flutter/flutter/issues/137073
     final bool validRender = platformDispatcher._renderedViews?.add(this) ?? false;
     if (validRender) {
-      // TODO(goderbauer): Wire "size" through to the embedder when we actually
-      //   support support embedder-provided constraints.
-      _render(viewId, scene as _NativeScene);
+      _render(viewId, scene as _NativeScene, size?.width ?? physicalSize.width, size?.height ?? physicalSize.height);
     }
   }
 
-  @Native<Void Function(Int64, Pointer<Void>)>(symbol: 'PlatformConfigurationNativeApi::Render')
+  @Native<Void Function(Int64, Pointer<Void>, Double, Double)>(symbol: 'PlatformConfigurationNativeApi::Render')
   external static void _render(int viewId, _NativeScene scene, Double, Double);
 
   /// Change the retained semantics data about this [FlutterView].

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -161,8 +161,10 @@ class FlutterView {
   /// See also:
   ///
   ///  * [physicalSize], which returns the current size of the view.
-  // TODO(goderbauer): Wire this up so embedders can configure it.
-  ViewConstraints get physicalConstraints => ViewConstraints.fromSize(physicalSize);
+  // TODO(goderbauer): Wire this up so embedders can configure it. This will
+  //   also require to message the size provided to the render call back to the
+  //   embedder.
+  ViewConstraints get physicalConstraints => ViewConstraints.tight(physicalSize);
 
   /// The current dimensions of the rectangle as last reported by the platform
   /// into which scenes rendered in this view are drawn.
@@ -378,7 +380,7 @@ class FlutterView {
   }
 
   @Native<Void Function(Int64, Pointer<Void>, Double, Double)>(symbol: 'PlatformConfigurationNativeApi::Render')
-  external static void _render(int viewId, _NativeScene scene, Double, Double);
+  external static void _render(int viewId, _NativeScene scene, double width, double height);
 
   /// Change the retained semantics data about this [FlutterView].
   ///

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -155,7 +155,7 @@ class FlutterView {
   /// This value does not take into account any on-screen keyboards or other
   /// system UI. If the constraints are tight, the [padding] and [viewInsets]
   /// properties provide information about how much of each side of the view may
-  /// be obscured by system UI. If the consraints are loose, this information
+  /// be obscured by system UI. If the constraints are loose, this information
   /// is not known upfront.
   ///
   /// See also:

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -361,7 +361,7 @@ class FlutterView {
   /// If the view is configured with loose [physicalConstraints] (i.e.
   /// [ViewConstraints.isTight] returns false) a `size` satisfying those
   /// constraints must be provided. This method does not check that the provided
-  /// `size` actually meets the constraints (this should be done in a heigher
+  /// `size` actually meets the constraints (this should be done in a higher
   /// level), but an illegal `size` may result in undefined rendering behavior.
   /// If no `size` is provided, [physicalSize] is used instead.
   ///

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -449,10 +449,13 @@ void PlatformConfiguration::CompletePlatformMessageResponse(
   response->Complete(std::make_unique<fml::DataMapping>(std::move(data)));
 }
 
-void PlatformConfigurationNativeApi::Render(int64_t view_id, Scene* scene, double width, double height) {
+void PlatformConfigurationNativeApi::Render(int64_t view_id,
+                                            Scene* scene,
+                                            double width,
+                                            double height) {
   UIDartState::ThrowIfUIOperationsProhibited();
-  UIDartState::Current()->platform_configuration()->client()->Render(view_id,
-                                                                     scene, width, height);
+  UIDartState::Current()->platform_configuration()->client()->Render(
+      view_id, scene, width, height);
 }
 
 void PlatformConfigurationNativeApi::SetNeedsReportTimings(bool value) {

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -449,10 +449,10 @@ void PlatformConfiguration::CompletePlatformMessageResponse(
   response->Complete(std::make_unique<fml::DataMapping>(std::move(data)));
 }
 
-void PlatformConfigurationNativeApi::Render(int64_t view_id, Scene* scene) {
+void PlatformConfigurationNativeApi::Render(int64_t view_id, Scene* scene, double width, double height) {
   UIDartState::ThrowIfUIOperationsProhibited();
   UIDartState::Current()->platform_configuration()->client()->Render(view_id,
-                                                                     scene);
+                                                                     scene, width, height);
 }
 
 void PlatformConfigurationNativeApi::SetNeedsReportTimings(bool value) {

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -69,7 +69,7 @@ class PlatformConfigurationClient {
   /// @brief      Updates the client's rendering on the GPU with the newly
   ///             provided Scene.
   ///
-  virtual void Render(int64_t view_id, Scene* scene) = 0;
+  virtual void Render(int64_t view_id, Scene* scene, double width, double height) = 0;
 
   //--------------------------------------------------------------------------
   /// @brief      Receives an updated semantics tree from the Framework.
@@ -557,7 +557,7 @@ class PlatformConfigurationNativeApi {
 
   static void ScheduleFrame();
 
-  static void Render(int64_t view_id, Scene* scene);
+  static void Render(int64_t view_id, Scene* scene, double width, double height);
 
   static void UpdateSemantics(SemanticsUpdate* update);
 

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -69,7 +69,10 @@ class PlatformConfigurationClient {
   /// @brief      Updates the client's rendering on the GPU with the newly
   ///             provided Scene.
   ///
-  virtual void Render(int64_t view_id, Scene* scene, double width, double height) = 0;
+  virtual void Render(int64_t view_id,
+                      Scene* scene,
+                      double width,
+                      double height) = 0;
 
   //--------------------------------------------------------------------------
   /// @brief      Receives an updated semantics tree from the Framework.
@@ -557,7 +560,10 @@ class PlatformConfigurationNativeApi {
 
   static void ScheduleFrame();
 
-  static void Render(int64_t view_id, Scene* scene, double width, double height);
+  static void Render(int64_t view_id,
+                     Scene* scene,
+                     double width,
+                     double height);
 
   static void UpdateSemantics(SemanticsUpdate* update);
 

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -288,6 +288,25 @@ abstract class ViewPadding {
   }
 }
 
+abstract class ViewConstraints {
+  const factory ViewConstraints({
+    double minWidth,
+    double maxWidth,
+    double minHeight,
+    double maxHeight,
+  }) = engine.ViewConstraints;
+
+  factory ViewConstraints.tight(Size size) = engine.ViewConstraints.tight;
+
+  double get minWidth;
+  double get maxWidth;
+  double get minHeight;
+  double get maxHeight;
+  bool isSatisfiedBy(Size size);
+  bool get isTight;
+  ViewConstraints operator/(double factor);
+}
+
 @Deprecated(
   'Use ViewPadding instead. '
   'This feature was deprecated after v3.8.0-14.0.pre.',

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -697,7 +697,7 @@ class ViewConstraints implements ui.ViewConstraints {
     );
   }
 
-    @override
+  @override
   bool operator ==(Object other) {
     if (identical(this, other)) {
       return true;
@@ -714,4 +714,24 @@ class ViewConstraints implements ui.ViewConstraints {
 
   @override
   int get hashCode => Object.hash(minWidth, maxWidth, minHeight, maxHeight);
+
+  @override
+  String toString() {
+    if (minWidth == double.infinity && minHeight == double.infinity) {
+      return 'ViewConstraints(biggest)';
+    }
+    if (minWidth == 0 && maxWidth == double.infinity &&
+        minHeight == 0 && maxHeight == double.infinity) {
+      return 'ViewConstraints(unconstrained)';
+    }
+    String describe(double min, double max, String dim) {
+      if (min == max) {
+        return '$dim=${min.toStringAsFixed(1)}';
+      }
+      return '${min.toStringAsFixed(1)}<=$dim<=${max.toStringAsFixed(1)}';
+    }
+    final String width = describe(minWidth, maxWidth, 'w');
+    final String height = describe(minHeight, maxHeight, 'h');
+    return 'ViewConstraints($width, $height)';
+  }
 }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -98,7 +98,7 @@ base class EngineFlutterView implements ui.FlutterView {
   @override
   void render(ui.Scene scene, {ui.Size? size}) {
     assert(!isDisposed, 'Trying to render a disposed EngineFlutterView.');
-    // TODO(goderbauer): Resepct the provided size when "physicalConstraints" are not allways tight. See TODO on "physicalConstraints".
+    // TODO(goderbauer): Respect the provided size when "physicalConstraints" are not always tight. See TODO on "physicalConstraints".
     platformDispatcher.render(scene, this);
   }
 

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -696,4 +696,22 @@ class ViewConstraints implements ui.ViewConstraints {
       maxHeight: maxHeight / factor,
     );
   }
+
+    @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is ViewConstraints
+        && other.minWidth == minWidth
+        && other.maxWidth == maxWidth
+        && other.minHeight == minHeight
+        && other.maxHeight == maxHeight;
+  }
+
+  @override
+  int get hashCode => Object.hash(minWidth, maxWidth, minHeight, maxHeight);
 }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -96,8 +96,9 @@ base class EngineFlutterView implements ui.FlutterView {
   }
 
   @override
-  void render(ui.Scene scene) {
+  void render(ui.Scene scene, {ui.Size? size}) {
     assert(!isDisposed, 'Trying to render a disposed EngineFlutterView.');
+    // TODO(goderbauer): Resepct the provided size when "physicalConstraints" are not allways tight. See TODO on "physicalConstraints".
     platformDispatcher.render(scene, this);
   }
 
@@ -120,6 +121,9 @@ base class EngineFlutterView implements ui.FlutterView {
 
   late final PlatformViewMessageHandler platformViewMessageHandler =
       PlatformViewMessageHandler(platformViewsContainer: dom.platformViewsHost);
+
+  // TODO(goderbauer): Provide API to configure constraints. See also TODO in "render".
+  ViewConstraints get physicalConstraints => ViewConstraints.tight(physicalSize);
 
   @override
   ui.Size get physicalSize {
@@ -648,4 +652,47 @@ class ViewPadding implements ui.ViewPadding {
   final double right;
   @override
   final double bottom;
+}
+
+class ViewConstraints implements ui.ViewConstraints {
+  const ViewConstraints({
+    this.minWidth = 0.0,
+    this.maxWidth = double.infinity,
+    this.minHeight = 0.0,
+    this.maxHeight = double.infinity,
+  });
+
+  ViewConstraints.tight(ui.Size size)
+    : minWidth = size.width,
+      maxWidth = size.width,
+      minHeight = size.height,
+      maxHeight = size.height;
+
+  @override
+  final double minWidth;
+  @override
+  final double maxWidth;
+  @override
+  final double minHeight;
+  @override
+  final double maxHeight;
+
+  @override
+  bool isSatisfiedBy(ui.Size size) {
+    return (minWidth <= size.width) && (size.width <= maxWidth) &&
+           (minHeight <= size.height) && (size.height <= maxHeight);
+  }
+  
+  @override
+  bool get isTight => minWidth >= maxWidth && minHeight >= maxHeight;
+  
+  @override
+  ViewConstraints operator/(double factor) {
+    return ViewConstraints(
+      minWidth: minWidth / factor,
+      maxWidth: maxWidth / factor,
+      minHeight: minHeight / factor,
+      maxHeight: maxHeight / factor,
+    );
+  }
 }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -123,6 +123,7 @@ base class EngineFlutterView implements ui.FlutterView {
       PlatformViewMessageHandler(platformViewsContainer: dom.platformViewsHost);
 
   // TODO(goderbauer): Provide API to configure constraints. See also TODO in "render".
+  @override
   ViewConstraints get physicalConstraints => ViewConstraints.tight(physicalSize);
 
   @override

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -682,10 +682,10 @@ class ViewConstraints implements ui.ViewConstraints {
     return (minWidth <= size.width) && (size.width <= maxWidth) &&
            (minHeight <= size.height) && (size.height <= maxHeight);
   }
-  
+
   @override
   bool get isTight => minWidth >= maxWidth && minHeight >= maxHeight;
-  
+
   @override
   ViewConstraints operator/(double factor) {
     return ViewConstraints(

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -24,7 +24,7 @@ abstract class FlutterView {
   GestureSettings get gestureSettings;
   List<DisplayFeature> get displayFeatures;
   Display get display;
-  void render(Scene scene, {Size? size}) => platformDispatcher.render(scene, this, size);
+  void render(Scene scene, {Size? size});
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 }
 

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -15,6 +15,7 @@ abstract class FlutterView {
   PlatformDispatcher get platformDispatcher;
   int get viewId;
   double get devicePixelRatio;
+  ViewConstraints get physicalConstraints;
   Size get physicalSize;
   ViewPadding get viewInsets;
   ViewPadding get viewPadding;
@@ -23,7 +24,7 @@ abstract class FlutterView {
   GestureSettings get gestureSettings;
   List<DisplayFeature> get displayFeatures;
   Display get display;
-  void render(Scene scene) => platformDispatcher.render(scene, this);
+  void render(Scene scene, {Size? size}) => platformDispatcher.render(scene, this, size);
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 }
 

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -341,15 +341,15 @@ void RuntimeController::ScheduleFrame() {
 }
 
 // |PlatformConfigurationClient|
-void RuntimeController::Render(int64_t view_id, Scene* scene) {
+void RuntimeController::Render(int64_t view_id, Scene* scene, double width, double height) {
   const ViewportMetrics* view_metrics =
       UIDartState::Current()->platform_configuration()->GetMetrics(view_id);
   if (view_metrics == nullptr) {
     return;
   }
   client_.Render(view_id,
-                 scene->takeLayerTree(view_metrics->physical_width,
-                                      view_metrics->physical_height),
+                 scene->takeLayerTree(width,
+                                      height),
                  view_metrics->device_pixel_ratio);
 }
 

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -341,15 +341,16 @@ void RuntimeController::ScheduleFrame() {
 }
 
 // |PlatformConfigurationClient|
-void RuntimeController::Render(int64_t view_id, Scene* scene, double width, double height) {
+void RuntimeController::Render(int64_t view_id,
+                               Scene* scene,
+                               double width,
+                               double height) {
   const ViewportMetrics* view_metrics =
       UIDartState::Current()->platform_configuration()->GetMetrics(view_id);
   if (view_metrics == nullptr) {
     return;
   }
-  client_.Render(view_id,
-                 scene->takeLayerTree(width,
-                                      height),
+  client_.Render(view_id, scene->takeLayerTree(width, height),
                  view_metrics->device_pixel_ratio);
 }
 

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -658,7 +658,7 @@ class RuntimeController : public PlatformConfigurationClient {
   void ScheduleFrame() override;
 
   // |PlatformConfigurationClient|
-  void Render(int64_t view_id, Scene* scene) override;
+  void Render(int64_t view_id, Scene* scene, double width, double height) override;
 
   // |PlatformConfigurationClient|
   void UpdateSemantics(SemanticsUpdate* update) override;

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -658,7 +658,10 @@ class RuntimeController : public PlatformConfigurationClient {
   void ScheduleFrame() override;
 
   // |PlatformConfigurationClient|
-  void Render(int64_t view_id, Scene* scene, double width, double height) override;
+  void Render(int64_t view_id,
+              Scene* scene,
+              double width,
+              double height) override;
 
   // |PlatformConfigurationClient|
   void UpdateSemantics(SemanticsUpdate* update) override;

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -38,6 +38,7 @@ tests = [
   "paragraph_test.dart",
   "path_test.dart",
   "picture_test.dart",
+  "platform_dispatcher_test.dart",
   "platform_view_test.dart",
   "plugin_utilities_test.dart",
   "semantics_test.dart",

--- a/testing/dart/platform_dispatcher_test.dart
+++ b/testing/dart/platform_dispatcher_test.dart
@@ -8,42 +8,42 @@ import 'package:litetest/litetest.dart';
 
 void main() {
   test('ViewConstraints.tight', () {
-    final ViewConstraints tightConstraints = ViewConstraints.tight(Size(200, 300));
+    final ViewConstraints tightConstraints = ViewConstraints.tight(const Size(200, 300));
     expect(tightConstraints.minWidth, 200);
     expect(tightConstraints.maxWidth, 200);
     expect(tightConstraints.minHeight, 300);
     expect(tightConstraints.maxHeight, 300);
 
     expect(tightConstraints.isTight, true);
-    expect(tightConstraints.isSatisfiedBy(Size(200, 300)), true);
-    expect(tightConstraints.isSatisfiedBy(Size(400, 500)), false);
-    expect(tightConstraints / 2, ViewConstraints.tight(Size(100, 150)));
+    expect(tightConstraints.isSatisfiedBy(const Size(200, 300)), true);
+    expect(tightConstraints.isSatisfiedBy(const Size(400, 500)), false);
+    expect(tightConstraints / 2, ViewConstraints.tight(const Size(100, 150)));
   });
 
   test('ViewConstraints unconstrained', () {
-    final ViewConstraints defaultValues = ViewConstraints();
+    const ViewConstraints defaultValues = ViewConstraints();
     expect(defaultValues.minWidth, 0);
     expect(defaultValues.maxWidth, double.infinity);
     expect(defaultValues.minHeight, 0);
     expect(defaultValues.maxHeight, double.infinity);
 
     expect(defaultValues.isTight, false);
-    expect(defaultValues.isSatisfiedBy(Size(200, 300)), true);
-    expect(defaultValues.isSatisfiedBy(Size(400, 500)), true);
-    expect(defaultValues / 2, ViewConstraints());
+    expect(defaultValues.isSatisfiedBy(const Size(200, 300)), true);
+    expect(defaultValues.isSatisfiedBy(const Size(400, 500)), true);
+    expect(defaultValues / 2, const ViewConstraints());
   });
 
 
   test('ViewConstraints', () {
-    final ViewConstraints constraints = ViewConstraints(minWidth: 100, maxWidth: 200, minHeight: 300, maxHeight: 400);
+    const ViewConstraints constraints = ViewConstraints(minWidth: 100, maxWidth: 200, minHeight: 300, maxHeight: 400);
     expect(constraints.minWidth, 100);
     expect(constraints.maxWidth, 200);
     expect(constraints.minHeight, 300);
     expect(constraints.maxHeight, 400);
 
     expect(constraints.isTight, false);
-    expect(constraints.isSatisfiedBy(Size(200, 300)), true);
-    expect(constraints.isSatisfiedBy(Size(400, 500)), false);
-    expect(constraints / 2, ViewConstraints(minWidth: 50, maxWidth: 100, minHeight: 150, maxHeight: 200));
+    expect(constraints.isSatisfiedBy(const Size(200, 300)), true);
+    expect(constraints.isSatisfiedBy(const Size(400, 500)), false);
+    expect(constraints / 2, const ViewConstraints(minWidth: 50, maxWidth: 100, minHeight: 150, maxHeight: 200));
   });
 }

--- a/testing/dart/platform_dispatcher_test.dart
+++ b/testing/dart/platform_dispatcher_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:litetest/litetest.dart';
+
+void main() {
+  test('ViewConstraints.tight', () {
+    final ViewConstraints tightConstraints = ViewConstraints.tight(Size(200, 300));
+    expect(tightConstraints.minWidth, 200);
+    expect(tightConstraints.maxWidth, 200);
+    expect(tightConstraints.minHeight, 300);
+    expect(tightConstraints.maxHeight, 300);
+
+    expect(tightConstraints.isTight, true);
+    expect(tightConstraints.isSatisfiedBy(Size(200, 300)), true);
+    expect(tightConstraints.isSatisfiedBy(Size(400, 500)), false);
+    expect(tightConstraints / 2, ViewConstraints.tight(Size(100, 150)));
+  });
+
+  test('ViewConstraints unconstrained', () {
+    final ViewConstraints defaultValues = ViewConstraints();
+    expect(defaultValues.minWidth, 0);
+    expect(defaultValues.maxWidth, double.infinity);
+    expect(defaultValues.minHeight, 0);
+    expect(defaultValues.maxHeight, double.infinity);
+
+    expect(defaultValues.isTight, false);
+    expect(defaultValues.isSatisfiedBy(Size(200, 300)), true);
+    expect(defaultValues.isSatisfiedBy(Size(400, 500)), true);
+    expect(defaultValues / 2, ViewConstraints());
+  });
+
+
+  test('ViewConstraints', () {
+    final ViewConstraints constraints = ViewConstraints(minWidth: 100, maxWidth: 200, minHeight: 300, maxHeight: 400);
+    expect(constraints.minWidth, 100);
+    expect(constraints.maxWidth, 200);
+    expect(constraints.minHeight, 300);
+    expect(constraints.maxHeight, 400);
+
+    expect(constraints.isTight, false);
+    expect(constraints.isSatisfiedBy(Size(200, 300)), true);
+    expect(constraints.isSatisfiedBy(Size(400, 500)), false);
+    expect(constraints / 2, ViewConstraints(minWidth: 50, maxWidth: 100, minHeight: 150, maxHeight: 200));
+  });
+}


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/134501.

This PR makes the following changes to the public dart:ui API:

* It adds the `FlutterView.pysicalConstraints` property that describes max and min width and height for a view. The framework is allowed to size the `FlutterView` to any `Size` that meets these constraints.
* It adds an optional `size` argument to `FlutterView.render`. The framework provides the chosen `Size` that meets the aforementioned constraints to the `render` method. If the `FlutterView.pysicalConstraints` are tight (minHeight == maxHeight and minWidth == maxWidth) the argument is optional to remain backwards compatible. In all other cases, a `Size` must be provided.
* It adds a `ViewConstraints` class, which is basically the `dart:ui` version of `BoxConstraints` (This is similar to how we have `ViewPadding` in dart:ui to mirror `EdgeInsets` from the framework). It describes the constraints of a `FlutterView`, i.e. it powers the `FlutterView.pysicalConstraints` property.

This change does not wire anything up to the embedders. For now, `FlutterView.pysicalConstraints` just returns tight constraints for the embedder-provided size of the view (`FlutterView.physicalSize`) and the size provided to `FlutterView.render` is ignored (after it is checked that it meets the constrains). 

This PR enables the framework to implement the new dynamic view sizing and embedders to separately expose the new functionality to their clients.

Presubmits will fail until https://github.com/flutter/flutter/pull/138565 is submitted to the framework.

**DO NOT SUBMIT until https://github.com/flutter/flutter/pull/138648 is ready.**