### PR TITLE
[Impeller] dont allocate capture strings in release mode.

### DIFF
--- a/impeller/core/capture.cc
+++ b/impeller/core/capture.cc
@@ -117,7 +117,7 @@ void Capture::Rewind() {
 #ifdef IMPELLER_ENABLE_CAPTURE
 #define _CAPTURE_PROPERTY_RECORDER_DEFINITION(type_name, pascal_name,          \
                                               lower_name)                      \
-  type_name Capture::Add##pascal_name(const std::string& label,                \
+  type_name Capture::Add##pascal_name(const std::string_view& label,           \
                                       type_name value,                         \
                                       CaptureProperty::Options options) {      \
     if (!active_) {                                                            \
@@ -125,8 +125,9 @@ void Capture::Rewind() {
     }                                                                          \
     FML_DCHECK(element_ != nullptr);                                           \
                                                                                \
+    std::string label_clone = std::string(label);                              \
     auto new_value = Capture##pascal_name##Property::Make(                     \
-        label, std::move(value), options);                                     \
+        label_clone, std::move(value), options);                               \
                                                                                \
     auto next = std::reinterpret_pointer_cast<Capture##pascal_name##Property>( \
         element_->properties.GetNext(std::move(new_value), options.readonly)); \

--- a/impeller/core/capture.cc
+++ b/impeller/core/capture.cc
@@ -117,8 +117,7 @@ void Capture::Rewind() {
 #ifdef IMPELLER_ENABLE_CAPTURE
 #define _CAPTURE_PROPERTY_RECORDER_DEFINITION(type_name, pascal_name,          \
                                               lower_name)                      \
-  type_name Capture::Add##pascal_name(const std::string_view& label,           \
-                                      type_name value,                         \
+  type_name Capture::Add##pascal_name(std::string_view label, type_name value, \
                                       CaptureProperty::Options options) {      \
     if (!active_) {                                                            \
       return value;                                                            \

--- a/impeller/core/capture.h
+++ b/impeller/core/capture.h
@@ -214,16 +214,17 @@ struct CaptureElement final : public CaptureCursorListElement<CaptureElement> {
 };
 
 #ifdef IMPELLER_ENABLE_CAPTURE
-#define _CAPTURE_PROPERTY_RECORDER_DECLARATION(type_name, pascal_name,  \
-                                               lower_name)              \
-  type_name Add##pascal_name(const std::string& label, type_name value, \
+#define _CAPTURE_PROPERTY_RECORDER_DECLARATION(type_name, pascal_name,       \
+                                               lower_name)                   \
+  type_name Add##pascal_name(const std::string_view& label, type_name value, \
                              CaptureProperty::Options options = {});
 #else
-#define _CAPTURE_PROPERTY_RECORDER_DECLARATION(type_name, pascal_name,         \
-                                               lower_name)                     \
-  inline type_name Add##pascal_name(const std::string& label, type_name value, \
-                                    CaptureProperty::Options options = {}) {   \
-    return value;                                                              \
+#define _CAPTURE_PROPERTY_RECORDER_DECLARATION(type_name, pascal_name,       \
+                                               lower_name)                   \
+  inline type_name Add##pascal_name(const std::string_view& label,           \
+                                    type_name value,                         \
+                                    CaptureProperty::Options options = {}) { \
+    return value;                                                            \
   }
 #endif
 
@@ -235,13 +236,14 @@ class Capture {
 
   static Capture MakeInactive();
 
-  inline Capture CreateChild(const std::string& label) {
+  inline Capture CreateChild(const std::string_view& label) {
 #ifdef IMPELLER_ENABLE_CAPTURE
     if (!active_) {
       return Capture();
     }
 
-    auto new_capture = Capture(label);
+    std::string label_copy = std::string(label);
+    auto new_capture = Capture(label_copy);
     new_capture.element_ =
         element_->children.GetNext(new_capture.element_, false);
     new_capture.element_->Rewind();

--- a/impeller/core/capture.h
+++ b/impeller/core/capture.h
@@ -214,15 +214,14 @@ struct CaptureElement final : public CaptureCursorListElement<CaptureElement> {
 };
 
 #ifdef IMPELLER_ENABLE_CAPTURE
-#define _CAPTURE_PROPERTY_RECORDER_DECLARATION(type_name, pascal_name,       \
-                                               lower_name)                   \
-  type_name Add##pascal_name(const std::string_view& label, type_name value, \
+#define _CAPTURE_PROPERTY_RECORDER_DECLARATION(type_name, pascal_name, \
+                                               lower_name)             \
+  type_name Add##pascal_name(std::string_view label, type_name value,  \
                              CaptureProperty::Options options = {});
 #else
 #define _CAPTURE_PROPERTY_RECORDER_DECLARATION(type_name, pascal_name,       \
                                                lower_name)                   \
-  inline type_name Add##pascal_name(const std::string_view& label,           \
-                                    type_name value,                         \
+  inline type_name Add##pascal_name(std::string_view label, type_name value, \
                                     CaptureProperty::Options options = {}) { \
     return value;                                                            \
   }
@@ -236,7 +235,7 @@ class Capture {
 
   static Capture MakeInactive();
 
-  inline Capture CreateChild(const std::string_view& label) {
+  inline Capture CreateChild(std::string_view label) {
 #ifdef IMPELLER_ENABLE_CAPTURE
     if (!active_) {
       return Capture();


### PR DESCRIPTION
I'm not exactly sure why, but this seems to stop the allocation of capture labels in release mode.

Fixes https://github.com/flutter/flutter/issues/138908
