### PR TITLE
[web] EngineFlutterView.dispose()

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -104,6 +104,12 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _disconnectFontSizeObserver();
     _removeLocaleChangedListener();
     HighContrastSupport.instance.removeListener(_updateHighContrast);
+
+    // We need to call `toList()` in order to avoid concurrent modification inside
+    // the loop (`view.dispose()` removes itself from the view map).
+    for (final EngineFlutterView view in views.toList()) {
+      view.dispose();
+    }
   }
 
   /// Receives all events related to platform configuration changes.

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart
@@ -55,6 +55,7 @@ class CustomElementDimensionsProvider extends DimensionsProvider {
 
   @override
   void close() {
+    super.close();
     _hostElementResizeObserver?.disconnect();
     // ignore:unawaited_futures
     _onResizeStreamController.close();

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:ui/src/engine/window.dart';
 import 'package:ui/ui.dart' as ui show Size;
 
@@ -58,9 +59,16 @@ abstract class DimensionsProvider {
   /// Returns a Stream with the changes to [ui.Size] (when cheap to get).
   Stream<ui.Size?> get onResize;
 
+  /// Whether the [DimensionsProvider] instance has been closed or not.
+  @visibleForTesting
+  bool isClosed = false;
+
   /// Clears any resources grabbed by the DimensionsProvider instance.
   ///
   /// All internal event handlers will be disconnected, and the [onResize] Stream
   /// will be closed.
-  void close();
+  @mustCallSuper
+  void close() {
+    isClosed = true;
+  }
 }

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
@@ -53,6 +53,7 @@ class FullPageDimensionsProvider extends DimensionsProvider {
 
   @override
   void close() {
+    super.close();
     _domResizeSubscription.cancel();
     // ignore:unawaited_futures
     _onResizeStreamController.close();

--- a/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
@@ -200,6 +200,30 @@ void testMain() {
       expect(ui.PlatformDispatcher.instance.textScaleFactor,
           findBrowserTextScaleFactor());
     });
+
+    test('disposes all its views', () {
+      final EnginePlatformDispatcher dispatcher = EnginePlatformDispatcher();
+      final EngineFlutterView view20 =
+          EngineFlutterView(20, dispatcher, createDomHTMLDivElement());
+      final EngineFlutterView view21 =
+          EngineFlutterView(21, dispatcher, createDomHTMLDivElement());
+      final EngineFlutterView view22 =
+          EngineFlutterView(22, dispatcher, createDomHTMLDivElement());
+
+      dispatcher
+        ..registerView(view20)
+        ..registerView(view21)
+        ..registerView(view22);
+
+      expect(view20.isDisposed, isFalse);
+      expect(view21.isDisposed, isFalse);
+      expect(view22.isDisposed, isFalse);
+
+      dispatcher.dispose();
+      expect(view20.isDisposed, isTrue);
+      expect(view21.isDisposed, isTrue);
+      expect(view22.isDisposed, isTrue);
+    });
   });
 }
 

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -12,6 +12,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
+import '../common/matchers.dart';
 import '../common/test_initialization.dart';
 
 const int kPhysicalKeyA = 0x00070004;
@@ -462,5 +463,37 @@ Future<void> testMain() async {
     });
 
     await expectLater(completer.future, completes);
+  });
+
+  test('dispose', () {
+    final DomHTMLDivElement host = createDomHTMLDivElement();
+    final EngineFlutterView view = EngineFlutterView(
+      123,
+      EnginePlatformDispatcher.instance,
+      host,
+    );
+
+    // First, let's make sure the view's root element was inserted into the
+    // host, and the dimensions provider is active.
+    expect(view.dom.rootElement.parentElement, host);
+    expect(view.dimensionsProvider.isClosed, isFalse);
+
+    // Now, let's dispose the view and make sure its root element was removed,
+    // and the dimensions provider is closed.
+    view.dispose();
+    expect(view.dom.rootElement.parentElement, isNull);
+    expect(view.dimensionsProvider.isClosed, isTrue);
+
+    // Can't render into a disposed view.
+    expect(
+      () => view.render(ui.SceneBuilder().build()),
+      throwsAssertionError,
+    );
+
+    // Can't update semantics on a disposed view.
+    expect(
+      () => view.updateSemantics(ui.SemanticsUpdateBuilder().build()),
+      throwsAssertionError,
+    );
   });
 }


### PR DESCRIPTION
- New `EngineFlutterView.dispose()` to cleanup when the view is removed (and in hot restart).
- `EnginePlatformDispatcher.dispose()` now disposes of all of its registered views.