### PR TITLE
[Impeller] Provide the clear color to an advanced blend if it was optimized out

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4249,5 +4249,17 @@ TEST_P(AiksTest, MaskBlurWithZeroSigmaIsSkipped) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, AdvancedBlendWithClearColorOptimization) {
+  Canvas canvas;
+  canvas.DrawPaint(
+      {.color = {1.0, 1.0, 0.0, 1.0}, .blend_mode = BlendMode::kSource});
+
+  canvas.DrawRect(
+      Rect::MakeXYWH(0, 0, 200, 300),
+      {.color = {1.0, 0.0, 1.0, 1.0}, .blend_mode = BlendMode::kMultiply});
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2443,6 +2443,14 @@ TEST_P(EntityTest, AdvancedBlendCoverageHintIsNotResetByEntityPass) {
                     "for advanced blends.";
   }
 
+  auto background_contents = std::make_shared<SolidColorContents>();
+  background_contents->SetGeometry(
+      Geometry::MakeRect(Rect::MakeXYWH(200, 200, 200, 200)));
+  background_contents->SetColor(Color::Blue());
+  Entity background_entity;
+  background_entity.SetTransform(Matrix::MakeScale(Vector3(2, 2, 1)));
+  background_entity.SetContents(background_contents);
+
   auto contents = std::make_shared<SolidColorContents>();
   contents->SetGeometry(Geometry::MakeRect(Rect::MakeXYWH(100, 100, 100, 100)));
   contents->SetColor(Color::Red());
@@ -2468,6 +2476,7 @@ TEST_P(EntityTest, AdvancedBlendCoverageHintIsNotResetByEntityPass) {
       RenderTarget::kDefaultColorAttachmentConfig, stencil_config);
   auto content_context = ContentContext(
       GetContext(), TypographerContextSkia::Make(), test_allocator);
+  pass->AddEntity(std::move(background_entity));
   pass->AddEntity(std::move(entity));
 
   EXPECT_TRUE(pass->Render(content_context, rt));


### PR DESCRIPTION
If all previous elements were skipped due to clear color optimization, then the clear color must be rendered as an input to the advanced blend if framebuffer fetch is not available.