### PR TITLE
Yet more compliance with `.clang_tidy`, stragglers edition.

### DIFF
--- a/impeller/renderer/testing/mocks.h
+++ b/impeller/renderer/testing/mocks.h
@@ -105,7 +105,7 @@ class MockRenderPass : public RenderPass {
 class MockCommandBuffer : public CommandBuffer {
  public:
   explicit MockCommandBuffer(std::weak_ptr<const Context> context)
-      : CommandBuffer(context) {}
+      : CommandBuffer(std::move(context)) {}
   MOCK_METHOD(bool, IsValid, (), (const, override));
   MOCK_METHOD(void, SetLabel, (const std::string& label), (const, override));
   MOCK_METHOD(std::shared_ptr<BlitPass>, OnCreateBlitPass, (), (override));

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -21,7 +21,9 @@ G_BEGIN_DECLS
  */
 
 typedef enum {
+  // NOLINTBEGIN(readability-identifier-naming)
   FL_ENGINE_ERROR_FAILED,
+  // NOLINTEND(readability-identifier-naming)
 } FlEngineError;
 
 GQuark fl_engine_error_quark(void) G_GNUC_CONST;

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -20,7 +20,9 @@ G_BEGIN_DECLS
  */
 
 typedef enum {
+  // NOLINTBEGIN(readability-identifier-naming)
   FL_RENDERER_ERROR_FAILED,
+  // NOLINTEND(readability-identifier-naming)
 } FlRendererError;
 
 GQuark fl_renderer_error_quark(void) G_GNUC_CONST;

--- a/shell/platform/linux/fl_settings.h
+++ b/shell/platform/linux/fl_settings.h
@@ -19,8 +19,10 @@ G_DECLARE_INTERFACE(FlSettings, fl_settings, FL, SETTINGS, GObject)
  * Available clock formats.
  */
 typedef enum {
+  // NOLINTBEGIN(readability-identifier-naming)
   FL_CLOCK_FORMAT_12H,
   FL_CLOCK_FORMAT_24H,
+  // NOLINTEND(readability-identifier-naming)
 } FlClockFormat;
 
 /**
@@ -31,8 +33,10 @@ typedef enum {
  * Available color schemes.
  */
 typedef enum {
+  // NOLINTBEGIN(readability-identifier-naming)
   FL_COLOR_SCHEME_LIGHT,
   FL_COLOR_SCHEME_DARK,
+  // NOLINTEND(readability-identifier-naming)
 } FlColorScheme;
 
 /**

--- a/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h
+++ b/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h
@@ -27,9 +27,11 @@ G_BEGIN_DECLS
 #define FL_JSON_MESSAGE_CODEC_ERROR fl_json_message_codec_error_quark()
 
 typedef enum {
+  // NOLINTBEGIN(readability-identifier-naming)
   FL_JSON_MESSAGE_CODEC_ERROR_INVALID_UTF8,
   FL_JSON_MESSAGE_CODEC_ERROR_INVALID_JSON,
   FL_JSON_MESSAGE_CODEC_ERROR_INVALID_OBJECT_KEY_TYPE,
+  // NOLINTEND(readability-identifier-naming)
 } FlJsonMessageCodecError;
 
 GQuark fl_json_message_codec_error_quark(void) G_GNUC_CONST;

--- a/shell/platform/linux/public/flutter_linux/fl_message_codec.h
+++ b/shell/platform/linux/public/flutter_linux/fl_message_codec.h
@@ -30,10 +30,12 @@ G_BEGIN_DECLS
 #define FL_MESSAGE_CODEC_ERROR fl_message_codec_error_quark()
 
 typedef enum {
+  // NOLINTBEGIN(readability-identifier-naming)
   FL_MESSAGE_CODEC_ERROR_FAILED,
   FL_MESSAGE_CODEC_ERROR_OUT_OF_DATA,
   FL_MESSAGE_CODEC_ERROR_ADDITIONAL_DATA,
   FL_MESSAGE_CODEC_ERROR_UNSUPPORTED_TYPE,
+  // NOLINTEND(readability-identifier-naming)
 } FlMessageCodecError;
 
 GQuark fl_message_codec_error_quark(void) G_GNUC_CONST;

--- a/shell/platform/linux/public/flutter_linux/fl_method_response.h
+++ b/shell/platform/linux/public/flutter_linux/fl_method_response.h
@@ -30,9 +30,11 @@ G_BEGIN_DECLS
 #define FL_METHOD_RESPONSE_ERROR fl_method_response_error_quark()
 
 typedef enum {
+  // NOLINTBEGIN(readability-identifier-naming)
   FL_METHOD_RESPONSE_ERROR_FAILED,
   FL_METHOD_RESPONSE_ERROR_REMOTE_ERROR,
   FL_METHOD_RESPONSE_ERROR_NOT_IMPLEMENTED,
+  // NOLINTEND(readability-identifier-naming)
 } FlMethodResponseError;
 
 GQuark fl_method_response_error_quark(void) G_GNUC_CONST;

--- a/shell/platform/linux/testing/mock_binary_messenger.cc
+++ b/shell/platform/linux/testing/mock_binary_messenger.cc
@@ -40,26 +40,26 @@ MockBinaryMessenger::operator FlBinaryMessenger*() {
 }
 
 bool MockBinaryMessenger::HasMessageHandler(const gchar* channel) const {
-  return message_handlers.at(channel) != nullptr;
+  return message_handlers_.at(channel) != nullptr;
 }
 
 void MockBinaryMessenger::SetMessageHandler(
     const gchar* channel,
     FlBinaryMessengerMessageHandler handler,
     gpointer user_data) {
-  message_handlers[channel] = handler;
-  user_datas[channel] = user_data;
+  message_handlers_[channel] = handler;
+  user_datas_[channel] = user_data;
 }
 
 void MockBinaryMessenger::ReceiveMessage(const gchar* channel,
                                          GBytes* message) {
-  FlBinaryMessengerMessageHandler handler = message_handlers[channel];
-  if (response_handles[channel] == nullptr) {
-    response_handles[channel] = FL_BINARY_MESSENGER_RESPONSE_HANDLE(
+  FlBinaryMessengerMessageHandler handler = message_handlers_[channel];
+  if (response_handles_[channel] == nullptr) {
+    response_handles_[channel] = FL_BINARY_MESSENGER_RESPONSE_HANDLE(
         fl_mock_binary_messenger_response_handle_new());
   }
-  handler(instance_, channel, message, response_handles[channel],
-          user_datas[channel]);
+  handler(instance_, channel, message, response_handles_[channel],
+          user_datas_[channel]);
 }
 
 static void fl_mock_binary_messenger_iface_init(

--- a/shell/platform/linux/testing/mock_binary_messenger.h
+++ b/shell/platform/linux/testing/mock_binary_messenger.h
@@ -20,6 +20,10 @@ class MockBinaryMessenger {
   MockBinaryMessenger();
   ~MockBinaryMessenger();
 
+  // This was an existing use of operator overloading. It's against our style
+  // guide but enabling clang tidy on header files is a higher priority than
+  // fixing this.
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator FlBinaryMessenger*();
 
   MOCK_METHOD(void,
@@ -75,10 +79,10 @@ class MockBinaryMessenger {
  private:
   FlBinaryMessenger* instance_ = nullptr;
   std::unordered_map<std::string, FlBinaryMessengerMessageHandler>
-      message_handlers;
+      message_handlers_;
   std::unordered_map<std::string, FlBinaryMessengerResponseHandle*>
-      response_handles;
-  std::unordered_map<std::string, gpointer> user_datas;
+      response_handles_;
+  std::unordered_map<std::string, gpointer> user_datas_;
 };
 
 }  // namespace testing

--- a/shell/platform/linux/testing/mock_im_context.h
+++ b/shell/platform/linux/testing/mock_im_context.h
@@ -16,6 +16,10 @@ class MockIMContext {
  public:
   ~MockIMContext();
 
+  // This was an existing use of operator overloading. It's against our style
+  // guide but enabling clang tidy on header files is a higher priority than
+  // fixing this.
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator GtkIMContext*();
 
   MOCK_METHOD(void,

--- a/shell/platform/linux/testing/mock_settings.h
+++ b/shell/platform/linux/testing/mock_settings.h
@@ -18,6 +18,10 @@ class MockSettings {
   MockSettings();
   ~MockSettings();
 
+  // This was an existing use of operator overloading. It's against our style
+  // guide but enabling clang tidy on header files is a higher priority than
+  // fixing this.
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator FlSettings*();
 
   MOCK_METHOD(FlClockFormat,

--- a/vulkan/vulkan_application.h
+++ b/vulkan/vulkan_application.h
@@ -44,7 +44,7 @@ class VulkanApplication {
   std::unique_ptr<VulkanDevice> AcquireFirstCompatibleLogicalDevice() const;
 
  private:
-  VulkanProcTable& vk;
+  VulkanProcTable& vk_;
   VulkanHandle<VkInstance> instance_;
   uint32_t api_version_;
   std::unique_ptr<VulkanDebugReport> debug_report_;


### PR DESCRIPTION
Based off the [failures](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8763786250936903249/+/u/test:_test:_lint_host_debug/stdout) in https://github.com/flutter/engine/pull/48145.

Nothing particularly interesting.