### PR TITLE
Remove pthread based thread local support.

### DIFF
--- a/fml/thread_local.cc
+++ b/fml/thread_local.cc
@@ -3,39 +3,3 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/thread_local.h"
-
-#if FML_THREAD_LOCAL_PTHREADS
-
-#include <cstring>
-
-#include "flutter/fml/logging.h"
-
-namespace fml {
-namespace internal {
-
-ThreadLocalPointer::ThreadLocalPointer(void (*destroy)(void*)) {
-  FML_CHECK(pthread_key_create(&key_, destroy) == 0);
-}
-
-ThreadLocalPointer::~ThreadLocalPointer() {
-  FML_CHECK(pthread_key_delete(key_) == 0);
-}
-
-void* ThreadLocalPointer::get() const {
-  return pthread_getspecific(key_);
-}
-
-void* ThreadLocalPointer::swap(void* ptr) {
-  void* old_ptr = get();
-  int err = pthread_setspecific(key_, ptr);
-  if (err) {
-    FML_CHECK(false) << "pthread_setspecific failed (" << err
-                     << "): " << strerror(err);
-  }
-  return old_ptr;
-}
-
-}  // namespace internal
-}  // namespace fml
-
-#endif  // FML_THREAD_LOCAL_PTHREADS

--- a/fml/thread_local.h
+++ b/fml/thread_local.h
@@ -10,63 +10,25 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/macros.h"
 
-#define FML_THREAD_LOCAL_PTHREADS \
-  FML_OS_MACOSX || FML_OS_LINUX || FML_OS_ANDROID
-
-#if FML_THREAD_LOCAL_PTHREADS
-#include <pthread.h>
-#endif
-
 namespace fml {
-
-#if FML_THREAD_LOCAL_PTHREADS
-
-#define FML_THREAD_LOCAL static
-
-namespace internal {
-
-class ThreadLocalPointer {
- public:
-  explicit ThreadLocalPointer(void (*destroy)(void*));
-  ~ThreadLocalPointer();
-
-  void* get() const;
-  void* swap(void* ptr);
-
- private:
-  pthread_key_t key_;
-
-  FML_DISALLOW_COPY_AND_ASSIGN(ThreadLocalPointer);
-};
-
-}  // namespace internal
-
-template <typename T>
-class ThreadLocalUniquePtr {
- public:
-  ThreadLocalUniquePtr() : ptr_(destroy) {}
-
-  T* get() const { return reinterpret_cast<T*>(ptr_.get()); }
-  void reset(T* ptr) { destroy(ptr_.swap(ptr)); }
-
- private:
-  static void destroy(void* ptr) { delete reinterpret_cast<T*>(ptr); }
-
-  internal::ThreadLocalPointer ptr_;
-
-  FML_DISALLOW_COPY_AND_ASSIGN(ThreadLocalUniquePtr);
-};
-
-#else  // FML_THREAD_LOCAL_PTHREADS
 
 #define FML_THREAD_LOCAL static thread_local
 
+//------------------------------------------------------------------------------
+/// @brief      A wrapper for a thread-local unique pointer. Do NOT use this
+///             class in new code and instead use unique pointers with the
+///             thread_local storage class directly. This was necessary for
+///             pre-C++11 code.
+///
+/// @tparam     T     The type held in the thread local unique pointer.
+///
 template <typename T>
 class ThreadLocalUniquePtr {
  public:
   ThreadLocalUniquePtr() = default;
 
   T* get() const { return ptr_.get(); }
+
   void reset(T* ptr) { ptr_.reset(ptr); }
 
  private:
@@ -77,12 +39,4 @@ class ThreadLocalUniquePtr {
 
 #endif  // FML_THREAD_LOCAL_PTHREADS
 
-#ifndef FML_THREAD_LOCAL
-
-#error Thread local storage unavailable on the platform.
-
-#endif  // FML_THREAD_LOCAL
-
 }  // namespace fml
-
-#endif  // FLUTTER_FML_THREAD_LOCAL_H_

--- a/fml/thread_local.h
+++ b/fml/thread_local.h
@@ -37,6 +37,6 @@ class ThreadLocalUniquePtr {
   FML_DISALLOW_COPY_AND_ASSIGN(ThreadLocalUniquePtr);
 };
 
-#endif  // FML_THREAD_LOCAL_PTHREADS
-
 }  // namespace fml
+
+#endif  // FLUTTER_FML_THREAD_LOCAL_H_


### PR DESCRIPTION
The thread_local storage class was not available pre-C++11. Even when C++11 was available, the C++ runtime in versions of iOS <= 9.0 was not capable of supporting this storage class. So we ended up using pthread directly in that case. The unique pointer support was added later. Now that the storage class has been supported on all Flutter platforms for a while, we can remove the fallback and remove a bunch of code. The ThreadLocalUniquePtr can be removed too but that can be attempted in a separate migration.