### PR TITLE
[Impeller] remove trace events that have outlived their usefulness.

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -91,8 +91,6 @@ AllocatorVK::AllocatorVK(std::weak_ptr<Context> context,
                          const vk::Instance& instance,
                          const CapabilitiesVK& capabilities)
     : context_(std::move(context)), device_holder_(device_holder) {
-  TRACE_EVENT0("impeller", "CreateAllocatorVK");
-
   auto limits = physical_device.getProperties().limits;
   max_texture_size_.width = max_texture_size_.height =
       limits.maxImageDimension2D;
@@ -273,7 +271,6 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
                            bool supports_framebuffer_fetch)
       : TextureSourceVK(desc), resource_(std::move(resource_manager)) {
     FML_DCHECK(desc.format != PixelFormat::kUnknown);
-    TRACE_EVENT0("impeller", "CreateDeviceTexture");
     vk::ImageCreateInfo image_info;
     image_info.flags = ToVKImageCreateFlags(desc.type);
     image_info.imageType = vk::ImageType::e2D;
@@ -402,7 +399,6 @@ class AllocatedTextureSourceVK final : public TextureSourceVK {
 // |Allocator|
 std::shared_ptr<Texture> AllocatorVK::OnCreateTexture(
     const TextureDescriptor& desc) {
-  TRACE_EVENT0("impeller", "AllocatorVK::OnCreateTexture");
   if (!IsValid()) {
     return nullptr;
   }
@@ -436,7 +432,6 @@ void AllocatorVK::DidAcquireSurfaceFrame() {
 // |Allocator|
 std::shared_ptr<DeviceBuffer> AllocatorVK::OnCreateBuffer(
     const DeviceBufferDescriptor& desc) {
-  TRACE_EVENT0("impeller", "AllocatorVK::OnCreateBuffer");
   vk::BufferCreateInfo buffer_info;
   buffer_info.usage = vk::BufferUsageFlagBits::eVertexBuffer |
                       vk::BufferUsageFlagBits::eIndexBuffer |

--- a/impeller/renderer/backend/vulkan/command_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_pool_vk.cc
@@ -212,8 +212,6 @@ std::optional<vk::UniqueCommandPool> CommandPoolRecyclerVK::Reuse() {
 }
 
 void CommandPoolRecyclerVK::Reclaim(vk::UniqueCommandPool&& pool) {
-  TRACE_EVENT0("impeller", "ReclaimCommandPool");
-
   // Reset the pool on a background thread.
   auto strong_context = context_.lock();
   if (!strong_context) {

--- a/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/descriptor_pool_vk.cc
@@ -116,8 +116,6 @@ DescriptorPoolVK::AllocateDescriptorSets(
 
 void DescriptorPoolRecyclerVK::Reclaim(vk::UniqueDescriptorPool&& pool,
                                        uint32_t allocated_capacity) {
-  TRACE_EVENT0("impeller", "DescriptorPoolRecyclerVK::Reclaim");
-
   // Reset the pool on a background thread.
   auto strong_context = context_.lock();
   if (!strong_context) {
@@ -172,8 +170,6 @@ DescriptorPoolAndSize DescriptorPoolRecyclerVK::Get(uint32_t minimum_capacity) {
 
 DescriptorPoolAndSize DescriptorPoolRecyclerVK::Create(
     uint32_t minimum_capacity) {
-  TRACE_EVENT0("impeller", "DescriptorPoolRecyclerVK::Create");
-
   FML_DCHECK(Allocation::NextPowerOfTwoSize(minimum_capacity) ==
              minimum_capacity);
   auto strong_context = context_.lock();
@@ -204,8 +200,6 @@ DescriptorPoolAndSize DescriptorPoolRecyclerVK::Create(
 
 std::optional<DescriptorPoolAndSize> DescriptorPoolRecyclerVK::Reuse(
     uint32_t minimum_capacity) {
-  TRACE_EVENT0("impeller", "DescriptorPoolRecyclerVK::Reuse");
-
   FML_DCHECK(Allocation::NextPowerOfTwoSize(minimum_capacity) ==
              minimum_capacity);
   Lock lock(recycled_mutex_);

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -64,7 +64,6 @@ FenceWaiterVK::~FenceWaiterVK() {
 
 bool FenceWaiterVK::AddFence(vk::UniqueFence fence,
                              const fml::closure& callback) {
-  TRACE_EVENT0("flutter", "FenceWaiterVK::AddFence");
   if (!fence || !callback) {
     return false;
   }


### PR DESCRIPTION
Dart timeline tracing events are surprisingly expensive. Lets remove events we're not using to track anything, in favor of CPU profiles.