### PR TITLE
Fix CanonicalizeURL for file schema

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -1046,6 +1046,7 @@
 ../../../flutter/third_party/tonic/AUTHORS
 ../../../flutter/third_party/tonic/PATENTS
 ../../../flutter/third_party/tonic/README.md
+../../../flutter/third_party/tonic/file_loader/file_loader_unittests.cc
 ../../../flutter/third_party/tonic/filesystem/README.md
 ../../../flutter/third_party/tonic/filesystem/tests
 ../../../flutter/third_party/tonic/tests

--- a/third_party/tonic/file_loader/file_loader.cc
+++ b/third_party/tonic/file_loader/file_loader.cc
@@ -139,7 +139,9 @@ Dart_Handle FileLoader::CanonicalizeURL(Dart_Handle library, Dart_Handle url) {
 
   if (string.find(kFileScheme) == 0u) {
     // CanonicalizeFileURL strips away the "file:" portion of the string.
-    auto res = "file:" + SanitizePath(CanonicalizeFileURL(string));
+    // Do not use SanitizePath so that we can preserve this as a URL.
+    auto res =
+        "file:" + SanitizeURIEscapedCharacters(CanonicalizeFileURL(string));
     return StdStringToDart(res);
   }
 

--- a/third_party/tonic/file_loader/file_loader.cc
+++ b/third_party/tonic/file_loader/file_loader.cc
@@ -138,11 +138,7 @@ Dart_Handle FileLoader::CanonicalizeURL(Dart_Handle library, Dart_Handle url) {
     return StdStringToDart(SanitizePath(string));
 
   if (string.find(kFileScheme) == 0u) {
-    // CanonicalizeFileURL strips away the "file:" portion of the string.
-    // Do not use SanitizePath so that we can preserve this as a URL.
-    auto res =
-        "file:" + SanitizeURIEscapedCharacters(CanonicalizeFileURL(string));
-    return StdStringToDart(res);
+    return StdStringToDart(SanitizeURIEscapedCharacters(string));
   }
 
   std::string library_url = StdStringFromDart(Dart_LibraryUrl(library));

--- a/third_party/tonic/file_loader/file_loader.cc
+++ b/third_party/tonic/file_loader/file_loader.cc
@@ -136,8 +136,12 @@ Dart_Handle FileLoader::CanonicalizeURL(Dart_Handle library, Dart_Handle url) {
     return url;
   if (string.find(kPackageScheme) == 0u)
     return StdStringToDart(SanitizePath(string));
-  if (string.find(kFileScheme) == 0u)
-    return StdStringToDart(SanitizePath(CanonicalizeFileURL(string)));
+
+  if (string.find(kFileScheme) == 0u) {
+    // CanonicalizeFileURL strips away the "file:" portion of the string.
+    auto res = "file:" + SanitizePath(CanonicalizeFileURL(string));
+    return StdStringToDart(res);
+  }
 
   std::string library_url = StdStringFromDart(Dart_LibraryUrl(library));
   std::string prefix = ExtractSchemePrefix(library_url);

--- a/third_party/tonic/file_loader/file_loader.h
+++ b/third_party/tonic/file_loader/file_loader.h
@@ -46,7 +46,6 @@ class FileLoader {
  private:
   static std::string SanitizeURIEscapedCharacters(const std::string& str);
   static std::string SanitizePath(const std::string& path);
-  static std::string CanonicalizeFileURL(const std::string& url);
 
   std::string GetFilePathForURL(std::string url);
   std::string GetFilePathForPackageURL(std::string url);

--- a/third_party/tonic/file_loader/file_loader_fuchsia.cc
+++ b/third_party/tonic/file_loader/file_loader_fuchsia.cc
@@ -26,18 +26,8 @@ const char FileLoader::kFileURLPrefix[] = "file://";
 const size_t FileLoader::kFileURLPrefixLength =
     sizeof(FileLoader::kFileURLPrefix) - 1;
 
-namespace {
-
-const size_t kFileSchemeLength = FileLoader::kFileURLPrefixLength - 2;
-
-}  // namespace
-
 std::string FileLoader::SanitizePath(const std::string& url) {
   return SanitizeURIEscapedCharacters(url);
-}
-
-std::string FileLoader::CanonicalizeFileURL(const std::string& url) {
-  return url.substr(kFileSchemeLength);
 }
 
 bool FileLoader::ReadFileToString(const std::string& path,

--- a/third_party/tonic/file_loader/file_loader_posix.cc
+++ b/third_party/tonic/file_loader/file_loader_posix.cc
@@ -21,18 +21,8 @@ const char FileLoader::kFileURLPrefix[] = "file://";
 const size_t FileLoader::kFileURLPrefixLength =
     sizeof(FileLoader::kFileURLPrefix) - 1;
 
-namespace {
-
-const size_t kFileSchemeLength = FileLoader::kFileURLPrefixLength - 2;
-
-}  // namespace
-
 std::string FileLoader::SanitizePath(const std::string& url) {
   return SanitizeURIEscapedCharacters(url);
-}
-
-std::string FileLoader::CanonicalizeFileURL(const std::string& url) {
-  return url.substr(kFileSchemeLength);
 }
 
 bool FileLoader::ReadFileToString(const std::string& path,

--- a/third_party/tonic/file_loader/file_loader_unittests.cc
+++ b/third_party/tonic/file_loader/file_loader_unittests.cc
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/dart_isolate_runner.h"
+#include "flutter/testing/fixture_test.h"
+
+#include "tonic/converter/dart_converter.h"
+#include "tonic/file_loader/file_loader.h"
+
+namespace flutter {
+namespace testing {
+
+using FileLoaderTest = FixtureTest;
+
+TEST_F(FileLoaderTest, CanonicalizesFileUrlCorrectly) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  auto settings = CreateSettingsForFixture();
+  auto vm_snapshot = DartSnapshot::VMSnapshotFromSettings(settings);
+  auto isolate_snapshot = DartSnapshot::IsolateSnapshotFromSettings(settings);
+  auto vm_ref = DartVMRef::Create(settings, vm_snapshot, isolate_snapshot);
+  ASSERT_TRUE(vm_ref);
+
+  TaskRunners task_runners(GetCurrentTestName(),    //
+                           GetCurrentTaskRunner(),  //
+                           GetCurrentTaskRunner(),  //
+                           GetCurrentTaskRunner(),  //
+                           GetCurrentTaskRunner()   //
+  );
+  auto isolate = RunDartCodeInIsolate(vm_ref, settings, task_runners, "main",
+                                      {}, GetDefaultKernelFilePath());
+  ASSERT_TRUE(isolate);
+
+  ASSERT_TRUE(isolate->RunInIsolateScope([]() {
+    tonic::FileLoader file_loader;
+    std::string original_url = "file:///Users/test/foo";
+    Dart_Handle dart_url = tonic::StdStringToDart(original_url);
+    auto canonicalized_url = file_loader.CanonicalizeURL(Dart_Null(), dart_url);
+    EXPECT_TRUE(canonicalized_url);
+    EXPECT_EQ(tonic::StdStringFromDart(canonicalized_url), original_url);
+    return true;
+  }));
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/third_party/tonic/file_loader/file_loader_win.cc
+++ b/third_party/tonic/file_loader/file_loader_win.cc
@@ -39,10 +39,6 @@ std::string FileLoader::SanitizePath(const std::string& url) {
   return SanitizeURIEscapedCharacters(sanitized);
 }
 
-std::string FileLoader::CanonicalizeFileURL(const std::string& url) {
-  return SanitizePath(url.substr(FileLoader::kFileURLPrefixLength));
-}
-
 bool FileLoader::ReadFileToString(const std::string& path,
                                   std::string* result) {
   TONIC_DCHECK(dirfd_ == -1);

--- a/third_party/tonic/tests/BUILD.gn
+++ b/third_party/tonic/tests/BUILD.gn
@@ -15,6 +15,7 @@ executable("tonic_unittests") {
   public_configs = [ "//flutter:export_dynamic_symbols" ]
 
   sources = [
+    "../file_loader/file_loader_unittests.cc",
     "dart_persistent_handle_unittest.cc",
     "dart_state_unittest.cc",
     "dart_weak_persistent_handle_unittest.cc",


### PR DESCRIPTION
The tonic method currently returns `///Users/test/foo` instead of `file:///Users/test/foo`.

Found while looking into making isolate spawning for flutter_tester work.