### PR TITLE
Fix testAppExtensionLaunching for Xcode 15/iOS 17

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/AppExtensionTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/AppExtensionTests.m
@@ -19,6 +19,11 @@
 }
 
 - (void)testAppExtensionLaunching {
+  // Launch the Scenarios app first to ensure it's installed then close it.
+  XCUIApplication* app = [[XCUIApplication alloc] init];
+  [app launch];
+  [app terminate];
+
   [self.hostApplication launch];
   XCUIElement* button = self.hostApplication.buttons[@"Open Share"];
   if (![button waitForExistenceWithTimeout:10]) {
@@ -27,13 +32,25 @@
   }
   [button tap];
   BOOL launchedExtensionInFlutter = NO;
-  // Custom share extension button (like the one in this test) does not have a unique
-  // identity. They are all identified as `XCElementSnapshotPrivilegedValuePlaceholder`.
-  // Loop through all the `XCElementSnapshotPrivilegedValuePlaceholder` and find the Flutter one.
+
+  // Wait for first cell of share sheet to appear.
+  XCUIElement* firstCell = self.hostApplication.collectionViews.cells.firstMatch;
+  if (![firstCell waitForExistenceWithTimeout:10]) {
+    NSLog(@"%@", self.hostApplication.debugDescription);
+    XCTFail(@"Failed due to not able to find any cells with %@ seconds", @(10));
+  }
+
+  // Custom share extension button (like the one in this test) does not have a
+  // unique identity on older versions of iOS. They are all identified as
+  // `XCElementSnapshotPrivilegedValuePlaceholder`. On iOS 17, they are
+  // identified by name. Loop through all the buttons labeled
+  // `XCElementSnapshotPrivilegedValuePlaceholder` or `Scenarios` to find the
+  // Flutter one.
   for (int i = 0; i < self.hostApplication.collectionViews.cells.count; i++) {
     XCUIElement* shareSheetCell =
         [self.hostApplication.collectionViews.cells elementBoundByIndex:i];
-    if (![shareSheetCell.label isEqualToString:@"XCElementSnapshotPrivilegedValuePlaceholder"]) {
+    if (![shareSheetCell.label isEqualToString:@"XCElementSnapshotPrivilegedValuePlaceholder"] &&
+        ![shareSheetCell.label isEqualToString:@"Scenarios"]) {
       continue;
     }
     [shareSheetCell tap];

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/AppExtensionTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/AppExtensionTests.m
@@ -46,13 +46,13 @@
   // identified by name. Loop through all the buttons labeled
   // `XCElementSnapshotPrivilegedValuePlaceholder` or `Scenarios` to find the
   // Flutter one.
-  for (int i = 0; i < self.hostApplication.collectionViews.cells.count; i++) {
-    XCUIElement* shareSheetCell =
-        [self.hostApplication.collectionViews.cells elementBoundByIndex:i];
-    if (![shareSheetCell.label isEqualToString:@"XCElementSnapshotPrivilegedValuePlaceholder"] &&
-        ![shareSheetCell.label isEqualToString:@"Scenarios"]) {
-      continue;
-    }
+  NSPredicate* cellPredicate = [NSPredicate
+      predicateWithFormat:
+          @"label == 'XCElementSnapshotPrivilegedValuePlaceholder' OR label = 'Scenarios'"];
+  NSArray<XCUIElement*>* shareSheetCells =
+      [self.hostApplication.collectionViews.cells matchingPredicate:cellPredicate]
+          .allElementsBoundByIndex;
+  for (XCUIElement* shareSheetCell in shareSheetCells) {
     [shareSheetCell tap];
 
     XCUIElement* flutterView = self.hostApplication.otherElements[@"flutter_view"];


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/140181.

Example of fix working on macOS 13 with Xcode 15 and iOS 17 simulator: https://ci.chromium.org/ui/p/flutter/builders/try/Mac%20Engine%20Drone/586366/overview

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
