### PR TITLE
[Impeller] Made the new blur work on devices without the decal address mode

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4445,6 +4445,12 @@ TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
   if (GetParam() != PlaygroundBackend::kMetal) {
     GTEST_SKIP_("This backend doesn't setting device capabilities.");
   }
+  if (!WillRenderSomething()) {
+    // Sometimes these tests are run without playgrounds enabled which is
+    // pointless for this test since we are asserting that
+    // `SupportsDecalSamplerAddressMode` is called.
+    GTEST_SKIP_("This test requires playgrounds.");
+  }
 
   std::shared_ptr<const Capabilities> old_capabilities =
       GetContext()->GetCapabilities();

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4443,7 +4443,8 @@ TEST_P(AiksTest, GaussianBlurAtPeripheryHorizontal) {
 
 TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
   if (GetParam() != PlaygroundBackend::kMetal) {
-    GTEST_SKIP_("This backend doesn't setting device capabilities.");
+    GTEST_SKIP_(
+        "This backend doesn't yet support setting device capabilities.");
   }
   if (!WillRenderSomething()) {
     // Sometimes these tests are run without playgrounds enabled which is

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4465,9 +4465,6 @@ TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
               SupportsTextureToTextureBlits);
   ASSERT_TRUE(SetCapabilities(mock_capabilities).ok());
 
-  std::shared_ptr<Context> context = GetContext();
-  ASSERT_FALSE(context->GetCapabilities()->SupportsDecalSamplerAddressMode());
-
   Canvas canvas;
   canvas.DrawPaint({.color = Color::Black()});
   canvas.DrawRect(Rect::MakeLTRB(200, 200, 824, 568),

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4474,6 +4474,7 @@ TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
 
   auto texture = std::make_shared<Image>(CreateTextureForFixture("boston.jpg"));
   Canvas canvas;
+  canvas.Scale(GetContentScale() * 0.5);
   canvas.DrawPaint({.color = Color::Black()});
   canvas.DrawImage(
       texture, Point(200, 200),

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4472,15 +4472,16 @@ TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
               SupportsTextureToTextureBlits);
   ASSERT_TRUE(SetCapabilities(mock_capabilities).ok());
 
+  auto texture = std::make_shared<Image>(CreateTextureForFixture("boston.jpg"));
   Canvas canvas;
   canvas.DrawPaint({.color = Color::Black()});
-  canvas.DrawRect(Rect::MakeLTRB(200, 200, 824, 568),
-                  {.color = Color::Green()});
-  canvas.SaveLayer({.blend_mode = BlendMode::kSource}, std::nullopt,
-                   ImageFilter::MakeBlur(Sigma(50), Sigma(50),
-                                         FilterContents::BlurStyle::kNormal,
-                                         Entity::TileMode::kDecal));
-  canvas.Restore();
+  canvas.DrawImage(
+      texture, Point(200, 200),
+      {
+          .image_filter = ImageFilter::MakeBlur(
+              Sigma(20.0), Sigma(20.0), FilterContents::BlurStyle::kNormal,
+              Entity::TileMode::kDecal),
+      });
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -50,6 +50,8 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
   return blur;
 }
 
+#define IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER 1
+
 std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     const FilterInput::Ref& input,
     Sigma sigma_x,

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -50,8 +50,6 @@ std::shared_ptr<FilterContents> FilterContents::MakeDirectionalGaussianBlur(
   return blur;
 }
 
-#define IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER 1
-
 std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     const FilterInput::Ref& input,
     Sigma sigma_x,

--- a/impeller/golden_tests/golden_playground_test.h
+++ b/impeller/golden_tests/golden_playground_test.h
@@ -61,6 +61,7 @@ class GoldenPlaygroundTest
   fml::Status SetCapabilities(
       const std::shared_ptr<Capabilities>& capabilities);
 
+  /// TODO(https://github.com/flutter/flutter/issues/139950): Remove this.
   /// Returns true if `OpenPlaygroundHere` will actually render anything.
   bool WillRenderSomething() const { return true; }
 

--- a/impeller/golden_tests/golden_playground_test.h
+++ b/impeller/golden_tests/golden_playground_test.h
@@ -58,6 +58,9 @@ class GoldenPlaygroundTest
 
   ISize GetWindowSize() const;
 
+  fml::Status SetCapabilities(
+      const std::shared_ptr<Capabilities>& capabilities);
+
  protected:
   void SetWindowSize(ISize size);
 

--- a/impeller/golden_tests/golden_playground_test.h
+++ b/impeller/golden_tests/golden_playground_test.h
@@ -58,7 +58,7 @@ class GoldenPlaygroundTest
 
   ISize GetWindowSize() const;
 
-  fml::Status SetCapabilities(
+  [[nodiscard]] fml::Status SetCapabilities(
       const std::shared_ptr<Capabilities>& capabilities);
 
   /// TODO(https://github.com/flutter/flutter/issues/139950): Remove this.

--- a/impeller/golden_tests/golden_playground_test.h
+++ b/impeller/golden_tests/golden_playground_test.h
@@ -61,6 +61,9 @@ class GoldenPlaygroundTest
   fml::Status SetCapabilities(
       const std::shared_ptr<Capabilities>& capabilities);
 
+  /// Returns true if `OpenPlaygroundHere` will actually render anything.
+  bool WillRenderSomething() const { return true; }
+
  protected:
   void SetWindowSize(ISize size);
 

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -198,4 +198,9 @@ void GoldenPlaygroundTest::GoldenPlaygroundTest::SetWindowSize(ISize size) {
   pimpl_->window_size = size;
 }
 
+fml::Status GoldenPlaygroundTest::SetCapabilities(
+    const std::shared_ptr<Capabilities>& capabilities) {
+  return pimpl_->screenshotter->GetPlayground().SetCapabilities(capabilities);
+}
+
 }  // namespace impeller

--- a/impeller/golden_tests/golden_playground_test_stub.cc
+++ b/impeller/golden_tests/golden_playground_test_stub.cc
@@ -66,4 +66,11 @@ ISize GoldenPlaygroundTest::GetWindowSize() const {
 
 void GoldenPlaygroundTest::SetWindowSize(ISize size) {}
 
+fml::Status GoldenPlaygroundTest::SetCapabilities(
+    const std::shared_ptr<Capabilities>& capabilities) {
+  return fml::Status(
+      fml::StatusCode::kUnimplemented,
+      "GoldenPlaygroundTest-Stub doesn't support SetCapabilities.");
+}
+
 }  // namespace impeller

--- a/impeller/golden_tests/metal_screenshotter.h
+++ b/impeller/golden_tests/metal_screenshotter.h
@@ -25,7 +25,7 @@ class MetalScreenshotter {
                                                                        300},
                                                   bool scale_content = true);
 
-  const PlaygroundImpl& GetPlayground() const { return *playground_; }
+  PlaygroundImpl& GetPlayground() { return *playground_; }
 
  private:
   std::unique_ptr<PlaygroundImpl> playground_;

--- a/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -156,4 +156,11 @@ std::unique_ptr<Surface> PlaygroundImplGLES::AcquireSurfaceFrame(
   );
 }
 
+fml::Status PlaygroundImplGLES::SetCapabilities(
+    const std::shared_ptr<Capabilities>& capabilities) {
+  return fml::Status(
+      fml::StatusCode::kUnimplemented,
+      "PlaygroundImplGLES doesn't support setting the capabilities.");
+}
+
 }  // namespace impeller

--- a/impeller/playground/backend/gles/playground_impl_gles.h
+++ b/impeller/playground/backend/gles/playground_impl_gles.h
@@ -16,6 +16,9 @@ class PlaygroundImplGLES final : public PlaygroundImpl {
 
   ~PlaygroundImplGLES();
 
+  fml::Status SetCapabilities(
+      const std::shared_ptr<Capabilities>& capabilities) override;
+
  private:
   class ReactorWorker;
 

--- a/impeller/playground/backend/metal/playground_impl_mtl.h
+++ b/impeller/playground/backend/metal/playground_impl_mtl.h
@@ -14,11 +14,17 @@
 
 namespace impeller {
 
+// Forward declared to avoid objc in a C++ header.
+class ContextMTL;
+
 class PlaygroundImplMTL final : public PlaygroundImpl {
  public:
   explicit PlaygroundImplMTL(PlaygroundSwitches switches);
 
   ~PlaygroundImplMTL();
+
+  fml::Status SetCapabilities(
+      const std::shared_ptr<Capabilities>& capabilities) override;
 
  private:
   struct Data;
@@ -29,7 +35,7 @@ class PlaygroundImplMTL final : public PlaygroundImpl {
 
   // To ensure that ObjC stuff doesn't leak into C++ TUs.
   std::unique_ptr<Data> data_;
-  std::shared_ptr<Context> context_;
+  std::shared_ptr<ContextMTL> context_;
   std::shared_ptr<fml::ConcurrentMessageLoop> concurrent_loop_;
   std::shared_ptr<const fml::SyncSwitch> is_gpu_disabled_sync_switch_;
 

--- a/impeller/playground/backend/metal/playground_impl_mtl.mm
+++ b/impeller/playground/backend/metal/playground_impl_mtl.mm
@@ -123,4 +123,10 @@ std::unique_ptr<Surface> PlaygroundImplMTL::AcquireSurfaceFrame(
   return SurfaceMTL::MakeFromMetalLayerDrawable(context, drawable);
 }
 
+fml::Status PlaygroundImplMTL::SetCapabilities(
+    const std::shared_ptr<Capabilities>& capabilities) {
+  context_->SetCapabilities(capabilities);
+  return fml::Status();
+}
+
 }  // namespace impeller

--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -182,4 +182,11 @@ void PlaygroundImplVK::InitGlobalVulkanInstance() {
   global_instance_ = std::move(instance_result.value);
 }
 
+fml::Status PlaygroundImplVK::SetCapabilities(
+    const std::shared_ptr<Capabilities>& capabilities) {
+  return fml::Status(
+      fml::StatusCode::kUnimplemented,
+      "PlaygroundImplVK doesn't support setting the capabilities.");
+}
+
 }  // namespace impeller

--- a/impeller/playground/backend/vulkan/playground_impl_vk.h
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.h
@@ -17,6 +17,9 @@ class PlaygroundImplVK final : public PlaygroundImpl {
 
   ~PlaygroundImplVK();
 
+  fml::Status SetCapabilities(
+      const std::shared_ptr<Capabilities>& capabilities) override;
+
  private:
   std::shared_ptr<Context> context_;
 

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -532,4 +532,9 @@ bool Playground::ShouldKeepRendering() const {
   return true;
 }
 
+fml::Status Playground::SetCapabilities(
+    const std::shared_ptr<Capabilities>& capabilities) {
+  return impl_->SetCapabilities(capabilities);
+}
+
 }  // namespace impeller

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -537,4 +537,8 @@ fml::Status Playground::SetCapabilities(
   return impl_->SetCapabilities(capabilities);
 }
 
+bool Playground::WillRenderSomething() const {
+  return switches_.enable_playground;
+}
+
 }  // namespace impeller

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -10,6 +10,7 @@
 
 #include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
+#include "flutter/fml/status.h"
 #include "flutter/fml/time/time_delta.h"
 #include "impeller/core/texture.h"
 #include "impeller/geometry/point.h"
@@ -87,6 +88,9 @@ class Playground {
       std::string asset_name) const = 0;
 
   virtual std::string GetWindowTitle() const = 0;
+
+  fml::Status SetCapabilities(
+      const std::shared_ptr<Capabilities>& capabilities);
 
  protected:
   const PlaygroundSwitches switches_;

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -89,9 +89,10 @@ class Playground {
 
   virtual std::string GetWindowTitle() const = 0;
 
-  fml::Status SetCapabilities(
+  [[nodiscard]] fml::Status SetCapabilities(
       const std::shared_ptr<Capabilities>& capabilities);
 
+  /// TODO(https://github.com/flutter/flutter/issues/139950): Remove this.
   /// Returns true if `OpenPlaygroundHere` will actually render anything.
   bool WillRenderSomething() const;
 

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -92,6 +92,9 @@ class Playground {
   fml::Status SetCapabilities(
       const std::shared_ptr<Capabilities>& capabilities);
 
+  /// Returns true if `OpenPlaygroundHere` will actually render anything.
+  bool WillRenderSomething() const;
+
  protected:
   const PlaygroundSwitches switches_;
 

--- a/impeller/playground/playground_impl.h
+++ b/impeller/playground/playground_impl.h
@@ -33,6 +33,9 @@ class PlaygroundImpl {
 
   Vector2 GetContentScale() const;
 
+  virtual fml::Status SetCapabilities(
+      const std::shared_ptr<Capabilities>& capabilities) = 0;
+
  protected:
   const PlaygroundSwitches switches_;
 

--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -83,6 +83,8 @@ class ContextMTL final : public Context,
   // |Context|
   const std::shared_ptr<const Capabilities>& GetCapabilities() const override;
 
+  void SetCapabilities(const std::shared_ptr<const Capabilities>& capabilities);
+
   // |Context|
   bool UpdateOffscreenLayerPixelFormat(PixelFormat format) override;
 

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -376,6 +376,11 @@ const std::shared_ptr<const Capabilities>& ContextMTL::GetCapabilities() const {
   return device_capabilities_;
 }
 
+void ContextMTL::SetCapabilities(
+    const std::shared_ptr<const Capabilities>& capabilities) {
+  device_capabilities_ = capabilities;
+}
+
 // |Context|
 bool ContextMTL::UpdateOffscreenLayerPixelFormat(PixelFormat format) {
   device_capabilities_ = InferMetalCapabilities(device_, format);


### PR DESCRIPTION
This also adds a new mechanism of override the device capabilities.

fixes https://github.com/flutter/flutter/issues/139773

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
