### PR TITLE
[macOS] Replace fixture subclasses with usings

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -80,17 +80,10 @@ class AccessibilityBridgeMacWindowTest : public AutoreleasePoolTest {
   FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridgeMacWindowTest);
 };
 
-// AutoreleasePoolTest subclass that exists simply to provide more specific naming.
-class AccessibilityBridgeMacTest : public AutoreleasePoolTest {
- public:
-  AccessibilityBridgeMacTest() = default;
-  ~AccessibilityBridgeMacTest() = default;
-
- private:
-  FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridgeMacTest);
-};
-
 NSWindow* AccessibilityBridgeMacWindowTest::gWindow_ = nil;
+
+// Test-specific name for AutoreleasePoolTest fixture.
+using AccessibilityBridgeMacTest = AutoreleasePoolTest;
 
 }  // namespace
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
@@ -67,15 +67,8 @@
 
 namespace flutter::testing {
 
-// AutoreleasePoolTest subclass that exists simply to provide more specific naming.
-class FlutterEmbedderExternalTextureTest : public AutoreleasePoolTest {
- public:
-  FlutterEmbedderExternalTextureTest() = default;
-  ~FlutterEmbedderExternalTextureTest() = default;
-
- private:
-  FML_DISALLOW_COPY_AND_ASSIGN(FlutterEmbedderExternalTextureTest);
-};
+// Test-specific name for AutoreleasePoolTest fixture.
+using FlutterEmbedderExternalTextureTest = AutoreleasePoolTest;
 
 TEST_F(FlutterEmbedderExternalTextureTest, TestTextureResolution) {
   // Constants.

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -174,25 +174,9 @@ NSEvent* CreateMouseEvent(NSEventModifierFlags modifierFlags) {
 
 #pragma mark - gtest tests
 
-// AutoreleasePoolTest subclass that exists simply to provide more specific naming.
-class FlutterViewControllerTest : public AutoreleasePoolTest {
- public:
-  FlutterViewControllerTest() = default;
-  ~FlutterViewControllerTest() = default;
-
- private:
-  FML_DISALLOW_COPY_AND_ASSIGN(FlutterViewControllerTest);
-};
-
-// MockFlutterEngineTest subclass that exists simply to provide more specific naming.
-class FlutterViewControllerMockEngineTest : public MockFlutterEngineTest {
- public:
-  FlutterViewControllerMockEngineTest() = default;
-  ~FlutterViewControllerMockEngineTest() = default;
-
- private:
-  FML_DISALLOW_COPY_AND_ASSIGN(FlutterViewControllerMockEngineTest);
-};
+// Test-specific names for AutoreleasePoolTest, MockFlutterEngineTest fixtures.
+using FlutterViewControllerTest = AutoreleasePoolTest;
+using FlutterViewControllerMockEngineTest = MockFlutterEngineTest;
 
 TEST_F(FlutterViewControllerTest, HasViewThatHidesOtherViewsInAccessibility) {
   FlutterViewController* viewControllerMock = CreateMockViewController();


### PR DESCRIPTION
In cases where we subclassed gtest fixtures purely to get better naming for test output (i.e. displaying/filtering on AccessibilityBridgeMacTest instead of AutoreleasePoolTest, replace these with `using` declarations, which is equally effective and avoids actually subclassing.

This applies no semantic changes to the code or tests.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
