### PR TITLE
[Linux] Remove the usage of std::function in FlKeyEmbedderResponder

### DIFF
--- a/shell/platform/linux/fl_key_embedder_responder.cc
+++ b/shell/platform/linux/fl_key_embedder_responder.cc
@@ -141,6 +141,7 @@ struct _FlKeyEmbedderResponder {
   GObject parent_instance;
 
   EmbedderSendKeyEvent send_key_event;
+  void* send_key_event_user_data;
 
   // Internal record for states of whether a key is pressed.
   //
@@ -260,11 +261,13 @@ static void initialize_logical_key_to_lock_bit_loop_body(gpointer lock_bit,
 
 // Creates a new FlKeyEmbedderResponder instance.
 FlKeyEmbedderResponder* fl_key_embedder_responder_new(
-    EmbedderSendKeyEvent send_key_event) {
+    EmbedderSendKeyEvent send_key_event,
+    void* send_key_event_user_data) {
   FlKeyEmbedderResponder* self = FL_KEY_EMBEDDER_RESPONDER(
       g_object_new(FL_TYPE_EMBEDDER_RESPONDER_USER_DATA, nullptr));
 
   self->send_key_event = std::move(send_key_event);
+  self->send_key_event_user_data = creation_user_data;
 
   self->pressing_records = g_hash_table_new(g_direct_hash, g_direct_equal);
   self->mapping_records = g_hash_table_new(g_direct_hash, g_direct_equal);

--- a/shell/platform/linux/fl_key_embedder_responder.h
+++ b/shell/platform/linux/fl_key_embedder_responder.h
@@ -15,10 +15,18 @@
 
 constexpr int kMaxConvertedKeyData = 3;
 
-typedef std::function<void(const FlutterKeyEvent* event,
-                           FlutterKeyEventCallback callback,
-                           void* user_data)>
-    EmbedderSendKeyEvent;
+// The signature of a function to be called on every key event.
+//
+// The creation_user_data is an opaque pointer created by the object that
+// manages FlKeyEmbedderResponder.
+//
+// The callback_user_data is an opaque pointer created and managed by
+// FlKeyEmbedderResponder. After the event is processed, the callback should be
+// called with callback_user_data.
+typedef void (*EmbedderSendKeyEvent)(const FlutterKeyEvent* event,
+                                     FlutterKeyEventCallback callback,
+                                     void* callback_user_data,
+                                     void* creation_user_data);
 
 G_BEGIN_DECLS
 
@@ -44,11 +52,16 @@ G_DECLARE_FINAL_TYPE(FlKeyEmbedderResponder,
  * the event.
  *
  * Creates a new #FlKeyEmbedderResponder.
+ * @send_key_event: a function that is called on every key event.
+ * @send_key_event_user_data: an opaque pointer that will be sent back as the
+ * last argument of send_key_event, created and managed by the object that holds
+ * FlKeyEmbedderResponder.
  *
  * Returns: a new #FlKeyEmbedderResponder.
  */
 FlKeyEmbedderResponder* fl_key_embedder_responder_new(
-    EmbedderSendKeyEvent send_key_event);
+    EmbedderSendKeyEvent send_key_event,
+    void* send_key_event_user_data);
 
 /**
  * fl_key_embedder_responder_sync_modifiers_if_needed:

--- a/shell/platform/linux/fl_key_embedder_responder_test.cc
+++ b/shell/platform/linux/fl_key_embedder_responder_test.cc
@@ -149,14 +149,15 @@ namespace {
 GPtrArray* g_call_records;
 }
 
-static EmbedderSendKeyEvent record_calls_in(GPtrArray* records_array) {
-  return [records_array](const FlutterKeyEvent* event,
-                         FlutterKeyEventCallback callback, void* user_data) {
-    if (records_array != nullptr) {
-      g_ptr_array_add(records_array, fl_key_embedder_call_record_new(
-                                         event, callback, user_data));
-    }
-  };
+static void record_calls(const FlutterKeyEvent* event,
+                         FlutterKeyEventCallback callback,
+                         void* callback_user_data,
+                         void* creation_user_data) {
+  GPtrArray* records_array = reinterpret_cast<GPtrArray*>(creation_user_data);
+  if (records_array != nullptr) {
+    g_ptr_array_add(records_array, fl_key_embedder_call_record_new(
+                                       event, callback, user_data));
+  }
 }
 
 static void clear_g_call_records() {
@@ -169,7 +170,7 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -265,7 +266,7 @@ TEST(FlKeyEmbedderResponderTest, UsesSpecifiedLogicalKey) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -300,7 +301,7 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -393,7 +394,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -554,7 +555,7 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -649,7 +650,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -810,7 +811,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -967,7 +968,7 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -1028,7 +1029,7 @@ TEST(FlKeyEmbedderResponderTest, IgnoreAbruptUpEvent) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   // Release KeyA before it was even pressed.
@@ -1058,7 +1059,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -1189,7 +1190,7 @@ TEST(FlKeyEmbedderResponderTest,
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -1320,7 +1321,7 @@ TEST(FlKeyEmbedderResponderTest,
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -1388,7 +1389,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -1496,7 +1497,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnSelfEvents) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -1595,7 +1596,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizationOccursOnIgnoredEvents) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
   int user_data = 123;  // Arbitrary user data
 
   FlKeyEmbedderCallRecord* record;
@@ -1648,7 +1649,7 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
 
   g_expected_handled = true;
   guint32 now_time = 1;
@@ -1746,7 +1747,7 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
   EXPECT_EQ(g_call_records, nullptr);
   g_call_records = g_ptr_array_new_with_free_func(g_object_unref);
   FlKeyResponder* responder = FL_KEY_RESPONDER(
-      fl_key_embedder_responder_new(record_calls_in(g_call_records)));
+      fl_key_embedder_responder_new(record_calls, g_call_records));
 
   g_expected_handled = true;
   guint32 now_time = 1;

--- a/shell/platform/linux/fl_keyboard_manager.cc
+++ b/shell/platform/linux/fl_keyboard_manager.cc
@@ -599,12 +599,14 @@ FlKeyboardManager* fl_keyboard_manager_new(
   g_ptr_array_add(
       self->responder_list,
       FL_KEY_RESPONDER(fl_key_embedder_responder_new(
-          [self](const FlutterKeyEvent* event, FlutterKeyEventCallback callback,
-                 void* user_data) {
+          [](const FlutterKeyEvent* event, FlutterKeyEventCallback callback,
+             void* callback_user_data, void* creation_user_data) {
+            FlKeyboardManager* self = FL_KEYBOARD_MANAGER(creation_user_data);
             g_return_if_fail(self->view_delegate != nullptr);
-            fl_keyboard_view_delegate_send_key_event(self->view_delegate, event,
-                                                     callback, user_data);
-          })));
+            fl_keyboard_view_delegate_send_key_event(
+                self->view_delegate, event, callback, callback_user_data);
+          },
+          self)));
   g_ptr_array_add(self->responder_list,
                   FL_KEY_RESPONDER(fl_key_channel_responder_new(
                       fl_keyboard_view_delegate_get_messenger(view_delegate))));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/140183

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
