### PR TITLE
[Impeller] Move BufferView/Texture/Sampler when binding.

### DIFF
--- a/impeller/core/resource_binder.h
+++ b/impeller/core/resource_binder.h
@@ -29,13 +29,13 @@ struct ResourceBinder {
   virtual bool BindResource(ShaderStage stage,
                             const ShaderUniformSlot& slot,
                             const ShaderMetadata& metadata,
-                            const BufferView& view) = 0;
+                            BufferView view) = 0;
 
   virtual bool BindResource(ShaderStage stage,
                             const SampledImageSlot& slot,
                             const ShaderMetadata& metadata,
-                            const std::shared_ptr<const Texture>& texture,
-                            const std::shared_ptr<const Sampler>& sampler) = 0;
+                            std::shared_ptr<const Texture> texture,
+                            std::shared_ptr<const Sampler> sampler) = 0;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/command.cc
+++ b/impeller/renderer/command.cc
@@ -33,23 +33,23 @@ BufferView Command::GetVertexBuffer() const {
 bool Command::BindResource(ShaderStage stage,
                            const ShaderUniformSlot& slot,
                            const ShaderMetadata& metadata,
-                           const BufferView& view) {
-  return DoBindResource(stage, slot, &metadata, view);
+                           BufferView view) {
+  return DoBindResource(stage, slot, &metadata, std::move(view));
 }
 
 bool Command::BindResource(
     ShaderStage stage,
     const ShaderUniformSlot& slot,
     const std::shared_ptr<const ShaderMetadata>& metadata,
-    const BufferView& view) {
-  return DoBindResource(stage, slot, metadata, view);
+    BufferView view) {
+  return DoBindResource(stage, slot, metadata, std::move(view));
 }
 
 template <class T>
 bool Command::DoBindResource(ShaderStage stage,
                              const ShaderUniformSlot& slot,
                              const T metadata,
-                             const BufferView& view) {
+                             BufferView view) {
   FML_DCHECK(slot.ext_res_0 != VertexDescriptor::kReservedVertexBufferIndex);
   if (!view) {
     return false;
@@ -58,11 +58,11 @@ bool Command::DoBindResource(ShaderStage stage,
   switch (stage) {
     case ShaderStage::kVertex:
       vertex_bindings.buffers[slot.ext_res_0] = {
-          .slot = slot, .view = BufferResource(metadata, view)};
+          .slot = slot, .view = BufferResource(metadata, std::move(view))};
       return true;
     case ShaderStage::kFragment:
       fragment_bindings.buffers[slot.ext_res_0] = {
-          .slot = slot, .view = BufferResource(metadata, view)};
+          .slot = slot, .view = BufferResource(metadata, std::move(view))};
       return true;
     case ShaderStage::kCompute:
       VALIDATION_LOG << "Use ComputeCommands for compute shader stages.";
@@ -78,8 +78,8 @@ bool Command::DoBindResource(ShaderStage stage,
 bool Command::BindResource(ShaderStage stage,
                            const SampledImageSlot& slot,
                            const ShaderMetadata& metadata,
-                           const std::shared_ptr<const Texture>& texture,
-                           const std::shared_ptr<const Sampler>& sampler) {
+                           std::shared_ptr<const Texture> texture,
+                           std::shared_ptr<const Sampler> sampler) {
   if (!sampler || !sampler->IsValid()) {
     return false;
   }
@@ -94,15 +94,15 @@ bool Command::BindResource(ShaderStage stage,
     case ShaderStage::kVertex:
       vertex_bindings.sampled_images[slot.sampler_index] = TextureAndSampler{
           .slot = slot,
-          .texture = {&metadata, texture},
-          .sampler = {&metadata, sampler},
+          .texture = {&metadata, std::move(texture)},
+          .sampler = {&metadata, std::move(sampler)},
       };
       return true;
     case ShaderStage::kFragment:
       fragment_bindings.sampled_images[slot.sampler_index] = TextureAndSampler{
           .slot = slot,
-          .texture = {&metadata, texture},
-          .sampler = {&metadata, sampler},
+          .texture = {&metadata, std::move(texture)},
+          .sampler = {&metadata, std::move(sampler)},
       };
       return true;
     case ShaderStage::kCompute:

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -189,19 +189,19 @@ struct Command : public ResourceBinder {
   bool BindResource(ShaderStage stage,
                     const ShaderUniformSlot& slot,
                     const ShaderMetadata& metadata,
-                    const BufferView& view) override;
+                    BufferView view) override;
 
   bool BindResource(ShaderStage stage,
                     const ShaderUniformSlot& slot,
                     const std::shared_ptr<const ShaderMetadata>& metadata,
-                    const BufferView& view);
+                    BufferView view);
 
   // |ResourceBinder|
   bool BindResource(ShaderStage stage,
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
-                    const std::shared_ptr<const Texture>& texture,
-                    const std::shared_ptr<const Sampler>& sampler) override;
+                    std::shared_ptr<const Texture> texture,
+                    std::shared_ptr<const Sampler> sampler) override;
 
   BufferView GetVertexBuffer() const;
 
@@ -212,7 +212,7 @@ struct Command : public ResourceBinder {
   bool DoBindResource(ShaderStage stage,
                       const ShaderUniformSlot& slot,
                       T metadata,
-                      const BufferView& view);
+                      BufferView view);
 };
 
 }  // namespace impeller

--- a/impeller/renderer/compute_command.cc
+++ b/impeller/renderer/compute_command.cc
@@ -23,16 +23,16 @@ bool ComputeCommand::BindResource(ShaderStage stage,
     return false;
   }
 
-  bindings.buffers[slot.ext_res_0] = {.slot = slot, .view = {&metadata, std::move(view)}};
+  bindings.buffers[slot.ext_res_0] = {.slot = slot,
+                                      .view = {&metadata, std::move(view)}};
   return true;
 }
 
-bool ComputeCommand::BindResource(
-    ShaderStage stage,
-    const SampledImageSlot& slot,
-    const ShaderMetadata& metadata,
-    std::shared_ptr<const Texture> texture,
-    std::shared_ptr<const Sampler> sampler) {
+bool ComputeCommand::BindResource(ShaderStage stage,
+                                  const SampledImageSlot& slot,
+                                  const ShaderMetadata& metadata,
+                                  std::shared_ptr<const Texture> texture,
+                                  std::shared_ptr<const Sampler> sampler) {
   if (stage != ShaderStage::kCompute) {
     VALIDATION_LOG << "Use Command for non-compute shader stages.";
     return false;

--- a/impeller/renderer/compute_command.cc
+++ b/impeller/renderer/compute_command.cc
@@ -14,7 +14,7 @@ namespace impeller {
 bool ComputeCommand::BindResource(ShaderStage stage,
                                   const ShaderUniformSlot& slot,
                                   const ShaderMetadata& metadata,
-                                  const BufferView& view) {
+                                  BufferView view) {
   if (stage != ShaderStage::kCompute) {
     VALIDATION_LOG << "Use Command for non-compute shader stages.";
     return false;
@@ -23,7 +23,7 @@ bool ComputeCommand::BindResource(ShaderStage stage,
     return false;
   }
 
-  bindings.buffers[slot.ext_res_0] = {.slot = slot, .view = {&metadata, view}};
+  bindings.buffers[slot.ext_res_0] = {.slot = slot, .view = {&metadata, std::move(view)}};
   return true;
 }
 
@@ -31,8 +31,8 @@ bool ComputeCommand::BindResource(
     ShaderStage stage,
     const SampledImageSlot& slot,
     const ShaderMetadata& metadata,
-    const std::shared_ptr<const Texture>& texture,
-    const std::shared_ptr<const Sampler>& sampler) {
+    std::shared_ptr<const Texture> texture,
+    std::shared_ptr<const Sampler> sampler) {
   if (stage != ShaderStage::kCompute) {
     VALIDATION_LOG << "Use Command for non-compute shader stages.";
     return false;
@@ -49,8 +49,8 @@ bool ComputeCommand::BindResource(
 
   bindings.sampled_images[slot.sampler_index] = TextureAndSampler{
       .slot = slot,
-      .texture = {&metadata, texture},
-      .sampler = {&metadata, sampler},
+      .texture = {&metadata, std::move(texture)},
+      .sampler = {&metadata, std::move(sampler)},
   };
 
   return false;

--- a/impeller/renderer/compute_command.h
+++ b/impeller/renderer/compute_command.h
@@ -62,14 +62,14 @@ struct ComputeCommand : public ResourceBinder {
   bool BindResource(ShaderStage stage,
                     const ShaderUniformSlot& slot,
                     const ShaderMetadata& metadata,
-                    const BufferView& view) override;
+                    BufferView view) override;
 
   // |ResourceBinder|
   bool BindResource(ShaderStage stage,
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
-                    const std::shared_ptr<const Texture>& texture,
-                    const std::shared_ptr<const Sampler>& sampler) override;
+                    std::shared_ptr<const Texture> texture,
+                    std::shared_ptr<const Sampler> sampler) override;
 
   constexpr explicit operator bool() const {
     return pipeline && pipeline->IsValid();


### PR DESCRIPTION
Most of the time we are passing an rvalue into this functions anyway, so in theory moving should be faster. Right?
