### PR TITLE
[Impeller] Remove the impeller_enable_vulkan_playgrounds flag.

### DIFF
--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -34,10 +34,6 @@ config("impeller_public_config") {
     defines += [ "IMPELLER_ENABLE_VULKAN=1" ]
   }
 
-  if (impeller_enable_vulkan_playgrounds) {
-    defines += [ "IMPELLER_ENABLE_VULKAN_PLAYGROUNDS=1" ]
-  }
-
   if (impeller_trace_all_gl_calls) {
     defines += [ "IMPELLER_TRACE_ALL_GL_CALLS" ]
   }

--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -45,13 +45,30 @@ ShaderLibraryMappingsForPlayground() {
   };
 }
 
-vk::UniqueInstance PlaygroundImplVK::global_instance_;
-
 void PlaygroundImplVK::DestroyWindowHandle(WindowHandle handle) {
   if (!handle) {
     return;
   }
   ::glfwDestroyWindow(reinterpret_cast<GLFWwindow*>(handle));
+}
+
+// Hold a reference to an instance of a Vulkan context in order to prevent
+// unloading of the Vulkan library.
+//
+// A test suite may repeatedly create and destroy PlaygroundImplVK instances,
+// and if the PlaygroundImplVK's Vulkan instance is the only one in the
+// process then the Vulkan library will be unloaded when the instance is
+// destroyed.
+//
+// Repeated loading and unloading of SwiftShader was leaking
+// resources, so this will work around that leak.
+//
+// @see https://github.com/flutter/flutter/issues/138028
+static void IntentionallyLeakContext(std::shared_ptr<ContextVK> context) {
+  if (!context) {
+    return;
+  }
+  static std::shared_ptr<ContextVK> gLeakedContext = std::move(context);
 }
 
 PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
@@ -68,8 +85,6 @@ PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
 #endif
     return;
   }
-
-  InitGlobalVulkanInstance();
 
   ::glfwDefaultWindowHints();
   ::glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
@@ -96,6 +111,7 @@ PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
     VALIDATION_LOG << "Could not create Vulkan context in the playground.";
     return;
   }
+  IntentionallyLeakContext(context_vk);
 
   // Without this, the playground will timeout waiting for the presentation.
   // It's better to have some Vulkan validation tests running on CI to catch
@@ -147,35 +163,6 @@ std::unique_ptr<Surface> PlaygroundImplVK::AcquireSurfaceFrame(
   SurfaceContextVK* surface_context_vk =
       reinterpret_cast<SurfaceContextVK*>(context_.get());
   return surface_context_vk->AcquireNextSurface();
-}
-
-// Create a global instance of Vulkan in order to prevent unloading of the
-// Vulkan library.
-// A test suite may repeatedly create and destroy PlaygroundImplVK instances,
-// and if the PlaygroundImplVK's Vulkan instance is the only one in the
-// process then the Vulkan library will be unloaded when the instance is
-// destroyed.  Repeated loading and unloading of SwiftShader was leaking
-// resources, so this will work around that leak.
-// (see https://github.com/flutter/flutter/issues/138028)
-void PlaygroundImplVK::InitGlobalVulkanInstance() {
-  if (global_instance_) {
-    return;
-  }
-
-  VULKAN_HPP_DEFAULT_DISPATCHER.init(::glfwGetInstanceProcAddress);
-
-  vk::ApplicationInfo application_info;
-  application_info.setApplicationVersion(VK_API_VERSION_1_0);
-  application_info.setApiVersion(VK_API_VERSION_1_1);
-  application_info.setEngineVersion(VK_API_VERSION_1_0);
-  application_info.setPEngineName("PlaygroundImplVK");
-  application_info.setPApplicationName("PlaygroundImplVK");
-
-  auto instance_result =
-      vk::createInstanceUnique(vk::InstanceCreateInfo({}, &application_info));
-  FML_CHECK(instance_result.result == vk::Result::eSuccess)
-      << "Unable to initialize global Vulkan instance";
-  global_instance_ = std::move(instance_result.value);
 }
 
 }  // namespace impeller

--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -71,9 +71,13 @@ static void IntentionallyLeakContext(std::shared_ptr<ContextVK> context) {
   static std::shared_ptr<ContextVK> gLeakedContext = std::move(context);
 }
 
+bool PlaygroundImplVK::HasSupportedVulkanDriver() {
+  return ::glfwVulkanSupported();
+}
+
 PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
     : PlaygroundImpl(switches), handle_(nullptr, &DestroyWindowHandle) {
-  if (!::glfwVulkanSupported()) {
+  if (!HasSupportedVulkanDriver()) {
 #ifdef TARGET_OS_MAC
     VALIDATION_LOG << "Attempted to initialize a Vulkan playground on macOS "
                       "where Vulkan cannot be found. It can be installed via "

--- a/impeller/playground/backend/vulkan/playground_impl_vk.h
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.h
@@ -41,8 +41,6 @@ class PlaygroundImplVK final : public PlaygroundImpl {
   PlaygroundImplVK(const PlaygroundImplVK&) = delete;
 
   PlaygroundImplVK& operator=(const PlaygroundImplVK&) = delete;
-
-  static void InitGlobalVulkanInstance();
 };
 
 }  // namespace impeller

--- a/impeller/playground/backend/vulkan/playground_impl_vk.h
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.h
@@ -12,6 +12,8 @@ namespace impeller {
 
 class PlaygroundImplVK final : public PlaygroundImpl {
  public:
+  static bool HasSupportedVulkanDriver();
+
   explicit PlaygroundImplVK(PlaygroundSwitches switches);
 
   ~PlaygroundImplVK();

--- a/impeller/playground/compute_playground_test.cc
+++ b/impeller/playground/compute_playground_test.cc
@@ -4,6 +4,9 @@
 
 #include "flutter/fml/time/time_point.h"
 
+#include <sstream>
+
+#include "flutter/fml/build_config.h"
 #include "flutter/testing/test_args.h"
 #include "impeller/playground/compute_playground_test.h"
 
@@ -15,13 +18,9 @@ ComputePlaygroundTest::ComputePlaygroundTest()
 ComputePlaygroundTest::~ComputePlaygroundTest() = default;
 
 void ComputePlaygroundTest::SetUp() {
-  if (!Playground::SupportsBackend(GetParam())) {
-    GTEST_SKIP_("Playground doesn't support this backend type.");
-    return;
-  }
-
-  if (!Playground::ShouldOpenNewPlaygrounds()) {
-    GTEST_SKIP_("Skipping due to user action.");
+  std::string skip_message;
+  if (Playground::ShouldSkipPlaygroundInvocation(GetParam(), skip_message)) {
+    GTEST_SKIP_(skip_message.c_str());
     return;
   }
 

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -80,7 +80,15 @@ class Playground {
   std::shared_ptr<Texture> CreateTextureCubeForFixture(
       std::array<const char*, 6> fixture_names) const;
 
-  static bool SupportsBackend(PlaygroundBackend backend);
+  enum class SupportStatus {
+    kSupported,
+    kDisabled,
+    kMissingDriver,
+  };
+  static SupportStatus SupportsBackend(PlaygroundBackend backend);
+
+  static bool ShouldSkipPlaygroundInvocation(PlaygroundBackend backend,
+                                             std::string& skip_message);
 
   virtual std::unique_ptr<fml::Mapping> OpenAssetAsMapping(
       std::string asset_name) const = 0;

--- a/impeller/playground/playground_impl.cc
+++ b/impeller/playground/playground_impl.cc
@@ -45,6 +45,21 @@ std::unique_ptr<PlaygroundImpl> PlaygroundImpl::Create(
   FML_UNREACHABLE();
 }
 
+bool PlaygroundImpl::QueryDriverSupport(PlaygroundBackend backend) {
+  switch (backend) {
+    case PlaygroundBackend::kMetal:
+      return true;
+    case PlaygroundBackend::kOpenGLES:
+      return true;
+    case PlaygroundBackend::kVulkan:
+#if IMPELLER_ENABLE_VULKAN
+      return PlaygroundImplVK::HasSupportedVulkanDriver();
+#else   // IMPELLER_ENABLE_VULKAN
+      return false;
+#endif  // IMPELLER_ENABLE_VULKAN
+  }
+}
+
 PlaygroundImpl::PlaygroundImpl(PlaygroundSwitches switches)
     : switches_(switches) {}
 

--- a/impeller/playground/playground_impl.h
+++ b/impeller/playground/playground_impl.h
@@ -19,6 +19,8 @@ class PlaygroundImpl {
   static std::unique_ptr<PlaygroundImpl> Create(PlaygroundBackend backend,
                                                 PlaygroundSwitches switches);
 
+  static bool QueryDriverSupport(PlaygroundBackend backend);
+
   virtual ~PlaygroundImpl();
 
   using WindowHandle = void*;

--- a/impeller/playground/playground_test.cc
+++ b/impeller/playground/playground_test.cc
@@ -16,13 +16,9 @@ PlaygroundTest::PlaygroundTest()
 PlaygroundTest::~PlaygroundTest() = default;
 
 void PlaygroundTest::SetUp() {
-  if (!Playground::SupportsBackend(GetParam())) {
-    GTEST_SKIP_("Playground doesn't support this backend type.");
-    return;
-  }
-
-  if (!Playground::ShouldOpenNewPlaygrounds()) {
-    GTEST_SKIP_("Skipping due to user action.");
+  std::string skip_message;
+  if (Playground::ShouldSkipPlaygroundInvocation(GetParam(), skip_message)) {
+    GTEST_SKIP_(skip_message.c_str());
     return;
   }
 

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -25,13 +25,6 @@ declare_args() {
   impeller_enable_vulkan = (is_linux || is_win || is_android ||
                             enable_unittests) && target_os != "fuchsia"
 
-  # Whether playgrounds should run with Vulkan.
-  #
-  # impeller_enable_vulkan may be true in build environments that run tests but
-  # do not have a Vulkan ICD present.
-  impeller_enable_vulkan_playgrounds =
-      (is_linux || is_win || is_android) && target_os != "fuchsia"
-
   # Whether to use a prebuilt impellerc.
   # If this is the empty string, impellerc will be built.
   # If it is non-empty, it should be the absolute path to impellerc.


### PR DESCRIPTION
Instead of failing, the test will be skipped if an incompatible driver is not
found. Along with the skip, a message detailing why the test was skipped along
with remedial actions will be printed to the console.

Earlier, these tests could not be run at all. Even if playgrounds were enabled.
