### PR TITLE
[Impeller] Unify around "transform"

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -83,9 +83,9 @@ TEST_P(AiksTest, RotateColorFilteredPath) {
 TEST_P(AiksTest, CanvasCTMCanBeUpdated) {
   Canvas canvas;
   Matrix identity;
-  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransformation(), identity);
+  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransform(), identity);
   canvas.Translate(Size{100, 100});
-  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransformation(),
+  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransform(),
                      Matrix::MakeTranslation({100.0, 100.0, 0.0}));
 }
 
@@ -97,11 +97,11 @@ TEST_P(AiksTest, CanvasCanPushPopCTM) {
   canvas.Translate(Size{100, 100});
   canvas.Save();
   ASSERT_EQ(canvas.GetSaveCount(), 2u);
-  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransformation(),
+  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransform(),
                      Matrix::MakeTranslation({100.0, 100.0, 0.0}));
   ASSERT_TRUE(canvas.Restore());
   ASSERT_EQ(canvas.GetSaveCount(), 1u);
-  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransformation(),
+  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransform(),
                      Matrix::MakeTranslation({100.0, 100.0, 0.0}));
 }
 
@@ -1889,12 +1889,12 @@ TEST_P(AiksTest, ColorWheel) {
 
 TEST_P(AiksTest, TransformMultipliesCorrectly) {
   Canvas canvas;
-  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransformation(), Matrix());
+  ASSERT_MATRIX_NEAR(canvas.GetCurrentTransform(), Matrix());
 
   // clang-format off
   canvas.Translate(Vector3(100, 200));
   ASSERT_MATRIX_NEAR(
-    canvas.GetCurrentTransformation(),
+    canvas.GetCurrentTransform(),
     Matrix(  1,   0,   0,   0,
              0,   1,   0,   0,
              0,   0,   1,   0,
@@ -1902,7 +1902,7 @@ TEST_P(AiksTest, TransformMultipliesCorrectly) {
 
   canvas.Rotate(Radians(kPiOver2));
   ASSERT_MATRIX_NEAR(
-    canvas.GetCurrentTransformation(),
+    canvas.GetCurrentTransform(),
     Matrix(  0,   1,   0,   0,
             -1,   0,   0,   0,
              0,   0,   1,   0,
@@ -1910,7 +1910,7 @@ TEST_P(AiksTest, TransformMultipliesCorrectly) {
 
   canvas.Scale(Vector3(2, 3));
   ASSERT_MATRIX_NEAR(
-    canvas.GetCurrentTransformation(),
+    canvas.GetCurrentTransform(),
     Matrix(  0,   2,   0,   0,
             -3,   0,   0,   0,
              0,   0,   0,   0,
@@ -1918,7 +1918,7 @@ TEST_P(AiksTest, TransformMultipliesCorrectly) {
 
   canvas.Translate(Vector3(100, 200));
   ASSERT_MATRIX_NEAR(
-    canvas.GetCurrentTransformation(),
+    canvas.GetCurrentTransform(),
     Matrix(   0,   2,   0,   0,
              -3,   0,   0,   0,
               0,   0,   0,   0,
@@ -1964,7 +1964,7 @@ TEST_P(AiksTest, SolidStrokesRenderCorrectly) {
       auto [handle_a, handle_b] = IMPELLER_PLAYGROUND_LINE(
           Point(60, 300), Point(600, 300), 20, Color::Red(), Color::Red());
 
-      auto screen_to_canvas = canvas.GetCurrentTransformation().Invert();
+      auto screen_to_canvas = canvas.GetCurrentTransform().Invert();
       Point point_a = screen_to_canvas * handle_a * GetContentScale();
       Point point_b = screen_to_canvas * handle_b * GetContentScale();
 
@@ -2105,7 +2105,7 @@ TEST_P(AiksTest, GradientStrokesRenderCorrectly) {
       auto [handle_a, handle_b] = IMPELLER_PLAYGROUND_LINE(
           Point(60, 300), Point(600, 300), 20, Color::Red(), Color::Red());
 
-      auto screen_to_canvas = canvas.GetCurrentTransformation().Invert();
+      auto screen_to_canvas = canvas.GetCurrentTransform().Invert();
       Point point_a = screen_to_canvas * handle_a * GetContentScale();
       Point point_b = screen_to_canvas * handle_b * GetContentScale();
 
@@ -3102,7 +3102,7 @@ TEST_P(AiksTest, OpaqueEntitiesGetCoercedToSource) {
   Entity entity;
   std::shared_ptr<SolidColorContents> contents;
   picture.pass->IterateAllEntities([&e = entity, &contents](Entity& entity) {
-    if (ScalarNearlyEqual(entity.GetTransformation().GetScale().x, 1.618f)) {
+    if (ScalarNearlyEqual(entity.GetTransform().GetScale().x, 1.618f)) {
       e = entity;
       contents =
           std::static_pointer_cast<SolidColorContents>(entity.GetContents());

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -322,8 +322,8 @@ void Canvas::ClipPath(const Path& path, Entity::ClipOperation clip_op) {
 void Canvas::ClipRect(const Rect& rect, Entity::ClipOperation clip_op) {
   auto geometry = Geometry::MakeRect(rect);
   auto& cull_rect = transform_stack_.back().cull_rect;
-  if (clip_op == Entity::ClipOperation::kIntersect &&                        //
-      cull_rect.has_value() &&                                               //
+  if (clip_op == Entity::ClipOperation::kIntersect &&                      //
+      cull_rect.has_value() &&                                             //
       geometry->CoversArea(transform_stack_.back().transform, *cull_rect)  //
   ) {
     return;  // This clip will do nothing, so skip it.
@@ -358,8 +358,8 @@ void Canvas::ClipRRect(const Rect& rect,
                                        : std::make_optional<Rect>();
   auto geometry = Geometry::MakeFillPath(path, inner_rect);
   auto& cull_rect = transform_stack_.back().cull_rect;
-  if (clip_op == Entity::ClipOperation::kIntersect &&                        //
-      cull_rect.has_value() &&                                               //
+  if (clip_op == Entity::ClipOperation::kIntersect &&                      //
+      cull_rect.has_value() &&                                             //
       geometry->CoversArea(transform_stack_.back().transform, *cull_rect)  //
   ) {
     return;  // This clip will do nothing, so skip it.
@@ -473,8 +473,7 @@ void Canvas::DrawPicture(const Picture& picture) {
   pass->IterateAllElements([&](auto& element) -> bool {
     if (auto entity = std::get_if<Entity>(&element)) {
       entity->IncrementStencilDepth(GetClipDepth());
-      entity->SetTransform(GetCurrentTransform() *
-                                entity->GetTransform());
+      entity->SetTransform(GetCurrentTransform() * entity->GetTransform());
       return true;
     }
 
@@ -586,7 +585,7 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
   text_contents->SetColor(paint.color);
 
   entity.SetTransform(GetCurrentTransform() *
-                           Matrix::MakeTranslation(position));
+                      Matrix::MakeTranslation(position));
 
   // TODO(bdero): This mask blur application is a hack. It will always wind up
   //              doing a gaussian blur that affects the color source itself

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -77,7 +77,7 @@ class Canvas {
 
   void RestoreToCount(size_t count);
 
-  const Matrix& GetCurrentTransformation() const;
+  const Matrix& GetCurrentTransform() const;
 
   const std::optional<Rect> GetCurrentLocalCullingBounds() const;
 

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -31,7 +31,7 @@ namespace impeller {
 class Entity;
 
 struct CanvasStackEntry {
-  Matrix xformation;
+  Matrix transform;
   // |cull_rect| is conservative screen-space bounds of the clipped output area
   std::optional<Rect> cull_rect;
   size_t clip_depth = 0u;
@@ -83,11 +83,11 @@ class Canvas {
 
   void ResetTransform();
 
-  void Transform(const Matrix& xformation);
+  void Transform(const Matrix& transform);
 
-  void Concat(const Matrix& xformation);
+  void Concat(const Matrix& transform);
 
-  void PreConcat(const Matrix& xformation);
+  void PreConcat(const Matrix& transform);
 
   void Translate(const Vector3& offset);
 
@@ -164,7 +164,7 @@ class Canvas {
  private:
   std::unique_ptr<EntityPass> base_pass_;
   EntityPass* current_pass_ = nullptr;
-  std::deque<CanvasStackEntry> xformation_stack_;
+  std::deque<CanvasStackEntry> transform_stack_;
   std::optional<Rect> initial_cull_rect_;
 
   void Initialize(std::optional<Rect> cull_rect);

--- a/impeller/aiks/canvas_recorder.h
+++ b/impeller/aiks/canvas_recorder.h
@@ -130,18 +130,18 @@ class CanvasRecorder {
     return ExecuteAndSerialize(FLT_CANVAS_RECORDER_OP_ARG(ResetTransform));
   }
 
-  void Transform(const Matrix& xformation) {
+  void Transform(const Matrix& transform) {
     return ExecuteAndSerialize(FLT_CANVAS_RECORDER_OP_ARG(Transform),
-                               xformation);
+                               transform);
   }
 
-  void Concat(const Matrix& xformation) {
-    return ExecuteAndSerialize(FLT_CANVAS_RECORDER_OP_ARG(Concat), xformation);
+  void Concat(const Matrix& transform) {
+    return ExecuteAndSerialize(FLT_CANVAS_RECORDER_OP_ARG(Concat), transform);
   }
 
-  void PreConcat(const Matrix& xformation) {
+  void PreConcat(const Matrix& transform) {
     return ExecuteAndSerialize(FLT_CANVAS_RECORDER_OP_ARG(PreConcat),
-                               xformation);
+                               transform);
   }
 
   void Translate(const Vector3& offset) {

--- a/impeller/aiks/canvas_recorder.h
+++ b/impeller/aiks/canvas_recorder.h
@@ -118,8 +118,8 @@ class CanvasRecorder {
                                count);
   }
 
-  const Matrix& GetCurrentTransformation() const {
-    return canvas_.GetCurrentTransformation();
+  const Matrix& GetCurrentTransform() const {
+    return canvas_.GetCurrentTransform();
   }
 
   const std::optional<Rect> GetCurrentLocalCullingBounds() const {

--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -45,9 +45,9 @@ std::shared_ptr<Texture> Picture::RenderToTexture(
 
   pass->IterateAllEntities([&translate](auto& entity) -> bool {
     auto matrix = translate.has_value()
-                      ? translate.value() * entity.GetTransformation()
-                      : entity.GetTransformation();
-    entity.SetTransformation(matrix);
+                      ? translate.value() * entity.GetTransform()
+                      : entity.GetTransform();
+    entity.SetTransform(matrix);
     return true;
   });
 

--- a/impeller/compiler/shader_lib/impeller/gradient.glsl
+++ b/impeller/compiler/shader_lib/impeller/gradient.glsl
@@ -77,7 +77,7 @@ vec2 IPComputeConicalT(vec2 c0, float r0, vec2 c1, float r1, vec2 pos) {
     }
 
     // Apply mapping from [Cf, C1] to unit x, and apply the precalculations from
-    // steps 3 and 4, all in the same transformation.
+    // steps 3 and 4, all in the same transform.
     vec2 cf = c0 * (1.0 - f) + c1 * f;
     mat3 transform = IPMapToUnitX(cf, c1);
 

--- a/impeller/compiler/types.cc
+++ b/impeller/compiler/types.cc
@@ -159,7 +159,7 @@ std::string ShaderCErrorToString(shaderc_compilation_status status) {
     case Status::shaderc_compilation_status_validation_error:
       return "Validation error";
     case Status::shaderc_compilation_status_transformation_error:
-      return "Transformation error";
+      return "Transform error";
     case Status::shaderc_compilation_status_configuration_error:
       return "Configuration error";
   }

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -693,14 +693,14 @@ void DlDispatcher::transformFullPerspective(SkScalar mxx,
   // The order of arguments is row-major but Impeller matrices are
   // column-major.
   // clang-format off
-  auto xformation = Matrix{
+  auto transform = Matrix{
     mxx, myx, mzx, mwx,
     mxy, myy, mzy, mwy,
     mxz, myz, mzz, mwz,
     mxt, myt, mzt, mwt
   };
   // clang-format on
-  canvas_.Transform(xformation);
+  canvas_.Transform(transform);
 }
 
 // |flutter::DlOpReceiver|

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -989,7 +989,7 @@ void DlDispatcher::drawDisplayList(
   // Matrix and clip are left untouched, the current
   // transform is saved as the new base matrix, and paint
   // values are reset to defaults.
-  initial_matrix_ = canvas_.GetCurrentTransformation();
+  initial_matrix_ = canvas_.GetCurrentTransform();
   paint_ = Paint();
 
   // Handle passed opacity in the most brute-force way by using
@@ -1096,7 +1096,7 @@ void DlDispatcher::drawShadow(const SkPath& path,
   paint.mask_blur_descriptor = Paint::MaskBlurDescriptor{
       .style = FilterContents::BlurStyle::kNormal,
       .sigma = Radius{kLightRadius * occluder_z /
-                      canvas_.GetCurrentTransformation().GetScale().y},
+                      canvas_.GetCurrentTransform().GetScale().y},
   };
 
   canvas_.Save();

--- a/impeller/display_list/dl_unittests.cc
+++ b/impeller/display_list/dl_unittests.cc
@@ -956,7 +956,7 @@ TEST_P(DisplayListTest, TransparentShadowProducesCorrectColor) {
 
   std::shared_ptr<SolidRRectBlurContents> rrect_blur;
   picture.pass->IterateAllEntities([&rrect_blur](Entity& entity) {
-    if (ScalarNearlyEqual(entity.GetTransformation().GetScale().x, 1.618f)) {
+    if (ScalarNearlyEqual(entity.GetTransform().GetScale().x, 1.618f)) {
       rrect_blur = std::static_pointer_cast<SolidRRectBlurContents>(
           entity.GetContents());
       return false;

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -148,9 +148,9 @@ std::shared_ptr<SubAtlasResult> AtlasContents::GenerateSubAtlas() const {
 
 std::optional<Rect> AtlasContents::GetCoverage(const Entity& entity) const {
   if (cull_rect_.has_value()) {
-    return cull_rect_.value().TransformBounds(entity.GetTransformation());
+    return cull_rect_.value().TransformBounds(entity.GetTransform());
   }
-  return ComputeBoundingBox().TransformBounds(entity.GetTransformation());
+  return ComputeBoundingBox().TransformBounds(entity.GetTransform());
 }
 
 Rect AtlasContents::ComputeBoundingBox() const {
@@ -283,7 +283,7 @@ bool AtlasContents::Render(const ContentContext& renderer,
     FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
 
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation();
+                     entity.GetTransform();
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
@@ -338,7 +338,7 @@ AtlasTextureContents::~AtlasTextureContents() {}
 
 std::optional<Rect> AtlasTextureContents::GetCoverage(
     const Entity& entity) const {
-  return coverage_.TransformBounds(entity.GetTransformation());
+  return coverage_.TransformBounds(entity.GetTransform());
 }
 
 void AtlasTextureContents::SetAlpha(Scalar alpha) {
@@ -419,7 +419,7 @@ bool AtlasTextureContents::Render(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+                   entity.GetTransform();
   frame_info.texture_sampler_y_coord_scale = texture->GetYCoordScale();
   frame_info.alpha = alpha_;
 
@@ -444,7 +444,7 @@ AtlasColorContents::~AtlasColorContents() {}
 
 std::optional<Rect> AtlasColorContents::GetCoverage(
     const Entity& entity) const {
-  return coverage_.TransformBounds(entity.GetTransformation());
+  return coverage_.TransformBounds(entity.GetTransform());
 }
 
 void AtlasColorContents::SetAlpha(Scalar alpha) {
@@ -507,7 +507,7 @@ bool AtlasColorContents::Render(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+                   entity.GetTransform();
 
   FS::FragInfo frag_info;
   frag_info.alpha = alpha_;

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -50,7 +50,7 @@ Contents::ClipCoverage ClipContents::GetClipCoverage(
       if (!geometry_) {
         return {.type = ClipCoverage::Type::kAppend, .coverage = std::nullopt};
       }
-      auto coverage = geometry_->GetCoverage(entity.GetTransformation());
+      auto coverage = geometry_->GetCoverage(entity.GetTransform());
       if (!coverage.has_value() || !current_clip_coverage.has_value()) {
         return {.type = ClipCoverage::Type::kAppend, .coverage = std::nullopt};
       }

--- a/impeller/entity/contents/clip_contents.h
+++ b/impeller/entity/contents/clip_contents.h
@@ -65,7 +65,7 @@ class ClipRestoreContents final : public Contents {
   /// @brief  The area on the pass texture where this clip restore will be
   ///         applied. If unset, the entire pass texture will be restored.
   ///
-  /// @note   This rectangle is not transformed by the entity's transformation.
+  /// @note   This rectangle is not transformed by the entity's transform.
   void SetRestoreCoverage(std::optional<Rect> coverage);
 
   // |Contents|

--- a/impeller/entity/contents/color_source_contents.cc
+++ b/impeller/entity/contents/color_source_contents.cc
@@ -44,7 +44,7 @@ bool ColorSourceContents::IsSolidColor() const {
 
 std::optional<Rect> ColorSourceContents::GetCoverage(
     const Entity& entity) const {
-  return geometry_->GetCoverage(entity.GetTransformation());
+  return geometry_->GetCoverage(entity.GetTransform());
 };
 
 bool ColorSourceContents::CanInheritOpacity(const Entity& entity) const {

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -49,7 +49,7 @@ class ColorSourceContents : public Contents {
   //----------------------------------------------------------------------------
   /// @brief  Set the effect transform for this color source.
   ///
-  ///         The effect transform is a transformation matrix that is applied to
+  ///         The effect transform is a transform matrix that is applied to
   ///         the shaded color output and does not impact geometry in any way.
   ///
   ///         For example: With repeat tiling, any gradient or

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -90,7 +90,7 @@ bool ConicalGradientContents::RenderSSBO(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+                   entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
   Command cmd;

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -87,9 +87,9 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
                                               RenderPass& pass) -> bool {
         Entity sub_entity;
         sub_entity.SetBlendMode(BlendMode::kSourceOver);
-        sub_entity.SetTransformation(
+        sub_entity.SetTransform(
             Matrix::MakeTranslation(Vector3(-coverage->origin)) *
-            entity.GetTransformation());
+            entity.GetTransform());
         return contents.Render(renderer, sub_entity, pass);
       },
       msaa_enabled);

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -372,7 +372,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
     FS::BindBlendInfo(cmd, blend_uniform);
 
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation();
+                     entity.GetTransform();
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
@@ -381,7 +381,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
   };
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage.TransformBounds(entity.GetTransformation());
+    return coverage.TransformBounds(entity.GetTransform());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);
@@ -497,7 +497,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
     FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
 
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation();
+                     entity.GetTransform();
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
@@ -507,7 +507,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage.TransformBounds(entity.GetTransformation());
+    return coverage.TransformBounds(entity.GetTransform());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -115,7 +115,7 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation();
+                     entity.GetTransform();
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 
@@ -136,7 +136,7 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage.TransformBounds(entity.GetTransformation());
+    return coverage.TransformBounds(entity.GetTransform());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -78,7 +78,7 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation() * input_snapshot->transform *
+                     entity.GetTransform() * input_snapshot->transform *
                      Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
@@ -109,7 +109,7 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage.TransformBounds(entity.GetTransformation());
+    return coverage.TransformBounds(entity.GetTransform());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.cc
@@ -95,7 +95,7 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
 
   auto radius = Radius{ScaleSigma(blur_sigma_)}.radius;
 
-  auto transform = entity.GetTransformation() * effect_transform.Basis();
+  auto transform = entity.GetTransform() * effect_transform.Basis();
   auto transformed_blur_radius =
       transform.TransformDirection(blur_direction_ * radius);
 

--- a/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents_unittests.cc
@@ -48,7 +48,7 @@ TEST_P(DirectionalGaussianBlurFilterContentsTest, CoverageWithEffectTransform) {
           desc);
   FilterInput::Vector inputs = {FilterInput::Make(texture)};
   Entity entity;
-  entity.SetTransformation(Matrix::MakeTranslation({100, 100, 0}));
+  entity.SetTransform(Matrix::MakeTranslation({100, 100, 0}));
   std::optional<Rect> coverage = contents->GetFilterCoverage(
       inputs, entity, /*effect_transform=*/Matrix::MakeScale({2.0, 2.0, 1.0}));
   EXPECT_TRUE(coverage.has_value());

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -203,8 +203,8 @@ std::optional<Rect> FilterContents::GetLocalCoverage(
 
 std::optional<Rect> FilterContents::GetCoverage(const Entity& entity) const {
   Entity entity_with_local_transform = entity;
-  entity_with_local_transform.SetTransformation(
-      GetTransform(entity.GetTransformation()));
+  entity_with_local_transform.SetTransform(
+      GetTransform(entity.GetTransform()));
 
   return GetLocalCoverage(entity_with_local_transform);
 }
@@ -271,8 +271,8 @@ std::optional<Entity> FilterContents::GetEntity(
     const Entity& entity,
     const std::optional<Rect>& coverage_hint) const {
   Entity entity_with_local_transform = entity;
-  entity_with_local_transform.SetTransformation(
-      GetTransform(entity.GetTransformation()));
+  entity_with_local_transform.SetTransform(
+      GetTransform(entity.GetTransform()));
 
   auto coverage = GetLocalCoverage(entity_with_local_transform);
   if (!coverage.has_value() || coverage->IsEmpty()) {

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -203,8 +203,7 @@ std::optional<Rect> FilterContents::GetLocalCoverage(
 
 std::optional<Rect> FilterContents::GetCoverage(const Entity& entity) const {
   Entity entity_with_local_transform = entity;
-  entity_with_local_transform.SetTransform(
-      GetTransform(entity.GetTransform()));
+  entity_with_local_transform.SetTransform(GetTransform(entity.GetTransform()));
 
   return GetLocalCoverage(entity_with_local_transform);
 }
@@ -271,8 +270,7 @@ std::optional<Entity> FilterContents::GetEntity(
     const Entity& entity,
     const std::optional<Rect>& coverage_hint) const {
   Entity entity_with_local_transform = entity;
-  entity_with_local_transform.SetTransform(
-      GetTransform(entity.GetTransform()));
+  entity_with_local_transform.SetTransform(GetTransform(entity.GetTransform()));
 
   auto coverage = GetLocalCoverage(entity_with_local_transform);
   if (!coverage.has_value() || coverage->IsEmpty()) {

--- a/impeller/entity/contents/filters/filter_contents.h
+++ b/impeller/entity/contents/filters/filter_contents.h
@@ -170,8 +170,8 @@ class FilterContents : public Contents {
   Matrix GetTransform(const Matrix& parent_transform) const;
 
   /// @brief  Returns true if this filter graph doesn't perform any basis
-  ///         transformations to the filtered content. For example: Rotating,
-  ///         scaling, and skewing are all basis transformations, but
+  ///         transforms to the filtered content. For example: Rotating,
+  ///         scaling, and skewing are all basis transforms, but
   ///         translating is not.
   ///
   ///         This is useful for determining whether a filtered object's space
@@ -191,8 +191,8 @@ class FilterContents : public Contents {
   /// @brief  Marks this filter chain as applying in a subpass scenario.
   ///
   ///         Subpasses render in screenspace, and this setting informs filters
-  ///         that the current transformation matrix of the entity is not stored
-  ///         in the Entity transformation matrix. Instead, the effect transform
+  ///         that the current transform matrix of the entity is not stored
+  ///         in the Entity transform matrix. Instead, the effect transform
   ///         is used in this case.
   virtual void SetRenderingMode(Entity::RenderingMode rendering_mode);
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -250,7 +250,7 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
       Snapshot{
           .texture = pass3_out_texture,
           .transform =
-              entity.GetTransformation() *
+              entity.GetTransform() *
               Matrix::MakeScale(
                   {input_snapshot->texture->GetSize().width /
                        static_cast<Scalar>(pass1_out_texture->GetSize().width),

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -197,7 +197,7 @@ TEST_P(GaussianBlurFilterContentsTest,
 
   Entity entity;
   entity.SetTransform(Matrix::MakeTranslation({400, 100, 0}) *
-                           Matrix::MakeRotationZ(Degrees(90.0)));
+                      Matrix::MakeRotationZ(Degrees(90.0)));
   std::optional<Entity> result =
       contents->GetEntity(*renderer, entity, /*coverage_hint=*/{});
   EXPECT_TRUE(result.has_value());

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -80,7 +80,7 @@ TEST_P(GaussianBlurFilterContentsTest, CoverageWithTexture) {
           desc);
   FilterInput::Vector inputs = {FilterInput::Make(texture)};
   Entity entity;
-  entity.SetTransformation(Matrix::MakeTranslation({100, 100, 0}));
+  entity.SetTransform(Matrix::MakeTranslation({100, 100, 0}));
   std::optional<Rect> coverage =
       contents.GetFilterCoverage(inputs, entity, /*effect_transform=*/Matrix());
   ASSERT_EQ(coverage, Rect::MakeLTRB(99, 99, 201, 201));
@@ -98,7 +98,7 @@ TEST_P(GaussianBlurFilterContentsTest, CoverageWithEffectTransform) {
           desc);
   FilterInput::Vector inputs = {FilterInput::Make(texture)};
   Entity entity;
-  entity.SetTransformation(Matrix::MakeTranslation({100, 100, 0}));
+  entity.SetTransform(Matrix::MakeTranslation({100, 100, 0}));
   std::optional<Rect> coverage = contents.GetFilterCoverage(
       inputs, entity, /*effect_transform=*/Matrix::MakeScale({2.0, 2.0, 1.0}));
   ASSERT_EQ(coverage, Rect::MakeLTRB(100 - 2, 100 - 2, 200 + 2, 200 + 2));
@@ -159,7 +159,7 @@ TEST_P(GaussianBlurFilterContentsTest,
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
   Entity entity;
-  entity.SetTransformation(Matrix::MakeTranslation({100, 200, 0}));
+  entity.SetTransform(Matrix::MakeTranslation({100, 200, 0}));
   std::optional<Entity> result =
       contents->GetEntity(*renderer, entity, /*coverage_hint=*/{});
   EXPECT_TRUE(result.has_value());
@@ -196,7 +196,7 @@ TEST_P(GaussianBlurFilterContentsTest,
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
   Entity entity;
-  entity.SetTransformation(Matrix::MakeTranslation({400, 100, 0}) *
+  entity.SetTransform(Matrix::MakeTranslation({400, 100, 0}) *
                            Matrix::MakeRotationZ(Degrees(90.0)));
   std::optional<Entity> result =
       contents->GetEntity(*renderer, entity, /*coverage_hint=*/{});

--- a/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_contents_filter_input.cc
@@ -51,11 +51,11 @@ std::optional<Rect> FilterContentsFilterInput::GetSourceCoverage(
 
 Matrix FilterContentsFilterInput::GetLocalTransform(
     const Entity& entity) const {
-  return filter_->GetLocalTransform(entity.GetTransformation());
+  return filter_->GetLocalTransform(entity.GetTransform());
 }
 
 Matrix FilterContentsFilterInput::GetTransform(const Entity& entity) const {
-  return filter_->GetTransform(entity.GetTransformation());
+  return filter_->GetTransform(entity.GetTransform());
 }
 
 void FilterContentsFilterInput::PopulateGlyphAtlas(

--- a/impeller/entity/contents/filters/inputs/filter_input.cc
+++ b/impeller/entity/contents/filters/inputs/filter_input.cc
@@ -62,7 +62,7 @@ Matrix FilterInput::GetLocalTransform(const Entity& entity) const {
 
 std::optional<Rect> FilterInput::GetLocalCoverage(const Entity& entity) const {
   Entity local_entity = entity;
-  local_entity.SetTransformation(GetLocalTransform(entity));
+  local_entity.SetTransform(GetLocalTransform(entity));
   return GetCoverage(local_entity);
 }
 
@@ -73,7 +73,7 @@ std::optional<Rect> FilterInput::GetSourceCoverage(
 }
 
 Matrix FilterInput::GetTransform(const Entity& entity) const {
-  return entity.GetTransformation() * GetLocalTransform(entity);
+  return entity.GetTransform() * GetLocalTransform(entity);
 }
 
 void FilterInput::PopulateGlyphAtlas(

--- a/impeller/entity/contents/filters/inputs/filter_input.h
+++ b/impeller/entity/contents/filters/inputs/filter_input.h
@@ -64,7 +64,7 @@ class FilterInput {
   virtual Matrix GetLocalTransform(const Entity& entity) const;
 
   /// @brief  Get the transform of this `FilterInput`. This is equivalent to
-  ///         calling `entity.GetTransformation() * GetLocalTransform()`.
+  ///         calling `entity.GetTransform() * GetLocalTransform()`.
   virtual Matrix GetTransform(const Entity& entity) const;
 
   /// @see    `Contents::PopulateGlyphAtlas`
@@ -72,7 +72,7 @@ class FilterInput {
       const std::shared_ptr<LazyGlyphAtlas>& lazy_glyph_atlas,
       Scalar scale);
 
-  /// @see  `FilterContents::HasBasisTransformations`
+  /// @see  `FilterContents::HasBasisTransforms`
   virtual bool IsTranslationOnly() const;
 
   /// @brief  Returns `true` unless this input is a `FilterInput`, which may

--- a/impeller/entity/contents/filters/inputs/filter_input_unittests.cc
+++ b/impeller/entity/contents/filters/inputs/filter_input_unittests.cc
@@ -19,7 +19,7 @@ TEST(FilterInputTest, CanSetLocalTransformForTexture) {
   auto input =
       FilterInput::Make(texture, Matrix::MakeTranslation({1.0, 0.0, 0.0}));
   Entity e;
-  e.SetTransformation(Matrix::MakeTranslation({0.0, 2.0, 0.0}));
+  e.SetTransform(Matrix::MakeTranslation({0.0, 2.0, 0.0}));
 
   ASSERT_MATRIX_NEAR(input->GetLocalTransform(e),
                      Matrix::MakeTranslation({1.0, 0.0, 0.0}));

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -69,7 +69,7 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation() * input_snapshot->transform *
+                     entity.GetTransform() * input_snapshot->transform *
                      Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
@@ -90,7 +90,7 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage.TransformBounds(entity.GetTransformation());
+    return coverage.TransformBounds(entity.GetTransform());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -57,7 +57,7 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
 
   auto transform = rendering_mode_ == Entity::RenderingMode::kSubpass
                        ? effect_transform
-                       : entity.GetTransformation();
+                       : entity.GetTransform();
   snapshot->transform = transform *           //
                         matrix_ *             //
                         transform.Invert() *  //

--- a/impeller/entity/contents/filters/matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/matrix_filter_contents.cc
@@ -41,7 +41,7 @@ std::optional<Entity> MatrixFilterContents::RenderFilter(
   }
 
   // The filter's matrix needs to be applied within the space defined by the
-  // scene's current transformation matrix (CTM). For example: If the CTM is
+  // scene's current transform matrix (CTM). For example: If the CTM is
   // scaled up, then translations applied by the matrix should be magnified
   // accordingly.
   //

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -92,7 +92,7 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 
-    auto transform = entity.GetTransformation() * effect_transform.Basis();
+    auto transform = entity.GetTransform() * effect_transform.Basis();
     auto transformed_radius =
         transform.TransformDirection(direction_ * radius_.radius);
     auto transformed_texture_vertices =

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -69,7 +69,7 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation() * input_snapshot->transform *
+                     entity.GetTransform() * input_snapshot->transform *
                      Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
@@ -90,7 +90,7 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage.TransformBounds(entity.GetTransformation());
+    return coverage.TransformBounds(entity.GetTransform());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -97,7 +97,7 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation() * y_input_snapshot->transform *
+                     entity.GetTransform() * y_input_snapshot->transform *
                      Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         y_input_snapshot->texture->GetYCoordScale();
@@ -125,7 +125,7 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage.TransformBounds(entity.GetTransformation());
+    return coverage.TransformBounds(entity.GetTransform());
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -152,7 +152,7 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+                   entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
   Command cmd;

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -89,7 +89,7 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+                   entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
   Command cmd;

--- a/impeller/entity/contents/scene_contents.cc
+++ b/impeller/entity/contents/scene_contents.cc
@@ -98,7 +98,7 @@ bool SceneContents::Render(const ContentContext& renderer,
   contents.SetGeometry(GetGeometry());
   contents.SetTexture(subpass_target.GetRenderTargetTexture());
   contents.SetEffectTransform(
-      Matrix::MakeScale(1 / entity.GetTransformation().GetScale()));
+      Matrix::MakeScale(1 / entity.GetTransform().GetScale()));
   return contents.Render(renderer, entity, pass);
 }
 

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -42,7 +42,7 @@ std::optional<Rect> SolidColorContents::GetCoverage(
   if (geometry == nullptr) {
     return std::nullopt;
   }
-  return geometry->GetCoverage(entity.GetTransformation());
+  return geometry->GetCoverage(entity.GetTransform());
 };
 
 bool SolidColorContents::Render(const ContentContext& renderer,
@@ -98,7 +98,7 @@ std::optional<Color> SolidColorContents::AsBackgroundColor(
     const Entity& entity,
     ISize target_size) const {
   Rect target_rect = Rect::MakeSize(target_size);
-  return GetGeometry()->CoversArea(entity.GetTransformation(), target_rect)
+  return GetGeometry()->CoversArea(entity.GetTransform(), target_rect)
              ? GetColor()
              : std::optional<Color>();
 }

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -57,7 +57,7 @@ std::optional<Rect> SolidRRectBlurContents::GetCoverage(
   auto ltrb = rect_->GetLTRB();
   Rect bounds = Rect::MakeLTRB(ltrb[0] - radius, ltrb[1] - radius,
                                ltrb[2] + radius, ltrb[3] + radius);
-  return bounds.TransformBounds(entity.GetTransformation());
+  return bounds.TransformBounds(entity.GetTransform());
 };
 
 bool SolidRRectBlurContents::Render(const ContentContext& renderer,
@@ -108,7 +108,7 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation() *
+                   entity.GetTransform() *
                    Matrix::MakeTranslation({positive_rect.origin});
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -95,7 +95,7 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation();
+                   entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
   Command cmd;

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -61,7 +61,7 @@ void TextContents::SetOffset(Vector2 offset) {
 }
 
 std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
-  return frame_->GetBounds().TransformBounds(entity.GetTransformation());
+  return frame_->GetBounds().TransformBounds(entity.GetTransform());
 }
 
 void TextContents::PopulateGlyphAtlas(
@@ -111,8 +111,8 @@ bool TextContents::Render(const ContentContext& renderer,
               static_cast<Scalar>(atlas->GetTexture()->GetSize().height)};
   frame_info.offset = offset_;
   frame_info.is_translation_scale =
-      entity.GetTransformation().IsTranslationScaleOnly();
-  frame_info.entity_transform = entity.GetTransformation();
+      entity.GetTransform().IsTranslationScaleOnly();
+  frame_info.entity_transform = entity.GetTransform();
   frame_info.text_color = ToVector(color.Premultiply());
 
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -71,7 +71,7 @@ std::optional<Rect> TextureContents::GetCoverage(const Entity& entity) const {
   if (GetOpacity() == 0) {
     return std::nullopt;
   }
-  return destination_rect_.TransformBounds(entity.GetTransformation());
+  return destination_rect_.TransformBounds(entity.GetTransform());
 };
 
 std::optional<Snapshot> TextureContents::RenderToSnapshot(
@@ -90,7 +90,7 @@ std::optional<Snapshot> TextureContents::RenderToSnapshot(
     auto scale = Vector2(bounds.size / Size(texture_->GetSize()));
     return Snapshot{
         .texture = texture_,
-        .transform = entity.GetTransformation() *
+        .transform = entity.GetTransform() *
                      Matrix::MakeTranslation(bounds.origin) *
                      Matrix::MakeScale(scale),
         .sampler_descriptor = sampler_descriptor.value_or(sampler_descriptor_),
@@ -143,7 +143,7 @@ bool TextureContents::Render(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   capture.AddMatrix("Transform", entity.GetTransformation());
+                   capture.AddMatrix("Transform", entity.GetTransform());
   frame_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();
   frame_info.alpha = capture.AddScalar("Alpha", GetOpacity());
 

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -19,7 +19,7 @@ VerticesContents::VerticesContents() = default;
 VerticesContents::~VerticesContents() = default;
 
 std::optional<Rect> VerticesContents::GetCoverage(const Entity& entity) const {
-  return geometry_->GetCoverage(entity.GetTransformation());
+  return geometry_->GetCoverage(entity.GetTransform());
 };
 
 void VerticesContents::SetGeometry(std::shared_ptr<VerticesGeometry> geometry) {

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -47,11 +47,11 @@ Entity::Entity() = default;
 Entity::~Entity() = default;
 
 const Matrix& Entity::GetTransform() const {
-  return transformation_;
+  return transform_;
 }
 
-void Entity::SetTransform(const Matrix& transformation) {
-  transformation_ = transformation;
+void Entity::SetTransform(const Matrix& transform) {
+  transform_ = transform;
 }
 
 std::optional<Rect> Entity::GetCoverage() const {

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -37,7 +37,7 @@ std::optional<Entity> Entity::FromSnapshot(
   Entity entity;
   entity.SetBlendMode(blend_mode);
   entity.SetClipDepth(clip_depth);
-  entity.SetTransformation(snapshot->transform);
+  entity.SetTransform(snapshot->transform);
   entity.SetContents(contents);
   return entity;
 }
@@ -46,11 +46,11 @@ Entity::Entity() = default;
 
 Entity::~Entity() = default;
 
-const Matrix& Entity::GetTransformation() const {
+const Matrix& Entity::GetTransform() const {
   return transformation_;
 }
 
-void Entity::SetTransformation(const Matrix& transformation) {
+void Entity::SetTransform(const Matrix& transformation) {
   transformation_ = transformation;
 }
 
@@ -167,7 +167,7 @@ bool Entity::Render(const ContentContext& renderer,
 }
 
 Scalar Entity::DeriveTextScale() const {
-  return GetTransformation().GetMaxBasisLengthXY();
+  return GetTransform().GetMaxBasisLengthXY();
 }
 
 Capture& Entity::GetCapture() const {

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -24,12 +24,12 @@ class Entity {
 
   enum class RenderingMode {
     /// In direct mode, the Entity's transform is used as the current
-    /// local-to-screen transformation matrix.
+    /// local-to-screen transform matrix.
     kDirect,
     /// In subpass mode, the Entity passed through the filter is in screen space
     /// rather than local space, and so some filters (namely,
     /// MatrixFilterContents) need to interpret the given EffectTransform as the
-    /// current transformation matrix.
+    /// current transform matrix.
     kSubpass,
   };
 
@@ -70,11 +70,11 @@ class Entity {
 
   ~Entity();
 
-  /// @brief  Get the global transformation matrix for this Entity.
+  /// @brief  Get the global transform matrix for this Entity.
   const Matrix& GetTransform() const;
 
-  /// @brief  Set the global transformation matrix for this Entity.
-  void SetTransform(const Matrix& transformation);
+  /// @brief  Set the global transform matrix for this Entity.
+  void SetTransform(const Matrix& transform);
 
   std::optional<Rect> GetCoverage() const;
 
@@ -114,7 +114,7 @@ class Entity {
   void SetCapture(Capture capture) const;
 
  private:
-  Matrix transformation_;
+  Matrix transform_;
   std::shared_ptr<Contents> contents_;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   uint32_t clip_depth_ = 0u;

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -71,10 +71,10 @@ class Entity {
   ~Entity();
 
   /// @brief  Get the global transformation matrix for this Entity.
-  const Matrix& GetTransformation() const;
+  const Matrix& GetTransform() const;
 
   /// @brief  Set the global transformation matrix for this Entity.
-  void SetTransformation(const Matrix& transformation);
+  void SetTransform(const Matrix& transformation);
 
   std::optional<Rect> GetCoverage() const;
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -947,8 +947,7 @@ bool EntityPass::OnRender(
         }
 
         FilterInput::Vector inputs = {
-            FilterInput::Make(texture,
-                              result.entity.GetTransform().Invert()),
+            FilterInput::Make(texture, result.entity.GetTransform().Invert()),
             FilterInput::Make(result.entity.GetContents())};
         auto contents = ColorFilterContents::MakeBlend(
             result.entity.GetBlendMode(), inputs);

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -154,7 +154,7 @@ std::optional<Rect> EntityPass::GetElementsCoverage(
                                              subpass.transform_);
       if (image_filter) {
         Entity subpass_entity;
-        subpass_entity.SetTransformation(subpass.transform_);
+        subpass_entity.SetTransform(subpass.transform_);
         element_coverage = image_filter->GetCoverage(subpass_entity);
       } else {
         element_coverage = unfiltered_coverage;
@@ -487,9 +487,9 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       // If the pass image is going to be rendered with a non-zero position,
       // apply the negative translation to entity copies before rendering them
       // so that they'll end up rendering to the correct on-screen position.
-      element_entity.SetTransformation(
+      element_entity.SetTransform(
           Matrix::MakeTranslation(Vector3(-global_pass_position)) *
-          element_entity.GetTransformation());
+          element_entity.GetTransform());
     }
     return EntityPass::EntityResult::Success(element_entity);
   }
@@ -667,7 +667,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     element_entity.SetContents(std::move(offscreen_texture_contents));
     element_entity.SetClipDepth(subpass->clip_depth_);
     element_entity.SetBlendMode(subpass->blend_mode_);
-    element_entity.SetTransformation(subpass_texture_capture.AddMatrix(
+    element_entity.SetTransform(subpass_texture_capture.AddMatrix(
         "Transform", Matrix::MakeTranslation(Vector3(subpass_coverage->origin -
                                                      global_pass_position))));
 
@@ -862,7 +862,7 @@ bool EntityPass::OnRender(
 
     Entity backdrop_entity;
     backdrop_entity.SetContents(std::move(backdrop_filter_contents));
-    backdrop_entity.SetTransformation(
+    backdrop_entity.SetTransform(
         Matrix::MakeTranslation(Vector3(-local_pass_position)));
     backdrop_entity.SetClipDepth(clip_depth_floor);
 
@@ -948,7 +948,7 @@ bool EntityPass::OnRender(
 
         FilterInput::Vector inputs = {
             FilterInput::Make(texture,
-                              result.entity.GetTransformation().Invert()),
+                              result.entity.GetTransform().Invert()),
             FilterInput::Make(result.entity.GetContents())};
         auto contents = ColorFilterContents::MakeBlend(
             result.entity.GetBlendMode(), inputs);
@@ -1109,7 +1109,7 @@ std::unique_ptr<EntityPass> EntityPass::Clone() const {
   return pass;
 }
 
-void EntityPass::SetTransformation(Matrix transform) {
+void EntityPass::SetTransform(Matrix transform) {
   transform_ = transform;
 }
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -126,7 +126,7 @@ class EntityPass {
   ///
   size_t GetElementCount() const;
 
-  void SetTransformation(Matrix transform);
+  void SetTransform(Matrix transform);
 
   void SetClipDepth(size_t clip_depth);
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -126,7 +126,7 @@ class EntityPass {
   ///
   size_t GetElementCount() const;
 
-  void SetTransformation(Matrix xformation);
+  void SetTransformation(Matrix transform);
 
   void SetClipDepth(size_t clip_depth);
 
@@ -281,7 +281,7 @@ class EntityPass {
   std::vector<Element> elements_;
 
   EntityPass* superpass_ = nullptr;
-  Matrix xformation_;
+  Matrix transform_;
   size_t clip_depth_ = 0u;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   bool flood_clip_ = false;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -59,7 +59,7 @@ INSTANTIATE_PLAYGROUND_SUITE(EntityTest);
 
 TEST_P(EntityTest, CanCreateEntity) {
   Entity entity;
-  ASSERT_TRUE(entity.GetTransformation().IsIdentity());
+  ASSERT_TRUE(entity.GetTransform().IsIdentity());
 }
 
 class TestPassDelegate final : public EntityPassDelegate {
@@ -146,7 +146,7 @@ TEST_P(EntityTest, EntityPassCanMergeSubpassIntoParent) {
   pass.AddSubpass(std::move(subpass));
 
   Entity entity;
-  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   auto contents = std::make_unique<SolidColorContents>();
   contents->SetGeometry(Geometry::MakeRect(Rect::MakeLTRB(100, 100, 200, 200)));
   contents->SetColor(Color::Blue());
@@ -218,7 +218,7 @@ TEST_P(EntityTest, CanDrawRect) {
   contents->SetColor(Color::Red());
 
   Entity entity;
-  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   entity.SetContents(contents);
 
   ASSERT_TRUE(OpenPlaygroundHere(entity));
@@ -234,7 +234,7 @@ TEST_P(EntityTest, CanDrawRRect) {
   contents->SetColor(Color::Red());
 
   Entity entity;
-  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   entity.SetContents(contents);
 
   ASSERT_TRUE(OpenPlaygroundHere(entity));
@@ -259,7 +259,7 @@ TEST_P(EntityTest, ThreeStrokesInOnePath) {
                   .TakePath();
 
   Entity entity;
-  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   auto contents = std::make_unique<SolidColorContents>();
   contents->SetGeometry(Geometry::MakeStrokePath(path, 5.0));
   contents->SetColor(Color::Red());
@@ -279,7 +279,7 @@ TEST_P(EntityTest, StrokeWithTextureContents) {
                   .TakePath();
 
   Entity entity;
-  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   auto contents = std::make_unique<TiledTextureContents>();
   contents->SetGeometry(Geometry::MakeStrokePath(path, 100.0));
   contents->SetTexture(bridge);
@@ -319,7 +319,7 @@ TEST_P(EntityTest, TriangleInsideASquare) {
                     .TakePath();
 
     Entity entity;
-    entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+    entity.SetTransform(Matrix::MakeScale(GetContentScale()));
     auto contents = std::make_unique<SolidColorContents>();
     contents->SetGeometry(Geometry::MakeStrokePath(path, 20.0));
     contents->SetColor(Color::Red());
@@ -361,7 +361,7 @@ TEST_P(EntityTest, StrokeCapAndJoinTest) {
       contents->SetColor(Color::Red());
 
       Entity entity;
-      entity.SetTransformation(world_matrix);
+      entity.SetTransform(world_matrix);
       entity.SetContents(std::move(contents));
 
       auto coverage = entity.GetCoverage();
@@ -469,12 +469,12 @@ TEST_P(EntityTest, CubicCurveTest) {
           .Close()
           .TakePath();
   Entity entity;
-  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   entity.SetContents(SolidColorContents::Make(path, Color::Red()));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
 }
 
-TEST_P(EntityTest, CanDrawCorrectlyWithRotatedTransformation) {
+TEST_P(EntityTest, CanDrawCorrectlyWithRotatedTransform) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     const char* input_axis[] = {"X", "Y", "Z"};
     static int rotation_axis_index = 0;
@@ -513,7 +513,7 @@ TEST_P(EntityTest, CanDrawCorrectlyWithRotatedTransformation) {
         PathBuilder{}.AddRect(Rect::MakeXYWH(-300, -400, 600, 800)).TakePath();
 
     Entity entity;
-    entity.SetTransformation(result_transform);
+    entity.SetTransform(result_transform);
     entity.SetContents(SolidColorContents::Make(path, Color::Red()));
     return entity.Render(context, pass);
   };
@@ -743,7 +743,7 @@ TEST_P(EntityTest, CubicCurveAndOverlapTest) {
           .Close()
           .TakePath();
   Entity entity;
-  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   entity.SetContents(SolidColorContents::Make(path, Color::Red()));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
 }
@@ -927,7 +927,7 @@ TEST_P(EntityTest, BezierCircleScaled) {
     ImGui::End();
 
     Entity entity;
-    entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+    entity.SetTransform(Matrix::MakeScale(GetContentScale()));
     auto path = PathBuilder{}
                     .MoveTo({97.325, 34.818})
                     .CubicCurveTo({98.50862885295136, 34.81812293973836},
@@ -944,7 +944,7 @@ TEST_P(EntityTest, BezierCircleScaled) {
                                   {97.32499434685802, 34.81799797758954})
                     .Close()
                     .TakePath();
-    entity.SetTransformation(
+    entity.SetTransform(
         Matrix::MakeScale({scale, scale, 1.0}).Translate({-90, -20, 0}));
     entity.SetContents(SolidColorContents::Make(path, Color::Red()));
     return entity.Render(context, pass);
@@ -971,7 +971,7 @@ TEST_P(EntityTest, Filters) {
         {FilterInput::Make(blend0), fi_bridge, fi_bridge, fi_bridge});
 
     Entity entity;
-    entity.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
                              Matrix::MakeTranslation({500, 300}) *
                              Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(blend1);
@@ -1105,7 +1105,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
 
     Entity entity;
     entity.SetContents(target_contents);
-    entity.SetTransformation(ctm);
+    entity.SetTransform(ctm);
 
     entity.Render(context, pass);
 
@@ -1114,7 +1114,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     Entity cover_entity;
     cover_entity.SetContents(SolidColorContents::Make(
         PathBuilder{}.AddRect(input_rect).TakePath(), cover_color));
-    cover_entity.SetTransformation(ctm);
+    cover_entity.SetTransform(ctm);
 
     cover_entity.Render(context, pass);
 
@@ -1128,7 +1128,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
               .AddRect(target_contents->GetCoverage(entity).value())
               .TakePath(),
           bounds_color));
-      bounds_entity.SetTransformation(Matrix());
+      bounds_entity.SetTransform(Matrix());
 
       bounds_entity.Render(context, pass);
     }
@@ -1211,7 +1211,7 @@ TEST_P(EntityTest, MorphologyFilter) {
 
     Entity entity;
     entity.SetContents(contents);
-    entity.SetTransformation(ctm);
+    entity.SetTransform(ctm);
 
     entity.Render(context, pass);
 
@@ -1220,7 +1220,7 @@ TEST_P(EntityTest, MorphologyFilter) {
     Entity cover_entity;
     cover_entity.SetContents(SolidColorContents::Make(
         PathBuilder{}.AddRect(input_rect).TakePath(), cover_color));
-    cover_entity.SetTransformation(ctm);
+    cover_entity.SetTransform(ctm);
 
     cover_entity.Render(context, pass);
 
@@ -1229,7 +1229,7 @@ TEST_P(EntityTest, MorphologyFilter) {
     bounds_entity.SetContents(SolidColorContents::Make(
         PathBuilder{}.AddRect(contents->GetCoverage(entity).value()).TakePath(),
         bounds_color));
-    bounds_entity.SetTransformation(Matrix());
+    bounds_entity.SetTransform(Matrix());
 
     bounds_entity.Render(context, pass);
 
@@ -1314,7 +1314,7 @@ TEST_P(EntityTest, BorderMaskBlurCoverageIsCorrect) {
 
   {
     Entity e;
-    e.SetTransformation(Matrix());
+    e.SetTransform(Matrix());
     auto actual = border_mask_blur->GetCoverage(e);
     auto expected = Rect::MakeXYWH(-3, -4, 306, 408);
     ASSERT_TRUE(actual.has_value());
@@ -1323,7 +1323,7 @@ TEST_P(EntityTest, BorderMaskBlurCoverageIsCorrect) {
 
   {
     Entity e;
-    e.SetTransformation(Matrix::MakeRotationZ(Radians{kPi / 4}));
+    e.SetTransform(Matrix::MakeRotationZ(Radians{kPi / 4}));
     auto actual = border_mask_blur->GetCoverage(e);
     auto expected = Rect::MakeXYWH(-287.792, -4.94975, 504.874, 504.874);
     ASSERT_TRUE(actual.has_value());
@@ -1357,7 +1357,7 @@ TEST_P(EntityTest, DrawAtlasNoColor) {
   contents->SetBlendMode(BlendMode::kSource);
 
   Entity e;
-  e.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  e.SetTransform(Matrix::MakeScale(GetContentScale()));
   e.SetContents(contents);
 
   ASSERT_TRUE(OpenPlaygroundHere(e));
@@ -1392,7 +1392,7 @@ TEST_P(EntityTest, DrawAtlasWithColorAdvanced) {
   contents->SetBlendMode(BlendMode::kModulate);
 
   Entity e;
-  e.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  e.SetTransform(Matrix::MakeScale(GetContentScale()));
   e.SetContents(contents);
 
   ASSERT_TRUE(OpenPlaygroundHere(e));
@@ -1428,7 +1428,7 @@ TEST_P(EntityTest, DrawAtlasWithColorSimple) {
   contents->SetBlendMode(BlendMode::kSourceATop);
 
   Entity e;
-  e.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  e.SetTransform(Matrix::MakeScale(GetContentScale()));
   e.SetContents(contents);
 
   ASSERT_TRUE(OpenPlaygroundHere(e));
@@ -1460,7 +1460,7 @@ TEST_P(EntityTest, DrawAtlasUsesProvidedCullRectForCoverage) {
 
   auto transform = Matrix::MakeScale(GetContentScale());
   Entity e;
-  e.SetTransformation(transform);
+  e.SetTransform(transform);
   e.SetContents(contents);
 
   ASSERT_EQ(contents->GetCoverage(e).value(),
@@ -1501,7 +1501,7 @@ TEST_P(EntityTest, DrawAtlasWithOpacity) {
   contents->SetAlpha(0.5);
 
   Entity e;
-  e.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  e.SetTransform(Matrix::MakeScale(GetContentScale()));
   e.SetContents(contents);
 
   ASSERT_TRUE(OpenPlaygroundHere(e));
@@ -1521,7 +1521,7 @@ TEST_P(EntityTest, DrawAtlasNoColorFullSize) {
   contents->SetBlendMode(BlendMode::kSource);
 
   Entity e;
-  e.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  e.SetTransform(Matrix::MakeScale(GetContentScale()));
   e.SetContents(contents);
 
   ASSERT_TRUE(OpenPlaygroundHere(e));
@@ -1549,7 +1549,7 @@ TEST_P(EntityTest, SolidFillCoverageIsCorrect) {
         PathBuilder{}.AddRect(Rect::MakeLTRB(100, 110, 200, 220)).TakePath()));
 
     Entity entity;
-    entity.SetTransformation(Matrix::MakeTranslation(Vector2(4, 5)));
+    entity.SetTransform(Matrix::MakeTranslation(Vector2(4, 5)));
     entity.SetContents(std::move(fill));
 
     auto coverage = entity.GetCoverage();
@@ -1716,7 +1716,7 @@ TEST_P(EntityTest, RRectShadowTest) {
     contents->SetSigma(Radius(blur_radius));
 
     Entity entity;
-    entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+    entity.SetTransform(Matrix::MakeScale(GetContentScale()));
     entity.SetContents(std::move(contents));
     entity.Render(context, pass);
 
@@ -1755,7 +1755,7 @@ TEST_P(EntityTest, ColorMatrixFilterCoverageIsCorrect) {
       ColorFilterContents::MakeColorMatrix(FilterInput::Make(fill), matrix);
 
   Entity e;
-  e.SetTransformation(Matrix());
+  e.SetTransform(Matrix());
 
   // Confirm that the actual filter coverage matches the expected coverage.
   auto actual = filter->GetCoverage(e);
@@ -1807,7 +1807,7 @@ TEST_P(EntityTest, ColorMatrixFilterEditable) {
 
     // Define the entity with the color matrix filter.
     Entity entity;
-    entity.SetTransformation(
+    entity.SetTransform(
         Matrix::MakeScale(GetContentScale()) *
         Matrix::MakeTranslation(Vector3(offset[0], offset[1])) *
         Matrix::MakeRotationZ(Radians(rotation)) *
@@ -1834,7 +1834,7 @@ TEST_P(EntityTest, LinearToSrgbFilterCoverageIsCorrect) {
       ColorFilterContents::MakeLinearToSrgbFilter(FilterInput::Make(fill));
 
   Entity e;
-  e.SetTransformation(Matrix());
+  e.SetTransform(Matrix());
 
   // Confirm that the actual filter coverage matches the expected coverage.
   auto actual = filter->GetCoverage(e);
@@ -1855,7 +1855,7 @@ TEST_P(EntityTest, LinearToSrgbFilter) {
     // Define the entity that will serve as the control image as a Gaussian blur
     // filter with no filter at all.
     Entity entity_left;
-    entity_left.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity_left.SetTransform(Matrix::MakeScale(GetContentScale()) *
                                   Matrix::MakeTranslation({100, 300}) *
                                   Matrix::MakeScale(Vector2{0.5, 0.5}));
     auto unfiltered = FilterContents::MakeGaussianBlur(FilterInput::Make(image),
@@ -1864,7 +1864,7 @@ TEST_P(EntityTest, LinearToSrgbFilter) {
 
     // Define the entity that will be filtered from linear to sRGB.
     Entity entity_right;
-    entity_right.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity_right.SetTransform(Matrix::MakeScale(GetContentScale()) *
                                    Matrix::MakeTranslation({500, 300}) *
                                    Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity_right.SetContents(filtered);
@@ -1886,7 +1886,7 @@ TEST_P(EntityTest, SrgbToLinearFilterCoverageIsCorrect) {
       ColorFilterContents::MakeSrgbToLinearFilter(FilterInput::Make(fill));
 
   Entity e;
-  e.SetTransformation(Matrix());
+  e.SetTransform(Matrix());
 
   // Confirm that the actual filter coverage matches the expected coverage.
   auto actual = filter->GetCoverage(e);
@@ -1907,7 +1907,7 @@ TEST_P(EntityTest, SrgbToLinearFilter) {
     // Define the entity that will serve as the control image as a Gaussian blur
     // filter with no filter at all.
     Entity entity_left;
-    entity_left.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity_left.SetTransform(Matrix::MakeScale(GetContentScale()) *
                                   Matrix::MakeTranslation({100, 300}) *
                                   Matrix::MakeScale(Vector2{0.5, 0.5}));
     auto unfiltered = FilterContents::MakeGaussianBlur(FilterInput::Make(image),
@@ -1916,7 +1916,7 @@ TEST_P(EntityTest, SrgbToLinearFilter) {
 
     // Define the entity that will be filtered from sRGB to linear.
     Entity entity_right;
-    entity_right.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity_right.SetTransform(Matrix::MakeScale(GetContentScale()) *
                                    Matrix::MakeTranslation({500, 300}) *
                                    Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity_right.SetContents(filtered);
@@ -2082,7 +2082,7 @@ TEST_P(EntityTest, YUVToRGBFilter) {
       contents->SetTexture(snapshot->texture);
       contents->SetSourceRect(Rect::MakeSize(snapshot->texture->GetSize()));
       entity.SetContents(contents);
-      entity.SetTransformation(
+      entity.SetTransform(
           Matrix::MakeTranslation({static_cast<Scalar>(100 + 400 * i), 300}));
       entity.Render(context, pass);
     }
@@ -2210,7 +2210,7 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorAdvancedBlend) {
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
-    entity.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
                              Matrix::MakeTranslation({500, 300}) *
                              Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
@@ -2226,7 +2226,7 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorClearBlend) {
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
-    entity.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
                              Matrix::MakeTranslation({500, 300}) *
                              Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
@@ -2242,7 +2242,7 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorSrcBlend) {
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
-    entity.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
                              Matrix::MakeTranslation({500, 300}) *
                              Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
@@ -2258,7 +2258,7 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorDstBlend) {
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
-    entity.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
                              Matrix::MakeTranslation({500, 300}) *
                              Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
@@ -2274,7 +2274,7 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorSrcInBlend) {
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
-    entity.SetTransformation(Matrix::MakeScale(GetContentScale()) *
+    entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
                              Matrix::MakeTranslation({500, 300}) *
                              Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
@@ -2386,7 +2386,7 @@ TEST_P(EntityTest, PointFieldGeometryCoverage) {
 
 TEST_P(EntityTest, ColorFilterContentsWithLargeGeometry) {
   Entity entity;
-  entity.SetTransformation(Matrix::MakeScale(GetContentScale()));
+  entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   auto src_contents = std::make_shared<SolidColorContents>();
   src_contents->SetGeometry(
       Geometry::MakeRect(Rect::MakeLTRB(-300, -500, 30000, 50000)));
@@ -2445,7 +2445,7 @@ TEST_P(EntityTest, AdvancedBlendCoverageHintIsNotResetByEntityPass) {
   contents->SetColor(Color::Red());
 
   Entity entity;
-  entity.SetTransformation(Matrix::MakeScale(Vector3(2, 2, 1)));
+  entity.SetTransform(Matrix::MakeScale(Vector3(2, 2, 1)));
   entity.SetBlendMode(BlendMode::kColorBurn);
   entity.SetContents(contents);
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -972,8 +972,8 @@ TEST_P(EntityTest, Filters) {
 
     Entity entity;
     entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                             Matrix::MakeTranslation({500, 300}) *
-                             Matrix::MakeScale(Vector2{0.5, 0.5}));
+                        Matrix::MakeTranslation({500, 300}) *
+                        Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(blend1);
     return entity.Render(context, pass);
   };
@@ -1856,8 +1856,8 @@ TEST_P(EntityTest, LinearToSrgbFilter) {
     // filter with no filter at all.
     Entity entity_left;
     entity_left.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                                  Matrix::MakeTranslation({100, 300}) *
-                                  Matrix::MakeScale(Vector2{0.5, 0.5}));
+                             Matrix::MakeTranslation({100, 300}) *
+                             Matrix::MakeScale(Vector2{0.5, 0.5}));
     auto unfiltered = FilterContents::MakeGaussianBlur(FilterInput::Make(image),
                                                        Sigma{0}, Sigma{0});
     entity_left.SetContents(unfiltered);
@@ -1865,8 +1865,8 @@ TEST_P(EntityTest, LinearToSrgbFilter) {
     // Define the entity that will be filtered from linear to sRGB.
     Entity entity_right;
     entity_right.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                                   Matrix::MakeTranslation({500, 300}) *
-                                   Matrix::MakeScale(Vector2{0.5, 0.5}));
+                              Matrix::MakeTranslation({500, 300}) *
+                              Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity_right.SetContents(filtered);
     return entity_left.Render(context, pass) &&
            entity_right.Render(context, pass);
@@ -1908,8 +1908,8 @@ TEST_P(EntityTest, SrgbToLinearFilter) {
     // filter with no filter at all.
     Entity entity_left;
     entity_left.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                                  Matrix::MakeTranslation({100, 300}) *
-                                  Matrix::MakeScale(Vector2{0.5, 0.5}));
+                             Matrix::MakeTranslation({100, 300}) *
+                             Matrix::MakeScale(Vector2{0.5, 0.5}));
     auto unfiltered = FilterContents::MakeGaussianBlur(FilterInput::Make(image),
                                                        Sigma{0}, Sigma{0});
     entity_left.SetContents(unfiltered);
@@ -1917,8 +1917,8 @@ TEST_P(EntityTest, SrgbToLinearFilter) {
     // Define the entity that will be filtered from sRGB to linear.
     Entity entity_right;
     entity_right.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                                   Matrix::MakeTranslation({500, 300}) *
-                                   Matrix::MakeScale(Vector2{0.5, 0.5}));
+                              Matrix::MakeTranslation({500, 300}) *
+                              Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity_right.SetContents(filtered);
     return entity_left.Render(context, pass) &&
            entity_right.Render(context, pass);
@@ -2211,8 +2211,8 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorAdvancedBlend) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
     entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                             Matrix::MakeTranslation({500, 300}) *
-                             Matrix::MakeScale(Vector2{0.5, 0.5}));
+                        Matrix::MakeTranslation({500, 300}) *
+                        Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
     return entity.Render(context, pass);
   };
@@ -2227,8 +2227,8 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorClearBlend) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
     entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                             Matrix::MakeTranslation({500, 300}) *
-                             Matrix::MakeScale(Vector2{0.5, 0.5}));
+                        Matrix::MakeTranslation({500, 300}) *
+                        Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
     return entity.Render(context, pass);
   };
@@ -2243,8 +2243,8 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorSrcBlend) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
     entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                             Matrix::MakeTranslation({500, 300}) *
-                             Matrix::MakeScale(Vector2{0.5, 0.5}));
+                        Matrix::MakeTranslation({500, 300}) *
+                        Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
     return entity.Render(context, pass);
   };
@@ -2259,8 +2259,8 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorDstBlend) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
     entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                             Matrix::MakeTranslation({500, 300}) *
-                             Matrix::MakeScale(Vector2{0.5, 0.5}));
+                        Matrix::MakeTranslation({500, 300}) *
+                        Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
     return entity.Render(context, pass);
   };
@@ -2275,8 +2275,8 @@ TEST_P(EntityTest, ColorFilterWithForegroundColorSrcInBlend) {
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
     Entity entity;
     entity.SetTransform(Matrix::MakeScale(GetContentScale()) *
-                             Matrix::MakeTranslation({500, 300}) *
-                             Matrix::MakeScale(Vector2{0.5, 0.5}));
+                        Matrix::MakeTranslation({500, 300}) *
+                        Matrix::MakeScale(Vector2{0.5, 0.5}));
     entity.SetContents(filter);
     return entity.Render(context, pass);
   };

--- a/impeller/entity/geometry/cover_geometry.cc
+++ b/impeller/entity/geometry/cover_geometry.cc
@@ -23,7 +23,7 @@ GeometryResult CoverGeometry::GetPositionBuffer(const ContentContext& renderer,
       .vertex_buffer =
           {
               .vertex_buffer = host_buffer.Emplace(
-                  rect.GetTransformedPoints(entity.GetTransformation().Invert())
+                  rect.GetTransformedPoints(entity.GetTransform().Invert())
                       .data(),
                   8 * sizeof(float), alignof(float)),
               .index_buffer = host_buffer.Emplace(
@@ -32,7 +32,7 @@ GeometryResult CoverGeometry::GetPositionBuffer(const ContentContext& renderer,
               .index_type = IndexType::k16bit,
           },
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -23,7 +23,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
   if (path_.GetFillType() == FillType::kNonZero &&  //
       path_.IsConvex()) {
     auto points = renderer.GetTessellator()->TessellateConvex(
-        path_, entity.GetTransformation().GetMaxBasisLength());
+        path_, entity.GetTransform().GetMaxBasisLength());
 
     vertex_buffer.vertex_buffer = host_buffer.Emplace(
         points.data(), points.size() * sizeof(Point), alignof(Point));
@@ -34,13 +34,13 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
         .type = PrimitiveType::kTriangleStrip,
         .vertex_buffer = vertex_buffer,
         .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation(),
+                     entity.GetTransform(),
         .prevent_overdraw = false,
     };
   }
 
   auto tesselation_result = renderer.GetTessellator()->Tessellate(
-      path_, entity.GetTransformation().GetMaxBasisLength(),
+      path_, entity.GetTransform().GetMaxBasisLength(),
       [&vertex_buffer, &host_buffer](
           const float* vertices, size_t vertices_count, const uint16_t* indices,
           size_t indices_count) {
@@ -65,7 +65,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
       .type = PrimitiveType::kTriangle,
       .vertex_buffer = vertex_buffer,
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -85,7 +85,7 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
   if (path_.GetFillType() == FillType::kNonZero &&  //
       path_.IsConvex()) {
     auto points = renderer.GetTessellator()->TessellateConvex(
-        path_, entity.GetTransformation().GetMaxBasisLength());
+        path_, entity.GetTransform().GetMaxBasisLength());
 
     VertexBufferBuilder<VS::PerVertexData> vertex_builder;
     vertex_builder.Reserve(points.size());
@@ -101,14 +101,14 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
         .vertex_buffer =
             vertex_builder.CreateVertexBuffer(pass.GetTransientsBuffer()),
         .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransformation(),
+                     entity.GetTransform(),
         .prevent_overdraw = false,
     };
   }
 
   VertexBufferBuilder<VS::PerVertexData> vertex_builder;
   auto tesselation_result = renderer.GetTessellator()->Tessellate(
-      path_, entity.GetTransformation().GetMaxBasisLength(),
+      path_, entity.GetTransform().GetMaxBasisLength(),
       [&vertex_builder, &uv_transform](
           const float* vertices, size_t vertices_count, const uint16_t* indices,
           size_t indices_count) {
@@ -135,7 +135,7 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
       .vertex_buffer =
           vertex_builder.CreateVertexBuffer(pass.GetTransientsBuffer()),
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -64,7 +64,7 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
               .index_type = IndexType::kNone,
           },
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -59,7 +59,7 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
   auto& host_buffer = pass.GetTransientsBuffer();
 
   Point corners[4];
-  if (!ComputeCorners(corners, entity.GetTransformation(),
+  if (!ComputeCorners(corners, entity.GetTransform(),
                       cap_ == Cap::kSquare)) {
     return {};
   }
@@ -74,7 +74,7 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
               .index_type = IndexType::kNone,
           },
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -90,7 +90,7 @@ GeometryResult LineGeometry::GetPositionUVBuffer(Rect texture_coverage,
   auto uv_transform =
       texture_coverage.GetNormalizingTransform() * effect_transform;
   Point corners[4];
-  if (!ComputeCorners(corners, entity.GetTransformation(),
+  if (!ComputeCorners(corners, entity.GetTransform(),
                       cap_ == Cap::kSquare)) {
     return {};
   }
@@ -111,7 +111,7 @@ GeometryResult LineGeometry::GetPositionUVBuffer(Rect texture_coverage,
               .index_type = IndexType::kNone,
           },
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -59,8 +59,7 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
   auto& host_buffer = pass.GetTransientsBuffer();
 
   Point corners[4];
-  if (!ComputeCorners(corners, entity.GetTransform(),
-                      cap_ == Cap::kSquare)) {
+  if (!ComputeCorners(corners, entity.GetTransform(), cap_ == Cap::kSquare)) {
     return {};
   }
 
@@ -90,8 +89,7 @@ GeometryResult LineGeometry::GetPositionUVBuffer(Rect texture_coverage,
   auto uv_transform =
       texture_coverage.GetNormalizingTransform() * effect_transform;
   Point corners[4];
-  if (!ComputeCorners(corners, entity.GetTransform(),
-                      cap_ == Cap::kSquare)) {
+  if (!ComputeCorners(corners, entity.GetTransform(), cap_ == Cap::kSquare)) {
     return {};
   }
 

--- a/impeller/entity/geometry/point_field_geometry.cc
+++ b/impeller/entity/geometry/point_field_geometry.cc
@@ -33,7 +33,7 @@ GeometryResult PointFieldGeometry::GetPositionBuffer(
       .type = PrimitiveType::kTriangle,
       .vertex_buffer = vtx_builder->CreateVertexBuffer(host_buffer),
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -61,7 +61,7 @@ GeometryResult PointFieldGeometry::GetPositionUVBuffer(
       .type = PrimitiveType::kTriangle,
       .vertex_buffer = uv_vtx_builder.CreateVertexBuffer(host_buffer),
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -73,7 +73,7 @@ PointFieldGeometry::GetPositionBufferCPU(const ContentContext& renderer,
   if (radius_ < 0.0) {
     return std::nullopt;
   }
-  auto determinant = entity.GetTransformation().GetDeterminant();
+  auto determinant = entity.GetTransform().GetDeterminant();
   if (determinant == 0) {
     return std::nullopt;
   }
@@ -82,7 +82,7 @@ PointFieldGeometry::GetPositionBufferCPU(const ContentContext& renderer,
   Scalar radius = std::max(radius_, min_size);
 
   auto vertices_per_geom = ComputeCircleDivisions(
-      entity.GetTransformation().GetMaxBasisLength() * radius, round_);
+      entity.GetTransform().GetMaxBasisLength() * radius, round_);
   auto points_per_circle = 3 + (vertices_per_geom - 3) * 3;
   auto total = points_per_circle * points_.size();
   auto radian_start = round_ ? 0.0f : 0.785398f;
@@ -132,7 +132,7 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
   if (radius_ < 0.0) {
     return {};
   }
-  auto determinant = entity.GetTransformation().GetDeterminant();
+  auto determinant = entity.GetTransform().GetDeterminant();
   if (determinant == 0) {
     return {};
   }
@@ -141,7 +141,7 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
   Scalar radius = std::max(radius_, min_size);
 
   auto vertices_per_geom = ComputeCircleDivisions(
-      entity.GetTransformation().GetMaxBasisLength() * radius, round_);
+      entity.GetTransform().GetMaxBasisLength() * radius, round_);
 
   auto points_per_circle = 3 + (vertices_per_geom - 3) * 3;
   auto total = points_per_circle * points_.size();
@@ -233,7 +233,7 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
                         .vertex_count = total,
                         .index_type = IndexType::kNone},
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/rect_geometry.cc
+++ b/impeller/entity/geometry/rect_geometry.cc
@@ -24,7 +24,7 @@ GeometryResult RectGeometry::GetPositionBuffer(const ContentContext& renderer,
               .index_type = IndexType::kNone,
           },
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -443,7 +443,7 @@ GeometryResult StrokePathGeometry::GetPositionBuffer(
   if (stroke_width_ < 0.0) {
     return {};
   }
-  auto determinant = entity.GetTransformation().GetDeterminant();
+  auto determinant = entity.GetTransform().GetDeterminant();
   if (determinant == 0) {
     return {};
   }
@@ -455,13 +455,13 @@ GeometryResult StrokePathGeometry::GetPositionBuffer(
   auto vertex_builder = CreateSolidStrokeVertices(
       path_, stroke_width, miter_limit_ * stroke_width_ * 0.5,
       GetJoinProc(stroke_join_), GetCapProc(stroke_cap_),
-      entity.GetTransformation().GetMaxBasisLength());
+      entity.GetTransform().GetMaxBasisLength());
 
   return GeometryResult{
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer = vertex_builder.CreateVertexBuffer(host_buffer),
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = true,
   };
 }
@@ -475,7 +475,7 @@ GeometryResult StrokePathGeometry::GetPositionUVBuffer(
   if (stroke_width_ < 0.0) {
     return {};
   }
-  auto determinant = entity.GetTransformation().GetDeterminant();
+  auto determinant = entity.GetTransform().GetDeterminant();
   if (determinant == 0) {
     return {};
   }
@@ -487,7 +487,7 @@ GeometryResult StrokePathGeometry::GetPositionUVBuffer(
   auto stroke_builder = CreateSolidStrokeVertices(
       path_, stroke_width, miter_limit_ * stroke_width_ * 0.5,
       GetJoinProc(stroke_join_), GetCapProc(stroke_cap_),
-      entity.GetTransformation().GetMaxBasisLength());
+      entity.GetTransform().GetMaxBasisLength());
   auto vertex_builder = ComputeUVGeometryCPU(
       stroke_builder, {0, 0}, texture_coverage.size, effect_transform);
 
@@ -495,7 +495,7 @@ GeometryResult StrokePathGeometry::GetPositionUVBuffer(
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer = vertex_builder.CreateVertexBuffer(host_buffer),
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = true,
   };
 }

--- a/impeller/entity/geometry/vertices_geometry.cc
+++ b/impeller/entity/geometry/vertices_geometry.cc
@@ -153,7 +153,7 @@ GeometryResult VerticesGeometry::GetPositionBuffer(
                   index_count > 0 ? IndexType::k16bit : IndexType::kNone,
           },
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -212,7 +212,7 @@ GeometryResult VerticesGeometry::GetPositionColorBuffer(
                   index_count > 0 ? IndexType::k16bit : IndexType::kNone,
           },
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -283,7 +283,7 @@ GeometryResult VerticesGeometry::GetPositionUVBuffer(
                   index_count > 0 ? IndexType::k16bit : IndexType::kNone,
           },
       .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransformation(),
+                   entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -67,7 +67,7 @@ TEST(RectTest, RectGetNormalizingTransform) {
   }
 
   {
-    // Checks for expected transformation of points relative to the rect
+    // Checks for expected transform of points relative to the rect
 
     auto r = Rect::MakeLTRB(300, 500, 400, 700);
     auto m = r.GetNormalizingTransform();
@@ -155,7 +155,7 @@ TEST(RectTest, IRectGetNormalizingTransform) {
   }
 
   {
-    // Checks for expected transformation of points relative to the rect
+    // Checks for expected transform of points relative to the rect
 
     auto r = IRect::MakeLTRB(300, 500, 400, 700);
     auto m = r.GetNormalizingTransform();


### PR DESCRIPTION
This replaces usage of "xformation" and "transformation".

test-exempt: refactor

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
