### PR TITLE
[WIP] Get the correct system font for each weight

### DIFF
--- a/third_party/txt/src/txt/platform_mac.mm
+++ b/third_party/txt/src/txt/platform_mac.mm
@@ -29,7 +29,6 @@ static const std::string kSFProTextName = "CupertinoSystemText";
 // Font weight representing Regular
 float kNormalWeightValue = 400;
 
-
 namespace txt {
 
 const FourCharCode kWeightTag = 'wght';
@@ -108,7 +107,7 @@ void RegisterSystemFonts(const DynamicFontManager& dynamic_font_manager) {
       (CTFontRef)CFAutorelease(MatchSystemUIFont(0, kSFProDisplayBreakPoint)));
   if (large_system_font_lightweight) {
     dynamic_font_manager.font_provider().RegisterTypeface(
-      large_system_font_lightweight, "CupertinoSystemDisplayw100");
+        large_system_font_lightweight, "CupertinoSystemDisplayw100");
   }
   sk_sp<SkTypeface> regular_system_font = SkMakeTypefaceFromCTFont(
       (CTFontRef)CFAutorelease(CTFontCreateUIFontForLanguage(


### PR DESCRIPTION
See [flutter/issue/139689](https://github.com/flutter/flutter/issues/139689) and [flutter/issue/132475](https://github.com/flutter/flutter/issues/132475)

Registers the lightweight font and registers it under the string `"CupertinoSystemDisplayw100"`. Currently this requires that the framework sends that string in order to get the correct font at that weight. If this general solution is used, then we'd have to loop through both the large and small font and register a typeface for each font weight.

Issues with this:
1. We'd have to loop through and register each font weight for both the large and small fonts. So 18 times.
2. This requires the framework to intercept a `TextStyle`'s `fontFamily` and optionally replace the string with something like above that has both the family name and weight in the font family name. This works in a POC, but is pretty hacky. Ideally that logic would be in the engine.

Questions:
1. Could we dynamically register the fonts as the family name and weight combinations are requested?
2. Is there a better place in the engine where we can intercept either add the `"CupertinoSystemDisplayw100"` proxy string based on the requested family name and weight?
3. I see a [TODO](https://github.com/flutter/engine/blob/c6092c3039e36a7e86ad0e98aa0241e716c98ca8/lib/ui/text/font_collection.cc#L121C56-L121C56) about registering fonts by weight and styles. Is it better to go down that route so we don't only register them by family name? Are there plans around resolving that TODO?

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
