### PR TITLE
[Impeller] Make Impeller create the context to be leaked in the playgrounds.

### DIFF
--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -45,13 +45,30 @@ ShaderLibraryMappingsForPlayground() {
   };
 }
 
-vk::UniqueInstance PlaygroundImplVK::global_instance_;
-
 void PlaygroundImplVK::DestroyWindowHandle(WindowHandle handle) {
   if (!handle) {
     return;
   }
   ::glfwDestroyWindow(reinterpret_cast<GLFWwindow*>(handle));
+}
+
+// Hold a reference to an instance of a Vulkan context in order to prevent
+// unloading of the Vulkan library.
+//
+// A test suite may repeatedly create and destroy PlaygroundImplVK instances,
+// and if the PlaygroundImplVK's Vulkan instance is the only one in the
+// process then the Vulkan library will be unloaded when the instance is
+// destroyed.
+//
+// Repeated loading and unloading of SwiftShader was leaking
+// resources, so this will work around that leak.
+//
+// @see https://github.com/flutter/flutter/issues/138028
+static void IntentionallyLeakContext(std::shared_ptr<ContextVK> context) {
+  if (!context) {
+    return;
+  }
+  static std::shared_ptr<ContextVK> gLeakedContext = std::move(context);
 }
 
 PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
@@ -68,8 +85,6 @@ PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
 #endif
     return;
   }
-
-  InitGlobalVulkanInstance();
 
   ::glfwDefaultWindowHints();
   ::glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
@@ -96,6 +111,7 @@ PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
     VALIDATION_LOG << "Could not create Vulkan context in the playground.";
     return;
   }
+  IntentionallyLeakContext(context_vk);
 
   // Without this, the playground will timeout waiting for the presentation.
   // It's better to have some Vulkan validation tests running on CI to catch
@@ -147,35 +163,6 @@ std::unique_ptr<Surface> PlaygroundImplVK::AcquireSurfaceFrame(
   SurfaceContextVK* surface_context_vk =
       reinterpret_cast<SurfaceContextVK*>(context_.get());
   return surface_context_vk->AcquireNextSurface();
-}
-
-// Create a global instance of Vulkan in order to prevent unloading of the
-// Vulkan library.
-// A test suite may repeatedly create and destroy PlaygroundImplVK instances,
-// and if the PlaygroundImplVK's Vulkan instance is the only one in the
-// process then the Vulkan library will be unloaded when the instance is
-// destroyed.  Repeated loading and unloading of SwiftShader was leaking
-// resources, so this will work around that leak.
-// (see https://github.com/flutter/flutter/issues/138028)
-void PlaygroundImplVK::InitGlobalVulkanInstance() {
-  if (global_instance_) {
-    return;
-  }
-
-  VULKAN_HPP_DEFAULT_DISPATCHER.init(::glfwGetInstanceProcAddress);
-
-  vk::ApplicationInfo application_info;
-  application_info.setApplicationVersion(VK_API_VERSION_1_0);
-  application_info.setApiVersion(VK_API_VERSION_1_1);
-  application_info.setEngineVersion(VK_API_VERSION_1_0);
-  application_info.setPEngineName("PlaygroundImplVK");
-  application_info.setPApplicationName("PlaygroundImplVK");
-
-  auto instance_result =
-      vk::createInstanceUnique(vk::InstanceCreateInfo({}, &application_info));
-  FML_CHECK(instance_result.result == vk::Result::eSuccess)
-      << "Unable to initialize global Vulkan instance";
-  global_instance_ = std::move(instance_result.value);
 }
 
 }  // namespace impeller

--- a/impeller/playground/backend/vulkan/playground_impl_vk.h
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.h
@@ -41,8 +41,6 @@ class PlaygroundImplVK final : public PlaygroundImpl {
   PlaygroundImplVK(const PlaygroundImplVK&) = delete;
 
   PlaygroundImplVK& operator=(const PlaygroundImplVK&) = delete;
-
-  static void InitGlobalVulkanInstance();
 };
 
 }  // namespace impeller


### PR DESCRIPTION
This came up when re-enabling Vulkan playgrounds with MoltenVK.

The playgrounds attempt to leak a context so that the library may not be unloaded. But creating the context with MoltenVK requires compatibility extensions to be setup. Otherwise, the setup fails. Setup failure then causes us not to leak the context (it fails earlier on an assertion).

This patch makes Impeller correctly setup the context first before leaking it.