### PR TITLE
[Windows] Fix incorrect surface manager comment

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -238,6 +238,9 @@ bool AngleSurfaceManager::CreateSurface(WindowsRenderTarget* render_target,
 
   EGLSurface surface = EGL_NO_SURFACE;
 
+  // Disable ANGLE's automatic surface resizing and provide an explicit size.
+  // The surface will need to be destroyed and re-created if the HWND is
+  // resized.
   const EGLint surfaceAttributes[] = {
       EGL_FIXED_SIZE_ANGLE, EGL_TRUE, EGL_WIDTH, width,
       EGL_HEIGHT,           height,   EGL_NONE};
@@ -285,9 +288,10 @@ void AngleSurfaceManager::GetSurfaceDimensions(EGLint* width, EGLint* height) {
     return;
   }
 
-  // Can't use eglQuerySurface here; Because we're not using
-  // EGL_FIXED_SIZE_ANGLE flag anymore, Angle may resize the surface before
-  // Flutter asks it to, which breaks resize redraw synchronization
+  // This avoids eglQuerySurface as ideally surfaces would be automatically
+  // sized by ANGLE to avoid expensive surface destroy & re-create. With
+  // automatic sizing, ANGLE could resize the surface before Flutter asks it to,
+  // which would break resize redraw synchronization.
   *width = surface_width_;
   *height = surface_height_;
 }

--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -270,6 +270,9 @@ void AngleSurfaceManager::ResizeSurface(WindowsRenderTarget* render_target,
     surface_width_ = width;
     surface_height_ = height;
 
+    // TODO: Destroying the surface and re-creating it is expensive.
+    // Ideally this would use ANGLE's automatic surface sizing instead.
+    // See: https://github.com/flutter/flutter/issues/79427
     ClearContext();
     DestroySurface();
     if (!CreateSurface(render_target, width, height)) {


### PR DESCRIPTION
https://github.com/flutter/engine/pull/24428 attempted to make surface resizing less expensive by using ANGLE's automatic resizing instead of manually destroying and then re-creating the surface. This caused some issues:

1. Flutter's surface size synchronization logic broke: https://github.com/flutter/engine/pull/24682
2. Resizing frameless windows caused the content to wiggle: https://github.com/flutter/flutter/issues/76465

The second issue caused the automatic resizing change to be reverted. However, the first fix was not reverted resulting in an incorrect comment.

Relanding this resizing performance improvement is tracked by https://github.com/flutter/flutter/issues/79427
