### PR TITLE
[Impeller] Add interactive Blur+Clip AiksTest.

### DIFF
--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1008,6 +1008,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
     static Color input_color = Color::Black();
     static int selected_blur_type = 0;
     static int selected_pass_variation = 0;
+    static bool combined_sigma = false;
     static float blur_amount_coarse[2] = {0, 0};
     static float blur_amount_fine[2] = {10, 10};
     static int selected_blur_style = 0;
@@ -1039,8 +1040,16 @@ TEST_P(EntityTest, GaussianBlurFilter) {
                      pass_variation_names,
                      sizeof(pass_variation_names) / sizeof(char*));
       }
-      ImGui::SliderFloat2("Sigma (coarse)", blur_amount_coarse, 0, 1000);
-      ImGui::SliderFloat2("Sigma (fine)", blur_amount_fine, 0, 10);
+      ImGui::Checkbox("Combined sigma", &combined_sigma);
+      if (combined_sigma) {
+        ImGui::SliderFloat("Sigma (coarse)", blur_amount_coarse, 0, 1000);
+        ImGui::SliderFloat("Sigma (fine)", blur_amount_fine, 0, 10);
+        blur_amount_coarse[1] = blur_amount_coarse[0];
+        blur_amount_fine[1] = blur_amount_fine[0];
+      } else {
+        ImGui::SliderFloat2("Sigma (coarse)", blur_amount_coarse, 0, 1000);
+        ImGui::SliderFloat2("Sigma (fine)", blur_amount_fine, 0, 10);
+      }
       ImGui::Combo("Blur style", &selected_blur_style, blur_style_names,
                    sizeof(blur_style_names) / sizeof(char*));
       ImGui::Combo("Tile mode", &selected_tile_mode, tile_mode_names,

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -33,20 +33,22 @@ static const std::vector<std::string> kSkipTests = {
     "impeller_Play_AiksTest_ClippedBlurFilterRendersCorrectlyInteractive_Metal",
     "impeller_Play_AiksTest_ClippedBlurFilterRendersCorrectlyInteractive_"
     "Vulkan",
-    "impeller_Play_AiksTest_TextFrameSubpixelAlignment_Metal",
-    "impeller_Play_AiksTest_TextFrameSubpixelAlignment_Vulkan",
-    "impeller_Play_AiksTest_ColorWheel_Metal",
-    "impeller_Play_AiksTest_ColorWheel_Vulkan",
-    "impeller_Play_AiksTest_SolidStrokesRenderCorrectly_Metal",
-    "impeller_Play_AiksTest_SolidStrokesRenderCorrectly_Vulkan",
-    "impeller_Play_AiksTest_GradientStrokesRenderCorrectly_Metal",
-    "impeller_Play_AiksTest_GradientStrokesRenderCorrectly_Vulkan",
     "impeller_Play_AiksTest_CoverageOriginShouldBeAccountedForInSubpasses_"
     "Metal",
     "impeller_Play_AiksTest_CoverageOriginShouldBeAccountedForInSubpasses_"
     "Vulkan",
+    "impeller_Play_AiksTest_GaussianBlurRotatedAndClippedInteractive_Metal",
+    "impeller_Play_AiksTest_GaussianBlurRotatedAndClippedInteractive_Vulkan",
+    "impeller_Play_AiksTest_GradientStrokesRenderCorrectly_Metal",
+    "impeller_Play_AiksTest_GradientStrokesRenderCorrectly_Vulkan",
+    "impeller_Play_AiksTest_ColorWheel_Metal",
+    "impeller_Play_AiksTest_ColorWheel_Vulkan",
     "impeller_Play_AiksTest_SceneColorSource_Metal",
     "impeller_Play_AiksTest_SceneColorSource_Vulkan",
+    "impeller_Play_AiksTest_SolidStrokesRenderCorrectly_Metal",
+    "impeller_Play_AiksTest_SolidStrokesRenderCorrectly_Vulkan",
+    "impeller_Play_AiksTest_TextFrameSubpixelAlignment_Metal",
+    "impeller_Play_AiksTest_TextFrameSubpixelAlignment_Vulkan",
     // TextRotated is flakey and we can't seem to get it to stabilize on Skia
     // Gold.
     "impeller_Play_AiksTest_TextRotated_Metal",


### PR DESCRIPTION
I used this interactive toy to inspect the change in https://github.com/flutter/engine/pull/49206. Perhaps this can become our "kitchen sink" interactive toy for debugging blurs in Aiks (where we can easily form clips and add options for other paint state interactions as they become relevant).

Video of `GaussianBlurRotatedAndClippedInteractive`:

https://github.com/flutter/engine/assets/919017/e5be5f38-3644-43c4-a3d0-d08b03fcb7b0

Video of `GaussianBlurFilter` with the "Combined sigma" checkbox to make playing with the new blur easier:

https://github.com/flutter/engine/assets/919017/65bd6567-83be-4337-8827-03e6a3dee9b1

