### PR TITLE
Avoid reloading the kernel snapshot when spawning an isolate in the same group

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -212,11 +212,10 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
 
   auto isolate_data = std::make_unique<std::shared_ptr<DartIsolate>>(
       std::shared_ptr<DartIsolate>(new DartIsolate(
-          settings,           // settings
-          true,               // is_root_isolate
-          context,            // context
-          !!spawning_isolate  // spawn_in_group
-          )));
+          /*settings=*/settings,
+          /*is_root_isolate=*/true,
+          /*context=*/context,
+          /*is_spawning_in_group=*/!!spawning_isolate)));
 
   DartErrorString error;
   Dart_Isolate vm_isolate = nullptr;
@@ -279,7 +278,7 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
 DartIsolate::DartIsolate(const Settings& settings,
                          bool is_root_isolate,
                          const UIDartState::Context& context,
-                         bool spawn_in_group)
+                         bool is_spawning_in_group)
     : UIDartState(settings.task_observer_add,
                   settings.task_observer_remove,
                   settings.log_tag,
@@ -291,7 +290,7 @@ DartIsolate::DartIsolate(const Settings& settings,
       may_insecurely_connect_to_all_domains_(
           settings.may_insecurely_connect_to_all_domains),
       domain_network_policy_(settings.domain_network_policy),
-      spawn_in_group_(spawn_in_group) {
+      is_spawning_in_group_(is_spawning_in_group) {
   phase_ = Phase::Uninitialized;
 }
 
@@ -554,7 +553,7 @@ bool DartIsolate::LoadKernel(const std::shared_ptr<const fml::Mapping>& mapping,
 
   tonic::DartState::Scope scope(this);
 
-  if (!child_isolate && !spawn_in_group_) {
+  if (!child_isolate && !is_spawning_in_group_) {
     if (!mapping || mapping->GetSize() == 0) {
       return false;
     }

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -20,6 +20,7 @@
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/platform_configuration.h"
 #include "flutter/runtime/dart_snapshot.h"
+#include "runtime/isolate_configuration.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/dart_state.h"
 
@@ -28,6 +29,7 @@ namespace flutter {
 class DartVM;
 class DartIsolateGroupData;
 class IsolateConfiguration;
+enum class IsolateLaunchType;
 
 //------------------------------------------------------------------------------
 /// @brief      Represents an instance of a live isolate. An isolate is a
@@ -412,6 +414,7 @@ class DartIsolate : public UIDartState {
   fml::RefPtr<fml::TaskRunner> message_handling_task_runner_;
   const bool may_insecurely_connect_to_all_domains_;
   std::string domain_network_policy_;
+  bool spawn_in_group_;
 
   static std::weak_ptr<DartIsolate> CreateRootIsolate(
       const Settings& settings,
@@ -425,7 +428,8 @@ class DartIsolate : public UIDartState {
 
   DartIsolate(const Settings& settings,
               bool is_root_isolate,
-              const UIDartState::Context& context);
+              const UIDartState::Context& context,
+              bool spawn_in_group = false);
 
   //----------------------------------------------------------------------------
   /// @brief      Initializes the given (current) isolate.

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -413,7 +413,7 @@ class DartIsolate : public UIDartState {
   fml::RefPtr<fml::TaskRunner> message_handling_task_runner_;
   const bool may_insecurely_connect_to_all_domains_;
   std::string domain_network_policy_;
-  bool is_spawning_in_group_;
+  const bool is_spawning_in_group_;
 
   static std::weak_ptr<DartIsolate> CreateRootIsolate(
       const Settings& settings,

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -413,7 +413,7 @@ class DartIsolate : public UIDartState {
   fml::RefPtr<fml::TaskRunner> message_handling_task_runner_;
   const bool may_insecurely_connect_to_all_domains_;
   std::string domain_network_policy_;
-  bool spawn_in_group_;
+  bool is_spawning_in_group_;
 
   static std::weak_ptr<DartIsolate> CreateRootIsolate(
       const Settings& settings,
@@ -428,7 +428,7 @@ class DartIsolate : public UIDartState {
   DartIsolate(const Settings& settings,
               bool is_root_isolate,
               const UIDartState::Context& context,
-              bool spawn_in_group = false);
+              bool is_spawning_in_group = false);
 
   //----------------------------------------------------------------------------
   /// @brief      Initializes the given (current) isolate.

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -29,7 +29,6 @@ namespace flutter {
 class DartVM;
 class DartIsolateGroupData;
 class IsolateConfiguration;
-enum class IsolateLaunchType;
 
 //------------------------------------------------------------------------------
 /// @brief      Represents an instance of a live isolate. An isolate is a

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -615,9 +615,12 @@ TEST_F(DartIsolateTest, SpawningAnIsolateDoesNotReloadKernel) {
     // This feels a little brittle, but the alternative seems to be making
     // DartIsolate have virtual methods so it can be mocked or exposing weird
     // test-only API on IsolateConfiguration.
-    settings.application_kernels =
-        [&get_kernel_count,
-         mapping = mappings.front().release()]() -> Mappings {
+    settings
+        .application_kernels = fml::MakeCopyable([&get_kernel_count,
+                                                  mapping = std::move(
+                                                      mappings
+                                                          .front())]() mutable
+                                                 -> Mappings {
       get_kernel_count++;
       if (get_kernel_count > 1) {
         FML_LOG(ERROR)
@@ -625,10 +628,9 @@ TEST_F(DartIsolateTest, SpawningAnIsolateDoesNotReloadKernel) {
         abort();
       }
       std::vector<std::unique_ptr<const fml::Mapping>> kernel_mappings;
-      kernel_mappings.emplace_back(
-          std::unique_ptr<const fml::Mapping>(mapping));
+      kernel_mappings.emplace_back(std::move(mapping));
       return kernel_mappings;
-    };
+    });
   }
 
   std::shared_ptr<DartIsolate> root_isolate;

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -649,7 +649,7 @@ TEST_F(DartIsolateTest, SpawningAnIsolateDoesNotReloadKernel) {
         /*isolate_shutdown_callback=*/settings.isolate_shutdown_callback,
         /*dart_entrypoint=*/"main",
         /*dart_entrypoint_library=*/std::nullopt,
-        /*dart_entrypoint_arguments=*/{},
+        /*dart_entrypoint_args=*/{},
         /*isolate_configuration=*/std::move(isolate_configuration),
         /*context=*/context);
     root_isolate = weak_isolate.lock();
@@ -680,7 +680,7 @@ TEST_F(DartIsolateTest, SpawningAnIsolateDoesNotReloadKernel) {
         /*isolate_shutdown_callback=*/settings.isolate_shutdown_callback,
         /*dart_entrypoint=*/"main",
         /*dart_entrypoint_library=*/std::nullopt,
-        /*dart_entrypoint_arguments=*/{},
+        /*dart_entrypoint_args=*/{},
         /*isolate_configuration=*/std::move(isolate_configuration),
         /*context=*/context,
         /*spawning_isolate=*/root_isolate.get());

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -607,7 +607,7 @@ TEST_F(DartIsolateTest, SpawningAnIsolateDoesNotReloadKernel) {
   );
 
   size_t get_kernel_count = 0u;
-  if (DartVM::IsRunningPrecompiledCode()) {
+  if (!DartVM::IsRunningPrecompiledCode()) {
     ASSERT_TRUE(settings.application_kernels);
     auto mappings = settings.application_kernels();
     ASSERT_EQ(mappings.size(), 1u);
@@ -656,7 +656,7 @@ TEST_F(DartIsolateTest, SpawningAnIsolateDoesNotReloadKernel) {
   }
   ASSERT_TRUE(root_isolate);
   ASSERT_EQ(root_isolate->GetPhase(), DartIsolate::Phase::Running);
-  if (DartVM::IsRunningPrecompiledCode()) {
+  if (!DartVM::IsRunningPrecompiledCode()) {
     ASSERT_EQ(get_kernel_count, 1u);
   }
 
@@ -687,7 +687,7 @@ TEST_F(DartIsolateTest, SpawningAnIsolateDoesNotReloadKernel) {
     auto spawned_isolate = weak_isolate.lock();
     ASSERT_TRUE(spawned_isolate);
     ASSERT_EQ(spawned_isolate->GetPhase(), DartIsolate::Phase::Running);
-    if (DartVM::IsRunningPrecompiledCode()) {
+    if (!DartVM::IsRunningPrecompiledCode()) {
       ASSERT_EQ(get_kernel_count, 1u);
     }
     ASSERT_TRUE(spawned_isolate->Shutdown());

--- a/runtime/isolate_configuration.h
+++ b/runtime/isolate_configuration.h
@@ -19,6 +19,17 @@
 
 namespace flutter {
 
+/// Describes whether the isolate is part of a group or not.
+///
+/// If the isolate is part of a group, it avoids reloading the kernel snapshot.
+enum class IsolateLaunchType {
+  /// The isolate is launched as a solo isolate or to start a new group.
+  kNewGroup,
+  /// The isolate is launched as part of a group, and avoids reloading the
+  /// kernel snapshot.
+  kExistingGroup,
+};
+
 //------------------------------------------------------------------------------
 /// @brief      An isolate configuration is a collection of snapshots and asset
 ///             managers that the engine will use to configure the isolate
@@ -57,6 +68,10 @@ class IsolateConfiguration {
   /// @param[in]  io_worker      An optional IO worker. Specify `nullptr` if a
   ///                            worker should not be used or one is not
   ///                            available.
+  /// @param[in]  launch_type    Whether the isolate is launching to form a new
+  ///                            group or as part of an existing group. If it is
+  ///                            part of an existing group, the isolate will
+  ///                            reuse resources if it can.
   ///
   /// @return     An isolate configuration if one can be inferred from the
   ///             settings. If not, returns `nullptr`.
@@ -64,7 +79,8 @@ class IsolateConfiguration {
   [[nodiscard]] static std::unique_ptr<IsolateConfiguration> InferFromSettings(
       const Settings& settings,
       const std::shared_ptr<AssetManager>& asset_manager = nullptr,
-      const fml::RefPtr<fml::TaskRunner>& io_worker = nullptr);
+      const fml::RefPtr<fml::TaskRunner>& io_worker = nullptr,
+      IsolateLaunchType launch_type = IsolateLaunchType::kNewGroup);
 
   //----------------------------------------------------------------------------
   /// @brief      Creates an AOT isolate configuration using snapshot symbols


### PR DESCRIPTION
Found by @mraleph while looking at flutter_tester related things with me.

I took some suggestions from him and added a test. This should eventually help speed up running large multi-file test suites.

The test is a little bit wonky because we don't have great inspection points (e.g. something to mock or examine from a test). It should break if we change the way we load kernel assets in the test harness, and is verifying that we only ask for the test asset once where we used to ask for it twice.