### PR TITLE
[Windows] Remove header guard from generated key map

### DIFF
--- a/shell/platform/windows/flutter_key_map.g.cc
+++ b/shell/platform/windows/flutter_key_map.g.cc
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_KEY_MAP_H_
-#define FLUTTER_SHELL_PLATFORM_WINDOWS_FLUTTER_KEY_MAP_H_
-
 #include "flutter/shell/platform/windows/keyboard_key_embedder_handler.h"
 
 #include <map>
@@ -335,5 +332,3 @@ const uint64_t KeyboardKeyEmbedderHandler::unicodePlane = 0x00000000000;
 const uint64_t KeyboardKeyEmbedderHandler::windowsPlane = 0x01600000000;
 
 }  // namespace flutter
-
-#endif


### PR DESCRIPTION
No tests as this is a refactoring with no semantic changes.

The generator was updated by https://github.com/flutter/flutter/pull/140082