### PR TITLE
[Impeller] Do not skip rendering when mask blur is zero

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3768,7 +3768,7 @@ TEST_P(AiksTest, MaskBlurWithZeroSigmaIsSkipped) {
   Canvas canvas;
 
   Paint paint = {
-      .color = Color::White(),
+      .color = Color::Blue(),
       .mask_blur_descriptor =
           Paint::MaskBlurDescriptor{
               .style = FilterContents::BlurStyle::kNormal,

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -281,7 +281,7 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
   }
   // A blur sigma that is close to zero should not result in any shadow.
   if (std::fabs(paint.mask_blur_descriptor->sigma.sigma) <= kEhCloseEnough) {
-    return true;
+    return false;
   }
 
   Paint new_paint = paint;


### PR DESCRIPTION
The original fix had a bad return value that caused the rendering to abort rather than proceed normally without the blurring.

I also changed the color being used so that the contents would show up in golden diffs which use a white background for unrendered pixels.