### PR TITLE
[Impeller] Switched to static linked libc++ in vulkan validation layers.

### DIFF
--- a/build/secondary/third_party/vulkan_validation_layers/BUILD.gn
+++ b/build/secondary/third_party/vulkan_validation_layers/BUILD.gn
@@ -464,7 +464,7 @@ foreach(layer_info, layers) {
     }
     if (is_android) {
       libs = [
-        "c++",  # Note: C++ added by Flutter.
+        "c++_static",  # Note: C++ added by Flutter.
         "log",
         "nativewindow",
       ]

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -500,8 +500,8 @@ action("android_jar") {
       rebase_path("$validation_layer_out_dir/libVkLayer_khronos_validation.so"),
     ]
     if (current_cpu != "arm64") {
-      # This may not be necessarily require anymore. It was kept to maintain old
-      # behavior.
+      # This may not be necessarily required anymore. It was kept to maintain
+      # old behavior.
       assert(false, "Validation layers not supported for arch.")
     }
   }

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -499,13 +499,9 @@ action("android_jar") {
       "--native_lib",
       rebase_path("$validation_layer_out_dir/libVkLayer_khronos_validation.so"),
     ]
-    if (current_cpu == "arm64") {
-      args += [
-        "--native_lib",
-        rebase_path("$android_libcpp_root/libs/arm64-v8a/libc++_shared.so",
-                    root_build_dir),
-      ]
-    } else {
+    if (current_cpu != "arm64") {
+      # This may not be necessarily require anymore. It was kept to maintain old
+      # behavior.
       assert(false, "Validation layers not supported for arch.")
     }
   }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/138535
test coverage: existing integration tests in flutter repo which look for validation layers

I also verified locally that the `libc++.so` is no longer present and that it runs correctly.

```
$ find lib/arm64-v8a/
lib/arm64-v8a/
lib/arm64-v8a//libflutter.so
lib/arm64-v8a//libVkLayer_khronos_validation.so
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
