### PR TITLE
Convert chromium wheel delta to physical pixels on macOS

### DIFF
--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -656,7 +656,7 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
         deltaX *= _view.physicalSize.width;
         deltaY *= _view.physicalSize.height;
       case domDeltaPixel:
-        if (operatingSystem == OperatingSystem.macOs && (isSafari || isFirefox)) {
+        if (operatingSystem == OperatingSystem.macOs) {
           // Safari and Firefox seem to report delta in logical pixels while
           // Chrome uses physical pixels.
           deltaX *= _view.devicePixelRatio;

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -858,51 +858,6 @@ void testMain() {
   );
 
   test(
-    'scroll delta are already in physical pixels (Chrome)',
-    () {
-      final _ButtonedEventMixin context = _PointerEventContext();
-
-      const double dpi = 2.5;
-      debugOperatingSystemOverride = OperatingSystem.macOs;
-      debugBrowserEngineOverride = BrowserEngine.blink;
-      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpi);
-
-      final List<ui.PointerDataPacket> packets = <ui.PointerDataPacket>[];
-      ui.PlatformDispatcher.instance.onPointerDataPacket = (ui.PointerDataPacket packet) {
-        packets.add(packet);
-      };
-
-      rootElement.dispatchEvent(context.wheel(
-        buttons: 0,
-        clientX: 10,
-        clientY: 10,
-        deltaX: 10,
-        deltaY: 10,
-      ));
-
-      expect(packets, hasLength(1));
-
-
-      // An add will be synthesized.
-      expect(packets[0].data, hasLength(2));
-      expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      // Scroll deltas should NOT be multiplied by `dpi`.
-      expect(packets[0].data[0].scrollDeltaX, equals(10.0));
-      expect(packets[0].data[0].scrollDeltaY, equals(10.0));
-
-      expect(packets[0].data[1].change, equals(ui.PointerChange.hover));
-      expect(packets[0].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
-      // Scroll deltas should NOT be multiplied by `dpi`.
-      expect(packets[0].data[0].scrollDeltaX, equals(10.0));
-      expect(packets[0].data[0].scrollDeltaY, equals(10.0));
-
-      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
-      debugOperatingSystemOverride = null;
-      debugBrowserEngineOverride = null;
-    },
-  );
-
-  test(
     'does set pointer device kind based on delta precision and wheelDelta',
     () {
       if (isFirefox) {

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -815,13 +815,12 @@ void testMain() {
   );
 
   test(
-    'converts scroll delta to physical pixels (Firefox)',
+    'converts scroll delta to physical pixels (macOs)',
     () {
       final _ButtonedEventMixin context = _PointerEventContext();
 
       const double dpi = 2.5;
       debugOperatingSystemOverride = OperatingSystem.macOs;
-      debugBrowserEngineOverride = BrowserEngine.firefox;
       EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpi);
 
       final List<ui.PointerDataPacket> packets = <ui.PointerDataPacket>[];
@@ -854,7 +853,6 @@ void testMain() {
       expect(packets[0].data[0].scrollDeltaY, equals(10.0 * dpi));
 
       EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
-      debugOperatingSystemOverride = null;
       debugBrowserEngineOverride = null;
     },
   );


### PR DESCRIPTION
This has been previously done for Safari in Firefox in https://github.com/flutter/engine/pull/35428. I'm not entirely sure since which release, but for past couple of months Chromium seems to be reporting logical pixels during scroll events as well, which now makes scrolling on Chrome / macOs 2x slower.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
