### PR TITLE
Reland "Replace use of Fontmgr::RefDefault with explicit creation calls"

### DIFF
--- a/build/secondary/flutter/third_party/glfw/BUILD.gn
+++ b/build/secondary/flutter/third_party/glfw/BUILD.gn
@@ -55,6 +55,8 @@ source_set("glfw") {
       "$_checkout_dir/src/win32_window.c",
     ]
 
+    libs = [ "Gdi32.lib" ]
+
     defines = [ "_GLFW_WIN32" ]
   } else if (is_linux) {
     sources += [

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -74,11 +74,12 @@ sk_sp<SkTextBlob> PerformanceOverlayLayer::MakeStatisticsText(
     const std::string& label_prefix,
     const std::string& font_path) {
   SkFont font;
-  if (font_path != "") {
-    sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
-    font = SkFont(font_mgr->makeFromFile(font_path.c_str()));
+  sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
+  if (font_path == "") {
+    font = SkFont(font_mgr->matchFamilyStyle(nullptr, {}), 15);
+  } else {
+    font = SkFont(font_mgr->makeFromFile(font_path.c_str()), 15);
   }
-  font.setSize(15);
 
   double max_ms_per_frame = stopwatch.MaxDelta().ToMillisecondsF();
   double average_ms_per_frame = stopwatch.AverageDelta().ToMillisecondsF();

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -277,6 +277,7 @@ impeller_component("entity_unittests") {
     ":entity_test_helpers",
     "../geometry:geometry_asserts",
     "../playground:playground_test",
+    "//flutter/display_list/testing:display_list_testing",
     "//flutter/impeller/typographer/backends/skia:typographer_skia_backend",
   ]
 }

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "flutter/display_list/testing/dl_test_snippets.h"
 #include "fml/logging.h"
 #include "gtest/gtest.h"
 #include "impeller/core/formats.h"
@@ -2192,8 +2193,7 @@ TEST_P(EntityTest, InheritOpacityTest) {
 
   // Text contents can accept opacity if the text frames do not
   // overlap
-  SkFont font;
-  font.setSize(30);
+  SkFont font = flutter::testing::CreateTestFontOfSize(30);
   auto blob = SkTextBlob::MakeFromString("A", font);
   auto frame = MakeTextFrameFromTextBlobSkia(blob);
   auto lazy_glyph_atlas =

--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -46,6 +46,7 @@ impeller_component("typographer_unittests") {
     "../playground:playground_test",
     "backends/skia:typographer_skia_backend",
     "backends/stb:typographer_stb_backend",
+    "//flutter/display_list/testing:display_list_testing",
     "//flutter/third_party/txt",
   ]
 }

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/display_list/testing/dl_test_snippets.h"
 #include "flutter/testing/testing.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/typographer/backends/skia/text_frame_skia.h"
@@ -9,6 +10,7 @@
 #include "impeller/typographer/lazy_glyph_atlas.h"
 #include "impeller/typographer/rectangle_packer.h"
 #include "third_party/skia/include/core/SkData.h"
+#include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkFontMgr.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
@@ -38,7 +40,7 @@ static std::shared_ptr<GlyphAtlas> CreateGlyphAtlas(
 }
 
 TEST_P(TypographerTest, CanConvertTextBlob) {
-  SkFont font;
+  SkFont font = flutter::testing::CreateTestFontOfSize(12);
   auto blob = SkTextBlob::MakeFromString(
       "the quick brown fox jumped over the lazy dog.", font);
   ASSERT_TRUE(blob);
@@ -59,7 +61,7 @@ TEST_P(TypographerTest, CanCreateGlyphAtlas) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font;
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
   auto blob = SkTextBlob::MakeFromString("hello", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
@@ -97,7 +99,7 @@ TEST_P(TypographerTest, LazyAtlasTracksColor) {
   ASSERT_TRUE(mapping);
   sk_sp<SkFontMgr> font_mgr = txt::GetDefaultFontManager();
   SkFont emoji_font(font_mgr->makeFromData(mapping), 50.0);
-  SkFont sk_font;
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
 
   auto blob = SkTextBlob::MakeFromString("hello", sk_font);
   ASSERT_TRUE(blob);
@@ -130,7 +132,7 @@ TEST_P(TypographerTest, GlyphAtlasWithOddUniqueGlyphSize) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font;
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
   auto blob = SkTextBlob::MakeFromString("AGH", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
@@ -147,7 +149,7 @@ TEST_P(TypographerTest, GlyphAtlasIsRecycledIfUnchanged) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font;
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
   auto blob = SkTextBlob::MakeFromString("spooky skellingtons", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
@@ -177,7 +179,7 @@ TEST_P(TypographerTest, GlyphAtlasWithLotsOfdUniqueGlyphSize) {
       "œ∑´®†¥¨ˆøπ““‘‘åß∂ƒ©˙∆˚¬…æ≈ç√∫˜µ≤≥≥≥≥÷¡™£¢∞§¶•ªº–≠⁄€‹›ﬁﬂ‡°·‚—±Œ„´‰Á¨Ø∏”’/"
       "* Í˝ */¸˛Ç◊ı˜Â¯˘¿";
 
-  SkFont sk_font;
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
   auto blob = SkTextBlob::MakeFromString(test_string, sk_font);
   ASSERT_TRUE(blob);
 
@@ -214,7 +216,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledIfUnchanged) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font;
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
   auto blob = SkTextBlob::MakeFromString("spooky 1", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(
@@ -247,7 +249,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecreatedIfTypeChanges) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
-  SkFont sk_font;
+  SkFont sk_font = flutter::testing::CreateTestFontOfSize(12);
   auto blob = SkTextBlob::MakeFromString("spooky 1", sk_font);
   ASSERT_TRUE(blob);
   auto atlas = CreateGlyphAtlas(

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -202,6 +202,7 @@ if (enable_unittests) {
     fixtures = [
       "fixtures/shelltest_screenshot.png",
       "fixtures/hello_loop_2.gif",
+      "//flutter/third_party/txt/third_party/fonts/Roboto-Regular.ttf",
     ]
   }
 
@@ -322,6 +323,7 @@ if (enable_unittests) {
       ":shell_unittests_fixtures",
       "//flutter/assets",
       "//flutter/common/graphics",
+      "//flutter/display_list/testing:display_list_testing",
       "//flutter/shell/common:base64",
       "//flutter/shell/profiling:profiling_unittests",
       "//flutter/shell/version",

--- a/shell/common/dl_op_spy_unittests.cc
+++ b/shell/common/dl_op_spy_unittests.cc
@@ -4,9 +4,11 @@
 
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/dl_builder.h"
+#include "flutter/display_list/testing/dl_test_snippets.h"
 #include "flutter/shell/common/dl_op_spy.h"
 #include "flutter/testing/testing.h"
 #include "third_party/skia/include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkRSXform.h"
 
 namespace flutter {
@@ -545,7 +547,7 @@ TEST(DlOpSpy, DrawTextBlob) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kBlack());
     std::string string = "xx";
-    SkFont font;
+    SkFont font = CreateTestFontOfSize(12);
     auto text_blob = SkTextBlob::MakeFromString(string.c_str(), font);
     builder.DrawTextBlob(text_blob, 1, 1, paint);
     sk_sp<DisplayList> dl = builder.Build();
@@ -557,7 +559,7 @@ TEST(DlOpSpy, DrawTextBlob) {
     DisplayListBuilder builder;
     DlPaint paint(DlColor::kTransparent());
     std::string string = "xx";
-    SkFont font;
+    SkFont font = CreateTestFontOfSize(12);
     auto text_blob = SkTextBlob::MakeFromString(string.c_str(), font);
     builder.DrawTextBlob(text_blob, 1, 1, paint);
     sk_sp<DisplayList> dl = builder.Build();

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -750,6 +750,11 @@ if (enable_unittests) {
             "$root_gen_dir/flutter/shell/common/assets/shelltest_screenshot.png"
         dest = "assets/shelltest_screenshot.png"
       },
+      {
+        path = rebase_path(
+                "//flutter/third_party/txt/third_party/fonts/Roboto-Regular.ttf")
+        dest = "assets/Roboto-Regular.ttf"
+      },
     ]
 
     libraries = vulkan_validation_libs

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -234,6 +234,17 @@ optional("fontmgr_custom") {
   sources = [ "$_skia_root/src/ports/SkFontMgr_custom.cpp" ]
 }
 
+optional("fontmgr_custom_directory") {
+  enabled = skia_enable_fontmgr_custom_directory
+  public_defines = [ "SK_FONTMGR_FREETYPE_DIRECTORY_AVAILABLE" ]
+  deps = [
+    ":fontmgr_custom",
+    ":typeface_freetype",
+  ]
+  public = [ "$_skia_root/include/ports/SkFontMgr_directory.h" ]
+  sources = [ "$_skia_root/src/ports/SkFontMgr_custom_directory.cpp" ]
+}
+
 optional("fontmgr_custom_embedded") {
   enabled = skia_enable_fontmgr_custom_embedded
   public_defines = [ "SK_FONTMGR_FREETYPE_EMBEDDED_AVAILABLE" ]
@@ -598,6 +609,7 @@ skia_component("skia") {
 
   public_deps = [
     ":fontmgr_android",
+    ":fontmgr_custom_directory",
     ":fontmgr_custom_embedded",
     ":fontmgr_custom_empty",
     ":fontmgr_fontconfig",

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -208,17 +208,9 @@ template("optional") {
   }
 }
 
-group("fontmgr_factory") {
-  public_deps = [ skia_fontmgr_factory ]
-}
-
-optional("fontmgr_empty_factory") {
-  enabled = true
-  sources = [ "$_skia_root/src/ports/SkFontMgr_empty_factory.cpp" ]
-}
-
 optional("fontmgr_android") {
   enabled = skia_enable_fontmgr_android
+  public_defines = [ "SK_FONTMGR_ANDROID_AVAILABLE" ]
 
   deps = [
     ":typeface_freetype",
@@ -231,11 +223,6 @@ optional("fontmgr_android") {
     "$_skia_root/src/ports/SkFontMgr_android_parser.h",
   ]
 }
-optional("fontmgr_android_factory") {
-  enabled = skia_enable_fontmgr_android
-  deps = [ ":fontmgr_android" ]
-  sources = [ "$_skia_root/src/ports/SkFontMgr_android_factory.cpp" ]
-}
 
 optional("fontmgr_custom") {
   enabled =
@@ -247,24 +234,9 @@ optional("fontmgr_custom") {
   sources = [ "$_skia_root/src/ports/SkFontMgr_custom.cpp" ]
 }
 
-optional("fontmgr_custom_directory") {
-  enabled = skia_enable_fontmgr_custom_directory
-
-  deps = [
-    ":fontmgr_custom",
-    ":typeface_freetype",
-  ]
-  public = [ "$_skia_root/include/ports/SkFontMgr_directory.h" ]
-  sources = [ "$_skia_root/src/ports/SkFontMgr_custom_directory.cpp" ]
-}
-optional("fontmgr_custom_directory_factory") {
-  enabled = skia_enable_fontmgr_custom_directory
-  deps = [ ":fontmgr_custom_directory" ]
-  sources = [ "$_skia_root/src/ports/SkFontMgr_custom_directory_factory.cpp" ]
-}
-
 optional("fontmgr_custom_embedded") {
   enabled = skia_enable_fontmgr_custom_embedded
+  public_defines = [ "SK_FONTMGR_FREETYPE_EMBEDDED_AVAILABLE" ]
 
   deps = [
     ":fontmgr_custom",
@@ -272,14 +244,10 @@ optional("fontmgr_custom_embedded") {
   ]
   sources = [ "$_skia_root/src/ports/SkFontMgr_custom_embedded.cpp" ]
 }
-optional("fontmgr_custom_embedded_factory") {
-  enabled = skia_enable_fontmgr_custom_embedded
-  deps = [ ":fontmgr_custom_embedded" ]
-  sources = [ "$_skia_root/src/ports/SkFontMgr_custom_embedded_factory.cpp" ]
-}
 
 optional("fontmgr_custom_empty") {
   enabled = skia_enable_fontmgr_custom_empty
+  public_defines = [ "SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE" ]
 
   deps = [
     ":fontmgr_custom",
@@ -288,14 +256,10 @@ optional("fontmgr_custom_empty") {
   public = [ "$_skia_root/include/ports/SkFontMgr_empty.h" ]
   sources = [ "$_skia_root/src/ports/SkFontMgr_custom_empty.cpp" ]
 }
-optional("fontmgr_custom_empty_factory") {
-  enabled = skia_enable_fontmgr_custom_empty
-  deps = [ ":fontmgr_custom_empty" ]
-  sources = [ "$_skia_root/src/ports/SkFontMgr_custom_empty_factory.cpp" ]
-}
 
 optional("fontmgr_fontconfig") {
   enabled = skia_enable_fontmgr_fontconfig
+  public_defines = [ "SK_FONTMGR_FONTCONFIG_AVAILABLE" ]
 
   # The public header includes fontconfig.h and uses FcConfig*
   public_deps = [ "//third_party:fontconfig" ]
@@ -303,40 +267,10 @@ optional("fontmgr_fontconfig") {
   deps = [ ":typeface_freetype" ]
   sources = [ "$_skia_root/src/ports/SkFontMgr_fontconfig.cpp" ]
 }
-optional("fontmgr_fontconfig_factory") {
-  enabled = skia_enable_fontmgr_fontconfig
-  deps = [ ":fontmgr_fontconfig" ]
-  sources = [ "$_skia_root/src/ports/SkFontMgr_fontconfig_factory.cpp" ]
-}
-
-optional("fontmgr_FontConfigInterface") {
-  enabled = skia_enable_fontmgr_FontConfigInterface
-
-  deps = [
-    ":typeface_freetype",
-    "//third_party:fontconfig",
-  ]
-  public = [
-    "$_skia_root/include/ports/SkFontConfigInterface.h",
-    "$_skia_root/include/ports/SkFontMgr_FontConfigInterface.h",
-  ]
-  sources = [
-    "$_skia_root/src/ports/SkFontConfigInterface.cpp",
-    "$_skia_root/src/ports/SkFontConfigInterface_direct.cpp",
-    "$_skia_root/src/ports/SkFontConfigInterface_direct_factory.cpp",
-    "$_skia_root/src/ports/SkFontConfigTypeface.h",
-    "$_skia_root/src/ports/SkFontMgr_FontConfigInterface.cpp",
-  ]
-}
-optional("fontmgr_FontConfigInterface_factory") {
-  enabled = skia_enable_fontmgr_FontConfigInterface
-  deps = [ ":fontmgr_FontConfigInterface" ]
-  sources =
-      [ "$_skia_root/src/ports/SkFontMgr_FontConfigInterface_factory.cpp" ]
-}
 
 optional("fontmgr_fuchsia") {
   enabled = skia_enable_fontmgr_fuchsia
+  public_defines = [ "SK_FONTMGR_FUCHSIA_AVAILABLE" ]
 
   deps = []
 
@@ -352,7 +286,10 @@ optional("fontmgr_fuchsia") {
 optional("fontmgr_mac_ct") {
   enabled = skia_use_fonthost_mac
 
-  public_defines = [ "SK_TYPEFACE_FACTORY_CORETEXT" ]
+  public_defines = [
+    "SK_TYPEFACE_FACTORY_CORETEXT",
+    "SK_FONTMGR_CORETEXT_AVAILABLE",
+  ]
   public = [
     "$_skia_root/include/ports/SkFontMgr_mac_ct.h",
     "$_skia_root/include/ports/SkTypeface_mac.h",
@@ -384,16 +321,14 @@ optional("fontmgr_mac_ct") {
     ]
   }
 }
-optional("fontmgr_mac_ct_factory") {
-  enabled = skia_use_fonthost_mac
-  deps = [ ":fontmgr_mac_ct" ]
-  sources = [ "$_skia_root/src/ports/SkFontMgr_mac_ct_factory.cpp" ]
-}
 
 optional("fontmgr_win") {
   enabled = skia_enable_fontmgr_win
 
-  public_defines = [ "SK_TYPEFACE_FACTORY_DIRECTWRITE" ]
+  public_defines = [
+    "SK_TYPEFACE_FACTORY_DIRECTWRITE",
+    "SK_FONTMGR_DIRECTWRITE_AVAILABLE",
+  ]
   public = [ "$_skia_root/include/ports/SkTypeface_win.h" ]
   sources = [
     "$_skia_root/include/ports/SkFontMgr_indirect.h",
@@ -421,19 +356,6 @@ optional("fontmgr_win") {
       include_dirs = [ "${skia_dwritecore_sdk}/include" ]
     }
   }
-}
-optional("fontmgr_win_factory") {
-  enabled = skia_enable_fontmgr_win
-  deps = [ ":fontmgr_win" ]
-  sources = [ "$_skia_root/src/ports/SkFontMgr_win_dw_factory.cpp" ]
-}
-
-optional("fontmgr_win_gdi") {
-  enabled = skia_enable_fontmgr_win_gdi
-
-  public = [ "$_skia_root/include/ports/SkTypeface_win.h" ]
-  sources = [ "$_skia_root/src/ports/SkFontHost_win.cpp" ]
-  libs = [ "Gdi32.lib" ]
 }
 
 optional("gpu_shared") {
@@ -675,16 +597,13 @@ skia_component("skia") {
   check_includes = false
 
   public_deps = [
-    ":fontmgr_FontConfigInterface",
     ":fontmgr_android",
-    ":fontmgr_custom_directory",
     ":fontmgr_custom_embedded",
     ":fontmgr_custom_empty",
     ":fontmgr_fontconfig",
     ":fontmgr_fuchsia",
     ":fontmgr_mac_ct",
     ":fontmgr_win",
-    ":fontmgr_win_gdi",
     ":gpu",
     ":jpeg_encode",
     ":png_encode",
@@ -693,7 +612,6 @@ skia_component("skia") {
   ]
 
   deps = [
-    ":fontmgr_factory",
     ":hsw",
     ":jpeg_decode",
     ":ndk_images",

--- a/skia/flutter_defines.gni
+++ b/skia/flutter_defines.gni
@@ -23,6 +23,12 @@ flutter_defines = [
   # When running Metal, ensure that command buffers are scheduled before
   # returning from submit.
   "SK_METAL_WAIT_UNTIL_SCHEDULED",
+
+  # Staging for b/305780908
+  "SK_DEFAULT_TYPEFACE_IS_EMPTY",
+  "SK_DISABLE_LEGACY_DEFAULT_TYPEFACE",
+  "SK_DISABLE_LEGACY_FONTMGR_FACTORY",
+  "SK_DISABLE_LEGACY_FONTMGR_REFDEFAULT",
 ]
 
 if (!is_fuchsia) {

--- a/third_party/txt/src/txt/platform.cc
+++ b/third_party/txt/src/txt/platform.cc
@@ -4,6 +4,10 @@
 
 #include "txt/platform.h"
 
+#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
+#include "third_party/skia/include/ports/SkFontMgr_empty.h"
+#endif
+
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
@@ -11,7 +15,12 @@ std::vector<std::string> GetDefaultFontFamilies() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
-  return SkFontMgr::RefDefault();
+#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
+  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
+#else
+  static sk_sp<SkFontMgr> mgr = SkFontMgr::RefEmpty();
+#endif
+  return mgr;
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/platform_android.cc
+++ b/third_party/txt/src/txt/platform_android.cc
@@ -4,6 +4,14 @@
 
 #include "txt/platform.h"
 
+#if defined(SK_FONTMGR_ANDROID_AVAILABLE)
+#include "third_party/skia/include/ports/SkFontMgr_android.h"
+#endif
+
+#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
+#include "third_party/skia/include/ports/SkFontMgr_empty.h"
+#endif
+
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
@@ -11,7 +19,14 @@ std::vector<std::string> GetDefaultFontFamilies() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
-  return SkFontMgr::RefDefault();
+#if defined(SK_FONTMGR_ANDROID_AVAILABLE)
+  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Android(nullptr);
+#elif defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
+  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
+#else
+  static sk_sp<SkFontMgr> mgr = SkFontMgr::RefEmpty();
+#endif
+  return mgr;
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/platform_fuchsia.cc
+++ b/third_party/txt/src/txt/platform_fuchsia.cc
@@ -7,6 +7,10 @@
 #include "third_party/skia/include/ports/SkFontMgr_fuchsia.h"
 #include "txt/platform.h"
 
+#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
+#include "third_party/skia/include/ports/SkFontMgr_empty.h"
+#endif
+
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
@@ -19,7 +23,12 @@ sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
     sync_font_provider.Bind(zx::channel(font_initialization_data));
     return SkFontMgr_New_Fuchsia(std::move(sync_font_provider));
   } else {
-    return SkFontMgr::RefDefault();
+#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
+    static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
+#else
+    static sk_sp<SkFontMgr> mgr = SkFontMgr::RefEmpty();
+#endif
+    return mgr;
   }
 }
 

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -8,6 +8,10 @@
 #include "third_party/skia/include/ports/SkFontMgr_fontconfig.h"
 #endif
 
+#if defined(SK_FONTMGR_FREETYPE_DIRECTORY_AVAILABLE)
+#include "include/ports/SkFontMgr_directory.h"
+#endif
+
 #if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
 #include "third_party/skia/include/ports/SkFontMgr_empty.h"
 #endif
@@ -21,6 +25,9 @@ std::vector<std::string> GetDefaultFontFamilies() {
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
 #if defined(SK_FONTMGR_FONTCONFIG_AVAILABLE)
   static sk_sp<SkFontMgr> mgr = SkFontMgr_New_FontConfig(nullptr);
+#elif defined(SK_FONTMGR_FREETYPE_DIRECTORY_AVAILABLE)
+  static sk_sp<SkFontMgr> mgr =
+      SkFontMgr_New_Custom_Directory("/usr/share/fonts/");
 #elif defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
   static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
 #else

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -4,6 +4,14 @@
 
 #include "txt/platform.h"
 
+#if defined(SK_FONTMGR_FONTCONFIG_AVAILABLE)
+#include "third_party/skia/include/ports/SkFontMgr_fontconfig.h"
+#endif
+
+#if defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
+#include "third_party/skia/include/ports/SkFontMgr_empty.h"
+#endif
+
 namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies() {
@@ -11,7 +19,14 @@ std::vector<std::string> GetDefaultFontFamilies() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
-  return SkFontMgr::RefDefault();
+#if defined(SK_FONTMGR_FONTCONFIG_AVAILABLE)
+  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_FontConfig(nullptr);
+#elif defined(SK_FONTMGR_FREETYPE_EMPTY_AVAILABLE)
+  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_Custom_Empty();
+#else
+  static sk_sp<SkFontMgr> mgr = SkFontMgr::RefEmpty();
+#endif
+  return mgr;
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/platform_mac.mm
+++ b/third_party/txt/src/txt/platform_mac.mm
@@ -5,6 +5,7 @@
 #include <TargetConditionals.h>
 
 #include "flutter/fml/platform/darwin/platform_version.h"
+#include "third_party/skia/include/ports/SkFontMgr_mac_ct.h"
 #include "third_party/skia/include/ports/SkTypeface_mac.h"
 #include "txt/platform.h"
 #include "txt/platform_mac.h"
@@ -37,7 +38,8 @@ std::vector<std::string> GetDefaultFontFamilies() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
-  return SkFontMgr::RefDefault();
+  static sk_sp<SkFontMgr> mgr = SkFontMgr_New_CoreText(nullptr);
+  return mgr;
 }
 
 void RegisterSystemFonts(const DynamicFontManager& dynamic_font_manager) {


### PR DESCRIPTION
Relands https://github.com/flutter/engine/pull/48571 with a patch that uses the directory-based SkFontMgr as a default font manager on Linux