### PR TITLE
[Impeller] preallocate command buffer to next power of two of entity list.

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -835,8 +835,9 @@ bool EntityPass::OnRender(
   TRACE_EVENT0("impeller", "EntityPass::OnRender");
 
   auto context = renderer.GetContext();
-  InlinePassContext pass_context(
-      context, pass_target, GetTotalPassReads(renderer), collapsed_parent_pass);
+  InlinePassContext pass_context(context, pass_target,
+                                 GetTotalPassReads(renderer), GetElementCount(),
+                                 collapsed_parent_pass);
   if (!pass_context.IsValid()) {
     VALIDATION_LOG << SPrintF("Pass context invalid (Depth=%d)", pass_depth);
     return false;

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -18,9 +18,11 @@ InlinePassContext::InlinePassContext(
     std::shared_ptr<Context> context,
     EntityPassTarget& pass_target,
     uint32_t pass_texture_reads,
+    uint32_t entity_count,
     std::optional<RenderPassResult> collapsed_parent_pass)
     : context_(std::move(context)),
       pass_target_(pass_target),
+      entity_count_(entity_count),
       is_collapsed_(collapsed_parent_pass.has_value()) {
   if (collapsed_parent_pass.has_value()) {
     pass_ = collapsed_parent_pass.value().pass;
@@ -149,7 +151,10 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
     VALIDATION_LOG << "Could not create render pass.";
     return {};
   }
-
+  // Commands are fairly large (500B) objects, so re-allocation of the command buffer
+  // while encoding can add a surprising amount of overhead. We make a conservative npot
+  // estimate to avoid this case.
+  pass_->ReserveCommands(Allocation::NextPowerOfTwoSize(entity_count_));
   pass_->SetLabel(
       "EntityPass Render Pass: Depth=" + std::to_string(pass_depth) +
       " Count=" + std::to_string(pass_count_));

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -151,9 +151,9 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
     VALIDATION_LOG << "Could not create render pass.";
     return {};
   }
-  // Commands are fairly large (500B) objects, so re-allocation of the command buffer
-  // while encoding can add a surprising amount of overhead. We make a conservative npot
-  // estimate to avoid this case.
+  // Commands are fairly large (500B) objects, so re-allocation of the command
+  // buffer while encoding can add a surprising amount of overhead. We make a
+  // conservative npot estimate to avoid this case.
   pass_->ReserveCommands(Allocation::NextPowerOfTwoSize(entity_count_));
   pass_->SetLabel(
       "EntityPass Render Pass: Depth=" + std::to_string(pass_depth) +

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -24,14 +24,21 @@ class InlinePassContext {
       std::shared_ptr<Context> context,
       EntityPassTarget& pass_target,
       uint32_t pass_texture_reads,
+      uint32_t entity_count,
       std::optional<RenderPassResult> collapsed_parent_pass = std::nullopt);
+
   ~InlinePassContext();
 
   bool IsValid() const;
+
   bool IsActive() const;
+
   std::shared_ptr<Texture> GetTexture();
+
   bool EndPass();
+
   EntityPassTarget& GetPassTarget() const;
+
   uint32_t GetPassCount() const;
 
   RenderPassResult GetRenderPass(uint32_t pass_depth);
@@ -42,6 +49,7 @@ class InlinePassContext {
   std::shared_ptr<CommandBuffer> command_buffer_;
   std::shared_ptr<RenderPass> pass_;
   uint32_t pass_count_ = 0;
+  uint32_t entity_count_ = 0;
 
   // Whether this context is collapsed into a parent entity pass.
   bool is_collapsed_ = false;

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -92,10 +92,9 @@ struct Bindings {
 ///             * Specify any stage bindings.
 ///             * (Optional) Specify a debug label.
 ///
-///             Command are very lightweight objects and can be created
-///             frequently and on demand. The resources referenced in commands
-///             views into buffers managed by other allocators and resource
-///             managers.
+///             Command can be created frequently and on demand. The resources
+///             referenced in commands views into buffers managed by other
+///             allocators and resource managers.
 ///
 struct Command : public ResourceBinder {
   //----------------------------------------------------------------------------

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -36,6 +36,13 @@ class RenderPass {
 
   void SetLabel(std::string label);
 
+  /// @brief Reserve [command_count] commands in the HAL command buffer.
+  ///
+  /// Note: this is not the native command buffer.
+  void ReserveCommands(size_t command_count) {
+    commands_.reserve(command_count);
+  }
+
   HostBuffer& GetTransientsBuffer();
 
   //----------------------------------------------------------------------------

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -1261,9 +1261,11 @@ TEST_P(RendererTest, StencilMask) {
 TEST_P(RendererTest, CanPreAllocateCommands) {
   auto context = GetContext();
   auto cmd_buffer = context->CreateCommandBuffer();
-  auto render_target_cache = std::make_shared<RenderTargetAllocator>(GetContext()->GetResourceAllocator());
+  auto render_target_cache = std::make_shared<RenderTargetAllocator>(
+      GetContext()->GetResourceAllocator());
 
-  auto render_target = RenderTarget::CreateOffscreen(*context, *render_target_cache, {100, 100});
+  auto render_target =
+      RenderTarget::CreateOffscreen(*context, *render_target_cache, {100, 100});
   auto render_pass = cmd_buffer->CreateRenderPass(render_target);
 
   render_pass->ReserveCommands(100u);

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -33,6 +33,7 @@
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/pipeline_builder.h"
 #include "impeller/renderer/pipeline_library.h"
+#include "impeller/renderer/render_target.h"
 #include "impeller/renderer/renderer.h"
 #include "impeller/renderer/sampler_library.h"
 #include "impeller/renderer/surface.h"
@@ -1255,6 +1256,19 @@ TEST_P(RendererTest, StencilMask) {
     return true;
   };
   OpenPlaygroundHere(callback);
+}
+
+TEST_P(RendererTest, CanPreAllocateCommands) {
+  auto context = GetContext();
+  auto cmd_buffer = context->CreateCommandBuffer();
+  auto render_target_cache = std::make_shared<RenderTargetAllocator>(GetContext()->GetResourceAllocator());
+
+  auto render_target = RenderTarget::CreateOffscreen(*context, *render_target_cache, {100, 100});
+  auto render_pass = cmd_buffer->CreateRenderPass(render_target);
+
+  render_pass->ReserveCommands(100u);
+
+  EXPECT_EQ(render_pass->GetCommands().capacity(), 100u);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Commands are massive 500 byte objects, re-allocating this vector while recording them can actually add a substantial amount of overhead to applications with lots of drawing commands. Sizing to npot so that underestimating by a few commands doesn't force us to immediately copy all command objects.

This is still a herustic driven approach. An alternative exact approach would have entities/contents describe how many commands they would add. This may be more important for stencil then cover (depending on how we do it) since some contents would need to create two commands.
