### PR TITLE
[Impeller] Remove impeller::Path copy constructor.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -80,8 +80,8 @@ TEST_P(AiksTest, RotateColorFilteredPath) {
           ColorFilter::MakeBlend(BlendMode::kSourceIn, Color::AliceBlue()),
   };
 
-  canvas.DrawPath(arrow_stem, paint);
-  canvas.DrawPath(arrow_head, paint);
+  canvas.DrawPath(std::move(arrow_stem), paint);
+  canvas.DrawPath(std::move(arrow_head), paint);
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
@@ -1266,7 +1266,7 @@ TEST_P(AiksTest, CanRenderRoundedRectWithNonUniformRadii) {
                   .AddRoundedRect(Rect::MakeXYWH(100, 100, 500, 500), radii)
                   .TakePath();
 
-  canvas.DrawPath(path, paint);
+  canvas.DrawPath(std::move(path), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -1323,7 +1323,7 @@ TEST_P(AiksTest, CanRenderDifferencePaths) {
   canvas.DrawImage(
       std::make_shared<Image>(CreateTextureForFixture("boston.jpg")), {10, 10},
       Paint{});
-  canvas.DrawPath(path, paint);
+  canvas.DrawPath(std::move(path), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
@@ -1984,7 +1984,7 @@ TEST_P(AiksTest, SolidStrokesRenderCorrectly) {
       paint.stroke_join = join;
       for (auto cap : {Cap::kButt, Cap::kSquare, Cap::kRound}) {
         paint.stroke_cap = cap;
-        canvas.DrawPath(path, paint);
+        canvas.DrawPath(std::move(path), paint);
         canvas.Translate({80, 0});
       }
       canvas.Translate({-240, 60});
@@ -2248,7 +2248,7 @@ TEST_P(AiksTest, GradientStrokesRenderCorrectly) {
       paint.stroke_join = join;
       for (auto cap : {Cap::kButt, Cap::kSquare, Cap::kRound}) {
         paint.stroke_cap = cap;
-        canvas.DrawPath(path, paint);
+        canvas.DrawPath(std::move(path), paint);
         canvas.Translate({80, 0});
       }
       canvas.Translate({-240, 60});
@@ -2980,7 +2980,7 @@ TEST_P(AiksTest, ImageFilteredSaveLayerWithUnboundedContents) {
                       .TakePath();
       Paint paint = p;
       paint.style = Paint::Style::kStroke;
-      canvas.DrawPath(path, paint);
+      canvas.DrawPath(std::move(path), paint);
     };
     // Registration marks for the edge of the SaveLayer
     DrawLine(Point(75, 100), Point(225, 100), {.color = Color::White()});

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1984,7 +1984,7 @@ TEST_P(AiksTest, SolidStrokesRenderCorrectly) {
       paint.stroke_join = join;
       for (auto cap : {Cap::kButt, Cap::kSquare, Cap::kRound}) {
         paint.stroke_cap = cap;
-        canvas.DrawPath(std::move(path), paint);
+        canvas.DrawPath(path.Clone(), paint);
         canvas.Translate({80, 0});
       }
       canvas.Translate({-240, 60});

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2248,7 +2248,7 @@ TEST_P(AiksTest, GradientStrokesRenderCorrectly) {
       paint.stroke_join = join;
       for (auto cap : {Cap::kButt, Cap::kSquare, Cap::kRound}) {
         paint.stroke_cap = cap;
-        canvas.DrawPath(std::move(path), paint);
+        canvas.DrawPath(path.Clone(), paint);
         canvas.Translate({80, 0});
       }
       canvas.Translate({-240, 60});

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -171,12 +171,13 @@ void Canvas::RestoreToCount(size_t count) {
   }
 }
 
-void Canvas::DrawPath(const Path& path, const Paint& paint) {
+void Canvas::DrawPath(Path path, const Paint& paint) {
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
   entity.SetClipDepth(GetClipDepth());
   entity.SetBlendMode(paint.blend_mode);
-  entity.SetContents(paint.WithFilters(paint.CreateContentsForEntity(path)));
+  entity.SetContents(
+      paint.WithFilters(paint.CreateContentsForEntity(std::move(path))));
 
   GetCurrentPass().AddEntity(entity);
 }
@@ -278,12 +279,12 @@ void Canvas::DrawRRect(Rect rect, Point corner_radii, const Paint& paint) {
     entity.SetClipDepth(GetClipDepth());
     entity.SetBlendMode(paint.blend_mode);
     entity.SetContents(paint.WithFilters(
-        paint.CreateContentsForGeometry(Geometry::MakeFillPath(path))));
+        paint.CreateContentsForGeometry(Geometry::MakeFillPath(std::move(path)))));
 
     GetCurrentPass().AddEntity(entity);
     return;
   }
-  DrawPath(path, paint);
+  DrawPath(std::move(path), paint);
 }
 
 void Canvas::DrawCircle(Point center, Scalar radius, const Paint& paint) {
@@ -308,10 +309,10 @@ void Canvas::DrawCircle(Point center, Scalar radius, const Paint& paint) {
   GetCurrentPass().AddEntity(entity);
 }
 
-void Canvas::ClipPath(const Path& path, Entity::ClipOperation clip_op) {
-  ClipGeometry(Geometry::MakeFillPath(path), clip_op);
+void Canvas::ClipPath(Path path, Entity::ClipOperation clip_op) {
+  auto bounds = path.GetBoundingBox();
+  ClipGeometry(Geometry::MakeFillPath(std::move(path)), clip_op);
   if (clip_op == Entity::ClipOperation::kIntersect) {
-    auto bounds = path.GetBoundingBox();
     if (bounds.has_value()) {
       IntersectCulling(bounds.value());
     }
@@ -355,7 +356,7 @@ void Canvas::ClipRRect(const Rect& rect,
   std::optional<Rect> inner_rect = (flat_on_LR && flat_on_TB)
                                        ? rect.Expand(-corner_radii)
                                        : std::make_optional<Rect>();
-  auto geometry = Geometry::MakeFillPath(path, inner_rect);
+  auto geometry = Geometry::MakeFillPath(std::move(path), inner_rect);
   auto& cull_rect = transform_stack_.back().cull_rect;
   if (clip_op == Entity::ClipOperation::kIntersect &&                      //
       cull_rect.has_value() &&                                             //

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -278,8 +278,8 @@ void Canvas::DrawRRect(Rect rect, Point corner_radii, const Paint& paint) {
     entity.SetTransform(GetCurrentTransform());
     entity.SetClipDepth(GetClipDepth());
     entity.SetBlendMode(paint.blend_mode);
-    entity.SetContents(paint.WithFilters(
-        paint.CreateContentsForGeometry(Geometry::MakeFillPath(std::move(path)))));
+    entity.SetContents(paint.WithFilters(paint.CreateContentsForGeometry(
+        Geometry::MakeFillPath(std::move(path)))));
 
     GetCurrentPass().AddEntity(entity);
     return;

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -97,7 +97,7 @@ class Canvas {
 
   void Rotate(Radians radians);
 
-  void DrawPath(const Path& path, const Paint& paint);
+  void DrawPath(Path path, const Paint& paint);
 
   void DrawPaint(const Paint& paint);
 
@@ -126,7 +126,7 @@ class Canvas {
                      SamplerDescriptor sampler = {});
 
   void ClipPath(
-      const Path& path,
+      Path path,
       Entity::ClipOperation clip_op = Entity::ClipOperation::kIntersect);
 
   void ClipRect(

--- a/impeller/aiks/canvas_recorder.h
+++ b/impeller/aiks/canvas_recorder.h
@@ -91,6 +91,16 @@ class CanvasRecorder {
     return (canvas_.*canvasMethod)(std::forward<Args>(args)...);
   }
 
+  template <typename FuncType, typename... Args>
+  auto ExecuteAndSkipArgSerialize(CanvasRecorderOp op,
+                                  FuncType canvasMethod,
+                                  Args&&... args)
+      -> decltype((std::declval<Canvas>().*
+                   canvasMethod)(std::forward<Args>(args)...)) {
+    serializer_.Write(op);
+    return (canvas_.*canvasMethod)(std::forward<Args>(args)...);
+  }
+
   //////////////////////////////////////////////////////////////////////////////
   // Canvas Static Polymorphism
   // ////////////////////////////////////////////////
@@ -169,9 +179,11 @@ class CanvasRecorder {
     return ExecuteAndSerialize(FLT_CANVAS_RECORDER_OP_ARG(Rotate), radians);
   }
 
-  void DrawPath(const Path& path, const Paint& paint) {
-    return ExecuteAndSerialize(FLT_CANVAS_RECORDER_OP_ARG(DrawPath), path,
-                               paint);
+  void DrawPath(Path path, const Paint& paint) {
+    serializer_.Write(path.Clone());
+    serializer_.Write(paint);
+    return ExecuteAndSkipArgSerialize(FLT_CANVAS_RECORDER_OP_ARG(DrawPath),
+                                      std::move(path), paint);
   }
 
   void DrawPaint(const Paint& paint) {
@@ -219,10 +231,12 @@ class CanvasRecorder {
   }
 
   void ClipPath(
-      const Path& path,
+      Path path,
       Entity::ClipOperation clip_op = Entity::ClipOperation::kIntersect) {
-    return ExecuteAndSerialize(FLT_CANVAS_RECORDER_OP_ARG(ClipPath), path,
-                               clip_op);
+    serializer_.Write(path.Clone());
+    serializer_.Write(clip_op);
+    return ExecuteAndSkipArgSerialize(FLT_CANVAS_RECORDER_OP_ARG(ClipPath),
+                                      std::move(path), clip_op);
   }
 
   void ClipRect(

--- a/impeller/aiks/canvas_recorder.h
+++ b/impeller/aiks/canvas_recorder.h
@@ -180,7 +180,7 @@ class CanvasRecorder {
   }
 
   void DrawPath(Path path, const Paint& paint) {
-    serializer_.Write(path.Clone());
+    serializer_.Write(path);
     serializer_.Write(paint);
     return ExecuteAndSkipArgSerialize(FLT_CANVAS_RECORDER_OP_ARG(DrawPath),
                                       std::move(path), paint);
@@ -233,7 +233,7 @@ class CanvasRecorder {
   void ClipPath(
       Path path,
       Entity::ClipOperation clip_op = Entity::ClipOperation::kIntersect) {
-    serializer_.Write(path.Clone());
+    serializer_.Write(path);
     serializer_.Write(clip_op);
     return ExecuteAndSkipArgSerialize(FLT_CANVAS_RECORDER_OP_ARG(ClipPath),
                                       std::move(path), clip_op);

--- a/impeller/aiks/canvas_recorder_unittests.cc
+++ b/impeller/aiks/canvas_recorder_unittests.cc
@@ -28,7 +28,7 @@ class Serializer {
 
   void Write(const Radians& vec2) {}
 
-  void Write(const Path& path) {}
+  void Write(Path path) {}
 
   void Write(const std::vector<Point>& points) {}
 

--- a/impeller/aiks/canvas_recorder_unittests.cc
+++ b/impeller/aiks/canvas_recorder_unittests.cc
@@ -28,7 +28,7 @@ class Serializer {
 
   void Write(const Radians& vec2) {}
 
-  void Write(Path path) {}
+  void Write(const Path& path) {}
 
   void Write(const std::vector<Point>& points) {}
 

--- a/impeller/aiks/canvas_unittests.cc
+++ b/impeller/aiks/canvas_unittests.cc
@@ -267,7 +267,7 @@ TEST(AiksCanvasTest, PathClipIntersectAgainstEmptyCullRect) {
   Rect rect_clip = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas;
-  canvas.ClipPath(path, Entity::ClipOperation::kIntersect);
+  canvas.ClipPath(std::move(path), Entity::ClipOperation::kIntersect);
 
   ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
   ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), rect_clip);
@@ -282,7 +282,7 @@ TEST(AiksCanvasTest, PathClipDiffAgainstEmptyCullRect) {
   Path path = builder.TakePath();
 
   Canvas canvas;
-  canvas.ClipPath(path, Entity::ClipOperation::kDifference);
+  canvas.ClipPath(std::move(path), Entity::ClipOperation::kDifference);
 
   ASSERT_FALSE(canvas.GetCurrentLocalCullingBounds().has_value());
 }
@@ -298,7 +298,7 @@ TEST(AiksCanvasTest, PathClipIntersectAgainstCullRect) {
   Rect result_cull = Rect::MakeXYWH(5, 5, 5, 5);
 
   Canvas canvas(initial_cull);
-  canvas.ClipPath(path, Entity::ClipOperation::kIntersect);
+  canvas.ClipPath(std::move(path), Entity::ClipOperation::kIntersect);
 
   ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
   ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
@@ -315,7 +315,7 @@ TEST(AiksCanvasTest, PathClipDiffAgainstNonCoveredCullRect) {
   Rect result_cull = Rect::MakeXYWH(0, 0, 10, 10);
 
   Canvas canvas(initial_cull);
-  canvas.ClipPath(path, Entity::ClipOperation::kDifference);
+  canvas.ClipPath(std::move(path), Entity::ClipOperation::kDifference);
 
   ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
   ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);
@@ -330,7 +330,7 @@ TEST(AiksCanvasTest, PathClipDiffAgainstFullyCoveredCullRect) {
   Rect result_cull = Rect::MakeXYWH(5, 5, 10, 10);
 
   Canvas canvas(initial_cull);
-  canvas.ClipPath(path, Entity::ClipOperation::kDifference);
+  canvas.ClipPath(std::move(path), Entity::ClipOperation::kDifference);
 
   ASSERT_TRUE(canvas.GetCurrentLocalCullingBounds().has_value());
   ASSERT_EQ(canvas.GetCurrentLocalCullingBounds().value(), result_cull);

--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -31,13 +31,14 @@ std::shared_ptr<Contents> Paint::CreateContentsForEntity(Path path,
   std::shared_ptr<Geometry> geometry;
   switch (style) {
     case Style::kFill:
-      geometry = cover ? Geometry::MakeCover() : Geometry::MakeFillPath(std::move(path));
+      geometry = cover ? Geometry::MakeCover()
+                       : Geometry::MakeFillPath(std::move(path));
       break;
     case Style::kStroke:
-      geometry =
-          cover ? Geometry::MakeCover()
-                : Geometry::MakeStrokePath(std::move(path), stroke_width, stroke_miter,
-                                           stroke_cap, stroke_join);
+      geometry = cover ? Geometry::MakeCover()
+                       : Geometry::MakeStrokePath(std::move(path), stroke_width,
+                                                  stroke_miter, stroke_cap,
+                                                  stroke_join);
       break;
   }
   return CreateContentsForGeometry(geometry);

--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -26,17 +26,17 @@ constexpr ColorMatrix kColorInversion = {
 };
 // clang-format on
 
-std::shared_ptr<Contents> Paint::CreateContentsForEntity(const Path& path,
+std::shared_ptr<Contents> Paint::CreateContentsForEntity(Path path,
                                                          bool cover) const {
   std::shared_ptr<Geometry> geometry;
   switch (style) {
     case Style::kFill:
-      geometry = cover ? Geometry::MakeCover() : Geometry::MakeFillPath(path);
+      geometry = cover ? Geometry::MakeCover() : Geometry::MakeFillPath(std::move(path));
       break;
     case Style::kStroke:
       geometry =
           cover ? Geometry::MakeCover()
-                : Geometry::MakeStrokePath(path, stroke_width, stroke_miter,
+                : Geometry::MakeStrokePath(std::move(path), stroke_width, stroke_miter,
                                            stroke_cap, stroke_join);
       break;
   }

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -84,7 +84,7 @@ struct Paint {
       std::shared_ptr<Contents> input,
       const Matrix& effect_transform = Matrix()) const;
 
-  std::shared_ptr<Contents> CreateContentsForEntity(const Path& path = {},
+  std::shared_ptr<Contents> CreateContentsForEntity(Path path = {},
                                                     bool cover = false) const;
 
   std::shared_ptr<Contents> CreateContentsForGeometry(

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -778,7 +778,7 @@ void DlDispatcher::drawOval(const SkRect& bounds) {
                     .AddOval(skia_conversions::ToRect(bounds))
                     .SetConvexity(Convexity::kConvex)
                     .TakePath();
-    canvas_.DrawPath(path, paint_);
+    canvas_.DrawPath(std::move(path), paint_);
   }
 }
 

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -86,10 +86,10 @@ bool SolidColorContents::Render(const ContentContext& renderer,
   return true;
 }
 
-std::unique_ptr<SolidColorContents> SolidColorContents::Make(const Path& path,
+std::unique_ptr<SolidColorContents> SolidColorContents::Make(Path path,
                                                              Color color) {
   auto contents = std::make_unique<SolidColorContents>();
-  contents->SetGeometry(Geometry::MakeFillPath(path));
+  contents->SetGeometry(Geometry::MakeFillPath(std::move(path)));
   contents->SetColor(color);
   return contents;
 }

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -27,7 +27,7 @@ class SolidColorContents final : public ColorSourceContents {
 
   ~SolidColorContents() override;
 
-  static std::unique_ptr<SolidColorContents> Make(const Path& path,
+  static std::unique_ptr<SolidColorContents> Make(Path path,
                                                   Color color);
 
   void SetColor(Color color);

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -27,8 +27,7 @@ class SolidColorContents final : public ColorSourceContents {
 
   ~SolidColorContents() override;
 
-  static std::unique_ptr<SolidColorContents> Make(Path path,
-                                                  Color color);
+  static std::unique_ptr<SolidColorContents> Make(Path path, Color color);
 
   void SetColor(Color color);
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -230,7 +230,7 @@ TEST_P(EntityTest, CanDrawRRect) {
                   .SetConvexity(Convexity::kConvex)
                   .AddRoundedRect(Rect::MakeXYWH(100, 100, 100, 100), 10.0)
                   .TakePath();
-  contents->SetGeometry(Geometry::MakeFillPath(path));
+  contents->SetGeometry(Geometry::MakeFillPath(std::move(path)));
   contents->SetColor(Color::Red());
 
   Entity entity;
@@ -261,7 +261,7 @@ TEST_P(EntityTest, ThreeStrokesInOnePath) {
   Entity entity;
   entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   auto contents = std::make_unique<SolidColorContents>();
-  contents->SetGeometry(Geometry::MakeStrokePath(path, 5.0));
+  contents->SetGeometry(Geometry::MakeStrokePath(std::move(path), 5.0));
   contents->SetColor(Color::Red());
   entity.SetContents(std::move(contents));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
@@ -281,7 +281,7 @@ TEST_P(EntityTest, StrokeWithTextureContents) {
   Entity entity;
   entity.SetTransform(Matrix::MakeScale(GetContentScale()));
   auto contents = std::make_unique<TiledTextureContents>();
-  contents->SetGeometry(Geometry::MakeStrokePath(path, 100.0));
+  contents->SetGeometry(Geometry::MakeStrokePath(std::move(path), 100.0));
   contents->SetTexture(bridge);
   contents->SetTileModes(Entity::TileMode::kClamp, Entity::TileMode::kClamp);
   entity.SetContents(std::move(contents));
@@ -321,7 +321,7 @@ TEST_P(EntityTest, TriangleInsideASquare) {
     Entity entity;
     entity.SetTransform(Matrix::MakeScale(GetContentScale()));
     auto contents = std::make_unique<SolidColorContents>();
-    contents->SetGeometry(Geometry::MakeStrokePath(path, 20.0));
+    contents->SetGeometry(Geometry::MakeStrokePath(std::move(path), 20.0));
     contents->SetColor(Color::Red());
     entity.SetContents(std::move(contents));
 
@@ -357,7 +357,7 @@ TEST_P(EntityTest, StrokeCapAndJoinTest) {
                            const Path& path, Cap cap, Join join) {
       auto contents = std::make_unique<SolidColorContents>();
       contents->SetGeometry(
-          Geometry::MakeStrokePath(path, width, miter_limit, cap, join));
+          Geometry::MakeStrokePath(path.Clone(), width, miter_limit, cap, join));
       contents->SetColor(Color::Red());
 
       Entity entity;
@@ -470,7 +470,7 @@ TEST_P(EntityTest, CubicCurveTest) {
           .TakePath();
   Entity entity;
   entity.SetTransform(Matrix::MakeScale(GetContentScale()));
-  entity.SetContents(SolidColorContents::Make(path, Color::Red()));
+  entity.SetContents(SolidColorContents::Make(std::move(path), Color::Red()));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
 }
 
@@ -514,7 +514,7 @@ TEST_P(EntityTest, CanDrawCorrectlyWithRotatedTransform) {
 
     Entity entity;
     entity.SetTransform(result_transform);
-    entity.SetContents(SolidColorContents::Make(path, Color::Red()));
+    entity.SetContents(SolidColorContents::Make(std::move(path), Color::Red()));
     return entity.Render(context, pass);
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));
@@ -744,7 +744,7 @@ TEST_P(EntityTest, CubicCurveAndOverlapTest) {
           .TakePath();
   Entity entity;
   entity.SetTransform(Matrix::MakeScale(GetContentScale()));
-  entity.SetContents(SolidColorContents::Make(path, Color::Red()));
+  entity.SetContents(SolidColorContents::Make(std::move(path), Color::Red()));
   ASSERT_TRUE(OpenPlaygroundHere(entity));
 }
 
@@ -946,7 +946,7 @@ TEST_P(EntityTest, BezierCircleScaled) {
                     .TakePath();
     entity.SetTransform(
         Matrix::MakeScale({scale, scale, 1.0}).Translate({-90, -20, 0}));
-    entity.SetContents(SolidColorContents::Make(path, Color::Red()));
+    entity.SetContents(SolidColorContents::Make(std::move(path), Color::Red()));
     return entity.Render(context, pass);
   };
   ASSERT_TRUE(OpenPlaygroundHere(callback));
@@ -2289,7 +2289,7 @@ TEST_P(EntityTest, CoverageForStrokePathWithNegativeValuesInTransform) {
                         .LineTo({120, 190})
                         .LineTo({190, 120})
                         .TakePath();
-  auto geometry = Geometry::MakeStrokePath(arrow_head, 15.0, 4.0, Cap::kRound,
+  auto geometry = Geometry::MakeStrokePath(std::move(arrow_head), 15.0, 4.0, Cap::kRound,
                                            Join::kRound);
 
   auto transform = Matrix::MakeTranslation({300, 300}) *

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -356,8 +356,8 @@ TEST_P(EntityTest, StrokeCapAndJoinTest) {
     auto render_path = [width = width, &context, &pass, &world_matrix](
                            const Path& path, Cap cap, Join join) {
       auto contents = std::make_unique<SolidColorContents>();
-      contents->SetGeometry(
-          Geometry::MakeStrokePath(path.Clone(), width, miter_limit, cap, join));
+      contents->SetGeometry(Geometry::MakeStrokePath(path.Clone(), width,
+                                                     miter_limit, cap, join));
       contents->SetColor(Color::Red());
 
       Entity entity;
@@ -2289,8 +2289,8 @@ TEST_P(EntityTest, CoverageForStrokePathWithNegativeValuesInTransform) {
                         .LineTo({120, 190})
                         .LineTo({190, 120})
                         .TakePath();
-  auto geometry = Geometry::MakeStrokePath(std::move(arrow_head), 15.0, 4.0, Cap::kRound,
-                                           Join::kRound);
+  auto geometry = Geometry::MakeStrokePath(std::move(arrow_head), 15.0, 4.0,
+                                           Cap::kRound, Join::kRound);
 
   auto transform = Matrix::MakeTranslation({300, 300}) *
                    Matrix::MakeRotationZ(Radians(kPiOver2));

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -7,8 +7,7 @@
 
 namespace impeller {
 
-FillPathGeometry::FillPathGeometry(Path path,
-                                   std::optional<Rect> inner_rect)
+FillPathGeometry::FillPathGeometry(Path path, std::optional<Rect> inner_rect)
     : path_(std::move(path)), inner_rect_(inner_rect) {}
 
 GeometryResult FillPathGeometry::GetPositionBuffer(

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -7,9 +7,9 @@
 
 namespace impeller {
 
-FillPathGeometry::FillPathGeometry(const Path& path,
+FillPathGeometry::FillPathGeometry(Path path,
                                    std::optional<Rect> inner_rect)
-    : path_(path), inner_rect_(inner_rect) {}
+    : path_(std::move(path)), inner_rect_(inner_rect) {}
 
 GeometryResult FillPathGeometry::GetPositionBuffer(
     const ContentContext& renderer,

--- a/impeller/entity/geometry/fill_path_geometry.h
+++ b/impeller/entity/geometry/fill_path_geometry.h
@@ -14,7 +14,7 @@ namespace impeller {
 /// @brief A geometry that is created from a filled path object.
 class FillPathGeometry final : public Geometry {
  public:
-  explicit FillPathGeometry(const Path& path,
+  explicit FillPathGeometry(Path path,
                             std::optional<Rect> inner_rect = std::nullopt);
 
   ~FillPathGeometry() = default;

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -80,9 +80,9 @@ GeometryResult Geometry::GetPositionUVBuffer(Rect texture_coverage,
 }
 
 std::shared_ptr<Geometry> Geometry::MakeFillPath(
-    const Path& path,
+    Path path,
     std::optional<Rect> inner_rect) {
-  return std::make_shared<FillPathGeometry>(path, inner_rect);
+  return std::make_shared<FillPathGeometry>(std::move(path), inner_rect);
 }
 
 std::shared_ptr<Geometry> Geometry::MakePointField(std::vector<Point> points,
@@ -91,7 +91,7 @@ std::shared_ptr<Geometry> Geometry::MakePointField(std::vector<Point> points,
   return std::make_shared<PointFieldGeometry>(std::move(points), radius, round);
 }
 
-std::shared_ptr<Geometry> Geometry::MakeStrokePath(const Path& path,
+std::shared_ptr<Geometry> Geometry::MakeStrokePath(Path path,
                                                    Scalar stroke_width,
                                                    Scalar miter_limit,
                                                    Cap stroke_cap,
@@ -100,7 +100,7 @@ std::shared_ptr<Geometry> Geometry::MakeStrokePath(const Path& path,
   if (miter_limit < 0) {
     miter_limit = 4.0;
   }
-  return std::make_shared<StrokePathGeometry>(path, stroke_width, miter_limit,
+  return std::make_shared<StrokePathGeometry>(std::move(path), stroke_width, miter_limit,
                                               stroke_cap, stroke_join);
 }
 

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -100,8 +100,8 @@ std::shared_ptr<Geometry> Geometry::MakeStrokePath(Path path,
   if (miter_limit < 0) {
     miter_limit = 4.0;
   }
-  return std::make_shared<StrokePathGeometry>(std::move(path), stroke_width, miter_limit,
-                                              stroke_cap, stroke_join);
+  return std::make_shared<StrokePathGeometry>(
+      std::move(path), stroke_width, miter_limit, stroke_cap, stroke_join);
 }
 
 std::shared_ptr<Geometry> Geometry::MakeCover() {

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -49,11 +49,11 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
 class Geometry {
  public:
   static std::shared_ptr<Geometry> MakeFillPath(
-      const Path& path,
+      Path path,
       std::optional<Rect> inner_rect = std::nullopt);
 
   static std::shared_ptr<Geometry> MakeStrokePath(
-      const Path& path,
+      Path path,
       Scalar stroke_width = 0.0,
       Scalar miter_limit = 4.0,
       Cap stroke_cap = Cap::kButt,

--- a/impeller/entity/geometry/geometry_unittests.cc
+++ b/impeller/entity/geometry/geometry_unittests.cc
@@ -20,7 +20,7 @@ TEST(EntityGeometryTest, RectGeometryCoversArea) {
 TEST(EntityGeometryTest, FillPathGeometryCoversArea) {
   auto path = PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath();
   auto geometry = Geometry::MakeFillPath(
-      path, /* inner rect */ Rect::MakeLTRB(0, 0, 100, 100));
+      std::move(path), /* inner rect */ Rect::MakeLTRB(0, 0, 100, 100));
   ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(0, 0, 100, 100)));
   ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(-1, 0, 100, 100)));
   ASSERT_TRUE(geometry->CoversArea({}, Rect::MakeLTRB(1, 1, 100, 100)));
@@ -29,7 +29,7 @@ TEST(EntityGeometryTest, FillPathGeometryCoversArea) {
 
 TEST(EntityGeometryTest, FillPathGeometryCoversAreaNoInnerRect) {
   auto path = PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 100, 100)).TakePath();
-  auto geometry = Geometry::MakeFillPath(path);
+  auto geometry = Geometry::MakeFillPath(std::move(path));
   ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(0, 0, 100, 100)));
   ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(-1, 0, 100, 100)));
   ASSERT_FALSE(geometry->CoversArea({}, Rect::MakeLTRB(1, 1, 100, 100)));

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -8,12 +8,12 @@
 
 namespace impeller {
 
-StrokePathGeometry::StrokePathGeometry(const Path& path,
+StrokePathGeometry::StrokePathGeometry(Path path,
                                        Scalar stroke_width,
                                        Scalar miter_limit,
                                        Cap stroke_cap,
                                        Join stroke_join)
-    : path_(path),
+    : path_(std::move(path)),
       stroke_width_(stroke_width),
       miter_limit_(miter_limit),
       stroke_cap_(stroke_cap),

--- a/impeller/entity/geometry/stroke_path_geometry.h
+++ b/impeller/entity/geometry/stroke_path_geometry.h
@@ -11,7 +11,7 @@ namespace impeller {
 /// @brief A geometry that is created from a stroked path object.
 class StrokePathGeometry final : public Geometry {
  public:
-  StrokePathGeometry(const Path& path,
+  StrokePathGeometry(Path path,
                      Scalar stroke_width,
                      Scalar miter_limit,
                      Cap stroke_cap,

--- a/impeller/geometry/geometry_benchmarks.cc
+++ b/impeller/geometry/geometry_benchmarks.cc
@@ -25,7 +25,7 @@ static Tessellator tess;
 template <class... Args>
 static void BM_Polyline(benchmark::State& state, Args&&... args) {
   auto args_tuple = std::make_tuple(std::move(args)...);
-  auto path = std::get<Path>(args_tuple);
+  auto path = std::get<Path>(args_tuple).Clone();
   bool tessellate = std::get<bool>(args_tuple);
 
   size_t point_count = 0u;
@@ -67,7 +67,7 @@ static void BM_Polyline(benchmark::State& state, Args&&... args) {
 template <class... Args>
 static void BM_Convex(benchmark::State& state, Args&&... args) {
   auto args_tuple = std::make_tuple(std::move(args)...);
-  auto path = std::get<Path>(args_tuple);
+  auto path = std::get<Path>(args_tuple).Clone();
 
   size_t point_count = 0u;
   size_t single_point_count = 0u;

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -73,6 +73,17 @@ void Path::Shift(Point shift) {
   }
 }
 
+Path Path::Clone() const {
+  Path new_path;
+  new_path.components_ = components_;
+  new_path.contours_ = contours_;
+  new_path.computed_bounds_ = computed_bounds_;
+  new_path.convexity_ = convexity_;
+  new_path.points_ = new_path.points_;
+  new_path.fill_ = fill_;
+  return new_path;
+}
+
 Path& Path::AddLinearComponent(const Point& p1, const Point& p2) {
   auto index = points_.size();
   points_.emplace_back(p1);

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -74,13 +74,7 @@ void Path::Shift(Point shift) {
 }
 
 Path Path::Clone() const {
-  Path new_path;
-  new_path.components_ = components_;
-  new_path.contours_ = contours_;
-  new_path.computed_bounds_ = computed_bounds_;
-  new_path.convexity_ = convexity_;
-  new_path.points_ = new_path.points_;
-  new_path.fill_ = fill_;
+  Path new_path = *this;
   return new_path;
 }
 

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -183,7 +183,7 @@ class Path {
  private:
   friend class PathBuilder;
 
-  Path(const Path& other);
+  Path(const Path& other) = default;
 
   void SetConvexity(Convexity value);
 

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -132,6 +132,13 @@ class Path {
 
   ~Path();
 
+  Path(const Path& other) = delete;
+
+  Path(Path&& other) = default;
+
+  /// @brief Deeply clone this path and all data associated with it.
+  Path Clone() const;
+
   size_t GetComponentCount(std::optional<ComponentType> type = {}) const;
 
   FillType GetFillType() const;

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -132,8 +132,6 @@ class Path {
 
   ~Path();
 
-  Path(const Path& other) = delete;
-
   Path(Path&& other) = default;
 
   /// @brief Deeply clone this path and all data associated with it.
@@ -184,6 +182,8 @@ class Path {
 
  private:
   friend class PathBuilder;
+
+  Path(const Path& other);
 
   void SetConvexity(Convexity value);
 

--- a/impeller/geometry/path_builder.cc
+++ b/impeller/geometry/path_builder.cc
@@ -13,13 +13,13 @@ PathBuilder::PathBuilder() = default;
 PathBuilder::~PathBuilder() = default;
 
 Path PathBuilder::CopyPath(FillType fill) const {
-  auto path = prototype_;
+  auto path = prototype_.Clone();
   path.SetFillType(fill);
   return path;
 }
 
 Path PathBuilder::TakePath(FillType fill) {
-  auto path = prototype_;
+  auto path = std::move(prototype_);
   path.SetFillType(fill);
   path.SetConvexity(convexity_);
   if (!did_compute_bounds_) {

--- a/impeller/geometry/path_unittests.cc
+++ b/impeller/geometry/path_unittests.cc
@@ -469,7 +469,8 @@ TEST(PathTest, CanBeCloned) {
 
   for (auto i = 0u; i < poly_a.contours.size(); i++) {
     EXPECT_EQ(poly_a.contours[i].start_index, poly_b.contours[i].start_index);
-    EXPECT_EQ(poly_a.contours[i].start_direction, poly_b.contours[i].start_direction);
+    EXPECT_EQ(poly_a.contours[i].start_direction,
+              poly_b.contours[i].start_direction);
   }
 }
 

--- a/impeller/geometry/path_unittests.cc
+++ b/impeller/geometry/path_unittests.cc
@@ -468,7 +468,8 @@ TEST(PathTest, CanBeCloned) {
   }
 
   for (auto i = 0u; i < poly_a.contours.size(); i++) {
-    EXPECT_EQ(poly_a.contours[i], poly_b.contours[i]);
+    EXPECT_EQ(poly_a.contours[i].start_index, poly_b.contours[i].start_index);
+    EXPECT_EQ(poly_a.contours[i].start_direction, poly_b.contours[i].start_direction);
   }
 }
 

--- a/impeller/geometry/path_unittests.cc
+++ b/impeller/geometry/path_unittests.cc
@@ -443,5 +443,34 @@ TEST(PathTest, SimplePath) {
       });
 }
 
+TEST(PathTest, CanBeCloned) {
+  PathBuilder builder;
+  builder.MoveTo({10, 10});
+  builder.LineTo({20, 20});
+  builder.SetBounds(Rect::MakeLTRB(0, 0, 100, 100));
+  builder.SetConvexity(Convexity::kConvex);
+
+  auto path_a = builder.TakePath(FillType::kAbsGeqTwo);
+  auto path_b = path_a.Clone();
+
+  EXPECT_EQ(path_a.GetBoundingBox(), path_b.GetBoundingBox());
+  EXPECT_EQ(path_a.GetFillType(), path_b.GetFillType());
+  EXPECT_EQ(path_a.IsConvex(), path_b.IsConvex());
+
+  auto poly_a = path_a.CreatePolyline(1.0);
+  auto poly_b = path_b.CreatePolyline(1.0);
+
+  ASSERT_EQ(poly_a.points->size(), poly_b.points->size());
+  ASSERT_EQ(poly_a.contours.size(), poly_b.contours.size());
+
+  for (auto i = 0u; i < poly_a.points->size(); i++) {
+    EXPECT_EQ((*poly_a.points)[i], (*poly_b.points)[i]);
+  }
+
+  for (auto i = 0u; i < poly_a.contours.size(); i++) {
+    EXPECT_EQ(poly_a.contours[i], poly_b.contours[i]);
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
From looking at profiles, we're always copying paths at least once when recording commands. By deleting the copy constructor, I cna ensure that we're always either moving or explicitly cloning the Path object.

Or, now that I fixed all the moves I could add the copy constructor back.
