### PR TITLE
[Impeller] Render emoji shadows with correct colors.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -19,14 +19,12 @@
 #include "impeller/aiks/paint_pass_delegate.h"
 #include "impeller/aiks/testing/context_spy.h"
 #include "impeller/core/capture.h"
-#include "impeller/entity/contents/color_source_contents.h"
 #include "impeller/entity/contents/conical_gradient_contents.h"
 #include "impeller/entity/contents/filters/inputs/filter_input.h"
 #include "impeller/entity/contents/linear_gradient_contents.h"
 #include "impeller/entity/contents/radial_gradient_contents.h"
 #include "impeller/entity/contents/solid_color_contents.h"
 #include "impeller/entity/contents/sweep_gradient_contents.h"
-#include "impeller/entity/contents/tiled_texture_contents.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/constants.h"
 #include "impeller/geometry/geometry_asserts.h"
@@ -45,7 +43,6 @@
 #include "impeller/typographer/backends/stb/typeface_stb.h"
 #include "impeller/typographer/backends/stb/typographer_context_stb.h"
 #include "third_party/imgui/imgui.h"
-#include "third_party/skia/include/core/SkData.h"
 #include "third_party/skia/include/core/SkFontMgr.h"
 #include "third_party/skia/include/core/SkTypeface.h"
 #include "txt/platform.h"
@@ -1378,7 +1375,7 @@ TEST_P(AiksTest, CanDrawAnOpenPathThatIsntARect) {
 
 struct TextRenderOptions {
   Scalar font_size = 50;
-  Scalar alpha = 1;
+  Color color = Color::Yellow();
   Point position = Vector2(100, 200);
   std::optional<Paint::MaskBlurDescriptor> mask_blur_descriptor;
 };
@@ -1386,7 +1383,7 @@ struct TextRenderOptions {
 bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
                             Canvas& canvas,
                             const std::string& text,
-                            const std::string& font_fixture,
+                            const std::string_view& font_fixture,
                             TextRenderOptions options = {}) {
   // Draw the baseline.
   canvas.DrawRect(
@@ -1398,7 +1395,8 @@ bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
                     Paint{.color = Color::Red().WithAlpha(0.25)});
 
   // Construct the text blob.
-  auto mapping = flutter::testing::OpenFixtureAsSkData(font_fixture.c_str());
+  auto c_font_fixture = std::string(font_fixture);
+  auto mapping = flutter::testing::OpenFixtureAsSkData(c_font_fixture.c_str());
   if (!mapping) {
     return false;
   }
@@ -1413,7 +1411,7 @@ bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
   auto frame = MakeTextFrameFromTextBlobSkia(blob);
 
   Paint text_paint;
-  text_paint.color = Color::Yellow().WithAlpha(options.alpha);
+  text_paint.color = options.color;
   text_paint.mask_blur_descriptor = options.mask_blur_descriptor;
   canvas.DrawTextFrame(frame, options.position, text_paint);
   return true;
@@ -1444,7 +1442,7 @@ bool RenderTextInCanvasSTB(const std::shared_ptr<Context>& context,
       typeface_stb, Font::Metrics{.point_size = options.font_size}, text);
 
   Paint text_paint;
-  text_paint.color = Color::Yellow().WithAlpha(options.alpha);
+  text_paint.color = options.color;
   canvas.DrawTextFrame(frame, options.position, text_paint);
   return true;
 }
@@ -1522,17 +1520,19 @@ TEST_P(AiksTest, CanRenderItalicizedText) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+static constexpr std::string_view kFontFixture =
+#if FML_OS_MACOSX
+    "Apple Color Emoji.ttc";
+#else
+    "NotoColorEmoji.ttf";
+#endif
+
 TEST_P(AiksTest, CanRenderEmojiTextFrame) {
   Canvas canvas;
   canvas.DrawPaint({.color = Color(0.1, 0.1, 0.1, 1.0)});
 
-  ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), canvas,
-                                     "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 😊",
-#if FML_OS_MACOSX
-                                     "Apple Color Emoji.ttc"));
-#else
-                                     "NotoColorEmoji.ttf"));
-#endif
+  ASSERT_TRUE(RenderTextInCanvasSkia(
+      GetContext(), canvas, "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 😊", kFontFixture));
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -1540,18 +1540,12 @@ TEST_P(AiksTest, CanRenderEmojiTextFrameWithBlur) {
   Canvas canvas;
   canvas.DrawPaint({.color = Color(0.1, 0.1, 0.1, 1.0)});
 
-  auto font_fixture =
-#if FML_OS_MACOSX
-      "Apple Color Emoji.ttc";
-#else
-      "NotoColorEmoji.ttf";
-#endif
-
   ASSERT_TRUE(RenderTextInCanvasSkia(
-      GetContext(), canvas, "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 😊", font_fixture,
-      TextRenderOptions{.mask_blur_descriptor = Paint::MaskBlurDescriptor{
+      GetContext(), canvas, "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 😊", kFontFixture,
+      TextRenderOptions{.color = Color::Blue(),
+                        .mask_blur_descriptor = Paint::MaskBlurDescriptor{
                             .style = FilterContents::BlurStyle::kNormal,
-                            .sigma = Sigma(16)}}));
+                            .sigma = Sigma(4)}}));
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -1559,14 +1553,9 @@ TEST_P(AiksTest, CanRenderEmojiTextFrameWithAlpha) {
   Canvas canvas;
   canvas.DrawPaint({.color = Color(0.1, 0.1, 0.1, 1.0)});
 
-  ASSERT_TRUE(RenderTextInCanvasSkia(GetContext(), canvas,
-                                     "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 😊",
-#if FML_OS_MACOSX
-                                     "Apple Color Emoji.ttc", { .alpha = 0.5 }
-#else
-                                     "NotoColorEmoji.ttf", {.alpha = 0.5}
-#endif
-                                     ));
+  ASSERT_TRUE(RenderTextInCanvasSkia(
+      GetContext(), canvas, "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 😊", kFontFixture,
+      {.color = Color::Black().WithAlpha(0.5)}));
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1380,6 +1380,7 @@ struct TextRenderOptions {
   Scalar font_size = 50;
   Scalar alpha = 1;
   Point position = Vector2(100, 200);
+  std::optional<Paint::MaskBlurDescriptor> mask_blur_descriptor;
 };
 
 bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
@@ -1413,6 +1414,7 @@ bool RenderTextInCanvasSkia(const std::shared_ptr<Context>& context,
 
   Paint text_paint;
   text_paint.color = Color::Yellow().WithAlpha(options.alpha);
+  text_paint.mask_blur_descriptor = options.mask_blur_descriptor;
   canvas.DrawTextFrame(frame, options.position, text_paint);
   return true;
 }
@@ -1531,6 +1533,25 @@ TEST_P(AiksTest, CanRenderEmojiTextFrame) {
 #else
                                      "NotoColorEmoji.ttf"));
 #endif
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, CanRenderEmojiTextFrameWithBlur) {
+  Canvas canvas;
+  canvas.DrawPaint({.color = Color(0.1, 0.1, 0.1, 1.0)});
+
+  auto font_fixture =
+#if FML_OS_MACOSX
+      "Apple Color Emoji.ttc";
+#else
+      "NotoColorEmoji.ttf";
+#endif
+
+  ASSERT_TRUE(RenderTextInCanvasSkia(
+      GetContext(), canvas, "😀 😃 😄 😁 😆 😅 😂 🤣 🥲 😊", font_fixture,
+      TextRenderOptions{.mask_blur_descriptor = Paint::MaskBlurDescriptor{
+                            .style = FilterContents::BlurStyle::kNormal,
+                            .sigma = Sigma(16)}}));
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -590,6 +590,7 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
   auto text_contents = std::make_shared<TextContents>();
   text_contents->SetTextFrame(text_frame);
   text_contents->SetColor(paint.color);
+  text_contents->SetForceTextColor(paint.mask_blur_descriptor.has_value());
 
   entity.SetTransform(GetCurrentTransform() *
                       Matrix::MakeTranslation(position));

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -60,6 +60,10 @@ void TextContents::SetOffset(Vector2 offset) {
   offset_ = offset;
 }
 
+void TextContents::SetForceTextColor(bool value) {
+  force_text_color_ = value;
+}
+
 std::optional<Rect> TextContents::GetCoverage(const Entity& entity) const {
   return frame_->GetBounds().TransformBounds(entity.GetTransform());
 }
@@ -116,6 +120,14 @@ bool TextContents::Render(const ContentContext& renderer,
   frame_info.text_color = ToVector(color.Premultiply());
 
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
+
+  if (type == GlyphAtlas::Type::kColorBitmap) {
+    using FSS = GlyphAtlasColorPipeline::FragmentShader;
+    FSS::FragInfo frag_info;
+    frag_info.use_text_color = force_text_color_ ? 1.0 : 0.0;
+    FSS::BindFragInfo(cmd,
+                      pass.GetTransientsBuffer().EmplaceUniform(frag_info));
+  }
 
   SamplerDescriptor sampler_desc;
   if (frame_info.is_translation_scale) {

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -30,6 +30,10 @@ class TextContents final : public Contents {
 
   void SetColor(Color color);
 
+  /// @brief Force the text color to apply to the rendered glyphs, even if those
+  ///        glyphs are bitmaps.
+  void SetForceTextColor(bool value);
+
   Color GetColor() const;
 
   // |Contents|
@@ -61,6 +65,7 @@ class TextContents final : public Contents {
   Color color_;
   Scalar inherited_opacity_ = 1.0;
   Vector2 offset_;
+  bool force_text_color_ = false;
 
   std::shared_ptr<GlyphAtlas> ResolveAtlas(
       Context& context,

--- a/impeller/entity/contents/text_contents.h
+++ b/impeller/entity/contents/text_contents.h
@@ -32,6 +32,8 @@ class TextContents final : public Contents {
 
   /// @brief Force the text color to apply to the rendered glyphs, even if those
   ///        glyphs are bitmaps.
+  ///
+  ///        This is used to ensure that mask blurs work correctly on emoji.
   void SetForceTextColor(bool value);
 
   Color GetColor() const;

--- a/impeller/entity/shaders/glyph_atlas_color.frag
+++ b/impeller/entity/shaders/glyph_atlas_color.frag
@@ -8,6 +8,11 @@ precision mediump float;
 
 uniform f16sampler2D glyph_atlas_sampler;
 
+uniform FragInfo {
+  float use_text_color;
+}
+frag_info;
+
 in highp vec2 v_uv;
 
 IMPELLER_MAYBE_FLAT in f16vec4 v_text_color;
@@ -16,5 +21,9 @@ out f16vec4 frag_color;
 
 void main() {
   f16vec4 value = texture(glyph_atlas_sampler, v_uv);
-  frag_color = value * v_text_color.aaaa;
+  if (frag_info.use_text_color == 1.0f) {
+    frag_color = value.aaaa * v_text_color;
+  } else {
+    frag_color = value * v_text_color.aaaa;
+  }
 }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -3758,7 +3758,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/gles/glyph_atlas_color.frag.gles",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -3773,9 +3773,9 @@
               "varying"
             ],
             "longest_path_cycles": [
-              0.03125,
-              0.03125,
-              0.03125,
+              0.0625,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
               0.5,
@@ -3794,9 +3794,9 @@
               "varying"
             ],
             "shortest_path_cycles": [
+              0.0625,
+              0.0625,
               0.03125,
-              0.03125,
-              0.0,
               0.0,
               0.0,
               0.5,
@@ -3806,9 +3806,9 @@
               "varying"
             ],
             "total_cycles": [
-              0.03125,
-              0.03125,
-              0.03125,
+              0.0625,
+              0.0625,
+              0.0625,
               0.0,
               0.0,
               0.5,
@@ -3857,17 +3857,16 @@
               1.0
             ],
             "total_bound_pipelines": [
-              "load_store",
-              "texture"
+              "arithmetic"
             ],
             "total_cycles": [
-              0.6666666865348816,
+              1.3333333730697632,
               1.0,
               1.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 0,
+          "uniform_registers_used": 1,
           "work_registers_used": 2
         }
       }
@@ -7544,7 +7543,7 @@
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/glyph_atlas_color.frag.vkspv",
       "has_side_effects": false,
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "modifies_coverage": false,
       "reads_color_buffer": false,
       "type": "Fragment",
@@ -7559,9 +7558,9 @@
               "varying"
             ],
             "longest_path_cycles": [
+              0.0625,
+              0.0625,
               0.03125,
-              0.03125,
-              0.0,
               0.0,
               0.0,
               0.5,
@@ -7580,9 +7579,9 @@
               "varying"
             ],
             "shortest_path_cycles": [
+              0.0625,
+              0.0625,
               0.03125,
-              0.03125,
-              0.0,
               0.0,
               0.0,
               0.5,
@@ -7592,9 +7591,9 @@
               "varying"
             ],
             "total_cycles": [
+              0.0625,
+              0.0625,
               0.03125,
-              0.03125,
-              0.0,
               0.0,
               0.0,
               0.5,
@@ -7604,7 +7603,7 @@
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
           "uniform_registers_used": 4,
-          "work_registers_used": 6
+          "work_registers_used": 8
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/138819

Emoji glyphs normally ignore their text color (except for alpha channel). Text shadows are created by rendering the font with the shadow color as the text color and then applying a blur. If this is done to an emoji, we need to apply the text color so that the shadow has the correct color.