### PR TITLE
Multiview pipeline Pt. 2: Split out EndFrame

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -60,6 +60,10 @@ void Animator::EnqueueTraceFlowId(uint64_t trace_flow_id) {
 
 void Animator::BeginFrame(
     std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder) {
+  // Both frame_timings_recorder_ and layer_trees_tasks_ must be empty if not
+  // between BeginFrame and EndFrame.
+  FML_DCHECK(frame_timings_recorder_ == nullptr);
+  FML_DCHECK(layer_trees_tasks_.empty());
   TRACE_EVENT_ASYNC_END0("flutter", "Frame Request Pending",
                          frame_request_number_);
   frame_request_number_++;
@@ -112,6 +116,33 @@ void Animator::BeginFrame(
   dart_frame_deadline_ = frame_target_time.ToEpochDelta();
   uint64_t frame_number = frame_timings_recorder_->GetFrameNumber();
   delegate_.OnAnimatorBeginFrame(frame_target_time, frame_number);
+}
+
+void Animator::EndFrame() {
+  FML_CHECK(frame_timings_recorder_ != nullptr);
+  if (!layer_trees_tasks_.empty()) {
+    // The build is completed in OnAnimatorBeginFrame.
+    frame_timings_recorder_->RecordBuildEnd(fml::TimePoint::Now());
+
+    delegate_.OnAnimatorUpdateLatestFrameTargetTime(
+        frame_timings_recorder_->GetVsyncTargetTime());
+
+    // Commit the pending continuation.
+    PipelineProduceResult result =
+        producer_continuation_.Complete(std::make_unique<FrameItem>(
+            std::move(layer_trees_tasks_), std::move(frame_timings_recorder_)));
+
+    if (!result.success) {
+      FML_DLOG(INFO) << "Failed to commit to the pipeline";
+    } else if (!result.is_first_item) {
+      // Do nothing. It has been successfully pushed to the pipeline but not as
+      // the first item. Eventually the 'Rasterizer' will consume it, so we
+      // don't need to notify the delegate.
+    } else {
+      delegate_.OnAnimatorDraw(layer_tree_pipeline_);
+    }
+  }
+  frame_timings_recorder_ = nullptr;  // Ensure it's cleared.
 
   if (!frame_scheduled_ && has_rendered_) {
     // Wait a tad more than 3 60hz frames before reporting a big idle period.
@@ -139,6 +170,10 @@ void Animator::BeginFrame(
         },
         kNotifyIdleTaskWaitTime);
   }
+  // Both frame_timings_recorder_ and layer_trees_tasks_ must be empty if not
+  // between BeginFrame and EndFrame.
+  FML_DCHECK(layer_trees_tasks_.empty());
+  FML_DCHECK(frame_timings_recorder_ == nullptr);
 }
 
 void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree,
@@ -150,38 +185,15 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree,
   }
   has_rendered_ = true;
 
+  // TODO(dkwingsmt): Use a real view ID when Animator supports multiple views.
+  int64_t view_id = kFlutterImplicitViewId;
+
   TRACE_EVENT_WITH_FRAME_NUMBER(frame_timings_recorder_, "flutter",
                                 "Animator::Render", /*flow_id_count=*/0,
                                 /*flow_ids=*/nullptr);
-  frame_timings_recorder_->RecordBuildEnd(fml::TimePoint::Now());
 
-  delegate_.OnAnimatorUpdateLatestFrameTargetTime(
-      frame_timings_recorder_->GetVsyncTargetTime());
-
-  // TODO(dkwingsmt): Currently only supports a single window.
-  // See https://github.com/flutter/flutter/issues/135530, item 2.
-  int64_t view_id = kFlutterImplicitViewId;
-  std::vector<std::unique_ptr<LayerTreeTask>> layer_trees_tasks;
-  layer_trees_tasks.push_back(std::make_unique<LayerTreeTask>(
+  layer_trees_tasks_.push_back(std::make_unique<LayerTreeTask>(
       view_id, std::move(layer_tree), device_pixel_ratio));
-  // Commit the pending continuation.
-  PipelineProduceResult result =
-      producer_continuation_.Complete(std::make_unique<FrameItem>(
-          std::move(layer_trees_tasks), std::move(frame_timings_recorder_)));
-
-  if (!result.success) {
-    FML_DLOG(INFO) << "No pending continuation to commit";
-    return;
-  }
-
-  if (!result.is_first_item) {
-    // It has been successfully pushed to the pipeline but not as the first
-    // item. Eventually the 'Rasterizer' will consume it, so we don't need to
-    // notify the delegate.
-    return;
-  }
-
-  delegate_.OnAnimatorDraw(layer_tree_pipeline_);
 }
 
 const std::weak_ptr<VsyncWaiter> Animator::GetVsyncWaiter() const {
@@ -253,6 +265,7 @@ void Animator::AwaitVSync() {
             self->DrawLastLayerTrees(std::move(frame_timings_recorder));
           } else {
             self->BeginFrame(std::move(frame_timings_recorder));
+            self->EndFrame();
           }
         }
       });

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -90,7 +90,13 @@ class Animator final {
   void EnqueueTraceFlowId(uint64_t trace_flow_id);
 
  private:
+  // Animator's work during a vsync is split into two methods, BeginFrame and
+  // EndFrame. The two methods should be called synchronously back-to-back to
+  // avoid being interrupted by a regular vsync. The reason to split them is to
+  // allow ShellTest::PumpOneFrame to insert a Render in between.
+
   void BeginFrame(std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder);
+  void EndFrame();
 
   bool CanReuseLastLayerTrees();
 
@@ -107,6 +113,7 @@ class Animator final {
   std::shared_ptr<VsyncWaiter> waiter_;
 
   std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder_;
+  std::vector<std::unique_ptr<LayerTreeTask>> layer_trees_tasks_;
   uint64_t frame_request_number_ = 1;
   fml::TimeDelta dart_frame_deadline_;
   std::shared_ptr<FramePipeline> layer_tree_pipeline_;

--- a/shell/common/input_events_unittests.cc
+++ b/shell/common/input_events_unittests.cc
@@ -127,11 +127,11 @@ static void TestSimulatedInputEvents(
         ShellTest::DispatchFakePointerData(shell.get());
         i += 1;
       }
-      ShellTest::VSyncFlush(shell.get(), will_draw_new_frame);
+      ShellTest::VSyncFlush(shell.get(), &will_draw_new_frame);
     }
     // Finally, issue a vsync for the pending event that may be generated duing
     // the last vsync.
-    ShellTest::VSyncFlush(shell.get(), will_draw_new_frame);
+    ShellTest::VSyncFlush(shell.get(), &will_draw_new_frame);
   });
 
   simulation.wait();
@@ -346,7 +346,7 @@ TEST_F(ShellTest, CanCorrectlyPipePointerPacket) {
   packet->SetPointerData(5, data);
   ShellTest::DispatchPointerData(shell.get(), std::move(packet));
   bool will_draw_new_frame;
-  ShellTest::VSyncFlush(shell.get(), will_draw_new_frame);
+  ShellTest::VSyncFlush(shell.get(), &will_draw_new_frame);
 
   reportLatch.Wait();
   size_t expect_length = 6;
@@ -408,7 +408,7 @@ TEST_F(ShellTest, CanCorrectlySynthesizePointerPacket) {
   packet->SetPointerData(3, data);
   ShellTest::DispatchPointerData(shell.get(), std::move(packet));
   bool will_draw_new_frame;
-  ShellTest::VSyncFlush(shell.get(), will_draw_new_frame);
+  ShellTest::VSyncFlush(shell.get(), &will_draw_new_frame);
 
   reportLatch.Wait();
   size_t expect_length = 6;

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -237,13 +237,13 @@ void ShellTest::PumpOneFrame(Shell* shell, FrameContent frame_content) {
         // causing flaky assertion errors.
 
         // TODO(dkwingsmt): The rendering system only supports single view for
-        // now. Remove the following checks and add view ID to
+        // now. Remove the following two `FML_DCHECK`s and add view ID to
         // runtime_delegate->Render after the rendering system supports multiple
         // views.
-        FML_DCHECK(frame_content.size() == 1);
-        FML_DCHECK(frame_content.begin()->first == kImplicitViewId);
+        FML_DCHECK(frame_content.size() <= 1);
 
         for (auto& [view_id, view_content] : frame_content) {
+          FML_DCHECK(view_id == kImplicitViewId);
           SkMatrix identity;
           identity.setIdentity();
           auto root_layer = std::make_shared<TransformLayer>(identity);
@@ -256,8 +256,7 @@ void ShellTest::PumpOneFrame(Shell* shell, FrameContent frame_content) {
           if (view_content.builder) {
             view_content.builder(root_layer);
           }
-          runtime_delegate->Render(std::move(layer_tree),
-                                   device_pixel_ratio);
+          runtime_delegate->Render(std::move(layer_tree), device_pixel_ratio);
         }
         engine->animator_->EndFrame();
         latch.Signal();

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -22,6 +22,39 @@ namespace testing {
 
 constexpr int64_t kImplicitViewId = 0;
 
+FrameContent ViewContent::NoViews() {
+  return std::map<int64_t, ViewContent>();
+}
+
+FrameContent ViewContent::DummyView(double width, double height) {
+  FrameContent result;
+  result[kImplicitViewId] = ViewContent{
+      .viewport_metrics = {1.0, width, height, 22, 0},
+      .builder = {},
+  };
+  return result;
+}
+
+FrameContent ViewContent::DummyView(flutter::ViewportMetrics viewport_metrics) {
+  FrameContent result;
+  result[kImplicitViewId] = ViewContent{
+      .viewport_metrics = std::move(viewport_metrics),
+      .builder = {},
+  };
+  return result;
+}
+
+FrameContent ViewContent::ImplicitView(double width,
+                                       double height,
+                                       LayerTreeBuilder builder) {
+  FrameContent result;
+  result[kImplicitViewId] = ViewContent{
+      .viewport_metrics = {1.0, width, height, 22, 0},
+      .builder = std::move(builder),
+  };
+  return result;
+}
+
 ShellTest::ShellTest()
     : thread_host_("io.flutter.test." + GetCurrentTestName() + ".",
                    ThreadHost::Type::kPlatform | ThreadHost::Type::kIo |
@@ -92,16 +125,18 @@ void ShellTest::RestartEngine(Shell* shell, RunConfiguration configuration) {
   ASSERT_TRUE(restarted.get_future().get());
 }
 
-void ShellTest::VSyncFlush(Shell* shell, bool& will_draw_new_frame) {
+void ShellTest::VSyncFlush(Shell* shell, bool* will_draw_new_frame) {
   fml::AutoResetWaitableEvent latch;
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetPlatformTaskRunner(),
-      [shell, &will_draw_new_frame, &latch] {
+      [shell, will_draw_new_frame, &latch] {
         // The following UI task ensures that all previous UI tasks are flushed.
         fml::AutoResetWaitableEvent ui_latch;
         shell->GetTaskRunners().GetUITaskRunner()->PostTask(
-            [&ui_latch, &will_draw_new_frame]() {
-              will_draw_new_frame = true;
+            [&ui_latch, will_draw_new_frame]() {
+              if (will_draw_new_frame != nullptr) {
+                *will_draw_new_frame = true;
+              }
               ui_latch.Signal();
             });
 
@@ -154,6 +189,7 @@ void ShellTest::SetViewportMetrics(Shell* shell, double width, double height) {
               std::make_unique<FrameTimingsRecorder>();
           recorder->RecordVsync(frame_begin_time, frame_end_time);
           engine->animator_->BeginFrame(std::move(recorder));
+          engine->animator_->EndFrame();
         }
         latch.Signal();
       });
@@ -172,23 +208,22 @@ void ShellTest::NotifyIdle(Shell* shell, fml::TimeDelta deadline) {
   latch.Wait();
 }
 
-void ShellTest::PumpOneFrame(Shell* shell,
-                             double width,
-                             double height,
-                             LayerTreeBuilder builder) {
-  PumpOneFrame(shell, {1.0, width, height, 22, 0}, std::move(builder));
+void ShellTest::PumpOneFrame(Shell* shell) {
+  PumpOneFrame(shell, ViewContent::DummyView());
 }
 
-void ShellTest::PumpOneFrame(Shell* shell,
-                             const flutter::ViewportMetrics& viewport_metrics,
-                             LayerTreeBuilder builder) {
+void ShellTest::PumpOneFrame(Shell* shell, FrameContent frame_content) {
   // Set viewport to nonempty, and call Animator::BeginFrame to make the layer
   // tree pipeline nonempty. Without either of this, the layer tree below
   // won't be rasterized.
   fml::AutoResetWaitableEvent latch;
+  fml::WeakPtr<RuntimeDelegate> runtime_delegate = shell->weak_engine_;
   shell->GetTaskRunners().GetUITaskRunner()->PostTask(
-      [&latch, engine = shell->weak_engine_, viewport_metrics]() {
-        engine->SetViewportMetrics(kImplicitViewId, viewport_metrics);
+      [&latch, engine = shell->weak_engine_, &frame_content,
+       runtime_delegate]() {
+        for (auto& [view_id, view_content] : frame_content) {
+          engine->SetViewportMetrics(view_id, view_content.viewport_metrics);
+        }
         const auto frame_begin_time = fml::TimePoint::Now();
         const auto frame_end_time =
             frame_begin_time + fml::TimeDelta::FromSecondsF(1.0 / 60.0);
@@ -196,28 +231,35 @@ void ShellTest::PumpOneFrame(Shell* shell,
             std::make_unique<FrameTimingsRecorder>();
         recorder->RecordVsync(frame_begin_time, frame_end_time);
         engine->animator_->BeginFrame(std::move(recorder));
-        latch.Signal();
-      });
-  latch.Wait();
 
-  latch.Reset();
-  // Call |Render| to rasterize a layer tree and trigger |OnFrameRasterized|
-  fml::WeakPtr<RuntimeDelegate> runtime_delegate = shell->weak_engine_;
-  shell->GetTaskRunners().GetUITaskRunner()->PostTask(
-      [&latch, runtime_delegate, &builder, viewport_metrics]() {
-        SkMatrix identity;
-        identity.setIdentity();
-        auto root_layer = std::make_shared<TransformLayer>(identity);
-        auto layer_tree = std::make_unique<LayerTree>(
-            LayerTree::Config{.root_layer = root_layer},
-            SkISize::Make(viewport_metrics.physical_width,
-                          viewport_metrics.physical_height));
-        float device_pixel_ratio =
-            static_cast<float>(viewport_metrics.device_pixel_ratio);
-        if (builder) {
-          builder(root_layer);
+        // The BeginFrame phase and the EndFrame phase must be performed in a
+        // single task, otherwise a normal vsync might be inserted in between,
+        // causing flaky assertion errors.
+
+        // TODO(dkwingsmt): The rendering system only supports single view for
+        // now. Remove the following checks and add view ID to
+        // runtime_delegate->Render after the rendering system supports multiple
+        // views.
+        FML_DCHECK(frame_content.size() == 1);
+        FML_DCHECK(frame_content.begin()->first == kImplicitViewId);
+
+        for (auto& [view_id, view_content] : frame_content) {
+          SkMatrix identity;
+          identity.setIdentity();
+          auto root_layer = std::make_shared<TransformLayer>(identity);
+          auto layer_tree = std::make_unique<LayerTree>(
+              LayerTree::Config{.root_layer = root_layer},
+              SkISize::Make(view_content.viewport_metrics.physical_width,
+                            view_content.viewport_metrics.physical_height));
+          float device_pixel_ratio = static_cast<float>(
+              view_content.viewport_metrics.device_pixel_ratio);
+          if (view_content.builder) {
+            view_content.builder(root_layer);
+          }
+          runtime_delegate->Render(std::move(layer_tree),
+                                   device_pixel_ratio);
         }
-        runtime_delegate->Render(std::move(layer_tree), device_pixel_ratio);
+        engine->animator_->EndFrame();
         latch.Signal();
       });
   latch.Wait();

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -29,6 +29,38 @@
 namespace flutter {
 namespace testing {
 
+// The signature of ViewContent::builder.
+using LayerTreeBuilder =
+    std::function<void(std::shared_ptr<ContainerLayer> root)>;
+struct ViewContent;
+// Defines the content to be rendered to all views of a frame in PumpOneFrame.
+using FrameContent = std::map<int64_t, ViewContent>;
+// Defines the content to be rendered to a view in PumpOneFrame.
+struct ViewContent {
+  flutter::ViewportMetrics viewport_metrics;
+  // Given the root layer, this callback builds the layer tree to be rasterized
+  // in PumpOneFrame.
+  LayerTreeBuilder builder;
+
+  // Build a frame with no views. This is useful when PumpOneFrame is used just
+  // to schedule the frame while the frame content is defined by other means.
+  static FrameContent NoViews();
+
+  // Build a frame with a single implicit view with the specific size and no
+  // content.
+  static FrameContent DummyView(double width = 1, double height = 1);
+
+  // Build a frame with a single implicit view with the specific viewport
+  // metrics and no content.
+  static FrameContent DummyView(flutter::ViewportMetrics viewport_metrics);
+
+  // Build a frame with a single implicit view with the specific size and
+  // content.
+  static FrameContent ImplicitView(double width,
+                                   double height,
+                                   LayerTreeBuilder builder);
+};
+
 class ShellTest : public FixtureTest {
  public:
   struct Config {
@@ -70,24 +102,14 @@ class ShellTest : public FixtureTest {
   static void RestartEngine(Shell* shell, RunConfiguration configuration);
 
   /// Issue as many VSYNC as needed to flush the UI tasks so far, and reset
-  /// the `will_draw_new_frame` to true.
-  static void VSyncFlush(Shell* shell, bool& will_draw_new_frame);
-
-  /// Given the root layer, this callback builds the layer tree to be rasterized
-  /// in PumpOneFrame.
-  using LayerTreeBuilder =
-      std::function<void(std::shared_ptr<ContainerLayer> root)>;
+  /// the content of `will_draw_new_frame` to true if it's not nullptr.
+  static void VSyncFlush(Shell* shell, bool* will_draw_new_frame = nullptr);
 
   static void SetViewportMetrics(Shell* shell, double width, double height);
   static void NotifyIdle(Shell* shell, fml::TimeDelta deadline);
 
-  static void PumpOneFrame(Shell* shell,
-                           double width = 1,
-                           double height = 1,
-                           LayerTreeBuilder = {});
-  static void PumpOneFrame(Shell* shell,
-                           const flutter::ViewportMetrics& viewport_metrics,
-                           LayerTreeBuilder = {});
+  static void PumpOneFrame(Shell* shell);
+  static void PumpOneFrame(Shell* shell, FrameContent frame_content);
   static void DispatchFakePointerData(Shell* shell);
   static void DispatchPointerData(Shell* shell,
                                   std::unique_ptr<PointerDataPacket> packet);

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -42,6 +42,7 @@
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/common/vsync_waiter_fallback.h"
+#include "flutter/shell/common/vsync_waiters_test.h"
 #include "flutter/shell/version/version.h"
 #include "flutter/testing/mock_canvas.h"
 #include "flutter/testing/testing.h"
@@ -875,7 +876,7 @@ TEST_F(ShellTest, ExternalEmbedderNoThreadMerger) {
     root->Add(display_list_layer);
   };
 
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   end_frame_latch.Wait();
   ASSERT_TRUE(end_frame_called);
 
@@ -949,7 +950,7 @@ TEST_F(ShellTest, PushBackdropFilterToVisitedPlatformViews) {
     backdrop_filter_layer->Add(platform_view_layer2);
   };
 
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   end_frame_latch.Wait();
   ASSERT_EQ(visited_platform_views, (std::vector<int64_t>{50, 75}));
   ASSERT_TRUE(stack_75.is_empty());
@@ -1010,7 +1011,7 @@ TEST_F(ShellTest,
     root->Add(display_list_layer);
   };
 
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   end_frame_latch.Wait();
 
   ASSERT_TRUE(end_frame_called);
@@ -1056,9 +1057,12 @@ TEST_F(ShellTest, OnPlatformViewDestroyDisablesThreadMerger) {
     root->Add(display_list_layer);
   };
 
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
 
   auto result = shell->WaitForFirstFrame(fml::TimeDelta::Max());
+  // Wait for the rasterizer to process the frame. WaitForFirstFrame only waits
+  // for the Animator, but end_frame_callback is called by the Rasterizer.
+  PostSync(shell->GetTaskRunners().GetRasterTaskRunner(), [] {});
   ASSERT_TRUE(result.ok()) << "Result: " << static_cast<int>(result.code())
                            << ": " << result.message();
 
@@ -1123,12 +1127,12 @@ TEST_F(ShellTest, OnPlatformViewDestroyAfterMergingThreads) {
     root->Add(display_list_layer);
   };
 
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   // Pump one frame to trigger thread merging.
   end_frame_latch.Wait();
   // Pump another frame to ensure threads are merged and a regular layer tree is
   // submitted.
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   // Threads are merged here. PlatformViewNotifyDestroy should be executed
   // successfully.
   ASSERT_TRUE(fml::TaskRunnerChecker::RunsOnTheSameThread(
@@ -1192,7 +1196,7 @@ TEST_F(ShellTest, OnPlatformViewDestroyWhenThreadsAreMerging) {
     root->Add(display_list_layer);
   };
 
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   // Pump one frame and threads aren't merged
   end_frame_latch.Wait();
   ASSERT_FALSE(fml::TaskRunnerChecker::RunsOnTheSameThread(
@@ -1203,7 +1207,7 @@ TEST_F(ShellTest, OnPlatformViewDestroyWhenThreadsAreMerging) {
   // threads
   external_view_embedder->UpdatePostPrerollResult(
       PostPrerollResult::kResubmitFrame);
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
 
   // Now destroy the platform view immediately.
   // Two things can happen here:
@@ -1259,7 +1263,7 @@ TEST_F(ShellTest,
         SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   end_frame_latch.Wait();
 
   // Threads should not be merged.
@@ -1298,7 +1302,7 @@ TEST_F(ShellTest, OnPlatformViewDestroyWithoutRasterThreadMerger) {
         SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
 
   // Threads should not be merged.
   ASSERT_FALSE(fml::TaskRunnerChecker::RunsOnTheSameThread(
@@ -1364,7 +1368,7 @@ TEST_F(ShellTest, OnPlatformViewDestroyWithStaticThreadMerging) {
         SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   end_frame_latch.Wait();
 
   ValidateDestroyPlatformView(shell.get());
@@ -1410,7 +1414,7 @@ TEST_F(ShellTest, GetUsedThisFrameShouldBeSetBeforeEndFrame) {
         SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   end_frame_latch.Wait();
   ASSERT_FALSE(used_this_frame);
 
@@ -1560,10 +1564,11 @@ TEST_F(ShellTest, WaitForFirstFrameZeroSizeFrame) {
   configuration.SetEntrypoint("emptyMain");
 
   RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get(), {1.0, 0.0, 0.0, 22, 0});
+  PumpOneFrame(shell.get(), ViewContent::DummyView({1.0, 0.0, 0.0, 22, 0}));
   fml::Status result = shell->WaitForFirstFrame(fml::TimeDelta::Zero());
-  ASSERT_FALSE(result.ok());
-  ASSERT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.message(), "timeout");
+  EXPECT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
 
   DestroyShell(std::move(shell));
 }
@@ -2079,6 +2084,7 @@ TEST_F(ShellTest, CanScheduleFrameFromPlatform) {
 TEST_F(ShellTest, SecondaryVsyncCallbackShouldBeCalledAfterVsyncCallback) {
   bool is_on_begin_frame_called = false;
   bool is_secondary_callback_called = false;
+  bool test_started = false;
   Settings settings = CreateSettingsForFixture();
   TaskRunners task_runners = GetTaskRunnersForFixture();
   fml::AutoResetWaitableEvent latch;
@@ -2088,12 +2094,18 @@ TEST_F(ShellTest, SecondaryVsyncCallbackShouldBeCalledAfterVsyncCallback) {
   fml::CountDownLatch count_down_latch(2);
   AddNativeCallback("NativeOnBeginFrame",
                     CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+                      if (!test_started) {
+                        return;
+                      }
                       EXPECT_FALSE(is_on_begin_frame_called);
                       EXPECT_FALSE(is_secondary_callback_called);
                       is_on_begin_frame_called = true;
                       count_down_latch.CountDown();
                     }));
-  std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+  });
   ASSERT_TRUE(shell->IsSetup());
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -2106,12 +2118,16 @@ TEST_F(ShellTest, SecondaryVsyncCallbackShouldBeCalledAfterVsyncCallback) {
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetUITaskRunner(), [&]() {
         shell->GetEngine()->ScheduleSecondaryVsyncCallback(0, [&]() {
+          if (!test_started) {
+            return;
+          }
           EXPECT_TRUE(is_on_begin_frame_called);
           EXPECT_FALSE(is_secondary_callback_called);
           is_secondary_callback_called = true;
           count_down_latch.CountDown();
         });
         shell->GetEngine()->ScheduleFrame();
+        test_started = true;
       });
   count_down_latch.Wait();
   EXPECT_TRUE(is_on_begin_frame_called);
@@ -2156,7 +2172,7 @@ TEST_F(ShellTest, Screenshot) {
     root->Add(display_list_layer);
   };
 
-  PumpOneFrame(shell.get(), 100, 100, builder);
+  PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
   firstFrameLatch.Wait();
 
   std::promise<Rasterizer::Screenshot> screenshot_promise;
@@ -2541,7 +2557,13 @@ TEST_F(ShellTest, OnServiceProtocolRenderFrameWithRasterStatsWorks) {
   configuration.SetEntrypoint("scene_with_red_box");
 
   RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get());
+  // Set a non-zero viewport metrics, otherwise the scene would be discarded.
+  PostSync(shell->GetTaskRunners().GetUITaskRunner(),
+           [engine = shell->GetEngine()]() {
+             engine->SetViewportMetrics(kImplicitViewId,
+                                        ViewportMetrics{1, 1, 1, 22, 0});
+           });
+  PumpOneFrame(shell.get(), ViewContent::NoViews());
 
   ServiceProtocol::Handler::ServiceProtocolMap empty_params;
   rapidjson::Document document;
@@ -2653,7 +2675,13 @@ TEST_F(ShellTest, OnServiceProtocolRenderFrameWithRasterStatsDisableImpeller) {
   configuration.SetEntrypoint("scene_with_red_box");
 
   RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get());
+  // Set a non-zero viewport metrics, otherwise the scene would be discarded.
+  PostSync(shell->GetTaskRunners().GetUITaskRunner(),
+           [engine = shell->GetEngine()]() {
+             engine->SetViewportMetrics(kImplicitViewId,
+                                        ViewportMetrics{1, 1, 1, 22, 0});
+           });
+  PumpOneFrame(shell.get(), ViewContent::NoViews());
 
   ServiceProtocol::Handler::ServiceProtocolMap empty_params;
   rapidjson::Document document;
@@ -2717,14 +2745,16 @@ TEST_F(ShellTest, DISABLED_DiscardLayerTreeOnResize) {
 
   RunEngine(shell.get(), std::move(configuration));
 
-  PumpOneFrame(shell.get(), static_cast<double>(wrong_size.width()),
-               static_cast<double>(wrong_size.height()));
+  PumpOneFrame(shell.get(), ViewContent::DummyView(
+                                static_cast<double>(wrong_size.width()),
+                                static_cast<double>(wrong_size.height())));
   end_frame_latch.Wait();
   // Wrong size, no frames are submitted.
   ASSERT_EQ(0, external_view_embedder->GetSubmittedFrameCount());
 
-  PumpOneFrame(shell.get(), static_cast<double>(expected_size.width()),
-               static_cast<double>(expected_size.height()));
+  PumpOneFrame(shell.get(), ViewContent::DummyView(
+                                static_cast<double>(expected_size.width()),
+                                static_cast<double>(expected_size.height())));
   end_frame_latch.Wait();
   // Expected size, 1 frame submitted.
   ASSERT_EQ(1, external_view_embedder->GetSubmittedFrameCount());
@@ -2795,8 +2825,9 @@ TEST_F(ShellTest, DISABLED_DiscardResubmittedLayerTreeOnResize) {
 
   RunEngine(shell.get(), std::move(configuration));
 
-  PumpOneFrame(shell.get(), static_cast<double>(origin_size.width()),
-               static_cast<double>(origin_size.height()));
+  PumpOneFrame(shell.get(), ViewContent::DummyView(
+                                static_cast<double>(origin_size.width()),
+                                static_cast<double>(origin_size.height())));
 
   end_frame_latch.Wait();
   ASSERT_EQ(0, external_view_embedder->GetSubmittedFrameCount());
@@ -2817,8 +2848,9 @@ TEST_F(ShellTest, DISABLED_DiscardResubmittedLayerTreeOnResize) {
   ASSERT_EQ(0, external_view_embedder->GetSubmittedFrameCount());
 
   // Threads will be merged at the end of this frame.
-  PumpOneFrame(shell.get(), static_cast<double>(new_size.width()),
-               static_cast<double>(new_size.height()));
+  PumpOneFrame(shell.get(),
+               ViewContent::DummyView(static_cast<double>(new_size.width()),
+                                      static_cast<double>(new_size.height())));
 
   end_frame_latch.Wait();
   ASSERT_TRUE(raster_thread_merger_ref->IsMerged());


### PR DESCRIPTION
This is one of a series of changes to reland https://github.com/flutter/engine/pull/47239, following https://github.com/flutter/engine/pull/49266. All changes included in this PR are exactly the same as they were in the original PR https://github.com/flutter/engine/pull/47239.

This PR is a refactor that splits out the per-frame operations of `Animator` at the end of `Render` and `BeginFrame` to a separate function, `EndFrame`, which is executed right after `Render`.

This PR is expected to increase the build time, because more code is now run before `frame_timings_recorder_->RecordBuildEnd`:
* The following lines of code are now run before the `RecordBuildEnd`:
```cpp
  // These lines were executed after `RecordBuildEnd`, but now before it.
  int64_t view_id = kFlutterImplicitViewId;
  std::vector<std::unique_ptr<LayerTreeTask>> layer_trees_tasks;
  layer_trees_tasks.push_back(std::make_unique<LayerTreeTask>(
      view_id, std::move(layer_tree), device_pixel_ratio));
```
* The `Render` call must now return to Dart, then to `Animator::BeginFrame`, before `RecordBuildEnd` in `EndFrame`. The two extra context switches are included in the build time.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
