### PR TITLE
[canvaskit] Do not rasterize when running in flutter_tester

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -5,7 +5,6 @@
 import 'dart:js_interop';
 
 import 'package:ui/ui.dart' as ui;
-import 'package:ui/ui_web/src/ui_web/testing.dart';
 
 import '../browser_detection.dart';
 import '../configuration.dart';


### PR DESCRIPTION
Do not rasterize to bitmaps when running in flutter_tester.

This was causing memory leaks on the GPU because we would create bitmaps on the OffscreenCanvas, but since we were running in a fake async environment, we wouldn't return from awaiting for the bitmap to be created and we wouldn't dispose of it. This means that every time we pumped a widget we would push a 2400x1800 bitmap to GPU memory and never free it.

Fixes https://github.com/flutter/flutter/issues/137669

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
