### PR TITLE
Android Platform Views support Verified Input Events

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 /** Sends touch information from Android to Flutter in a format that Flutter understands. */
 public class AndroidTouchProcessor {
-
+  private static final String TAG = "AndroidTouchProcessor";
   // Must match the PointerChange enum in pointer.dart.
   @IntDef({
     PointerChange.CANCEL,

--- a/shell/platform/android/io/flutter/embedding/android/MotionEventTracker.java
+++ b/shell/platform/android/io/flutter/embedding/android/MotionEventTracker.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /** Tracks the motion events received by the FlutterView. */
 public final class MotionEventTracker {
-
+  private static final String TAG = "MotionEventTracker";
   /** Represents a unique identifier corresponding to a motion event. */
   public static class MotionEventId {
     private static final AtomicLong ID_COUNTER = new AtomicLong(0);
@@ -55,7 +55,14 @@ public final class MotionEventTracker {
   @NonNull
   public MotionEventId track(@NonNull MotionEvent event) {
     MotionEventId eventId = MotionEventId.createUnique();
-    eventById.put(eventId.id, MotionEvent.obtain(event));
+    // We copy event here because the original MotionEvent delivered to us
+    // will be automatically recycled (`MotionEvent.recycle`) by the RootView and we need
+    // access to it after the RootView code runs.
+    // The return value of `MotionEvent.obtain(event)` is still verifiable if the input
+    // event was verifiable. Other overloads of `MotionEvent.obtain` do not have this
+    // guarantee and should be avoided when possible.
+    MotionEvent eventCopy = MotionEvent.obtain(event);
+    eventById.put(eventId.id, eventCopy);
     unusedEvents.add(eventId.id);
     return eventId;
   }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -677,6 +677,15 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
         MotionEventTracker.MotionEventId.from(touch.motionEventId);
     MotionEvent trackedEvent = motionEventTracker.pop(motionEventId);
 
+    if (!usingVirtualDiplay && trackedEvent != null) {
+      // We have the original event, deliver it as it will pass the verifiable
+      // input check.
+      return trackedEvent;
+    }
+    // We are in virtual display mode or don't have a reference to the original MotionEvent.
+    // In this case we manually recreate a MotionEvent to be delivered. This MotionEvent
+    // will fail the verifiable input check.
+
     // Pointer coordinates in the tracked events are global to FlutterView
     // framework converts them to be local to a widget, given that
     // motion events operate on local coords, we need to replace these in the tracked
@@ -687,24 +696,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     PointerCoords[] pointerCoords =
         parsePointerCoordsList(touch.rawPointerCoords, density)
             .toArray(new PointerCoords[touch.pointerCount]);
-
-    if (!usingVirtualDiplay && trackedEvent != null) {
-      return MotionEvent.obtain(
-          trackedEvent.getDownTime(),
-          trackedEvent.getEventTime(),
-          trackedEvent.getAction(),
-          trackedEvent.getPointerCount(),
-          pointerProperties,
-          pointerCoords,
-          trackedEvent.getMetaState(),
-          trackedEvent.getButtonState(),
-          trackedEvent.getXPrecision(),
-          trackedEvent.getYPrecision(),
-          trackedEvent.getDeviceId(),
-          trackedEvent.getEdgeFlags(),
-          trackedEvent.getSource(),
-          trackedEvent.getFlags());
-    }
 
     // TODO (kaushikiska) : warn that we are potentially using an untracked
     // event in the platform views.


### PR DESCRIPTION
Android Platform Views process MotionEvents in a complicated way:

1. MotionEvent is captured and delivered to PlatformViewWrapper.onTouchEvent (TLHC) or FlutterMutatorView.onTouchEvent (HC)
2. MotionEvent is transformed by the AndroidTouchProcessor into a PointerEvent
3. AndroidTouchProcessor sends the PointerEvent over the PlatformViewChannel
4. Framework processes the PointerEvent
5. Framework sends the PointerEvent over the PlatformViewChannel.
6. in PlatformViewsController.onTouch a new MotionEvent is synthesized
7. The MotionEvent is delivered to the platform view

After step (6) the MotionEvent will fail Verification (`android.hardware.input.InputManager.verifyInputEvent`).

The fix requires that in step (6) we use the original motion event delivered in step (1) instead of synthesizing a new instance. 