### PR TITLE
[Impeller] recycle glyph atlas texture more aggressively.

### DIFF
--- a/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -446,6 +446,18 @@ std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
   }
   atlas_context_skia.UpdateBitmap(bitmap);
 
+  // If the new atlas size is the same size as the previous texture, reuse the
+  // texture and treat this as an updated that replaces all glyphs.
+  if (last_atlas && last_atlas->GetTexture() &&
+      atlas_size == last_atlas->GetTexture()->GetSize()) {
+    if (!UpdateGlyphTextureAtlas(bitmap, last_atlas->GetTexture())) {
+      return nullptr;
+    }
+
+    glyph_atlas->SetTexture(last_atlas->GetTexture());
+    return glyph_atlas;
+  }
+
   // ---------------------------------------------------------------------------
   // Step 7b: Upload the atlas as a texture.
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
If we need to remake the glyph atlas texture but the size is the same, then reuse the old texture.