### PR TITLE
Workarounds for clang-tidy warnings in the next roll of Clang

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderTest.mm
@@ -136,6 +136,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, BasicKeyEvent) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->timestamp, 123000000.0f);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
@@ -158,6 +159,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, BasicKeyEvent) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeRepeat);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -179,6 +181,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, BasicKeyEvent) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->timestamp, 124000000.0f);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
@@ -213,6 +216,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, NonAsciiCharacters) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalAltRight);
   EXPECT_EQ(event->logical, kLogicalAltRight);
@@ -227,6 +231,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, NonAsciiCharacters) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyW);
   EXPECT_EQ(event->logical, kLogicalKeyW);
@@ -241,6 +246,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, NonAsciiCharacters) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalAltRight);
   EXPECT_EQ(event->logical, kLogicalAltRight);
@@ -255,6 +261,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, NonAsciiCharacters) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalKeyW);
   EXPECT_EQ(event->logical, kLogicalKeyW);
@@ -282,6 +289,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, MultipleCharacters) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, 0x1400000000ull);
@@ -296,6 +304,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, MultipleCharacters) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, 0x1400000000ull);
@@ -326,6 +335,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeForDuplicateDownEvent) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -346,6 +356,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeForDuplicateDownEvent) {
   EXPECT_EQ([events count], 2u);
 
   event = [events firstObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -353,6 +364,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeForDuplicateDownEvent) {
   EXPECT_EQ(event->synthesized, true);
 
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, 0xE0ull /* à */);
@@ -386,6 +398,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, IgnoreDuplicateUpEvent) {
   EXPECT_EQ([events count], 1u);
   EXPECT_EQ(last_handled, TRUE);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->physical, 0ull);
   EXPECT_EQ(event->logical, 0ull);
   EXPECT_FALSE([[events lastObject] hasCallback]);
@@ -415,6 +428,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ConvertAbruptRepeatEventsToDown) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -450,6 +464,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ToggleModifiersDuringKeyTap) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->timestamp, 123000000.0f);
   EXPECT_EQ(event->physical, kPhysicalShiftRight);
@@ -466,6 +481,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ToggleModifiersDuringKeyTap) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -481,6 +497,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ToggleModifiersDuringKeyTap) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeRepeat);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -497,6 +514,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ToggleModifiersDuringKeyTap) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalShiftRight);
   EXPECT_EQ(event->logical, kLogicalShiftRight);
@@ -512,6 +530,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ToggleModifiersDuringKeyTap) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeRepeat);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -526,6 +545,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ToggleModifiersDuringKeyTap) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -563,6 +583,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SpecialModiferFlags) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalNumpad1);
   EXPECT_EQ(event->logical, kLogicalNumpad1);
@@ -580,6 +601,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SpecialModiferFlags) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalF1);
   EXPECT_EQ(event->logical, kLogicalF1);
@@ -596,6 +618,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SpecialModiferFlags) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -613,6 +636,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SpecialModiferFlags) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -629,6 +653,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SpecialModiferFlags) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalNumpad1);
   EXPECT_EQ(event->logical, kLogicalNumpad1);
@@ -646,6 +671,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SpecialModiferFlags) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalF1);
   EXPECT_EQ(event->logical, kLogicalF1);
@@ -662,6 +688,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SpecialModiferFlags) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -679,6 +706,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SpecialModiferFlags) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -708,6 +736,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, IdentifyLeftAndRightModifiers) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -724,6 +753,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, IdentifyLeftAndRightModifiers) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalShiftRight);
   EXPECT_EQ(event->logical, kLogicalShiftRight);
@@ -740,6 +770,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, IdentifyLeftAndRightModifiers) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -756,6 +787,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, IdentifyLeftAndRightModifiers) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalShiftRight);
   EXPECT_EQ(event->logical, kLogicalShiftRight);
@@ -797,6 +829,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -816,8 +849,10 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
          callback:keyEventCallback];
 
   EXPECT_EQ([events count], 1u);
-  EXPECT_EQ([events lastObject].data->physical, 0u);
-  EXPECT_EQ([events lastObject].data->logical, 0u);
+  event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
+  EXPECT_EQ(event->physical, 0u);
+  EXPECT_EQ(event->logical, 0u);
   EXPECT_FALSE([[events lastObject] hasCallback]);
   EXPECT_EQ(last_handled, TRUE);
   [events removeAllObjects];
@@ -829,6 +864,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -852,8 +888,10 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
          callback:keyEventCallback];
 
   EXPECT_EQ([events count], 1u);
-  EXPECT_EQ([events lastObject].data->physical, 0u);
-  EXPECT_EQ([events lastObject].data->logical, 0u);
+  event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
+  EXPECT_EQ(event->physical, 0u);
+  EXPECT_EQ(event->logical, 0u);
   EXPECT_FALSE([[events lastObject] hasCallback]);
   EXPECT_EQ(last_handled, TRUE);
   [events removeAllObjects];
@@ -869,6 +907,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -889,6 +928,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -912,6 +952,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -932,6 +973,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
 
   EXPECT_EQ([events count], 1u);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalShiftRight);
   EXPECT_EQ(event->logical, kLogicalShiftRight);
@@ -952,6 +994,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
 
   EXPECT_EQ([events count], 2u);
   event = [events firstObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -961,6 +1004,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEvents) {
   EXPECT_FALSE([[events firstObject] hasCallback]);
 
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalShiftRight);
   EXPECT_EQ(event->logical, kLogicalShiftRight);
@@ -1000,6 +1044,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEventsInNorma
 
   EXPECT_EQ([events count], 2u);
   event = [events firstObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -1008,6 +1053,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEventsInNorma
   EXPECT_FALSE([[events firstObject] hasCallback]);
 
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -1027,6 +1073,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEventsInNorma
 
   EXPECT_EQ([events count], 2u);
   event = [events firstObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(event->logical, kLogicalShiftLeft);
@@ -1035,6 +1082,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynthesizeMissedModifierEventsInNorma
   EXPECT_FALSE([[events firstObject] hasCallback]);
 
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);
@@ -1075,6 +1123,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ConvertCapsLockEvents) {
   EXPECT_EQ([events count], 2u);
 
   event = [events firstObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalCapsLock);
   EXPECT_EQ(event->logical, kLogicalCapsLock);
@@ -1083,6 +1132,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ConvertCapsLockEvents) {
   EXPECT_TRUE([[events firstObject] hasCallback]);
 
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalCapsLock);
   EXPECT_EQ(event->logical, kLogicalCapsLock);
@@ -1105,6 +1155,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ConvertCapsLockEvents) {
   EXPECT_EQ([events count], 2u);
 
   event = [events firstObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalCapsLock);
   EXPECT_EQ(event->logical, kLogicalCapsLock);
@@ -1113,6 +1164,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, ConvertCapsLockEvents) {
   EXPECT_TRUE([[events firstObject] hasCallback]);
 
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalCapsLock);
   EXPECT_EQ(event->logical, kLogicalCapsLock);
@@ -1153,6 +1205,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynchronizeCapsLockStateOnCapsLock) {
   EXPECT_EQ([events count], 1u);
   EXPECT_EQ(last_handled, TRUE);
   event = [events lastObject].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->physical, 0ull);
   EXPECT_EQ(event->logical, 0ull);
   EXPECT_FALSE([[events lastObject] hasCallback]);
@@ -1185,6 +1238,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynchronizeCapsLockStateOnNormalKey) 
   EXPECT_EQ([events count], 3u);
 
   event = events[0].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalCapsLock);
   EXPECT_EQ(event->logical, kLogicalCapsLock);
@@ -1193,6 +1247,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynchronizeCapsLockStateOnNormalKey) 
   EXPECT_FALSE([events[0] hasCallback]);
 
   event = events[1].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(event->physical, kPhysicalCapsLock);
   EXPECT_EQ(event->logical, kLogicalCapsLock);
@@ -1201,6 +1256,7 @@ TEST(FlutterEmbedderKeyResponderUnittests, SynchronizeCapsLockStateOnNormalKey) 
   EXPECT_FALSE([events[1] hasCallback]);
 
   event = events[2].data;
+  ASSERT_NE(event, nullptr);
   EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(event->physical, kPhysicalKeyA);
   EXPECT_EQ(event->logical, kLogicalKeyA);

--- a/shell/platform/embedder/embedder_external_view.cc
+++ b/shell/platform/embedder/embedder_external_view.cc
@@ -74,6 +74,7 @@ bool EmbedderExternalView::HasEngineRenderedContents() {
   DlOpSpy dl_op_spy;
   slice_->dispatch(dl_op_spy);
   has_engine_rendered_contents_ = dl_op_spy.did_draw() && !slice_->is_empty();
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   return has_engine_rendered_contents_.value();
 }
 


### PR DESCRIPTION
See https://github.com/flutter/engine/pull/48928