### PR TITLE
[Impeller] fix descriptor pool recycler test flake.

### DIFF
--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -56,13 +56,7 @@ std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     Sigma sigma_y,
     BlurStyle blur_style,
     Entity::TileMode tile_mode) {
-  constexpr bool use_new_filter =
-#ifdef IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER
-      true;
-#else
-      false;
-#endif
-
+  constexpr bool use_new_filter = true;
   // TODO(https://github.com/flutter/flutter/issues/131580): Remove once the new
   // blur handles all cases.
   if (use_new_filter) {

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -56,7 +56,13 @@ std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     Sigma sigma_y,
     BlurStyle blur_style,
     Entity::TileMode tile_mode) {
-  constexpr bool use_new_filter = true;
+  constexpr bool use_new_filter =
+#ifdef IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER
+      true;
+#else
+      false;
+#endif
+
   // TODO(https://github.com/flutter/flutter/issues/131580): Remove once the new
   // blur handles all cases.
   if (use_new_filter) {


### PR DESCRIPTION
This test worked by 1) releasing an item to be destructed on a background thead 2) adding a second item to this queue with a waitable event.

The idea being you could wait for the event and that would tell you when 1) was complete. Unfortunately these items are released by being placed into a std::vector, which destroyed in _reverse_ order. Somtimes when the test state was queried the work was done and sometimes it wasn't

To fix this, add a second waitable event that guarantees that both the first event and the original event have finished - because we do not add these event until the first is destructed and we do not add items to the destroy list while it is in progress.