### PR TITLE
Add FlutterMetalLayer as optional alternative to CAMetalLayer

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -6628,6 +6628,7 @@ ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeybo
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayerTest.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h + ../../../flutter/LICENSE
@@ -9456,6 +9457,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboar
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayerTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -6626,6 +6626,8 @@ ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeySe
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h + ../../../flutter/LICENSE
@@ -9452,6 +9454,8 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeySeco
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -264,8 +264,12 @@ bool SurfaceMTL::Present() const {
       [command_buffer waitUntilScheduled];
       [drawable_ present];
     } else {
-      [command_buffer presentDrawable:drawable_];
       [command_buffer commit];
+
+      // The drawable is not actual metal drawable so it can't be present
+      // through the command buffer.
+      [command_buffer waitUntilScheduled];
+      [drawable_ present];
     }
   }
 

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -264,17 +264,12 @@ bool SurfaceMTL::Present() const {
       [command_buffer waitUntilScheduled];
       [drawable_ present];
     } else {
-      // Check whether CAMetalLayer or FlutterMetalLayer is being used.
-      if (drawable_.layer.class == [CAMetalLayer class]) {
-        [command_buffer presentDrawable:drawable_];
-      } else {
-        // The drawable is not actual metal drawable so it can't be present
-        // through the command buffer.
-        id<CAMetalDrawable> drawable = drawable_;
-        [command_buffer addScheduledHandler:^(id<MTLCommandBuffer> buffer) {
-          [drawable present];
-        }];
-      }
+      // The drawable may come from a FlutterMetalLayer, so it can't be
+      // presented through the command buffer.
+      id<CAMetalDrawable> drawable = drawable_;
+      [command_buffer addScheduledHandler:^(id<MTLCommandBuffer> buffer) {
+        [drawable present];
+      }];
       [command_buffer commit];
     }
   }

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -264,12 +264,14 @@ bool SurfaceMTL::Present() const {
       [command_buffer waitUntilScheduled];
       [drawable_ present];
     } else {
-      [command_buffer commit];
-
       // The drawable is not actual metal drawable so it can't be present
       // through the command buffer.
-      [command_buffer waitUntilScheduled];
-      [drawable_ present];
+
+      id drawable = drawable_;
+      [command_buffer addScheduledHandler:^(id<MTLCommandBuffer> buffer) {
+        [drawable present];
+      }];
+      [command_buffer commit];
     }
   }
 

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -264,7 +264,7 @@ bool SurfaceMTL::Present() const {
       [command_buffer waitUntilScheduled];
       [drawable_ present];
     } else {
-      // Check whether FlutterMetalLayer is being used.
+      // Check whether CAMetalLayer or FlutterMetalLayer is being used.
       if (drawable_.layer.class == [CAMetalLayer class]) {
         [command_buffer presentDrawable:drawable_];
       } else {

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -266,8 +266,7 @@ bool SurfaceMTL::Present() const {
     } else {
       // The drawable is not actual metal drawable so it can't be present
       // through the command buffer.
-
-      id drawable = drawable_;
+      id<CAMetalDrawable> drawable = drawable_;
       [command_buffer addScheduledHandler:^(id<MTLCommandBuffer> buffer) {
         [drawable present];
       }];

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -264,12 +264,17 @@ bool SurfaceMTL::Present() const {
       [command_buffer waitUntilScheduled];
       [drawable_ present];
     } else {
-      // The drawable is not actual metal drawable so it can't be present
-      // through the command buffer.
-      id<CAMetalDrawable> drawable = drawable_;
-      [command_buffer addScheduledHandler:^(id<MTLCommandBuffer> buffer) {
-        [drawable present];
-      }];
+      // Check whether FlutterMetalLayer is being used.
+      if (drawable_.layer.class == [CAMetalLayer class]) {
+        [command_buffer presentDrawable:drawable_];
+      } else {
+        // The drawable is not actual metal drawable so it can't be present
+        // through the command buffer.
+        id<CAMetalDrawable> drawable = drawable_;
+        [command_buffer addScheduledHandler:^(id<MTLCommandBuffer> buffer) {
+          [drawable present];
+        }];
+      }
       [command_buffer commit];
     }
   }

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -262,6 +262,7 @@ shared_library("ios_test_flutter") {
     "framework/Source/FlutterFakeKeyEvents.h",
     "framework/Source/FlutterFakeKeyEvents.mm",
     "framework/Source/FlutterKeyboardManagerTest.mm",
+    "framework/Source/FlutterMetalLayerTest.mm",
     "framework/Source/FlutterPlatformPluginTest.mm",
     "framework/Source/FlutterPlatformViewsTest.mm",
     "framework/Source/FlutterPluginAppLifeCycleDelegateTest.mm",

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -58,12 +58,17 @@ source_set("flutter_framework_source_arc") {
   public_configs = [ "//flutter:config" ]
 
   sources = [
+    "framework/Source/FlutterMetalLayer.h",
+    "framework/Source/FlutterMetalLayer.mm",
     "framework/Source/FlutterTextInputDelegate.h",
     "framework/Source/FlutterTextInputPlugin.h",
     "framework/Source/FlutterTextInputPlugin.mm",
   ]
 
-  frameworks = [ "UIKit.framework" ]
+  frameworks = [
+    "UIKit.framework",
+    "IOSurface.framework",
+  ]
 }
 
 source_set("flutter_framework_source") {

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
@@ -19,4 +19,8 @@
 
 - (nullable id<CAMetalDrawable>)nextDrawable;
 
+/// Returns whether the Metal layer is enabled.
+/// This is controlled by FLTUseFlutterMetalLayer value in Info.plist.
++ (BOOL)enabled;
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #import <QuartzCore/QuartzCore.h>
 
 /// Drop-in replacement (as far as Flutter is concerned) for CAMetalLayer

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
@@ -1,0 +1,18 @@
+#import <QuartzCore/QuartzCore.h>
+
+/// Drop-in replacement (as far as Flutter is concerned) for CAMetalLayer
+/// that can present with transaction from a background thread.
+@interface FlutterMetalLayer : CALayer
+
+@property(nullable, retain) id<MTLDevice> device;
+@property(nullable, readonly) id<MTLDevice> preferredDevice;
+@property MTLPixelFormat pixelFormat;
+@property BOOL framebufferOnly;
+@property CGSize drawableSize;
+@property BOOL presentsWithTransaction;
+@property(nullable) CGColorSpaceRef colorspace;
+@property BOOL wantsExtendedDynamicRangeContent;
+
+- (nullable id<CAMetalDrawable>)nextDrawable;
+
+@end

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -6,6 +6,7 @@
 #include <Metal/Metal.h>
 #include <UIKit/UIKit.h>
 
+#include "flutter/fml/logging.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
 
 @interface DisplayLinkManager : NSObject
@@ -367,6 +368,21 @@ extern CFTimeInterval display_link_target;
   @synchronized(self) {
     [_availableTextures addObject:texture];
   }
+}
+
++ (BOOL)enabled {
+  static BOOL enabled = NO;
+  static BOOL didCheckInfoPlist = NO;
+  if (!didCheckInfoPlist) {
+    didCheckInfoPlist = YES;
+    NSNumber* use_flutter_metal_layer =
+        [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTUseFlutterMetalLayer"];
+    if (use_flutter_metal_layer != nil && [use_flutter_metal_layer boolValue]) {
+      enabled = YES;
+      FML_LOG(WARNING) << "Using FlutterMetalLayer. This is an experimental feature.";
+    }
+  }
+  return enabled;
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -313,15 +313,15 @@ extern CFTimeInterval display_link_target;
           NSLog(@"Had to wait %f seconds for a drawable", elapsed);
         }
       }
-      // Return first drawable that is not in use or the one that was presented
-      // the longest time ago.
-      // isInUse means the compositor has picked up the surface. This is useful
-      // to detect a skipped frame, in which case the surface will be returned
-      // in the next call to nextDrawable.
-      // It is possible that both back buffers are in use, in which case we
-      // don't block here but return the oldest presented texture.
+
+      // Prefer surface that is not in use and has been presented the longest
+      // time ago.
+      // When isInUse is false, the surface is definitely not used by the compositor.
+      // When isInUse is true, the surface may be used by the compositor.
+      // When both surfaces are in use, the one presented earlier will be returned.
       // The assumption here is that the compositor is already aware of the
-      // newer texture and is unlikely to use the older one.
+      // newer texture and is unlikely to read from the older one, even though it
+      // has not decreased the use count yet (there seems to be certain latency).
       FlutterTexture* res = nil;
       for (FlutterTexture* texture in _availableTextures) {
         if (res == nil) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -78,8 +78,16 @@ extern CFTimeInterval display_link_target;
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onDisplayLink:)];
     [self setMaxRefreshRate:[DisplayLinkManager displayRefreshRate] forceMax:NO];
     [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(didEnterBackground:)
+                                                 name:UIApplicationDidEnterBackgroundNotification
+                                               object:nil];
   }
   return self;
+}
+
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)setMaxRefreshRate:(double)refreshRate forceMax:(BOOL)forceMax {
@@ -120,9 +128,16 @@ extern CFTimeInterval display_link_target;
 
 - (void)setDrawableSize:(CGSize)drawableSize {
   [_availableDrawables removeAllObjects];
-  _front = nullptr;
+  _front = nil;
   _totalDrawables = 0;
   _drawableSize = drawableSize;
+}
+
+- (void)didEnterBackground:(id)notification {
+  [_availableDrawables removeAllObjects];
+  _totalDrawables = 0;
+  self.contents = nil;
+  _displayLink.paused = YES;
 }
 
 - (CGSize)drawableSize {

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -16,11 +16,12 @@
 @class FlutterTexture;
 @class FlutterDrawable;
 
-extern CFTimeInterval display_link_target;
+static MTLPixelFormat _defaultPixelFormat = MTLPixelFormatBGRA8Unorm;
 
 @interface FlutterMetalLayer () {
   id<MTLDevice> _preferredDevice;
   CGSize _drawableSize;
+  MTLPixelFormat _pixelFormat;
 
   NSUInteger _nextDrawableId;
 
@@ -149,7 +150,6 @@ extern CFTimeInterval display_link_target;
 
 @synthesize preferredDevice = _preferredDevice;
 @synthesize device = _device;
-@synthesize pixelFormat = _pixelFormat;
 @synthesize framebufferOnly = _framebufferOnly;
 @synthesize colorspace = _colorspace;
 @synthesize wantsExtendedDynamicRangeContent = _wantsExtendedDynamicRangeContent;
@@ -158,7 +158,7 @@ extern CFTimeInterval display_link_target;
   if (self = [super init]) {
     _preferredDevice = MTLCreateSystemDefaultDevice();
     self.device = self.preferredDevice;
-    self.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    _pixelFormat = _defaultPixelFormat;
     _availableTextures = [[NSMutableSet alloc] init];
 
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onDisplayLink:)];
@@ -170,6 +170,18 @@ extern CFTimeInterval display_link_target;
                                                object:nil];
   }
   return self;
+}
+
+- (MTLPixelFormat)pixelFormat {
+  return _pixelFormat;
+}
+
+- (void)setPixelFormat:(MTLPixelFormat)pixelFormat {
+  _pixelFormat = pixelFormat;
+
+  // FlutterView updates pixel format on it's layer, but the overlay views
+  // don't - they get correct pixel format right magically.
+  _defaultPixelFormat = pixelFormat;
 }
 
 - (void)dealloc {

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -287,10 +287,10 @@ extern CFTimeInterval display_link_target;
                                                             height:_drawableSize.height
                                                          mipmapped:NO];
 
-      FML_DCHECK(surface.bytesPerElement > 0);
-      FML_DCHECK(_drawableSize.width > 0);
+      FML_CHECK(surface.bytesPerElement > 0);
+      FML_CHECK(_drawableSize.width > 0);
       // >= because of alignment
-      FML_DCHECK(surface.bytesPerRow >= _drawableSize.width * surface.bytesPerElement);
+      FML_CHECK(surface.bytesPerRow >= _drawableSize.width * surface.bytesPerElement);
 
       if (_framebufferOnly) {
         textureDescriptor.usage = MTLTextureUsageRenderTarget;

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -16,12 +16,11 @@
 @class FlutterTexture;
 @class FlutterDrawable;
 
-static MTLPixelFormat _defaultPixelFormat = MTLPixelFormatBGRA8Unorm;
+extern CFTimeInterval display_link_target;
 
 @interface FlutterMetalLayer () {
   id<MTLDevice> _preferredDevice;
   CGSize _drawableSize;
-  MTLPixelFormat _pixelFormat;
 
   NSUInteger _nextDrawableId;
 
@@ -150,6 +149,7 @@ static MTLPixelFormat _defaultPixelFormat = MTLPixelFormatBGRA8Unorm;
 
 @synthesize preferredDevice = _preferredDevice;
 @synthesize device = _device;
+@synthesize pixelFormat = _pixelFormat;
 @synthesize framebufferOnly = _framebufferOnly;
 @synthesize colorspace = _colorspace;
 @synthesize wantsExtendedDynamicRangeContent = _wantsExtendedDynamicRangeContent;
@@ -158,7 +158,7 @@ static MTLPixelFormat _defaultPixelFormat = MTLPixelFormatBGRA8Unorm;
   if (self = [super init]) {
     _preferredDevice = MTLCreateSystemDefaultDevice();
     self.device = self.preferredDevice;
-    _pixelFormat = _defaultPixelFormat;
+    self.pixelFormat = MTLPixelFormatBGRA8Unorm;
     _availableTextures = [[NSMutableSet alloc] init];
 
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onDisplayLink:)];
@@ -170,18 +170,6 @@ static MTLPixelFormat _defaultPixelFormat = MTLPixelFormatBGRA8Unorm;
                                                object:nil];
   }
   return self;
-}
-
-- (MTLPixelFormat)pixelFormat {
-  return _pixelFormat;
-}
-
-- (void)setPixelFormat:(MTLPixelFormat)pixelFormat {
-  _pixelFormat = pixelFormat;
-
-  // FlutterView updates pixel format on it's layer, but the overlay views
-  // don't - they get correct pixel format right magically.
-  _defaultPixelFormat = pixelFormat;
 }
 
 - (void)dealloc {

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -339,7 +339,7 @@ extern CFTimeInterval display_link_target;
   [CATransaction commit];
   _displayLink.paused = NO;
   _displayLinkPauseCountdown = 0;
-  if (_didSetContentsDuringThisDisplayLinkPeriod) {
+  if (!_didSetContentsDuringThisDisplayLinkPeriod) {
     _didSetContentsDuringThisDisplayLinkPeriod = YES;
   } else if (!_displayLinkForcedMaxRate) {
     _displayLinkForcedMaxRate = YES;

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -267,8 +267,11 @@ extern CFTimeInterval display_link_target;
   };
 
   IOSurfaceRef res = IOSurfaceCreate((CFDictionaryRef)options);
-  FML_CHECK(res != nil) << "Failed to create IOSurface with options "
-                        << options.debugDescription.UTF8String;
+  if (res == nil) {
+    FML_LOG(ERROR) << "Failed to create IOSurface with options "
+                   << options.debugDescription.UTF8String;
+    return nil;
+  }
 
   if (self.colorspace != nil) {
     CFStringRef name = CGColorSpaceGetName(self.colorspace);
@@ -284,16 +287,14 @@ extern CFTimeInterval display_link_target;
     if (_totalTextures < 3) {
       ++_totalTextures;
       IOSurface* surface = [self createIOSurface];
+      if (surface == nil) {
+        return nil;
+      }
       MTLTextureDescriptor* textureDescriptor =
           [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:_pixelFormat
                                                              width:_drawableSize.width
                                                             height:_drawableSize.height
                                                          mipmapped:NO];
-
-      FML_CHECK(surface.bytesPerElement > 0);
-      FML_CHECK(_drawableSize.width > 0);
-      // >= because of alignment
-      FML_CHECK(surface.bytesPerRow >= _drawableSize.width * surface.bytesPerElement);
 
       if (_framebufferOnly) {
         textureDescriptor.usage = MTLTextureUsageRenderTarget;

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -267,6 +267,9 @@ extern CFTimeInterval display_link_target;
   };
 
   IOSurfaceRef res = IOSurfaceCreate((CFDictionaryRef)options);
+  FML_CHECK(res != nil) << "Failed to create IOSurface with options "
+                        << options.debugDescription.UTF8String;
+
   if (self.colorspace != nil) {
     CFStringRef name = CGColorSpaceGetName(self.colorspace);
     IOSurfaceSetValue(res, CFSTR("IOSurfaceColorSpace"), name);

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -238,6 +238,7 @@ extern CFTimeInterval display_link_target;
         }
       }
       [_availableDrawables removeObject:res];
+      return res;
     }
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -1,0 +1,271 @@
+#include <IOSurface/IOSurfaceObjC.h>
+#include <Metal/Metal.h>
+#include <UIKit/UIKit.h>
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
+
+@interface DisplayLinkManager : NSObject
+@property(class, nonatomic, readonly) BOOL maxRefreshRateEnabledOnIPhone;
++ (double)displayRefreshRate;
+@end
+
+@class FlutterDrawable;
+
+extern CFTimeInterval display_link_target;
+
+@interface FlutterMetalLayer () {
+  id<MTLDevice> _preferredDevice;
+  CGSize _drawableSize;
+
+  NSUInteger _nextDrawableId;
+
+  NSMutableSet<FlutterDrawable*>* _availableDrawables;
+  NSUInteger _totalDrawables;
+
+  FlutterDrawable* _front;
+
+  // There must be a CADisplayLink scheduled *on main thread* otherwise
+  // core animation only updates layers 60 times a second.
+  CADisplayLink* _displayLink;
+  NSUInteger _displayLinkPauseCountdown;
+}
+
+- (void)presentDrawable:(FlutterDrawable*)drawable;
+
+@end
+
+@interface FlutterDrawable : NSObject <CAMetalDrawable> {
+  id<MTLTexture> _texture;
+  __weak FlutterMetalLayer* _layer;
+  NSUInteger _drawableId;
+  IOSurface* _surface;
+}
+
+- (instancetype)initWithTexture:(id<MTLTexture>)texture
+                          layer:(FlutterMetalLayer*)layer
+                     drawableId:(NSUInteger)drawableId
+                        surface:(IOSurface*)surface;
+
+@property(readonly) IOSurface* surface;
+
+@end
+
+@implementation FlutterMetalLayer
+
+@synthesize preferredDevice = _preferredDevice;
+@synthesize device = _device;
+@synthesize pixelFormat = _pixelFormat;
+@synthesize framebufferOnly = _framebufferOnly;
+@synthesize colorspace = _colorspace;
+@synthesize wantsExtendedDynamicRangeContent = _wantsExtendedDynamicRangeContent;
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _preferredDevice = MTLCreateSystemDefaultDevice();
+    self.device = self.preferredDevice;
+    _availableDrawables = [[NSMutableSet alloc] init];
+
+    _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onDisplayLink:)];
+    [self setMaxRefreshRate:[DisplayLinkManager displayRefreshRate]];
+    [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+  }
+  return self;
+}
+
+- (void)setMaxRefreshRate:(double)refreshRate {
+  if (!DisplayLinkManager.maxRefreshRateEnabledOnIPhone) {
+    return;
+  }
+  double maxFrameRate = fmax(refreshRate, 60);
+  double minFrameRate = fmax(maxFrameRate / 2, 60);
+  if (@available(iOS 15.0, *)) {
+    _displayLink.preferredFrameRateRange =
+        CAFrameRateRangeMake(minFrameRate, maxFrameRate, maxFrameRate);
+  } else {
+    _displayLink.preferredFramesPerSecond = maxFrameRate;
+  }
+}
+
+- (void)onDisplayLink:(CADisplayLink*)link {
+  // Do not pause immediately, this seems to prevent 120hz while touching.
+  if (_displayLinkPauseCountdown == 5) {
+    _displayLink.paused = YES;
+  } else {
+    ++_displayLinkPauseCountdown;
+  }
+}
+
+- (BOOL)isKindOfClass:(Class)aClass {
+  // Pretend that we're a CAMetalLayer so that the rest of Flutter plays along
+  if ([aClass isEqual:[CAMetalLayer class]]) {
+    return YES;
+  }
+  return [super isKindOfClass:aClass];
+}
+
+- (void)setDrawableSize:(CGSize)drawableSize {
+  [_availableDrawables removeAllObjects];
+  _front = nullptr;
+  _totalDrawables = 0;
+  _drawableSize = drawableSize;
+}
+
+- (CGSize)drawableSize {
+  return _drawableSize;
+}
+
+- (IOSurface*)createIOSurface {
+  unsigned pixelFormat;
+  unsigned bytesPerElement;
+  if (self.pixelFormat == MTLPixelFormatRGBA16Float) {
+    pixelFormat = kCVPixelFormatType_64RGBAHalf;
+    bytesPerElement = 8;
+  } else {
+    pixelFormat = kCVPixelFormatType_32BGRA;
+    bytesPerElement = 4;
+  }
+  size_t bytesPerRow =
+      IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, _drawableSize.width * bytesPerElement);
+  size_t totalBytes =
+      IOSurfaceAlignProperty(kIOSurfaceAllocSize, _drawableSize.height * bytesPerRow);
+  NSDictionary* options = @{
+    (id)kIOSurfaceWidth : @(_drawableSize.width),
+    (id)kIOSurfaceHeight : @(_drawableSize.height),
+    (id)kIOSurfacePixelFormat : @(pixelFormat),
+    (id)kIOSurfaceBytesPerElement : @(bytesPerElement),
+    (id)kIOSurfaceBytesPerRow : @(bytesPerRow),
+    (id)kIOSurfaceAllocSize : @(totalBytes),
+  };
+
+  IOSurfaceRef res = IOSurfaceCreate((CFDictionaryRef)options);
+  if (self.colorspace != nil) {
+    CFStringRef name = CGColorSpaceGetName(self.colorspace);
+    IOSurfaceSetValue(res, CFSTR("IOSurfaceColorSpace"), name);
+  } else {
+    IOSurfaceSetValue(res, CFSTR("IOSurfaceColorSpace"), kCGColorSpaceSRGB);
+  }
+  return (__bridge_transfer IOSurface*)res;
+}
+
+- (id<CAMetalDrawable>)nextDrawable {
+  @synchronized(self) {
+    // IOSurface.isInUse to determine when compositor is done with the surface.
+    // That a rather blunt instrument and we are probably waiting longer than
+    // we really need to. With triple buffering at 120Hz that results in about
+    // 2-3 milliseconds wait time at beginning of display link callback.
+    // With four buffers this number gets close to zero.
+    if (_totalDrawables < 4) {
+      ++_totalDrawables;
+      IOSurface* surface = [self createIOSurface];
+      MTLTextureDescriptor* textureDescriptor =
+          [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:_pixelFormat
+                                                             width:_drawableSize.width
+                                                            height:_drawableSize.height
+                                                         mipmapped:NO];
+      textureDescriptor.usage =
+          MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget | MTLTextureUsageShaderWrite;
+      id<MTLTexture> texture = [self.device newTextureWithDescriptor:textureDescriptor
+                                                           iosurface:(__bridge IOSurfaceRef)surface
+                                                               plane:0];
+      FlutterDrawable* drawable = [[FlutterDrawable alloc] initWithTexture:texture
+                                                                     layer:self
+                                                                drawableId:_nextDrawableId++
+                                                                   surface:surface];
+      return drawable;
+    } else {
+      FlutterDrawable* res;
+      CFTimeInterval start = CACurrentMediaTime();
+
+      while (true) {
+        for (FlutterDrawable* drawable in _availableDrawables) {
+          if (!drawable.surface.inUse) {
+            res = drawable;
+            [_availableDrawables removeObject:drawable];
+            goto done;
+          }
+        }
+        usleep(10);
+      }
+    done:
+      CFTimeInterval duration = CACurrentMediaTime() - start;
+      if (duration > 0.003) {
+        NSLog(@"Getting drawable took %f", duration);
+      }
+      return res;
+    }
+  }
+  return nil;
+}
+
+- (void)presentOnMainThread:(FlutterDrawable*)drawable {
+  // This is needed otherwise frame gets skipped on touch begin / end. Go figure.
+  // Might also be placebo
+  [self setNeedsDisplay];
+
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+  self.contents = drawable.surface;
+  [CATransaction commit];
+  _displayLink.paused = NO;
+  _displayLinkPauseCountdown = 0;
+}
+
+- (void)presentDrawable:(FlutterDrawable*)drawable {
+  @synchronized(self) {
+    if (_front != nil) {
+      [_availableDrawables addObject:_front];
+    }
+    _front = drawable;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self presentOnMainThread:drawable];
+    });
+  }
+}
+
+@end
+
+@implementation FlutterDrawable
+
+- (instancetype)initWithTexture:(id<MTLTexture>)texture
+                          layer:(FlutterMetalLayer*)layer
+                     drawableId:(NSUInteger)drawableId
+                        surface:(IOSurface*)surface {
+  if (self = [super init]) {
+    _texture = texture;
+    _layer = layer;
+    _drawableId = drawableId;
+    _surface = surface;
+  }
+  return self;
+}
+
+- (id<MTLTexture>)texture {
+  return self->_texture;
+}
+
+- (CAMetalLayer*)layer {
+  return (id)self->_layer;
+}
+
+- (CFTimeInterval)presentedTime {
+  return 0;
+}
+
+- (NSUInteger)drawableID {
+  return self->_drawableId;
+}
+
+- (void)present {
+  [_layer presentDrawable:self];
+}
+
+- (void)addPresentedHandler:(nonnull MTLDrawablePresentedHandler)block {
+}
+
+- (void)presentAtTime:(CFTimeInterval)presentationTime {
+}
+
+- (void)presentAfterMinimumDuration:(CFTimeInterval)duration {
+}
+
+@end

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -324,11 +324,14 @@ extern CFTimeInterval display_link_target;
       // newer texture and is unlikely to use the older one.
       FlutterTexture* res = nil;
       for (FlutterTexture* texture in _availableTextures) {
-        if (!texture.surface.isInUse) {
+        if (res == nil) {
           res = texture;
-          break;
-        }
-        if (res == nil || texture.presentedTime < res.presentedTime) {
+        } else if (res.surface.isInUse && !texture.surface.isInUse) {
+          // prefer texture that is not in use.
+          res = texture;
+        } else if (res.surface.isInUse == texture.surface.isInUse &&
+                   texture.presentedTime < res.presentedTime) {
+          // prefer texture with older presented time.
           res = texture;
         }
       }

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -119,10 +119,13 @@ extern CFTimeInterval display_link_target;
 }
 
 - (BOOL)isKindOfClass:(Class)aClass {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
   // Pretend that we're a CAMetalLayer so that the rest of Flutter plays along
   if ([aClass isEqual:[CAMetalLayer class]]) {
     return YES;
   }
+#pragma clang diagnostic pop
   return [super isKindOfClass:aClass];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <IOSurface/IOSurfaceObjC.h>
 #include <Metal/Metal.h>
 #include <UIKit/UIKit.h>
@@ -281,9 +285,12 @@ extern CFTimeInterval display_link_target;
   return self->_texture;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
 - (CAMetalLayer*)layer {
   return (id)self->_layer;
 }
+#pragma clang diagnostic pop
 
 - (CFTimeInterval)presentedTime {
   return 0;

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -135,8 +135,7 @@ extern CFTimeInterval display_link_target;
 
 - (void)didEnterBackground:(id)notification {
   [_availableDrawables removeAllObjects];
-  _totalDrawables = 0;
-  self.contents = nil;
+  _totalDrawables = _front != nil ? 1 : 0;
   _displayLink.paused = YES;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -286,8 +286,12 @@ extern CFTimeInterval display_link_target;
                                                              width:_drawableSize.width
                                                             height:_drawableSize.height
                                                          mipmapped:NO];
-      textureDescriptor.usage =
-          MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget | MTLTextureUsageShaderWrite;
+      if (_framebufferOnly) {
+        textureDescriptor.usage = MTLTextureUsageRenderTarget;
+      } else {
+        textureDescriptor.usage =
+            MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
+      }
       id<MTLTexture> texture = [self.device newTextureWithDescriptor:textureDescriptor
                                                            iosurface:(__bridge IOSurfaceRef)surface
                                                                plane:0];

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -286,6 +286,12 @@ extern CFTimeInterval display_link_target;
                                                              width:_drawableSize.width
                                                             height:_drawableSize.height
                                                          mipmapped:NO];
+
+      FML_DCHECK(surface.bytesPerElement > 0);
+      FML_DCHECK(_drawableSize.width > 0);
+      // >= because of alignment
+      FML_DCHECK(surface.bytesPerRow >= _drawableSize.width * surface.bytesPerElement);
+
       if (_framebufferOnly) {
         textureDescriptor.usage = MTLTextureUsageRenderTarget;
       } else {

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -371,6 +371,7 @@ extern CFTimeInterval display_link_target;
     if ([NSThread isMainThread]) {
       [self presentOnMainThread:texture];
     } else {
+      // Core animation layers can only be updated on main thread.
       dispatch_async(dispatch_get_main_queue(), ^{
         [self presentOnMainThread:texture];
       });

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -279,11 +279,6 @@ static MTLPixelFormat _defaultPixelFormat = MTLPixelFormatBGRA8Unorm;
 
 - (FlutterTexture*)nextTexture {
   @synchronized(self) {
-    // IOSurface.isInUse to determine when compositor is done with the surface.
-    // That a rather blunt instrument and we are probably waiting longer than
-    // we really need to. With triple buffering at 120Hz that results in about
-    // 2-3 milliseconds wait time at beginning of display link callback.
-    // With four buffers this number gets close to zero.
     if (_totalTextures < 3) {
       ++_totalTextures;
       IOSurface* surface = [self createIOSurface];
@@ -304,7 +299,7 @@ static MTLPixelFormat _defaultPixelFormat = MTLPixelFormatBGRA8Unorm;
       // Make sure raster thread doesn't have too many drawables in flight.
       if (_availableTextures.count == 0) {
         CFTimeInterval start = CACurrentMediaTime();
-        while (_availableTextures.count == 0 && CACurrentMediaTime() - start < 0.1) {
+        while (_availableTextures.count == 0 && CACurrentMediaTime() - start < 1.0) {
           usleep(100);
         }
         CFTimeInterval elapsed = CACurrentMediaTime() - start;

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -315,6 +315,13 @@ extern CFTimeInterval display_link_target;
       }
       // Return first drawable that is not in use or the one that was presented
       // the longest time ago.
+      // isInUse means the compositor has picked up the surface. This is useful
+      // to detect a skipped frame, in which case the surface will be returned
+      // in the next call to nextDrawable.
+      // It is possible that both back buffers are in use, in which case we
+      // don't block here but return the oldest presented texture.
+      // The assumption here is that the compositor is already aware of the
+      // newer texture and is unlikely to use the older one.
       FlutterTexture* res = nil;
       for (FlutterTexture* texture in _availableTextures) {
         if (!texture.surface.isInUse) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayerTest.mm
@@ -11,10 +11,10 @@
 @interface FlutterMetalLayerTest : XCTestCase
 @end
 
-@interface MetalView : UIView
+@interface TestFlutterMetalLayerView : UIView
 @end
 
-@implementation MetalView
+@implementation TestFlutterMetalLayerView
 
 + (Class)layerClass {
   return [FlutterMetalLayer class];
@@ -25,7 +25,8 @@
 @implementation FlutterMetalLayerTest
 
 - (FlutterMetalLayer*)addMetalLayer {
-  MetalView* view = [[MetalView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  TestFlutterMetalLayerView* view =
+      [[TestFlutterMetalLayerView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
   FlutterMetalLayer* layer = (FlutterMetalLayer*)view.layer;
   layer.drawableSize = CGSizeMake(100, 100);
   [UIApplication.sharedApplication.keyWindow addSubview:view];

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayerTest.mm
@@ -158,6 +158,32 @@
     id<CAMetalDrawable> drawable = [layer nextDrawable];
     XCTAssertEqual(texture, drawable.texture);
   }
+
+  [self removeMetalLayer:layer];
+}
+
+- (void)testLayerLimitsDrawableCount {
+  FlutterMetalLayer* layer = [self addMetalLayer];
+
+  id<CAMetalDrawable> d1 = [layer nextDrawable];
+  id<CAMetalDrawable> d2 = [layer nextDrawable];
+  id<CAMetalDrawable> d3 = [layer nextDrawable];
+  XCTAssertNotNil(d3);
+
+  // Layer should not return more than 3 drawables.
+  id<CAMetalDrawable> d4 = [layer nextDrawable];
+  XCTAssertNil(d4);
+
+  [d1 present];
+
+  // Still no drawable, until the front buffer returns to pool
+  id<CAMetalDrawable> d5 = [layer nextDrawable];
+  XCTAssertNil(d5);
+
+  [d2 present];
+  id<CAMetalDrawable> d6 = [layer nextDrawable];
+  XCTAssertNotNil(d6);
+
   [self removeMetalLayer:layer];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayerTest.mm
@@ -1,0 +1,164 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Metal/Metal.h>
+#import <QuartzCore/QuartzCore.h>
+#import <XCTest/XCTest.h>
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
+
+@interface FlutterMetalLayerTest : XCTestCase
+@end
+
+@interface MetalView : UIView
+@end
+
+@implementation MetalView
+
++ (Class)layerClass {
+  return [FlutterMetalLayer class];
+}
+
+@end
+
+@implementation FlutterMetalLayerTest
+
+- (FlutterMetalLayer*)addMetalLayer {
+  MetalView* view = [[MetalView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  FlutterMetalLayer* layer = (FlutterMetalLayer*)view.layer;
+  layer.drawableSize = CGSizeMake(100, 100);
+  [UIApplication.sharedApplication.keyWindow addSubview:view];
+  return layer;
+}
+
+- (void)removeMetalLayer:(FlutterMetalLayer*)layer {
+  [(UIView*)layer.delegate removeFromSuperview];
+}
+
+/// Waits until compositor picks up front surface.
+- (void)waitUntilFrontSurfaceIsInUse:(FlutterMetalLayer*)layer {
+  IOSurfaceRef surface = (__bridge IOSurfaceRef)layer.contents;
+  while (!IOSurfaceIsInUse(surface)) {
+    [NSRunLoop.mainRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.001]];
+  }
+}
+
+- (void)testFlip {
+  FlutterMetalLayer* layer = [self addMetalLayer];
+
+  id<MTLTexture> t1, t2, t3;
+
+  id<CAMetalDrawable> drawable = [layer nextDrawable];
+  t1 = drawable.texture;
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+  XCTAssertTrue(IOSurfaceIsInUse(t1.iosurface));
+
+  drawable = [layer nextDrawable];
+  t2 = drawable.texture;
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+  XCTAssertTrue(IOSurfaceIsInUse(t2.iosurface));
+
+  drawable = [layer nextDrawable];
+  t3 = drawable.texture;
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+  XCTAssertTrue(IOSurfaceIsInUse(t3.iosurface));
+
+  // If there was no frame drop, layer should return oldest presented
+  // texture.
+  drawable = [layer nextDrawable];
+  XCTAssertEqual(drawable.texture, t1);
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+
+  drawable = [layer nextDrawable];
+  XCTAssertEqual(drawable.texture, t2);
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+
+  drawable = [layer nextDrawable];
+  XCTAssertEqual(drawable.texture, t3);
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+
+  drawable = [layer nextDrawable];
+  XCTAssertEqual(drawable.texture, t1);
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+
+  [self removeMetalLayer:layer];
+}
+
+- (void)testFlipWithDroppedFrame {
+  FlutterMetalLayer* layer = [self addMetalLayer];
+
+  id<MTLTexture> t1, t2, t3;
+
+  id<CAMetalDrawable> drawable = [layer nextDrawable];
+  t1 = drawable.texture;
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+  XCTAssertTrue(IOSurfaceIsInUse(t1.iosurface));
+
+  drawable = [layer nextDrawable];
+  t2 = drawable.texture;
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+  XCTAssertTrue(IOSurfaceIsInUse(t2.iosurface));
+
+  drawable = [layer nextDrawable];
+  t3 = drawable.texture;
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+  XCTAssertTrue(IOSurfaceIsInUse(t3.iosurface));
+
+  // Here the drawable is presented, but immediately replaced by another drawable
+  // (before the compositor has a chance to pick it up). This should result
+  // in same drawable returned in next call to nextDrawable.
+  drawable = [layer nextDrawable];
+  XCTAssertEqual(drawable.texture, t1);
+  XCTAssertFalse(IOSurfaceIsInUse(drawable.texture.iosurface));
+  [drawable present];
+
+  drawable = [layer nextDrawable];
+  XCTAssertEqual(drawable.texture, t2);
+  [drawable present];
+  [self waitUntilFrontSurfaceIsInUse:layer];
+
+  // Next drawable should be t1, since it was never picked up by compositor.
+  drawable = [layer nextDrawable];
+  XCTAssertEqual(drawable.texture, t1);
+
+  [self removeMetalLayer:layer];
+}
+
+- (void)testDroppedDrawableReturnsTextureToPool {
+  FlutterMetalLayer* layer = [self addMetalLayer];
+  // FlutterMetalLayer will keep creating new textures until it has 3.
+  @autoreleasepool {
+    for (int i = 0; i < 3; ++i) {
+      id<CAMetalDrawable> drawable = [layer nextDrawable];
+      XCTAssertNotNil(drawable);
+    }
+  }
+  id<MTLTexture> texture;
+  {
+    @autoreleasepool {
+      id<CAMetalDrawable> drawable = [layer nextDrawable];
+      XCTAssertNotNil(drawable);
+      texture = (id<MTLTexture>)drawable.texture;
+      // Dropping the drawable must return texture to pool, so
+      // next drawable should return the same texture.
+    }
+  }
+  {
+    id<CAMetalDrawable> drawable = [layer nextDrawable];
+    XCTAssertEqual(texture, drawable.texture);
+  }
+  [self removeMetalLayer:layer];
+}
+
+@end

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -13,6 +13,7 @@
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/common/rasterizer.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface_software.h"
 #include "third_party/skia/include/utils/mac/SkCGUtils.h"
@@ -146,8 +147,7 @@ static BOOL _forceSoftwareRendering;
 }
 
 + (Class)layerClass {
-  return flutter::GetCoreAnimationLayerClassForRenderingAPI(
-      flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering));
+  return [FlutterMetalLayer class];
 }
 
 - (void)drawLayer:(CALayer*)layer inContext:(CGContextRef)context {

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -147,6 +147,8 @@ static BOOL _forceSoftwareRendering;
 }
 
 + (Class)layerClass {
+  // return flutter::GetCoreAnimationLayerClassForRenderingAPI(
+  // flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering));
   return [FlutterMetalLayer class];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -13,7 +13,6 @@
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/common/rasterizer.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface_software.h"
 #include "third_party/skia/include/utils/mac/SkCGUtils.h"
@@ -147,9 +146,8 @@ static BOOL _forceSoftwareRendering;
 }
 
 + (Class)layerClass {
-  // return flutter::GetCoreAnimationLayerClassForRenderingAPI(
-  // flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering));
-  return [FlutterMetalLayer class];
+  return flutter::GetCoreAnimationLayerClassForRenderingAPI(
+      flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering));
 }
 
 - (void)drawLayer:(CALayer*)layer inContext:(CGContextRef)context {

--- a/shell/platform/darwin/ios/rendering_api_selection.mm
+++ b/shell/platform/darwin/ios/rendering_api_selection.mm
@@ -66,14 +66,7 @@ Class GetCoreAnimationLayerClassForRenderingAPI(IOSRenderingAPI rendering_api) {
       return [CALayer class];
     case IOSRenderingAPI::kMetal:
       if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
-        NSNumber* use_flutter_metal_layer =
-            [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTUseFlutterMetalLayer"];
-        if (use_flutter_metal_layer != nil && [use_flutter_metal_layer boolValue]) {
-          static bool did_log = false;
-          if (!did_log) {
-            did_log = true;
-            FML_LOG(WARNING) << "Using FlutterMetalLayer. This is an experimental feature.";
-          }
+        if ([FlutterMetalLayer enabled]) {
           return [FlutterMetalLayer class];
         } else {
           return [CAMetalLayer class];

--- a/shell/platform/darwin/ios/rendering_api_selection.mm
+++ b/shell/platform/darwin/ios/rendering_api_selection.mm
@@ -14,6 +14,8 @@
 
 #include "flutter/fml/logging.h"
 
+#include "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
+
 namespace flutter {
 
 #if SHELL_ENABLE_METAL
@@ -64,7 +66,18 @@ Class GetCoreAnimationLayerClassForRenderingAPI(IOSRenderingAPI rendering_api) {
       return [CALayer class];
     case IOSRenderingAPI::kMetal:
       if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
-        return [CAMetalLayer class];
+        NSNumber* use_flutter_metal_layer =
+            [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTUseFlutterMetalLayer"];
+        if (use_flutter_metal_layer != nil && [use_flutter_metal_layer boolValue]) {
+          static bool did_log = false;
+          if (!did_log) {
+            did_log = true;
+            FML_LOG(WARNING) << "Using FlutterMetalLayer. This is an experimental feature.";
+          }
+          return [FlutterMetalLayer class];
+        } else {
+          return [CAMetalLayer class];
+        }
       }
       FML_CHECK(false) << "Metal availability should already have been checked";
       break;

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -69,10 +69,11 @@
 		0D6AB6C922BB05E200EEE540 /* IosUnitTestsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IosUnitTestsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D6AB6CF22BB05E200EEE540 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FlutterEngineConfig.xcconfig; sourceTree = "<group>"; };
+		3DD7D38C27D2B81000DA365C /* FlutterUndoManagerPluginTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterUndoManagerPluginTest.mm; sourceTree = "<group>"; };
 		689EC1E2281B30D3008FEB58 /* FlutterSpellCheckPluginTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterSpellCheckPluginTest.mm; sourceTree = "<group>"; };
 		68B6091227F62F990036AC78 /* VsyncWaiterIosTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VsyncWaiterIosTest.mm; sourceTree = "<group>"; };
-		3DD7D38C27D2B81000DA365C /* FlutterUndoManagerPluginTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterUndoManagerPluginTest.mm; sourceTree = "<group>"; };
-        73F12C22288F92FF00AFC3A6 /* FlutterViewControllerTest_mrc.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterViewControllerTest_mrc.mm; sourceTree = "<group>"; };
+		73F12C22288F92FF00AFC3A6 /* FlutterViewControllerTest_mrc.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterViewControllerTest_mrc.mm; sourceTree = "<group>"; };
+		D2D361A52B234EAC0018964E /* FlutterMetalLayerTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterMetalLayerTest.mm; sourceTree = "<group>"; };
 		F7521D7226BB671E005F15C5 /* libios_test_flutter.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libios_test_flutter.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libios_test_flutter.dylib"; sourceTree = "<group>"; };
 		F7521D7526BB673E005F15C5 /* libocmock_shared.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libocmock_shared.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libocmock_shared.dylib"; sourceTree = "<group>"; };
 		F77E081726FA9CE6003E6E4C /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = "../../../../out/$(FLUTTER_ENGINE)/Flutter.framework"; sourceTree = "<group>"; };
@@ -114,6 +115,7 @@
 				0AC2331924BA71D300A85907 /* FlutterPluginAppLifeCycleDelegateTest.mm */,
 				0AC2332124BA71D300A85907 /* FlutterViewControllerTest.mm */,
 				73F12C22288F92FF00AFC3A6 /* FlutterViewControllerTest_mrc.mm */,
+				D2D361A52B234EAC0018964E /* FlutterMetalLayerTest.mm */,
 			);
 			name = Source;
 			path = ../../../shell/platform/darwin/ios/framework/Source;


### PR DESCRIPTION
This PR implements `FlutterMetalLayer`, a drop-in (as far as Flutter is concerned) replacement for `CAMetalLayer`. The biggest difference is that `FlutterMetalLayer` can present frames from background thread within a `CATransaction`.

`FlutterMetalLayer` is disabled by default. To opt-in, add the following item to `Info.plist`:

```xml
        <key>FLTUseFlutterMetalLayer</key>
	<true/>
```

The performance seems quite good, consistent 120hz on iPhone 13 Pro.

Benefits
  - presenting with transaction from background thread, which, down the line, would allow for platform views without thread merging.
  - fine control over how the surface is displayed - we can display single surface on multiple `CALayers`, each showing different part, allowing for performant implementation of unobstructed platform views.
 
Drawbacks
  - this not being a metal layer makes working with metal instrument tools more awkward
