### PR TITLE
[Web] Fix an assertion error due to synthesized keyboard events

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -472,7 +472,7 @@ class KeyboardConverter {
             timeStamp: timeStamp,
             type: ui.KeyEventType.up,
             physical: physicalKey,
-            logical: logicalKey(),
+            logical: _pressingRecords[physicalKey]!,
             character: null,
             synthesized: true,
           ));

--- a/lib/web_ui/test/engine/keyboard_converter_test.dart
+++ b/lib/web_ui/test/engine/keyboard_converter_test.dart
@@ -28,6 +28,7 @@ final int kPhysicalMetaLeft = kWebToPhysicalKey['MetaLeft']!;
 final int kPhysicalTab = kWebToPhysicalKey['Tab']!;
 final int kPhysicalCapsLock = kWebToPhysicalKey['CapsLock']!;
 final int kPhysicalScrollLock = kWebToPhysicalKey['ScrollLock']!;
+final int kPhysicalBracketLeft = kWebToPhysicalKey['BracketLeft']!;
 // A web-specific physical key when code is empty.
 const int kPhysicalEmptyCode = 0x1700000000;
 
@@ -44,6 +45,9 @@ final int kLogicalMetaLeft = kWebLogicalLocationMap['Meta']![kLocationLeft]!;
 const int kLogicalTab = 0x0000000009;
 final int kLogicalCapsLock = kWebToLogicalKey['CapsLock']!;
 final int kLogicalScrollLock = kWebToLogicalKey['ScrollLock']!;
+final int kLogicalProcess = kWebToLogicalKey['Process']!;
+const int kWebKeyIdPlane = 0x1700000000;
+final int kLogicalBracketLeft = kPhysicalBracketLeft + kWebKeyIdPlane; // Dead key algorithm.
 
 typedef VoidCallback = void Function();
 
@@ -520,6 +524,49 @@ void testMain() {
       deviceType: ui.KeyEventDeviceType.keyboard,
       physical: kPhysicalShiftLeft,
       logical: kLogicalShiftLeft,
+      character: null,
+    );
+    expect(MockKeyboardEvent.lastDefaultPrevented, isTrue);
+  });
+
+  test('Duplicate down is preceded with synthesized up using registered logical key', () {
+    // Regression test for https://github.com/flutter/flutter/issues/126247.
+    final List<ui.KeyData> keyDataList = <ui.KeyData>[];
+    final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
+      keyDataList.add(key);
+      return true;
+    }, OperatingSystem.linux);
+
+    // This test simulates the use of 'BracketLeft' on a french keyboard, see:
+    // https://github.com/flutter/flutter/issues/126247#issuecomment-1856112566.
+    converter.handleEvent(keyDownEvent('BracketLeft', 'Dead'));
+    expect(MockKeyboardEvent.lastDefaultPrevented, isTrue);
+    expectKeyData(keyDataList.first,
+      type: ui.KeyEventType.down,
+      deviceType: ui.KeyEventDeviceType.keyboard,
+      physical: kPhysicalBracketLeft,
+      logical: kLogicalBracketLeft,
+      character: null,
+    );
+
+    // A KeyUp of BracketLeft is missed.
+    keyDataList.clear();
+
+    converter.handleEvent(keyDownEvent('BracketLeft', 'Process'));
+    expect(keyDataList, hasLength(2));
+    expectKeyData(keyDataList.first,
+      type: ui.KeyEventType.up,
+      deviceType: ui.KeyEventDeviceType.keyboard,
+      physical: kPhysicalBracketLeft,
+      logical: kLogicalBracketLeft,
+      character: null,
+      synthesized: true,
+    );
+    expectKeyData(keyDataList.last,
+      type: ui.KeyEventType.down,
+      deviceType: ui.KeyEventDeviceType.keyboard,
+      physical: kPhysicalBracketLeft,
+      logical: kLogicalProcess,
       character: null,
     );
     expect(MockKeyboardEvent.lastDefaultPrevented, isTrue);


### PR DESCRIPTION
## Description

On Web, browsers can emit key events with a logical key sets to `Process` during compostion.
It is usually not a problem, but in some edge cases (for instance when the browser window lost focus and some keys events were missed), the Flutter web engine might synthesize an up event with a logical key value different that the one used for the down event and this will lead to an assertion message on the framework side.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/126247.

## Tests

Adds 1 test.