### PR TITLE
[CP][Impeller] Skip mask blur with 0 sigma. (#48457)

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3627,5 +3627,23 @@ TEST_P(AiksTest, ClearColorOptimizationWhenSubpassIsBiggerThanParentPass) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, MaskBlurWithZeroSigmaIsSkipped) {
+  Canvas canvas;
+
+  Paint paint = {
+      .color = Color::White(),
+      .mask_blur_descriptor =
+          Paint::MaskBlurDescriptor{
+              .style = FilterContents::BlurStyle::kNormal,
+              .sigma = Sigma(0),
+          },
+  };
+
+  canvas.DrawCircle({300, 300}, 200, paint);
+  canvas.DrawRect(Rect::MakeLTRB(100, 300, 500, 600), paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -18,6 +18,7 @@
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/contents/vertices_contents.h"
 #include "impeller/entity/geometry/geometry.h"
+#include "impeller/geometry/constants.h"
 #include "impeller/geometry/path_builder.h"
 
 namespace impeller {
@@ -203,6 +204,11 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
       new_paint.mask_blur_descriptor->style !=
           FilterContents::BlurStyle::kNormal) {
     return false;
+  }
+
+  if (std::fabs(new_paint.mask_blur_descriptor->sigma.sigma) <=
+      kEhCloseEnough) {
+    return true;
   }
 
   // For symmetrically mask blurred solid RRects, absorb the mask blur and use

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -8,6 +8,7 @@
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/color.h"
+#include "impeller/geometry/constants.h"
 #include "impeller/geometry/path.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/renderer/render_pass.h"
@@ -55,7 +56,8 @@ std::optional<Rect> SolidRRectBlurContents::GetCoverage(
 bool SolidRRectBlurContents::Render(const ContentContext& renderer,
                                     const Entity& entity,
                                     RenderPass& pass) const {
-  if (!rect_.has_value()) {
+  // Early return if sigma is close to zero to avoid rendering NaNs.
+  if (!rect_.has_value() || std::fabs(sigma_.sigma) <= kEhCloseEnough) {
     return true;
   }
 


### PR DESCRIPTION
<0 sigma render incorrectly with wide gamut, but these shouldn't produce shadows at all as far as I can tell.

https://github.com/flutter/flutter/issues/138842
