### PR TITLE
Revert "Replace use of Fontmgr::RefDefault with explicit creation calls"

### DIFF
--- a/build/secondary/flutter/third_party/glfw/BUILD.gn
+++ b/build/secondary/flutter/third_party/glfw/BUILD.gn
@@ -55,8 +55,6 @@ source_set("glfw") {
       "$_checkout_dir/src/win32_window.c",
     ]
 
-    libs = [ "Gdi32.lib" ]
-
     defines = [ "_GLFW_WIN32" ]
   } else if (is_linux) {
     sources += [

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -11,7 +11,6 @@
 #include "flutter/display_list/skia/dl_sk_canvas.h"
 #include "flutter/display_list/skia/dl_sk_conversions.h"
 #include "flutter/display_list/skia/dl_sk_dispatcher.h"
-#include "flutter/display_list/testing/dl_test_snippets.h"
 #include "flutter/display_list/testing/dl_test_surface_provider.h"
 #include "flutter/display_list/utils/dl_comparable.h"
 #include "flutter/fml/file.h"
@@ -59,7 +58,7 @@ constexpr SkScalar kRenderRadius = std::min(kRenderWidth, kRenderHeight) / 2.0;
 constexpr SkScalar kRenderCornerRadius = kRenderRadius / 5.0;
 
 constexpr SkPoint kTestCenter = SkPoint::Make(kTestWidth / 2, kTestHeight / 2);
-constexpr SkRect kTestBounds2 = SkRect::MakeWH(kTestWidth, kTestHeight);
+constexpr SkRect kTestBounds = SkRect::MakeWH(kTestWidth, kTestHeight);
 constexpr SkRect kRenderBounds =
     SkRect::MakeLTRB(kRenderLeft, kRenderTop, kRenderRight, kRenderBottom);
 
@@ -487,7 +486,7 @@ struct SkJobRenderer : public MatrixClipJobRenderer {
   sk_sp<SkPicture> MakePicture(const RenderJobInfo& info) {
     SkPictureRecorder recorder;
     SkRTreeFactory rtree_factory;
-    SkCanvas* cv = recorder.beginRecording(kTestBounds2, &rtree_factory);
+    SkCanvas* cv = recorder.beginRecording(kTestBounds, &rtree_factory);
     Render(cv, info);
     return recorder.finishRecordingAsPicture();
   }
@@ -533,7 +532,7 @@ struct DlJobRenderer : public MatrixClipJobRenderer {
   }
 
   sk_sp<DisplayList> MakeDisplayList(const RenderJobInfo& info) {
-    DisplayListBuilder builder(kTestBounds2);
+    DisplayListBuilder builder(kTestBounds);
     Render(&builder, info);
     return builder.Build();
   }
@@ -2751,10 +2750,9 @@ class CanvasCompareTester {
 
   static sk_sp<SkTextBlob> MakeTextBlob(const std::string& string,
                                         SkScalar font_height) {
-    SkFont font = CreateTestFontOfSize(font_height);
-    sk_sp<SkTypeface> face = font.refTypeface();
-    FML_CHECK(face);
-    FML_CHECK(face->countGlyphs() > 0) << "No glyphs in font";
+    SkFont font(txt::GetDefaultFontManager()->matchFamilyStyle(
+                    "ahem", SkFontStyle::Normal()),
+                font_height);
     return SkTextBlob::MakeFromText(string.c_str(), string.size(), font,
                                     SkTextEncoding::kUTF8);
   }
@@ -3803,7 +3801,7 @@ TEST_F(DisplayListRendering, SaveLayerClippedContentStillFilters) {
   const SkRect draw_rect = SkRect::MakeLTRB(  //
       kRenderRight + 1,                       //
       kRenderTop,                             //
-      kTestBounds2.fRight,                    //
+      kTestBounds.fRight,                     //
       kRenderBottom                           //
   );
   TestParameters test_params(
@@ -3814,7 +3812,7 @@ TEST_F(DisplayListRendering, SaveLayerClippedContentStillFilters) {
         layer_paint.setImageFilter(layer_filter);
         ctx.canvas->save();
         ctx.canvas->clipRect(kRenderBounds, SkClipOp::kIntersect, false);
-        ctx.canvas->saveLayer(&kTestBounds2, &layer_paint);
+        ctx.canvas->saveLayer(&kTestBounds, &layer_paint);
         ctx.canvas->drawRect(draw_rect, ctx.paint);
         ctx.canvas->restore();
         ctx.canvas->restore();
@@ -3826,7 +3824,7 @@ TEST_F(DisplayListRendering, SaveLayerClippedContentStillFilters) {
         layer_paint.setImageFilter(layer_filter);
         ctx.canvas->Save();
         ctx.canvas->ClipRect(kRenderBounds, ClipOp::kIntersect, false);
-        ctx.canvas->SaveLayer(&kTestBounds2, &layer_paint);
+        ctx.canvas->SaveLayer(&kTestBounds, &layer_paint);
         ctx.canvas->DrawRect(draw_rect, ctx.paint);
         ctx.canvas->Restore();
         ctx.canvas->Restore();
@@ -3908,19 +3906,19 @@ TEST_F(DisplayListRendering, SaveLayerConsolidation) {
                        const std::string& desc1, const std::string& desc2,
                        const RenderEnvironment* env) {
         DisplayListBuilder nested_builder;
-        nested_builder.SaveLayer(&kTestBounds2, &paint1);
-        nested_builder.SaveLayer(&kTestBounds2, &paint2);
+        nested_builder.SaveLayer(&kTestBounds, &paint1);
+        nested_builder.SaveLayer(&kTestBounds, &paint2);
         render_content(nested_builder);
         auto nested_results = env->getResult(nested_builder.Build());
 
         DisplayListBuilder reverse_builder;
-        reverse_builder.SaveLayer(&kTestBounds2, &paint2);
-        reverse_builder.SaveLayer(&kTestBounds2, &paint1);
+        reverse_builder.SaveLayer(&kTestBounds, &paint2);
+        reverse_builder.SaveLayer(&kTestBounds, &paint1);
         render_content(reverse_builder);
         auto reverse_results = env->getResult(reverse_builder.Build());
 
         DisplayListBuilder combined_builder;
-        combined_builder.SaveLayer(&kTestBounds2, &paint_both);
+        combined_builder.SaveLayer(&kTestBounds, &paint_both);
         render_content(combined_builder);
         auto combined_results = env->getResult(combined_builder.Build());
 
@@ -4058,7 +4056,7 @@ TEST_F(DisplayListRendering, MatrixColorFilterModifyTransparencyCheck) {
     builder2.Translate(kTestCenter.fX, kTestCenter.fY);
     builder2.Rotate(45);
     builder2.Translate(-kTestCenter.fX, -kTestCenter.fY);
-    builder2.SaveLayer(&kTestBounds2, &filter_save_paint);
+    builder2.SaveLayer(&kTestBounds, &filter_save_paint);
     builder2.DrawRect(kRenderBounds, paint);
     builder2.Restore();
     auto display_list2 = builder2.Build();
@@ -4117,8 +4115,8 @@ TEST_F(DisplayListRendering, MatrixColorFilterOpacityCommuteCheck) {
     DlPaint filter_save_paint = DlPaint().setColorFilter(filter);
 
     DisplayListBuilder builder1;
-    builder1.SaveLayer(&kTestBounds2, &opacity_save_paint);
-    builder1.SaveLayer(&kTestBounds2, &filter_save_paint);
+    builder1.SaveLayer(&kTestBounds, &opacity_save_paint);
+    builder1.SaveLayer(&kTestBounds, &filter_save_paint);
     // builder1.DrawRect(kRenderBounds.makeOffset(20, 20), DlPaint());
     builder1.DrawRect(kRenderBounds, paint);
     builder1.Restore();
@@ -4126,8 +4124,8 @@ TEST_F(DisplayListRendering, MatrixColorFilterOpacityCommuteCheck) {
     auto display_list1 = builder1.Build();
 
     DisplayListBuilder builder2;
-    builder2.SaveLayer(&kTestBounds2, &filter_save_paint);
-    builder2.SaveLayer(&kTestBounds2, &opacity_save_paint);
+    builder2.SaveLayer(&kTestBounds, &filter_save_paint);
+    builder2.SaveLayer(&kTestBounds, &opacity_save_paint);
     // builder1.DrawRect(kRenderBounds.makeOffset(20, 20), DlPaint());
     builder2.DrawRect(kRenderBounds, paint);
     builder2.Restore();
@@ -4234,7 +4232,7 @@ TEST_F(DisplayListRendering, BlendColorFilterModifyTransparencyCheck) {
     builder2.Translate(kTestCenter.fX, kTestCenter.fY);
     builder2.Rotate(45);
     builder2.Translate(-kTestCenter.fX, -kTestCenter.fY);
-    builder2.SaveLayer(&kTestBounds2, &filter_save_paint);
+    builder2.SaveLayer(&kTestBounds, &filter_save_paint);
     builder2.DrawRect(kRenderBounds, paint);
     builder2.Restore();
     auto display_list2 = builder2.Build();
@@ -4286,8 +4284,8 @@ TEST_F(DisplayListRendering, BlendColorFilterOpacityCommuteCheck) {
     DlPaint filter_save_paint = DlPaint().setColorFilter(&filter);
 
     DisplayListBuilder builder1;
-    builder1.SaveLayer(&kTestBounds2, &opacity_save_paint);
-    builder1.SaveLayer(&kTestBounds2, &filter_save_paint);
+    builder1.SaveLayer(&kTestBounds, &opacity_save_paint);
+    builder1.SaveLayer(&kTestBounds, &filter_save_paint);
     // builder1.DrawRect(kRenderBounds.makeOffset(20, 20), DlPaint());
     builder1.DrawRect(kRenderBounds, paint);
     builder1.Restore();
@@ -4295,8 +4293,8 @@ TEST_F(DisplayListRendering, BlendColorFilterOpacityCommuteCheck) {
     auto display_list1 = builder1.Build();
 
     DisplayListBuilder builder2;
-    builder2.SaveLayer(&kTestBounds2, &filter_save_paint);
-    builder2.SaveLayer(&kTestBounds2, &opacity_save_paint);
+    builder2.SaveLayer(&kTestBounds, &filter_save_paint);
+    builder2.SaveLayer(&kTestBounds, &opacity_save_paint);
     // builder1.DrawRect(kRenderBounds.makeOffset(20, 20), DlPaint());
     builder2.DrawRect(kRenderBounds, paint);
     builder2.Restore();

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -74,12 +74,11 @@ sk_sp<SkTextBlob> PerformanceOverlayLayer::MakeStatisticsText(
     const std::string& label_prefix,
     const std::string& font_path) {
   SkFont font;
-  sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
-  if (font_path == "") {
-    font = SkFont(font_mgr->matchFamilyStyle(nullptr, {}), 15);
-  } else {
-    font = SkFont(font_mgr->makeFromFile(font_path.c_str()), 15);
+  if (font_path != "") {
+    sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
+    font = SkFont(font_mgr->makeFromFile(font_path.c_str()));
   }
+  font.setSize(15);
 
   double max_ms_per_frame = stopwatch.MaxDelta().ToMillisecondsF();
   double average_ms_per_frame = stopwatch.AverageDelta().ToMillisecondsF();

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -277,7 +277,6 @@ impeller_component("entity_unittests") {
     ":entity_test_helpers",
     "../geometry:geometry_asserts",
     "../playground:playground_test",
-    "//flutter/display_list/testing:display_list_testing",
     "//flutter/impeller/typographer/backends/skia:typographer_skia_backend",
   ]
 }

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -8,7 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include "flutter/display_list/testing/dl_test_snippets.h"
 #include "fml/logging.h"
 #include "gtest/gtest.h"
 #include "impeller/core/formats.h"
@@ -2193,7 +2192,8 @@ TEST_P(EntityTest, InheritOpacityTest) {
 
   // Text contents can accept opacity if the text frames do not
   // overlap
-  SkFont font = flutter::testing::CreateTestFontOfSize(30);
+  SkFont font;
+  font.setSize(30);
   auto blob = SkTextBlob::MakeFromString("A", font);
   auto frame = MakeTextFrameFromTextBlobSkia(blob);
   auto lazy_glyph_atlas =

--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -46,7 +46,6 @@ impeller_component("typographer_unittests") {
     "../playground:playground_test",
     "backends/skia:typographer_skia_backend",
     "backends/stb:typographer_stb_backend",
-    "//flutter/display_list/testing:display_list_testing",
     "//flutter/third_party/txt",
   ]
 }

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/display_list/testing/dl_test_snippets.h"
 #include "flutter/testing/testing.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/typographer/backends/skia/text_frame_skia.h"
@@ -10,7 +9,6 @@
 #include "impeller/typographer/lazy_glyph_atlas.h"
 #include "impeller/typographer/rectangle_packer.h"
 #include "third_party/skia/include/core/SkData.h"
-#include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkFontMgr.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
@@ -40,7 +38,7 @@ static std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
 }
 
 TEST_P(TypographerTest, CanConvertTextBlob) {
-  SkFont font = flutter::testing::CreateTestFontOfSize(12);
+  SkFont font;
   auto blob = SkTextBlob::MakeFromString(
       "the quick brown fox jumped over the lazy dog.", font);
   ASSERT_TRUE(blob);
@@ -61,7 +59,7 @@ TEST_P(TypographerTest, CanCreateGlyphAtlas) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("hello", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
@@ -99,7 +97,7 @@ TEST_P(TypographerTest, LazyAtlasTracksColor) {
   ASSERT_TRUE(mapping);
   sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
   SkFont emoji_font(font_mgr->makeFromData(mapping), 50.0);
-  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  SkFont sk_font;
 
   auto blob = SkTextBlob::MakeFromString("hello", sk_font);
   ASSERT_TRUE(blob);
@@ -132,7 +130,7 @@ TEST_P(TypographerTest, GlyphAtlasWithOddUniqueGlyphSize) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("AGH", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
@@ -149,7 +147,7 @@ TEST_P(TypographerTest, GlyphAtlasIsRecycledIfUnchanged) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("spooky skellingtons", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
@@ -179,7 +177,7 @@ TEST_P(TypographerTest, GlyphAtlasWithLotsOfdUniqueGlyphSize) {
       "œ∑´®†¥¨ˆøπ““‘‘åß∂ƒ©˙∆˚¬…æ≈ç√∫˜µ≤≥≥≥≥÷¡™£¢∞§¶•ªº–≠⁄€‹›ﬁﬂ‡°·‚—±Œ„´‰Á¨Ø∏”’/"
       "* Í˝ */¸˛Ç◊ı˜Â¯˘¿";
 
-  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString(test_string, sk_font);
   ASSERT_TRUE(blob);
 
@@ -216,7 +214,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledIfUnchanged) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("spooky 1", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
@@ -249,7 +247,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
+  SkFont sk_font;
   auto blob = SkTextBlob::MakeFromString("spooky 1", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -202,7 +202,6 @@ if (enable_unittests) {
     fixtures = [
       "fixtures/shelltest_screenshot.png",
       "fixtures/hello_loop_2.gif",
-      "//flutter/third_party/txt/third_party/fonts/Roboto-Regular.ttf",
     ]
   }
 
@@ -323,7 +322,6 @@ if (enable_unittests) {
       ":shell_unittests_fixtures",
       "//flutter/assets",
       "//flutter/common/graphics",
-      "//flutter/display_list/testing:display_list_testing",
       "//flutter/shell/common:base64",
       "//flutter/shell/profiling:profiling_unittests",
       "//flutter/shell/version",

--- a/shell/common/dl_op_spy_unittests.cc
+++ b/shell/common/dl_op_spy_unittests.cc
@@ -4,11 +4,9 @@
 
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/dl_builder.h"
-#include "flutter/display_list/testing/dl_test_snippets.h"
 #include "flutter/shell/common/dl_op_spy.h"
 #include "flutter/testing/testing.h"
 #include "third_party/skia/include/core/SkBitmap.h"
-#include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkRSXform.h"
 
 namespace flutter {
@@ -547,7 +545,7 @@ TEST(DlOpSpy, DrawTextBlob) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
     std::string string = "xx";
-    SkFont font = CreateTestFontOfSize(12);
+    SkFont font;
     auto text_blob = SkTextBlob::MakeFromString(string.c_str(), font);
     builder.DrawTextBlob(text_blob, 1, 1, paint);
     sk_sp<DisplayList> dl = builder.Build();
@@ -559,7 +557,7 @@ TEST(DlOpSpy, DrawTextBlob) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
     std::string string = "xx";
-    SkFont font = CreateTestFontOfSize(12);
+    SkFont font;
     auto text_blob = SkTextBlob::MakeFromString(string.c_str(), font);
     builder.DrawTextBlob(text_blob, 1, 1, paint);
     sk_sp<DisplayList> dl = builder.Build();

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -750,11 +750,6 @@ if (enable_unittests) {
             "$root_gen_dir/flutter/shell/common/assets/shelltest_screenshot.png"
         dest = "assets/shelltest_screenshot.png"
       },
-      {
-        path = rebase_path(
-                "//flutter/third_party/txt/third_party/fonts/Roboto-Regular.ttf")
-        dest = "assets/Roboto-Regular.ttf"
-      },
     ]
 
     libraries = vulkan_validation_libs

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -208,9 +208,17 @@ template("optional") {
   }
 }
 
+group("fontmgr_factory") {
+  public_deps = [ skia_fontmgr_factory ]
+}
+
+optional("fontmgr_empty_factory") {
+  enabled = true
+  sources = [ "$_skia_root/src/ports/SkFontMgr_empty_factory.cpp" ]
+}
+
 optional("fontmgr_android") {
   enabled = skia_enable_fontmgr_android
-  public_defines = [ "SK_FONTMGR_ANDROID_AVAILABLE" ]
 
   deps = [
     ":typeface_freetype",
@@ -223,6 +231,11 @@ optional("fontmgr_android") {
     "$_skia_root/src/ports/SkFontMgr_android_parser.h",
   ]
 }
+optional("fontmgr_android_factory") {
+  enabled = skia_enable_fontmgr_android
+  deps = [ ":fontmgr_android" ]
+  sources = [ "$_skia_root/src/ports/SkFontMgr_android_factory.cpp" ]
+}
 
 optional("fontmgr_custom") {
   enabled =
@@ -234,9 +247,24 @@ optional("fontmgr_custom") {
   sources = [ "$_skia_root/src/ports/SkFontMgr_custom.cpp" ]
 }
 
+optional("fontmgr_custom_directory") {
+  enabled = skia_enable_fontmgr_custom_directory
+
+  deps = [
+    ":fontmgr_custom",
+    ":typeface_freetype",
+  ]
+  public = [ "$_skia_root/include/ports/SkFontMgr_directory.h" ]
+  sources = [ "$_skia_root/src/ports/SkFontMgr_custom_directory.cpp" ]
+}
+optional("fontmgr_custom_directory_factory") {
+  enabled = skia_enable_fontmgr_custom_directory
+  deps = [ ":fontmgr_custom_directory" ]
+  sources = [ "$_skia_root/src/ports/SkFontMgr_custom_directory_factory.cpp" ]
+}
+
 optional("fontmgr_custom_embedded") {
   enabled = skia_enable_fontmgr_custom_embedded
-  public_defines = [ "SK_FONTMGR_FREETYPE_EMBEDDED_AVAILABLE" ]
 
   deps = [
     ":fontmgr_custom",
@@ -244,10 +272,14 @@ optional("fontmgr_custom_embedded") {
   ]
   sources = [ "$_skia_root/src/ports/SkFontMgr_custom_embedded.cpp" ]
 }
+optional("fontmgr_custom_embedded_factory") {
+  enabled = skia_enable_fontmgr_custom_embedded
+  deps = [ ":fontmgr_custom_embedded" ]
+  sources = [ "$_skia_root/src/ports/SkFontMgr_custom_embedded_factory.cpp" ]
+}
 
 optional("fontmgr_custom_empty") {
   enabled = skia_enable_fontmgr_custom_empty
-  public_defines = [ "SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE" ]
 
   deps = [
     ":fontmgr_custom",
@@ -256,10 +288,14 @@ optional("fontmgr_custom_empty") {
   public = [ "$_skia_root/include/ports/SkFontMgr_empty.h" ]
   sources = [ "$_skia_root/src/ports/SkFontMgr_custom_empty.cpp" ]
 }
+optional("fontmgr_custom_empty_factory") {
+  enabled = skia_enable_fontmgr_custom_empty
+  deps = [ ":fontmgr_custom_empty" ]
+  sources = [ "$_skia_root/src/ports/SkFontMgr_custom_empty_factory.cpp" ]
+}
 
 optional("fontmgr_fontconfig") {
   enabled = skia_enable_fontmgr_fontconfig
-  public_defines = [ "SK_FONTMGR_FONTCONFIG_AVAILABLE" ]
 
   # The public header includes fontconfig.h and uses FcConfig*
   public_deps = [ "//third_party:fontconfig" ]
@@ -267,10 +303,40 @@ optional("fontmgr_fontconfig") {
   deps = [ ":typeface_freetype" ]
   sources = [ "$_skia_root/src/ports/SkFontMgr_fontconfig.cpp" ]
 }
+optional("fontmgr_fontconfig_factory") {
+  enabled = skia_enable_fontmgr_fontconfig
+  deps = [ ":fontmgr_fontconfig" ]
+  sources = [ "$_skia_root/src/ports/SkFontMgr_fontconfig_factory.cpp" ]
+}
+
+optional("fontmgr_FontConfigInterface") {
+  enabled = skia_enable_fontmgr_FontConfigInterface
+
+  deps = [
+    ":typeface_freetype",
+    "//third_party:fontconfig",
+  ]
+  public = [
+    "$_skia_root/include/ports/SkFontConfigInterface.h",
+    "$_skia_root/include/ports/SkFontMgr_FontConfigInterface.h",
+  ]
+  sources = [
+    "$_skia_root/src/ports/SkFontConfigInterface.cpp",
+    "$_skia_root/src/ports/SkFontConfigInterface_direct.cpp",
+    "$_skia_root/src/ports/SkFontConfigInterface_direct_factory.cpp",
+    "$_skia_root/src/ports/SkFontConfigTypeface.h",
+    "$_skia_root/src/ports/SkFontMgr_FontConfigInterface.cpp",
+  ]
+}
+optional("fontmgr_FontConfigInterface_factory") {
+  enabled = skia_enable_fontmgr_FontConfigInterface
+  deps = [ ":fontmgr_FontConfigInterface" ]
+  sources =
+      [ "$_skia_root/src/ports/SkFontMgr_FontConfigInterface_factory.cpp" ]
+}
 
 optional("fontmgr_fuchsia") {
   enabled = skia_enable_fontmgr_fuchsia
-  public_defines = [ "SK_FONTMGR_FUCHSIA_AVAILABLE" ]
 
   deps = []
 
@@ -286,10 +352,7 @@ optional("fontmgr_fuchsia") {
 optional("fontmgr_mac_ct") {
   enabled = skia_use_fonthost_mac
 
-  public_defines = [
-    "SK_TYPEFACE_FACTORY_CORETEXT",
-    "SK_FONTMGR_CORETEXT_AVAILABLE",
-  ]
+  public_defines = [ "SK_TYPEFACE_FACTORY_CORETEXT" ]
   public = [
     "$_skia_root/include/ports/SkFontMgr_mac_ct.h",
     "$_skia_root/include/ports/SkTypeface_mac.h",
@@ -321,14 +384,16 @@ optional("fontmgr_mac_ct") {
     ]
   }
 }
+optional("fontmgr_mac_ct_factory") {
+  enabled = skia_use_fonthost_mac
+  deps = [ ":fontmgr_mac_ct" ]
+  sources = [ "$_skia_root/src/ports/SkFontMgr_mac_ct_factory.cpp" ]
+}
 
 optional("fontmgr_win") {
   enabled = skia_enable_fontmgr_win
 
-  public_defines = [
-    "SK_TYPEFACE_FACTORY_DIRECTWRITE",
-    "SK_FONTMGR_DIRECTWRITE_AVAILABLE",
-  ]
+  public_defines = [ "SK_TYPEFACE_FACTORY_DIRECTWRITE" ]
   public = [ "$_skia_root/include/ports/SkTypeface_win.h" ]
   sources = [
     "$_skia_root/include/ports/SkFontMgr_indirect.h",
@@ -356,6 +421,19 @@ optional("fontmgr_win") {
       include_dirs = [ "${skia_dwritecore_sdk}/include" ]
     }
   }
+}
+optional("fontmgr_win_factory") {
+  enabled = skia_enable_fontmgr_win
+  deps = [ ":fontmgr_win" ]
+  sources = [ "$_skia_root/src/ports/SkFontMgr_win_dw_factory.cpp" ]
+}
+
+optional("fontmgr_win_gdi") {
+  enabled = skia_enable_fontmgr_win_gdi
+
+  public = [ "$_skia_root/include/ports/SkTypeface_win.h" ]
+  sources = [ "$_skia_root/src/ports/SkFontHost_win.cpp" ]
+  libs = [ "Gdi32.lib" ]
 }
 
 optional("gpu_shared") {
@@ -597,13 +675,16 @@ skia_component("skia") {
   check_includes = false
 
   public_deps = [
+    ":fontmgr_FontConfigInterface",
     ":fontmgr_android",
+    ":fontmgr_custom_directory",
     ":fontmgr_custom_embedded",
     ":fontmgr_custom_empty",
     ":fontmgr_fontconfig",
     ":fontmgr_fuchsia",
     ":fontmgr_mac_ct",
     ":fontmgr_win",
+    ":fontmgr_win_gdi",
     ":gpu",
     ":jpeg_encode",
     ":png_encode",
@@ -612,6 +693,7 @@ skia_component("skia") {
   ]
 
   deps = [
+    ":fontmgr_factory",
     ":hsw",
     ":jpeg_decode",
     ":ndk_images",

--- a/skia/flutter_defines.gni
+++ b/skia/flutter_defines.gni
@@ -23,12 +23,6 @@ flutter_defines = [
   # When running Metal, ensure that command buffers are scheduled before
   # returning from submit.
   "SK_METAL_WAIT_UNTIL_SCHEDULED",
-
-  # Staging for b/305780908
-  "SK_DEFAULT_TYPEFACE_IS_EMPTY",
-  "SK_DISABLE_LEGACY_DEFAULT_TYPEFACE",
-  "SK_DISABLE_LEGACY_FONTMGR_FACTORY",
-  "SK_DISABLE_LEGACY_FONTMGR_REFDEFAULT",
 ]
 
 if (!is_fuchsia) {

--- a/third_party/txt/src/txt/platform.cc
+++ b/third_party/txt/src/txt/platform.cc
@@ -4,10 +4,6 @@
 
 #include "txt/platform.h"
 
-#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
-#include "third_party/skia/include/ports/SkFontMgr_empty.h"
-#endif
-
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
@@ -15,12 +11,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
-#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
-  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
-#else
-  static sk_sp<SkFontMgr> mgr = SkFontMgr::RefEmpty();
-#endif
-  return mgr;
+  return SkFontMgr::RefDefault();
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/platform_android.cc
+++ b/third_party/txt/src/txt/platform_android.cc
@@ -4,14 +4,6 @@
 
 #include "txt/platform.h"
 
-#if defined(SK_FONTMGR_ANDROID_AVAILABLE)
-#include "third_party/skia/include/ports/SkFontMgr_android.h"
-#endif
-
-#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
-#include "third_party/skia/include/ports/SkFontMgr_empty.h"
-#endif
-
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
@@ -19,14 +11,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
-#if defined(SK_FONTMGR_ANDROID_AVAILABLE)
-  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Android(nullptr);
-#elif defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
-  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
-#else
-  static sk_sp<SkFontMgr> mgr = SkFontMgr::RefEmpty();
-#endif
-  return mgr;
+  return SkFontMgr::RefDefault();
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/platform_fuchsia.cc
+++ b/third_party/txt/src/txt/platform_fuchsia.cc
@@ -7,10 +7,6 @@
 #include "third_party/skia/include/ports/SkFontMgr_fuchsia.h"
 #include "txt/platform.h"
 
-#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
-#include "third_party/skia/include/ports/SkFontMgr_empty.h"
-#endif
-
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
@@ -23,12 +19,7 @@ sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
     sync_font_provider.Bind(zx::channel(font_initialization_data));
     return SkFontMgr_New_Fuchsia(std::move(sync_font_provider));
   } else {
-#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
-    static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
-#else
-    static sk_sp<SkFontMgr> mgr = SkFontMgr::RefEmpty();
-#endif
-    return mgr;
+    return SkFontMgr::RefDefault();
   }
 }
 

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -4,14 +4,6 @@
 
 #include "txt/platform.h"
 
-#if defined(SK_FONTMGR_FONTCONFIG_AVAILABLE)
-#include "third_party/skia/include/ports/SkFontMgr_fontconfig.h"
-#endif
-
-#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
-#include "third_party/skia/include/ports/SkFontMgr_empty.h"
-#endif
-
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
@@ -19,14 +11,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
-#if defined(SK_FONTMGR_FONTCONFIG_AVAILABLE)
-  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_FontConfig(nullptr);
-#elif defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
-  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
-#else
-  static sk_sp<SkFontMgr> mgr = SkFontMgr::RefEmpty();
-#endif
-  return mgr;
+  return SkFontMgr::RefDefault();
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/platform_mac.mm
+++ b/third_party/txt/src/txt/platform_mac.mm
@@ -5,7 +5,6 @@
 #include <TargetConditionals.h>
 
 #include "flutter/fml/platform/darwin/platform_version.h"
-#include "third_party/skia/include/ports/SkFontMgr_mac_ct.h"
 #include "third_party/skia/include/ports/SkTypeface_mac.h"
 #include "txt/platform.h"
 #include "txt/platform_mac.h"
@@ -38,8 +37,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
-  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_CoreText(nullptr);
-  return mgr;
+  return SkFontMgr::RefDefault();
 }
 
 void RegisterSystemFonts(const DynamicFontManager& dynamic_font_manager) {


### PR DESCRIPTION
This reverts commit ab89510f4e1eeea49ec01dd55656b126a4b06b19.

The flutter/tests/skp_generator test (running in flutter_tester on Linux) was failing, along with some customer tests.