### PR TITLE
Only run systrace test on API 29+, avoid building scenario app for 28

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -89,7 +89,6 @@ targets:
     enabled_branches:
       - main
     recipe: engine_v2/engine_v2
-    bringup: true
     properties:
       config_name: linux_android_emulator
     timeout: 60

--- a/ci/builders/linux_android_emulator.json
+++ b/ci/builders/linux_android_emulator.json
@@ -80,8 +80,7 @@
             "ninja": {
                 "config": "android_debug_x86",
                 "targets": [
-                    "flutter/shell/platform/android:flutter_shell_native_unittests",
-                    "flutter/testing/scenario_app"
+                    "flutter/shell/platform/android:flutter_shell_native_unittests"
                 ]
             },
             "tests": [

--- a/testing/android_systrace_test.py
+++ b/testing/android_systrace_test.py
@@ -140,6 +140,17 @@ def main():
 
   args = parser.parse_args()
 
+  android_api_level = subprocess.check_output([
+      args.adb_path, 'shell', 'getprop', 'ro.build.version.sdk'
+  ],
+                                              text=True).strip()
+  if int(android_api_level) < 29:
+    print(
+        'Android API %s detected. This script requires API 29 or above.' %
+        android_api_level
+    )
+    return 0
+
   install_apk(args.apk_path, args.package_name, args.adb_path)
   start_perfetto(args.package_name, args.adb_path)
   launch_package(args.package_name, args.activity_name, args.adb_path)


### PR DESCRIPTION
The emulator tests I added yesterday are failing because the systrace python test script uses features introduced in API 29, which causes the `perfetto` invocation to fail.

It's not essential that we run this test on lower API levels, so instead I'm making the script bail out in this case.

Other than that, the shard seems to be consistently passing, so I'm removing bringup.