### PR TITLE
Platform channel for predictive back in route transitions on android

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -271,6 +271,7 @@ android_java_sources = [
   "io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java",
   "io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java",
   "io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java",
+  "io/flutter/embedding/engine/systemchannels/BackGestureChannel.java",
   "io/flutter/embedding/engine/systemchannels/DeferredComponentChannel.java",
   "io/flutter/embedding/engine/systemchannels/KeyEventChannel.java",
   "io/flutter/embedding/engine/systemchannels/KeyboardChannel.java",

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -7,6 +7,7 @@ package io.flutter.embedding.android;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DEFAULT_INITIAL_ROUTE;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -16,10 +17,14 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver.OnPreDrawListener;
+import android.window.BackEvent;
+import android.window.OnBackAnimationCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.Lifecycle;
+import io.flutter.Build.API_LEVELS;
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine;
@@ -776,6 +781,93 @@ import java.util.List;
       flutterEngine.getNavigationChannel().popRoute();
     } else {
       Log.w(TAG, "Invoked onBackPressed() before FlutterFragment was attached to an Activity.");
+    }
+  }
+
+  /**
+   * Invoke this from {@link OnBackAnimationCallback#onBackStarted(BackEvent)}.
+   *
+   * <p>This method should be called when the back gesture is initiated, as part of the
+   * implementation of {@link OnBackAnimationCallback}. It's responsible for handling the initial
+   * response to the start of a back gesture, such as initiating animations or preparing the UI for
+   * the back navigation process.
+   *
+   * @param backEvent The BackEvent object containing information about the touch.
+   */
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  void startBackGesture(@NonNull BackEvent backEvent) {
+    ensureAlive();
+    if (flutterEngine != null) {
+      Log.v(TAG, "Forwarding startBackGesture() to FlutterEngine.");
+      flutterEngine.getBackGestureChannel().startBackGesture(backEvent);
+    } else {
+      Log.w(TAG, "Invoked startBackGesture() before FlutterFragment was attached to an Activity.");
+    }
+  }
+
+  /**
+   * Invoke this from {@link OnBackAnimationCallback#onBackProgressed(BackEvent)}.
+   *
+   * <p>This method should be called in response to progress in a back gesture, as part of the
+   * implementation of {@link OnBackAnimationCallback}. It allows for updating the state of the
+   * application or UI elements based on the ongoing back gesture, such as progressing animations or
+   * interactive elements.
+   *
+   * @param backEvent An BackEvent object describing the progress event.
+   */
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  void updateBackGestureProgress(@NonNull BackEvent backEvent) {
+    ensureAlive();
+    if (flutterEngine != null) {
+      Log.v(TAG, "Forwarding updateBackGestureProgress() to FlutterEngine.");
+      flutterEngine.getBackGestureChannel().updateBackGestureProgress(backEvent);
+    } else {
+      Log.w(
+          TAG,
+          "Invoked updateBackGestureProgress() before FlutterFragment was attached to an Activity.");
+    }
+  }
+
+  /**
+   * Invoke this from {@link OnBackAnimationCallback#onBackInvoked()}.
+   *
+   * <p>This method signifies the completion of a back gesture and commits the navigation action
+   * initiated by the gesture. It should be called as a final step in the back gesture handling,
+   * indicating that the application is ready to proceed with the back navigation. This could
+   * involve finalizing animations, updating the UI to reflect the navigation, or performing cleanup
+   * tasks related to the gesture.
+   */
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  void commitBackGesture() {
+    ensureAlive();
+    if (flutterEngine != null) {
+      Log.v(TAG, "Forwarding commitBackGesture() to FlutterEngine.");
+      flutterEngine.getBackGestureChannel().commitBackGesture();
+    } else {
+      Log.w(TAG, "Invoked commitBackGesture() before FlutterFragment was attached to an Activity.");
+    }
+  }
+
+  /**
+   * Invoke this from {@link OnBackAnimationCallback#onBackCancelled()}.
+   *
+   * <p>This method should be called when a back gesture is cancelled or back button pressed, as
+   * part of the implementation of {@link OnBackAnimationCallback}. It's responsible for handling
+   * the rollback of any changes or animations that were initiated in response to the back gesture.
+   * This includes resetting UI elements or state to their original form before the gesture started.
+   */
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  void cancelBackGesture() {
+    ensureAlive();
+    if (flutterEngine != null) {
+      Log.v(TAG, "Forwarding cancelBackGesture() to FlutterEngine.");
+      flutterEngine.getBackGestureChannel().cancelBackGesture();
+    } else {
+      Log.w(TAG, "Invoked cancelBackGesture() before FlutterFragment was attached to an Activity.");
     }
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -787,10 +787,12 @@ import java.util.List;
   /**
    * Invoke this from {@link OnBackAnimationCallback#onBackStarted(BackEvent)}.
    *
-   * <p>This method should be called when the back gesture is initiated, as part of the
-   * implementation of {@link OnBackAnimationCallback}. It's responsible for handling the initial
-   * response to the start of a back gesture, such as initiating animations or preparing the UI for
-   * the back navigation process.
+   * <p>This method should be called when the back gesture is initiated. It should be invoked as
+   * part of the implementation of {@link OnBackAnimationCallback}.
+   *
+   * <p>This method delegates the handling of the start of a back gesture to the Flutter framework,
+   * which is responsible for the appropriate response, such as initiating animations or preparing
+   * the UI for the back navigation process.
    *
    * @param backEvent The BackEvent object containing information about the touch.
    */
@@ -810,9 +812,10 @@ import java.util.List;
    * Invoke this from {@link OnBackAnimationCallback#onBackProgressed(BackEvent)}.
    *
    * <p>This method should be called in response to progress in a back gesture, as part of the
-   * implementation of {@link OnBackAnimationCallback}. It allows for updating the state of the
-   * application or UI elements based on the ongoing back gesture, such as progressing animations or
-   * interactive elements.
+   * implementation of {@link OnBackAnimationCallback}.
+   *
+   * <p>This method delegates to the Flutter framework to update UI elements or animations based on
+   * the progression of the back gesture.
    *
    * @param backEvent An BackEvent object describing the progress event.
    */
@@ -833,11 +836,13 @@ import java.util.List;
   /**
    * Invoke this from {@link OnBackAnimationCallback#onBackInvoked()}.
    *
-   * <p>This method signifies the completion of a back gesture and commits the navigation action
-   * initiated by the gesture. It should be called as a final step in the back gesture handling,
-   * indicating that the application is ready to proceed with the back navigation. This could
-   * involve finalizing animations, updating the UI to reflect the navigation, or performing cleanup
-   * tasks related to the gesture.
+   * <p>This method is called to signify the completion of a back gesture and commits the navigation
+   * action initiated by the gesture. It should be invoked as the final step in handling a back
+   * gesture.
+   *
+   * <p>This method indicates to the Flutter framework that it should proceed with the back
+   * navigation, including finalizing animations and updating the UI to reflect the navigation
+   * outcome.
    */
   @TargetApi(API_LEVELS.API_34)
   @RequiresApi(API_LEVELS.API_34)
@@ -854,10 +859,12 @@ import java.util.List;
   /**
    * Invoke this from {@link OnBackAnimationCallback#onBackCancelled()}.
    *
-   * <p>This method should be called when a back gesture is cancelled or back button pressed, as
-   * part of the implementation of {@link OnBackAnimationCallback}. It's responsible for handling
-   * the rollback of any changes or animations that were initiated in response to the back gesture.
-   * This includes resetting UI elements or state to their original form before the gesture started.
+   * <p>This method should be called when a back gesture is cancelled or the back button is pressed.
+   * It informs the Flutter framework about the cancellation.
+   *
+   * <p>This method enables the Flutter framework to rollback any UI changes or animations initiated
+   * in response to the back gesture. This includes resetting UI elements to their state prior to
+   * the gesture's start.
    */
   @TargetApi(API_LEVELS.API_34)
   @RequiresApi(API_LEVELS.API_34)

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -25,6 +25,7 @@ import io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.RenderSurface;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
+import io.flutter.embedding.engine.systemchannels.BackGestureChannel;
 import io.flutter.embedding.engine.systemchannels.DeferredComponentChannel;
 import io.flutter.embedding.engine.systemchannels.LifecycleChannel;
 import io.flutter.embedding.engine.systemchannels.LocalizationChannel;
@@ -95,6 +96,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
   @NonNull private final LocalizationChannel localizationChannel;
   @NonNull private final MouseCursorChannel mouseCursorChannel;
   @NonNull private final NavigationChannel navigationChannel;
+  @NonNull private final BackGestureChannel backGestureChannel;
   @NonNull private final RestorationChannel restorationChannel;
   @NonNull private final PlatformChannel platformChannel;
   @NonNull private final ProcessTextChannel processTextChannel;
@@ -331,6 +333,7 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
     localizationChannel = new LocalizationChannel(dartExecutor);
     mouseCursorChannel = new MouseCursorChannel(dartExecutor);
     navigationChannel = new NavigationChannel(dartExecutor);
+    backGestureChannel = new BackGestureChannel(dartExecutor);
     platformChannel = new PlatformChannel(dartExecutor);
     processTextChannel = new ProcessTextChannel(dartExecutor, context.getPackageManager());
     restorationChannel = new RestorationChannel(dartExecutor, waitForRestorationData);
@@ -539,6 +542,12 @@ public class FlutterEngine implements ViewUtils.DisplayUpdater {
   @NonNull
   public NavigationChannel getNavigationChannel() {
     return navigationChannel;
+  }
+
+  /** System channel that sends back gesture commands from Android to Flutter. */
+  @NonNull
+  public BackGestureChannel getBackGestureChannel() {
+    return backGestureChannel;
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
@@ -12,9 +12,10 @@ import androidx.annotation.RequiresApi;
 import io.flutter.Build.API_LEVELS;
 import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.StandardMethodCodec;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +38,7 @@ public class BackGestureChannel {
    *     framework.
    */
   public BackGestureChannel(@NonNull DartExecutor dartExecutor) {
-    this.channel = new MethodChannel(dartExecutor, "flutter/backgesture", JSONMethodCodec.INSTANCE);
+    this.channel = new MethodChannel(dartExecutor, "flutter/backgesture", StandardMethodCodec.INSTANCE);
     channel.setMethodCallHandler(defaultHandler);
   }
 
@@ -116,9 +117,13 @@ public class BackGestureChannel {
   @TargetApi(API_LEVELS.API_34)
   @RequiresApi(API_LEVELS.API_34)
   private Map<String, Object> backEventToJsonMap(@NonNull BackEvent backEvent) {
-    Map<String, Object> message = new HashMap<>(4);
-    message.put("x", Float.isNaN(backEvent.getTouchX()) ? null : backEvent.getTouchX());
-    message.put("y", Float.isNaN(backEvent.getTouchY()) ? null : backEvent.getTouchY());
+    Map<String, Object> message = new HashMap<>(3);
+    final float x = backEvent.getTouchX();
+    final float y = backEvent.getTouchY();
+    final Object touchOffset = (Float.isNaN(x) || Float.isNaN(y))
+            ? null
+            : Arrays.asList(x, y);
+    message.put("touchOffset", touchOffset);
     message.put("progress", backEvent.getProgress());
     message.put("swipeEdge", backEvent.getSwipeEdge());
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
@@ -38,7 +38,8 @@ public class BackGestureChannel {
    *     framework.
    */
   public BackGestureChannel(@NonNull DartExecutor dartExecutor) {
-    this.channel = new MethodChannel(dartExecutor, "flutter/backgesture", StandardMethodCodec.INSTANCE);
+    this.channel =
+        new MethodChannel(dartExecutor, "flutter/backgesture", StandardMethodCodec.INSTANCE);
     channel.setMethodCallHandler(defaultHandler);
   }
 
@@ -120,9 +121,7 @@ public class BackGestureChannel {
     Map<String, Object> message = new HashMap<>(3);
     final float x = backEvent.getTouchX();
     final float y = backEvent.getTouchY();
-    final Object touchOffset = (Float.isNaN(x) || Float.isNaN(y))
-            ? null
-            : Arrays.asList(x, y);
+    final Object touchOffset = (Float.isNaN(x) || Float.isNaN(y)) ? null : Arrays.asList(x, y);
     message.put("touchOffset", touchOffset);
     message.put("progress", backEvent.getProgress());
     message.put("swipeEdge", backEvent.getSwipeEdge());

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
@@ -37,7 +37,7 @@ public class BackGestureChannel {
    *     framework.
    */
   public BackGestureChannel(@NonNull DartExecutor dartExecutor) {
-    this.channel = new MethodChannel(dartExecutor, "flutter/backGesture", JSONMethodCodec.INSTANCE);
+    this.channel = new MethodChannel(dartExecutor, "flutter/backgesture", JSONMethodCodec.INSTANCE);
     channel.setMethodCallHandler(defaultHandler);
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
@@ -1,0 +1,127 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.embedding.engine.systemchannels;
+
+import android.annotation.TargetApi;
+import android.window.BackEvent;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import io.flutter.Build.API_LEVELS;
+import io.flutter.Log;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.plugin.common.JSONMethodCodec;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link MethodChannel} for communicating back gesture events to the Flutter framework.
+ *
+ * <p>The BackGestureChannel facilitates communication between the platform-specific Android back
+ * gesture handling code and the Flutter framework. It enables the dispatch of back gesture events
+ * such as start, progress, commit, and cancellation from the platform to the Flutter application.
+ */
+public class BackGestureChannel {
+  private static final String TAG = "BackGestureChannel";
+
+  @NonNull public final MethodChannel channel;
+
+  /**
+   * Constructs a BackGestureChannel.
+   *
+   * @param dartExecutor The DartExecutor used to establish communication with the Flutter
+   *     framework.
+   */
+  public BackGestureChannel(@NonNull DartExecutor dartExecutor) {
+    this.channel = new MethodChannel(dartExecutor, "flutter/backGesture", JSONMethodCodec.INSTANCE);
+    channel.setMethodCallHandler(defaultHandler);
+  }
+
+  // Provide a default handler that returns an empty response to any messages
+  // on this channel.
+  private final MethodChannel.MethodCallHandler defaultHandler =
+      new MethodChannel.MethodCallHandler() {
+        @Override
+        public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+          result.success(null);
+        }
+      };
+
+  /**
+   * Initiates a back gesture event.
+   *
+   * <p>This method should be called when the back gesture is initiated by the user.
+   *
+   * @param backEvent The BackEvent object containing information about the touch.
+   */
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  public void startBackGesture(@NonNull BackEvent backEvent) {
+    Log.v(TAG, "Sending message to start back gesture");
+    channel.invokeMethod("startBackGesture", backEventToJsonMap(backEvent));
+  }
+
+  /**
+   * Updates the progress of a back gesture event.
+   *
+   * <p>This method should be called to update the progress of an ongoing back gesture event.
+   *
+   * @param backEvent An BackEvent object describing the progress event.
+   */
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  public void updateBackGestureProgress(@NonNull BackEvent backEvent) {
+    Log.v(TAG, "Sending message to update back gesture progress");
+    channel.invokeMethod("updateBackGestureProgress", backEventToJsonMap(backEvent));
+  }
+
+  /**
+   * Commits the back gesture event.
+   *
+   * <p>This method should be called to signify the completion of a back gesture event and commit
+   * the navigation action initiated by the gesture.
+   */
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  public void commitBackGesture() {
+    Log.v(TAG, "Sending message to commit back gesture");
+    channel.invokeMethod("commitBackGesture", null);
+  }
+
+  /**
+   * Cancels the back gesture event.
+   *
+   * <p>This method should be called when a back gesture is cancelled or the back button is pressed.
+   */
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  public void cancelBackGesture() {
+    Log.v(TAG, "Sending message to cancel back gesture");
+    channel.invokeMethod("cancelBackGesture", null);
+  }
+
+  /**
+   * Sets a method call handler for the channel.
+   *
+   * @param handler The handler to set for the channel.
+   */
+  public void setMethodCallHandler(@Nullable MethodChannel.MethodCallHandler handler) {
+    channel.setMethodCallHandler(handler);
+  }
+
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  private Map<String, Object> backEventToJsonMap(@NonNull BackEvent backEvent) {
+    Map<String, Object> message = new HashMap<>(4);
+    message.put("touchX", Float.isNaN(backEvent.getTouchX()) ? null : backEvent.getTouchX());
+    message.put("touchY", Float.isNaN(backEvent.getTouchY()) ? null : backEvent.getTouchY());
+    message.put("progress", backEvent.getProgress());
+    message.put("swipeEdge", backEvent.getSwipeEdge());
+
+    return message;
+  }
+}

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/BackGestureChannel.java
@@ -117,8 +117,8 @@ public class BackGestureChannel {
   @RequiresApi(API_LEVELS.API_34)
   private Map<String, Object> backEventToJsonMap(@NonNull BackEvent backEvent) {
     Map<String, Object> message = new HashMap<>(4);
-    message.put("touchX", Float.isNaN(backEvent.getTouchX()) ? null : backEvent.getTouchX());
-    message.put("touchY", Float.isNaN(backEvent.getTouchY()) ? null : backEvent.getTouchY());
+    message.put("x", Float.isNaN(backEvent.getTouchX()) ? null : backEvent.getTouchX());
+    message.put("y", Float.isNaN(backEvent.getTouchY()) ? null : backEvent.getTouchY());
     message.put("progress", backEvent.getProgress());
     message.put("swipeEdge", backEvent.getSwipeEdge());
 

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -38,6 +38,7 @@ import android.view.autofill.AutofillValue;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
+import android.window.BackEvent;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
@@ -49,6 +50,7 @@ import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.SurfaceTextureWrapper;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
+import io.flutter.embedding.engine.systemchannels.BackGestureChannel;
 import io.flutter.embedding.engine.systemchannels.LifecycleChannel;
 import io.flutter.embedding.engine.systemchannels.LocalizationChannel;
 import io.flutter.embedding.engine.systemchannels.MouseCursorChannel;
@@ -124,6 +126,7 @@ public class FlutterView extends SurfaceView
   private final DartExecutor dartExecutor;
   private final FlutterRenderer flutterRenderer;
   private final NavigationChannel navigationChannel;
+  private final BackGestureChannel backGestureChannel;
   private final LifecycleChannel lifecycleChannel;
   private final LocalizationChannel localizationChannel;
   private final PlatformChannel platformChannel;
@@ -214,6 +217,7 @@ public class FlutterView extends SurfaceView
 
     // Create all platform channels
     navigationChannel = new NavigationChannel(dartExecutor);
+    backGestureChannel = new BackGestureChannel(dartExecutor);
     lifecycleChannel = new LifecycleChannel(dartExecutor);
     localizationChannel = new LocalizationChannel(dartExecutor);
     platformChannel = new PlatformChannel(dartExecutor);
@@ -367,6 +371,30 @@ public class FlutterView extends SurfaceView
 
   public void popRoute() {
     navigationChannel.popRoute();
+  }
+
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  public void startBackGesture(@NonNull BackEvent backEvent) {
+    backGestureChannel.startBackGesture(backEvent);
+  }
+
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  public void updateBackGestureProgress(@NonNull BackEvent backEvent) {
+    backGestureChannel.updateBackGestureProgress(backEvent);
+  }
+
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  public void commitBackGesture() {
+    backGestureChannel.commitBackGesture();
+  }
+
+  @TargetApi(API_LEVELS.API_34)
+  @RequiresApi(API_LEVELS.API_34)
+  public void cancelBackGesture() {
+    backGestureChannel.cancelBackGesture();
   }
 
   private void sendUserPlatformSettingsToDart() {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.view.View;
+import android.window.BackEvent;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 import androidx.test.core.app.ApplicationProvider;
@@ -39,6 +40,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
+import io.flutter.embedding.engine.systemchannels.BackGestureChannel;
 import io.flutter.embedding.engine.systemchannels.LifecycleChannel;
 import io.flutter.embedding.engine.systemchannels.LocalizationChannel;
 import io.flutter.embedding.engine.systemchannels.MouseCursorChannel;
@@ -669,6 +671,73 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // Verify that the navigation channel tried to send a message to Flutter.
     verify(mockFlutterEngine.getNavigationChannel(), times(1)).popRoute();
+  }
+
+  @Test
+  public void itForwardsStartBackGestureToFlutter() {
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is set up in onAttach().
+    delegate.onAttach(ctx);
+
+    // Emulate the host and inform our delegate of the start back gesture with a mocked BackEvent
+    BackEvent backEvent = mock(BackEvent.class);
+    delegate.startBackGesture(backEvent);
+
+    // Verify that the back gesture tried to send a message to Flutter.
+    verify(mockFlutterEngine.getBackGestureChannel(), times(1)).startBackGesture(backEvent);
+  }
+
+  @Test
+  public void itForwardsUpdateBackGestureProgressToFlutter() {
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is set up in onAttach().
+    delegate.onAttach(ctx);
+
+    // Emulate the host and inform our delegate of the back gesture progress with a mocked BackEvent
+    BackEvent backEvent = mock(BackEvent.class);
+    delegate.updateBackGestureProgress(backEvent);
+
+    // Verify that the back gesture tried to send a message to Flutter.
+    verify(mockFlutterEngine.getBackGestureChannel(), times(1))
+        .updateBackGestureProgress(backEvent);
+  }
+
+  @Test
+  public void itForwardsCommitBackGestureToFlutter() {
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is set up in onAttach().
+    delegate.onAttach(ctx);
+
+    // Emulate the host and inform our delegate when the back gesture is committed
+    delegate.commitBackGesture();
+
+    // Verify that the back gesture tried to send a message to Flutter.
+    verify(mockFlutterEngine.getBackGestureChannel(), times(1)).commitBackGesture();
+  }
+
+  @Test
+  public void itForwardsCancelBackGestureToFlutter() {
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is set up in onAttach().
+    delegate.onAttach(ctx);
+
+    // Emulate the host and inform our delegate of the back gesture cancellation
+    delegate.cancelBackGesture();
+
+    // Verify that the back gesture tried to send a message to Flutter.
+    verify(mockFlutterEngine.getBackGestureChannel(), times(1)).cancelBackGesture();
   }
 
   @Test
@@ -1396,6 +1465,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     when(engine.getLocalizationPlugin()).thenReturn(mock(LocalizationPlugin.class));
     when(engine.getMouseCursorChannel()).thenReturn(mock(MouseCursorChannel.class));
     when(engine.getNavigationChannel()).thenReturn(mock(NavigationChannel.class));
+    when(engine.getBackGestureChannel()).thenReturn(mock(BackGestureChannel.class));
     when(engine.getPlatformViewsController()).thenReturn(mock(PlatformViewsController.class));
 
     FlutterRenderer renderer = mock(FlutterRenderer.class);


### PR DESCRIPTION
This pull request introduces platform channel support for predictive back route transitions on Android, as part of the ongoing efforts in flutter/flutter#131961.

- For Android SDK 33: Utilizes [`OnBackInvokedCallback`](https://developer.android.com/reference/android/window/OnBackInvokedCallback) to handle back navigation events (#39208).
- For Android SDK 34 and above: Employs [`OnBackAnimationCallback`](https://developer.android.com/reference/android/window/OnBackAnimationCallback), taking advantage of the enhanced back navigation capabilities introduced in this version.

In both scenarios, the callbacks are appropriately forwarded to the Flutter framework.
This PR focuses on the engine part, setting the stage for integrating these enhancements into the broader Flutter ecosystem.

### References

Part of flutter/flutter#131961
Framework PR: flutter/flutter#141373
Fixes https://github.com/flutter/flutter/issues/111295

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
