### PR TITLE
Revert "[Impeller] Provide the clear color to an advanced blend if it was optimized out"

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -4483,16 +4483,6 @@ TEST_P(AiksTest, MaskBlurWithZeroSigmaIsSkipped) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
-TEST_P(AiksTest, AdvancedBlendWithClearColorOptimization) {
-  Canvas canvas;
-  canvas.DrawPaint(
-      {.color = {1.0, 1.0, 0.0, 1.0}, .blend_mode = BlendMode::kSource});
-
-  canvas.DrawRect(
-      Rect::MakeXYWH(0, 0, 200, 300),
-      {.color = {1.0, 0.0, 1.0, 1.0}, .blend_mode = BlendMode::kMultiply});
-}
-
 TEST_P(AiksTest, GaussianBlurAtPeripheryVertical) {
   Canvas canvas;
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -877,7 +877,6 @@ bool EntityPass::OnRender(
                                     !backdrop_filter_proc_;
   for (const auto& element : elements_) {
     // Skip elements that are incorporated into the clear color.
-    bool was_collapsing_clear_colors = is_collapsing_clear_colors;
     if (is_collapsing_clear_colors) {
       auto [entity_color, _] =
           ElementAsBackgroundColor(element, clear_color_size);
@@ -951,20 +950,9 @@ bool EntityPass::OnRender(
         FilterInput::Vector inputs = {
             FilterInput::Make(texture, result.entity.GetTransform().Invert()),
             FilterInput::Make(result.entity.GetContents())};
-        std::optional<Color> foreground_color;
-        std::optional<Rect> coverage;
-        if (was_collapsing_clear_colors) {
-          // If all previous elements were skipped due to clear color
-          // optimization, then provide the clear color as the foreground of the
-          // advanced blend.
-          foreground_color = GetClearColorOrDefault(clear_color_size);
-          coverage = Rect::MakeSize(clear_color_size);
-        } else {
-          coverage = result.entity.GetCoverage();
-        }
         auto contents = ColorFilterContents::MakeBlend(
-            result.entity.GetBlendMode(), inputs, foreground_color);
-        contents->SetCoverageHint(coverage);
+            result.entity.GetBlendMode(), inputs);
+        contents->SetCoverageHint(result.entity.GetCoverage());
         result.entity.SetContents(std::move(contents));
         result.entity.SetBlendMode(BlendMode::kSource);
       }

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2470,14 +2470,6 @@ TEST_P(EntityTest, AdvancedBlendCoverageHintIsNotResetByEntityPass) {
                     "for advanced blends.";
   }
 
-  auto background_contents = std::make_shared<SolidColorContents>();
-  background_contents->SetGeometry(
-      Geometry::MakeRect(Rect::MakeXYWH(200, 200, 200, 200)));
-  background_contents->SetColor(Color::Blue());
-  Entity background_entity;
-  background_entity.SetTransform(Matrix::MakeScale(Vector3(2, 2, 1)));
-  background_entity.SetContents(background_contents);
-
   auto contents = std::make_shared<SolidColorContents>();
   contents->SetGeometry(Geometry::MakeRect(Rect::MakeXYWH(100, 100, 100, 100)));
   contents->SetColor(Color::Red());
@@ -2503,7 +2495,6 @@ TEST_P(EntityTest, AdvancedBlendCoverageHintIsNotResetByEntityPass) {
       RenderTarget::kDefaultColorAttachmentConfig, stencil_config);
   auto content_context = ContentContext(
       GetContext(), TypographerContextSkia::Make(), test_allocator);
-  pass->AddEntity(std::move(background_entity));
   pass->AddEntity(std::move(entity));
 
   EXPECT_TRUE(pass->Render(content_context, rt));


### PR DESCRIPTION
This reverts commit c32eb048d55b5efb2d49ca6afc0644c021102558.

That PR was outputting incorrect colors on the Play/AiksTest.BlendMode advanced blend tests.