### PR TITLE
Add support for exposing accessibility identifier as accessibilityIdentifier on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -524,6 +524,17 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   return YES;
 }
 
+- (NSString*)accessibilityIdentifier {
+  if (![self isAccessibilityBridgeAlive]) {
+    return nil;
+  }
+
+  if ([self node].identifier.empty()) {
+    return nil;
+  }
+  return @([self node].identifier.data());
+}
+
 - (NSString*)accessibilityLabel {
   if (![self isAccessibilityBridgeAlive]) {
     return nil;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -508,7 +508,22 @@ FLUTTER_ASSERT_ARC
   XCTAssertFalse(scrollView.isAccessibilityElement);
 }
 
-- (void)testFlutterScrollableSemanticsObjectWithLabelValueHintIsNotHiddenWhenVoiceOverIsRunning {
+- (void)testFlutterSemanticsObjectHasIdentifier {
+  flutter::testing::MockAccessibilityBridge* mock = new flutter::testing::MockAccessibilityBridge();
+  mock->isVoiceOverRunningValue = true;
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(mock);
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+
+  flutter::SemanticsNode node;
+  node.identifier = "identifier";
+
+  FlutterSemanticsObject* object = [[FlutterSemanticsObject alloc] initWithBridge:bridge uid:0];
+  [object setSemanticsNode:&node];
+  XCTAssertTrue([object.accessibilityIdentifier isEqualToString:@"identifier"]);
+}
+
+- (void)
+    testFlutterScrollableSemanticsObjectWithIdentifierLabelValueHintIsNotHiddenWhenVoiceOverIsRunning {
   flutter::testing::MockAccessibilityBridge* mock = new flutter::testing::MockAccessibilityBridge();
   mock->isVoiceOverRunningValue = true;
   fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(mock);
@@ -518,6 +533,7 @@ FLUTTER_ASSERT_ARC
   node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kHasImplicitScrolling);
   node.actions = flutter::kHorizontalScrollSemanticsActions;
   node.rect = SkRect::MakeXYWH(0, 0, 100, 200);
+  node.identifier = "identifier";
   node.label = "label";
   node.value = "value";
   node.hint = "hint";
@@ -530,6 +546,8 @@ FLUTTER_ASSERT_ARC
   [scrollable accessibilityBridgeDidFinishUpdate];
   UIScrollView* scrollView = [scrollable nativeAccessibility];
   XCTAssertTrue(scrollView.isAccessibilityElement);
+  FML_LOG(INFO) << "scrollView.accessibilityIdentifier" << scrollView.accessibilityIdentifier;
+  XCTAssertTrue([scrollView.accessibilityIdentifier isEqualToString:@"identifier"]);
   XCTAssertTrue(
       [scrollView.accessibilityLabel isEqualToString:NSLocalizedString(@"label", @"test")]);
   XCTAssertTrue(

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -522,8 +522,7 @@ FLUTTER_ASSERT_ARC
   XCTAssertTrue([object.accessibilityIdentifier isEqualToString:@"identifier"]);
 }
 
-- (void)
-    testFlutterScrollableSemanticsObjectWithIdentifierLabelValueHintIsNotHiddenWhenVoiceOverIsRunning {
+- (void)testFlutterScrollableSemanticsObjectWithLabelValueHintIsNotHiddenWhenVoiceOverIsRunning {
   flutter::testing::MockAccessibilityBridge* mock = new flutter::testing::MockAccessibilityBridge();
   mock->isVoiceOverRunningValue = true;
   fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(mock);
@@ -533,7 +532,6 @@ FLUTTER_ASSERT_ARC
   node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kHasImplicitScrolling);
   node.actions = flutter::kHorizontalScrollSemanticsActions;
   node.rect = SkRect::MakeXYWH(0, 0, 100, 200);
-  node.identifier = "identifier";
   node.label = "label";
   node.value = "value";
   node.hint = "hint";
@@ -546,8 +544,6 @@ FLUTTER_ASSERT_ARC
   [scrollable accessibilityBridgeDidFinishUpdate];
   UIScrollView* scrollView = [scrollable nativeAccessibility];
   XCTAssertTrue(scrollView.isAccessibilityElement);
-  FML_LOG(INFO) << "scrollView.accessibilityIdentifier" << scrollView.accessibilityIdentifier;
-  XCTAssertTrue([scrollView.accessibilityIdentifier isEqualToString:@"identifier"]);
   XCTAssertTrue(
       [scrollView.accessibilityLabel isEqualToString:NSLocalizedString(@"label", @"test")]);
   XCTAssertTrue(


### PR DESCRIPTION
This PR is a sibling of #47961 but for iOS

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
