### PR TITLE
Use sound null safety for Dart tests on Fuchsia

### DIFF
--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -56,9 +56,9 @@ const char* kDartVMArgs[] = {
 #if !defined(DART_PRODUCT) && (!defined(FLUTTER_PROFILE) || !defined(NDEBUG))
     "--enable_asserts",
 #endif
-    // Run in unsound null safety mode as some packages used in Integration
-    // testing have not been migrated yet.
-    "--no-sound-null-safety",
+    // // Run in unsound null safety mode as some packages used in Integration
+    // // testing have not been migrated yet.
+    // "--no-sound-null-safety",
     // clang-format on
 };
 

--- a/shell/platform/fuchsia/dart_runner/dart_test_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_test_component_controller.cc
@@ -341,9 +341,18 @@ bool DartTestComponentController::CreateIsolate(
   auto state = new std::shared_ptr<tonic::DartState>(new tonic::DartState(
       namespace_fd, [this](Dart_Handle result) { MessageEpilogue(result); }));
 
+  Dart_IsolateFlags flags;
+  flags.null_safety = Dart_DetectNullSafety(
+      /*script_uri=*/nullptr, /*package_config=*/nullptr,
+      /*original_working_directory=*/nullptr,
+      /*snapshot_data=*/isolate_snapshot_data,
+      /*snapshot_instructions=*/isolate_snapshot_instructions,
+      /*kernel_buffer=*/nullptr,
+      /*kernel_buffer_size=*/0);
+
   isolate_ = Dart_CreateIsolateGroup(
       url_.c_str(), label_.c_str(), isolate_snapshot_data,
-      isolate_snapshot_instructions, nullptr /* flags */, state, state, &error);
+      isolate_snapshot_instructions, &flags, state, state, &error);
   if (!isolate_) {
     FX_LOGF(ERROR, LOG_TAG, "Dart_CreateIsolateGroup failed: %s", error);
     return false;

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -486,10 +486,7 @@ ComponentV2::ComponentV2(
   };
 
   settings_.dart_flags = {};
-
-  // Run in unsound null safety mode as some packages used in Integration
-  // testing have not been migrated yet.
-  settings_.dart_flags.push_back("--no-sound-null-safety");
+  // settings_.dart_flags.push_back("--sound-null-safety");
 
   // Don't collect CPU samples from Dart VM C++ code.
   settings_.dart_flags.push_back("--no_profile_vm");

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -20,7 +20,7 @@ compile_platform("kernel_platform_files") {
   ]
 
   args = [
-    "--nnbd-agnostic",
+    "--nnbd-strong",
     "--target=flutter_runner",
     "dart:core",
   ]
@@ -78,6 +78,7 @@ template("core_snapshot") {
           rebase_path(isolate_snapshot_instructions, root_build_dir),
       "--write_v8_snapshot_profile_to=" +
           rebase_path(snapshot_profile, root_build_dir),
+      "--sound_null_safety",
     ]
 
     # No asserts in debug or release product.

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/child-view/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/child-view/BUILD.gn
@@ -10,6 +10,7 @@ import("//flutter/tools/fuchsia/gn-sdk/package.gni")
 dart_library("lib") {
   package_name = "child-view"
   sources = [ "child_view.dart" ]
+  null_safe = true
 }
 
 flutter_component("component") {

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/BUILD.gn
@@ -10,11 +10,11 @@ import("//flutter/tools/fuchsia/gn-sdk/package.gni")
 dart_library("lib") {
   package_name = "parent-view"
   sources = [ "parent_view.dart" ]
-
   deps = [
     "//flutter/shell/platform/fuchsia/dart:args",
     "//flutter/shell/platform/fuchsia/dart:vector_math",
   ]
+  null_safe = true
 }
 
 flutter_component("component") {

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/lib/parent_view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/lib/parent_view.dart
@@ -50,7 +50,7 @@ class TestApp {
       this.focusable = true}) {}
 
   void run() {
-    childView.create(focusable, (ByteData reply) {
+    childView.create(focusable, (ByteData? reply) {
       // Set up window allbacks.
       window.onPointerDataPacket = (PointerDataPacket packet) {
         for (final data in packet.data) {
@@ -181,8 +181,8 @@ Future<int> _launchChildView() async {
   final message = Int8List.fromList([0x31]);
   final completer = new Completer<ByteData>();
   PlatformDispatcher.instance.sendPlatformMessage(
-      'fuchsia/child_view', ByteData.sublistView(message), (ByteData reply) {
-    completer.complete(reply);
+      'fuchsia/child_view', ByteData.sublistView(message), (ByteData? reply) {
+    completer.complete(reply!);
   });
 
   return int.parse(

--- a/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/BUILD.gn
@@ -11,7 +11,7 @@ import("//flutter/tools/fuchsia/gn-sdk/package.gni")
 dart_library("lib") {
   package_name = "mouse-input-view"
   sources = [ "mouse-input-view.dart" ]
-
+  null_safe = true
   deps = [ "//flutter/shell/platform/fuchsia/dart:args" ]
 }
 

--- a/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/lib/mouse-input-view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/lib/mouse-input-view.dart
@@ -100,13 +100,13 @@ class MyApp {
   }
 
   void _reportMouseInput(
-      {double localX,
-      double localY,
-      int timeReceived,
-      int buttons,
-      String phase,
-      double wheelXPhysicalPixel,
-      double wheelYPhysicalPixel}) {
+      {required double localX,
+      required double localY,
+      required int timeReceived,
+      required int buttons,
+      required String phase,
+      required double wheelXPhysicalPixel,
+      required double wheelYPhysicalPixel}) {
     print('mouse-input-view reporting mouse input to MouseInputListener');
     final message = ByteData.sublistView(utf8.encode(json.encode({
         'method': 'MouseInputListener.ReportMouseInput',

--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/BUILD.gn
@@ -13,6 +13,7 @@ dart_library("lib") {
   package_name = "text-input-view"
   sources = [ "text_input_view.dart" ]
   deps = [ "//flutter/shell/platform/fuchsia/dart:args" ]
+  null_safe = true
 }
 
 flutter_component("component") {

--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/lib/text_input_view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/lib/text_input_view.dart
@@ -25,8 +25,11 @@ final Map<int, String> hidToKey = {
   458759: 'D', // Keyboard d and D
 };
 
-int main() {
+void main() {
   print('Launching text-input-view');
+  if (<int?>[null, 1 , 2] is List<int>) {
+    throw Exception('Unsound mode!');
+  }
   TestApp app = TestApp();
   app.run();
 }
@@ -37,7 +40,7 @@ class TestApp {
 
   void run() {
     // Set up window callbacks
-    window.onPlatformMessage = (String name, ByteData data, PlatformMessageResponseCallback callback) {
+    window.onPlatformMessage = (String name, ByteData? data, PlatformMessageResponseCallback? callback) {
       this.decodeAndReportPlatformMessage(name, data);
     };
     window.onMetricsChanged = () {
@@ -72,8 +75,8 @@ class TestApp {
     window.render(sceneBuilder.build());
   }
 
-  void decodeAndReportPlatformMessage(String name, ByteData data) async {
-    final buffer = data.buffer;
+  void decodeAndReportPlatformMessage(String name, ByteData? data) async {
+    final buffer = data!.buffer;
     var list = buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
     var decoded = utf8.decode(list);
     var decodedJson = json.decode(decoded);
@@ -81,7 +84,7 @@ class TestApp {
 
     if (name == "flutter/keyevent" && decodedJson["type"] == "keydown") {
       if (hidToKey[decodedJson["hidUsage"]] != null) {
-        _reportTextInput(hidToKey[decodedJson["hidUsage"]]);
+        _reportTextInput(hidToKey[decodedJson["hidUsage"]]!);
       }
     }
 

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/BUILD.gn
@@ -16,6 +16,7 @@ dart_library("lib") {
     "//flutter/shell/platform/fuchsia/dart:args",
     "//flutter/shell/platform/fuchsia/dart:vector_math",
   ]
+  null_safe = true
 }
 
 flutter_component("component") {

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/lib/embedding-flutter-view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/lib/embedding-flutter-view.dart
@@ -53,7 +53,7 @@ class TestApp {
   }
 
   void run() {
-    childView.create(focusable, (ByteData reply) {
+    childView.create(focusable, (ByteData? reply) {
         // Set up window callbacks.
         window.onPointerDataPacket = (PointerDataPacket packet) {
           this.pointerDataPacket(packet);
@@ -161,7 +161,7 @@ class TestApp {
     window.scheduleFrame();
   }
 
-  void _reportTouchInput({double localX, double localY, int timeReceived}) {
+  void _reportTouchInput({required double localX, required double localY, required int timeReceived}) {
     print('embedding-flutter-view reporting touch input to TouchInputListener');
     final message = utf8.encode(json.encode({
       'method': 'TouchInputListener.ReportTouchInput',
@@ -219,8 +219,8 @@ Future<int> _launchChildView() async {
   final message = Int8List.fromList([0x31]);
   final completer = new Completer<ByteData>();
   PlatformDispatcher.instance.sendPlatformMessage(
-      'fuchsia/child_view', ByteData.sublistView(message), (ByteData reply) {
-    completer.complete(reply);
+      'fuchsia/child_view', ByteData.sublistView(message), (ByteData? reply) {
+    completer.complete(reply!);
   });
 
   return int.parse(

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/BUILD.gn
@@ -11,8 +11,8 @@ import("//flutter/tools/fuchsia/gn-sdk/package.gni")
 dart_library("lib") {
   package_name = "touch-input-view"
   sources = [ "touch-input-view.dart" ]
-
   deps = [ "//flutter/shell/platform/fuchsia/dart:args" ]
+  null_safe = true
 }
 
 flutter_component("component") {

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/lib/touch-input-view.dart
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/lib/touch-input-view.dart
@@ -80,7 +80,7 @@ class TestApp {
     window.scheduleFrame();
   }
 
-  void _reportTouchInput({double localX, double localY, int timeReceived}) {
+  void _reportTouchInput({required double localX, required double localY, required int timeReceived}) {
     print('touch-input-view reporting touch input to TouchInputListener');
     final message = utf8.encode(json.encode({
       'method': 'TouchInputListener.ReportTouchInput',

--- a/tools/fuchsia/dart/kernel/dart_kernel.gni
+++ b/tools/fuchsia/dart/kernel/dart_kernel.gni
@@ -258,7 +258,8 @@ template("dart_kernel") {
     }
     args += [
       "--verbosity=warning",
-      "--no-sound-null-safety",
+
+      # "--no-sound-null-safety",
       "--target",
       invoker.platform_name,
       "--platform",


### PR DESCRIPTION
Otherwise Dart tests run without sound null safety, see b/315776399

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
