### PR TITLE
[Impeller] prefer moving vertex buffer, place on command instead of binding object.

### DIFF
--- a/impeller/core/vertex_buffer.h
+++ b/impeller/core/vertex_buffer.h
@@ -11,10 +11,20 @@ namespace impeller {
 
 struct VertexBuffer {
   BufferView vertex_buffer;
+
+  //----------------------------------------------------------------------------
+  /// The index buffer binding used by the vertex shader stage.
   BufferView index_buffer;
-  // The total count of vertices, either in the vertex_buffer if the
-  // index_type is IndexType::kNone or in the index_buffer otherwise.
+
+  //----------------------------------------------------------------------------
+  /// The total count of vertices, either in the vertex_buffer if the
+  /// index_type is IndexType::kNone or in the index_buffer otherwise.
   size_t vertex_count = 0u;
+
+  //----------------------------------------------------------------------------
+  /// The type of indices in the index buffer. The indices must be tightly
+  /// packed in the index buffer.
+  ///
   IndexType index_type = IndexType::kUnknown;
 
   constexpr explicit operator bool() const {

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -244,12 +244,10 @@ bool AtlasContents::Render(const ContentContext& renderer,
       }
     }
 
-    auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-
     Command cmd;
     DEBUG_COMMAND_INFO(
         cmd, SPrintF("DrawAtlas Blend (%s)", BlendModeToString(blend_mode_)));
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
     cmd.stencil_reference = entity.GetClipDepth();
     auto options = OptionsFromPass(pass);
     cmd.pipeline = renderer.GetPorterDuffBlendPipeline(options);

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -98,7 +98,7 @@ bool ClipContents::Render(const ContentContext& renderer,
           VertexBufferBuilder<VS::PerVertexData>{}
               .AddVertices({{points[0]}, {points[1]}, {points[2]}, {points[3]}})
               .CreateVertexBuffer(pass.GetTransientsBuffer());
-      cmd.BindVertices(vertices);
+      cmd.BindVertices(std::move(vertices));
 
       info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
       VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
@@ -126,7 +126,7 @@ bool ClipContents::Render(const ContentContext& renderer,
   cmd.pipeline = renderer.GetClipPipeline(options);
 
   auto allocator = renderer.GetContext()->GetResourceAllocator();
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
 
   info.mvp = geometry_result.transform;
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -107,7 +107,7 @@ bool ConicalGradientContents::RenderSSBO(const ContentContext& renderer,
   options.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetConicalGradientSSBOFillPipeline(options);
 
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   FS::BindColorData(cmd, color_buffer);
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
@@ -173,7 +173,7 @@ bool ConicalGradientContents::RenderTexture(const ContentContext& renderer,
   options.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetConicalGradientFillPipeline(options);
 
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -169,7 +169,7 @@ static std::optional<Entity> AdvancedBlend(
     Command cmd;
     DEBUG_COMMAND_INFO(cmd, SPrintF("Advanced Blend Filter (%s)",
                                     BlendModeToString(blend_mode)));
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(std::move(vtx_buffer));
     cmd.pipeline = std::move(pipeline);
 
     typename FS::BlendInfo blend_info;
@@ -289,7 +289,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
     Command cmd;
     DEBUG_COMMAND_INFO(cmd, SPrintF("Foreground Advanced Blend Filter (%s)",
                                     BlendModeToString(blend_mode)));
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(std::move(vtx_buffer));
     cmd.stencil_reference = entity.GetClipDepth();
     auto options = OptionsFromPass(pass);
     options.primitive_type = PrimitiveType::kTriangleStrip;
@@ -460,7 +460,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
     Command cmd;
     DEBUG_COMMAND_INFO(cmd, SPrintF("Foreground PorterDuff Blend Filter (%s)",
                                     BlendModeToString(blend_mode)));
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(std::move(vtx_buffer));
     cmd.stencil_reference = entity.GetClipDepth();
     auto options = OptionsFromPass(pass);
     options.primitive_type = PrimitiveType::kTriangleStrip;
@@ -583,8 +583,7 @@ static std::optional<Entity> PipelineBlend(
           {Point(0, size.height), Point(0, 1)},
           {Point(size.width, size.height), Point(1, 1)},
       });
-      auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-      cmd.BindVertices(vtx_buffer);
+      cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
       VS::FrameInfo frame_info;
       frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -102,7 +102,6 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
           coverage.origin.y + coverage.size.height},
          input_uvs[3]},
     });
-    auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
     Command cmd;
     DEBUG_COMMAND_INFO(cmd, "Border Mask Blur Filter");
@@ -110,7 +109,7 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     options.primitive_type = PrimitiveType::kTriangleStrip;
 
     cmd.pipeline = renderer.GetBorderMaskBlurPipeline(options);
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
     cmd.stencil_reference = entity.GetClipDepth();
 
     VS::FrameInfo frame_info;

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -73,8 +73,7 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
         {Point(1, 1)},
     });
     auto& host_buffer = pass.GetTransientsBuffer();
-    auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.cc
@@ -174,7 +174,6 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
         {Point(0, 1), input_uvs[2]},
         {Point(1, 1), input_uvs[3]},
     });
-    auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
@@ -195,7 +194,7 @@ std::optional<Entity> DirectionalGaussianBlurFilterContents::RenderFilter(
     Command cmd;
     DEBUG_COMMAND_INFO(cmd, SPrintF("Gaussian Blur Filter (Radius=%.2f)",
                                     transformed_blur_radius_length));
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     auto options = OptionsFromPass(pass);
     options.primitive_type = PrimitiveType::kTriangleStrip;

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -44,8 +44,7 @@ void BindVertices(Command& cmd,
                   std::initializer_list<typename T::PerVertexData>&& vertices) {
   VertexBufferBuilder<typename T::PerVertexData> vtx_builder;
   vtx_builder.AddVertices(vertices);
-  auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-  cmd.BindVertices(vtx_buffer);
+  cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 }
 
 Matrix MakeAnchorScale(const Point& anchor, Vector2 scale) {

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -64,8 +64,7 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();
-    auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -85,8 +85,6 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
         {Point(1, 1), input_uvs[3]},
     });
 
-    auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
     frame_info.texture_sampler_y_coord_scale =
@@ -120,7 +118,7 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
     options.primitive_type = PrimitiveType::kTriangleStrip;
     options.blend_mode = BlendMode::kSource;
     cmd.pipeline = renderer.GetMorphologyFilterPipeline(options);
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     auto sampler_descriptor = input_snapshot->sampler_descriptor;
     if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -64,8 +64,7 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();
-    auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -92,8 +92,7 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     });
 
     auto& host_buffer = pass.GetTransientsBuffer();
-    auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
-    cmd.BindVertices(vtx_buffer);
+    cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -66,7 +66,6 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
       {Point(0, size.height), Point(0, 1)},
       {Point(size.width, size.height), Point(1, 1)},
   });
-  auto vtx_buffer = vtx_builder.CreateVertexBuffer(host_buffer);
 
   auto options = OptionsFromPass(pass);
   options.blend_mode = BlendMode::kSource;
@@ -74,7 +73,7 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
 
   Command cmd;
   DEBUG_COMMAND_INFO(cmd, "Framebuffer Advanced Blend Filter");
-  cmd.BindVertices(vtx_buffer);
+  cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
   cmd.stencil_reference = entity.GetClipDepth();
 
   switch (blend_mode_) {

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -107,7 +107,7 @@ bool LinearGradientContents::RenderTexture(const ContentContext& renderer,
   options.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetLinearGradientFillPipeline(options);
 
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;
@@ -169,7 +169,7 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
   options.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetLinearGradientSSBOFillPipeline(options);
 
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   FS::BindColorData(cmd, color_buffer);
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -106,7 +106,7 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
   options.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetRadialGradientSSBOFillPipeline(options);
 
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   FS::BindColorData(cmd, color_buffer);
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
@@ -165,7 +165,7 @@ bool RadialGradientContents::RenderTexture(const ContentContext& renderer,
   options.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetRadialGradientFillPipeline(options);
 
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   SamplerDescriptor sampler_desc;
   sampler_desc.min_filter = MinMagFilter::kLinear;

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -154,7 +154,7 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
   DEBUG_COMMAND_INFO(cmd, "RuntimeEffectContents");
   cmd.pipeline = pipeline;
   cmd.stencil_reference = entity.GetClipDepth();
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
 
   //--------------------------------------------------------------------------
   /// Vertex stage uniforms.

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -67,7 +67,7 @@ bool SolidColorContents::Render(const ContentContext& renderer,
 
   options.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetSolidFillPipeline(options);
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
 
   VS::FrameInfo frame_info;
   frame_info.mvp = capture.AddMatrix("Transform", geometry_result.transform);

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -112,7 +112,7 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
   options.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetSweepGradientSSBOFillPipeline(options);
 
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   FS::BindColorData(cmd, color_buffer);
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
@@ -172,7 +172,7 @@ bool SweepGradientContents::RenderTexture(const ContentContext& renderer,
   options.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetSweepGradientFillPipeline(options);
 
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
   SamplerDescriptor sampler_desc;

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -174,7 +174,7 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
                      : renderer.GetTexturePipeline(options);
 #endif  // IMPELLER_ENABLE_OPENGLES
 
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
   VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
 
   if (is_external_texture) {

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -135,7 +135,7 @@ bool VerticesUVContents::Render(const ContentContext& renderer,
   opts.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetTexturePipeline(opts);
   cmd.stencil_reference = entity.GetClipDepth();
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
 
   VS::FrameInfo frame_info;
   frame_info.mvp = geometry_result.transform;
@@ -185,7 +185,7 @@ bool VerticesColorContents::Render(const ContentContext& renderer,
   opts.primitive_type = geometry_result.type;
   cmd.pipeline = renderer.GetGeometryColorPipeline(opts);
   cmd.stencil_reference = entity.GetClipDepth();
-  cmd.BindVertices(geometry_result.vertex_buffer);
+  cmd.BindVertices(std::move(geometry_result.vertex_buffer));
 
   VS::FrameInfo frame_info;
   frame_info.mvp = geometry_result.transform;

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -263,7 +263,7 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
                 pcmd->ElemCount * sizeof(ImDrawIdx))};
         vertex_buffer.vertex_count = pcmd->ElemCount;
         vertex_buffer.index_type = impeller::IndexType::k16bit;
-        cmd.BindVertices(vertex_buffer);
+        cmd.BindVertices(std::move(vertex_buffer));
         cmd.base_vertex = pcmd->VtxOffset;
 
         render_pass.AddCommand(std::move(cmd));

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -377,7 +377,7 @@ std::optional<size_t> BufferBindingsGLES::BindTextures(
     /// If there is a sampler for the texture at the same index, configure the
     /// bound texture using that sampler.
     ///
-    const auto& sampler_gles = SamplerGLES::Cast(*data.second.sampler.resource);
+    const auto& sampler_gles = SamplerGLES::Cast(*data.second.sampler);
     if (!sampler_gles.ConfigureBoundTexture(texture_gles, gl)) {
       return std::nullopt;
     }

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -372,7 +372,7 @@ struct RenderPassData {
         break;
     }
 
-    if (command.index_type == IndexType::kUnknown) {
+    if (command.vertex_buffer.index_type == IndexType::kUnknown) {
       return false;
     }
 
@@ -381,7 +381,7 @@ struct RenderPassData {
     //--------------------------------------------------------------------------
     /// Bind vertex and index buffers.
     ///
-    auto vertex_buffer_view = command.GetVertexBuffer();
+    auto& vertex_buffer_view = command.vertex_buffer.vertex_buffer;
 
     if (!vertex_buffer_view) {
       return false;
@@ -441,11 +441,12 @@ struct RenderPassData {
     //--------------------------------------------------------------------------
     /// Finally! Invoke the draw call.
     ///
-    if (command.index_type == IndexType::kNone) {
-      gl.DrawArrays(mode, command.base_vertex, command.vertex_count);
+    if (command.vertex_buffer.index_type == IndexType::kNone) {
+      gl.DrawArrays(mode, command.base_vertex,
+                    command.vertex_buffer.vertex_count);
     } else {
       // Bind the index buffer if necessary.
-      auto index_buffer_view = command.index_buffer;
+      auto index_buffer_view = command.vertex_buffer.index_buffer;
       auto index_buffer =
           index_buffer_view.buffer->GetDeviceBuffer(*transients_allocator);
       const auto& index_buffer_gles = DeviceBufferGLES::Cast(*index_buffer);
@@ -453,9 +454,9 @@ struct RenderPassData {
               DeviceBufferGLES::BindingType::kElementArrayBuffer)) {
         return false;
       }
-      gl.DrawElements(mode,                             // mode
-                      command.vertex_count,             // count
-                      ToIndexType(command.index_type),  // type
+      gl.DrawElements(mode,                                           // mode
+                      command.vertex_buffer.vertex_count,             // count
+                      ToIndexType(command.vertex_buffer.index_type),  // type
                       reinterpret_cast<const GLvoid*>(static_cast<GLsizei>(
                           index_buffer_view.range.offset))  // indices
       );

--- a/impeller/renderer/backend/metal/compute_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.mm
@@ -231,7 +231,7 @@ bool ComputePassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
     }
 
     for (const auto& data : command.bindings.sampled_images) {
-      if (!Bind(pass_bindings, data.first, *data.second.sampler.resource,
+      if (!Bind(pass_bindings, data.first, *data.second.sampler,
                 *data.second.texture.resource)) {
         return false;
       }

--- a/impeller/renderer/backend/vulkan/binding_helpers_vk.cc
+++ b/impeller/renderer/backend/vulkan/binding_helpers_vk.cc
@@ -26,7 +26,7 @@ static bool BindImages(const Bindings& bindings,
   for (const auto& [index, data] : bindings.sampled_images) {
     auto texture = data.texture.resource;
     const auto& texture_vk = TextureVK::Cast(*texture);
-    const SamplerVK& sampler = SamplerVK::Cast(*data.sampler.resource);
+    const SamplerVK& sampler = SamplerVK::Cast(*data.sampler);
 
     if (!encoder->Track(texture) ||
         !encoder->Track(sampler.GetSharedSampler())) {

--- a/impeller/renderer/command.cc
+++ b/impeller/renderer/command.cc
@@ -12,22 +12,14 @@
 
 namespace impeller {
 
-bool Command::BindVertices(const VertexBuffer& buffer) {
+bool Command::BindVertices(VertexBuffer buffer) {
   if (buffer.index_type == IndexType::kUnknown) {
     VALIDATION_LOG << "Cannot bind vertex buffer with an unknown index type.";
     return false;
   }
 
-  vertex_bindings.vertex_buffer =
-      BufferAndUniformSlot{.slot = {}, .view = {nullptr, buffer.vertex_buffer}};
-  index_buffer = buffer.index_buffer;
-  vertex_count = buffer.vertex_count;
-  index_type = buffer.index_type;
+  vertex_buffer = std::move(buffer);
   return true;
-}
-
-BufferView Command::GetVertexBuffer() const {
-  return vertex_bindings.vertex_buffer.view.resource;
 }
 
 bool Command::BindResource(ShaderStage stage,
@@ -95,14 +87,14 @@ bool Command::BindResource(ShaderStage stage,
       vertex_bindings.sampled_images[slot.sampler_index] = TextureAndSampler{
           .slot = slot,
           .texture = {&metadata, texture},
-          .sampler = {&metadata, sampler},
+          .sampler = sampler,
       };
       return true;
     case ShaderStage::kFragment:
       fragment_bindings.sampled_images[slot.sampler_index] = TextureAndSampler{
           .slot = slot,
           .texture = {&metadata, texture},
-          .sampler = {&metadata, sampler},
+          .sampler = sampler,
       };
       return true;
     case ShaderStage::kCompute:

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -60,13 +60,12 @@ struct Resource {
 
 using BufferResource = Resource<BufferView>;
 using TextureResource = Resource<std::shared_ptr<const Texture>>;
-using SamplerResource = Resource<std::shared_ptr<const Sampler>>;
 
 /// @brief combines the texture, sampler and sampler slot information.
 struct TextureAndSampler {
   SampledImageSlot slot;
   TextureResource texture;
-  SamplerResource sampler;
+  std::shared_ptr<const Sampler> sampler;
 };
 
 /// @brief combines the buffer resource and its uniform slot information.
@@ -78,8 +77,6 @@ struct BufferAndUniformSlot {
 struct Bindings {
   std::map<size_t, TextureAndSampler> sampled_images;
   std::map<size_t, BufferAndUniformSlot> buffers;
-  // This is only valid for vertex bindings.
-  BufferAndUniformSlot vertex_buffer;
 };
 
 //------------------------------------------------------------------------------
@@ -111,29 +108,6 @@ struct Command : public ResourceBinder {
   /// stage.
   ///
   Bindings fragment_bindings;
-  //----------------------------------------------------------------------------
-  /// The index buffer binding used by the vertex shader stage. Instead of
-  /// setting this directly, it usually easier to specify the vertex and index
-  /// buffer bindings directly via a single call to `BindVertices`.
-  ///
-  /// @see         `BindVertices`
-  ///
-  BufferView index_buffer;
-  //----------------------------------------------------------------------------
-  /// The number of vertices to draw.
-  ///
-  /// If the index_type is `IndexType::kNone`, this is a count into the vertex
-  /// buffer. Otherwise, it is a count into the index buffer. Set the vertex and
-  /// index buffers as well as the index count using a call to `BindVertices`.
-  ///
-  /// @see         `BindVertices`
-  ///
-  size_t vertex_count = 0u;
-  //----------------------------------------------------------------------------
-  /// The type of indices in the index buffer. The indices must be tightly
-  /// packed in the index buffer.
-  ///
-  IndexType index_type = IndexType::kUnknown;
 
 #ifdef IMPELLER_DEBUG
   //----------------------------------------------------------------------------
@@ -177,13 +151,18 @@ struct Command : public ResourceBinder {
   size_t instance_count = 1u;
 
   //----------------------------------------------------------------------------
+  /// The bound per-vertex data and optional index buffer.
+  VertexBuffer vertex_buffer;
+
+  //----------------------------------------------------------------------------
   /// @brief      Specify the vertex and index buffer to use for this command.
   ///
-  /// @param[in]  buffer  The vertex and index buffer definition.
+  /// @param[in]  buffer  The vertex and index buffer definition. If possible,
+  ///             this value should be moved and not copied.
   ///
   /// @return     returns if the binding was updated.
   ///
-  bool BindVertices(const VertexBuffer& buffer);
+  bool BindVertices(VertexBuffer buffer);
 
   // |ResourceBinder|
   bool BindResource(ShaderStage stage,
@@ -202,8 +181,6 @@ struct Command : public ResourceBinder {
                     const ShaderMetadata& metadata,
                     const std::shared_ptr<const Texture>& texture,
                     const std::shared_ptr<const Sampler>& sampler) override;
-
-  BufferView GetVertexBuffer() const;
 
   bool IsValid() const { return pipeline && pipeline->IsValid(); }
 

--- a/impeller/renderer/compute_command.cc
+++ b/impeller/renderer/compute_command.cc
@@ -48,10 +48,7 @@ bool ComputeCommand::BindResource(
   }
 
   bindings.sampled_images[slot.sampler_index] = TextureAndSampler{
-      .slot = slot,
-      .texture = {&metadata, texture},
-      .sampler = {&metadata, sampler},
-  };
+      .slot = slot, .texture = {&metadata, texture}, .sampler = sampler};
 
   return false;
 }

--- a/impeller/renderer/compute_subgroup_unittests.cc
+++ b/impeller/renderer/compute_subgroup_unittests.cc
@@ -153,11 +153,10 @@ TEST_P(ComputeSubgroupTest, PathPlayground) {
                      vertex_buffer_count->AsBufferView().contents)
                      ->count;
 
-    VertexBuffer render_vertex_buffer{
-        .vertex_buffer = vertex_buffer->AsBufferView(),
-        .vertex_count = count,
-        .index_type = IndexType::kNone};
-    cmd.BindVertices(render_vertex_buffer);
+    cmd.BindVertices(
+        VertexBuffer{.vertex_buffer = vertex_buffer->AsBufferView(),
+                     .vertex_count = count,
+                     .index_type = IndexType::kNone});
 
     VS::FrameInfo frame_info;
     auto world_matrix = Matrix::MakeScale(GetContentScale());
@@ -357,11 +356,10 @@ TEST_P(ComputeSubgroupTest, LargePath) {
                      vertex_buffer_count->AsBufferView().contents)
                      ->count;
 
-    VertexBuffer render_vertex_buffer{
-        .vertex_buffer = vertex_buffer->AsBufferView(),
-        .vertex_count = count,
-        .index_type = IndexType::kNone};
-    cmd.BindVertices(render_vertex_buffer);
+    cmd.BindVertices(
+        VertexBuffer{.vertex_buffer = vertex_buffer->AsBufferView(),
+                     .vertex_count = count,
+                     .index_type = IndexType::kNone});
 
     VS::FrameInfo frame_info;
     auto world_matrix = Matrix::MakeScale(GetContentScale());
@@ -441,11 +439,10 @@ TEST_P(ComputeSubgroupTest, QuadAndCubicInOnePath) {
                      vertex_buffer_count->AsBufferView().contents)
                      ->count;
 
-    VertexBuffer render_vertex_buffer{
-        .vertex_buffer = vertex_buffer->AsBufferView(),
-        .vertex_count = count,
-        .index_type = IndexType::kNone};
-    cmd.BindVertices(render_vertex_buffer);
+    cmd.BindVertices(
+        VertexBuffer{.vertex_buffer = vertex_buffer->AsBufferView(),
+                     .vertex_count = count,
+                     .index_type = IndexType::kNone});
 
     VS::FrameInfo frame_info;
     auto world_matrix = Matrix::MakeScale(GetContentScale());

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -74,13 +74,8 @@ bool RenderPass::AddCommand(Command&& command) {
     }
   }
 
-  if (command.vertex_count == 0u) {
-    // Essentially a no-op. Don't record the command but this is not necessary
-    // an error either.
-    return true;
-  }
-
-  if (command.instance_count == 0u) {
+  if (command.vertex_buffer.vertex_count == 0u ||
+      command.instance_count == 0u) {
     // Essentially a no-op. Don't record the command but this is not necessary
     // an error either.
     return true;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -72,10 +72,6 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
       {{800, 800, 0.0}, {1.0, 1.0}},  // 3
       {{100, 800, 0.0}, {0.0, 1.0}},  // 4
   });
-  auto vertex_buffer =
-      vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator());
-  ASSERT_TRUE(vertex_buffer);
-
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
@@ -96,7 +92,8 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
     DEBUG_COMMAND_INFO(cmd, "Box");
     cmd.pipeline = pipeline;
 
-    cmd.BindVertices(vertex_buffer);
+    cmd.BindVertices(
+        vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator()));
 
     VS::UniformBuffer uniforms;
     uniforms.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -395,10 +395,9 @@ bool InternalFlutterGpu_RenderPass_BindTexture(
 void InternalFlutterGpu_RenderPass_ClearBindings(
     flutter::gpu::RenderPass* wrapper) {
   auto& command = wrapper->GetCommand();
-  command.vertex_count = 0;
+  command.vertex_buffer = {};
   command.vertex_bindings = {};
   command.fragment_bindings = {};
-  command.index_buffer = {};
 }
 
 void InternalFlutterGpu_RenderPass_SetColorBlendEnable(


### PR DESCRIPTION
Placing the vertex buffer on the binding object meant that we were actually paying 2x the size cost for it (one for vertex bindings, one for fragment bindings). By moving this object onto command itself, we reduce the size and avoid spliting up the command state in a weird way.


Also updates most of the contents to prefer moving the VertexBuffer.
