### PR TITLE
Fix GetImpellerContext for ShellTestPlatformViewGL

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -262,6 +262,10 @@ if (enable_unittests) {
       "//flutter/third_party/rapidjson",
     ]
 
+    if (impeller_supports_rendering) {
+      deps += [ "//flutter/impeller" ]
+    }
+
     public_configs = [
       ":shell_test_fixture_sources_config",
       ":shell_unittests_gpu_configuration_config",

--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -12,7 +12,7 @@
 #include "impeller/entity/gles/entity_shaders_gles.h"
 
 #if IMPELLER_ENABLE_3D
-#include "impeller/scene/shaders/gles/scene_shaders_gles.h"
+#include "impeller/scene/shaders/gles/scene_shaders_gles.h"  // nogncheck
 #endif
 
 namespace flutter {

--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -6,10 +6,29 @@
 
 #include <utility>
 
+#include <EGL/egl.h>
+
 #include "flutter/shell/gpu/gpu_surface_gl_skia.h"
+#include "impeller/entity/gles/entity_shaders_gles.h"
+
+#if IMPELLER_ENABLE_3D
+#include "impeller/scene/shaders/gles/scene_shaders_gles.h"
+#endif
 
 namespace flutter {
 namespace testing {
+
+static std::vector<std::shared_ptr<fml::Mapping>> ShaderLibraryMappings() {
+  return {
+      std::make_shared<fml::NonOwnedMapping>(
+          impeller_entity_shaders_gles_data,
+          impeller_entity_shaders_gles_length),
+#if IMPELLER_ENABLE_3D
+      std::make_shared<fml::NonOwnedMapping>(
+          impeller_scene_shaders_gles_data, impeller_scene_shaders_gles_length),
+#endif
+  };
+}
 
 ShellTestPlatformViewGL::ShellTestPlatformViewGL(
     PlatformView::Delegate& delegate,
@@ -23,7 +42,23 @@ ShellTestPlatformViewGL::ShellTestPlatformViewGL(
       create_vsync_waiter_(std::move(create_vsync_waiter)),
       vsync_clock_(std::move(vsync_clock)),
       shell_test_external_view_embedder_(
-          std::move(shell_test_external_view_embedder)) {}
+          std::move(shell_test_external_view_embedder)) {
+  if (GetSettings().enable_impeller) {
+    auto resolver = [](const char* name) -> void* {
+      return reinterpret_cast<void*>(::eglGetProcAddress(name));
+    };
+    // ANGLE needs this to initialize version strings checked by
+    // impeller::ProcTableGLES.
+    gl_surface_.MakeCurrent();
+    auto gl = std::make_unique<impeller::ProcTableGLES>(resolver);
+    if (!gl->IsValid()) {
+      FML_LOG(ERROR) << "Proc table when a shell unittests invalid.";
+      return;
+    }
+    impeller_context_ = impeller::ContextGLES::Create(
+        std::move(gl), ShaderLibraryMappings(), true);
+  }
+}
 
 ShellTestPlatformViewGL::~ShellTestPlatformViewGL() = default;
 

--- a/shell/common/shell_test_platform_view_gl.h
+++ b/shell/common/shell_test_platform_view_gl.h
@@ -9,6 +9,7 @@
 #include "flutter/shell/common/shell_test_platform_view.h"
 #include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
 #include "flutter/testing/test_gl_surface.h"
+#include "impeller/renderer/backend/gles/context_gles.h"
 
 namespace flutter {
 namespace testing {
@@ -29,7 +30,14 @@ class ShellTestPlatformViewGL : public ShellTestPlatformView,
   // |ShellTestPlatformView|
   virtual void SimulateVSync() override;
 
+  // |PlatformView|
+  std::shared_ptr<impeller::Context> GetImpellerContext() const {
+    return impeller_context_;
+  }
+
  private:
+  std::shared_ptr<impeller::ContextGLES> impeller_context_;
+
   TestGLSurface gl_surface_;
 
   CreateVsyncWaiter create_vsync_waiter_;

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -4597,9 +4597,6 @@ TEST_F(ShellTest, RuntimeStageBackendDefaultsToSkSLWithoutImpeller) {
   DestroyShell(std::move(shell), task_runners);
 }
 
-// TODO(dnfield): Enable GL and Vulkan after
-// https://github.com/flutter/flutter/issues/140419
-#if SHELL_ENABLE_METAL
 TEST_F(ShellTest, RuntimeStageBackendWithImpeller) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
@@ -4653,7 +4650,6 @@ TEST_F(ShellTest, RuntimeStageBackendWithImpeller) {
 
   DestroyShell(std::move(shell), task_runners);
 }
-#endif  // SHELL_ENABLE_METAL
 
 }  // namespace testing
 }  // namespace flutter

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -4597,6 +4597,7 @@ TEST_F(ShellTest, RuntimeStageBackendDefaultsToSkSLWithoutImpeller) {
   DestroyShell(std::move(shell), task_runners);
 }
 
+#if IMPELLER_SUPPORTS_RENDERING
 TEST_F(ShellTest, RuntimeStageBackendWithImpeller) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
@@ -4650,6 +4651,7 @@ TEST_F(ShellTest, RuntimeStageBackendWithImpeller) {
 
   DestroyShell(std::move(shell), task_runners);
 }
+#endif  // IMPELLER_SUPPORTS_RENDERING
 
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
I tried to do this for Vulkan too but hit the limit of my patience for today on debugging why the Vulkan backend was segfaulting on shutdown.

Half of https://github.com/flutter/flutter/issues/140419