### PR TITLE
[Impeller] pass const ref to binding helpers.

### DIFF
--- a/impeller/compiler/code_gen_template.h
+++ b/impeller/compiler/code_gen_template.h
@@ -163,7 +163,7 @@ struct {{camel_case(shader_name)}}{{camel_case(shader_stage)}}Shader {
     return {{ proto.args.0.argument_name }}.BindResource({% for arg in proto.args %}
   {% if loop.is_first %}
 {{to_shader_stage(shader_stage)}}, kResource{{ proto.name }}, kMetadata{{ proto.name }}, {% else %}
-std::move({{ arg.argument_name }}){% if not loop.is_last %}, {% endif %}
+{{ arg.argument_name }}{% if not loop.is_last %}, {% endif %}
   {% endif %}
   {% endfor %});
   }

--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -1137,7 +1137,7 @@ std::vector<Reflector::BindPrototype> Reflector::ReflectBindPrototypes(
         .argument_name = "command",
     });
     proto.args.push_back(BindPrototypeArgument{
-        .type_name = "BufferView",
+        .type_name = "const BufferView&",
         .argument_name = "view",
     });
   }
@@ -1156,7 +1156,7 @@ std::vector<Reflector::BindPrototype> Reflector::ReflectBindPrototypes(
         .argument_name = "command",
     });
     proto.args.push_back(BindPrototypeArgument{
-        .type_name = "BufferView",
+        .type_name = "const BufferView&",
         .argument_name = "view",
     });
   }
@@ -1175,11 +1175,11 @@ std::vector<Reflector::BindPrototype> Reflector::ReflectBindPrototypes(
         .argument_name = "command",
     });
     proto.args.push_back(BindPrototypeArgument{
-        .type_name = "std::shared_ptr<const Texture>",
+        .type_name = "const std::shared_ptr<const Texture>&",
         .argument_name = "texture",
     });
     proto.args.push_back(BindPrototypeArgument{
-        .type_name = "std::shared_ptr<const Sampler>",
+        .type_name = "const std::shared_ptr<const Sampler>&",
         .argument_name = "sampler",
     });
   }
@@ -1198,7 +1198,7 @@ std::vector<Reflector::BindPrototype> Reflector::ReflectBindPrototypes(
         .argument_name = "command",
     });
     proto.args.push_back(BindPrototypeArgument{
-        .type_name = "std::shared_ptr<const Texture>",
+        .type_name = "const std::shared_ptr<const Texture>&",
         .argument_name = "texture",
     });
   }
@@ -1217,7 +1217,7 @@ std::vector<Reflector::BindPrototype> Reflector::ReflectBindPrototypes(
         .argument_name = "command",
     });
     proto.args.push_back(BindPrototypeArgument{
-        .type_name = "std::shared_ptr<const Sampler>",
+        .type_name = "const std::shared_ptr<const Sampler>&",
         .argument_name = "sampler",
     });
   }


### PR DESCRIPTION
No point in passing by value and moving, just pass a const ref through. Trivial performance improvement.

# Before
```cpp
  /// Bind uniform buffer for resource named FragInfo.
  static bool BindFragInfo(ResourceBinder& command, BufferView view) {
    return command.BindResource(ShaderStage::kFragment, kResourceFragInfo, kMetadataFragInfo, std::move(view));
  }

  /// Bind combined image sampler for resource named texture_sampler.
  static bool BindTextureSampler(ResourceBinder& command, std::shared_ptr<const Texture> texture, std::shared_ptr<const Sampler> sampler) {
    return command.BindResource(ShaderStage::kFragment, kResourceTextureSampler, kMetadataTextureSampler, std::move(texture), std::move(sampler));
  }
  ```

# After
```cpp
  /// Bind uniform buffer for resource named FragInfo.
  static bool BindFragInfo(ResourceBinder& command, const BufferView& view) {
    return command.BindResource(ShaderStage::kFragment, kResourceFragInfo, kMetadataFragInfo, view);
  }

  /// Bind combined image sampler for resource named texture_sampler.
  static bool BindTextureSampler(ResourceBinder& command, const std::shared_ptr<const Texture>& texture, const std::shared_ptr<const Sampler>& sampler) {
    return command.BindResource(ShaderStage::kFragment, kResourceTextureSampler, kMetadataTextureSampler, texture, sampler);
  }
  ```