### PR TITLE
[Impeller] Started expanding the blur clip region

### DIFF
--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -50,6 +50,8 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
   return blur;
 }
 
+#define IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER 1
+
 std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     const FilterInput::Ref& input,
     Sigma sigma_x,

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -50,8 +50,6 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
   return blur;
 }
 
-#define IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER 1
-
 std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     const FilterInput::Ref& input,
     Sigma sigma_x,

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -54,6 +54,8 @@ Matrix MakeAnchorScale(const Point& anchor, Vector2 scale) {
          Matrix::MakeTranslation({-anchor.x, -anchor.y, 0});
 }
 
+/// Makes a subpass that will render the scaled down input and add the
+/// transparent gutter required for the blur halo.
 std::shared_ptr<Texture> MakeDownsampleSubpass(
     const ContentContext& renderer,
     std::shared_ptr<Texture> input_texture,

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -243,6 +243,9 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
   }
 
   Scalar desired_scalar = CalculateScale(sigma_);
+  // TODO(jonahwilliams): If desired_scalar is 1.0 and we fully acquired the
+  // gutter from the expanded_coverage_hint, we can skip the downsample pass.
+  // pass.
   Vector2 downsample_scalar(desired_scalar, desired_scalar);
   Vector2 padded_size =
       Vector2(input_snapshot->texture->GetSize()) + 2.0 * padding;


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/139317
test: AiksTest.CanRenderClippedBlur

This works by double padding.  First it applies the padding to clip region, then it add a transparent gutter around the snapshot to account for any of the expanded clip region that was ignored.  This is suboptimal since there maybe a considerable region for which blur is calculated that is clipped.  That can be optimized in the future by adjusting the UVs in the blur phases to match the clip region.

## screenshot of result
<img width="1026" alt="Screenshot 2023-11-30 at 10 28 14 AM" src="https://github.com/flutter/engine/assets/30870216/a0c673db-8b7a-465e-a75c-09f19d1b98aa">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
