### PR TITLE
Roll `buildroot` and delete `libxml`.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -195,7 +195,6 @@ vars = {
   "upstream_libpng": "https://github.com/glennrp/libpng.git",
   "upstream_libtess2": "https://github.com/memononen/libtess2.git",
   "upstream_libwebp": "https://chromium.googlesource.com/webm/libwebp.git",
-  "upstream_libxml": "https://gitlab.gnome.org/GNOME/libxml2.git",
   "upstream_leak_tracker": "https://github.com/dart-lang/leak_tracker.git",
   "upstream_logging": "https://github.com/dart-lang/logging.git",
   "upstream_markdown": "https://github.com/dart-lang/markdown.git",
@@ -273,7 +272,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e0aa3ae49a32df7dd00655ee4dd55b00d84a47ea',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '1570fb412dab333e380450ddee32ba8c60edef2f',
 
   'src/flutter/third_party/rapidjson':
    Var('fuchsia_git') + '/third_party/rapidjson' + '@' + 'ef3564c5c8824989393b87df25355baf35ff544b',
@@ -647,9 +646,6 @@ deps = {
 
   'src/flutter/third_party/wuffs':
    Var('skia_git') + '/external/github.com/google/wuffs-mirror-release-c.git' + '@' + '600cd96cf47788ee3a74b40a6028b035c9fd6a61',
-
-  'src/third_party/libxml':
-   Var('flutter_git') + '/third_party/libxml' + '@' + 'a143e452b5fc7d872813eeadc8db421694058098',
 
   'src/third_party/zlib':
    Var('chromium_git') + '/chromium/src/third_party/zlib.git' + '@' + Var('dart_zlib_rev'),

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -2873,7 +2873,6 @@
 ../../../third_party/libpng/projects
 ../../../third_party/libpng/scripts
 ../../../third_party/libpng/tests
-../../../third_party/libxml
 ../../../third_party/perfetto/.clang-format
 ../../../third_party/perfetto/.clang-tidy
 ../../../third_party/perfetto/.git


### PR DESCRIPTION
The only reference to `libxml` was deleted in https://github.com/flutter/buildroot/pull/801.

This PR updates the buildroot, and removes the library.