### PR TITLE
[Impeller] updated gaussian blur tests to use device private textures

### DIFF
--- a/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents_unittests.cc
@@ -89,6 +89,7 @@ TEST_P(DirectionalGaussianBlurFilterContentsTest, RenderNoCoverage) {
 TEST_P(DirectionalGaussianBlurFilterContentsTest,
        RenderCoverageMatchesGetCoverage) {
   TextureDescriptor desc = {
+      .storage_mode = StorageMode::kDevicePrivate,
       .format = PixelFormat::kB8G8R8A8UNormInt,
       .size = ISize(100, 100),
   };

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -70,6 +70,7 @@ TEST(GaussianBlurFilterContentsTest, CoverageWithSigma) {
 
 TEST_P(GaussianBlurFilterContentsTest, CoverageWithTexture) {
   TextureDescriptor desc = {
+      .storage_mode = StorageMode::kDevicePrivate,
       .format = PixelFormat::kB8G8R8A8UNormInt,
       .size = ISize(100, 100),
   };
@@ -88,6 +89,7 @@ TEST_P(GaussianBlurFilterContentsTest, CoverageWithTexture) {
 
 TEST_P(GaussianBlurFilterContentsTest, CoverageWithEffectTransform) {
   TextureDescriptor desc = {
+      .storage_mode = StorageMode::kDevicePrivate,
       .format = PixelFormat::kB8G8R8A8UNormInt,
       .size = ISize(100, 100),
   };
@@ -115,6 +117,7 @@ TEST(GaussianBlurFilterContentsTest, FilterSourceCoverage) {
 
 TEST_P(GaussianBlurFilterContentsTest, RenderCoverageMatchesGetCoverage) {
   TextureDescriptor desc = {
+      .storage_mode = StorageMode::kDevicePrivate,
       .format = PixelFormat::kB8G8R8A8UNormInt,
       .size = ISize(100, 100),
   };
@@ -146,6 +149,7 @@ TEST_P(GaussianBlurFilterContentsTest, RenderCoverageMatchesGetCoverage) {
 TEST_P(GaussianBlurFilterContentsTest,
        RenderCoverageMatchesGetCoverageTranslate) {
   TextureDescriptor desc = {
+      .storage_mode = StorageMode::kDevicePrivate,
       .format = PixelFormat::kB8G8R8A8UNormInt,
       .size = ISize(100, 100),
   };
@@ -159,6 +163,7 @@ TEST_P(GaussianBlurFilterContentsTest,
   entity.SetTransform(Matrix::MakeTranslation({100, 200, 0}));
   std::optional<Entity> result =
       contents->GetEntity(*renderer, entity, /*coverage_hint=*/{});
+
   EXPECT_TRUE(result.has_value());
   if (result.has_value()) {
     EXPECT_EQ(result.value().GetBlendMode(), BlendMode::kSourceOver);
@@ -178,6 +183,7 @@ TEST_P(GaussianBlurFilterContentsTest,
 TEST_P(GaussianBlurFilterContentsTest,
        RenderCoverageMatchesGetCoverageRotated) {
   TextureDescriptor desc = {
+      .storage_mode = StorageMode::kDevicePrivate,
       .format = PixelFormat::kB8G8R8A8UNormInt,
       .size = ISize(400, 300),
   };
@@ -210,6 +216,7 @@ TEST_P(GaussianBlurFilterContentsTest,
 
 TEST_P(GaussianBlurFilterContentsTest, CalculateUVsSimple) {
   TextureDescriptor desc = {
+      .storage_mode = StorageMode::kDevicePrivate,
       .format = PixelFormat::kB8G8R8A8UNormInt,
       .size = ISize(100, 100),
   };


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/138955

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
