### PR TITLE
[Impeller] OES extension does not apply to regular textures for decal support

### DIFF
--- a/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -16,8 +16,6 @@ static const constexpr char* kTextureBorderClampExt =
     "GL_EXT_texture_border_clamp";
 static const constexpr char* kNvidiaTextureBorderClampExt =
     "GL_NV_texture_border_clamp";
-static const constexpr char* kOESTextureBorderClampExt =
-    "GL_OES_texture_border_clamp";
 
 // https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_multisampled_render_to_texture.txt
 static const constexpr char* kMultisampledRenderToTextureExt =
@@ -107,8 +105,7 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   supports_framebuffer_fetch_ = desc->HasExtension(kFramebufferFetchExt);
 
   if (desc->HasExtension(kTextureBorderClampExt) ||
-      desc->HasExtension(kNvidiaTextureBorderClampExt) ||
-      desc->HasExtension(kOESTextureBorderClampExt)) {
+      desc->HasExtension(kNvidiaTextureBorderClampExt)) {
     supports_decal_sampler_address_mode_ = true;
   }
 

--- a/impeller/renderer/backend/gles/test/capabilities_unittests.cc
+++ b/impeller/renderer/backend/gles/test/capabilities_unittests.cc
@@ -43,6 +43,16 @@ TEST(CapabilitiesGLES, SupportsDecalSamplerAddressMode) {
   EXPECT_TRUE(capabilities->SupportsDecalSamplerAddressMode());
 }
 
+TEST(CapabilitiesGLES, SupportsDecalSamplerAddressModeNotOES) {
+  auto const extensions = std::vector<const unsigned char*>{
+      reinterpret_cast<const unsigned char*>("GL_KHR_debug"),                 //
+      reinterpret_cast<const unsigned char*>("GL_OES_texture_border_clamp"),  //
+  };
+  auto mock_gles = MockGLES::Init(extensions);
+  auto capabilities = mock_gles->GetProcTable().GetCapabilities();
+  EXPECT_FALSE(capabilities->SupportsDecalSamplerAddressMode());
+}
+
 TEST(CapabilitiesGLES, SupportsFramebufferFetch) {
   auto const extensions = std::vector<const unsigned char*>{
       reinterpret_cast<const unsigned char*>("GL_KHR_debug"),  //


### PR DESCRIPTION
This extension only implies decal support for OES textures. Remove it from the check for generic decal support.

In practice i think it would be unlikely that a driver supports this and not regular decal, but that would only make the bugs this may cause even harder to track down.
