### PR TITLE
[Impeller] Make Rect origin and size fields private

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -341,7 +341,7 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
 void Canvas::DrawOval(const Rect& rect, const Paint& paint) {
   if (rect.IsSquare()) {
     // Circles have slightly less overhead and can do stroking
-    DrawCircle(rect.GetCenter(), rect.GetSize().width * 0.5f, paint);
+    DrawCircle(rect.GetCenter(), rect.GetWidth() * 0.5f, paint);
     return;
   }
 
@@ -471,10 +471,9 @@ void Canvas::ClipOval(const Rect& bounds, Entity::ClipOperation clip_op) {
 void Canvas::ClipRRect(const Rect& rect,
                        const Size& corner_radii,
                        Entity::ClipOperation clip_op) {
-  auto size = rect.GetSize();
   // Does the rounded rect have a flat part on the top/bottom or left/right?
-  bool flat_on_TB = corner_radii.width * 2 < size.width;
-  bool flat_on_LR = corner_radii.height * 2 < size.height;
+  bool flat_on_TB = corner_radii.width * 2 < rect.GetWidth();
+  bool flat_on_LR = corner_radii.height * 2 < rect.GetHeight();
   auto geometry = Geometry::MakeRoundRect(rect, corner_radii);
   auto& cull_rect = transform_stack_.back().cull_rect;
   if (clip_op == Entity::ClipOperation::kIntersect &&                      //

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -72,9 +72,9 @@ struct AtlasBlenderKey {
 
   struct Hash {
     std::size_t operator()(const AtlasBlenderKey& key) const {
-      return fml::HashCombine(key.color_key, key.rect.size.width,
-                              key.rect.size.height, key.rect.origin.x,
-                              key.rect.origin.y);
+      return fml::HashCombine(key.color_key, key.rect.GetWidth(),
+                              key.rect.GetHeight(), key.rect.GetX(),
+                              key.rect.GetY());
     }
   };
 
@@ -124,18 +124,18 @@ std::shared_ptr<SubAtlasResult> AtlasContents::GenerateSubAtlas() const {
     auto key = it->first;
     auto transforms = it->second;
 
-    auto new_rect = Rect::MakeXYWH(x_offset, y_offset, key.rect.size.width,
-                                   key.rect.size.height);
+    auto new_rect = Rect::MakeXYWH(x_offset, y_offset, key.rect.GetWidth(),
+                                   key.rect.GetHeight());
     auto sub_transform = Matrix::MakeTranslation(Vector2(x_offset, y_offset));
 
-    x_offset += std::ceil(key.rect.size.width) + 1.0;
+    x_offset += std::ceil(key.rect.GetWidth()) + 1.0;
 
     result->sub_texture_coords.push_back(key.rect);
     result->sub_colors.push_back(key.color);
     result->sub_transforms.push_back(sub_transform);
 
     x_extent = std::max(x_extent, x_offset);
-    y_extent = std::max(y_extent, std::ceil(y_offset + key.rect.size.height));
+    y_extent = std::max(y_extent, std::ceil(y_offset + key.rect.GetHeight()));
 
     for (auto transform : transforms) {
       result->result_texture_coords.push_back(new_rect);
@@ -159,7 +159,8 @@ Rect AtlasContents::ComputeBoundingBox() const {
     for (size_t i = 0; i < texture_coords_.size(); i++) {
       auto matrix = transforms_[i];
       auto sample_rect = texture_coords_[i];
-      auto bounds = Rect::MakeSize(sample_rect.size).TransformBounds(matrix);
+      auto bounds =
+          Rect::MakeSize(sample_rect.GetSize()).TransformBounds(matrix);
       bounding_box = bounds.Union(bounding_box);
     }
     bounding_box_cache_ = bounding_box;
@@ -230,15 +231,13 @@ bool AtlasContents::Render(const ContentContext& renderer,
       auto sample_rect = texture_coords_[i];
       auto matrix = transforms_[i];
       auto transformed_points =
-          Rect::MakeSize(sample_rect.size).GetTransformedPoints(matrix);
+          Rect::MakeSize(sample_rect.GetSize()).GetTransformedPoints(matrix);
       auto color = colors_[i].Premultiply();
       for (size_t j = 0; j < 6; j++) {
         VS::PerVertexData data;
         data.vertices = transformed_points[indices[j]];
         data.texture_coords =
-            (sample_rect.origin + Point(sample_rect.size.width * width[j],
-                                        sample_rect.size.height * height[j])) /
-            texture_size;
+            sample_rect.GetRelative(width[j], height[j]) / texture_size;
         data.color = color;
         vtx_builder.AppendVertex(data);
       }
@@ -393,15 +392,13 @@ bool AtlasTextureContents::Render(const ContentContext& renderer,
     auto sample_rect = texture_coords[i];
     auto matrix = transforms[i];
     auto transformed_points =
-        Rect::MakeSize(sample_rect.size).GetTransformedPoints(matrix);
+        Rect::MakeSize(sample_rect.GetSize()).GetTransformedPoints(matrix);
 
     for (size_t j = 0; j < 6; j++) {
       VS::PerVertexData data;
       data.position = transformed_points[indices[j]];
       data.texture_coords =
-          (sample_rect.origin + Point(sample_rect.size.width * width[j],
-                                      sample_rect.size.height * height[j])) /
-          texture_size;
+          sample_rect.GetRelative(width[j], height[j]) / texture_size;
       vertex_builder.AppendVertex(data);
     }
   }
@@ -484,7 +481,7 @@ bool AtlasColorContents::Render(const ContentContext& renderer,
     auto sample_rect = texture_coords[i];
     auto matrix = transforms[i];
     auto transformed_points =
-        Rect::MakeSize(sample_rect.size).GetTransformedPoints(matrix);
+        Rect::MakeSize(sample_rect.GetSize()).GetTransformedPoints(matrix);
 
     for (size_t j = 0; j < 6; j++) {
       VS::PerVertexData data;

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -214,8 +214,6 @@ bool AtlasContents::Render(const ContentContext& renderer,
   }
 
   constexpr size_t indices[6] = {0, 1, 2, 1, 2, 3};
-  constexpr Scalar width[6] = {0, 1, 0, 1, 0, 1};
-  constexpr Scalar height[6] = {0, 0, 1, 0, 1, 1};
 
   if (blend_mode_ <= BlendMode::kModulate) {
     // Simple Porter-Duff blends can be accomplished without a subpass.
@@ -230,14 +228,14 @@ bool AtlasContents::Render(const ContentContext& renderer,
     for (size_t i = 0; i < texture_coords_.size(); i++) {
       auto sample_rect = texture_coords_[i];
       auto matrix = transforms_[i];
+      auto points = sample_rect.GetPoints();
       auto transformed_points =
           Rect::MakeSize(sample_rect.GetSize()).GetTransformedPoints(matrix);
       auto color = colors_[i].Premultiply();
       for (size_t j = 0; j < 6; j++) {
         VS::PerVertexData data;
         data.vertices = transformed_points[indices[j]];
-        data.texture_coords =
-            sample_rect.GetRelative(width[j], height[j]) / texture_size;
+        data.texture_coords = points[indices[j]] / texture_size;
         data.color = color;
         vtx_builder.AppendVertex(data);
       }
@@ -386,19 +384,17 @@ bool AtlasTextureContents::Render(const ContentContext& renderer,
   VertexBufferBuilder<VS::PerVertexData> vertex_builder;
   vertex_builder.Reserve(texture_coords.size() * 6);
   constexpr size_t indices[6] = {0, 1, 2, 1, 2, 3};
-  constexpr Scalar width[6] = {0, 1, 0, 1, 0, 1};
-  constexpr Scalar height[6] = {0, 0, 1, 0, 1, 1};
   for (size_t i = 0; i < texture_coords.size(); i++) {
     auto sample_rect = texture_coords[i];
     auto matrix = transforms[i];
+    auto points = sample_rect.GetPoints();
     auto transformed_points =
         Rect::MakeSize(sample_rect.GetSize()).GetTransformedPoints(matrix);
 
     for (size_t j = 0; j < 6; j++) {
       VS::PerVertexData data;
       data.position = transformed_points[indices[j]];
-      data.texture_coords =
-          sample_rect.GetRelative(width[j], height[j]) / texture_size;
+      data.texture_coords = points[indices[j]] / texture_size;
       vertex_builder.AppendVertex(data);
     }
   }

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -80,13 +80,13 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
   }
 
   auto texture = renderer.MakeSubpass(
-      label, ISize::Ceil(coverage->size),
+      label, ISize::Ceil(coverage->GetSize()),
       [&contents = *this, &entity, &coverage](const ContentContext& renderer,
                                               RenderPass& pass) -> bool {
         Entity sub_entity;
         sub_entity.SetBlendMode(BlendMode::kSourceOver);
         sub_entity.SetTransform(
-            Matrix::MakeTranslation(Vector3(-coverage->origin)) *
+            Matrix::MakeTranslation(Vector3(-coverage->GetOrigin())) *
             entity.GetTransform());
         return contents.Render(renderer, sub_entity, pass);
       },
@@ -98,7 +98,7 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
 
   auto snapshot = Snapshot{
       .texture = texture,
-      .transform = Matrix::MakeTranslation(coverage->origin),
+      .transform = Matrix::MakeTranslation(coverage->GetOrigin()),
   };
   if (sampler_descriptor.has_value()) {
     snapshot.sampler_descriptor = sampler_descriptor.value();

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -212,9 +212,9 @@ static std::optional<Entity> AdvancedBlend(
     auto blend_uniform = host_buffer.EmplaceUniform(blend_info);
     FS::BindBlendInfo(cmd, blend_uniform);
 
-    frame_info.mvp =
-        Matrix::MakeOrthographic(size) *
-        Matrix::MakeTranslation(coverage.origin - subpass_coverage.origin);
+    frame_info.mvp = Matrix::MakeOrthographic(size) *
+                     Matrix::MakeTranslation(coverage.GetOrigin() -
+                                             subpass_coverage.GetOrigin());
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
@@ -224,7 +224,7 @@ static std::optional<Entity> AdvancedBlend(
   };
 
   auto out_texture = renderer.MakeSubpass(
-      "Advanced Blend Filter", ISize(subpass_coverage.size), callback);
+      "Advanced Blend Filter", ISize(subpass_coverage.GetSize()), callback);
   if (!out_texture) {
     return std::nullopt;
   }
@@ -232,7 +232,7 @@ static std::optional<Entity> AdvancedBlend(
   return Entity::FromSnapshot(
       Snapshot{
           .texture = out_texture,
-          .transform = Matrix::MakeTranslation(subpass_coverage.origin),
+          .transform = Matrix::MakeTranslation(subpass_coverage.GetOrigin()),
           // Since we absorbed the transform of the inputs and used the
           // respective snapshot sampling modes when blending, pass on
           // the default NN clamp sampler.
@@ -274,8 +274,8 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
     }
     auto dst_uvs = maybe_dst_uvs.value();
 
-    auto size = coverage.size;
-    auto origin = coverage.origin;
+    auto size = coverage.GetSize();
+    auto origin = coverage.GetOrigin();
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
         {origin, dst_uvs[0], dst_uvs[0]},
@@ -444,8 +444,8 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
     }
     auto dst_uvs = maybe_dst_uvs.value();
 
-    auto size = coverage.size;
-    auto origin = coverage.origin;
+    auto size = coverage.GetSize();
+    auto origin = coverage.GetOrigin();
     auto color = foreground_color.Premultiply();
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     vtx_builder.AddVertices({
@@ -587,7 +587,7 @@ static std::optional<Entity> PipelineBlend(
 
       VS::FrameInfo frame_info;
       frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                       Matrix::MakeTranslation(-subpass_coverage.origin) *
+                       Matrix::MakeTranslation(-subpass_coverage.GetOrigin()) *
                        input->transform;
       frame_info.texture_sampler_y_coord_scale =
           input->texture->GetYCoordScale();
@@ -647,7 +647,7 @@ static std::optional<Entity> PipelineBlend(
   };
 
   auto out_texture = renderer.MakeSubpass(
-      "Pipeline Blend Filter", ISize(subpass_coverage.size), callback);
+      "Pipeline Blend Filter", ISize(subpass_coverage.GetSize()), callback);
 
   if (!out_texture) {
     return std::nullopt;
@@ -656,7 +656,7 @@ static std::optional<Entity> PipelineBlend(
   return Entity::FromSnapshot(
       Snapshot{
           .texture = out_texture,
-          .transform = Matrix::MakeTranslation(subpass_coverage.origin),
+          .transform = Matrix::MakeTranslation(subpass_coverage.GetOrigin()),
           // Since we absorbed the transform of the inputs and used the
           // respective snapshot sampling modes when blending, pass on
           // the default NN clamp sampler.

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -93,15 +93,13 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     auto& host_buffer = pass.GetTransientsBuffer();
 
     VertexBufferBuilder<VS::PerVertexData> vtx_builder;
+    auto origin = coverage.GetOrigin();
+    auto size = coverage.GetSize();
     vtx_builder.AddVertices({
-        {coverage.origin, input_uvs[0]},
-        {{coverage.origin.x + coverage.size.width, coverage.origin.y},
-         input_uvs[1]},
-        {{coverage.origin.x, coverage.origin.y + coverage.size.height},
-         input_uvs[2]},
-        {{coverage.origin.x + coverage.size.width,
-          coverage.origin.y + coverage.size.height},
-         input_uvs[3]},
+        {origin, input_uvs[0]},
+        {{origin.x + size.width, origin.y}, input_uvs[1]},
+        {{origin.x, origin.y + size.height}, input_uvs[2]},
+        {{origin.x + size.width, origin.y + size.height}, input_uvs[3]},
     });
 
     Command cmd;

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -138,7 +138,7 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
   };
 
   auto out_texture = renderer.MakeSubpass("Directional Morphology Filter",
-                                          ISize(coverage.size), callback);
+                                          ISize(coverage.GetSize()), callback);
   if (!out_texture) {
     return std::nullopt;
   }
@@ -149,7 +149,7 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
 
   return Entity::FromSnapshot(
       Snapshot{.texture = out_texture,
-               .transform = Matrix::MakeTranslation(coverage.origin),
+               .transform = Matrix::MakeTranslation(coverage.GetOrigin()),
                .sampler_descriptor = sampler_desc,
                .opacity = input_snapshot->opacity},
       entity.GetBlendMode(), entity.GetClipDepth());
@@ -171,8 +171,8 @@ std::optional<Rect> DirectionalMorphologyFilterContents::GetFilterCoverage(
   auto transformed_vector =
       transform.TransformDirection(direction_ * radius_.radius).Abs();
 
-  auto origin = coverage->origin;
-  auto size = Vector2(coverage->size);
+  auto origin = coverage->GetOrigin();
+  auto size = Vector2(coverage->GetSize());
   switch (morph_type_) {
     case FilterContents::MorphType::kDilate:
       origin -= transformed_vector;

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -58,7 +58,7 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
   }
   Rect src_coverage = coverage.value();
 
-  auto size = src_coverage.size;
+  auto size = src_coverage.GetSize();
   VertexBufferBuilder<VS::PerVertexData> vtx_builder;
   vtx_builder.AddVertices({
       {Point(0, 0), Point(0, 0)},

--- a/impeller/entity/contents/scene_contents.cc
+++ b/impeller/entity/contents/scene_contents.cc
@@ -47,10 +47,10 @@ bool SceneContents::Render(const ContentContext& renderer,
   RenderTarget subpass_target;
   if (renderer.GetContext()->GetCapabilities()->SupportsOffscreenMSAA()) {
     subpass_target = RenderTarget::CreateOffscreenMSAA(
-        *renderer.GetContext(),            // context
-        *renderer.GetRenderTargetCache(),  // allocator
-        ISize(coverage.value().size),      // size
-        "SceneContents",                   // label
+        *renderer.GetContext(),             // context
+        *renderer.GetRenderTargetCache(),   // allocator
+        ISize(coverage.value().GetSize()),  // size
+        "SceneContents",                    // label
         RenderTarget::AttachmentConfigMSAA{
             .storage_mode = StorageMode::kDeviceTransient,
             .resolve_storage_mode = StorageMode::kDevicePrivate,
@@ -65,10 +65,10 @@ bool SceneContents::Render(const ContentContext& renderer,
     );
   } else {
     subpass_target = RenderTarget::CreateOffscreen(
-        *renderer.GetContext(),            // context
-        *renderer.GetRenderTargetCache(),  // allocator
-        ISize(coverage.value().size),      // size
-        "SceneContents",                   // label
+        *renderer.GetContext(),             // context
+        *renderer.GetRenderTargetCache(),   // allocator
+        ISize(coverage.value().GetSize()),  // size
+        "SceneContents",                    // label
         RenderTarget::AttachmentConfig{
             .storage_mode = StorageMode::kDevicePrivate,
             .load_action = LoadAction::kClear,

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -83,8 +83,8 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
   {
     auto left = -blur_radius;
     auto top = -blur_radius;
-    auto right = positive_rect.size.width + blur_radius;
-    auto bottom = positive_rect.size.height + blur_radius;
+    auto right = positive_rect.GetWidth() + blur_radius;
+    auto bottom = positive_rect.GetHeight() + blur_radius;
 
     vtx_builder.AddVertices({
         {Point(left, top)},
@@ -111,16 +111,16 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
   VS::FrameInfo frame_info;
   frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
                    entity.GetTransform() *
-                   Matrix::MakeTranslation({positive_rect.origin});
+                   Matrix::MakeTranslation(positive_rect.GetOrigin());
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
   FS::FragInfo frag_info;
   frag_info.color = color;
   frag_info.blur_sigma = blur_sigma;
-  frag_info.rect_size = Point(positive_rect.size);
+  frag_info.rect_size = Point(positive_rect.GetSize());
   frag_info.corner_radius =
-      std::min(corner_radius_, std::min(positive_rect.size.width / 2.0f,
-                                        positive_rect.size.height / 2.0f));
+      std::min(corner_radius_, std::min(positive_rect.GetWidth() / 2.0f,
+                                        positive_rect.GetHeight() / 2.0f));
   FS::BindFragInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frag_info));
 
   if (!pass.AddCommand(std::move(cmd))) {

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -195,13 +195,8 @@ bool TextContents::Render(const ContentContext& renderer,
               continue;
             }
             const Rect& atlas_glyph_bounds = maybe_atlas_glyph_bounds.value();
-            vtx.atlas_glyph_bounds = Vector4(
-                atlas_glyph_bounds.origin.x, atlas_glyph_bounds.origin.y,
-                atlas_glyph_bounds.size.width, atlas_glyph_bounds.size.height);
-            vtx.glyph_bounds = Vector4(glyph_position.glyph.bounds.origin.x,
-                                       glyph_position.glyph.bounds.origin.y,
-                                       glyph_position.glyph.bounds.size.width,
-                                       glyph_position.glyph.bounds.size.height);
+            vtx.atlas_glyph_bounds = Vector4(atlas_glyph_bounds.GetXYWH());
+            vtx.glyph_bounds = Vector4(glyph_position.glyph.bounds.GetXYWH());
             vtx.glyph_position = glyph_position.position;
 
             for (const Point& point : unit_points) {

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -87,11 +87,11 @@ std::optional<Snapshot> TextureContents::RenderToSnapshot(
   auto opacity = GetOpacity();
   if (source_rect_ == Rect::MakeSize(texture_->GetSize()) &&
       (opacity >= 1 - kEhCloseEnough || defer_applying_opacity_)) {
-    auto scale = Vector2(bounds.size / Size(texture_->GetSize()));
+    auto scale = Vector2(bounds.GetSize() / Size(texture_->GetSize()));
     return Snapshot{
         .texture = texture_,
         .transform = entity.GetTransform() *
-                     Matrix::MakeTranslation(bounds.origin) *
+                     Matrix::MakeTranslation(bounds.GetOrigin()) *
                      Matrix::MakeScale(scale),
         .sampler_descriptor = sampler_descriptor.value_or(sampler_descriptor_),
         .opacity = opacity};
@@ -114,7 +114,7 @@ bool TextureContents::Render(const ContentContext& renderer,
   using FS = TextureFillFragmentShader;
   using FSExternal = TextureFillExternalFragmentShader;
 
-  if (destination_rect_.size.IsEmpty() || source_rect_.IsEmpty() ||
+  if (destination_rect_.IsEmpty() || source_rect_.IsEmpty() ||
       texture_ == nullptr || texture_->GetSize().IsEmpty()) {
     return true;  // Nothing to render.
   }

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -247,11 +247,11 @@ std::optional<Snapshot> TiledTextureContents::RenderToSnapshot(
     if (!coverage.has_value()) {
       return std::nullopt;
     }
-    auto scale = Vector2(coverage->size / Size(texture_->GetSize()));
+    auto scale = Vector2(coverage->GetSize() / Size(texture_->GetSize()));
 
     return Snapshot{
         .texture = texture_,
-        .transform = Matrix::MakeTranslation(coverage->origin) *
+        .transform = Matrix::MakeTranslation(coverage->GetOrigin()) *
                      Matrix::MakeScale(scale),
         .sampler_descriptor = sampler_descriptor.value_or(sampler_descriptor_),
         .opacity = GetOpacityFactor(),

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -593,7 +593,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
 
     subpass_coverage = Rect::RoundOut(subpass_coverage.value());
 
-    auto subpass_size = ISize(subpass_coverage->size);
+    auto subpass_size = ISize(subpass_coverage->GetSize());
     if (subpass_size.IsEmpty()) {
       capture.CreateChild("Subpass Entity (Skipped: Empty subpass coverage B)");
       return EntityPass::EntityResult::Skip();
@@ -623,12 +623,12 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     // Stencil textures aren't shared between EntityPasses (as much of the
     // time they are transient).
     if (!subpass->OnRender(
-            renderer,                  // renderer
-            subpass_capture,           // capture
-            root_pass_size,            // root_pass_size
-            subpass_target,            // pass_target
-            subpass_coverage->origin,  // global_pass_position
-            subpass_coverage->origin -
+            renderer,                       // renderer
+            subpass_capture,                // capture
+            root_pass_size,                 // root_pass_size
+            subpass_target,                 // pass_target
+            subpass_coverage->GetOrigin(),  // global_pass_position
+            subpass_coverage->GetOrigin() -
                 global_pass_position,         // local_pass_position
             ++pass_depth,                     // pass_depth
             subpass_clip_coverage_stack,      // clip_coverage_stack
@@ -669,8 +669,9 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     element_entity.SetClipDepth(subpass->clip_depth_);
     element_entity.SetBlendMode(subpass->blend_mode_);
     element_entity.SetTransform(subpass_texture_capture.AddMatrix(
-        "Transform", Matrix::MakeTranslation(Vector3(subpass_coverage->origin -
-                                                     global_pass_position))));
+        "Transform",
+        Matrix::MakeTranslation(
+            Vector3(subpass_coverage->GetOrigin() - global_pass_position))));
 
     return EntityPass::EntityResult::Success(std::move(element_entity));
   }
@@ -727,7 +728,7 @@ bool EntityPass::RenderElement(Entity& element_entity,
   if (current_clip_coverage.has_value()) {
     // Entity transforms are relative to the current pass position, so we need
     // to check clip coverage in the same space.
-    current_clip_coverage->origin -= global_pass_position;
+    current_clip_coverage->Shift(-global_pass_position);
   }
 
   if (!element_entity.ShouldRender(current_clip_coverage)) {
@@ -736,7 +737,7 @@ bool EntityPass::RenderElement(Entity& element_entity,
 
   auto clip_coverage = element_entity.GetClipCoverage(current_clip_coverage);
   if (clip_coverage.coverage.has_value()) {
-    clip_coverage.coverage->origin += global_pass_position;
+    clip_coverage.coverage->Shift(global_pass_position);
   }
 
   // The coverage hint tells the rendered Contents which portion of the
@@ -784,7 +785,7 @@ bool EntityPass::RenderElement(Entity& element_entity,
               : std::nullopt;
       if (restore_coverage.has_value()) {
         // Make the coverage rectangle relative to the current pass.
-        restore_coverage->origin -= global_pass_position;
+        restore_coverage->Shift(-global_pass_position);
       }
       clip_coverage_stack.resize(restoration_index + 1);
 
@@ -804,7 +805,7 @@ bool EntityPass::RenderElement(Entity& element_entity,
   {
     auto element_entity_coverage = element_entity.GetCoverage();
     if (element_entity_coverage.has_value()) {
-      element_entity_coverage->origin += global_pass_position;
+      element_entity_coverage->Shift(global_pass_position);
       element_entity.GetCapture().AddRect("Coverage", *element_entity_coverage,
                                           {.readonly = true});
     }

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -728,7 +728,7 @@ bool EntityPass::RenderElement(Entity& element_entity,
   if (current_clip_coverage.has_value()) {
     // Entity transforms are relative to the current pass position, so we need
     // to check clip coverage in the same space.
-    current_clip_coverage->Shift(-global_pass_position);
+    current_clip_coverage = current_clip_coverage->Shift(-global_pass_position);
   }
 
   if (!element_entity.ShouldRender(current_clip_coverage)) {
@@ -737,7 +737,8 @@ bool EntityPass::RenderElement(Entity& element_entity,
 
   auto clip_coverage = element_entity.GetClipCoverage(current_clip_coverage);
   if (clip_coverage.coverage.has_value()) {
-    clip_coverage.coverage->Shift(global_pass_position);
+    clip_coverage.coverage =
+        clip_coverage.coverage->Shift(global_pass_position);
   }
 
   // The coverage hint tells the rendered Contents which portion of the
@@ -785,7 +786,7 @@ bool EntityPass::RenderElement(Entity& element_entity,
               : std::nullopt;
       if (restore_coverage.has_value()) {
         // Make the coverage rectangle relative to the current pass.
-        restore_coverage->Shift(-global_pass_position);
+        restore_coverage = restore_coverage->Shift(-global_pass_position);
       }
       clip_coverage_stack.resize(restoration_index + 1);
 
@@ -805,7 +806,8 @@ bool EntityPass::RenderElement(Entity& element_entity,
   {
     auto element_entity_coverage = element_entity.GetCoverage();
     if (element_entity_coverage.has_value()) {
-      element_entity_coverage->Shift(global_pass_position);
+      element_entity_coverage =
+          element_entity_coverage->Shift(global_pass_position);
       element_entity.GetCapture().AddRect("Coverage", *element_entity_coverage,
                                           {.readonly = true});
     }

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1073,7 +1073,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
       texture->SetOpacity(input_color.alpha);
 
       input = texture;
-      input_size = input_rect.size;
+      input_size = input_rect.GetSize();
     } else {
       auto fill = std::make_shared<SolidColorContents>();
       fill->SetColor(input_color);
@@ -1081,7 +1081,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
           Geometry::MakeFillPath(PathBuilder{}.AddRect(input_rect).TakePath()));
 
       input = fill;
-      input_size = input_rect.size;
+      input_size = input_rect.GetSize();
     }
 
     std::shared_ptr<FilterContents> blur;
@@ -1211,7 +1211,7 @@ TEST_P(EntityTest, MorphologyFilter) {
     texture->SetOpacity(input_color.alpha);
 
     input = texture;
-    input_size = input_rect.size;
+    input_size = input_rect.GetSize();
 
     auto contents = FilterContents::MakeMorphology(
         FilterInput::Make(input), Radius{radius[0]}, Radius{radius[1]},

--- a/impeller/entity/geometry/point_field_geometry.cc
+++ b/impeller/entity/geometry/point_field_geometry.cc
@@ -51,8 +51,9 @@ GeometryResult PointFieldGeometry::GetPositionUVBuffer(
   if (!vtx_builder.has_value()) {
     return {};
   }
-  auto uv_vtx_builder = ComputeUVGeometryCPU(
-      vtx_builder.value(), {0, 0}, texture_coverage.size, effect_transform);
+  auto uv_vtx_builder =
+      ComputeUVGeometryCPU(vtx_builder.value(), {0, 0},
+                           texture_coverage.GetSize(), effect_transform);
 
   auto& host_buffer = pass.GetTransientsBuffer();
   return {
@@ -213,7 +214,7 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
     frame_info.count = total;
     frame_info.effect_transform = effect_transform.value();
     frame_info.texture_origin = {0, 0};
-    frame_info.texture_size = Vector2(texture_coverage.value().size);
+    frame_info.texture_size = Vector2(texture_coverage.value().GetSize());
 
     UV::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
     UV::BindGeometryData(cmd, geometry_buffer);

--- a/impeller/entity/geometry/round_rect_geometry.cc
+++ b/impeller/entity/geometry/round_rect_geometry.cc
@@ -50,8 +50,8 @@ bool RoundRectGeometry::CoversArea(const Matrix& transform,
   if (!transform.IsTranslationScaleOnly()) {
     return false;
   }
-  bool flat_on_tb = bounds_.GetSize().width > radii_.width * 2;
-  bool flat_on_lr = bounds_.GetSize().height > radii_.height * 2;
+  bool flat_on_tb = bounds_.GetWidth() > radii_.width * 2;
+  bool flat_on_lr = bounds_.GetHeight() > radii_.height * 2;
   if (!flat_on_tb && !flat_on_lr) {
     return false;
   }

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -489,7 +489,7 @@ GeometryResult StrokePathGeometry::GetPositionUVBuffer(
       GetJoinProc(stroke_join_), GetCapProc(stroke_cap_),
       entity.GetTransform().GetMaxBasisLength());
   auto vertex_builder = ComputeUVGeometryCPU(
-      stroke_builder, {0, 0}, texture_coverage.size, effect_transform);
+      stroke_builder, {0, 0}, texture_coverage.GetSize(), effect_transform);
 
   return GeometryResult{
       .type = PrimitiveType::kTriangleStrip,

--- a/impeller/geometry/geometry_asserts.h
+++ b/impeller/geometry/geometry_asserts.h
@@ -54,10 +54,10 @@ inline ::testing::AssertionResult QuaternionNear(impeller::Quaternion a,
 }
 
 inline ::testing::AssertionResult RectNear(impeller::Rect a, impeller::Rect b) {
-  auto equal = NumberNear(a.GetOrigin().x, b.GetOrigin().x) &&
-               NumberNear(a.GetOrigin().y, b.GetOrigin().y) &&
-               NumberNear(a.GetSize().width, b.GetSize().width) &&
-               NumberNear(a.GetSize().height, b.GetSize().height);
+  auto equal = NumberNear(a.GetX(), b.GetX()) &&
+               NumberNear(a.GetY(), b.GetY()) &&
+               NumberNear(a.GetWidth(), b.GetWidth()) &&
+               NumberNear(a.GetHeight(), b.GetHeight());
 
   return equal ? ::testing::AssertionSuccess()
                : ::testing::AssertionFailure()

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -630,6 +630,10 @@ TEST(GeometryTest, CanConvertTTypesExplicitly) {
     ASSERT_EQ(r2.GetOrigin().y, 2u);
     ASSERT_EQ(r2.GetSize().width, 3u);
     ASSERT_EQ(r2.GetSize().height, 4u);
+    ASSERT_EQ(r2.GetX(), 1u);
+    ASSERT_EQ(r2.GetY(), 2u);
+    ASSERT_EQ(r2.GetWidth(), 3u);
+    ASSERT_EQ(r2.GetHeight(), 4u);
   }
 }
 

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -82,62 +82,66 @@ struct TRect {
         size(static_cast<T>(other.GetWidth()),
              static_cast<T>(other.GetHeight())) {}
 
-  constexpr TRect operator+(const TRect& r) const {
+  [[nodiscard]] constexpr TRect operator+(const TRect& r) const {
     return TRect({origin.x + r.origin.x, origin.y + r.origin.y},
                  {size.width + r.size.width, size.height + r.size.height});
   }
 
-  constexpr TRect operator-(const TRect& r) const {
+  [[nodiscard]] constexpr TRect operator-(const TRect& r) const {
     return TRect({origin.x - r.origin.x, origin.y - r.origin.y},
                  {size.width - r.size.width, size.height - r.size.height});
   }
 
-  constexpr TRect operator*(Type scale) const { return Scale(scale); }
+  [[nodiscard]] constexpr TRect operator*(Type scale) const {
+    return Scale(scale);
+  }
 
-  constexpr TRect operator*(const TRect& r) const {
+  [[nodiscard]] constexpr TRect operator*(const TRect& r) const {
     return TRect({origin.x * r.origin.x, origin.y * r.origin.y},
                  {size.width * r.size.width, size.height * r.size.height});
   }
 
-  constexpr bool operator==(const TRect& r) const {
+  [[nodiscard]] constexpr bool operator==(const TRect& r) const {
     return origin == r.origin && size == r.size;
   }
 
-  constexpr TRect Scale(Type scale) const {
+  [[nodiscard]] constexpr TRect Scale(Type scale) const {
     return TRect({origin.x * scale, origin.y * scale},
                  {size.width * scale, size.height * scale});
   }
 
-  constexpr TRect Scale(Type scale_x, Type scale_y) const {
+  [[nodiscard]] constexpr TRect Scale(Type scale_x, Type scale_y) const {
     return TRect({origin.x * scale_x, origin.y * scale_y},
                  {size.width * scale_x, size.height * scale_y});
   }
 
-  constexpr TRect Scale(TPoint<T> scale) const {
+  [[nodiscard]] constexpr TRect Scale(TPoint<T> scale) const {
     return TRect({origin.x * scale.x, origin.y * scale.y},
                  {size.width * scale.x, size.height * scale.y});
   }
 
-  constexpr TRect Scale(TSize<T> scale) const {
+  [[nodiscard]] constexpr TRect Scale(TSize<T> scale) const {
     return Scale(TPoint<T>(scale));
   }
 
-  constexpr bool Contains(const TPoint<Type>& p) const {
+  [[nodiscard]] constexpr bool Contains(const TPoint<Type>& p) const {
     return p.x >= GetLeft() && p.x < GetRight() && p.y >= GetTop() &&
            p.y < GetBottom();
   }
 
-  constexpr bool Contains(const TRect& o) const {
+  [[nodiscard]] constexpr bool Contains(const TRect& o) const {
     return Union(o).size == size;
   }
 
   /// Returns true if either of the width or height are 0, negative, or NaN.
-  constexpr bool IsEmpty() const { return size.IsEmpty(); }
+  [[nodiscard]] constexpr bool IsEmpty() const { return size.IsEmpty(); }
 
   /// Returns true if width and height are equal and neither is NaN.
-  constexpr bool IsSquare() const { return size.IsSquare(); }
+  [[nodiscard]] constexpr bool IsSquare() const { return size.IsSquare(); }
 
-  constexpr bool IsMaximum() const { return *this == MakeMaximum(); }
+  [[nodiscard]] constexpr bool IsMaximum() const {
+    return *this == MakeMaximum();
+  }
 
   /// @brief Returns the upper left corner of the rectangle as specified
   ///        when it was constructed.
@@ -146,100 +150,106 @@ struct TRect {
   ///        methods which will return values as if the rectangle had been
   ///        "unswapped" by calling |GetPositive| on it, this method
   ///        returns the raw origin values.
-  constexpr TPoint<Type> GetOrigin() const { return origin; }
+  [[nodiscard]] constexpr TPoint<Type> GetOrigin() const { return origin; }
 
   /// @brief Returns the size of the rectangle as specified when it was
   ///        constructed and which may be negative in either width or
   ///        height.
-  constexpr TSize<Type> GetSize() const { return size; }
+  [[nodiscard]] constexpr TSize<Type> GetSize() const { return size; }
 
   /// @brief Returns the X coordinate of the upper left corner, equivalent
   ///        to |GetOrigin().x|
-  constexpr Type GetX() const { return origin.x; }
+  [[nodiscard]] constexpr Type GetX() const { return origin.x; }
 
   /// @brief Returns the Y coordinate of the upper left corner, equivalent
   ///        to |GetOrigin().y|
-  constexpr Type GetY() const { return origin.y; }
+  [[nodiscard]] constexpr Type GetY() const { return origin.y; }
 
   /// @brief Returns the width of the rectangle, equivalent to
   ///        |GetSize().width|
-  constexpr Type GetWidth() const { return size.width; }
+  [[nodiscard]] constexpr Type GetWidth() const { return size.width; }
 
   /// @brief Returns the height of the rectangle, equivalent to
   ///        |GetSize().height|
-  constexpr Type GetHeight() const { return size.height; }
+  [[nodiscard]] constexpr Type GetHeight() const { return size.height; }
 
-  constexpr auto GetLeft() const {
+  [[nodiscard]] constexpr auto GetLeft() const {
     if (IsMaximum()) {
       return -std::numeric_limits<Type>::infinity();
     }
     return std::min(origin.x, origin.x + size.width);
   }
 
-  constexpr auto GetTop() const {
+  [[nodiscard]] constexpr auto GetTop() const {
     if (IsMaximum()) {
       return -std::numeric_limits<Type>::infinity();
     }
     return std::min(origin.y, origin.y + size.height);
   }
 
-  constexpr auto GetRight() const {
+  [[nodiscard]] constexpr auto GetRight() const {
     if (IsMaximum()) {
       return std::numeric_limits<Type>::infinity();
     }
     return std::max(origin.x, origin.x + size.width);
   }
 
-  constexpr auto GetBottom() const {
+  [[nodiscard]] constexpr auto GetBottom() const {
     if (IsMaximum()) {
       return std::numeric_limits<Type>::infinity();
     }
     return std::max(origin.y, origin.y + size.height);
   }
 
-  constexpr TPoint<T> GetLeftTop() const { return {GetLeft(), GetTop()}; }
+  [[nodiscard]] constexpr TPoint<T> GetLeftTop() const {
+    return {GetLeft(), GetTop()};
+  }
 
-  constexpr TPoint<T> GetRightTop() const { return {GetRight(), GetTop()}; }
+  [[nodiscard]] constexpr TPoint<T> GetRightTop() const {
+    return {GetRight(), GetTop()};
+  }
 
-  constexpr TPoint<T> GetLeftBottom() const { return {GetLeft(), GetBottom()}; }
+  [[nodiscard]] constexpr TPoint<T> GetLeftBottom() const {
+    return {GetLeft(), GetBottom()};
+  }
 
-  constexpr TPoint<T> GetRightBottom() const {
+  [[nodiscard]] constexpr TPoint<T> GetRightBottom() const {
     return {GetRight(), GetBottom()};
   }
 
   /// @brief  Get the area of the rectangle, equivalent to |GetSize().Area()|
-  constexpr T Area() const { return size.Area(); }
+  [[nodiscard]] constexpr T Area() const { return size.Area(); }
 
   /// @brief  Get the center point as a |Point|.
-  constexpr Point GetCenter() const {
+  [[nodiscard]] constexpr Point GetCenter() const {
     return Point(origin.x + size.width * 0.5f, origin.y + size.height * 0.5f);
   }
 
-  constexpr std::array<T, 4> GetLTRB() const {
+  [[nodiscard]] constexpr std::array<T, 4> GetLTRB() const {
     return {GetLeft(), GetTop(), GetRight(), GetBottom()};
   }
 
   /// @brief  Get the x, y coordinates of the origin and the width and
   ///         height of the rectangle in an array.
-  constexpr std::array<T, 4> GetXYWH() const {
+  [[nodiscard]] constexpr std::array<T, 4> GetXYWH() const {
     return {origin.x, origin.y, size.width, size.height};
   }
 
   /// @brief  Get a version of this rectangle that has a non-negative size.
-  constexpr TRect GetPositive() const {
+  [[nodiscard]] constexpr TRect GetPositive() const {
     auto ltrb = GetLTRB();
     return MakeLTRB(ltrb[0], ltrb[1], ltrb[2], ltrb[3]);
   }
 
-  /// @brief  Get the points that represent the 4 corners of this rectangle. The
-  ///         order is: Top left, top right, bottom left, bottom right.
-  constexpr std::array<TPoint<T>, 4> GetPoints() const {
+  /// @brief  Get the points that represent the 4 corners of this rectangle.
+  ///         The order is: Top left, top right, bottom left, bottom right.
+  [[nodiscard]] constexpr std::array<TPoint<T>, 4> GetPoints() const {
     auto [left, top, right, bottom] = GetLTRB();
     return {TPoint(left, top), TPoint(right, top), TPoint(left, bottom),
             TPoint(right, bottom)};
   }
 
-  constexpr std::array<TPoint<T>, 4> GetTransformedPoints(
+  [[nodiscard]] constexpr std::array<TPoint<T>, 4> GetTransformedPoints(
       const Matrix& transform) const {
     auto points = GetPoints();
     for (size_t i = 0; i < points.size(); i++) {
@@ -250,7 +260,7 @@ struct TRect {
 
   /// @brief  Creates a new bounding box that contains this transformed
   ///         rectangle.
-  constexpr TRect TransformBounds(const Matrix& transform) const {
+  [[nodiscard]] constexpr TRect TransformBounds(const Matrix& transform) const {
     auto points = GetTransformedPoints(transform);
     auto bounds = TRect::MakePointBounds(points.begin(), points.end());
     if (bounds.has_value()) {
@@ -266,7 +276,7 @@ struct TRect {
   ///
   ///         Empty and non-finite rectangles will return a zero-scaling
   ///         transform that maps all points to (0, 0).
-  constexpr Matrix GetNormalizingTransform() const {
+  [[nodiscard]] constexpr Matrix GetNormalizingTransform() const {
     if (!IsEmpty()) {
       Scalar sx = 1.0 / size.width;
       Scalar sy = 1.0 / size.height;
@@ -288,7 +298,7 @@ struct TRect {
     return Matrix::MakeScale({0.0f, 0.0f, 1.0f});
   }
 
-  constexpr TRect Union(const TRect& o) const {
+  [[nodiscard]] constexpr TRect Union(const TRect& o) const {
     auto this_ltrb = GetLTRB();
     auto other_ltrb = o.GetLTRB();
     return TRect::MakeLTRB(std::min(this_ltrb[0], other_ltrb[0]),  //
@@ -298,7 +308,8 @@ struct TRect {
     );
   }
 
-  constexpr std::optional<TRect<T>> Intersection(const TRect& o) const {
+  [[nodiscard]] constexpr std::optional<TRect<T>> Intersection(
+      const TRect& o) const {
     auto this_ltrb = GetLTRB();
     auto other_ltrb = o.GetLTRB();
     auto intersection =
@@ -313,13 +324,13 @@ struct TRect {
     return intersection;
   }
 
-  constexpr bool IntersectsWithRect(const TRect& o) const {
+  [[nodiscard]] constexpr bool IntersectsWithRect(const TRect& o) const {
     return Intersection(o).has_value();
   }
 
   /// @brief Returns the new boundary rectangle that would result from the
   ///        rectangle being cutout by a second rectangle.
-  constexpr std::optional<TRect<T>> Cutout(const TRect& o) const {
+  [[nodiscard]] constexpr std::optional<TRect<T>> Cutout(const TRect& o) const {
     const auto& [a_left, a_top, a_right, a_bottom] = GetLTRB();  // Source rect.
     const auto& [b_left, b_top, b_right, b_bottom] = o.GetLTRB();  // Cutout.
     if (b_left <= a_left && b_right >= a_right) {
@@ -351,14 +362,17 @@ struct TRect {
   }
 
   /// @brief  Returns a new rectangle translated by the given offset.
-  constexpr TRect<T> Shift(TPoint<T> offset) const {
+  [[nodiscard]] constexpr TRect<T> Shift(TPoint<T> offset) const {
     return TRect(origin.x + offset.x, origin.y + offset.y, size.width,
                  size.height);
   }
 
   /// @brief  Returns a rectangle with expanded edges. Negative expansion
   ///         results in shrinking.
-  constexpr TRect<T> Expand(T left, T top, T right, T bottom) const {
+  [[nodiscard]] constexpr TRect<T> Expand(T left,
+                                          T top,
+                                          T right,
+                                          T bottom) const {
     return TRect(origin.x - left,            //
                  origin.y - top,             //
                  size.width + left + right,  //
@@ -367,7 +381,7 @@ struct TRect {
 
   /// @brief  Returns a rectangle with expanded edges in all directions.
   ///         Negative expansion results in shrinking.
-  constexpr TRect<T> Expand(T amount) const {
+  [[nodiscard]] constexpr TRect<T> Expand(T amount) const {
     return TRect(origin.x - amount,        //
                  origin.y - amount,        //
                  size.width + amount * 2,  //
@@ -376,7 +390,8 @@ struct TRect {
 
   /// @brief  Returns a rectangle with expanded edges in all directions.
   ///         Negative expansion results in shrinking.
-  constexpr TRect<T> Expand(T horizontal_amount, T vertical_amount) const {
+  [[nodiscard]] constexpr TRect<T> Expand(T horizontal_amount,
+                                          T vertical_amount) const {
     return TRect(origin.x - horizontal_amount,        //
                  origin.y - vertical_amount,          //
                  size.width + horizontal_amount * 2,  //
@@ -385,7 +400,7 @@ struct TRect {
 
   /// @brief  Returns a rectangle with expanded edges in all directions.
   ///         Negative expansion results in shrinking.
-  constexpr TRect<T> Expand(TPoint<T> amount) const {
+  [[nodiscard]] constexpr TRect<T> Expand(TPoint<T> amount) const {
     return TRect(origin.x - amount.x,        //
                  origin.y - amount.y,        //
                  size.width + amount.x * 2,  //
@@ -394,7 +409,7 @@ struct TRect {
 
   /// @brief  Returns a rectangle with expanded edges in all directions.
   ///         Negative expansion results in shrinking.
-  constexpr TRect<T> Expand(TSize<T> amount) const {
+  [[nodiscard]] constexpr TRect<T> Expand(TSize<T> amount) const {
     return TRect(origin.x - amount.width,        //
                  origin.y - amount.height,       //
                  size.width + amount.width * 2,  //
@@ -405,45 +420,48 @@ struct TRect {
   ///         source rectangle onto this rectangle. In other words, the source
   ///         rectangle is redefined in terms of the corrdinate space of this
   ///         rectangle.
-  constexpr TRect<T> Project(TRect<T> source) const {
+  [[nodiscard]] constexpr TRect<T> Project(TRect<T> source) const {
     return source.Shift(-origin).Scale(
         TSize<T>(1.0 / static_cast<Scalar>(size.width),
                  1.0 / static_cast<Scalar>(size.height)));
   }
 
-  constexpr static TRect RoundOut(const TRect& r) {
+  [[nodiscard]] constexpr static TRect RoundOut(const TRect& r) {
     return TRect::MakeLTRB(floor(r.GetLeft()), floor(r.GetTop()),
                            ceil(r.GetRight()), ceil(r.GetBottom()));
   }
 
-  constexpr static std::optional<TRect> Union(const TRect& a,
-                                              const std::optional<TRect> b) {
+  [[nodiscard]] constexpr static std::optional<TRect> Union(
+      const TRect& a,
+      const std::optional<TRect> b) {
     return b.has_value() ? a.Union(b.value()) : a;
   }
 
-  constexpr static std::optional<TRect> Union(const std::optional<TRect> a,
-                                              const TRect& b) {
+  [[nodiscard]] constexpr static std::optional<TRect> Union(
+      const std::optional<TRect> a,
+      const TRect& b) {
     return Union(b, a);
   }
 
-  constexpr static std::optional<TRect> Union(const std::optional<TRect> a,
-                                              const std::optional<TRect> b) {
+  [[nodiscard]] constexpr static std::optional<TRect> Union(
+      const std::optional<TRect> a,
+      const std::optional<TRect> b) {
     return a.has_value() ? Union(a.value(), b) : b;
   }
 
-  constexpr static std::optional<TRect> Intersection(
+  [[nodiscard]] constexpr static std::optional<TRect> Intersection(
       const TRect& a,
       const std::optional<TRect> b) {
     return b.has_value() ? a.Intersection(b.value()) : a;
   }
 
-  constexpr static std::optional<TRect> Intersection(
+  [[nodiscard]] constexpr static std::optional<TRect> Intersection(
       const std::optional<TRect> a,
       const TRect& b) {
     return Intersection(b, a);
   }
 
-  constexpr static std::optional<TRect> Intersection(
+  [[nodiscard]] constexpr static std::optional<TRect> Intersection(
       const std::optional<TRect> a,
       const std::optional<TRect> b) {
     return a.has_value() ? Intersection(a.value(), b) : b;

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -215,26 +215,6 @@ struct TRect {
     return Point(origin.x + size.width * 0.5f, origin.y + size.height * 0.5f);
   }
 
-  /// @brief  Get the point related to this rectangle associated with
-  ///         the given fractional values |tx| and |ty| with a fractional
-  ///         value of 0 referring to the left or upper edge of the
-  ///         rectangle and a fractional value of 1 referring to the right
-  ///         or bottom edge of the rectangle.
-  ///
-  ///         GetRelative(0, 0) returns the upper left corner
-  ///         GetRelative(0.5, 0.5) returns the center of the rectangle
-  ///         GetRelative(1, 1) returns the lower right corner
-  constexpr Point GetRelative(Scalar tx, Scalar ty) const {
-    return {origin.x + size.width * tx, origin.y + size.height * ty};
-  }
-
-  /// @brief  Get the pointe related to this rectangle associated with
-  ///         the fractional values in the point |t|, equivalent to
-  ///         |GetRelative(t.x, t.y)|
-  constexpr Point GetRelative(const Point& t) const {
-    return GetRelative(t.x, t.y);
-  }
-
   constexpr std::array<T, 4> GetLTRB() const {
     return {GetLeft(), GetTop(), GetRight(), GetBottom()};
   }

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -11,18 +11,89 @@
 namespace impeller {
 namespace testing {
 
-TEST(RectTest, RectOriginSizeGetters) {
+TEST(RectTest, RectOriginSizeXYWHGetters) {
   {
     Rect r = Rect::MakeOriginSize({10, 20}, {50, 40});
     EXPECT_EQ(r.GetOrigin(), Point(10, 20));
     EXPECT_EQ(r.GetSize(), Size(50, 40));
+    EXPECT_EQ(r.GetX(), 10);
+    EXPECT_EQ(r.GetY(), 20);
+    EXPECT_EQ(r.GetWidth(), 50);
+    EXPECT_EQ(r.GetHeight(), 40);
+    auto expected_array = std::array<Scalar, 4>{10, 20, 50, 40};
+    EXPECT_EQ(r.GetXYWH(), expected_array);
   }
 
   {
     Rect r = Rect::MakeLTRB(10, 20, 50, 40);
     EXPECT_EQ(r.GetOrigin(), Point(10, 20));
     EXPECT_EQ(r.GetSize(), Size(40, 20));
+    EXPECT_EQ(r.GetX(), 10);
+    EXPECT_EQ(r.GetY(), 20);
+    EXPECT_EQ(r.GetWidth(), 40);
+    EXPECT_EQ(r.GetHeight(), 20);
+    auto expected_array = std::array<Scalar, 4>{10, 20, 40, 20};
+    EXPECT_EQ(r.GetXYWH(), expected_array);
   }
+}
+
+TEST(RectTest, IRectOriginSizeXYWHGetters) {
+  {
+    IRect r = IRect::MakeOriginSize({10, 20}, {50, 40});
+    EXPECT_EQ(r.GetOrigin(), IPoint(10, 20));
+    EXPECT_EQ(r.GetSize(), ISize(50, 40));
+    EXPECT_EQ(r.GetX(), 10);
+    EXPECT_EQ(r.GetY(), 20);
+    EXPECT_EQ(r.GetWidth(), 50);
+    EXPECT_EQ(r.GetHeight(), 40);
+    auto expected_array = std::array<int64_t, 4>{10, 20, 50, 40};
+    EXPECT_EQ(r.GetXYWH(), expected_array);
+  }
+
+  {
+    IRect r = IRect::MakeLTRB(10, 20, 50, 40);
+    EXPECT_EQ(r.GetOrigin(), IPoint(10, 20));
+    EXPECT_EQ(r.GetSize(), ISize(40, 20));
+    EXPECT_EQ(r.GetX(), 10);
+    EXPECT_EQ(r.GetY(), 20);
+    EXPECT_EQ(r.GetWidth(), 40);
+    EXPECT_EQ(r.GetHeight(), 20);
+    auto expected_array = std::array<int64_t, 4>{10, 20, 40, 20};
+    EXPECT_EQ(r.GetXYWH(), expected_array);
+  }
+}
+
+TEST(RectTest, RectFromRect) {
+  EXPECT_EQ(Rect(Rect::MakeXYWH(2, 3, 7, 15)),
+            Rect::MakeXYWH(2.0, 3.0, 7.0, 15.0));
+  EXPECT_EQ(Rect(Rect::MakeLTRB(2, 3, 7, 15)),
+            Rect::MakeLTRB(2.0, 3.0, 7.0, 15.0));
+}
+
+TEST(RectTest, RectFromIRect) {
+  EXPECT_EQ(Rect(IRect::MakeXYWH(2, 3, 7, 15)),
+            Rect::MakeXYWH(2.0, 3.0, 7.0, 15.0));
+  EXPECT_EQ(Rect(IRect::MakeLTRB(2, 3, 7, 15)),
+            Rect::MakeLTRB(2.0, 3.0, 7.0, 15.0));
+}
+
+TEST(RectTest, IRectFromRect) {
+  EXPECT_EQ(IRect(Rect::MakeXYWH(2, 3, 7, 15)),  //
+            IRect::MakeXYWH(2, 3, 7, 15));
+  EXPECT_EQ(IRect(Rect::MakeLTRB(2, 3, 7, 15)),  //
+            IRect::MakeLTRB(2, 3, 7, 15));
+
+  EXPECT_EQ(IRect(Rect::MakeXYWH(2.5, 3.5, 7.75, 15.75)),
+            IRect::MakeXYWH(2, 3, 7, 15));
+  EXPECT_EQ(IRect(Rect::MakeLTRB(2.5, 3.5, 7.75, 15.75)),
+            IRect::MakeLTRB(2, 3, 7, 15));
+}
+
+TEST(RectTest, IRectFromIRect) {
+  EXPECT_EQ(IRect(IRect::MakeXYWH(2, 3, 7, 15)),  //
+            IRect::MakeXYWH(2, 3, 7, 15));
+  EXPECT_EQ(IRect(IRect::MakeLTRB(2, 3, 7, 15)),  //
+            IRect::MakeLTRB(2, 3, 7, 15));
 }
 
 TEST(RectTest, RectMakeSize) {
@@ -53,6 +124,108 @@ TEST(RectTest, RectMakeSize) {
     IRect expected = IRect::MakeLTRB(0, 0, 100, 200);
     EXPECT_EQ(r, expected);
   }
+}
+
+TEST(RectTest, RectScale) {
+  auto test1 = [](Rect rect, Scalar scale) {
+    Rect expected = Rect::MakeXYWH(rect.GetX() * scale,      //
+                                   rect.GetY() * scale,      //
+                                   rect.GetWidth() * scale,  //
+                                   rect.GetHeight() * scale);
+
+    EXPECT_RECT_NEAR(rect.Scale(scale), expected)  //
+        << rect << " * " << scale;
+    EXPECT_RECT_NEAR(rect.Scale(scale, scale), expected)  //
+        << rect << " * " << scale;
+    EXPECT_RECT_NEAR(rect.Scale(Point(scale, scale)), expected)  //
+        << rect << " * " << scale;
+    EXPECT_RECT_NEAR(rect.Scale(Size(scale, scale)), expected)  //
+        << rect << " * " << scale;
+  };
+
+  auto test2 = [&test1](Rect rect, Scalar scale_x, Scalar scale_y) {
+    Rect expected = Rect::MakeXYWH(rect.GetX() * scale_x,      //
+                                   rect.GetY() * scale_y,      //
+                                   rect.GetWidth() * scale_x,  //
+                                   rect.GetHeight() * scale_y);
+
+    EXPECT_RECT_NEAR(rect.Scale(scale_x, scale_y), expected)  //
+        << rect << " * " << scale_x << ", " << scale_y;
+    EXPECT_RECT_NEAR(rect.Scale(Point(scale_x, scale_y)), expected)  //
+        << rect << " * " << scale_x << ", " << scale_y;
+    EXPECT_RECT_NEAR(rect.Scale(Size(scale_x, scale_y)), expected)  //
+        << rect << " * " << scale_x << ", " << scale_y;
+
+    test1(rect, scale_x);
+    test1(rect, scale_y);
+  };
+
+  test2(Rect::MakeLTRB(10, 15, 100, 150), 2.5, 3.5);
+  test2(Rect::MakeLTRB(10, 15, 100, 150), 3.5, 2.5);
+  test2(Rect::MakeLTRB(10, 15, -100, 150), 2.5, 3.5);
+  test2(Rect::MakeLTRB(10, 15, 100, -150), 2.5, 3.5);
+  test2(Rect::MakeLTRB(10, 15, 100, 150), -2.5, 3.5);
+  test2(Rect::MakeLTRB(10, 15, 100, 150), 2.5, -3.5);
+}
+
+TEST(RectTest, IRectScale) {
+  auto test1 = [](IRect rect, int64_t scale) {
+    IRect expected = IRect::MakeXYWH(rect.GetX() * scale,      //
+                                     rect.GetY() * scale,      //
+                                     rect.GetWidth() * scale,  //
+                                     rect.GetHeight() * scale);
+
+    EXPECT_EQ(rect.Scale(scale), expected)  //
+        << rect << " * " << scale;
+    EXPECT_EQ(rect.Scale(scale, scale), expected)  //
+        << rect << " * " << scale;
+    EXPECT_EQ(rect.Scale(IPoint(scale, scale)), expected)  //
+        << rect << " * " << scale;
+    EXPECT_EQ(rect.Scale(ISize(scale, scale)), expected)  //
+        << rect << " * " << scale;
+  };
+
+  auto test2 = [&test1](IRect rect, int64_t scale_x, int64_t scale_y) {
+    IRect expected = IRect::MakeXYWH(rect.GetX() * scale_x,      //
+                                     rect.GetY() * scale_y,      //
+                                     rect.GetWidth() * scale_x,  //
+                                     rect.GetHeight() * scale_y);
+
+    EXPECT_EQ(rect.Scale(scale_x, scale_y), expected)  //
+        << rect << " * " << scale_x << ", " << scale_y;
+    EXPECT_EQ(rect.Scale(IPoint(scale_x, scale_y)), expected)  //
+        << rect << " * " << scale_x << ", " << scale_y;
+    EXPECT_EQ(rect.Scale(ISize(scale_x, scale_y)), expected)  //
+        << rect << " * " << scale_x << ", " << scale_y;
+
+    test1(rect, scale_x);
+    test1(rect, scale_y);
+  };
+
+  test2(IRect::MakeLTRB(10, 15, 100, 150), 2, 3);
+  test2(IRect::MakeLTRB(10, 15, 100, 150), 3, 2);
+  test2(IRect::MakeLTRB(10, 15, -100, 150), 2, 3);
+  test2(IRect::MakeLTRB(10, 15, 100, -150), 2, 3);
+  test2(IRect::MakeLTRB(10, 15, 100, 150), -2, 3);
+  test2(IRect::MakeLTRB(10, 15, 100, 150), 2, -3);
+}
+
+TEST(RectTest, RectArea) {
+  EXPECT_EQ(Rect::MakeXYWH(0, 0, 100, 200).Area(), 20000);
+  EXPECT_EQ(Rect::MakeXYWH(10, 20, 100, 200).Area(), 20000);
+  EXPECT_EQ(Rect::MakeXYWH(0, 0, 200, 100).Area(), 20000);
+  EXPECT_EQ(Rect::MakeXYWH(10, 20, 200, 100).Area(), 20000);
+  EXPECT_EQ(Rect::MakeXYWH(0, 0, 100, 100).Area(), 10000);
+  EXPECT_EQ(Rect::MakeXYWH(10, 20, 100, 100).Area(), 10000);
+}
+
+TEST(RectTest, IRectArea) {
+  EXPECT_EQ(IRect::MakeXYWH(0, 0, 100, 200).Area(), 20000);
+  EXPECT_EQ(IRect::MakeXYWH(10, 20, 100, 200).Area(), 20000);
+  EXPECT_EQ(IRect::MakeXYWH(0, 0, 200, 100).Area(), 20000);
+  EXPECT_EQ(IRect::MakeXYWH(10, 20, 200, 100).Area(), 20000);
+  EXPECT_EQ(IRect::MakeXYWH(0, 0, 100, 100).Area(), 10000);
+  EXPECT_EQ(IRect::MakeXYWH(10, 20, 100, 100).Area(), 10000);
 }
 
 TEST(RectTest, RectGetNormalizingTransform) {
@@ -258,6 +431,53 @@ TEST(RectTest, IsSquare) {
   EXPECT_FALSE(IRect::MakeXYWH(10, 30, 19, 20).IsSquare());
 }
 
+TEST(RectTest, RectGetRelative) {
+  Rect rect = Rect::MakeXYWH(10, 30, 40, 50);
+  EXPECT_EQ(rect.GetRelative(0, 0), Point(10, 30));
+  EXPECT_EQ(rect.GetRelative(0, 1), Point(10, 80));
+  EXPECT_EQ(rect.GetRelative(1, 0), Point(50, 30));
+  EXPECT_EQ(rect.GetRelative(1, 1), Point(50, 80));
+  EXPECT_EQ(rect.GetRelative(0.5, 0.5), Point(30, 55));
+
+  EXPECT_EQ(rect.GetRelative(Point(0, 0)), Point(10, 30));
+  EXPECT_EQ(rect.GetRelative(Point(0, 1)), Point(10, 80));
+  EXPECT_EQ(rect.GetRelative(Point(1, 0)), Point(50, 30));
+  EXPECT_EQ(rect.GetRelative(Point(1, 1)), Point(50, 80));
+  EXPECT_EQ(rect.GetRelative(Point(0.5, 0.5)), Point(30, 55));
+
+  EXPECT_EQ(rect.GetRelative(0, 0), rect.GetLeftTop());
+  EXPECT_EQ(rect.GetRelative(0, 1), rect.GetLeftBottom());
+  EXPECT_EQ(rect.GetRelative(1, 0), rect.GetRightTop());
+  EXPECT_EQ(rect.GetRelative(1, 1), rect.GetRightBottom());
+  EXPECT_EQ(rect.GetRelative(0.5, 0.5), rect.GetCenter());
+}
+
+TEST(RectTest, IRectGetRelative) {
+  IRect rect = IRect::MakeXYWH(10, 30, 40, 50);
+  EXPECT_EQ(rect.GetRelative(0, 0), Point(10, 30));
+  EXPECT_EQ(rect.GetRelative(0, 1), Point(10, 80));
+  EXPECT_EQ(rect.GetRelative(1, 0), Point(50, 30));
+  EXPECT_EQ(rect.GetRelative(1, 1), Point(50, 80));
+  EXPECT_EQ(rect.GetRelative(0.5, 0.5), Point(30, 55));
+
+  EXPECT_EQ(rect.GetRelative(Point(0, 0)), Point(10, 30));
+  EXPECT_EQ(rect.GetRelative(Point(0, 1)), Point(10, 80));
+  EXPECT_EQ(rect.GetRelative(Point(1, 0)), Point(50, 30));
+  EXPECT_EQ(rect.GetRelative(Point(1, 1)), Point(50, 80));
+  EXPECT_EQ(rect.GetRelative(Point(0.5, 0.5)), Point(30, 55));
+
+  EXPECT_EQ(rect.GetRelative(0, 0), Point(rect.GetLeftTop()));
+  EXPECT_EQ(rect.GetRelative(0, 1), Point(rect.GetLeftBottom()));
+  EXPECT_EQ(rect.GetRelative(1, 0), Point(rect.GetRightTop()));
+  EXPECT_EQ(rect.GetRelative(1, 1), Point(rect.GetRightBottom()));
+  EXPECT_EQ(rect.GetRelative(0.5, 0.5), Point(rect.GetCenter()));
+
+  // Even IRect will return a Scalar Point value so it can reference
+  // sub-pixel precision:
+  EXPECT_EQ(IRect::MakeXYWH(10, 15, 5, 5).GetRelative(0.5, 0.5),
+            Point(12.5, 17.5));
+}
+
 TEST(RectTest, GetCenter) {
   EXPECT_EQ(Rect::MakeXYWH(10, 30, 20, 20).GetCenter(), Point(20, 40));
   EXPECT_EQ(Rect::MakeXYWH(10, 30, 20, 19).GetCenter(), Point(20, 39.5));
@@ -267,12 +487,18 @@ TEST(RectTest, GetCenter) {
   EXPECT_EQ(IRect::MakeXYWH(10, 30, 20, 19).GetCenter(), Point(20, 39.5));
 }
 
-TEST(RectTest, Expand) {
+TEST(RectTest, RectExpand) {
   auto rect = Rect::MakeLTRB(100, 100, 200, 200);
 
   // Expand(T amount)
   EXPECT_EQ(rect.Expand(10), Rect::MakeLTRB(90, 90, 210, 210));
   EXPECT_EQ(rect.Expand(-10), Rect::MakeLTRB(110, 110, 190, 190));
+
+  // Expand(amount, amount)
+  EXPECT_EQ(rect.Expand(10, 10), Rect::MakeLTRB(90, 90, 210, 210));
+  EXPECT_EQ(rect.Expand(10, -10), Rect::MakeLTRB(90, 110, 210, 190));
+  EXPECT_EQ(rect.Expand(-10, 10), Rect::MakeLTRB(110, 90, 190, 210));
+  EXPECT_EQ(rect.Expand(-10, -10), Rect::MakeLTRB(110, 110, 190, 190));
 
   // Expand(Point amount)
   EXPECT_EQ(rect.Expand(Point{10, 10}), Rect::MakeLTRB(90, 90, 210, 210));
@@ -285,6 +511,32 @@ TEST(RectTest, Expand) {
   EXPECT_EQ(rect.Expand(Size{10, -10}), Rect::MakeLTRB(90, 110, 210, 190));
   EXPECT_EQ(rect.Expand(Size{-10, 10}), Rect::MakeLTRB(110, 90, 190, 210));
   EXPECT_EQ(rect.Expand(Size{-10, -10}), Rect::MakeLTRB(110, 110, 190, 190));
+}
+
+TEST(RectTest, IRectExpand) {
+  auto rect = IRect::MakeLTRB(100, 100, 200, 200);
+
+  // Expand(T amount)
+  EXPECT_EQ(rect.Expand(10), IRect::MakeLTRB(90, 90, 210, 210));
+  EXPECT_EQ(rect.Expand(-10), IRect::MakeLTRB(110, 110, 190, 190));
+
+  // Expand(amount, amount)
+  EXPECT_EQ(rect.Expand(10, 10), IRect::MakeLTRB(90, 90, 210, 210));
+  EXPECT_EQ(rect.Expand(10, -10), IRect::MakeLTRB(90, 110, 210, 190));
+  EXPECT_EQ(rect.Expand(-10, 10), IRect::MakeLTRB(110, 90, 190, 210));
+  EXPECT_EQ(rect.Expand(-10, -10), IRect::MakeLTRB(110, 110, 190, 190));
+
+  // Expand(IPoint amount)
+  EXPECT_EQ(rect.Expand(IPoint{10, 10}), IRect::MakeLTRB(90, 90, 210, 210));
+  EXPECT_EQ(rect.Expand(IPoint{10, -10}), IRect::MakeLTRB(90, 110, 210, 190));
+  EXPECT_EQ(rect.Expand(IPoint{-10, 10}), IRect::MakeLTRB(110, 90, 190, 210));
+  EXPECT_EQ(rect.Expand(IPoint{-10, -10}), IRect::MakeLTRB(110, 110, 190, 190));
+
+  // Expand(ISize amount)
+  EXPECT_EQ(rect.Expand(ISize{10, 10}), IRect::MakeLTRB(90, 90, 210, 210));
+  EXPECT_EQ(rect.Expand(ISize{10, -10}), IRect::MakeLTRB(90, 110, 210, 190));
+  EXPECT_EQ(rect.Expand(ISize{-10, 10}), IRect::MakeLTRB(110, 90, 190, 210));
+  EXPECT_EQ(rect.Expand(ISize{-10, -10}), IRect::MakeLTRB(110, 110, 190, 190));
 }
 
 }  // namespace testing

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -431,53 +431,6 @@ TEST(RectTest, IsSquare) {
   EXPECT_FALSE(IRect::MakeXYWH(10, 30, 19, 20).IsSquare());
 }
 
-TEST(RectTest, RectGetRelative) {
-  Rect rect = Rect::MakeXYWH(10, 30, 40, 50);
-  EXPECT_EQ(rect.GetRelative(0, 0), Point(10, 30));
-  EXPECT_EQ(rect.GetRelative(0, 1), Point(10, 80));
-  EXPECT_EQ(rect.GetRelative(1, 0), Point(50, 30));
-  EXPECT_EQ(rect.GetRelative(1, 1), Point(50, 80));
-  EXPECT_EQ(rect.GetRelative(0.5, 0.5), Point(30, 55));
-
-  EXPECT_EQ(rect.GetRelative(Point(0, 0)), Point(10, 30));
-  EXPECT_EQ(rect.GetRelative(Point(0, 1)), Point(10, 80));
-  EXPECT_EQ(rect.GetRelative(Point(1, 0)), Point(50, 30));
-  EXPECT_EQ(rect.GetRelative(Point(1, 1)), Point(50, 80));
-  EXPECT_EQ(rect.GetRelative(Point(0.5, 0.5)), Point(30, 55));
-
-  EXPECT_EQ(rect.GetRelative(0, 0), rect.GetLeftTop());
-  EXPECT_EQ(rect.GetRelative(0, 1), rect.GetLeftBottom());
-  EXPECT_EQ(rect.GetRelative(1, 0), rect.GetRightTop());
-  EXPECT_EQ(rect.GetRelative(1, 1), rect.GetRightBottom());
-  EXPECT_EQ(rect.GetRelative(0.5, 0.5), rect.GetCenter());
-}
-
-TEST(RectTest, IRectGetRelative) {
-  IRect rect = IRect::MakeXYWH(10, 30, 40, 50);
-  EXPECT_EQ(rect.GetRelative(0, 0), Point(10, 30));
-  EXPECT_EQ(rect.GetRelative(0, 1), Point(10, 80));
-  EXPECT_EQ(rect.GetRelative(1, 0), Point(50, 30));
-  EXPECT_EQ(rect.GetRelative(1, 1), Point(50, 80));
-  EXPECT_EQ(rect.GetRelative(0.5, 0.5), Point(30, 55));
-
-  EXPECT_EQ(rect.GetRelative(Point(0, 0)), Point(10, 30));
-  EXPECT_EQ(rect.GetRelative(Point(0, 1)), Point(10, 80));
-  EXPECT_EQ(rect.GetRelative(Point(1, 0)), Point(50, 30));
-  EXPECT_EQ(rect.GetRelative(Point(1, 1)), Point(50, 80));
-  EXPECT_EQ(rect.GetRelative(Point(0.5, 0.5)), Point(30, 55));
-
-  EXPECT_EQ(rect.GetRelative(0, 0), Point(rect.GetLeftTop()));
-  EXPECT_EQ(rect.GetRelative(0, 1), Point(rect.GetLeftBottom()));
-  EXPECT_EQ(rect.GetRelative(1, 0), Point(rect.GetRightTop()));
-  EXPECT_EQ(rect.GetRelative(1, 1), Point(rect.GetRightBottom()));
-  EXPECT_EQ(rect.GetRelative(0.5, 0.5), Point(rect.GetCenter()));
-
-  // Even IRect will return a Scalar Point value so it can reference
-  // sub-pixel precision:
-  EXPECT_EQ(IRect::MakeXYWH(10, 15, 5, 5).GetRelative(0.5, 0.5),
-            Point(12.5, 17.5));
-}
-
 TEST(RectTest, GetCenter) {
   EXPECT_EQ(Rect::MakeXYWH(10, 30, 20, 20).GetCenter(), Point(20, 40));
   EXPECT_EQ(Rect::MakeXYWH(10, 30, 20, 19).GetCenter(), Point(20, 39.5));

--- a/impeller/geometry/vector.h
+++ b/impeller/geometry/vector.h
@@ -252,6 +252,9 @@ struct Vector4 {
 
   constexpr Vector4(const Point& p) : x(p.x), y(p.y) {}
 
+  constexpr Vector4(std::array<Scalar, 4> values)
+      : x(values[0]), y(values[1]), z(values[2]), w(values[3]) {}
+
   Vector4 Normalize() const {
     const Scalar inverse = 1.0f / sqrt(x * x + y * y + z * z + w * w);
     return Vector4(x * inverse, y * inverse, z * inverse, w * inverse);

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -150,16 +150,13 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
       draw_data->DisplaySize.x, draw_data->DisplaySize.y);
 
   auto viewport = impeller::Viewport{
-      .rect = impeller::Rect::MakeXYWH(
-          display_rect.origin.x * draw_data->FramebufferScale.x,
-          display_rect.origin.y * draw_data->FramebufferScale.y,
-          display_rect.size.width * draw_data->FramebufferScale.x,
-          display_rect.size.height * draw_data->FramebufferScale.y)};
+      .rect = display_rect.Scale(draw_data->FramebufferScale.x,
+                                 draw_data->FramebufferScale.y)};
 
   // Allocate vertex shader uniform buffer.
   VS::UniformBuffer uniforms;
-  uniforms.mvp = impeller::Matrix::MakeOrthographic(display_rect.size)
-                     .Translate(-display_rect.origin);
+  uniforms.mvp = impeller::Matrix::MakeOrthographic(display_rect.GetSize())
+                     .Translate(-display_rect.GetOrigin());
   auto vtx_uniforms =
       render_pass.GetTransientsBuffer().EmplaceUniform(uniforms);
 

--- a/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -102,14 +102,14 @@ bool BlitCopyTextureToTextureCommandGLES::Encode(
   gl.Disable(GL_DEPTH_TEST);
   gl.Disable(GL_STENCIL_TEST);
 
-  gl.BlitFramebuffer(source_region.origin.x,     // srcX0
-                     source_region.origin.y,     // srcY0
-                     source_region.size.width,   // srcX1
-                     source_region.size.height,  // srcY1
+  gl.BlitFramebuffer(source_region.GetX(),       // srcX0
+                     source_region.GetY(),       // srcY0
+                     source_region.GetWidth(),   // srcX1
+                     source_region.GetHeight(),  // srcY1
                      destination_origin.x,       // dstX0
                      destination_origin.y,       // dstY0
-                     source_region.size.width,   // dstX1
-                     source_region.size.height,  // dstY1
+                     source_region.GetWidth(),   // dstX1
+                     source_region.GetHeight(),  // dstY1
                      GL_COLOR_BUFFER_BIT,        // mask
                      GL_NEAREST                  // filter
   );
@@ -147,8 +147,8 @@ bool BlitCopyTextureToBufferCommandGLES::Encode(
 
   DeviceBufferGLES::Cast(*destination)
       .UpdateBufferData([&gl, this](uint8_t* data, size_t length) {
-        gl.ReadPixels(source_region.origin.x, source_region.origin.y,
-                      source_region.size.width, source_region.size.height,
+        gl.ReadPixels(source_region.GetX(), source_region.GetY(),
+                      source_region.GetWidth(), source_region.GetHeight(),
                       GL_RGBA, GL_UNSIGNED_BYTE, data + destination_offset);
       });
 

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -313,11 +313,11 @@ struct RenderPassData {
     /// Setup the viewport.
     ///
     const auto& viewport = command.viewport.value_or(pass_data.viewport);
-    gl.Viewport(viewport.rect.origin.x,  // x
-                target_size.height - viewport.rect.origin.y -
-                    viewport.rect.size.height,  // y
-                viewport.rect.size.width,       // width
-                viewport.rect.size.height       // height
+    gl.Viewport(viewport.rect.GetX(),  // x
+                target_size.height - viewport.rect.GetY() -
+                    viewport.rect.GetHeight(),  // y
+                viewport.rect.GetWidth(),       // width
+                viewport.rect.GetHeight()       // height
     );
     if (pass_data.depth_attachment) {
       // TODO(bdero): Desktop GL for Apple requires glDepthRange. glDepthRangef
@@ -335,10 +335,10 @@ struct RenderPassData {
       const auto& scissor = command.scissor.value();
       gl.Enable(GL_SCISSOR_TEST);
       gl.Scissor(
-          scissor.origin.x,                                             // x
-          target_size.height - scissor.origin.y - scissor.size.height,  // y
-          scissor.size.width,                                           // width
-          scissor.size.height  // height
+          scissor.GetX(),                                             // x
+          target_size.height - scissor.GetY() - scissor.GetHeight(),  // y
+          scissor.GetWidth(),                                         // width
+          scissor.GetHeight()                                         // height
       );
     } else {
       gl.Disable(GL_SCISSOR_TEST);

--- a/impeller/renderer/backend/metal/blit_command_mtl.mm
+++ b/impeller/renderer/backend/metal/blit_command_mtl.mm
@@ -31,9 +31,9 @@ bool BlitCopyTextureToTextureCommandMTL::Encode(
   }
 
   auto source_origin_mtl =
-      MTLOriginMake(source_region.origin.x, source_region.origin.y, 0);
+      MTLOriginMake(source_region.GetX(), source_region.GetY(), 0);
   auto source_size_mtl =
-      MTLSizeMake(source_region.size.width, source_region.size.height, 1);
+      MTLSizeMake(source_region.GetWidth(), source_region.GetHeight(), 1);
   auto destination_origin_mtl =
       MTLOriginMake(destination_origin.x, destination_origin.y, 0);
 
@@ -70,9 +70,9 @@ bool BlitCopyTextureToBufferCommandMTL::Encode(
   }
 
   auto source_origin_mtl =
-      MTLOriginMake(source_region.origin.x, source_region.origin.y, 0);
+      MTLOriginMake(source_region.GetX(), source_region.GetY(), 0);
   auto source_size_mtl =
-      MTLSizeMake(source_region.size.width, source_region.size.height, 1);
+      MTLSizeMake(source_region.GetWidth(), source_region.GetHeight(), 1);
 
   auto destination_bytes_per_pixel =
       BytesPerPixelForPixelFormat(source->GetTextureDescriptor().format);

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -311,10 +311,10 @@ struct PassBindingsCache {
       return;
     }
     [encoder_ setViewport:MTLViewport{
-                              .originX = viewport.rect.origin.x,
-                              .originY = viewport.rect.origin.y,
-                              .width = viewport.rect.size.width,
-                              .height = viewport.rect.size.height,
+                              .originX = viewport.rect.GetX(),
+                              .originY = viewport.rect.GetY(),
+                              .width = viewport.rect.GetWidth(),
+                              .height = viewport.rect.GetHeight(),
                               .znear = viewport.depth_range.z_near,
                               .zfar = viewport.depth_range.z_far,
                           }];
@@ -327,11 +327,11 @@ struct PassBindingsCache {
     }
     [encoder_
         setScissorRect:MTLScissorRect{
-                           .x = static_cast<NSUInteger>(scissor.origin.x),
-                           .y = static_cast<NSUInteger>(scissor.origin.y),
-                           .width = static_cast<NSUInteger>(scissor.size.width),
+                           .x = static_cast<NSUInteger>(scissor.GetX()),
+                           .y = static_cast<NSUInteger>(scissor.GetY()),
+                           .width = static_cast<NSUInteger>(scissor.GetWidth()),
                            .height =
-                               static_cast<NSUInteger>(scissor.size.height),
+                               static_cast<NSUInteger>(scissor.GetHeight()),
                        }];
     scissor_ = scissor;
   }

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -54,7 +54,7 @@ static std::optional<RenderTarget> WrapTextureWithRenderTarget(
       VALIDATION_LOG << "Missing clip rectangle.";
       return std::nullopt;
     }
-    root_size = ISize(clip_rect->size.width, clip_rect->size.height);
+    root_size = ISize(clip_rect->GetWidth(), clip_rect->GetHeight());
   } else {
     root_size = {static_cast<ISize::Type>(texture.width),
                  static_cast<ISize::Type>(texture.height)};
@@ -207,7 +207,7 @@ bool SurfaceMTL::ShouldPerformPartialRepaint(std::optional<IRect> damage_rect) {
   }
   // If the damage rect is 0 in at least one dimension, partial repaint isn't
   // performed as we skip right to present.
-  if (damage_rect->size.width <= 0 || damage_rect->size.height <= 0) {
+  if (damage_rect->IsEmpty()) {
     return false;
   }
   return true;
@@ -240,7 +240,7 @@ bool SurfaceMTL::Present() const {
       return false;
     }
     blit_pass->AddCopy(source_texture_, destination_texture_, std::nullopt,
-                       clip_rect_->origin);
+                       clip_rect_->GetOrigin());
     blit_pass->EncodeCommands(context->GetResourceAllocator());
     if (!blit_command_buffer->SubmitCommands()) {
       return false;

--- a/impeller/renderer/backend/vulkan/blit_command_vk.cc
+++ b/impeller/renderer/backend/vulkan/blit_command_vk.cc
@@ -70,11 +70,11 @@ bool BlitCopyTextureToTextureCommandVK::Encode(
       vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1));
 
   image_copy.srcOffset =
-      vk::Offset3D(source_region.origin.x, source_region.origin.y, 0);
+      vk::Offset3D(source_region.GetX(), source_region.GetY(), 0);
   image_copy.dstOffset =
       vk::Offset3D(destination_origin.x, destination_origin.y, 0);
   image_copy.extent =
-      vk::Extent3D(source_region.size.width, source_region.size.height, 1);
+      vk::Extent3D(source_region.GetWidth(), source_region.GetHeight(), 1);
 
   // Issue the copy command now that the images are already in the right
   // layouts.
@@ -130,9 +130,9 @@ bool BlitCopyTextureToBufferCommandVK::Encode(CommandEncoderVK& encoder) const {
   image_copy.setImageSubresource(
       vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1));
   image_copy.setImageOffset(
-      vk::Offset3D(source_region.origin.x, source_region.origin.y, 0));
+      vk::Offset3D(source_region.GetX(), source_region.GetY(), 0));
   image_copy.setImageExtent(
-      vk::Extent3D(source_region.size.width, source_region.size.height, 1));
+      vk::Extent3D(source_region.GetWidth(), source_region.GetHeight(), 1));
 
   if (!src.SetLayout(barrier)) {
     VALIDATION_LOG << "Could not encode layout transition.";

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -348,9 +348,9 @@ static void SetViewportAndScissor(const Command& command,
   const auto& vp = command.viewport.value_or<Viewport>(
       {.rect = Rect::MakeSize(target_size)});
   vk::Viewport viewport = vk::Viewport()
-                              .setWidth(vp.rect.size.width)
-                              .setHeight(-vp.rect.size.height)
-                              .setY(vp.rect.size.height)
+                              .setWidth(vp.rect.GetWidth())
+                              .setHeight(-vp.rect.GetHeight())
+                              .setY(vp.rect.GetHeight())
                               .setMinDepth(0.0f)
                               .setMaxDepth(1.0f);
   cmd_buffer_cache.SetViewport(cmd_buffer, 0, 1, &viewport);
@@ -359,8 +359,8 @@ static void SetViewportAndScissor(const Command& command,
   const auto& sc = command.scissor.value_or(IRect::MakeSize(target_size));
   vk::Rect2D scissor =
       vk::Rect2D()
-          .setOffset(vk::Offset2D(sc.origin.x, sc.origin.y))
-          .setExtent(vk::Extent2D(sc.size.width, sc.size.height));
+          .setOffset(vk::Offset2D(sc.GetX(), sc.GetY()))
+          .setExtent(vk::Extent2D(sc.GetWidth(), sc.GetHeight()));
   cmd_buffer_cache.SetScissor(cmd_buffer, 0, 1, &scissor);
 }
 

--- a/impeller/renderer/blit_pass.cc
+++ b/impeller/renderer/blit_pass.cc
@@ -107,7 +107,7 @@ bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
 
   auto bytes_per_pixel =
       BytesPerPixelForPixelFormat(source->GetTextureDescriptor().format);
-  auto bytes_per_image = source_region->size.Area() * bytes_per_pixel;
+  auto bytes_per_image = source_region->Area() * bytes_per_pixel;
   if (destination_offset + bytes_per_image >
       destination->GetDeviceBufferDescriptor().size) {
     VALIDATION_LOG

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -452,7 +452,7 @@ EllipticalVertexGenerator Tessellator::FilledEllipse(
     const Rect& bounds) {
   if (bounds.IsSquare()) {
     return FilledCircle(view_transform, bounds.GetCenter(),
-                        bounds.GetSize().width * 0.5f);
+                        bounds.GetWidth() * 0.5f);
   }
   auto max_radius = bounds.GetSize().MaxDimension();
   auto divisions =
@@ -472,8 +472,8 @@ EllipticalVertexGenerator Tessellator::FilledRoundRect(
     const Matrix& view_transform,
     const Rect& bounds,
     const Size& radii) {
-  if (radii.width * 2 < bounds.GetSize().width ||
-      radii.height * 2 < bounds.GetSize().height) {
+  if (radii.width * 2 < bounds.GetWidth() ||
+      radii.height * 2 < bounds.GetHeight()) {
     auto max_radius = radii.MaxDimension();
     auto divisions = ComputeQuadrantDivisions(
         view_transform.GetMaxBasisLength() * max_radius);

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -416,15 +416,13 @@ TEST(TessellatorTest, FilledRoundRectTessellationVertices) {
 
   auto test = [&tessellator](const Matrix& transform, const Rect& bounds,
                              const Size& radii) {
-    FML_DCHECK(radii.width * 2 <= bounds.GetSize().width) << radii << bounds;
-    FML_DCHECK(radii.height * 2 <= bounds.GetSize().height) << radii << bounds;
+    FML_DCHECK(radii.width * 2 <= bounds.GetWidth()) << radii << bounds;
+    FML_DCHECK(radii.height * 2 <= bounds.GetHeight()) << radii << bounds;
 
-    Scalar middle_left = bounds.GetOrigin().x + radii.width;
-    Scalar middle_top = bounds.GetOrigin().y + radii.height;
-    Scalar middle_right =
-        bounds.GetOrigin().x + bounds.GetSize().width - radii.width;
-    Scalar middle_bottom =
-        bounds.GetOrigin().y + bounds.GetSize().height - radii.height;
+    Scalar middle_left = bounds.GetX() + radii.width;
+    Scalar middle_top = bounds.GetY() + radii.height;
+    Scalar middle_right = bounds.GetX() + bounds.GetWidth() - radii.width;
+    Scalar middle_bottom = bounds.GetY() + bounds.GetHeight() - radii.height;
 
     auto generator = tessellator->FilledRoundRect(transform, bounds, radii);
     EXPECT_EQ(generator.GetTriangleType(), PrimitiveType::kTriangleStrip);

--- a/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -57,7 +57,7 @@ static size_t PairsFitInAtlasOfSize(
     const auto& pair = *it;
 
     const auto glyph_size =
-        ISize::Ceil(pair.glyph.bounds.size * pair.scaled_font.scale);
+        ISize::Ceil(pair.glyph.bounds.GetSize() * pair.scaled_font.scale);
     IPoint16 location_in_atlas;
     if (!rect_packer->addRect(glyph_size.width + kPadding,   //
                               glyph_size.height + kPadding,  //
@@ -95,7 +95,7 @@ static bool CanAppendToExistingAtlas(
     const FontGlyphPair& pair = extra_pairs[i];
 
     const auto glyph_size =
-        ISize::Ceil(pair.glyph.bounds.size * pair.scaled_font.scale);
+        ISize::Ceil(pair.glyph.bounds.GetSize() * pair.scaled_font.scale);
     IPoint16 location_in_atlas;
     if (!rect_packer->addRect(glyph_size.width + kPadding,   //
                               glyph_size.height + kPadding,  //
@@ -158,8 +158,8 @@ static void DrawGlyph(SkCanvas* canvas,
                       const Rect& location,
                       bool has_color) {
   const auto& metrics = scaled_font.font.GetMetrics();
-  const auto position = SkPoint::Make(location.origin.x / scaled_font.scale,
-                                      location.origin.y / scaled_font.scale);
+  const auto position = SkPoint::Make(location.GetX() / scaled_font.scale,
+                                      location.GetY() / scaled_font.scale);
   SkGlyphID glyph_id = glyph.index;
 
   SkFont sk_font(

--- a/impeller/typographer/backends/stb/text_frame_stb.cc
+++ b/impeller/typographer/backends/stb/text_frame_stb.cc
@@ -56,8 +56,8 @@ std::shared_ptr<TextFrame> MakeTextFrameSTB(
   std::optional<Rect> result;
   for (const auto& glyph_position : run.GetGlyphPositions()) {
     Rect glyph_rect = Rect::MakeOriginSize(
-        glyph_position.position + glyph_position.glyph.bounds.origin,
-        glyph_position.glyph.bounds.size);
+        glyph_position.position + glyph_position.glyph.bounds.GetOrigin(),
+        glyph_position.glyph.bounds.GetSize());
     result = result.has_value() ? result->Union(glyph_rect) : glyph_rect;
   }
 

--- a/impeller/typographer/backends/stb/typographer_context_stb.cc
+++ b/impeller/typographer/backends/stb/typographer_context_stb.cc
@@ -214,15 +214,14 @@ static void DrawGlyph(BitmapSTB* bitmap,
       stbtt_ScaleForPixelHeight(typeface_stb->GetFontInfo(), text_size_pixels);
   float scale_x = scale_y;
 
-  auto output =
-      bitmap->GetPixelAddress({static_cast<size_t>(location.origin.x),
-                               static_cast<size_t>(location.origin.y)});
+  auto output = bitmap->GetPixelAddress({static_cast<size_t>(location.GetX()),
+                                         static_cast<size_t>(location.GetY())});
   // For Alpha and Signed Distance field bitmaps we can use STB to draw the
   // Glyph in place
   if (!has_color || DISABLE_COLOR_FONT_SUPPORT) {
     stbtt_MakeGlyphBitmap(typeface_stb->GetFontInfo(), output,
-                          location.size.width - kPadding,
-                          location.size.height - kPadding,
+                          location.GetWidth() - kPadding,
+                          location.GetHeight() - kPadding,
                           bitmap->GetRowBytes(), scale_x, scale_y, glyph.index);
   } else {
     // But for color bitmaps we need to get the glyph pixels and then carry all

--- a/impeller/typographer/text_frame.cc
+++ b/impeller/typographer/text_frame.cc
@@ -46,13 +46,13 @@ bool TextFrame::MaybeHasOverlapping() const {
   // on text runs.
   auto first_position = glyph_positions[0];
   auto overlapping_rect = Rect::MakeOriginSize(
-      first_position.position + first_position.glyph.bounds.origin,
-      first_position.glyph.bounds.size);
+      first_position.position + first_position.glyph.bounds.GetOrigin(),
+      first_position.glyph.bounds.GetSize());
   for (auto i = 1u; i < glyph_positions.size(); i++) {
     auto glyph_position = glyph_positions[i];
     auto glyph_rect = Rect::MakeOriginSize(
-        glyph_position.position + glyph_position.glyph.bounds.origin,
-        glyph_position.glyph.bounds.size);
+        glyph_position.position + glyph_position.glyph.bounds.GetOrigin(),
+        glyph_position.glyph.bounds.GetSize());
     auto intersection = glyph_rect.Intersection(overlapping_rect);
     if (intersection.has_value()) {
       return true;

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -149,12 +149,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
         auto surface = impeller::SurfaceMTL::MakeFromMetalLayerDrawable(
             impeller_renderer_->GetContext(), drawable, clip_rect);
 
-        if (clip_rect && (clip_rect->size.width == 0 || clip_rect->size.height == 0)) {
+        if (clip_rect && clip_rect->IsEmpty()) {
           return surface->Present();
         }
 
         impeller::IRect cull_rect = surface->coverage();
-        SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.size.width, cull_rect.size.height);
+        SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
         impeller::DlDispatcher impeller_dispatcher(cull_rect);
         display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
         auto picture = impeller_dispatcher.EndRecordingAsPicture();
@@ -247,12 +247,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromMTLTextur
         auto surface =
             impeller::SurfaceMTL::MakeFromTexture(renderer->GetContext(), mtl_texture, clip_rect);
 
-        if (clip_rect && (clip_rect->size.width == 0 || clip_rect->size.height == 0)) {
+        if (clip_rect && clip_rect->IsEmpty()) {
           return surface->Present();
         }
 
         impeller::IRect cull_rect = surface->coverage();
-        SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.size.width, cull_rect.size.height);
+        SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
         impeller::DlDispatcher impeller_dispatcher(cull_rect);
         display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
         auto picture = impeller_dispatcher.EndRecordingAsPicture();


### PR DESCRIPTION
Make the implementation fields of Rect private in preparation for switching its internal operations from XYWH to LTRB fields.

Additionally `[[nodiscard]]` tags are added to all of the Rect methods that return a value to avoid problems with confusing mutator methods and return value methods.