### PR TITLE
[Impeller] Declare specialization constants as floats.

### DIFF
--- a/impeller/docs/specialization_constants.md
+++ b/impeller/docs/specialization_constants.md
@@ -58,7 +58,7 @@ Instead of using a runtime check, we can create a specialization constant that i
 shader. This constant will be `1` if decal is supported and `0` otherwise.
 
 ```glsl
-layout(constant_id = 0) const int supports_decal = 1;
+layout(constant_id = 0) const float supports_decal = 1.0;
 
 vec4 Sample(sampler2D sampler, vec2 coord) {
   if (supports_decal) {
@@ -77,7 +77,7 @@ Immediately we realize a number of benefits:
 
 ## Implementation
 
-Only 32bit ints are supported as const values and can be used to represent:
+Const values are floats and can be used to represent:
 
 * true/false via 0/1.
 * function selection, such as advanced blends. The specialization value maps to a specific blend function. For example, 0 maps to screen and 1 to overlay via a giant if/else macro.

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -197,8 +197,8 @@ ContentContext::ContentContext(
       .primitive_type = PrimitiveType::kTriangleStrip,
       .color_attachment_pixel_format =
           context_->GetCapabilities()->GetDefaultColorFormat()};
-  const auto supports_decal =
-      context_->GetCapabilities()->SupportsDecalSamplerAddressMode();
+  const auto supports_decal = static_cast<Scalar>(
+      context_->GetCapabilities()->SupportsDecalSamplerAddressMode());
 
 #ifdef IMPELLER_DEBUG
   checkerboard_pipelines_.CreateDefault(*context_, options);
@@ -221,96 +221,96 @@ ContentContext::ContentContext(
   if (context_->GetCapabilities()->SupportsFramebufferFetch()) {
     framebuffer_blend_color_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kColor), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kColor), supports_decal});
     framebuffer_blend_colorburn_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kColorBurn), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kColorBurn), supports_decal});
     framebuffer_blend_colordodge_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kColorDodge), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kColorDodge), supports_decal});
     framebuffer_blend_darken_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kDarken), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kDarken), supports_decal});
     framebuffer_blend_difference_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kDifference), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kDifference), supports_decal});
     framebuffer_blend_exclusion_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kExclusion), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kExclusion), supports_decal});
     framebuffer_blend_hardlight_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kHardLight), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kHardLight), supports_decal});
     framebuffer_blend_hue_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kHue), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kHue), supports_decal});
     framebuffer_blend_lighten_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kLighten), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kLighten), supports_decal});
     framebuffer_blend_luminosity_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kLuminosity), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kLuminosity), supports_decal});
     framebuffer_blend_multiply_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kMultiply), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kMultiply), supports_decal});
     framebuffer_blend_overlay_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kOverlay), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kOverlay), supports_decal});
     framebuffer_blend_saturation_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kSaturation), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kSaturation), supports_decal});
     framebuffer_blend_screen_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kScreen), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kScreen), supports_decal});
     framebuffer_blend_softlight_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
-        {static_cast<int32_t>(BlendSelectValues::kSoftLight), supports_decal});
+        {static_cast<Scalar>(BlendSelectValues::kSoftLight), supports_decal});
   }
 
   blend_color_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kColor), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kColor), supports_decal});
   blend_colorburn_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kColorBurn), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kColorBurn), supports_decal});
   blend_colordodge_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kColorDodge), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kColorDodge), supports_decal});
   blend_darken_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kDarken), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kDarken), supports_decal});
   blend_difference_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kDifference), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kDifference), supports_decal});
   blend_exclusion_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kExclusion), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kExclusion), supports_decal});
   blend_hardlight_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kHardLight), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kHardLight), supports_decal});
   blend_hue_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kHue), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kHue), supports_decal});
   blend_lighten_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kLighten), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kLighten), supports_decal});
   blend_luminosity_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kLuminosity), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kLuminosity), supports_decal});
   blend_multiply_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kMultiply), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kMultiply), supports_decal});
   blend_overlay_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kOverlay), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kOverlay), supports_decal});
   blend_saturation_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kSaturation), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kSaturation), supports_decal});
   blend_screen_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kScreen), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kScreen), supports_decal});
   blend_softlight_pipelines_.CreateDefault(
       *context_, options_trianglestrip,
-      {static_cast<int32_t>(BlendSelectValues::kSoftLight), supports_decal});
+      {static_cast<Scalar>(BlendSelectValues::kSoftLight), supports_decal});
 
   rrect_blur_pipelines_.CreateDefault(*context_, options_trianglestrip);
   texture_blend_pipelines_.CreateDefault(*context_, options);

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -713,7 +713,7 @@ class ContentContext {
 
     void CreateDefault(const Context& context,
                        const ContentContextOptions& options,
-                       const std::initializer_list<int32_t>& constants = {}) {
+                       const std::initializer_list<Scalar>& constants = {}) {
       auto desc =
           PipelineT::Builder::MakeDefaultPipelineDescriptor(context, constants);
       if (!desc.has_value()) {

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2507,9 +2507,9 @@ TEST_P(EntityTest, SpecializationConstantsAreAppliedToVariants) {
   ASSERT_EQ(default_color_burn->GetDescriptor().GetSpecializationConstants(),
             alt_color_burn->GetDescriptor().GetSpecializationConstants());
 
-  auto decal_supported = static_cast<int32_t>(
+  auto decal_supported = static_cast<Scalar>(
       GetContext()->GetCapabilities()->SupportsDecalSamplerAddressMode());
-  std::vector<int32_t> expected_constants = {5, decal_supported};
+  std::vector<Scalar> expected_constants = {5, decal_supported};
   ASSERT_EQ(default_color_burn->GetDescriptor().GetSpecializationConstants(),
             expected_constants);
 }
@@ -2520,9 +2520,9 @@ TEST_P(EntityTest, DecalSpecializationAppliedToMorphologyFilter) {
 
   auto default_color_burn = content_context.GetMorphologyFilterPipeline({});
 
-  auto decal_supported = static_cast<int32_t>(
+  auto decal_supported = static_cast<Scalar>(
       GetContext()->GetCapabilities()->SupportsDecalSamplerAddressMode());
-  std::vector<int32_t> expected_constants = {decal_supported};
+  std::vector<Scalar> expected_constants = {decal_supported};
   ASSERT_EQ(default_color_burn->GetDescriptor().GetSpecializationConstants(),
             expected_constants);
 }

--- a/impeller/entity/shaders/blending/advanced_blend.frag
+++ b/impeller/entity/shaders/blending/advanced_blend.frag
@@ -8,8 +8,8 @@
 #include <impeller/types.glsl>
 #include "blend_select.glsl"
 
-layout(constant_id = 0) const int blend_type = 0;
-layout(constant_id = 1) const int supports_decal = 1;
+layout(constant_id = 0) const float blend_type = 0.0;
+layout(constant_id = 1) const float supports_decal = 1.0;
 
 uniform BlendInfo {
   float16_t dst_input_alpha;
@@ -49,7 +49,7 @@ void main() {
                              ) *
                           blend_info.src_input_alpha;
 
-  f16vec3 blend_result = AdvancedBlend(dst.rgb, src.rgb, blend_type);
+  f16vec3 blend_result = AdvancedBlend(dst.rgb, src.rgb, int(blend_type));
   f16vec4 blended = mix(src, f16vec4(blend_result, dst.a), dst.a);
   frag_color = mix(dst_sample, blended, src.a);
 }

--- a/impeller/entity/shaders/blending/framebuffer_blend.frag
+++ b/impeller/entity/shaders/blending/framebuffer_blend.frag
@@ -10,8 +10,8 @@
 #include <impeller/types.glsl>
 #include "blend_select.glsl"
 
-layout(constant_id = 0) const int blend_type = 0;
-layout(constant_id = 1) const int supports_decal = 1;
+layout(constant_id = 0) const float blend_type = 0.0;
+layout(constant_id = 1) const float supports_decal = 1.0;
 
 layout(set = 0,
        binding = 0,
@@ -46,7 +46,7 @@ void main() {
                                )) *
                 frag_info.src_input_alpha;
 
-  f16vec3 blend_result = AdvancedBlend(dst.rgb, src.rgb, blend_type);
+  f16vec3 blend_result = AdvancedBlend(dst.rgb, src.rgb, int(blend_type));
   f16vec4 blended = mix(src, f16vec4(blend_result, dst.a), dst.a);
   frag_color = vec4(mix(dst, blended, src.a));
 }

--- a/impeller/entity/shaders/blending/porter_duff_blend.frag
+++ b/impeller/entity/shaders/blending/porter_duff_blend.frag
@@ -9,7 +9,7 @@ precision mediump float;
 #include <impeller/texture.glsl>
 #include <impeller/types.glsl>
 
-layout(constant_id = 0) const int supports_decal = 1;
+layout(constant_id = 0) const float supports_decal = 1.0;
 
 uniform f16sampler2D texture_sampler_dst;
 

--- a/impeller/entity/shaders/morphology_filter.frag
+++ b/impeller/entity/shaders/morphology_filter.frag
@@ -4,7 +4,7 @@
 
 precision mediump float;
 
-layout(constant_id = 0) const int supports_decal = 1;
+layout(constant_id = 0) const float supports_decal = 1.0;
 
 #include <impeller/constants.glsl>
 #include <impeller/texture.glsl>

--- a/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -142,7 +142,7 @@ bool ProcTableGLES::IsValid() const {
 void ProcTableGLES::ShaderSourceMapping(
     GLuint shader,
     const fml::Mapping& mapping,
-    const std::vector<int32_t>& defines) const {
+    const std::vector<Scalar>& defines) const {
   if (defines.empty()) {
     const GLchar* sources[] = {
         reinterpret_cast<const GLchar*>(mapping.GetMapping())};
@@ -165,7 +165,7 @@ void ProcTableGLES::ShaderSourceMapping(
 // Visible For testing.
 std::optional<std::string> ProcTableGLES::ComputeShaderWithDefines(
     const fml::Mapping& mapping,
-    const std::vector<int32_t>& defines) const {
+    const std::vector<Scalar>& defines) const {
   auto shader_source = std::string{
       reinterpret_cast<const char*>(mapping.GetMapping()), mapping.GetSize()};
 
@@ -178,6 +178,7 @@ std::optional<std::string> ProcTableGLES::ComputeShaderWithDefines(
   }
 
   std::stringstream ss;
+  ss << std::fixed;
   for (auto i = 0u; i < defines.size(); i++) {
     ss << "#define SPIRV_CROSS_CONSTANT_ID_" << i << " " << defines[i] << '\n';
   }

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -239,7 +239,7 @@ class ProcTableGLES {
   /// support static specialization. For example, setting "#define Foo 1".
   void ShaderSourceMapping(GLuint shader,
                            const fml::Mapping& mapping,
-                           const std::vector<int32_t>& defines = {}) const;
+                           const std::vector<Scalar>& defines = {}) const;
 
   const DescriptionGLES* GetDescription() const;
 
@@ -262,7 +262,7 @@ class ProcTableGLES {
   // Visible For testing.
   std::optional<std::string> ComputeShaderWithDefines(
       const fml::Mapping& mapping,
-      const std::vector<int32_t>& defines) const;
+      const std::vector<Scalar>& defines) const;
 
  private:
   bool is_valid_ = false;

--- a/impeller/renderer/backend/gles/test/specialization_constants_unittests.cc
+++ b/impeller/renderer/backend/gles/test/specialization_constants_unittests.cc
@@ -26,7 +26,7 @@ TEST(SpecConstant, CanCreateShaderWithSpecializationConstant) {
 
   auto expected_shader_source =
       "#version 100\n"
-      "#define SPIRV_CROSS_CONSTANT_ID_0 0\n"
+      "#define SPIRV_CROSS_CONSTANT_ID_0 0.000000\n"
       "#ifndef SPIRV_CROSS_CONSTANT_ID_0\n"
       "#define SPIRV_CROSS_CONSTANT_ID_0 1\n"
       "#endif\n"
@@ -54,12 +54,12 @@ TEST(SpecConstant, CanCreateShaderWithSpecializationConstantMultipleValues) {
 
   auto expected_shader_source =
       "#version 100\n"
-      "#define SPIRV_CROSS_CONSTANT_ID_0 0\n"
-      "#define SPIRV_CROSS_CONSTANT_ID_1 1\n"
-      "#define SPIRV_CROSS_CONSTANT_ID_2 2\n"
-      "#define SPIRV_CROSS_CONSTANT_ID_3 3\n"
-      "#define SPIRV_CROSS_CONSTANT_ID_4 4\n"
-      "#define SPIRV_CROSS_CONSTANT_ID_5 5\n"
+      "#define SPIRV_CROSS_CONSTANT_ID_0 0.000000\n"
+      "#define SPIRV_CROSS_CONSTANT_ID_1 1.000000\n"
+      "#define SPIRV_CROSS_CONSTANT_ID_2 2.000000\n"
+      "#define SPIRV_CROSS_CONSTANT_ID_3 3.000000\n"
+      "#define SPIRV_CROSS_CONSTANT_ID_4 4.000000\n"
+      "#define SPIRV_CROSS_CONSTANT_ID_5 5.000000\n"
       "#ifndef SPIRV_CROSS_CONSTANT_ID_0\n"
       "#define SPIRV_CROSS_CONSTANT_ID_0 1\n"
       "#endif\n"

--- a/impeller/renderer/backend/metal/shader_function_mtl.h
+++ b/impeller/renderer/backend/metal/shader_function_mtl.h
@@ -23,7 +23,7 @@ class ShaderFunctionMTL final
 
   using CompileCallback = std::function<void(id<MTLFunction>)>;
 
-  void GetMTLFunctionSpecialized(const std::vector<int>& constants,
+  void GetMTLFunctionSpecialized(const std::vector<Scalar>& constants,
                                  const CompileCallback& callback) const;
 
  private:

--- a/impeller/renderer/backend/metal/shader_function_mtl.mm
+++ b/impeller/renderer/backend/metal/shader_function_mtl.mm
@@ -18,15 +18,15 @@ ShaderFunctionMTL::ShaderFunctionMTL(UniqueID parent_library_id,
 ShaderFunctionMTL::~ShaderFunctionMTL() = default;
 
 void ShaderFunctionMTL::GetMTLFunctionSpecialized(
-    const std::vector<int>& constants,
+    const std::vector<Scalar>& constants,
     const CompileCallback& callback) const {
   MTLFunctionConstantValues* constantValues =
       [[MTLFunctionConstantValues alloc] init];
   size_t index = 0;
   for (const auto value : constants) {
-    int copied_value = value;
+    Scalar copied_value = value;
     [constantValues setConstantValue:&copied_value
-                                type:MTLDataTypeInt
+                                type:MTLDataTypeFloat
                              atIndex:index];
     index++;
   }

--- a/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
@@ -299,8 +299,8 @@ std::unique_ptr<PipelineVK> PipelineLibraryVK::CreatePipeline(
         map_entries[entrypoint_count];
     for (auto i = 0u; i < constants.size(); i++) {
       vk::SpecializationMapEntry entry;
-      entry.offset = (i * sizeof(int32_t));
-      entry.size = sizeof(int32_t);
+      entry.offset = (i * sizeof(Scalar));
+      entry.size = sizeof(Scalar);
       entry.constantID = i;
       entries.emplace_back(entry);
     }
@@ -309,7 +309,7 @@ std::unique_ptr<PipelineVK> PipelineLibraryVK::CreatePipeline(
         specialization_infos[entrypoint_count];
     specialization_info.setMapEntries(map_entries[entrypoint_count]);
     specialization_info.setPData(constants.data());
-    specialization_info.setDataSize(sizeof(int32_t) * constants.size());
+    specialization_info.setDataSize(sizeof(Scalar) * constants.size());
 
     vk::PipelineShaderStageCreateInfo info;
     info.setStage(stage.value());

--- a/impeller/renderer/pipeline_builder.h
+++ b/impeller/renderer/pipeline_builder.h
@@ -49,7 +49,7 @@ struct PipelineBuilder {
   ///
   static std::optional<PipelineDescriptor> MakeDefaultPipelineDescriptor(
       const Context& context,
-      const std::vector<int>& constants = {}) {
+      const std::vector<Scalar>& constants = {}) {
     PipelineDescriptor desc;
     desc.SetSpecializationConstants(constants);
     if (InitializePipelineDescriptorDefaults(context, desc)) {

--- a/impeller/renderer/pipeline_descriptor.cc
+++ b/impeller/renderer/pipeline_descriptor.cc
@@ -282,11 +282,11 @@ PolygonMode PipelineDescriptor::GetPolygonMode() const {
 }
 
 void PipelineDescriptor::SetSpecializationConstants(
-    std::vector<int32_t> values) {
+    std::vector<Scalar> values) {
   specialization_constants_ = std::move(values);
 }
 
-const std::vector<int32_t>& PipelineDescriptor::GetSpecializationConstants()
+const std::vector<Scalar>& PipelineDescriptor::GetSpecializationConstants()
     const {
   return specialization_constants_;
 }

--- a/impeller/renderer/pipeline_descriptor.h
+++ b/impeller/renderer/pipeline_descriptor.h
@@ -124,9 +124,9 @@ class PipelineDescriptor final : public Comparable<PipelineDescriptor> {
 
   PolygonMode GetPolygonMode() const;
 
-  void SetSpecializationConstants(std::vector<int32_t> values);
+  void SetSpecializationConstants(std::vector<Scalar> values);
 
-  const std::vector<int32_t>& GetSpecializationConstants() const;
+  const std::vector<Scalar>& GetSpecializationConstants() const;
 
  private:
   std::string label_;
@@ -146,7 +146,7 @@ class PipelineDescriptor final : public Comparable<PipelineDescriptor> {
       back_stencil_attachment_descriptor_;
   PrimitiveType primitive_type_ = PrimitiveType::kTriangle;
   PolygonMode polygon_mode_ = PolygonMode::kFill;
-  std::vector<int32_t> specialization_constants_;
+  std::vector<Scalar> specialization_constants_;
 };
 
 }  // namespace impeller


### PR DESCRIPTION
This provides more flexibility and works around issues seen when using int constants in GLSL on some devices.

Fixes https://github.com/flutter/flutter/issues/139408