### PR TITLE
Revert "[Impeller] Turned on new blur."

### DIFF
--- a/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.h
+++ b/impeller/entity/contents/filters/directional_gaussian_blur_filter_contents.h
@@ -43,9 +43,6 @@ namespace impeller {
 ///   - `FilterContents::MakeGaussianBlur`
 ///   - //flutter/impeller/entity/shaders/gaussian_blur/gaussian_blur.glsl
 ///
-///\deprecated Previously 2 of these were chained to do 2D blurs, use
-///            \ref GaussianBlurFilterContents instead since it has better
-///            performance.
 class DirectionalGaussianBlurFilterContents final : public FilterContents {
  public:
   DirectionalGaussianBlurFilterContents();

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -56,10 +56,38 @@ std::shared_ptr<FilterContents> FilterContents::MakeGaussianBlur(
     Sigma sigma_y,
     BlurStyle blur_style,
     Entity::TileMode tile_mode) {
-  auto blur = std::make_shared<GaussianBlurFilterContents>(
-      sigma_x.sigma, sigma_y.sigma, tile_mode);
-  blur->SetInputs({input});
-  return blur;
+  constexpr bool use_new_filter =
+#ifdef IMPELLER_ENABLE_NEW_GAUSSIAN_FILTER
+      true;
+#else
+      false;
+#endif
+
+  // TODO(https://github.com/flutter/flutter/issues/131580): Remove once the new
+  // blur handles all cases.
+  if (use_new_filter) {
+    auto blur = std::make_shared<GaussianBlurFilterContents>(
+        sigma_x.sigma, sigma_y.sigma, tile_mode);
+    blur->SetInputs({input});
+    return blur;
+  }
+  std::shared_ptr<FilterContents> x_blur = MakeDirectionalGaussianBlur(
+      /*input=*/input,
+      /*sigma=*/sigma_x,
+      /*direction=*/Point(1, 0),
+      /*blur_style=*/BlurStyle::kNormal,
+      /*tile_mode=*/tile_mode,
+      /*is_second_pass=*/false,
+      /*secondary_sigma=*/{});
+  std::shared_ptr<FilterContents> y_blur = MakeDirectionalGaussianBlur(
+      /*input=*/FilterInput::Make(x_blur),
+      /*sigma=*/sigma_y,
+      /*direction=*/Point(0, 1),
+      /*blur_style=*/blur_style,
+      /*tile_mode=*/tile_mode,
+      /*is_second_pass=*/true,
+      /*secondary_sigma=*/sigma_x);
+  return y_blur;
 }
 
 std::shared_ptr<FilterContents> FilterContents::MakeBorderMaskBlur(


### PR DESCRIPTION
Reverts flutter/engine#48472

This is causing memory crashes in the device lab: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_ios%20backdrop_filter_perf_ios__timeline_summary/14324/overview
```
[2023-12-14 15:55:20.660354] [STDOUT] stdout: [+1764 ms] Process 611 stopped
[2023-12-14 15:55:20.662620] [STDOUT] stdout: [   +2 ms] * thread #12, name = 'io.flutter.1.raster', stop reason = EXC_RESOURCE (RESOURCE_TYPE_MEMORY: high watermark memory limit exceeded) (limit=2098 MB)
[2023-12-14 15:55:20.662686] [STDOUT] stdout: [        ]     frame #0: 0x0000000106705e78 Flutter`void std::_LIBCPP_ABI_NAMESPACE::allocator<impeller::Command>::construct[abi:v15000]<impeller::Command, impeller::Command>(impeller::Command*, impeller::Command&&) + 8
[2023-12-14 15:55:20.662784] [STDOUT] stdout: [        ] Flutter`std::_LIBCPP_ABI_NAMESPACE::allocator<impeller::Command>::construct[abi:v15000]<impeller::Command, impeller::Command>:
[2023-12-14 15:55:20.662883] [STDOUT] stdout: [        ] ->  0x106705e78 <+8>:  str    x8, [x0]
[2023-12-14 15:55:20.662932] [STDOUT] stdout: [        ]     0x106705e7c <+12>: ldr    x8, [x1, #0x8]
[2023-12-14 15:55:20.663033] [STDOUT] stdout: [        ]     0x106705e80 <+16>: str    x8, [x0, #0x8]
[2023-12-14 15:55:20.663097] [STDOUT] stdout: [        ]     0x106705e84 <+20>: ldr    x8, [x1, #0x10]
[2023-12-14 15:55:20.663194] [STDOUT] stdout: [        ] Target 0: (Runner) stopped.
[2023-12-14 15:55:20.663309] [STDOUT] stdout: [        ] thread backtrace all
[2023-12-14 15:55:20.663403] [STDOUT] stdout: [        ] process detach
```