### PR TITLE
Replace calls to SkFontMgr::RefDefault

### DIFF
--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -34,7 +34,7 @@ impeller_component("typographer") {
     "../renderer",
   ]
 
-  deps = [ "//flutter/fml"]
+  deps = [ "//flutter/fml" ]
 }
 
 impeller_component("typographer_unittests") {
@@ -46,6 +46,6 @@ impeller_component("typographer_unittests") {
     "../playground:playground_test",
     "backends/skia:typographer_skia_backend",
     "backends/stb:typographer_stb_backend",
-          "//flutter/third_party/txt",
+    "//flutter/third_party/txt",
   ]
 }

--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -34,7 +34,7 @@ impeller_component("typographer") {
     "../renderer",
   ]
 
-  deps = [ "//flutter/fml" ]
+  deps = [ "//flutter/fml"]
 }
 
 impeller_component("typographer_unittests") {
@@ -46,5 +46,6 @@ impeller_component("typographer_unittests") {
     "../playground:playground_test",
     "backends/skia:typographer_skia_backend",
     "backends/stb:typographer_stb_backend",
+          "//flutter/third_party/txt",
   ]
 }

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -12,6 +12,7 @@
 #include "third_party/skia/include/core/SkFontMgr.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
+#include "txt/platform.h"
 
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
@@ -275,7 +276,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
 }
 
 TEST_P(TypographerTest, MaybeHasOverlapping) {
-  sk_sp<SkFontMgr> font_mgr = SkFontMgr::RefDefault();
+  sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
   sk_sp<SkTypeface> typeface =
       font_mgr->matchFamilyStyle("Arial", SkFontStyle::Normal());
   SkFont sk_font(typeface, 0.5f);

--- a/lib/web_ui/skwasm/BUILD.gn
+++ b/lib/web_ui/skwasm/BUILD.gn
@@ -70,6 +70,5 @@ wasm_lib("skwasm") {
   deps = [
     "//flutter/skia",
     "//flutter/skia/modules/skparagraph",
-    "//flutter/third_party/txt",
   ]
 }

--- a/lib/web_ui/skwasm/BUILD.gn
+++ b/lib/web_ui/skwasm/BUILD.gn
@@ -70,5 +70,6 @@ wasm_lib("skwasm") {
   deps = [
     "//flutter/skia",
     "//flutter/skia/modules/skparagraph",
+          "//flutter/third_party/txt",
   ]
 }

--- a/lib/web_ui/skwasm/BUILD.gn
+++ b/lib/web_ui/skwasm/BUILD.gn
@@ -70,6 +70,6 @@ wasm_lib("skwasm") {
   deps = [
     "//flutter/skia",
     "//flutter/skia/modules/skparagraph",
-          "//flutter/third_party/txt",
+    "//flutter/third_party/txt",
   ]
 }

--- a/lib/web_ui/skwasm/fonts.cpp
+++ b/lib/web_ui/skwasm/fonts.cpp
@@ -4,9 +4,9 @@
 
 #include "export.h"
 #include "third_party/skia/include/core/SkFontMgr.h"
+#include "third_party/skia/include/ports/SkFontMgr_empty.h"
 #include "third_party/skia/modules/skparagraph/include/FontCollection.h"
 #include "third_party/skia/modules/skparagraph/include/TypefaceFontProvider.h"
-#include "third_party/txt/platform.h"
 #include "wrappers.h"
 
 #include <memory>
@@ -29,9 +29,13 @@ SKWASM_EXPORT void fontCollection_dispose(FlutterFontCollection* collection) {
   delete collection;
 }
 
+static sk_sp<SkFontMgr> default_fontmgr() {
+  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
+  return mgr;
+}
+
 SKWASM_EXPORT SkTypeface* typeface_create(SkData* fontData) {
-  auto typeface =
-      txt::GetDefaultFontManager()->makeFromData(sk_ref_sp<SkData>(fontData));
+  auto typeface = default_fontmgr()->makeFromData(sk_ref_sp<SkData>(fontData));
   return typeface.release();
 }
 

--- a/lib/web_ui/skwasm/fonts.cpp
+++ b/lib/web_ui/skwasm/fonts.cpp
@@ -6,6 +6,7 @@
 #include "third_party/skia/include/core/SkFontMgr.h"
 #include "third_party/skia/modules/skparagraph/include/FontCollection.h"
 #include "third_party/skia/modules/skparagraph/include/TypefaceFontProvider.h"
+#include "third_party/txt/platform.h"
 #include "wrappers.h"
 
 #include <memory>
@@ -30,7 +31,7 @@ SKWASM_EXPORT void fontCollection_dispose(FlutterFontCollection* collection) {
 
 SKWASM_EXPORT SkTypeface* typeface_create(SkData* fontData) {
   auto typeface =
-      SkFontMgr::RefDefault()->makeFromData(sk_ref_sp<SkData>(fontData));
+      txt::GetDefaultFontManager()->makeFromData(sk_ref_sp<SkData>(fontData));
   return typeface.release();
 }
 

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -155,6 +155,7 @@ source_set("flutter_shell_native_src") {
     "//flutter/shell/platform/android/surface:native_window",
     "//flutter/skia",
     "//flutter/vulkan",
+        "//flutter/third_party/txt",
   ]
 
   public_configs = [ "//flutter:config" ]

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -154,8 +154,8 @@ source_set("flutter_shell_native_src") {
     "//flutter/shell/platform/android/surface",
     "//flutter/shell/platform/android/surface:native_window",
     "//flutter/skia",
+    "//flutter/third_party/txt",
     "//flutter/vulkan",
-        "//flutter/third_party/txt",
   ]
 
   public_configs = [ "//flutter:config" ]

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -25,7 +25,7 @@
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/switches.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
-#include "third_party/skia/include/core/SkFontMgr.h"
+#include "third_party/txt/platform.h"
 
 namespace flutter {
 
@@ -198,7 +198,7 @@ void FlutterMain::SetupDartVMServiceUriCallback(JNIEnv* env) {
 
 static void PrefetchDefaultFontManager(JNIEnv* env, jclass jcaller) {
   // Initialize a singleton owned by Skia.
-  SkFontMgr::RefDefault();
+  txt::GetDefaultFontManager();
 }
 
 bool FlutterMain::Register(JNIEnv* env) {

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -25,7 +25,7 @@
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/switches.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
-#include "third_party/txt/platform.h"
+#include "txt/platform.h"
 
 namespace flutter {
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -151,8 +151,8 @@ public class FlutterJNI {
   private static native void nativePrefetchDefaultFontManager();
 
   /**
-   * Prefetch the default font manager provided by SkFontMgr::RefDefault() which is a process-wide
-   * singleton owned by Skia. Note that, the first call to SkFontMgr::RefDefault() will take
+   * Prefetch the default font manager provided by txt::GetDefaultFontManager() which is a process-wide
+   * singleton owned by Skia. Note that, the first call to txt::GetDefaultFontManager() will take
    * noticeable time, but later calls will return a reference to the preexisting font manager.
    *
    * <p>This method should only be called once across all FlutterJNI instances.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -151,9 +151,10 @@ public class FlutterJNI {
   private static native void nativePrefetchDefaultFontManager();
 
   /**
-   * Prefetch the default font manager provided by txt::GetDefaultFontManager() which is a process-wide
-   * singleton owned by Skia. Note that, the first call to txt::GetDefaultFontManager() will take
-   * noticeable time, but later calls will return a reference to the preexisting font manager.
+   * Prefetch the default font manager provided by txt::GetDefaultFontManager() which is a
+   * process-wide singleton owned by Skia. Note that, the first call to txt::GetDefaultFontManager()
+   * will take noticeable time, but later calls will return a reference to the preexisting font
+   * manager.
    *
    * <p>This method should only be called once across all FlutterJNI instances.
    */

--- a/third_party/txt/src/txt/platform.h
+++ b/third_party/txt/src/txt/platform.h
@@ -15,7 +15,7 @@ namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies();
 
-sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data);
+sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data = 0);
 
 }  // namespace txt
 


### PR DESCRIPTION
Skia is removing this API, so clients must track a default FontMgr if they want one. See https://issues.skia.org/issues/305780908

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
