### PR TITLE
Add build dependencies for Android Embedder

### DIFF
--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -91,6 +91,36 @@
             ],
             "gn": [
                 "--android",
+                "--embedder-for-target",
+                "--target-dir",
+                "android_embedder_debug_unopt",
+                "--unoptimized",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "android_embedder_debug_unopt",
+            "ninja": {
+                "config": "android_embedder_debug_unopt",
+                "targets": [
+                    "flutter/impeller",
+                    "flutter/shell/platform/android:android_jar",
+                    "flutter/shell/platform/android:robolectric_tests"
+                ]
+            }
+        },
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "dependencies": [
+                {
+                    "dependency": "arm_tools",
+                    "version": "last_updated:2023-02-03T15:32:01-0800"
+                }
+            ],
+            "gn": [
+                "--android",
                 "--unoptimized",
                 "--rbe",
                 "--no-goma"

--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -83,12 +83,7 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "dependencies": [
-                {
-                    "dependency": "arm_tools",
-                    "version": "last_updated:2023-02-03T15:32:01-0800"
-                }
-            ],
+            "dependencies": [],
             "gn": [
                 "--android",
                 "--embedder-for-target",
@@ -102,9 +97,7 @@
             "ninja": {
                 "config": "android_embedder_debug_unopt",
                 "targets": [
-                    "flutter/impeller",
-                    "flutter/shell/platform/android:android_jar",
-                    "flutter/shell/platform/android:robolectric_tests"
+                    "flutter/shell/platform/android:android_jar"
                 ]
             }
         },

--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -97,7 +97,7 @@
             "ninja": {
                 "config": "android_embedder_debug_unopt",
                 "targets": [
-                    "flutter/shell/platform/android:android_jar"
+                    "flutter/shell/platform/embedder:flutter_engine"
                 ]
             }
         },

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -177,8 +177,7 @@ template("embedder_source_set") {
       ]
     }
 
-    # For the Android, avoid dynamic lookups of the engine library's symbols need to depend on the 'icudtl.dat.S',
-    # which comes from the change '0f32302bc17d39032393b6f287ad5055b89f9392' and '60968c892649301dadb15f4c2ce7329b04bf8827'.
+    # Depend on 'icudtl.dat.S' to avoid dynamic lookups of engine library symbols.
     if (is_android) {
       deps += [ "//flutter/shell/platform/android:icudtl_asm" ]
       sources += [ "$root_build_dir/gen/flutter/shell/platform/android/third_party/icu/flutter/icudtl.dat.S" ]

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -177,6 +177,13 @@ template("embedder_source_set") {
       ]
     }
 
+    # For the Android, avoid dynamic lookups of the engine library's symbols need to depend on the 'icudtl.dat.S',
+    # which comes from the change '0f32302bc17d39032393b6f287ad5055b89f9392' and '60968c892649301dadb15f4c2ce7329b04bf8827'.
+    if (is_android) {
+      deps += [ "//flutter/shell/platform/android:icudtl_asm" ]
+      sources += [ "$root_build_dir/gen/flutter/shell/platform/android/third_party/icu/flutter/icudtl.dat.S" ]
+    }
+
     public_configs += [
       ":embedder_gpu_configuration_config",
       ":embedder_header_config",


### PR DESCRIPTION
The build of embedded Android depends on the symbols of the 'icudtl.dat', as described in the change '0f32302bc17d39032393b6f287ad5055b89f9392' and '60968c892649301dadb15f4c2ce7329b04bf8827'.

fixes https://github.com/flutter/flutter/issues/97347


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
