### PR TITLE
[Impeller] implements new blur tile mode

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4258,7 +4258,49 @@ TEST_P(AiksTest, AdvancedBlendWithClearColorOptimization) {
       Rect::MakeXYWH(0, 0, 200, 300),
       {.color = {1.0, 0.0, 1.0, 1.0}, .blend_mode = BlendMode::kMultiply});
 
+}
+
+TEST_P(AiksTest, GaussianBlurAtPeripheryVertical) {
+  Canvas canvas;
+
+  canvas.Scale(GetContentScale());
+  canvas.DrawRRect(Rect::MakeLTRB(0, 0, GetWindowSize().width, 100),
+                   Point(10, 10), Paint{.color = Color::LimeGreen()});
+  canvas.DrawRRect(Rect::MakeLTRB(0, 110, GetWindowSize().width, 210),
+                   Point(10, 10), Paint{.color = Color::Magenta()});
+  canvas.ClipRect(Rect::MakeLTRB(100, 0, 200, GetWindowSize().height));
+  canvas.SaveLayer({.blend_mode = BlendMode::kSource}, std::nullopt,
+                   ImageFilter::MakeBlur(Sigma(20.0), Sigma(20.0),
+                                         FilterContents::BlurStyle::kNormal,
+                                         Entity::TileMode::kClamp));
+  canvas.Restore();
+
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
+TEST_P(AiksTest, GaussianBlurAtPeripheryHorizontal) {
+  auto callback = [&](AiksContext& renderer) -> std::optional<Picture> {
+    Canvas canvas;
+
+    canvas.Scale(GetContentScale());
+    std::shared_ptr<Texture> boston = CreateTextureForFixture("boston.jpg");
+    canvas.DrawImageRect(
+        std::make_shared<Image>(boston),
+        Rect::MakeXYWH(0, 0, boston->GetSize().width, boston->GetSize().height),
+        Rect::MakeLTRB(0, 0, GetWindowSize().width, 100), Paint{});
+    canvas.DrawRRect(Rect::MakeLTRB(0, 110, GetWindowSize().width, 210),
+                     Point(10, 10), Paint{.color = Color::Magenta()});
+    canvas.ClipRect(Rect::MakeLTRB(0, 50, GetWindowSize().width, 150));
+    static int64_t i = 0;
+    Scalar sigma = sin(i++ * 2.0 * 3.1415 * 0.1 / 60.0) * 10.0 + 10;
+    canvas.SaveLayer({.blend_mode = BlendMode::kSource}, std::nullopt,
+                     ImageFilter::MakeBlur(Sigma(sigma), Sigma(sigma),
+                                           FilterContents::BlurStyle::kNormal,
+                                           Entity::TileMode::kClamp));
+    canvas.Restore();
+    return canvas.EndRecordingAsPicture();
+  };
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
 }  // namespace testing

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4278,28 +4278,23 @@ TEST_P(AiksTest, GaussianBlurAtPeripheryVertical) {
 }
 
 TEST_P(AiksTest, GaussianBlurAtPeripheryHorizontal) {
-  auto callback = [&](AiksContext& renderer) -> std::optional<Picture> {
-    Canvas canvas;
+  Canvas canvas;
 
-    canvas.Scale(GetContentScale());
-    std::shared_ptr<Texture> boston = CreateTextureForFixture("boston.jpg");
-    canvas.DrawImageRect(
-        std::make_shared<Image>(boston),
-        Rect::MakeXYWH(0, 0, boston->GetSize().width, boston->GetSize().height),
-        Rect::MakeLTRB(0, 0, GetWindowSize().width, 100), Paint{});
-    canvas.DrawRRect(Rect::MakeLTRB(0, 110, GetWindowSize().width, 210),
-                     Point(10, 10), Paint{.color = Color::Magenta()});
-    canvas.ClipRect(Rect::MakeLTRB(0, 50, GetWindowSize().width, 150));
-    static int64_t i = 0;
-    Scalar sigma = sin(i++ * 2.0 * 3.1415 * 0.1 / 60.0) * 10.0 + 10;
-    canvas.SaveLayer({.blend_mode = BlendMode::kSource}, std::nullopt,
-                     ImageFilter::MakeBlur(Sigma(sigma), Sigma(sigma),
-                                           FilterContents::BlurStyle::kNormal,
-                                           Entity::TileMode::kClamp));
-    canvas.Restore();
-    return canvas.EndRecordingAsPicture();
-  };
-  ASSERT_TRUE(OpenPlaygroundHere(callback));
+  canvas.Scale(GetContentScale());
+  std::shared_ptr<Texture> boston = CreateTextureForFixture("boston.jpg");
+  canvas.DrawImageRect(
+      std::make_shared<Image>(boston),
+      Rect::MakeXYWH(0, 0, boston->GetSize().width, boston->GetSize().height),
+      Rect::MakeLTRB(0, 0, GetWindowSize().width, 100), Paint{});
+  canvas.DrawRRect(Rect::MakeLTRB(0, 110, GetWindowSize().width, 210),
+                   Point(10, 10), Paint{.color = Color::Magenta()});
+  canvas.ClipRect(Rect::MakeLTRB(0, 50, GetWindowSize().width, 150));
+  canvas.SaveLayer({.blend_mode = BlendMode::kSource}, std::nullopt,
+                   ImageFilter::MakeBlur(Sigma(20.0), Sigma(20.0),
+                                         FilterContents::BlurStyle::kNormal,
+                                         Entity::TileMode::kClamp));
+  canvas.Restore();
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
 }  // namespace testing

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4257,7 +4257,6 @@ TEST_P(AiksTest, AdvancedBlendWithClearColorOptimization) {
   canvas.DrawRect(
       Rect::MakeXYWH(0, 0, 200, 300),
       {.color = {1.0, 0.0, 1.0, 1.0}, .blend_mode = BlendMode::kMultiply});
-
 }
 
 TEST_P(AiksTest, GaussianBlurAtPeripheryVertical) {

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -50,6 +50,8 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
   return blur;
 }
 
+#define IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER 1
+
 std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     const FilterInput::Ref& input,
     Sigma sigma_x,

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -50,6 +50,8 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
   return blur;
 }
 
+#define IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER 1
+
 std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     const FilterInput::Ref& input,
     Sigma sigma_x,
@@ -66,7 +68,8 @@ std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
   // TODO(https://github.com/flutter/flutter/issues/131580): Remove once the new
   // blur handles all cases.
   if (use_new_filter) {
-    auto blur = std::make_shared<GaussianBlurFilterContents>(sigma_x.sigma);
+    auto blur =
+        std::make_shared<GaussianBlurFilterContents>(sigma_x.sigma, tile_mode);
     blur->SetInputs({input});
     return blur;
   }

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -50,8 +50,6 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
   return blur;
 }
 
-#define IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER 1
-
 std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     const FilterInput::Ref& input,
     Sigma sigma_x,

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -54,6 +54,31 @@ Matrix MakeAnchorScale(const Point& anchor, Vector2 scale) {
          Matrix::MakeTranslation({-anchor.x, -anchor.y, 0});
 }
 
+void SetTileMode(SamplerDescriptor* descriptor,
+                 const ContentContext& renderer,
+                 Entity::TileMode tile_mode) {
+  switch (tile_mode) {
+    case Entity::TileMode::kDecal:
+      if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {
+        descriptor->width_address_mode = SamplerAddressMode::kDecal;
+        descriptor->height_address_mode = SamplerAddressMode::kDecal;
+      }
+      break;
+    case Entity::TileMode::kClamp:
+      descriptor->width_address_mode = SamplerAddressMode::kClampToEdge;
+      descriptor->height_address_mode = SamplerAddressMode::kClampToEdge;
+      break;
+    case Entity::TileMode::kMirror:
+      descriptor->width_address_mode = SamplerAddressMode::kMirror;
+      descriptor->height_address_mode = SamplerAddressMode::kMirror;
+      break;
+    case Entity::TileMode::kRepeat:
+      descriptor->width_address_mode = SamplerAddressMode::kRepeat;
+      descriptor->height_address_mode = SamplerAddressMode::kRepeat;
+      break;
+  }
+}
+
 /// Makes a subpass that will render the scaled down input and add the
 /// transparent gutter required for the blur halo.
 std::shared_ptr<Texture> MakeDownsampleSubpass(
@@ -98,35 +123,7 @@ std::shared_ptr<Texture> MakeDownsampleSubpass(
             });
 
         SamplerDescriptor linear_sampler_descriptor = sampler_descriptor;
-        switch (tile_mode) {
-          case Entity::TileMode::kDecal:
-            if (renderer.GetDeviceCapabilities()
-                    .SupportsDecalSamplerAddressMode()) {
-              linear_sampler_descriptor.width_address_mode =
-                  SamplerAddressMode::kDecal;
-              linear_sampler_descriptor.height_address_mode =
-                  SamplerAddressMode::kDecal;
-            }
-            break;
-          case Entity::TileMode::kClamp:
-            linear_sampler_descriptor.width_address_mode =
-                SamplerAddressMode::kClampToEdge;
-            linear_sampler_descriptor.height_address_mode =
-                SamplerAddressMode::kClampToEdge;
-            break;
-          case Entity::TileMode::kMirror:
-            linear_sampler_descriptor.width_address_mode =
-                SamplerAddressMode::kMirror;
-            linear_sampler_descriptor.height_address_mode =
-                SamplerAddressMode::kMirror;
-            break;
-          case Entity::TileMode::kRepeat:
-            linear_sampler_descriptor.width_address_mode =
-                SamplerAddressMode::kRepeat;
-            linear_sampler_descriptor.height_address_mode =
-                SamplerAddressMode::kRepeat;
-            break;
-        }
+        SetTileMode(&linear_sampler_descriptor, renderer, tile_mode);
         linear_sampler_descriptor.mag_filter = MinMagFilter::kLinear;
         linear_sampler_descriptor.min_filter = MinMagFilter::kLinear;
         TextureFillVertexShader::BindFrameInfo(

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -62,7 +62,8 @@ std::shared_ptr<Texture> MakeDownsampleSubpass(
     const SamplerDescriptor& sampler_descriptor,
     const Quad& uvs,
     const ISize& subpass_size,
-    const Vector2 padding) {
+    const Vector2 padding,
+    Entity::TileMode tile_mode) {
   ContentContext::SubpassCallback subpass_callback =
       [&](const ContentContext& renderer, RenderPass& pass) {
         HostBuffer& host_buffer = pass.GetTransientsBuffer();
@@ -82,21 +83,50 @@ std::shared_ptr<Texture> MakeDownsampleSubpass(
         // creates a halo effect. This compensates for when the expanded clip
         // region can't give us the full gutter we want.
         Vector2 texture_size = Vector2(input_texture->GetSize());
-        Quad vertices =
+        Quad guttered_uvs =
             MakeAnchorScale({0.5, 0.5},
-                            texture_size / (texture_size + padding * 2))
-                .Transform(
-                    {Point(0, 0), Point(1, 0), Point(0, 1), Point(1, 1)});
+                            (texture_size + padding * 2) / texture_size)
+                .Transform(uvs);
 
-        BindVertices<TextureFillVertexShader>(cmd, host_buffer,
-                                              {
-                                                  {vertices[0], uvs[0]},
-                                                  {vertices[1], uvs[1]},
-                                                  {vertices[2], uvs[2]},
-                                                  {vertices[3], uvs[3]},
-                                              });
+        BindVertices<TextureFillVertexShader>(
+            cmd, host_buffer,
+            {
+                {Point(0, 0), guttered_uvs[0]},
+                {Point(1, 0), guttered_uvs[1]},
+                {Point(0, 1), guttered_uvs[2]},
+                {Point(1, 1), guttered_uvs[3]},
+            });
 
         SamplerDescriptor linear_sampler_descriptor = sampler_descriptor;
+        switch (tile_mode) {
+          case Entity::TileMode::kDecal:
+            if (renderer.GetDeviceCapabilities()
+                    .SupportsDecalSamplerAddressMode()) {
+              linear_sampler_descriptor.width_address_mode =
+                  SamplerAddressMode::kDecal;
+              linear_sampler_descriptor.height_address_mode =
+                  SamplerAddressMode::kDecal;
+            }
+            break;
+          case Entity::TileMode::kClamp:
+            linear_sampler_descriptor.width_address_mode =
+                SamplerAddressMode::kClampToEdge;
+            linear_sampler_descriptor.height_address_mode =
+                SamplerAddressMode::kClampToEdge;
+            break;
+          case Entity::TileMode::kMirror:
+            linear_sampler_descriptor.width_address_mode =
+                SamplerAddressMode::kMirror;
+            linear_sampler_descriptor.height_address_mode =
+                SamplerAddressMode::kMirror;
+            break;
+          case Entity::TileMode::kRepeat:
+            linear_sampler_descriptor.width_address_mode =
+                SamplerAddressMode::kRepeat;
+            linear_sampler_descriptor.height_address_mode =
+                SamplerAddressMode::kRepeat;
+            break;
+        }
         linear_sampler_descriptor.mag_filter = MinMagFilter::kLinear;
         linear_sampler_descriptor.min_filter = MinMagFilter::kLinear;
         TextureFillVertexShader::BindFrameInfo(
@@ -165,8 +195,10 @@ std::shared_ptr<Texture> MakeBlurSubpass(
 
 }  // namespace
 
-GaussianBlurFilterContents::GaussianBlurFilterContents(Scalar sigma)
-    : sigma_(sigma) {}
+GaussianBlurFilterContents::GaussianBlurFilterContents(
+    Scalar sigma,
+    Entity::TileMode tile_mode)
+    : sigma_(sigma), tile_mode_(tile_mode) {}
 
 // This value was extracted from Skia, see:
 //  * https://github.com/google/skia/blob/d29cc3fe182f6e8a8539004a6a4ee8251677a6fd/src/gpu/ganesh/GrBlurUtils.cpp#L2561-L2576
@@ -264,7 +296,7 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
 
   std::shared_ptr<Texture> pass1_out_texture = MakeDownsampleSubpass(
       renderer, input_snapshot->texture, input_snapshot->sampler_descriptor,
-      uvs, subpass_size, padding);
+      uvs, subpass_size, padding, tile_mode_);
 
   Vector2 pass1_pixel_size = 1.0 / Vector2(pass1_out_texture->GetSize());
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.h
@@ -15,7 +15,7 @@ namespace impeller {
 /// Note: This will replace `DirectionalGaussianBlurFilterContents`.
 class GaussianBlurFilterContents final : public FilterContents {
  public:
-  explicit GaussianBlurFilterContents(Scalar sigma = 0.0f);
+  explicit GaussianBlurFilterContents(Scalar sigma, Entity::TileMode tile_mode);
 
   Scalar GetSigma() const { return sigma_; }
 
@@ -58,6 +58,7 @@ class GaussianBlurFilterContents final : public FilterContents {
       const std::optional<Rect>& coverage_hint) const override;
 
   const Scalar sigma_ = 0.0;
+  const Entity::TileMode tile_mode_;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -60,7 +60,8 @@ TEST(GaussianBlurFilterContentsTest, CoverageSimple) {
 
 TEST(GaussianBlurFilterContentsTest, CoverageWithSigma) {
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1, Entity::TileMode::kDecal);
+  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1,
+                                      Entity::TileMode::kDecal);
   FilterInput::Vector inputs = {
       FilterInput::Make(Rect::MakeLTRB(100, 100, 200, 200))};
   Entity entity;
@@ -76,7 +77,8 @@ TEST_P(GaussianBlurFilterContentsTest, CoverageWithTexture) {
       .size = ISize(100, 100),
   };
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1, Entity::TileMode::kDecal);
+  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1,
+                                      Entity::TileMode::kDecal);
   std::shared_ptr<Texture> texture =
       GetContentContext()->GetContext()->GetResourceAllocator()->CreateTexture(
           desc);
@@ -95,7 +97,8 @@ TEST_P(GaussianBlurFilterContentsTest, CoverageWithEffectTransform) {
       .size = ISize(100, 100),
   };
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1, Entity::TileMode::kDecal);
+  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1,
+                                      Entity::TileMode::kDecal);
   std::shared_ptr<Texture> texture =
       GetContentContext()->GetContext()->GetResourceAllocator()->CreateTexture(
           desc);
@@ -109,7 +112,8 @@ TEST_P(GaussianBlurFilterContentsTest, CoverageWithEffectTransform) {
 
 TEST(GaussianBlurFilterContentsTest, FilterSourceCoverage) {
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(
+      sigma_radius_1, Entity::TileMode::kDecal);
   std::optional<Rect> coverage = contents->GetFilterSourceCoverage(
       /*effect_transform=*/Matrix::MakeScale({2.0, 2.0, 1.0}),
       /*output_limit=*/Rect::MakeLTRB(100, 100, 200, 200));
@@ -133,7 +137,8 @@ TEST_P(GaussianBlurFilterContentsTest, RenderCoverageMatchesGetCoverage) {
   };
   std::shared_ptr<Texture> texture = MakeTexture(desc);
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(
+      sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
@@ -165,7 +170,8 @@ TEST_P(GaussianBlurFilterContentsTest,
   };
   std::shared_ptr<Texture> texture = MakeTexture(desc);
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(
+      sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
@@ -199,7 +205,8 @@ TEST_P(GaussianBlurFilterContentsTest,
   };
   std::shared_ptr<Texture> texture = MakeTexture(desc);
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(
+      sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
@@ -258,7 +265,8 @@ TEST_P(GaussianBlurFilterContentsTest, TextureContentsWithDestinationRect) {
       50, 40, texture->GetSize().width, texture->GetSize().height));
 
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(
+      sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture_contents)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
@@ -296,7 +304,8 @@ TEST_P(GaussianBlurFilterContentsTest,
       50, 40, texture->GetSize().width, texture->GetSize().height));
 
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(
+      sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture_contents)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -35,12 +35,12 @@ class GaussianBlurFilterContentsTest : public EntityPlayground {
 INSTANTIATE_PLAYGROUND_SUITE(GaussianBlurFilterContentsTest);
 
 TEST(GaussianBlurFilterContentsTest, Create) {
-  GaussianBlurFilterContents contents;
+  GaussianBlurFilterContents contents(/*sigma=*/0.0, Entity::TileMode::kDecal);
   ASSERT_EQ(contents.GetSigma(), 0.0);
 }
 
 TEST(GaussianBlurFilterContentsTest, CoverageEmpty) {
-  GaussianBlurFilterContents contents;
+  GaussianBlurFilterContents contents(/*sigma=*/0.0, Entity::TileMode::kDecal);
   FilterInput::Vector inputs = {};
   Entity entity;
   std::optional<Rect> coverage =
@@ -49,7 +49,7 @@ TEST(GaussianBlurFilterContentsTest, CoverageEmpty) {
 }
 
 TEST(GaussianBlurFilterContentsTest, CoverageSimple) {
-  GaussianBlurFilterContents contents;
+  GaussianBlurFilterContents contents(/*sigma=*/0.0, Entity::TileMode::kDecal);
   FilterInput::Vector inputs = {
       FilterInput::Make(Rect::MakeLTRB(10, 10, 110, 110))};
   Entity entity;
@@ -60,7 +60,7 @@ TEST(GaussianBlurFilterContentsTest, CoverageSimple) {
 
 TEST(GaussianBlurFilterContentsTest, CoverageWithSigma) {
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1);
+  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1, Entity::TileMode::kDecal);
   FilterInput::Vector inputs = {
       FilterInput::Make(Rect::MakeLTRB(100, 100, 200, 200))};
   Entity entity;
@@ -76,7 +76,7 @@ TEST_P(GaussianBlurFilterContentsTest, CoverageWithTexture) {
       .size = ISize(100, 100),
   };
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1);
+  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1, Entity::TileMode::kDecal);
   std::shared_ptr<Texture> texture =
       GetContentContext()->GetContext()->GetResourceAllocator()->CreateTexture(
           desc);
@@ -95,7 +95,7 @@ TEST_P(GaussianBlurFilterContentsTest, CoverageWithEffectTransform) {
       .size = ISize(100, 100),
   };
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1);
+  GaussianBlurFilterContents contents(/*sigma=*/sigma_radius_1, Entity::TileMode::kDecal);
   std::shared_ptr<Texture> texture =
       GetContentContext()->GetContext()->GetResourceAllocator()->CreateTexture(
           desc);
@@ -109,7 +109,7 @@ TEST_P(GaussianBlurFilterContentsTest, CoverageWithEffectTransform) {
 
 TEST(GaussianBlurFilterContentsTest, FilterSourceCoverage) {
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
   std::optional<Rect> coverage = contents->GetFilterSourceCoverage(
       /*effect_transform=*/Matrix::MakeScale({2.0, 2.0, 1.0}),
       /*output_limit=*/Rect::MakeLTRB(100, 100, 200, 200));
@@ -133,7 +133,7 @@ TEST_P(GaussianBlurFilterContentsTest, RenderCoverageMatchesGetCoverage) {
   };
   std::shared_ptr<Texture> texture = MakeTexture(desc);
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
@@ -165,7 +165,7 @@ TEST_P(GaussianBlurFilterContentsTest,
   };
   std::shared_ptr<Texture> texture = MakeTexture(desc);
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
@@ -199,7 +199,7 @@ TEST_P(GaussianBlurFilterContentsTest,
   };
   std::shared_ptr<Texture> texture = MakeTexture(desc);
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
@@ -258,7 +258,7 @@ TEST_P(GaussianBlurFilterContentsTest, TextureContentsWithDestinationRect) {
       50, 40, texture->GetSize().width, texture->GetSize().height));
 
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture_contents)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 
@@ -296,7 +296,7 @@ TEST_P(GaussianBlurFilterContentsTest,
       50, 40, texture->GetSize().width, texture->GetSize().height));
 
   Scalar sigma_radius_1 = CalculateSigmaForBlurRadius(1.0);
-  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1);
+  auto contents = std::make_unique<GaussianBlurFilterContents>(sigma_radius_1, Entity::TileMode::kDecal);
   contents->SetInputs({FilterInput::Make(texture_contents)});
   std::shared_ptr<ContentContext> renderer = GetContentContext();
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/139165

## before

<img width="1027" alt="Screenshot 2023-12-07 at 2 18 42 PM" src="https://github.com/flutter/engine/assets/30870216/606d7203-20d6-4efd-a788-2f539508a280">


## after

<img width="1026" alt="Screenshot 2023-12-07 at 2 14 39 PM" src="https://github.com/flutter/engine/assets/30870216/8209b372-e477-4552-b4d1-2296b1e6d2d8">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
