### PR TITLE
[Windows] Use #pragma once

### DIFF
--- a/shell/platform/windows/accessibility_bridge_windows.h
+++ b/shell/platform/windows/accessibility_bridge_windows.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_BRIDGE_WINDOWS_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_BRIDGE_WINDOWS_H_
+#pragma once
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/accessibility_bridge.h"
@@ -78,5 +77,3 @@ class AccessibilityBridgeWindows : public AccessibilityBridge,
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_ACCESSIBILITY_BRIDGE_WINDOWS_H_

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_ANGLE_SURFACE_MANAGER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_ANGLE_SURFACE_MANAGER_H_
+#pragma once
 
 // OpenGL ES and EGL includes
 #include <EGL/egl.h>
@@ -151,5 +150,3 @@ class AngleSurfaceManager {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_ANGLE_SURFACE_MANAGER_H_

--- a/shell/platform/windows/cursor_handler.h
+++ b/shell/platform/windows/cursor_handler.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_CURSOR_HANDLER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_CURSOR_HANDLER_H_
+#pragma once
 
 #include <unordered_map>
 
@@ -53,5 +52,3 @@ HCURSOR GetCursorFromBuffer(const std::vector<uint8_t>& buffer,
 void GetMaskBitmaps(HBITMAP bitmap, HBITMAP& mask_bitmap);
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_CURSOR_HANDLER_H_

--- a/shell/platform/windows/direct_manipulation.h
+++ b/shell/platform/windows/direct_manipulation.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_DIRECT_MANIPULATION_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_DIRECT_MANIPULATION_H_
+#pragma once
 
 #include "flutter/fml/memory/ref_counted.h"
 
@@ -140,5 +139,3 @@ class DirectManipulationEventHandler
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_DIRECT_MANIPULATION_H_

--- a/shell/platform/windows/dpi_utils.h
+++ b/shell/platform/windows/dpi_utils.h
@@ -4,8 +4,7 @@
 
 #include "Windows.h"
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_DPI_UTILS_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_DPI_UTILS_H_
+#pragma once
 
 namespace flutter {
 
@@ -20,5 +19,3 @@ UINT GetDpiForHWND(HWND hwnd);
 UINT GetDpiForMonitor(HMONITOR monitor);
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_DPI_UTILS_H_

--- a/shell/platform/windows/event_watcher.h
+++ b/shell/platform/windows/event_watcher.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_EVENT_WATCHER_WIN32_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_EVENT_WATCHER_WIN32_H_
+#pragma once
 
 #include <Windows.h>
 
@@ -34,5 +33,3 @@ class EventWatcher {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_EVENT_WATCHER_WIN32_H_

--- a/shell/platform/windows/external_texture.h
+++ b/shell/platform/windows/external_texture.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_H_
+#pragma once
 
 #include "flutter/shell/platform/embedder/embedder.h"
 
@@ -29,5 +28,3 @@ class ExternalTexture {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_H_

--- a/shell/platform/windows/external_texture_d3d.h
+++ b/shell/platform/windows/external_texture_d3d.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_D3D_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_D3D_H_
+#pragma once
 
 #include <memory>
 
@@ -51,5 +50,3 @@ class ExternalTextureD3d : public ExternalTexture {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_D3D_H_

--- a/shell/platform/windows/external_texture_pixelbuffer.h
+++ b/shell/platform/windows/external_texture_pixelbuffer.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_PIXELBUFFER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_PIXELBUFFER_H_
+#pragma once
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
@@ -45,5 +44,3 @@ class ExternalTexturePixelBuffer : public ExternalTexture {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_EXTERNAL_TEXTURE_PIXELBUFFER_H_

--- a/shell/platform/windows/flutter_desktop_messenger.h
+++ b/shell/platform/windows/flutter_desktop_messenger.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_DESKTOP_MESSENGER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_DESKTOP_MESSENGER_H_
+#pragma once
 
 #include <atomic>
 #include <mutex>
@@ -79,5 +78,3 @@ class FlutterDesktopMessenger {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_

--- a/shell/platform/windows/flutter_platform_node_delegate_windows.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_windows.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_PLATFORM_NODE_DELEGATE_WINDOWS_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_PLATFORM_NODE_DELEGATE_WINDOWS_H_
+#pragma once
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/common/flutter_platform_node_delegate.h"
@@ -64,5 +63,3 @@ class FlutterPlatformNodeDelegateWindows : public FlutterPlatformNodeDelegate {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_PLATFORM_NODE_DELEGATE_WINDOWS_H_

--- a/shell/platform/windows/flutter_project_bundle.h
+++ b/shell/platform/windows/flutter_project_bundle.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_PROJECT_BUNDLE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_PROJECT_BUNDLE_H_
+#pragma once
 
 #include <filesystem>
 #include <string>
@@ -77,5 +76,3 @@ class FlutterProjectBundle {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_PROJECT_BUNDLE_H_

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_ENGINE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_ENGINE_H_
+#pragma once
 
 #include <chrono>
 #include <map>
@@ -427,5 +426,3 @@ class FlutterWindowsEngine {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_ENGINE_H_

--- a/shell/platform/windows/flutter_windows_texture_registrar.h
+++ b/shell/platform/windows/flutter_windows_texture_registrar.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_TEXTURE_REGISTRAR_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_TEXTURE_REGISTRAR_H_
+#pragma once
 
 #include <memory>
 #include <mutex>
@@ -60,5 +59,3 @@ class FlutterWindowsTextureRegistrar {
 };
 
 };  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_TEXTURE_REGISTRAR_H_

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_VIEW_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_VIEW_H_
+#pragma once
 
 #include <memory>
 #include <mutex>
@@ -396,5 +395,3 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_VIEW_H_

--- a/shell/platform/windows/flutter_windows_view_controller.h
+++ b/shell/platform/windows/flutter_windows_view_controller.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_VIEW_CONTROLLER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_VIEW_CONTROLLER_H_
+#pragma once
 
 #include <memory>
 
@@ -28,5 +27,3 @@ class FlutterWindowsViewController {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOWS_VIEW_CONTROLLER_H_

--- a/shell/platform/windows/gl_proc_table.h
+++ b/shell/platform/windows/gl_proc_table.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_GL_PROC_TABLE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_GL_PROC_TABLE_H_
+#pragma once
 
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
@@ -66,5 +65,3 @@ class GlProcTable {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_GL_PROC_TABLE_H_

--- a/shell/platform/windows/keyboard_handler_base.h
+++ b/shell/platform/windows/keyboard_handler_base.h
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_HOOK_HANDLER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_HOOK_HANDLER_H_
+#pragma once
 
+#include <functional>
+#include <map>
 #include <string>
 
 namespace flutter {
@@ -42,5 +43,3 @@ class KeyboardHandlerBase {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_HOOK_HANDLER_H_

--- a/shell/platform/windows/keyboard_key_channel_handler.h
+++ b/shell/platform/windows/keyboard_key_channel_handler.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_CHANNEL_HANDLER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_CHANNEL_HANDLER_H_
+#pragma once
 
 #include <deque>
 #include <memory>
@@ -51,5 +50,3 @@ class KeyboardKeyChannelHandler
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_CHANNEL_HANDLER_H_

--- a/shell/platform/windows/keyboard_key_embedder_handler.h
+++ b/shell/platform/windows/keyboard_key_embedder_handler.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_EMBEDDER_HANDLER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_EMBEDDER_HANDLER_H_
+#pragma once
 
 #include <functional>
 #include <map>
@@ -199,5 +198,3 @@ class KeyboardKeyEmbedderHandler
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_EMBEDDER_HANDLER_H_

--- a/shell/platform/windows/keyboard_key_handler.h
+++ b/shell/platform/windows/keyboard_key_handler.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_HANDLER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_HANDLER_H_
+#pragma once
 
 #include <windows.h>
 #include <deque>
@@ -149,5 +148,3 @@ class KeyboardKeyHandler : public KeyboardHandlerBase {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_KEY_HANDLER_H_

--- a/shell/platform/windows/keyboard_manager.h
+++ b/shell/platform/windows/keyboard_manager.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_MANAGER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_MANAGER_H_
+#pragma once
 
 #include <windows.h>
 
@@ -233,5 +232,3 @@ class KeyboardManager {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_MANAGER_H_

--- a/shell/platform/windows/keyboard_utils.h
+++ b/shell/platform/windows/keyboard_utils.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_WIN32_COMMON_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_WIN32_COMMON_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -42,5 +41,3 @@ inline uint32_t UndeadChar(uint32_t ch) {
 std::u16string EncodeUtf16(char32_t character);
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_KEYBOARD_WIN32_COMMON_H_

--- a/shell/platform/windows/platform_handler.h
+++ b/shell/platform/windows/platform_handler.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_PLATFORM_HANDLER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_PLATFORM_HANDLER_H_
+#pragma once
 
 #include <Windows.h>
 
@@ -154,5 +153,3 @@ class ScopedClipboardInterface {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_PLATFORM_HANDLER_H_

--- a/shell/platform/windows/sequential_id_generator.h
+++ b/shell/platform/windows/sequential_id_generator.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_SEQUENTIAL_ID_GENERATOR_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_SEQUENTIAL_ID_GENERATOR_H_
+#pragma once
 
 #include <cstdint>
 #include <unordered_map>
@@ -59,5 +58,3 @@ class SequentialIdGenerator {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_SEQUENTIAL_ID_GENERATOR_H_

--- a/shell/platform/windows/settings_plugin.h
+++ b/shell/platform/windows/settings_plugin.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_SETTINGS_PLUGIN_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_SETTINGS_PLUGIN_H_
+#pragma once
 
 #include <Windows.h>
 
@@ -76,5 +75,3 @@ class SettingsPlugin {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_SETTINGS_PLUGIN_H_

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -4,8 +4,7 @@
 
 // This file contains utilities for system-level information/settings.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_SYSTEM_UTILS_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_SYSTEM_UTILS_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -51,5 +50,3 @@ std::wstring GetUserTimeFormat();
 bool Prefer24HourTime(std::wstring time_format);
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_SYSTEM_UTILS_H_

--- a/shell/platform/windows/task_runner.h
+++ b/shell/platform/windows/task_runner.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TASK_RUNNER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TASK_RUNNER_H_
+#pragma once
 
 #include <chrono>
 #include <deque>
@@ -106,5 +105,3 @@ class TaskRunner : public TaskRunnerWindow::Delegate {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TASK_RUNNER_H_

--- a/shell/platform/windows/task_runner_window.h
+++ b/shell/platform/windows/task_runner_window.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TASK_RUNNER_WIN32_WINDOW_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TASK_RUNNER_WIN32_WINDOW_H_
+#pragma once
 
 #include <windows.h>
 
@@ -64,5 +63,3 @@ class TaskRunnerWindow {
   FML_DISALLOW_COPY_AND_ASSIGN(TaskRunnerWindow);
 };
 }  // namespace flutter
-
-#endif

--- a/shell/platform/windows/testing/engine_modifier.h
+++ b/shell/platform/windows/testing/engine_modifier.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_ENGINE_MODIFIER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_ENGINE_MODIFIER_H_
+#pragma once
 
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 
@@ -77,5 +76,3 @@ class EngineModifier {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_ENGINE_MODIFIER_H_

--- a/shell/platform/windows/testing/flutter_window_test.h
+++ b/shell/platform/windows/testing/flutter_window_test.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WIN32_FLUTTER_WINDOW_TEST_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WIN32_FLUTTER_WINDOW_TEST_H_
+#pragma once
 
 #include "flutter/shell/platform/windows/flutter_window.h"
 
@@ -24,5 +23,3 @@ class FlutterWindowTest : public FlutterWindow {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WIN32_FLUTTER_WINDOW_TEST_H_

--- a/shell/platform/windows/testing/flutter_windows_engine_builder.h
+++ b/shell/platform/windows/testing/flutter_windows_engine_builder.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_FLUTTER_WINDOWS_ENGINE_BUILDER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_FLUTTER_WINDOWS_ENGINE_BUILDER_H_
+#pragma once
 
 #include <memory>
 
@@ -51,5 +50,3 @@ class FlutterWindowsEngineBuilder {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_FLUTTER_WINDOWS_ENGINE_BUILDER_H_

--- a/shell/platform/windows/testing/mock_direct_manipulation.h
+++ b/shell/platform/windows/testing/mock_direct_manipulation.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_
+#pragma once
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/direct_manipulation.h"
@@ -27,5 +26,3 @@ class MockDirectManipulationOwner : public DirectManipulationOwner {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_DIRECT_MANIPULATION_H_

--- a/shell/platform/windows/testing/mock_gl_proc_table.h
+++ b/shell/platform/windows/testing/mock_gl_proc_table.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_GL_PROC_TABLE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_GL_PROC_TABLE_H_
+#pragma once
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/gl_proc_table.h"
@@ -53,5 +52,3 @@ class MockGlProcTable : public GlProcTable {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_GL_PROC_TABLE_H_

--- a/shell/platform/windows/testing/mock_text_input_manager.h
+++ b/shell/platform/windows/testing/mock_text_input_manager.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_TEXT_INPUT_MANAGER_WIN32_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_TEXT_INPUT_MANAGER_WIN32_H_
+#pragma once
 
 #include <cstring>
 #include <optional>
@@ -37,5 +36,3 @@ class MockTextInputManager : public TextInputManager {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_TEXT_INPUT_MANAGER_WIN32_H_

--- a/shell/platform/windows/testing/mock_window.h
+++ b/shell/platform/windows/testing/mock_window.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WIN32_WINDOW_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WIN32_WINDOW_H_
+#pragma once
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/flutter_window.h"
@@ -102,5 +101,3 @@ class MockWindow : public FlutterWindow {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WIN32_WINDOW_H_

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_H_
+#pragma once
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/window_binding_handler.h"
@@ -48,5 +47,3 @@ class MockWindowBindingHandler : public WindowBindingHandler {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_H_

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_DELEGATE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_DELEGATE_H_
+#pragma once
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/window_binding_handler_delegate.h"
@@ -83,5 +82,3 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOW_BINDING_HANDLER_DELEGATE_H_

--- a/shell/platform/windows/testing/mock_windows_proc_table.h
+++ b/shell/platform/windows/testing/mock_windows_proc_table.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_
+#pragma once
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/windows_proc_table.h"
@@ -36,5 +35,3 @@ class MockWindowsProcTable : public WindowsProcTable {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_WINDOWS_PROC_TABLE_H_

--- a/shell/platform/windows/testing/test_binary_messenger.h
+++ b/shell/platform/windows/testing/test_binary_messenger.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_TEST_BINARY_MESSENGER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_TEST_BINARY_MESSENGER_H_
+#pragma once
 
 #include <functional>
 #include <map>
@@ -75,5 +74,3 @@ class TestBinaryMessenger : public BinaryMessenger {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_TEST_BINARY_MESSENGER_H_

--- a/shell/platform/windows/testing/test_keyboard.h
+++ b/shell/platform/windows/testing/test_keyboard.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_TEST_KEYBOARD_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_TEST_KEYBOARD_H_
+#pragma once
 
 #include <windows.h>
 
@@ -153,5 +152,3 @@ class MockMessageQueue {
                           .character = _character,                           \
                           .synthesized = _synthesized,                       \
                       }));
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_TEST_KEYBOARD_H_

--- a/shell/platform/windows/testing/windows_test.h
+++ b/shell/platform/windows/testing/windows_test.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WINDOWS_TEST_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WINDOWS_TEST_H_
+#pragma once
 
 #include <string>
 
@@ -43,5 +42,3 @@ class WindowsTest : public ThreadTest {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WINDOWS_TEST_H_

--- a/shell/platform/windows/testing/windows_test_config_builder.h
+++ b/shell/platform/windows/testing/windows_test_config_builder.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WINDOWS_TEST_CONFIG_BUILDER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WINDOWS_TEST_CONFIG_BUILDER_H_
+#pragma once
 
 #include <string>
 #include <string_view>
@@ -82,5 +81,3 @@ class WindowsConfigBuilder {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WINDOWS_TEST_CONFIG_BUILDER_H_

--- a/shell/platform/windows/testing/windows_test_context.h
+++ b/shell/platform/windows/testing/windows_test_context.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WINDOWS_TEST_CONTEXT_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WINDOWS_TEST_CONTEXT_H_
+#pragma once
 
 #include <string>
 #include <string_view>
@@ -60,5 +59,3 @@ class WindowsTestContext {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WINDOWS_TEST_CONTEXT_H_

--- a/shell/platform/windows/testing/wm_builders.h
+++ b/shell/platform/windows/testing/wm_builders.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WM_BUILDERS_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WM_BUILDERS_H_
+#pragma once
 
 #include <stdint.h>
 #include <windows.h>
@@ -182,5 +181,3 @@ typedef struct WmDeadCharInfo {
 
 }  // namespace testing
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_WM_BUILDERS_H_

--- a/shell/platform/windows/text_input_manager.h
+++ b/shell/platform/windows/text_input_manager.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TEXT_INPUT_MANAGER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TEXT_INPUT_MANAGER_H_
+#pragma once
 
 #include <Windows.h>
 #include <Windowsx.h>
@@ -103,5 +102,3 @@ class TextInputManager {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TEXT_INPUT_MANAGER_H_

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TEXT_INPUT_PLUGIN_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_TEXT_INPUT_PLUGIN_H_
+#pragma once
 
 #include <array>
 #include <map>
@@ -133,5 +132,3 @@ class TextInputPlugin {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TEXT_INPUT_PLUGIN_H_

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOW_BINDING_HANDLER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOW_BINDING_HANDLER_H_
+#pragma once
 
 #include <windows.h>
 
@@ -110,5 +109,3 @@ class WindowBindingHandler {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOW_BINDING_HANDLER_H_

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOW_BINDING_HANDLER_DELEGATE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOW_BINDING_HANDLER_DELEGATE_H_
+#pragma once
 
 #include <functional>
 
@@ -153,5 +152,3 @@ class WindowBindingHandlerDelegate {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOW_BINDING_HANDLER_DELEGATE_H_

--- a/shell/platform/windows/window_proc_delegate_manager.h
+++ b/shell/platform/windows/window_proc_delegate_manager.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_WIN32_WINDOW_PROC_DELEGATE_MANAGER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_WIN32_WINDOW_PROC_DELEGATE_MANAGER_H_
+#pragma once
 
 #include <Windows.h>
 
@@ -51,5 +50,3 @@ class WindowProcDelegateManager {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_WIN32_WINDOW_PROC_DELEGATE_MANAGER_H_

--- a/shell/platform/windows/window_state.h
+++ b/shell/platform/windows/window_state.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_
+#pragma once
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
@@ -24,5 +23,3 @@ struct FlutterDesktopPluginRegistrar {
   // The engine that owns this state object.
   flutter::FlutterWindowsEngine* engine = nullptr;
 };
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_WINDOW_STATE_H_

--- a/shell/platform/windows/windows_lifecycle_manager.h
+++ b/shell/platform/windows/windows_lifecycle_manager.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_LIFECYCLE_MANAGER_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_LIFECYCLE_MANAGER_H_
+#pragma once
 
 #include <Windows.h>
 
@@ -123,5 +122,3 @@ class WindowsLifecycleManager {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_LIFECYCLE_MANAGER_H_

--- a/shell/platform/windows/windows_proc_table.h
+++ b/shell/platform/windows/windows_proc_table.h
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_
+#pragma once
 
 #include <optional>
 
@@ -55,5 +54,3 @@ class WindowsProcTable {
 };
 
 }  // namespace flutter
-
-#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_WINDOWS_PROC_TABLE_H_


### PR DESCRIPTION
Updates non-public Windows files to use `#pragma once` instead of header guards.

In the future https://github.com/flutter/engine/pull/48903 might be used to enforce this.