### PR TITLE
[fuchsia] Wire through the tzdata-icu capability

### DIFF
--- a/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
+++ b/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
@@ -13,7 +13,7 @@
         },
     ],
     use: [
-	// This is used by the Dart VM to communicate from Dart code to C++ code.
+        // This is used by the Dart VM to communicate from Dart code to C++ code.
         {
             storage: "tmp",
             path: "/tmp",
@@ -23,6 +23,14 @@
             directory: "config-data",
             rights: [ "r*" ],
             path: "/config/data",
+        },
+        // The ICU time zone data, factored out of `config-data`.
+        // See:
+        // https://fuchsia.dev/fuchsia-src/concepts/process/namespaces?typical_directory_structure
+        {
+            directory: "tzdata-icu",
+            rights: [ "r*" ],
+            path: "/config/tzdata/icu",
         },
         {
             protocol: [

--- a/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
+++ b/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
@@ -36,6 +36,12 @@
             from: "framework",
             to: "#realm_builder",
         },
+        // See common.shard.cml.
+        {
+            directory: "tzdata-icu",
+            from: "framework",
+            to: "#realm_builder",
+        },
     ],
     // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
     facets: {

--- a/shell/platform/fuchsia/flutter/meta/common.shard.cml
+++ b/shell/platform/fuchsia/flutter/meta/common.shard.cml
@@ -13,7 +13,7 @@
         },
     ],
     use: [
-	// This is used by the Dart VM to communicate from Dart code to C++ code.
+        // This is used by the Dart VM to communicate from Dart code to C++ code.
         {
             storage: "tmp",
             path: "/tmp",
@@ -23,6 +23,14 @@
             directory: "config-data",
             rights: [ "r*" ],
             path: "/config/data",
+        },
+        // The ICU time zone data, factored out of `config-data`.
+        // See:
+        // https://fuchsia.dev/fuchsia-src/concepts/process/namespaces?typical_directory_structure
+        {
+            directory: "tzdata-icu",
+            rights: [ "r*" ],
+            path: "/config/tzdata/icu",
         },
         {
             directory: "root-ssl-certificates",

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/meta/parent-view.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/meta/parent-view.cml
@@ -26,6 +26,12 @@
             rights: [ "r*" ],
             path: "/config/data",
         },
+        // See common.shard.cml.
+        {
+            directory: "tzdata-icu",
+            rights: [ "r*" ],
+            path: "/config/tzdata/icu",
+        },
     ],
     expose: [
         {

--- a/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
@@ -50,6 +50,12 @@
             from: "framework",
             to: "#realm_builder",
         },
+        // See common.shard.cml.
+        {
+            directory: "tzdata-icu",
+            from: "framework",
+            to: "#realm_builder",
+        },
     ],
     // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
     facets: {

--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
@@ -52,6 +52,12 @@
             from: "framework",
             to: "#realm_builder",
         },
+        // See common.shard.cml.
+        {
+            directory: "tzdata-icu",
+            from: "framework",
+            to: "#realm_builder",
+        },
     ],
     // TODO(https://fxbug.dev/114584): Figure out how to bring these in as deps (if possible oot).
     facets: {


### PR DESCRIPTION
The `tzdata-icu` capability is a directory containing
ICU time zone resource files. These are requried for
correct computation of local times.

Issue: https://github.com/flutter/flutter/issues/139952

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
