### PR TITLE
[Impeller] Fix size of squares in DrawPoints(PointMode).

### DIFF
--- a/impeller/entity/geometry/point_field_geometry.cc
+++ b/impeller/entity/geometry/point_field_geometry.cc
@@ -181,7 +181,7 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
 
     PS::FrameInfo frame_info;
     frame_info.count = points_.size();
-    frame_info.radius = radius;
+    frame_info.radius = round_ ? radius : radius * kSqrt2;
     frame_info.radian_start = round_ ? 0.0f : kPiOver4;
     frame_info.radian_step = k2Pi / vertices_per_geom;
     frame_info.points_per_circle = points_per_circle;


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/138877

The existing golden tests were already showing this bug, but we didn't see it. With this fix the size of the squares should be the same as the circle for the round caps in the DrawPoints playground goldens.

Test exemption request: This fix is covered by existing golden tests.