### PR TITLE
SurfaceFrame root DisplayLists will no longer prepare an RTree

### DIFF
--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -153,17 +153,12 @@ void DisplayList::Dispatch(DlOpReceiver& receiver,
   if (cull_rect.isEmpty()) {
     return;
   }
-  if (cull_rect.contains(bounds())) {
+  if (!has_rtree() || cull_rect.contains(bounds())) {
     Dispatch(receiver);
     return;
   }
   const DlRTree* rtree = this->rtree().get();
   FML_DCHECK(rtree != nullptr);
-  if (rtree == nullptr) {
-    FML_LOG(ERROR) << "dispatched with culling rect on DL with no rtree";
-    Dispatch(receiver);
-    return;
-  }
   uint8_t* ptr = storage_.get();
   std::vector<int> rect_indices;
   rtree->search(cull_rect, &rect_indices);

--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -18,6 +18,7 @@ DlCanvas* DisplayListEmbedderViewSlice::canvas() {
 
 void DisplayListEmbedderViewSlice::end_recording() {
   display_list_ = builder_->Build();
+  FML_DCHECK(display_list_->has_rtree());
   builder_ = nullptr;
 }
 

--- a/flow/surface_frame.cc
+++ b/flow/surface_frame.cc
@@ -31,8 +31,13 @@ SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
     canvas_ = &adapter_;
   } else if (display_list_fallback) {
     FML_DCHECK(!frame_size.isEmpty());
-    dl_builder_ =
-        sk_make_sp<DisplayListBuilder>(SkRect::Make(frame_size), true);
+    // The root frame of a surface will be filled by the layer_tree which
+    // performs branch culling so it will be unlikely to need an rtree for
+    // further culling during `DisplayList::Dispatch`. Further, this canvas
+    // will live underneath any platform views so we do not need to compute
+    // exact coverage to describe "pixel ownership" to the platform.
+    dl_builder_ = sk_make_sp<DisplayListBuilder>(SkRect::Make(frame_size),
+                                                 /*prepare_rtree=*/false);
     canvas_ = dl_builder_.get();
   }
 }

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -36,9 +36,11 @@ void PictureRecorder::endRecording(Dart_Handle dart_picture) {
     return;
   }
 
-  Picture::CreateAndAssociateWithDartWrapper(dart_picture,
-                                             display_list_builder_->Build());
+  auto display_list = display_list_builder_->Build();
   display_list_builder_ = nullptr;
+
+  FML_DCHECK(display_list->has_rtree());
+  Picture::CreateAndAssociateWithDartWrapper(dart_picture, display_list);
 
   canvas_->Invalidate();
   canvas_ = nullptr;


### PR DESCRIPTION
The root slice of a surface frame was requesting the construction of an RTree from its DisplayList when it was built from a layer tree, but since the layer tree already does branch culling, it would not benefit from any further culling during `DisplayList::Dispatch`. Further, if there are platform views present in the layer tree then they will need an RTree to accurately convey "pixel ownership" information to the platform, but the root slice lives below any and all platform views, so it is the only slice that doesn't need an RTree for that case.

The cost of having an RTree in that slice was the accumulation of information and lists of rects that would never prove useful.