### PR TITLE
Add the `flutter_js` target as a dep to `web_sdk`.

### DIFF
--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -31,6 +31,7 @@ group("web_sdk") {
   deps = [
     ":flutter_ddc_modules",
     ":flutter_platform_dills",
+    "//flutter/lib/web_ui/flutter_js",
   ]
 }
 


### PR DESCRIPTION
Currently, the `flutter_js` target is built as part of the flutter_web_sdk_archive target. However, it should also be built when doing the normal web_sdk, as that is what the monorepo builds (and does its own archiving).