### PR TITLE
Avoid non-const sizes in VLAs.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -8,8 +8,8 @@
 #include "flutter/fml/platform/darwin/cf_utils.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
 
-static int kMaxPointsInVerb = 4;
-static const NSUInteger kFlutterClippingMaskViewPoolCapacity = 5;
+static constexpr int kMaxPointsInVerb = 4;
+static constexpr NSUInteger kFlutterClippingMaskViewPoolCapacity = 5;
 
 namespace flutter {
 

--- a/third_party/accessibility/ax/platform/ax_unique_id_unittest.cc
+++ b/third_party/accessibility/ax/platform/ax_unique_id_unittest.cc
@@ -54,7 +54,7 @@ TEST(AXPlatformUniqueIdTest, UnassignedIdsAreReused) {
 }
 
 TEST(AXPlatformUniqueIdTest, DoesCreateCorrectId) {
-  int kLargerThanMaxId = kMaxId * 2;
+  constexpr int kLargerThanMaxId = kMaxId * 2;
   std::unique_ptr<AXUniqueId> ids[kLargerThanMaxId];
   // Creates and releases to fill up the internal static counter.
   for (int i = 0; i < kLargerThanMaxId; i++) {


### PR DESCRIPTION
I was shocked this was even legal earlier. But a new Clang roll makes this an a warning which gets converted into an error.

I attempted to roll to the Clang roll the roller did and fixed the issues I found. Hopefully, the next roll is unblocked.

Original failure: https://github.com/flutter/engine/pull/48563