### PR TITLE
[web] Add `views` proxy and `getInitialData`.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -6137,6 +6137,7 @@ ORIGIN: ../../../flutter/lib/web_ui/lib/ui.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/asset_manager.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/benchmarks.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/images.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/initialization.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/navigation/platform_location.dart + ../../../flutter/LICENSE
@@ -8978,6 +8979,7 @@ FILE: ../../../flutter/lib/web_ui/lib/ui.dart
 FILE: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web.dart
 FILE: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/asset_manager.dart
 FILE: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/benchmarks.dart
+FILE: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
 FILE: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/images.dart
 FILE: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/initialization.dart
 FILE: ../../../flutter/lib/web_ui/lib/ui_web/src/ui_web/navigation/platform_location.dart

--- a/lib/web_ui/lib/src/engine/js_interop/js_app.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_app.dart
@@ -25,7 +25,7 @@ extension JsFlutterViewOptionsExtension on JsFlutterViewOptions {
     return _hostElement!;
   }
 
-  external Object? get initialData;
+  external JSAny? get initialData;
 }
 
 /// The public JS API of a running Flutter Web App.

--- a/lib/web_ui/lib/src/engine/js_interop/js_app.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_app.dart
@@ -25,7 +25,7 @@ extension JsFlutterViewOptionsExtension on JsFlutterViewOptions {
     return _hostElement!;
   }
 
-  external JSAny? get initialData;
+  external Object? get initialData;
 }
 
 /// The public JS API of a running Flutter Web App.

--- a/lib/web_ui/lib/src/engine/js_interop/js_app.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_app.dart
@@ -24,8 +24,6 @@ extension JsFlutterViewOptionsExtension on JsFlutterViewOptions {
     assert (_hostElement != null, '`hostElement` passed to addView cannot be null.');
     return _hostElement!;
   }
-
-  external JSAny? get initialData;
 }
 
 /// The public JS API of a running Flutter Web App.

--- a/lib/web_ui/lib/src/engine/js_interop/js_app.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_app.dart
@@ -24,6 +24,8 @@ extension JsFlutterViewOptionsExtension on JsFlutterViewOptions {
     assert (_hostElement != null, '`hostElement` passed to addView cannot be null.');
     return _hostElement!;
   }
+
+  external JSAny? get initialData;
 }
 
 /// The public JS API of a running Flutter Web App.

--- a/lib/web_ui/lib/src/engine/js_interop/js_app.dart
+++ b/lib/web_ui/lib/src/engine/js_interop/js_app.dart
@@ -25,9 +25,7 @@ extension JsFlutterViewOptionsExtension on JsFlutterViewOptions {
     return _hostElement!;
   }
 
-  @JS('initialData')
-  external JSObject? get _initialData;
-  Object? get initialData => _initialData?.toObjectDeep;
+  external JSAny? get initialData;
 }
 
 /// The public JS API of a running Flutter Web App.

--- a/lib/web_ui/lib/ui_web/src/ui_web.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web.dart
@@ -10,6 +10,7 @@ library ui_web;
 
 export 'ui_web/asset_manager.dart';
 export 'ui_web/benchmarks.dart';
+export 'ui_web/flutter_views_proxy.dart';
 export 'ui_web/images.dart';
 export 'ui_web/initialization.dart';
 export 'ui_web/navigation/platform_location.dart';

--- a/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
@@ -16,14 +16,13 @@ class FlutterViewManagerProxy {
     }) : _viewManager = viewManager;
   // The proxied viewManager instance.
   final FlutterViewManager _viewManager;
-  /// Returns the `initialData` configuration value passed from JS when `viewId` was added.
+
+  /// Returns the `hostElement` configuration value passed from JS when `viewId` was added.
   ///
-  /// Developers can access the initial data from Dart in two ways:
-  ///  * Defining their own `staticInterop` class that describes what you're
-  ///    passing to your views, to retain type safety on Dart (preferred).
-  ///  * Calling [NullableUndefineableJSAnyExtension.dartify] and accessing the
-  ///    returned object as if it were a [Map] (not recommended).
-  Object? getInitialData(int viewId) {
-    return _viewManager.getOptions(viewId)?.initialData;
+  /// This is useful for plugins and apps to have a safe DOM Element where they
+  /// can add their own custom HTML elements (for example: file inputs for the
+  /// file_selector plugin).
+  JSAny? getHostElement(int viewId) {
+    return _viewManager.getOptions(viewId)?.hostElement as JSAny?;
   }
 }

--- a/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'dart:js_interop';
+import 'package:ui/src/engine.dart';
+
+/// The proxy instance for the internal `viewManager` of this app.
+final FlutterViewManagerProxy viewsProxy = FlutterViewManagerProxy();
+
+/// Proxy class for the internal [FlutterViewManager].
+class FlutterViewManagerProxy {
+  /// Returns the `initialData` configuration value passed from JS when `viewId` was added.
+  ///
+  /// Developers can access the initial data from Dart in two ways:
+  ///  * Defining their own `staticInterop` class that describes what you're
+  ///    passing to your views, to retain type safety on Dart (preferred).
+  ///  * Calling [NullableUndefineableJSAnyExtension.dartify] and accessing the
+  ///    returned object as if it were a [Map] (not recommended).
+  JSAny? getInitialData(int viewId) {
+    return EnginePlatformDispatcher.instance.viewManager.getOptions(viewId)?.initialData;
+  }
+}

--- a/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
@@ -16,6 +16,16 @@ class FlutterViewManagerProxy {
     }) : _viewManager = viewManager;
   // The proxied viewManager instance.
   final FlutterViewManager _viewManager;
+
+  /// Returns the `hostElement` configuration value passed from JS when `viewId` was added.
+  ///
+  /// This is useful for plugins and apps to have a safe DOM Element where they
+  /// can add their own custom HTML elements (for example: file inputs for the
+  /// file_selector plugin).
+  JSAny? getHostElement(int viewId) {
+    return _viewManager.getOptions(viewId)?.hostElement as JSAny?;
+  }
+
   /// Returns the `initialData` configuration value passed from JS when `viewId` was added.
   ///
   /// Developers can access the initial data from Dart in two ways:
@@ -23,7 +33,7 @@ class FlutterViewManagerProxy {
   ///    passing to your views, to retain type safety on Dart (preferred).
   ///  * Calling [NullableUndefineableJSAnyExtension.dartify] and accessing the
   ///    returned object as if it were a [Map] (not recommended).
-  Object? getInitialData(int viewId) {
+  JSAny? getInitialData(int viewId) {
     return _viewManager.getOptions(viewId)?.initialData;
   }
 }

--- a/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
@@ -4,11 +4,18 @@
 import 'dart:js_interop';
 import 'package:ui/src/engine.dart';
 
-/// The proxy instance for the internal `viewManager` of this app.
-final FlutterViewManagerProxy viewsProxy = FlutterViewManagerProxy();
+/// Exposes web-only functionality for this app's `FlutterView`s objects.
+final FlutterViewManagerProxy views = FlutterViewManagerProxy(
+  viewManager: EnginePlatformDispatcher.instance.viewManager,
+);
 
-/// Proxy class for the internal [FlutterViewManager].
+/// This class exposes web-only attributes for the registered views in a multi-view app.
 class FlutterViewManagerProxy {
+  FlutterViewManagerProxy({
+      required FlutterViewManager viewManager,
+    }) : _viewManager = viewManager;
+  // The proxied viewManager instance.
+  final FlutterViewManager _viewManager;
   /// Returns the `initialData` configuration value passed from JS when `viewId` was added.
   ///
   /// Developers can access the initial data from Dart in two ways:
@@ -16,7 +23,7 @@ class FlutterViewManagerProxy {
   ///    passing to your views, to retain type safety on Dart (preferred).
   ///  * Calling [NullableUndefineableJSAnyExtension.dartify] and accessing the
   ///    returned object as if it were a [Map] (not recommended).
-  JSAny? getInitialData(int viewId) {
-    return EnginePlatformDispatcher.instance.viewManager.getOptions(viewId)?.initialData;
+  Object? getInitialData(int viewId) {
+    return _viewManager.getOptions(viewId)?.initialData;
   }
 }

--- a/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/flutter_views_proxy.dart
@@ -16,13 +16,14 @@ class FlutterViewManagerProxy {
     }) : _viewManager = viewManager;
   // The proxied viewManager instance.
   final FlutterViewManager _viewManager;
-
-  /// Returns the `hostElement` configuration value passed from JS when `viewId` was added.
+  /// Returns the `initialData` configuration value passed from JS when `viewId` was added.
   ///
-  /// This is useful for plugins and apps to have a safe DOM Element where they
-  /// can add their own custom HTML elements (for example: file inputs for the
-  /// file_selector plugin).
-  JSAny? getHostElement(int viewId) {
-    return _viewManager.getOptions(viewId)?.hostElement as JSAny?;
+  /// Developers can access the initial data from Dart in two ways:
+  ///  * Defining their own `staticInterop` class that describes what you're
+  ///    passing to your views, to retain type safety on Dart (preferred).
+  ///  * Calling [NullableUndefineableJSAnyExtension.dartify] and accessing the
+  ///    returned object as if it were a [Map] (not recommended).
+  Object? getInitialData(int viewId) {
+    return _viewManager.getOptions(viewId)?.initialData;
   }
 }

--- a/lib/web_ui/test/engine/view_embedder/flutter_views_proxy_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/flutter_views_proxy_test.dart
@@ -1,0 +1,107 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:math' as math;
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => doTests);
+}
+
+Future<void> doTests() async {
+  group('FlutterViewManagerProxy', () {
+    final EnginePlatformDispatcher platformDispatcher =
+        EnginePlatformDispatcher.instance;
+    final FlutterViewManager viewManager =
+        FlutterViewManager(platformDispatcher);
+    final FlutterViewManagerProxy views =
+        FlutterViewManagerProxy(viewManager: viewManager);
+
+    late EngineFlutterView view;
+    late int viewId;
+    late DomElement hostElement;
+
+    int registerViewWithOptions(Map<String, Object?> options) {
+      final JsFlutterViewOptions jsOptions =
+          options.toJSAnyDeep as JsFlutterViewOptions;
+      viewManager.registerView(view, jsViewOptions: jsOptions);
+      return viewId;
+    }
+
+    setUp(() {
+      view = EngineFlutterView(platformDispatcher, createDomElement('div'));
+      viewId = view.viewId;
+      hostElement = createDomElement('div');
+    });
+
+    tearDown(() {
+      viewManager.unregisterView(viewId);
+    });
+
+    group('getHostElement', () {
+      test('null when viewId is unknown', () {
+        final JSAny? element = views.getHostElement(33930);
+        expect(element, isNull);
+      });
+
+      test('can retrieve hostElement for a known view', () {
+        final int viewId = registerViewWithOptions(<String, Object?>{
+          'hostElement': hostElement,
+        });
+
+        final JSAny? element = views.getHostElement(viewId);
+
+        expect(element, hostElement);
+      });
+    });
+
+    group('getInitialData', () {
+      test('null when viewId is unknown', () {
+        final JSAny? element = views.getInitialData(33930);
+        expect(element, isNull);
+      });
+
+      test('can retrieve initialData for a known view', () {
+        final int viewId = registerViewWithOptions(<String, Object?>{
+          'hostElement': hostElement,
+          'initialData': <String, Object?>{
+            'someInt': 42,
+            'someString': 'A String',
+            'decimals': <double>[math.pi, math.e],
+          },
+        });
+
+        final InitialData? element =
+            views.getInitialData(viewId) as InitialData?;
+
+        expect(element, isNotNull);
+        expect(element!.someInt, 42);
+        expect(element.someString, 'A String');
+        expect(element.decimals, <double>[math.pi, math.e]);
+      });
+    });
+  });
+}
+
+// The JS-interop definition of the `initialData` object passed to the views of this app.
+@JS()
+@staticInterop
+class InitialData {}
+
+/// The attributes of the [InitialData] object.
+extension InitialDataExtension on InitialData {
+  external int get someInt;
+  external String? get someString;
+
+  @JS('decimals')
+  external JSArray<JSNumber> get _decimals;
+  List<double> get decimals =>
+      _decimals.toDart.map((JSNumber e) => e.toDartDouble).toList();
+}


### PR DESCRIPTION
Adds a Dart API so Application/Plugin programmers can retrieve the `initialData` configuration value that may be passed when adding a view from JS in a multiViewEnabled app.

When adding a view to an app like this:

```js
flutterApp.addView({
  hostElement: someElement,
  initialData: {
    randomUUID: globalThis.crypto.randomUUID(),
  }
});
```

`initialData` can be accessed from Dart by defining a JS-interop class like:

```dart
import 'dart:js_interop';

// The JS-interop definition of the `initialData` object passed to the views of this app.
@JS()
@staticInterop
class InitialData {}

/// The attributes of the [InitialData] object.
extension InitialDataExtension on InitialData {
  external String? get randomUUID;
}
```

And then, from the code of the application:

```dart
...
  Widget build(BuildContext context) {
    final int viewId = View.of(context).viewId;
    final InitialData? data = ui_web.views.getInitialData(viewId) as InitialData?;
    return Text('${data?.randomUUID}');
  }
...
```

## Testing

Will add unit tests once naming is sorted out :)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
