### PR TITLE
Don't guard Windows arm64 Dart SDK download on the release candidate flag

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -572,7 +572,7 @@ deps = {
       }
     ],
     'dep_type': 'cipd',
-    'condition': 'host_os == "win" and download_dart_sdk and not release_candidate'
+    'condition': 'host_os == "win" and download_dart_sdk'
   },
 
   # esbuild download


### PR DESCRIPTION
According to https://github.com/flutter/flutter/issues/139370#issuecomment-1862652535, this check is now safe to remove.