### PR TITLE
Remove use of variable length arrays

### DIFF
--- a/display_list/benchmarking/dl_complexity_helper.h
+++ b/display_list/benchmarking/dl_complexity_helper.h
@@ -221,8 +221,8 @@ class ComplexityCalculatorHelper
                                        unsigned int conic_verb_cost,
                                        unsigned int cubic_verb_cost) {
     int verb_count = path.countVerbs();
-    uint8_t verbs[verb_count];
-    path.getVerbs(verbs, verb_count);
+    std::vector<uint8_t> verbs(verb_count);
+    path.getVerbs(verbs.data(), verbs.size());
 
     unsigned int complexity = 0;
     for (int i = 0; i < verb_count; i++) {

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -578,7 +578,7 @@ TEST_F(DisplayListLayerTest, OverflowCachedDisplayListOpacityInheritance) {
   int layer_count = per_frame + 1;
   SkPoint opacity_offset = {10, 10};
   auto opacity_layer = std::make_shared<OpacityLayer>(0.5f, opacity_offset);
-  std::shared_ptr<DisplayListLayer> layers[layer_count];
+  std::vector<std::shared_ptr<DisplayListLayer>> layers;
   for (int i = 0; i < layer_count; i++) {
     DisplayListBuilder builder(false);
     builder.DrawRect({0, 0, 100, 100}, DlPaint());
@@ -587,9 +587,9 @@ TEST_F(DisplayListLayerTest, OverflowCachedDisplayListOpacityInheritance) {
     ASSERT_FALSE(display_list->can_apply_group_opacity());
     SkPoint offset = {i * 200.0f, 0};
 
-    layers[i] =
-        std::make_shared<DisplayListLayer>(offset, display_list, true, false);
-    opacity_layer->Add(layers[i]);
+    layers.push_back(
+        std::make_shared<DisplayListLayer>(offset, display_list, true, false));
+    opacity_layer->Add(layers.back());
   }
   for (size_t j = 0; j < context->raster_cache->access_threshold(); j++) {
     context->raster_cache->BeginFrame();

--- a/lib/ui/hooks_unittests.cc
+++ b/lib/ui/hooks_unittests.cc
@@ -54,14 +54,14 @@ TEST_F(HooksTest, HooksUnitTests) {
     int64_t arg_count;
     Dart_IntegerToInt64(arg_count_handle, &arg_count);
 
-    Dart_Handle hook_args[arg_count];
+    std::vector<Dart_Handle> hook_args;
     for (int i = 0; i < static_cast<int>(arg_count); i++) {
-      hook_args[i] = Dart_GetNativeArgument(args, 2 + i);
-      CHECK_DART_ERROR(hook_args[i]);
+      hook_args.push_back(Dart_GetNativeArgument(args, 2 + i));
+      CHECK_DART_ERROR(hook_args.back());
     }
 
     Dart_Handle hook_result =
-        Dart_InvokeClosure(hook, static_cast<int>(arg_count), hook_args);
+        Dart_InvokeClosure(hook, hook_args.size(), hook_args.data());
     CHECK_DART_ERROR(hook_result);
   };
 

--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -50,10 +50,10 @@ VulkanApplication::VulkanApplication(
   }
 #endif
 
-  const char* extensions[enabled_extensions.size()];
+  std::vector<const char*> extensions;
 
   for (size_t i = 0; i < enabled_extensions.size(); i++) {
-    extensions[i] = enabled_extensions[i].c_str();
+    extensions.push_back(enabled_extensions[i].c_str());
   }
 
   // Configure layers.
@@ -61,10 +61,10 @@ VulkanApplication::VulkanApplication(
   const std::vector<std::string> enabled_layers =
       InstanceLayersToEnable(vk_, enable_validation_layers_);
 
-  const char* layers[enabled_layers.size()];
+  std::vector<const char*> layers;
 
   for (size_t i = 0; i < enabled_layers.size(); i++) {
-    layers[i] = enabled_layers[i].c_str();
+    layers.push_back(enabled_layers[i].c_str());
   }
 
   // Configure init structs.
@@ -84,10 +84,10 @@ VulkanApplication::VulkanApplication(
       .pNext = nullptr,
       .flags = 0,
       .pApplicationInfo = &info,
-      .enabledLayerCount = static_cast<uint32_t>(enabled_layers.size()),
-      .ppEnabledLayerNames = layers,
-      .enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size()),
-      .ppEnabledExtensionNames = extensions,
+      .enabledLayerCount = static_cast<uint32_t>(layers.size()),
+      .ppEnabledLayerNames = layers.data(),
+      .enabledExtensionCount = static_cast<uint32_t>(extensions.size()),
+      .ppEnabledExtensionNames = extensions.data(),
   };
 
   // Perform initialization.

--- a/vulkan/vulkan_backbuffer.cc
+++ b/vulkan/vulkan_backbuffer.cc
@@ -97,7 +97,7 @@ bool VulkanBackbuffer::CreateFences() {
 }
 
 bool VulkanBackbuffer::WaitFences() {
-  VkFence fences[use_fences_.size()];
+  VkFence fences[std::tuple_size_v<decltype(use_fences_)>];
 
   for (size_t i = 0; i < use_fences_.size(); i++) {
     fences[i] = use_fences_[i];
@@ -109,7 +109,7 @@ bool VulkanBackbuffer::WaitFences() {
 }
 
 bool VulkanBackbuffer::ResetFences() {
-  VkFence fences[use_fences_.size()];
+  VkFence fences[std::tuple_size_v<decltype(use_fences_)>];
 
   for (size_t i = 0; i < use_fences_.size(); i++) {
     fences[i] = use_fences_[i];

--- a/vulkan/vulkan_device.cc
+++ b/vulkan/vulkan_device.cc
@@ -75,10 +75,10 @@ VulkanDevice::VulkanDevice(VulkanProcTable& p_vk,
   auto enabled_layers =
       DeviceLayersToEnable(vk_, physical_device_, enable_validation_layers);
 
-  const char* layers[enabled_layers.size()];
+  std::vector<const char*> layers;
 
   for (size_t i = 0; i < enabled_layers.size(); i++) {
-    layers[i] = enabled_layers[i].c_str();
+    layers.push_back(enabled_layers[i].c_str());
   }
 
   const VkDeviceCreateInfo create_info = {
@@ -87,8 +87,8 @@ VulkanDevice::VulkanDevice(VulkanProcTable& p_vk,
       .flags = 0,
       .queueCreateInfoCount = 1,
       .pQueueCreateInfos = &queue_create,
-      .enabledLayerCount = static_cast<uint32_t>(enabled_layers.size()),
-      .ppEnabledLayerNames = layers,
+      .enabledLayerCount = static_cast<uint32_t>(layers.size()),
+      .ppEnabledLayerNames = layers.data(),
       .enabledExtensionCount = sizeof(extensions) / sizeof(const char*),
       .ppEnabledExtensionNames = extensions,
       .pEnabledFeatures = nullptr,


### PR DESCRIPTION
The variable length array extension will be disabled by default in the next roll of Clang.