### PR TITLE
SemanticsUpdateBuilder migration: introduce `identifier`

### DIFF
--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -145,6 +145,7 @@ external void _validateVertices(Vertices vertices);
 @pragma('vm:entry-point')
 void sendSemanticsUpdate() {
   final SemanticsUpdateBuilder builder = SemanticsUpdateBuilder();
+  final String identifier = "identifier";
   final String label = "label";
   final List<StringAttribute> labelAttributes = <StringAttribute> [
     SpellOutStringAttribute(range: TextRange(start: 1, end: 2)),
@@ -212,6 +213,7 @@ void sendSemanticsUpdate() {
     rect: Rect.fromLTRB(0, 0, 10, 10),
     elevation: 0,
     thickness: 0,
+    identifier: identifier,
     label: label,
     labelAttributes: labelAttributes,
     value: value,

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -807,8 +807,7 @@ abstract class SemanticsUpdateBuilder {
     required double elevation,
     required double thickness,
     required Rect rect,
-    // TODO(bartekpacia): Re-add once migration is complete
-    // String identifier,
+    required String identifier,
     required String label,
     required List<StringAttribute> labelAttributes,
     required String value,
@@ -878,8 +877,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1 implem
     required double elevation,
     required double thickness,
     required Rect rect,
-    // TODO(bartekpacia): Re-add once migration is complete
-    // String identifier,
+    required String identifier,
     required String label,
     required List<StringAttribute> labelAttributes,
     required String value,
@@ -918,8 +916,7 @@ base class _NativeSemanticsUpdateBuilder extends NativeFieldWrapperClass1 implem
       rect.bottom,
       elevation,
       thickness,
-      // TODO(bartekpacia): Pass real identifier parameter once migration is complete
-      '',
+      identifier,
       label,
       labelAttributes,
       value,

--- a/lib/web_ui/lib/semantics.dart
+++ b/lib/web_ui/lib/semantics.dart
@@ -360,8 +360,7 @@ class SemanticsUpdateBuilder {
     required double elevation,
     required double thickness,
     required Rect rect,
-    // TODO(bartekpacia): Re-add once migration is complete
-    // String identifier,
+    required String identifier,
     required String label,
     required List<StringAttribute> labelAttributes,
     required String value,
@@ -396,8 +395,7 @@ class SemanticsUpdateBuilder {
       scrollExtentMax: scrollExtentMax,
       scrollExtentMin: scrollExtentMin,
       rect: rect,
-      // TODO(bartekpacia): Pass real identifier parameter once migration is complete
-      identifier: '',
+      identifier: identifier,
       label: label,
       labelAttributes: labelAttributes,
       value: value,

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -3092,8 +3092,7 @@ void updateNode(
     elevation: elevation,
     thickness: thickness,
     rect: rect,
-    // TODO(bartekpacia): Pass real identifier parameter once migration is complete
-    // identifier: '',
+    identifier: identifier,
     label: label,
     labelAttributes: labelAttributes,
     hint: hint,

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -137,6 +137,7 @@ Future<void> a11y_main() async {
   final SemanticsUpdateBuilder builder = SemanticsUpdateBuilder()
     ..updateNode(
       id: 42,
+      identifier: '',
       label: 'A: root',
       labelAttributes: <StringAttribute>[],
       rect: Rect.fromLTRB(0.0, 0.0, 10.0, 10.0),
@@ -170,6 +171,7 @@ Future<void> a11y_main() async {
     )
     ..updateNode(
       id: 84,
+      identifier: '',
       label: 'B: leaf',
       labelAttributes: <StringAttribute>[],
       rect: Rect.fromLTRB(40.0, 40.0, 80.0, 80.0),
@@ -203,6 +205,7 @@ Future<void> a11y_main() async {
     )
     ..updateNode(
       id: 96,
+      identifier: '',
       label: 'C: branch',
       labelAttributes: <StringAttribute>[],
       rect: Rect.fromLTRB(40.0, 40.0, 80.0, 80.0),
@@ -236,6 +239,7 @@ Future<void> a11y_main() async {
     )
     ..updateNode(
       id: 128,
+      identifier: '',
       label: 'D: leaf',
       labelAttributes: <StringAttribute>[],
       rect: Rect.fromLTRB(40.0, 40.0, 80.0, 80.0),
@@ -301,6 +305,7 @@ Future<void> a11y_string_attributes() async {
   final SemanticsUpdateBuilder builder = SemanticsUpdateBuilder()
     ..updateNode(
       id: 42,
+      identifier: 'identifier',
       label: 'What is the meaning of life?',
       labelAttributes: <StringAttribute>[
         LocaleStringAttribute(

--- a/testing/scenario_app/lib/src/locale_initialization.dart
+++ b/testing/scenario_app/lib/src/locale_initialization.dart
@@ -49,6 +49,7 @@ class LocaleInitialization extends Scenario {
         // SemanticsAction.tap.
         actions: 1,
         rect: const Rect.fromLTRB(0.0, 0.0, 414.0, 48.0),
+        identifier: '',
         label: view.platformDispatcher.locales.toString(),
         labelAttributes: <StringAttribute>[],
         textDirection: TextDirection.ltr,
@@ -107,6 +108,7 @@ class LocaleInitialization extends Scenario {
         // SemanticsAction.tap.
         actions: 1,
         rect: const Rect.fromLTRB(0.0, 0.0, 414.0, 48.0),
+        identifier: '',
         label: label,
         labelAttributes: <StringAttribute>[],
         textDirection: TextDirection.ltr,


### PR DESCRIPTION
This PR adds `String? identifier` to `SemanticsUpdateBuilder` (currently it's only available in the temproary `SemanticsUpdateBuilderNew` API.

This is mainly targeted at https://github.com/flutter/flutter/issues/17988

Steps:
part 1: [engine] add `SemanticsUpdateBuilderNew` https://github.com/flutter/engine/pull/47961
part 2: [flutter] use `SemanticsUpdateBuilderNew`  https://github.com/flutter/flutter/pull/138331
**part 3: [engine] update `SemanticsUpdateBuilder` to be the same as `SemanticsUpdateBuilderNew`** <-- we are here
part 4: [flutter] use (now updated) `SemanticsUpdateBuilder` again.
part 5: [engine] remove `SemanticsBuilderNew`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.