### PR TITLE
Make `impeller/...` compatible with `.clang-tidy`.

### DIFF
--- a/impeller/image/backends/skia/compressed_image_skia.h
+++ b/impeller/image/backends/skia/compressed_image_skia.h
@@ -14,7 +14,7 @@ class CompressedImageSkia final : public CompressedImage {
   static std::shared_ptr<CompressedImage> Create(
       std::shared_ptr<const fml::Mapping> allocation);
 
-  CompressedImageSkia(std::shared_ptr<const fml::Mapping> allocation);
+  explicit CompressedImageSkia(std::shared_ptr<const fml::Mapping> allocation);
 
   ~CompressedImageSkia() override;
 

--- a/impeller/playground/compute_playground_test.h
+++ b/impeller/playground/compute_playground_test.h
@@ -39,7 +39,7 @@ class ComputePlaygroundTest
 
   template <typename T>
   std::shared_ptr<DeviceBuffer> CreateHostVisibleDeviceBuffer(
-      std::shared_ptr<Context> context,
+      const std::shared_ptr<Context>& context,
       const std::string& label) {
     DeviceBufferDescriptor desc;
     desc.storage_mode = StorageMode::kHostVisible;

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -104,7 +104,7 @@ class ContextMTL final : public Context,
  private:
   class SyncSwitchObserver : public fml::SyncSwitch::Observer {
    public:
-    SyncSwitchObserver(ContextMTL& parent);
+    explicit SyncSwitchObserver(ContextMTL& parent);
     virtual ~SyncSwitchObserver() = default;
     void OnSyncSwitchUpdate(bool new_value) override;
 

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -99,7 +99,7 @@ class ContextMTL final : public Context,
 #endif  // IMPELLER_DEBUG
 
   // |Context|
-  void StoreTaskForGPU(std::function<void()> task) override;
+  void StoreTaskForGPU(const std::function<void()>& task) override;
 
  private:
   class SyncSwitchObserver : public fml::SyncSwitch::Observer {

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -390,8 +390,8 @@ id<MTLCommandBuffer> ContextMTL::CreateMTLCommandBuffer(
   return buffer;
 }
 
-void ContextMTL::StoreTaskForGPU(std::function<void()> task) {
-  tasks_awaiting_gpu_.emplace_back(std::move(task));
+void ContextMTL::StoreTaskForGPU(const std::function<void()>& task) {
+  tasks_awaiting_gpu_.emplace_back(task);
   while (tasks_awaiting_gpu_.size() > kMaxTasksAwaitingGPU) {
     tasks_awaiting_gpu_.front()();
     tasks_awaiting_gpu_.pop_front();

--- a/impeller/renderer/backend/metal/sampler_library_mtl.h
+++ b/impeller/renderer/backend/metal/sampler_library_mtl.h
@@ -29,7 +29,7 @@ class SamplerLibraryMTL final
   id<MTLDevice> device_ = nullptr;
   SamplerMap samplers_;
 
-  SamplerLibraryMTL(id<MTLDevice> device);
+  explicit SamplerLibraryMTL(id<MTLDevice> device);
 
   // |SamplerLibrary|
   std::shared_ptr<const Sampler> GetSampler(

--- a/impeller/renderer/backend/vulkan/blit_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/blit_pass_vk.h
@@ -26,7 +26,7 @@ class BlitPassVK final : public BlitPass {
   std::vector<std::unique_ptr<BlitEncodeVK>> commands_;
   std::string label_;
 
-  BlitPassVK(std::weak_ptr<CommandBufferVK> command_buffer);
+  explicit BlitPassVK(std::weak_ptr<CommandBufferVK> command_buffer);
 
   // |BlitPass|
   bool IsValid() const override;

--- a/impeller/renderer/backend/vulkan/shared_object_vk.h
+++ b/impeller/renderer/backend/vulkan/shared_object_vk.h
@@ -25,8 +25,6 @@ class SharedObjectVKT : public SharedObjectVK {
 
   explicit SharedObjectVKT(UniqueResource res) : resource_(std::move(res)) {}
 
-  operator Resource() const { return Get(); }
-
   const Resource& Get() const { return *resource_; }
 
  private:

--- a/impeller/renderer/backend/vulkan/shared_object_vk.h
+++ b/impeller/renderer/backend/vulkan/shared_object_vk.h
@@ -25,6 +25,9 @@ class SharedObjectVKT : public SharedObjectVK {
 
   explicit SharedObjectVKT(UniqueResource res) : resource_(std::move(res)) {}
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  operator Resource() const { return Get(); }
+
   const Resource& Get() const { return *resource_; }
 
  private:

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.cc
@@ -339,7 +339,7 @@ std::shared_ptr<Context> SwapchainImplVK::GetContext() const {
 SwapchainImplVK::AcquireResult SwapchainImplVK::AcquireNextDrawable() {
   auto context_strong = context_.lock();
   if (!context_strong) {
-    return {};
+    return SwapchainImplVK::AcquireResult{};
   }
 
   const auto& context = ContextVK::Cast(*context_strong);
@@ -353,7 +353,7 @@ SwapchainImplVK::AcquireResult SwapchainImplVK::AcquireNextDrawable() {
   ///
   if (!sync->WaitForFence(context.GetDevice())) {
     VALIDATION_LOG << "Could not wait for fence.";
-    return {};
+    return SwapchainImplVK::AcquireResult{};
   }
 
   //----------------------------------------------------------------------------
@@ -368,7 +368,7 @@ SwapchainImplVK::AcquireResult SwapchainImplVK::AcquireNextDrawable() {
     if (caps_result != vk::Result::eSuccess) {
       VALIDATION_LOG << "Could not get surface capabilities: "
                      << vk::to_string(caps_result);
-      return {};
+      return SwapchainImplVK::AcquireResult{};
     }
     if (caps.currentTransform != transform_if_changed_discard_swapchain_) {
       transform_if_changed_discard_swapchain_ = caps.currentTransform;
@@ -404,7 +404,7 @@ SwapchainImplVK::AcquireResult SwapchainImplVK::AcquireNextDrawable() {
 
   if (index >= images_.size()) {
     VALIDATION_LOG << "Swapchain returned an invalid image index.";
-    return {};
+    return SwapchainImplVK::AcquireResult{};
   }
 
   /// Record all subsequent cmd buffers as part of the current frame.

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
@@ -45,9 +45,10 @@ class SwapchainImplVK final
     std::unique_ptr<Surface> surface;
     bool out_of_date = false;
 
-    AcquireResult(bool p_out_of_date = false) : out_of_date(p_out_of_date) {}
+    explicit AcquireResult(bool p_out_of_date = false)
+        : out_of_date(p_out_of_date) {}
 
-    AcquireResult(std::unique_ptr<Surface> p_surface)
+    explicit AcquireResult(std::unique_ptr<Surface> p_surface)
         : surface(std::move(p_surface)) {}
   };
 

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -195,7 +195,7 @@ class Context {
   /// Threadsafe.
   ///
   /// `task` will be executed on the platform thread.
-  virtual void StoreTaskForGPU(std::function<void()> task) {
+  virtual void StoreTaskForGPU(const std::function<void()>& task) {
     FML_CHECK(false && "not supported in this context");
   }
 

--- a/impeller/renderer/renderer.h
+++ b/impeller/renderer/renderer.h
@@ -24,8 +24,8 @@ class Renderer {
 
   using RenderCallback = std::function<bool(RenderTarget& render_target)>;
 
-  Renderer(std::shared_ptr<Context> context,
-           size_t max_frames_in_flight = kDefaultMaxFramesInFlight);
+  explicit Renderer(std::shared_ptr<Context> context,
+                    size_t max_frames_in_flight = kDefaultMaxFramesInFlight);
 
   ~Renderer();
 

--- a/impeller/renderer/testing/mocks.h
+++ b/impeller/renderer/testing/mocks.h
@@ -16,7 +16,8 @@ namespace testing {
 
 class MockDeviceBuffer : public DeviceBuffer {
  public:
-  MockDeviceBuffer(const DeviceBufferDescriptor& desc) : DeviceBuffer(desc) {}
+  explicit MockDeviceBuffer(const DeviceBufferDescriptor& desc)
+      : DeviceBuffer(desc) {}
 
   MOCK_METHOD(bool, SetLabel, (const std::string& label), (override));
 
@@ -87,7 +88,7 @@ class MockBlitPass : public BlitPass {
 
 class MockCommandBuffer : public CommandBuffer {
  public:
-  MockCommandBuffer(std::weak_ptr<const Context> context)
+  explicit MockCommandBuffer(std::weak_ptr<const Context> context)
       : CommandBuffer(context) {}
   MOCK_METHOD(bool, IsValid, (), (const, override));
   MOCK_METHOD(void, SetLabel, (const std::string& label), (const, override));
@@ -150,7 +151,7 @@ class MockImpellerContext : public Context {
 
 class MockTexture : public Texture {
  public:
-  MockTexture(const TextureDescriptor& desc) : Texture(desc) {}
+  explicit MockTexture(const TextureDescriptor& desc) : Texture(desc) {}
   MOCK_METHOD(void, SetLabel, (std::string_view label), (override));
   MOCK_METHOD(bool, IsValid, (), (const, override));
   MOCK_METHOD(ISize, GetSize, (), (const, override));

--- a/impeller/scene/scene_context.h
+++ b/impeller/scene/scene_context.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include "fml/logging.h"
 #include "impeller/renderer/context.h"
 #include "impeller/renderer/pipeline.h"
 #include "impeller/renderer/pipeline_descriptor.h"
@@ -68,9 +69,12 @@ class SceneContext {
     explicit PipelineVariantsT(Context& context) {
       auto desc = PipelineT::Builder::MakeDefaultPipelineDescriptor(context);
       // Apply default ContentContextOptions to the descriptor.
-      SceneContextOptions{}.ApplyToPipelineDescriptor(
-          *context.GetCapabilities(), *desc);
-      variants_[{}] = std::make_unique<PipelineT>(context, desc);
+      if (desc.has_value()) {
+        SceneContextOptions{}.ApplyToPipelineDescriptor(
+            *context.GetCapabilities(), desc.get_value());
+        variants_[{}] = std::make_unique<PipelineT>(context, desc);
+      }
+      FML_UNREACHABLE()
     };
 
     // |PipelineVariants|

--- a/impeller/scene/scene_context.h
+++ b/impeller/scene/scene_context.h
@@ -71,7 +71,7 @@ class SceneContext {
       // Apply default ContentContextOptions to the descriptor.
       if (desc.has_value()) {
         SceneContextOptions{}.ApplyToPipelineDescriptor(
-            *context.GetCapabilities(), desc.get_value());
+            *context.GetCapabilities(), desc.value());
         variants_[{}] = std::make_unique<PipelineT>(context, desc);
       }
       FML_UNREACHABLE()

--- a/impeller/scene/scene_context.h
+++ b/impeller/scene/scene_context.h
@@ -6,7 +6,6 @@
 
 #include <memory>
 
-#include "fml/logging.h"
 #include "impeller/renderer/context.h"
 #include "impeller/renderer/pipeline.h"
 #include "impeller/renderer/pipeline_descriptor.h"
@@ -69,12 +68,9 @@ class SceneContext {
     explicit PipelineVariantsT(Context& context) {
       auto desc = PipelineT::Builder::MakeDefaultPipelineDescriptor(context);
       // Apply default ContentContextOptions to the descriptor.
-      if (desc.has_value()) {
-        SceneContextOptions{}.ApplyToPipelineDescriptor(
-            *context.GetCapabilities(), desc.value());
-        variants_[{}] = std::make_unique<PipelineT>(context, desc);
-      }
-      FML_UNREACHABLE()
+      SceneContextOptions{}.ApplyToPipelineDescriptor(
+          *context.GetCapabilities(), *desc);
+      variants_[{}] = std::make_unique<PipelineT>(context, desc);
     };
 
     // |PipelineVariants|

--- a/impeller/typographer/backends/skia/typeface_skia.h
+++ b/impeller/typographer/backends/skia/typeface_skia.h
@@ -15,7 +15,7 @@ namespace impeller {
 class TypefaceSkia final : public Typeface,
                            public BackendCast<TypefaceSkia, Typeface> {
  public:
-  TypefaceSkia(sk_sp<SkTypeface> typeface);
+  explicit TypefaceSkia(sk_sp<SkTypeface> typeface);
 
   ~TypefaceSkia() override;
 

--- a/impeller/typographer/backends/stb/typeface_stb.cc
+++ b/impeller/typographer/backends/stb/typeface_stb.cc
@@ -13,8 +13,7 @@ namespace impeller {
 // Instantiate a typeface based on a .ttf or other font file
 TypefaceSTB::TypefaceSTB(std::unique_ptr<fml::Mapping> typeface_mapping)
     : typeface_mapping_(std::move(typeface_mapping)),
-      font_info_(std::make_unique<stbtt_fontinfo>()),
-      is_valid_(false) {
+      font_info_(std::make_unique<stbtt_fontinfo>()) {
   // We need an "offset" into the ttf file
   auto offset = stbtt_GetFontOffsetForIndex(typeface_mapping_->GetMapping(), 0);
   if (stbtt_InitFont(font_info_.get(), typeface_mapping_->GetMapping(),

--- a/impeller/typographer/backends/stb/typeface_stb.h
+++ b/impeller/typographer/backends/stb/typeface_stb.h
@@ -38,7 +38,7 @@ class TypefaceSTB final : public Typeface,
  private:
   std::unique_ptr<fml::Mapping> typeface_mapping_;
   std::unique_ptr<stbtt_fontinfo> font_info_;
-  bool is_valid_;
+  bool is_valid_ = false;
 
   TypefaceSTB(const TypefaceSTB&) = delete;
 


### PR DESCRIPTION
I moved [`scene_context.h` to another PR](https://github.com/flutter/engine/pull/48194), and here are the boring remains.