### PR TITLE
Remove some trivial forward declares from Impeller

### DIFF
--- a/impeller/aiks/aiks_context.h
+++ b/impeller/aiks/aiks_context.h
@@ -15,7 +15,6 @@
 namespace impeller {
 
 struct Picture;
-class RenderPass;
 
 class AiksContext {
  public:

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -15,6 +15,7 @@
 #include "impeller/aiks/paint.h"
 #include "impeller/aiks/picture.h"
 #include "impeller/core/sampler_descriptor.h"
+#include "impeller/entity/entity.h"
 #include "impeller/entity/entity_pass.h"
 #include "impeller/entity/geometry/geometry.h"
 #include "impeller/entity/geometry/vertices_geometry.h"
@@ -25,8 +26,6 @@
 #include "impeller/typographer/text_frame.h"
 
 namespace impeller {
-
-class Entity;
 
 struct CanvasStackEntry {
   Matrix transform;

--- a/impeller/aiks/paint_pass_delegate.h
+++ b/impeller/aiks/paint_pass_delegate.h
@@ -12,8 +12,6 @@
 
 namespace impeller {
 
-class EntityPass;
-
 class PaintPassDelegate final : public EntityPassDelegate {
  public:
   explicit PaintPassDelegate(Paint paint);

--- a/impeller/core/allocator.h
+++ b/impeller/core/allocator.h
@@ -14,7 +14,6 @@ namespace impeller {
 
 class Context;
 class DeviceBuffer;
-class Texture;
 
 //------------------------------------------------------------------------------
 /// @brief      An object that allocates device memory.

--- a/impeller/core/sampler.h
+++ b/impeller/core/sampler.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <unordered_map>
+
+#include "impeller/base/comparable.h"
 #include "impeller/core/sampler_descriptor.h"
 
 namespace impeller {
@@ -26,5 +29,10 @@ class Sampler {
 
   Sampler& operator=(const Sampler&) = delete;
 };
+
+using SamplerMap = std::unordered_map<SamplerDescriptor,
+                                      std::shared_ptr<const Sampler>,
+                                      ComparableHash<SamplerDescriptor>,
+                                      ComparableEqual<SamplerDescriptor>>;
 
 }  // namespace impeller

--- a/impeller/core/sampler_descriptor.h
+++ b/impeller/core/sampler_descriptor.h
@@ -4,14 +4,11 @@
 
 #pragma once
 
-#include <unordered_map>
-
 #include "impeller/base/comparable.h"
 #include "impeller/core/formats.h"
 
 namespace impeller {
 
-class Sampler;
 class Context;
 
 struct SamplerDescriptor final : public Comparable<SamplerDescriptor> {
@@ -48,10 +45,5 @@ struct SamplerDescriptor final : public Comparable<SamplerDescriptor> {
            depth_address_mode == o.depth_address_mode;
   }
 };
-
-using SamplerMap = std::unordered_map<SamplerDescriptor,
-                                      std::shared_ptr<const Sampler>,
-                                      ComparableHash<SamplerDescriptor>,
-                                      ComparableEqual<SamplerDescriptor>>;
 
 }  // namespace impeller

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "flutter/fml/macros.h"
+#include "impeller/core/allocator.h"
 #include "impeller/core/capture.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/host_buffer.h"
@@ -20,7 +21,6 @@ class ShaderLibrary;
 class SamplerLibrary;
 class CommandBuffer;
 class PipelineLibrary;
-class Allocator;
 
 //------------------------------------------------------------------------------
 /// @brief      To do anything rendering related with Impeller, you need a

--- a/impeller/renderer/sampler_library.h
+++ b/impeller/renderer/sampler_library.h
@@ -4,9 +4,7 @@
 
 #pragma once
 
-#include <unordered_map>
-
-#include "flutter/fml/macros.h"
+#include "impeller/core/sampler.h"
 #include "impeller/core/sampler_descriptor.h"
 
 namespace impeller {


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/133417#issuecomment-1839273553

I'll request a test exemption for this as it's a semantics-only refactor.

There are still a bunch of other forward declares in Impeller that make things confusing for tooling, but some of those will require less trivial changes to interfaces.