### PR TITLE
[CP][Impeller] Switched to static linked libc++ in vulkan validation layers.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -262,7 +262,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '9780f253156165c515962f5f0c56235d34617689',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'f27d99b4428dea312646130d60c33a2d38fa9dc6',
 
    # Fuchsia compatibility
    #

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -507,13 +507,9 @@ action("android_jar") {
       "--native_lib",
       rebase_path("$validation_layer_out_dir/libVkLayer_khronos_validation.so"),
     ]
-    if (current_cpu == "arm64") {
-      args += [
-        "--native_lib",
-        rebase_path("$android_libcpp_root/libs/arm64-v8a/libc++_shared.so",
-                    root_build_dir),
-      ]
-    } else {
+    if (current_cpu != "arm64") {
+      # This may not be necessarily required anymore. It was kept to maintain
+      # old behavior.
       assert(false, "Validation layers not supported for arch.")
     }
   }


### PR DESCRIPTION
CP of the flutter/engine part of https://github.com/flutter/engine/pull/48290.