### PR TITLE
Update NDK to version 26

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks: >-
   -clang-analyzer-nullability.NullablePassedToNonnull,
   -clang-analyzer-nullability.NullReturnedFromNonnull,
   -clang-analyzer-nullability.NullableReturnedFromNonnull,
+  -clang-analyzer-nullability.NullableDereferenced,
   performance-for-range-copy,
   performance-inefficient-vector-operation,
   performance-move-const-arg,

--- a/DEPS
+++ b/DEPS
@@ -274,7 +274,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '52689fe8955a9a4916a38f0b8ae5ea3e217037f4',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '71c9a9987171ef3f8b60a9e0b346bce30ee65933',
 
   'src/flutter/third_party/rapidjson':
    Var('flutter_git') + '/third_party/rapidjson' + '@' + 'ef3564c5c8824989393b87df25355baf35ff544b',
@@ -754,7 +754,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/sdk/all/${{platform}}',
-        'version': 'version:34v3'
+        'version': 'version:34v7'
        }
      ],
      'condition': 'download_android_deps',

--- a/build/secondary/third_party/vulkan_validation_layers/BUILD.gn
+++ b/build/secondary/third_party/vulkan_validation_layers/BUILD.gn
@@ -464,7 +464,6 @@ foreach(layer_info, layers) {
     }
     if (is_android) {
       libs = [
-        "c++_static",  # Note: C++ added by Flutter.
         "log",
         "nativewindow",
       ]

--- a/ci/binary_size_treemap.sh
+++ b/ci/binary_size_treemap.sh
@@ -22,10 +22,11 @@ if [ "$(uname)" == "Darwin" ]; then
 else
   NDK_PLATFORM="linux-x86_64"
 fi
-ADDR2LINE="third_party/android_tools/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/$NDK_PLATFORM/bin/aarch64-linux-android-addr2line"
+ADDR2LINE="third_party/android_tools/ndk/toolchains/llvm/prebuilt/$NDK_PLATFORM/bin/llvm-addr2line"
+NM="third_party/android_tools/ndk/toolchains/llvm/prebuilt/$NDK_PLATFORM/bin/llvm-nm"
 
 # Run the binary size script from the buildroot directory so the treemap path
 # navigation will start from there.
 cd "$ENGINE_BUILDROOT"
 RUN_BINARY_SIZE_ANALYSIS="third_party/dart/third_party/binary_size/src/run_binary_size_analysis.py"
-python3 "$RUN_BINARY_SIZE_ANALYSIS" --library "$INPUT_PATH" --destdir "$DEST_DIR" --addr2line-binary "$ADDR2LINE"
+python3 "$RUN_BINARY_SIZE_ANALYSIS" --library "$INPUT_PATH" --destdir "$DEST_DIR" --addr2line-binary "$ADDR2LINE" --nm-binary "$NM" --jobs 1 --no-check-support


### PR DESCRIPTION
This PR adjusts the GN build for a newer Android NDK. It relies on https://github.com/flutter/buildroot/pull/822.