### PR TITLE
[Impeller] Dont copy the paint until we're sure that the RRect blur optimization will apply.

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -199,8 +199,7 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
   }
 
   if (!paint.mask_blur_descriptor.has_value() ||
-      paint.mask_blur_descriptor->style !=
-          FilterContents::BlurStyle::kNormal) {
+      paint.mask_blur_descriptor->style != FilterContents::BlurStyle::kNormal) {
     return false;
   }
 

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -193,17 +193,18 @@ void Canvas::DrawPaint(const Paint& paint) {
 bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
                                      Scalar corner_radius,
                                      const Paint& paint) {
-  Paint new_paint = paint;
-  if (new_paint.color_source.GetType() != ColorSource::Type::kColor ||
-      new_paint.style != Paint::Style::kFill) {
+  if (paint.color_source.GetType() != ColorSource::Type::kColor ||
+      paint.style != Paint::Style::kFill) {
     return false;
   }
 
-  if (!new_paint.mask_blur_descriptor.has_value() ||
-      new_paint.mask_blur_descriptor->style !=
+  if (!paint.mask_blur_descriptor.has_value() ||
+      paint.mask_blur_descriptor->style !=
           FilterContents::BlurStyle::kNormal) {
     return false;
   }
+
+  Paint new_paint = paint;
 
   // For symmetrically mask blurred solid RRects, absorb the mask blur and use
   // a faster SDF approximation.


### PR DESCRIPTION
Extremely minor micro optimization. Dont copy the paint too early.

Before

![image](https://github.com/flutter/engine/assets/8975114/b5884e02-25ed-4e53-a6e0-d8d5a6a9a79a)


13/269 = ~5%

After:

![image](https://github.com/flutter/engine/assets/8975114/ac5981bb-40c6-4a38-b24c-46b7ad5399a4)

3/262 = ~1%