### PR TITLE
[Impeller] Write a text-decoration test at the `dart:ui` layer

### DIFF
--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -52,8 +52,13 @@ foreach(test, tests) {
   flutter_frontend_server("compile_$test") {
     main_dart = test
     kernel_output = "$root_gen_dir/$test.dill"
-    extra_args = [ "-DkSkiaGoldWorkDirectory=$skia_gold_work_dir" ]
+    extra_args = [
+      "-DkFlutterBuildDirectory=$root_gen_dir",
+      "-DkSkiaGoldWorkDirectory=$skia_gold_work_dir",
+    ]
     package_config = ".dart_tool/package_config.json"
+    deps = [ "//flutter/third_party/txt:txt_fixtures" ]
+    testonly = true
   }
 }
 

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -48,12 +48,13 @@ tests = [
 ]
 
 foreach(test, tests) {
+  flutter_build_dir = rebase_path("$root_gen_dir")
   skia_gold_work_dir = rebase_path("$root_gen_dir/skia_gold_$test")
   flutter_frontend_server("compile_$test") {
     main_dart = test
     kernel_output = "$root_gen_dir/$test.dill"
     extra_args = [
-      "-DkFlutterBuildDirectory=$root_gen_dir",
+      "-DkFlutterBuildDirectory=$flutter_build_dir",
       "-DkSkiaGoldWorkDirectory=$skia_gold_work_dir",
     ]
     package_config = ".dart_tool/package_config.json"

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -1031,6 +1031,38 @@ void main() async {
     canvas.restoreToCount(canvas.getSaveCount() + 1);
     expect(canvas.getSaveCount(), equals(6));
   });
+
+  test('TextDecoration renders non-solid lines', () async {
+    final File file = File(path.join('flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
+    final Uint8List fontData = await file.readAsBytes();
+    await loadFontFromList(fontData, fontFamily: 'RobotoSlab');
+
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+
+    for (final (int index, TextDecorationStyle style) in TextDecorationStyle.values.indexed) {
+      final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
+      builder.pushStyle(TextStyle(
+        decoration: TextDecoration.underline,
+        decorationStyle: style,
+        decorationThickness: 1.0,
+        decorationColor: const Color(0xFFFF0000),
+        fontFamily: 'RobotoSlab',
+        fontSize: 24.0,
+      ));
+
+      builder.addText(style.name);
+      final Paragraph paragraph = builder.build();
+      paragraph.layout(const ParagraphConstraints(width: 1000));
+      
+      // Draw and layout based on the index vertically.
+      canvas.drawParagraph(paragraph, Offset(0, index * 40.0));
+    }
+
+    final Picture picture = recorder.endRecording();
+    final Image image = await picture.toImage(200, 200);
+    await comparer.addGoldenImage(image, 'text_decoration.png');
+  });
 }
 
 Matcher listEquals(ByteData expected) => (dynamic v) {

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -1059,6 +1059,7 @@ void main() async {
         decorationColor: const Color(0xFFFF0000),
         fontFamily: 'RobotoSlab',
         fontSize: 24.0,
+        foreground: Paint()..color = const Color(0xFF0000FF),
       ));
 
       builder.addText(style.name);

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -131,9 +131,6 @@ String get _flutterBuildPath {
   if (buildPath.isEmpty) {
     throw StateError('kFlutterBuildDirectory -D variable is not set.');
   }
-  if (buildPath.startsWith('//')) {
-    return buildPath.substring(2);
-  }
   return buildPath;
 }
 

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -124,6 +124,14 @@ void testNoCrashes() {
   });
 }
 
+String get _flutterBuildPath {
+  final String? buildPath = Platform.environment['FLUTTER_BUILD_DIRECTORY'];
+  if (buildPath == null) {
+    throw StateError('FLUTTER_BUILD_DIRECTORY environment variable is not set.');
+  }
+  return buildPath;
+}
+
 void main() async {
   final ImageComparer comparer = await ImageComparer.create();
 
@@ -530,7 +538,7 @@ void main() async {
     // Skia renders a tofu if the font does not have a glyph for a character.
     // However, Flutter opts-in to a Skia feature to render tabs as a single space.
     // See: https://github.com/flutter/flutter/issues/79153
-    final File file = File(path.join('flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
+    final File file = File(path.join(_flutterBuildPath, 'flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
     final Uint8List fontData = await file.readAsBytes();
     await loadFontFromList(fontData, fontFamily: 'RobotoSerif');
 
@@ -1033,7 +1041,7 @@ void main() async {
   });
 
   test('TextDecoration renders non-solid lines', () async {
-    final File file = File(path.join('flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
+    final File file = File(path.join(_flutterBuildPath, 'flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
     final Uint8List fontData = await file.readAsBytes();
     await loadFontFromList(fontData, fontFamily: 'RobotoSlab');
 

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -124,10 +124,15 @@ void testNoCrashes() {
   });
 }
 
+const String kFlutterBuildDirectory = 'kFlutterBuildDirectory';
+
 String get _flutterBuildPath {
-  final String? buildPath = Platform.environment['FLUTTER_BUILD_DIRECTORY'];
-  if (buildPath == null) {
-    throw StateError('FLUTTER_BUILD_DIRECTORY environment variable is not set.');
+  const String buildPath = String.fromEnvironment(kFlutterBuildDirectory);
+  if (buildPath.isEmpty) {
+    throw StateError('kFlutterBuildDirectory -D variable is not set.');
+  }
+  if (buildPath.startsWith('//')) {
+    return buildPath.substring(2);
   }
   return buildPath;
 }
@@ -538,7 +543,7 @@ void main() async {
     // Skia renders a tofu if the font does not have a glyph for a character.
     // However, Flutter opts-in to a Skia feature to render tabs as a single space.
     // See: https://github.com/flutter/flutter/issues/79153
-    final File file = File(path.join(_flutterBuildPath, 'gen', 'flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
+    final File file = File(path.join(_flutterBuildPath, 'flutter', 'third_party', 'txt', 'assets', 'Roboto-Regular.ttf'));
     final Uint8List fontData = await file.readAsBytes();
     await loadFontFromList(fontData, fontFamily: 'RobotoSerif');
 
@@ -1041,7 +1046,7 @@ void main() async {
   });
 
   test('TextDecoration renders non-solid lines', () async {
-    final File file = File(path.join(_flutterBuildPath, 'gen', 'flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
+    final File file = File(path.join(_flutterBuildPath, 'flutter', 'third_party', 'txt', 'assets', 'Roboto-Regular.ttf'));
     final Uint8List fontData = await file.readAsBytes();
     await loadFontFromList(fontData, fontFamily: 'RobotoSlab');
 

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -1054,7 +1054,7 @@ void main() async {
       builder.addText(style.name);
       final Paragraph paragraph = builder.build();
       paragraph.layout(const ParagraphConstraints(width: 1000));
-      
+
       // Draw and layout based on the index vertically.
       canvas.drawParagraph(paragraph, Offset(0, index * 40.0));
     }

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -538,7 +538,7 @@ void main() async {
     // Skia renders a tofu if the font does not have a glyph for a character.
     // However, Flutter opts-in to a Skia feature to render tabs as a single space.
     // See: https://github.com/flutter/flutter/issues/79153
-    final File file = File(path.join(_flutterBuildPath, 'flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
+    final File file = File(path.join(_flutterBuildPath, 'gen', 'flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
     final Uint8List fontData = await file.readAsBytes();
     await loadFontFromList(fontData, fontFamily: 'RobotoSerif');
 
@@ -1041,7 +1041,7 @@ void main() async {
   });
 
   test('TextDecoration renders non-solid lines', () async {
-    final File file = File(path.join(_flutterBuildPath, 'flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
+    final File file = File(path.join(_flutterBuildPath, 'gen', 'flutter', 'testing', 'resources', 'RobotoSlab-VariableFont_wght.ttf'));
     final Uint8List fontData = await file.readAsBytes();
     await loadFontFromList(fontData, fontFamily: 'RobotoSlab');
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/138501.

---

It would be nice to turn this into a test-fixture, and create a better local environment.

Here is how to run it locally:

```bash
# The test expects you to be PWD in the `src` directory or it crashes.
cd $ENGINE_SRC

out/host_debug_unopt_arm64/flutter_tester \
  --force-multithreading \
  --disable-observatory \
  --use-test-fonts \
  --icu-data-file-path=out/host_debug_unopt_arm64/icudtl.dat \
  --flutter-assets-dir=out/host_debug_unopt_arm64/gen/flutter/lib/ui/assets \
  --disable-asset-fonts \
  --enable-impeller \
  out/host_debug_unopt_arm64/gen/canvas_test.dart.dill

# "See" the output goldens.
open out/host_debug_unopt_arm64/gen/skia_gold_canvas_test.dart
```

![image](https://github.com/flutter/engine/assets/168174/3deeab8d-409d-4b2e-8bdf-1cae272636f8)