### PR TITLE
[Windows] Remove `PlatformWindow` and `RenderTarget` abstractions

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -229,10 +229,10 @@ void AngleSurfaceManager::CleanUp() {
   }
 }
 
-bool AngleSurfaceManager::CreateSurface(WindowsRenderTarget* render_target,
+bool AngleSurfaceManager::CreateSurface(HWND hwnd,
                                         EGLint width,
                                         EGLint height) {
-  if (!render_target || !initialize_succeeded_) {
+  if (!hwnd || !initialize_succeeded_) {
     return false;
   }
 
@@ -242,10 +242,9 @@ bool AngleSurfaceManager::CreateSurface(WindowsRenderTarget* render_target,
       EGL_FIXED_SIZE_ANGLE, EGL_TRUE, EGL_WIDTH, width,
       EGL_HEIGHT,           height,   EGL_NONE};
 
-  surface = eglCreateWindowSurface(
-      egl_display_, egl_config_,
-      static_cast<EGLNativeWindowType>(std::get<HWND>(*render_target)),
-      surfaceAttributes);
+  surface = eglCreateWindowSurface(egl_display_, egl_config_,
+                                   static_cast<EGLNativeWindowType>(hwnd),
+                                   surfaceAttributes);
   if (surface == EGL_NO_SURFACE) {
     LogEglError("Surface creation failed.");
     return false;
@@ -257,7 +256,7 @@ bool AngleSurfaceManager::CreateSurface(WindowsRenderTarget* render_target,
   return true;
 }
 
-void AngleSurfaceManager::ResizeSurface(WindowsRenderTarget* render_target,
+void AngleSurfaceManager::ResizeSurface(HWND hwnd,
                                         EGLint width,
                                         EGLint height,
                                         bool vsync_enabled) {
@@ -269,7 +268,7 @@ void AngleSurfaceManager::ResizeSurface(WindowsRenderTarget* render_target,
 
     ClearContext();
     DestroySurface();
-    if (!CreateSurface(render_target, width, height)) {
+    if (!CreateSurface(hwnd, width, height)) {
       FML_LOG(ERROR)
           << "AngleSurfaceManager::ResizeSurface failed to create surface";
     }

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -33,14 +33,12 @@ class AngleSurfaceManager {
 
   // Creates an EGLSurface wrapper and backing DirectX 11 SwapChain
   // associated with window, in the appropriate format for display.
-  // Target represents the visual entity to bind to. Width and
-  // height represent dimensions surface is created at.
+  // HWND is the window backing the surface. Width and height represent
+  // dimensions surface is created at.
   //
   // After the surface is created, |SetVSyncEnabled| should be called on a
   // thread that can bind the |egl_context_|.
-  virtual bool CreateSurface(WindowsRenderTarget* render_target,
-                             EGLint width,
-                             EGLint height);
+  virtual bool CreateSurface(HWND hwnd, EGLint width, EGLint height);
 
   // Resizes backing surface from current size to newly requested size
   // based on width and height for the specific case when width and height do
@@ -48,7 +46,7 @@ class AngleSurfaceManager {
   // to bind to.
   //
   // This binds |egl_context_| to the current thread.
-  virtual void ResizeSurface(WindowsRenderTarget* render_target,
+  virtual void ResizeSurface(HWND hwnd,
                              EGLint width,
                              EGLint height,
                              bool enable_vsync);

--- a/shell/platform/windows/compositor_opengl_unittests.cc
+++ b/shell/platform/windows/compositor_opengl_unittests.cc
@@ -104,7 +104,7 @@ class CompositorOpenGLTest : public WindowsTest {
 
     auto window = std::make_unique<MockWindowBindingHandler>();
     EXPECT_CALL(*window.get(), SetView).Times(1);
-    EXPECT_CALL(*window.get(), GetRenderTarget).WillRepeatedly(Return(nullptr));
+    EXPECT_CALL(*window.get(), GetWindowHandle).WillRepeatedly(Return(nullptr));
 
     view_ = std::make_unique<MockFlutterWindowsView>(std::move(window));
 

--- a/shell/platform/windows/compositor_software_unittests.cc
+++ b/shell/platform/windows/compositor_software_unittests.cc
@@ -56,7 +56,7 @@ class CompositorSoftwareTest : public WindowsTest {
 
     auto window = std::make_unique<MockWindowBindingHandler>();
     EXPECT_CALL(*window.get(), SetView).Times(1);
-    EXPECT_CALL(*window.get(), GetRenderTarget).WillRepeatedly(Return(nullptr));
+    EXPECT_CALL(*window.get(), GetWindowHandle).WillRepeatedly(Return(nullptr));
 
     engine_ = builder.Build();
     view_ = std::make_unique<MockFlutterWindowsView>(std::move(window));

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -76,7 +76,6 @@ class CursorHandlerTest : public WindowsTest {
 
     window_ = window.get();
     EXPECT_CALL(*window_, SetView).Times(1);
-    EXPECT_CALL(*window_, GetRenderTarget).WillOnce(Return(nullptr));
 
     engine_ = builder.Build();
     view_ = std::make_unique<FlutterWindowsView>(std::move(window));

--- a/shell/platform/windows/flutter_platform_node_delegate_windows.cc
+++ b/shell/platform/windows/flutter_platform_node_delegate_windows.cc
@@ -87,8 +87,8 @@ gfx::Rect FlutterPlatformNodeDelegateWindows::GetBoundsRect(
       coordinate_system, clipping_behavior, offscreen_result);
   POINT origin{bounds.x(), bounds.y()};
   POINT extent{bounds.x() + bounds.width(), bounds.y() + bounds.height()};
-  ClientToScreen(view_->GetPlatformWindow(), &origin);
-  ClientToScreen(view_->GetPlatformWindow(), &extent);
+  ClientToScreen(view_->GetWindowHandle(), &origin);
+  ClientToScreen(view_->GetWindowHandle(), &extent);
   return gfx::Rect(origin.x, origin.y, extent.x - origin.x,
                    extent.y - origin.y);
 }
@@ -107,7 +107,7 @@ void FlutterPlatformNodeDelegateWindows::SetFocus() {
 
 gfx::AcceleratedWidget
 FlutterPlatformNodeDelegateWindows::GetTargetForNativeAccessibilityEvent() {
-  return view_->GetPlatformWindow();
+  return view_->GetWindowHandle();
 }
 
 ui::AXPlatformNode* FlutterPlatformNodeDelegateWindows::GetPlatformNode()

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -164,14 +164,6 @@ void FlutterWindow::SetView(WindowBindingHandlerDelegate* window) {
   }
 }
 
-WindowsRenderTarget FlutterWindow::GetRenderTarget() {
-  return WindowsRenderTarget(GetWindowHandle());
-}
-
-PlatformWindow FlutterWindow::GetPlatformWindow() {
-  return GetWindowHandle();
-}
-
 float FlutterWindow::GetDpiScale() {
   return static_cast<float>(GetCurrentDPI()) / static_cast<float>(base_dpi);
 }
@@ -408,7 +400,7 @@ void FlutterWindow::OnWindowStateEvent(WindowStateEvent event) {
       focused_ = false;
       break;
   }
-  HWND hwnd = GetPlatformWindow();
+  HWND hwnd = GetWindowHandle();
   if (hwnd && binding_handler_delegate_) {
     binding_handler_delegate_->OnWindowStateEvent(hwnd, event);
   }

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -50,8 +50,6 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
                        unsigned int width,
                        unsigned int height);
 
-  HWND GetWindowHandle();
-
   // |KeyboardManager::WindowDelegate|
   virtual BOOL Win32PeekMessage(LPMSG lpMsg,
                                 UINT wMsgFilterMin,
@@ -155,10 +153,7 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
   virtual void SetView(WindowBindingHandlerDelegate* view) override;
 
   // |FlutterWindowBindingHandler|
-  virtual WindowsRenderTarget GetRenderTarget() override;
-
-  // |FlutterWindowBindingHandler|
-  virtual PlatformWindow GetPlatformWindow() override;
+  virtual HWND GetWindowHandle() override;
 
   // |FlutterWindowBindingHandler|
   virtual float GetDpiScale() override;

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -72,7 +72,7 @@ class MockFlutterWindow : public FlutterWindow {
   MOCK_METHOD(UINT, Win32DispatchMessage, (UINT, WPARAM, LPARAM), (override));
   MOCK_METHOD(BOOL, Win32PeekMessage, (LPMSG, UINT, UINT, UINT), (override));
   MOCK_METHOD(uint32_t, Win32MapVkToChar, (uint32_t), (override));
-  MOCK_METHOD(HWND, GetPlatformWindow, (), (override));
+  MOCK_METHOD(HWND, GetWindowHandle, (), (override));
   MOCK_METHOD(ui::AXFragmentRootDelegateWin*,
               GetAxFragmentRootDelegate,
               (),
@@ -341,7 +341,7 @@ TEST(FlutterWindowTest, AlertNode) {
 
 TEST(FlutterWindowTest, LifecycleFocusMessages) {
   MockFlutterWindow win32window;
-  EXPECT_CALL(win32window, GetPlatformWindow)
+  EXPECT_CALL(win32window, GetWindowHandle)
       .WillRepeatedly(Return(reinterpret_cast<HWND>(1)));
   MockWindowBindingHandlerDelegate delegate;
 
@@ -373,7 +373,7 @@ TEST(FlutterWindowTest, LifecycleFocusMessages) {
 
 TEST(FlutterWindowTest, CachedLifecycleMessage) {
   MockFlutterWindow win32window;
-  EXPECT_CALL(win32window, GetPlatformWindow)
+  EXPECT_CALL(win32window, GetWindowHandle)
       .WillRepeatedly(Return(reinterpret_cast<HWND>(1)));
   EXPECT_CALL(win32window, OnWindowStateEvent)
       .WillRepeatedly([&](WindowStateEvent event) {
@@ -413,8 +413,8 @@ TEST(FlutterWindowTest, PosthumousWindowMessage) {
 
   {
     MockFlutterWindow win32window(false);
-    EXPECT_CALL(win32window, GetPlatformWindow).WillRepeatedly([&]() {
-      return win32window.FlutterWindow::GetPlatformWindow();
+    EXPECT_CALL(win32window, GetWindowHandle).WillRepeatedly([&]() {
+      return win32window.FlutterWindow::GetWindowHandle();
     });
     EXPECT_CALL(win32window, OnWindowStateEvent)
         .WillRepeatedly([&](WindowStateEvent event) {
@@ -423,7 +423,7 @@ TEST(FlutterWindowTest, PosthumousWindowMessage) {
     EXPECT_CALL(win32window, OnResize).Times(AnyNumber());
     win32window.SetView(&delegate);
     win32window.InitializeChild("Title", 1, 1);
-    hwnd = win32window.GetPlatformWindow();
+    hwnd = win32window.GetWindowHandle();
     SendMessage(hwnd, WM_SIZE, 0, MAKEWORD(1, 1));
     SendMessage(hwnd, WM_SETFOCUS, 0, 0);
 

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -211,7 +211,7 @@ void FlutterDesktopEngineSetNextFrameCallback(FlutterDesktopEngineRef engine,
 }
 
 HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef view) {
-  return ViewFromHandle(view)->GetPlatformWindow();
+  return ViewFromHandle(view)->GetWindowHandle();
 }
 
 IDXGIAdapter* FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef view) {

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -626,7 +626,7 @@ class MockFlutterWindowsView : public FlutterWindowsView {
               NotifyWinEventWrapper,
               (ui::AXPlatformNodeWin*, ax::mojom::Event),
               (override));
-  MOCK_METHOD(PlatformWindow, GetPlatformWindow, (), (const, override));
+  MOCK_METHOD(HWND, GetWindowHandle, (), (const, override));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsView);
@@ -1017,7 +1017,7 @@ TEST_F(FlutterWindowsEngineTest, InnerWindowHidden) {
   auto window_binding_handler =
       std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
   MockFlutterWindowsView view(std::move(window_binding_handler));
-  ON_CALL(view, GetPlatformWindow).WillByDefault([=]() { return inner; });
+  ON_CALL(view, GetWindowHandle).WillByDefault([=]() { return inner; });
   view.SetEngine(engine.get());
 
   EngineModifier modifier(engine.get());

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -76,9 +76,6 @@ FlutterWindowsView::FlutterWindowsView(
   // Take the binding handler, and give it a pointer back to self.
   binding_handler_ = std::move(window_binding);
   binding_handler_->SetView(this);
-
-  render_target_ = std::make_unique<WindowsRenderTarget>(
-      binding_handler_->GetRenderTarget());
 }
 
 FlutterWindowsView::~FlutterWindowsView() {
@@ -116,7 +113,7 @@ void FlutterWindowsView::OnEmptyFrameGenerated() {
   // Platform thread is blocked for the entire duration until the
   // resize_status_ is set to kDone.
   engine_->surface_manager()->ResizeSurface(
-      GetRenderTarget(), resize_target_width_, resize_target_height_,
+      GetWindowHandle(), resize_target_width_, resize_target_height_,
       binding_handler_->NeedsVSync());
   resize_status_ = ResizeState::kFrameGenerated;
 }
@@ -132,7 +129,7 @@ bool FlutterWindowsView::OnFrameGenerated(size_t width, size_t height) {
   if (resize_target_width_ == width && resize_target_height_ == height) {
     // Platform thread is blocked for the entire duration until the
     // resize_status_ is set to kDone.
-    engine_->surface_manager()->ResizeSurface(GetRenderTarget(), width, height,
+    engine_->surface_manager()->ResizeSurface(GetWindowHandle(), width, height,
                                               binding_handler_->NeedsVSync());
     resize_status_ = ResizeState::kFrameGenerated;
     return true;
@@ -638,7 +635,7 @@ bool FlutterWindowsView::PresentSoftwareBitmap(const void* allocation,
 void FlutterWindowsView::CreateRenderSurface() {
   if (engine_ && engine_->surface_manager()) {
     PhysicalWindowBounds bounds = binding_handler_->GetPhysicalWindowBounds();
-    engine_->surface_manager()->CreateSurface(GetRenderTarget(), bounds.width,
+    engine_->surface_manager()->CreateSurface(GetWindowHandle(), bounds.width,
                                               bounds.height);
 
     UpdateVsync(*engine_, *binding_handler_);
@@ -658,12 +655,8 @@ void FlutterWindowsView::OnHighContrastChanged() {
   engine_->UpdateHighContrastMode();
 }
 
-WindowsRenderTarget* FlutterWindowsView::GetRenderTarget() const {
-  return render_target_.get();
-}
-
-PlatformWindow FlutterWindowsView::GetPlatformWindow() const {
-  return binding_handler_->GetPlatformWindow();
+HWND FlutterWindowsView::GetWindowHandle() const {
+  return binding_handler_->GetWindowHandle();
 }
 
 FlutterWindowsEngine* FlutterWindowsView::GetEngine() {

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -50,11 +50,8 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // Destroys current rendering surface if one has been allocated.
   void DestroyRenderSurface();
 
-  // Return the currently configured WindowsRenderTarget.
-  WindowsRenderTarget* GetRenderTarget() const;
-
-  // Return the currently configured PlatformWindow.
-  virtual PlatformWindow GetPlatformWindow() const;
+  // Return the currently configured HWND.
+  virtual HWND GetWindowHandle() const;
 
   // Returns the engine backing this view.
   FlutterWindowsEngine* GetEngine();
@@ -367,11 +364,6 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // needed before passing on to engine.
   void SendPointerEventWithData(const FlutterPointerEvent& event_data,
                                 PointerState* state);
-
-  // Currently configured WindowsRenderTarget for this view used by
-  // surface_manager for creation of render surfaces and bound to the physical
-  // os window.
-  std::unique_ptr<WindowsRenderTarget> render_target_;
 
   // The engine associated with this view.
   FlutterWindowsEngine* engine_ = nullptr;

--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -258,7 +258,7 @@ void PlatformHandler::GetPlainText(
   std::unique_ptr<ScopedClipboardInterface> clipboard =
       scoped_clipboard_provider_();
 
-  int open_result = clipboard->Open(std::get<HWND>(*view->GetRenderTarget()));
+  int open_result = clipboard->Open(view->GetWindowHandle());
   if (open_result != kErrorSuccess) {
     rapidjson::Document error_code;
     error_code.SetInt(open_result);
@@ -302,7 +302,7 @@ void PlatformHandler::GetHasStrings(
       scoped_clipboard_provider_();
 
   bool hasStrings;
-  int open_result = clipboard->Open(std::get<HWND>(*view->GetRenderTarget()));
+  int open_result = clipboard->Open(view->GetWindowHandle());
   if (open_result != kErrorSuccess) {
     // Swallow errors of type ERROR_ACCESS_DENIED. These happen when the app is
     // not in the foreground and GetHasStrings is irrelevant.
@@ -339,7 +339,7 @@ void PlatformHandler::SetPlainText(
   std::unique_ptr<ScopedClipboardInterface> clipboard =
       scoped_clipboard_provider_();
 
-  int open_result = clipboard->Open(std::get<HWND>(*view->GetRenderTarget()));
+  int open_result = clipboard->Open(view->GetWindowHandle());
   if (open_result != kErrorSuccess) {
     rapidjson::Document error_code;
     error_code.SetInt(open_result);

--- a/shell/platform/windows/testing/mock_angle_surface_manager.h
+++ b/shell/platform/windows/testing/mock_angle_surface_manager.h
@@ -17,14 +17,8 @@ class MockAngleSurfaceManager : public AngleSurfaceManager {
  public:
   MockAngleSurfaceManager() : AngleSurfaceManager(false) {}
 
-  MOCK_METHOD(bool,
-              CreateSurface,
-              (WindowsRenderTarget*, EGLint, EGLint),
-              (override));
-  MOCK_METHOD(void,
-              ResizeSurface,
-              (WindowsRenderTarget*, EGLint, EGLint, bool),
-              (override));
+  MOCK_METHOD(bool, CreateSurface, (HWND, EGLint, EGLint), (override));
+  MOCK_METHOD(void, ResizeSurface, (HWND, EGLint, EGLint, bool), (override));
   MOCK_METHOD(void, DestroySurface, (), (override));
 
   MOCK_METHOD(bool, MakeCurrent, (), (override));

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -20,8 +20,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   virtual ~MockWindowBindingHandler();
 
   MOCK_METHOD(void, SetView, (WindowBindingHandlerDelegate * view), (override));
-  MOCK_METHOD(WindowsRenderTarget, GetRenderTarget, (), (override));
-  MOCK_METHOD(PlatformWindow, GetPlatformWindow, (), (override));
+  MOCK_METHOD(HWND, GetWindowHandle, (), (override));
   MOCK_METHOD(float, GetDpiScale, (), (override));
   MOCK_METHOD(bool, IsVisible, (), (override));
   MOCK_METHOD(void, OnWindowResized, (), (override));

--- a/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/shell/platform/windows/text_input_plugin_unittest.cc
@@ -140,7 +140,7 @@ class TextInputPluginTest : public WindowsTest {
 
     window_ = window.get();
     EXPECT_CALL(*window_, SetView).Times(1);
-    EXPECT_CALL(*window, GetRenderTarget).WillRepeatedly(Return(nullptr));
+    EXPECT_CALL(*window, GetWindowHandle).WillRepeatedly(Return(nullptr));
 
     engine_ = builder.Build();
     view_ = std::make_unique<MockFlutterWindowsView>(std::move(window));

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -36,13 +36,6 @@ struct PointerLocation {
   size_t y;
 };
 
-// Type representing an underlying platform window.
-using PlatformWindow = HWND;
-
-// Type representing a platform object that can be accepted by the Angle
-// rendering layer to bind to and render pixels into.
-using WindowsRenderTarget = std::variant<HWND>;
-
 // Abstract class for binding Windows platform windows to Flutter views.
 class WindowBindingHandler {
  public:
@@ -52,18 +45,13 @@ class WindowBindingHandler {
   // such as key presses, mouse position updates etc.
   virtual void SetView(WindowBindingHandlerDelegate* view) = 0;
 
-  // Returns a valid WindowsRenderTarget representing the platform object that
-  // rendering can be bound to by ANGLE rendering backend.
-  virtual WindowsRenderTarget GetRenderTarget() = 0;
-
-  // Returns a valid PlatformWindow representing the backing
-  // window.
-  virtual PlatformWindow GetPlatformWindow() = 0;
+  // Returns the underlying HWND backing the window.
+  virtual HWND GetWindowHandle() = 0;
 
   // Returns the scale factor for the backing window.
   virtual float GetDpiScale() = 0;
 
-  // Returns whether the PlatformWindow is currently visible.
+  // Returns whether the HWND is currently visible.
   virtual bool IsVisible() = 0;
 
   // Returns the bounds of the backing window in physical pixels.


### PR DESCRIPTION
The Windows embedder has three ways to get an `HWND`:

1. `GetWindowHandle` which returns the `HWND`
2. `GetPlatformWindow` which returns the `HWND` wrapped as a `PlatformWindow`
3. `GetRenderTarget` which returns the `HWND` wrapped as a `RenderTarget`

These abstractions are no longer useful now that we removed the UWP embedder. This change removes `PlatformWindow` and `RenderTarget` and uses `HWND` directly.

This change is a refactoring with no semantic changes.