### PR TITLE
[Impeller] make host buffer state internally ref counted.

### DIFF
--- a/impeller/base/allocation.cc
+++ b/impeller/base/allocation.cc
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cstring>
 
-#include "flutter/fml/logging.h"
 #include "impeller/base/validation.h"
 
 namespace impeller {

--- a/impeller/base/allocation.h
+++ b/impeller/base/allocation.h
@@ -8,7 +8,6 @@
 #include <limits>
 #include <memory>
 
-#include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
 
 namespace impeller {

--- a/impeller/core/host_buffer.cc
+++ b/impeller/core/host_buffer.cc
@@ -24,41 +24,58 @@ HostBuffer::HostBuffer() = default;
 HostBuffer::~HostBuffer() = default;
 
 void HostBuffer::SetLabel(std::string label) {
-  label_ = std::move(label);
+  state_->label = std::move(label);
 }
 
 BufferView HostBuffer::Emplace(const void* buffer,
                                size_t length,
                                size_t align) {
-  if (align == 0 || (GetLength() % align) == 0) {
-    return Emplace(buffer, length);
+  auto [device_buffer, range] = state_->Emplace(buffer, length, align);
+  if (!device_buffer) {
+    return {};
   }
-
-  {
-    auto pad = Emplace(nullptr, align - (GetLength() % align));
-    if (!pad) {
-      return {};
-    }
-  }
-
-  return Emplace(buffer, length);
+  return BufferView{state_, device_buffer, range};
 }
 
 BufferView HostBuffer::Emplace(const void* buffer, size_t length) {
-  auto old_length = GetLength();
-  if (!Truncate(old_length + length)) {
+  auto [device_buffer, range] = state_->Emplace(buffer, length);
+  if (!device_buffer) {
     return {};
   }
-  generation_++;
-  if (buffer) {
-    ::memmove(GetBuffer() + old_length, buffer, length);
-  }
-  return BufferView{shared_from_this(), GetBuffer(), Range{old_length, length}};
+  return BufferView{state_, device_buffer, range};
 }
 
 BufferView HostBuffer::Emplace(size_t length,
                                size_t align,
                                const EmplaceProc& cb) {
+  auto [buffer, range] = state_->Emplace(length, align, cb);
+  if (!buffer) {
+    return {};
+  }
+  return BufferView{state_, buffer, range};
+}
+
+std::shared_ptr<const DeviceBuffer> HostBuffer::GetDeviceBuffer(
+    Allocator& allocator) const {
+  return state_->GetDeviceBuffer(allocator);
+}
+
+void HostBuffer::Reset() {
+  state_->Reset();
+}
+
+size_t HostBuffer::GetSize() const {
+  return state_->GetReservedLength();
+}
+
+size_t HostBuffer::GetLength() const {
+  return state_->GetLength();
+}
+
+std::pair<uint8_t*, Range> HostBuffer::HostBufferState::Emplace(
+    size_t length,
+    size_t align,
+    const EmplaceProc& cb) {
   if (!cb) {
     return {};
   }
@@ -66,36 +83,64 @@ BufferView HostBuffer::Emplace(size_t length,
   if (!Truncate(old_length + length)) {
     return {};
   }
-  generation_++;
+  generation++;
   cb(GetBuffer() + old_length);
 
-  return BufferView{shared_from_this(), GetBuffer(), Range{old_length, length}};
+  return std::make_pair(GetBuffer(), Range{old_length, length});
 }
 
-std::shared_ptr<const DeviceBuffer> HostBuffer::GetDeviceBuffer(
-    Allocator& allocator) const {
-  if (generation_ == device_buffer_generation_) {
-    return device_buffer_;
+std::shared_ptr<const DeviceBuffer>
+HostBuffer::HostBufferState::GetDeviceBuffer(Allocator& allocator) const {
+  if (generation == device_buffer_generation) {
+    return device_buffer;
   }
   auto new_buffer = allocator.CreateBufferWithCopy(GetBuffer(), GetLength());
   if (!new_buffer) {
     return nullptr;
   }
-  new_buffer->SetLabel(label_);
-  device_buffer_generation_ = generation_;
-  device_buffer_ = std::move(new_buffer);
-  return device_buffer_;
+  new_buffer->SetLabel(label);
+  device_buffer_generation = generation;
+  device_buffer = std::move(new_buffer);
+  return device_buffer;
 }
 
-void HostBuffer::Reset() {
-  generation_ += 1;
-  device_buffer_ = nullptr;
+std::pair<uint8_t*, Range> HostBuffer::HostBufferState::Emplace(
+    const void* buffer,
+    size_t length) {
+  auto old_length = GetLength();
+  if (!Truncate(old_length + length)) {
+    return {};
+  }
+  generation++;
+  if (buffer) {
+    ::memmove(GetBuffer() + old_length, buffer, length);
+  }
+  return std::make_pair(GetBuffer(), Range{old_length, length});
+}
+
+std::pair<uint8_t*, Range> HostBuffer::HostBufferState::Emplace(
+    const void* buffer,
+    size_t length,
+    size_t align) {
+  if (align == 0 || (GetLength() % align) == 0) {
+    return Emplace(buffer, length);
+  }
+
+  {
+    auto [buffer, range] = Emplace(nullptr, align - (GetLength() % align));
+    if (!buffer) {
+      return {};
+    }
+  }
+
+  return Emplace(buffer, length);
+}
+
+void HostBuffer::HostBufferState::Reset() {
+  generation += 1;
+  device_buffer = nullptr;
   bool did_truncate = Truncate(0);
   FML_CHECK(did_truncate);
-}
-
-size_t HostBuffer::GetSize() const {
-  return GetReservedLength();
 }
 
 }  // namespace impeller

--- a/impeller/core/host_buffer.h
+++ b/impeller/core/host_buffer.h
@@ -16,9 +16,7 @@
 
 namespace impeller {
 
-class HostBuffer final : public std::enable_shared_from_this<HostBuffer>,
-                         public Allocation,
-                         public Buffer {
+class HostBuffer final : public Buffer {
  public:
   static std::shared_ptr<HostBuffer> Create();
 
@@ -116,14 +114,42 @@ class HostBuffer final : public std::enable_shared_from_this<HostBuffer>,
   void Reset();
 
   //----------------------------------------------------------------------------
-  /// @brief Returns the size of the HostBuffer in memory in bytes.
+  /// @brief Returns the capacity of the HostBuffer in memory in bytes.
   size_t GetSize() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief Returns the size of the currently allocated HostBuffer memory in
+  /// bytes.
+  size_t GetLength() const;
+
  private:
-  mutable std::shared_ptr<DeviceBuffer> device_buffer_;
-  mutable size_t device_buffer_generation_ = 0u;
-  size_t generation_ = 1u;
-  std::string label_;
+  class HostBufferState : public Buffer, public Allocation {
+   public:
+    std::shared_ptr<const DeviceBuffer> GetDeviceBuffer(
+        Allocator& allocator) const override;
+
+    [[nodiscard]] std::pair<uint8_t*, Range> Emplace(const void* buffer,
+                                                     size_t length);
+
+    std::pair<uint8_t*, Range> Emplace(size_t length,
+                                       size_t align,
+                                       const EmplaceProc& cb);
+
+    std::pair<uint8_t*, Range> Emplace(const void* buffer,
+                                       size_t length,
+                                       size_t align);
+
+    void Reset();
+
+    size_t GetSize() const;
+
+    mutable std::shared_ptr<DeviceBuffer> device_buffer;
+    mutable size_t device_buffer_generation = 0u;
+    size_t generation = 1u;
+    std::string label;
+  };
+
+  std::shared_ptr<HostBufferState> state_ = std::make_shared<HostBufferState>();
 
   // |Buffer|
   std::shared_ptr<const DeviceBuffer> GetDeviceBuffer(

--- a/impeller/core/host_buffer.h
+++ b/impeller/core/host_buffer.h
@@ -119,12 +119,11 @@ class HostBuffer final : public Buffer {
 
   //----------------------------------------------------------------------------
   /// @brief Returns the size of the currently allocated HostBuffer memory in
-  /// bytes.
+  ///        bytes.
   size_t GetLength() const;
 
  private:
-  class HostBufferState : public Buffer, public Allocation {
-   public:
+  struct HostBufferState : public Buffer, public Allocation {
     std::shared_ptr<const DeviceBuffer> GetDeviceBuffer(
         Allocator& allocator) const override;
 
@@ -140,8 +139,6 @@ class HostBuffer final : public Buffer {
                                        size_t align);
 
     void Reset();
-
-    size_t GetSize() const;
 
     mutable std::shared_ptr<DeviceBuffer> device_buffer;
     mutable size_t device_buffer_generation = 0u;

--- a/impeller/renderer/host_buffer_unittests.cc
+++ b/impeller/renderer/host_buffer_unittests.cc
@@ -12,7 +12,7 @@ TEST(HostBufferTest, TestInitialization) {
   ASSERT_TRUE(HostBuffer::Create());
   // Newly allocated buffers don't touch the heap till they have to.
   ASSERT_EQ(HostBuffer::Create()->GetLength(), 0u);
-  ASSERT_EQ(HostBuffer::Create()->GetReservedLength(), 0u);
+  ASSERT_EQ(HostBuffer::Create()->GetSize(), 0u);
 }
 
 TEST(HostBufferTest, CanEmplace) {


### PR DESCRIPTION
std::shared_from_this is actually incredibly slow, and dominates the cost of host buffer allocation at 20x more expensive than the memcpy. We can remove the usage of shared_from_this by making an internal class hold the actual allocation/buffer state instead.


### Before

![image](https://github.com/flutter/engine/assets/8975114/d6cd69c7-de1d-4b05-bd76-1d9a3353e350)


146 ms / 647ms = ~20%
### After

33 ms / 540 ms = ~6%

![image](https://github.com/flutter/engine/assets/8975114/e624dd94-9718-404a-a0f8-b359df9f0109)
