### PR TITLE
[Impeller] Remove duplicate entity test suite instantiations.

### DIFF
--- a/impeller/entity/contents/checkerboard_contents_unittests.cc
+++ b/impeller/entity/contents/checkerboard_contents_unittests.cc
@@ -17,7 +17,6 @@ namespace impeller {
 namespace testing {
 
 using EntityTest = EntityPlayground;
-INSTANTIATE_PLAYGROUND_SUITE(EntityTest);
 
 #ifdef IMPELLER_DEBUG
 TEST(EntityTest, HasNulloptCoverage) {

--- a/impeller/entity/contents/tiled_texture_contents_unittests.cc
+++ b/impeller/entity/contents/tiled_texture_contents_unittests.cc
@@ -15,7 +15,6 @@ namespace impeller {
 namespace testing {
 
 using EntityTest = EntityPlayground;
-INSTANTIATE_PLAYGROUND_SUITE(EntityTest);
 
 TEST_P(EntityTest, TiledTextureContentsRendersWithCorrectPipeline) {
   TextureDescriptor texture_desc;

--- a/impeller/entity/contents/vertices_contents_unittests.cc
+++ b/impeller/entity/contents/vertices_contents_unittests.cc
@@ -21,7 +21,6 @@ namespace impeller {
 namespace testing {
 
 using EntityTest = EntityPlayground;
-INSTANTIATE_PLAYGROUND_SUITE(EntityTest);
 
 std::shared_ptr<VerticesGeometry> CreateColorVertices(
     const std::vector<Point>& vertices,

--- a/impeller/playground/playground_test.h
+++ b/impeller/playground/playground_test.h
@@ -55,14 +55,16 @@ class PlaygroundTest : public Playground,
   PlaygroundTest& operator=(const PlaygroundTest&) = delete;
 };
 
-#define INSTANTIATE_PLAYGROUND_SUITE(playground)                            \
-  INSTANTIATE_TEST_SUITE_P(                                                 \
-      Play, playground,                                                     \
-      ::testing::Values(PlaygroundBackend::kMetal,                          \
-                        PlaygroundBackend::kOpenGLES,                       \
-                        PlaygroundBackend::kVulkan),                        \
-      [](const ::testing::TestParamInfo<PlaygroundTest::ParamType>& info) { \
-        return PlaygroundBackendToString(info.param);                       \
+#define INSTANTIATE_PLAYGROUND_SUITE(playground)                             \
+  [[maybe_unused]] const char* kYouInstantiated##playground##MultipleTimes = \
+      "";                                                                    \
+  INSTANTIATE_TEST_SUITE_P(                                                  \
+      Play, playground,                                                      \
+      ::testing::Values(PlaygroundBackend::kMetal,                           \
+                        PlaygroundBackend::kOpenGLES,                        \
+                        PlaygroundBackend::kVulkan),                         \
+      [](const ::testing::TestParamInfo<PlaygroundTest::ParamType>& info) {  \
+        return PlaygroundBackendToString(info.param);                        \
       });
 
 }  // namespace impeller


### PR DESCRIPTION
And make it illegal to do so in the future. Now, making such a mistake will lead to a linker error complaining about duplicate definitions of `kYouInstantiatedEntityTestMultipleTimes`.

Fixes https://github.com/flutter/flutter/issues/139090