### PR TITLE
[Impeller] Directly tessellate stroked circles.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2060,7 +2060,7 @@ TEST_P(AiksTest, DrawLinesRenderCorrectly) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
-TEST_P(AiksTest, FillCirclesRenderCorrectly) {
+TEST_P(AiksTest, FilledCirclesRenderCorrectly) {
   Canvas canvas;
   canvas.Scale(GetContentScale());
   Paint paint;
@@ -2070,6 +2070,9 @@ TEST_P(AiksTest, FillCirclesRenderCorrectly) {
       Color::Green(),
       Color::Crimson(),
   };
+
+  paint.color = Color::White();
+  canvas.DrawPaint(paint);
 
   int c_index = 0;
   int radius = 600;
@@ -2082,6 +2085,100 @@ TEST_P(AiksTest, FillCirclesRenderCorrectly) {
       radius -= 2;
     }
   }
+
+  std::vector<Color> gradient_colors = {
+      Color{0x1f / 255.0, 0.0, 0x5c / 255.0, 1.0},
+      Color{0x5b / 255.0, 0.0, 0x60 / 255.0, 1.0},
+      Color{0x87 / 255.0, 0x01 / 255.0, 0x60 / 255.0, 1.0},
+      Color{0xac / 255.0, 0x25 / 255.0, 0x53 / 255.0, 1.0},
+      Color{0xe1 / 255.0, 0x6b / 255.0, 0x5c / 255.0, 1.0},
+      Color{0xf3 / 255.0, 0x90 / 255.0, 0x60 / 255.0, 1.0},
+      Color{0xff / 255.0, 0xb5 / 255.0, 0x6b / 250.0, 1.0}};
+  std::vector<Scalar> stops = {
+      0.0,
+      (1.0 / 6.0) * 1,
+      (1.0 / 6.0) * 2,
+      (1.0 / 6.0) * 3,
+      (1.0 / 6.0) * 4,
+      (1.0 / 6.0) * 5,
+      1.0,
+  };
+  auto texture = CreateTextureForFixture("airplane.jpg",
+                                         /*enable_mipmapping=*/true);
+
+  paint.color_source = ColorSource::MakeRadialGradient(
+      {500, 600}, 75, std::move(gradient_colors), std::move(stops),
+      Entity::TileMode::kMirror, {});
+  canvas.DrawCircle({500, 600}, 100, paint);
+
+  paint.color_source = ColorSource::MakeImage(
+      texture, Entity::TileMode::kRepeat, Entity::TileMode::kRepeat, {},
+      Matrix::MakeTranslation({700, 200}));
+  canvas.DrawCircle({800, 300}, 100, paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, StrokedCirclesRenderCorrectly) {
+  Canvas canvas;
+  canvas.Scale(GetContentScale());
+  Paint paint;
+  const int color_count = 3;
+  Color colors[color_count] = {
+      Color::Blue(),
+      Color::Green(),
+      Color::Crimson(),
+  };
+
+  paint.color = Color::White();
+  canvas.DrawPaint(paint);
+
+  int c_index = 0;
+
+  auto draw = [&paint, &colors, &c_index](Canvas& canvas, Point center,
+                                          Scalar r, Scalar dr, int n) {
+    for (int i = 0; i < n; i++) {
+      paint.color = colors[(c_index++) % color_count];
+      canvas.DrawCircle(center, r, paint);
+      r += dr;
+    }
+  };
+
+  paint.style = Paint::Style::kStroke;
+  paint.stroke_width = 1;
+  draw(canvas, {10, 10}, 2, 2, 14);  // r = [2, 28], covers [1,29]
+  paint.stroke_width = 5;
+  draw(canvas, {10, 10}, 35, 10, 56);  // r = [35, 585], covers [30,590]
+
+  std::vector<Color> gradient_colors = {
+      Color{0x1f / 255.0, 0.0, 0x5c / 255.0, 1.0},
+      Color{0x5b / 255.0, 0.0, 0x60 / 255.0, 1.0},
+      Color{0x87 / 255.0, 0x01 / 255.0, 0x60 / 255.0, 1.0},
+      Color{0xac / 255.0, 0x25 / 255.0, 0x53 / 255.0, 1.0},
+      Color{0xe1 / 255.0, 0x6b / 255.0, 0x5c / 255.0, 1.0},
+      Color{0xf3 / 255.0, 0x90 / 255.0, 0x60 / 255.0, 1.0},
+      Color{0xff / 255.0, 0xb5 / 255.0, 0x6b / 250.0, 1.0}};
+  std::vector<Scalar> stops = {
+      0.0,
+      (1.0 / 6.0) * 1,
+      (1.0 / 6.0) * 2,
+      (1.0 / 6.0) * 3,
+      (1.0 / 6.0) * 4,
+      (1.0 / 6.0) * 5,
+      1.0,
+  };
+  auto texture = CreateTextureForFixture("airplane.jpg",
+                                         /*enable_mipmapping=*/true);
+
+  paint.color_source = ColorSource::MakeRadialGradient(
+      {500, 600}, 75, std::move(gradient_colors), std::move(stops),
+      Entity::TileMode::kMirror, {});
+  draw(canvas, {500, 600}, 5, 10, 10);
+
+  paint.color_source = ColorSource::MakeImage(
+      texture, Entity::TileMode::kRepeat, Entity::TileMode::kRepeat, {},
+      Matrix::MakeTranslation({700, 200}));
+  draw(canvas, {800, 300}, 5, 10, 10);
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/impeller/entity/geometry/ellipse_geometry.h
+++ b/impeller/entity/geometry/ellipse_geometry.h
@@ -11,6 +11,7 @@ namespace impeller {
 class EllipseGeometry final : public Geometry {
  public:
   explicit EllipseGeometry(Point center, Scalar radius);
+  explicit EllipseGeometry(Point center, Scalar radius, Scalar stroke_width);
 
   ~EllipseGeometry() = default;
 
@@ -59,6 +60,7 @@ class EllipseGeometry final : public Geometry {
 
   Point center_;
   Scalar radius_;
+  Scalar stroke_width_;
 
   EllipseGeometry(const EllipseGeometry&) = delete;
 

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -123,6 +123,12 @@ std::shared_ptr<Geometry> Geometry::MakeCircle(Point center, Scalar radius) {
   return std::make_shared<EllipseGeometry>(center, radius);
 }
 
+std::shared_ptr<Geometry> Geometry::MakeStrokedCircle(Point center,
+                                                      Scalar radius,
+                                                      Scalar stroke_width) {
+  return std::make_shared<EllipseGeometry>(center, radius, stroke_width);
+}
+
 bool Geometry::CoversArea(const Matrix& transform, const Rect& rect) const {
   return false;
 }

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -70,6 +70,10 @@ class Geometry {
 
   static std::shared_ptr<Geometry> MakeCircle(Point center, Scalar radius);
 
+  static std::shared_ptr<Geometry> MakeStrokedCircle(Point center,
+                                                     Scalar radius,
+                                                     Scalar stroke_width);
+
   static std::shared_ptr<Geometry> MakePointField(std::vector<Point> points,
                                                   Scalar radius,
                                                   bool round);

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -13,19 +13,20 @@ LineGeometry::LineGeometry(Point p0, Point p1, Scalar width, Cap cap)
   FML_DCHECK(width >= 0);
 }
 
-Scalar LineGeometry::ComputeHalfWidth(const Matrix& transform) const {
+Scalar LineGeometry::ComputePixelHalfWidth(const Matrix& transform,
+                                           Scalar width) {
   auto determinant = transform.GetDeterminant();
   if (determinant == 0) {
     return 0.0f;
   }
 
   Scalar min_size = 1.0f / sqrt(std::abs(determinant));
-  return std::max(width_, min_size) * 0.5f;
+  return std::max(width, min_size) * 0.5f;
 }
 
 Vector2 LineGeometry::ComputeAlongVector(const Matrix& transform,
                                          bool allow_zero_length) const {
-  Scalar stroke_half_width = ComputeHalfWidth(transform);
+  Scalar stroke_half_width = ComputePixelHalfWidth(transform, width_);
   if (stroke_half_width < kEhCloseEnough) {
     return {};
   }
@@ -72,7 +73,7 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
   using VT = SolidFillVertexShader::PerVertexData;
 
   auto& transform = entity.GetTransform();
-  auto radius = ComputeHalfWidth(transform);
+  auto radius = ComputePixelHalfWidth(transform, width_);
 
   size_t count;
   BufferView vertex_buffer;
@@ -138,7 +139,7 @@ GeometryResult LineGeometry::GetPositionUVBuffer(Rect texture_coverage,
   using VT = TextureFillVertexShader::PerVertexData;
 
   auto& transform = entity.GetTransform();
-  auto radius = ComputeHalfWidth(transform);
+  auto radius = ComputePixelHalfWidth(transform, width_);
 
   auto uv_transform =
       texture_coverage.GetNormalizingTransform() * effect_transform;

--- a/impeller/entity/geometry/line_geometry.h
+++ b/impeller/entity/geometry/line_geometry.h
@@ -15,6 +15,8 @@ class LineGeometry final : public Geometry {
 
   ~LineGeometry() = default;
 
+  static Scalar ComputePixelHalfWidth(const Matrix& transform, Scalar width);
+
   // |Geometry|
   bool CoversArea(const Matrix& transform, const Rect& rect) const override;
 
@@ -42,8 +44,6 @@ class LineGeometry final : public Geometry {
 
   Vector2 ComputeAlongVector(const Matrix& transform,
                              bool allow_zero_length) const;
-
-  Scalar ComputeHalfWidth(const Matrix& transform) const;
 
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,

--- a/impeller/tessellator/circle_tessellator.cc
+++ b/impeller/tessellator/circle_tessellator.cc
@@ -162,19 +162,69 @@ void CircleTessellator::GenerateCircleTriangleStrip(
     const TessellatedPointProc& proc,
     const Point& center,
     Scalar radius) const {
+  // Quadrant 1 connecting with Quadrant 4:
   for (auto& trig : trigs_) {
     auto offset = trig * radius;
     proc({center.x - offset.x, center.y + offset.y});
     proc({center.x - offset.x, center.y - offset.y});
   }
+
   // The second half of the circle should be iterated in reverse, but
   // we can instead iterate forward and swap the x/y values of the
   // offset as the angles should be symmetric and thus should generate
-  // symmetrically reversed offset vectors.
+  // symmetrically reversed trig vectors.
+  // Quadrant 2 connecting with Quadrant 2:
   for (auto& trig : trigs_) {
     auto offset = trig * radius;
     proc({center.x + offset.y, center.y + offset.x});
     proc({center.x + offset.y, center.y - offset.x});
+  }
+}
+
+void CircleTessellator::GenerateStrokedCircleTriangleStrip(
+    const TessellatedPointProc& proc,
+    const Point& center,
+    Scalar outer_radius,
+    Scalar inner_radius) const {
+  // Zig-zag back and forth between points on the outer circle and the
+  // inner circle. Both circles are evaluated at the same number of
+  // quadrant divisions so the points for a given division should match
+  // 1 for 1 other than their applied radius.
+
+  // Quadrant 1:
+  for (auto& trig : trigs_) {
+    auto outer = trig * outer_radius;
+    auto inner = trig * inner_radius;
+    proc({center.x - outer.x, center.y - outer.y});
+    proc({center.x - inner.x, center.y - inner.y});
+  }
+
+  // The even quadrants of the circle should be iterated in reverse, but
+  // we can instead iterate forward and swap the x/y values of the
+  // offset as the angles should be symmetric and thus should generate
+  // symmetrically reversed trig vectors.
+  // Quadrant 2:
+  for (auto& trig : trigs_) {
+    auto outer = trig * outer_radius;
+    auto inner = trig * inner_radius;
+    proc({center.x + outer.y, center.y - outer.x});
+    proc({center.x + inner.y, center.y - inner.x});
+  }
+
+  // Quadrant 3:
+  for (auto& trig : trigs_) {
+    auto outer = trig * outer_radius;
+    auto inner = trig * inner_radius;
+    proc({center.x + outer.x, center.y + outer.y});
+    proc({center.x + inner.x, center.y + inner.y});
+  }
+
+  // Quadrant 4:
+  for (auto& trig : trigs_) {
+    auto outer = trig * outer_radius;
+    auto inner = trig * inner_radius;
+    proc({center.x - outer.y, center.y + outer.x});
+    proc({center.x - inner.y, center.y + inner.x});
   }
 }
 

--- a/impeller/tessellator/circle_tessellator.h
+++ b/impeller/tessellator/circle_tessellator.h
@@ -67,6 +67,15 @@ class CircleTessellator {
   ///          |GenerateRoundCapLineTriangleStrip| methods.
   size_t GetCircleVertexCount() const { return trigs_.size() * 4; }
 
+  /// @brief   Return the number of vertices that will be generated to
+  ///          tessellate a full stroked circle with a triangle strip.
+  ///
+  ///          This value can be used to pre-allocate space in a vector
+  ///          to hold the vertices that will be produced by the
+  ///          |GenerateCircleTriangleStrip| and
+  ///          |GenerateRoundCapLineTriangleStrip| methods.
+  size_t GetStrokedCircleVertexCount() const { return trigs_.size() * 8; }
+
   /// @brief   Generate the vertices for a triangle strip that covers the
   ///          circle at a given |radius| from a given |center|, delivering
   ///          the computed coordinates to the supplied |proc|.
@@ -77,6 +86,19 @@ class CircleTessellator {
   void GenerateCircleTriangleStrip(const TessellatedPointProc& proc,
                                    const Point& center,
                                    Scalar radius) const;
+
+  /// @brief   Generate the vertices for a triangle strip that draws the gap
+  ///          between 2 circles at |outer_radius| and |inner_radius|
+  ///          from a given |center|, delivering the computed coordinates to
+  ///          the supplied |proc|.
+  ///
+  ///          This procedure will generate no more than the number of
+  ///          vertices returned by |GetStrokedCircleVertexCount| in an order
+  ///          appropriate for rendering as a triangle strip.
+  void GenerateStrokedCircleTriangleStrip(const TessellatedPointProc& proc,
+                                          const Point& center,
+                                          Scalar outer_radius,
+                                          Scalar inner_radius) const;
 
   /// @brief   Generate the vertices for a triangle strip that covers the
   ///          line from |p0| to |p1| with round caps of the specified


### PR DESCRIPTION
Similar work as done for filled circles in https://github.com/flutter/engine/pull/48103, stroked circles can also be directly tessellated using the same internal data structures used for filled circles.