### PR TITLE
[Impeller] Skip mask blur with 0 sigma.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4096,5 +4096,23 @@ TEST_P(AiksTest, ArcWithZeroSweepAndBlur) {
   canvas.EndRecordingAsPicture();
 }
 
+TEST_P(AiksTest, MaskBlurWithZeroSigmaIsSkipped) {
+  Canvas canvas;
+
+  Paint paint = {
+      .color = Color::White(),
+      .mask_blur_descriptor =
+          Paint::MaskBlurDescriptor{
+              .style = FilterContents::BlurStyle::kNormal,
+              .sigma = Sigma(0),
+          },
+  };
+
+  canvas.DrawCircle({300, 300}, 200, paint);
+  canvas.DrawRect(Rect::MakeLTRB(100, 300, 500, 600), paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -18,6 +18,7 @@
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/contents/vertices_contents.h"
 #include "impeller/entity/geometry/geometry.h"
+#include "impeller/geometry/constants.h"
 #include "impeller/geometry/path_builder.h"
 
 namespace impeller {
@@ -201,6 +202,11 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
   if (!paint.mask_blur_descriptor.has_value() ||
       paint.mask_blur_descriptor->style != FilterContents::BlurStyle::kNormal) {
     return false;
+  }
+  // A blur sigma that is close to zero should not result in any shadow.
+  if (paint.mask_blur_descriptor->sigma.sigma <= kEhCloseEnough &&
+      paint.mask_blur_descriptor->sigma.sigma >= -kEhCloseEnough) {
+    return true;
   }
 
   Paint new_paint = paint;

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -204,8 +204,7 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
     return false;
   }
   // A blur sigma that is close to zero should not result in any shadow.
-  if (paint.mask_blur_descriptor->sigma.sigma <= kEhCloseEnough &&
-      paint.mask_blur_descriptor->sigma.sigma >= -kEhCloseEnough) {
+  if (std::fabs(paint.mask_blur_descriptor->sigma.sigma) <= kEhCloseEnough) {
     return true;
   }
 

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -8,6 +8,7 @@
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/color.h"
+#include "impeller/geometry/constants.h"
 #include "impeller/geometry/path.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/renderer/render_pass.h"
@@ -63,7 +64,8 @@ std::optional<Rect> SolidRRectBlurContents::GetCoverage(
 bool SolidRRectBlurContents::Render(const ContentContext& renderer,
                                     const Entity& entity,
                                     RenderPass& pass) const {
-  if (!rect_.has_value()) {
+  // Early return if sigma is close to zero to avoid rendering NaNs.
+  if (!rect_.has_value() || std::fabs(sigma_.sigma) <= kEhCloseEnough) {
     return true;
   }
 


### PR DESCRIPTION
<0 sigma render incorrectly with wide gamut, but these shouldn't produce shadows at all as far as I can tell.

https://github.com/flutter/flutter/issues/138842
