### PR TITLE
[Windows] Move DWM composition status to Windows proc table for mocking

### DIFF
--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -372,18 +372,6 @@ ui::AXPlatformNodeWin* FlutterWindow::GetAlert() {
   return alert_node_.get();
 }
 
-bool FlutterWindow::NeedsVSync() const {
-  // If the Desktop Window Manager composition is enabled,
-  // the system itself synchronizes with v-sync.
-  // See: https://learn.microsoft.com/windows/win32/dwm/composition-ovw
-  BOOL composition_enabled;
-  if (SUCCEEDED(::DwmIsCompositionEnabled(&composition_enabled))) {
-    return !composition_enabled;
-  }
-
-  return true;
-}
-
 void FlutterWindow::OnWindowStateEvent(WindowStateEvent event) {
   switch (event) {
     case WindowStateEvent::kShow:

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -193,9 +193,6 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
   // |WindowBindingHandler|
   virtual ui::AXPlatformNodeWin* GetAlert() override;
 
-  // |WindowBindingHandler|
-  virtual bool NeedsVSync() const override;
-
   // Called to obtain a pointer to the fragment root delegate.
   virtual ui::AXFragmentRootDelegateWin* GetAxFragmentRootDelegate();
 

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -82,8 +82,8 @@ FlutterDesktopViewControllerRef FlutterDesktopViewControllerCreate(
           width, height, engine_ptr->windows_proc_table());
 
   auto engine = std::unique_ptr<flutter::FlutterWindowsEngine>(engine_ptr);
-  auto view =
-      std::make_unique<flutter::FlutterWindowsView>(std::move(window_wrapper));
+  auto view = std::make_unique<flutter::FlutterWindowsView>(
+      std::move(window_wrapper), engine_ptr->windows_proc_table());
   auto controller = std::make_unique<flutter::FlutterWindowsViewController>(
       std::move(engine), std::move(view));
 

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -23,6 +23,7 @@
 #include "flutter/shell/platform/windows/window_binding_handler.h"
 #include "flutter/shell/platform/windows/window_binding_handler_delegate.h"
 #include "flutter/shell/platform/windows/window_state.h"
+#include "flutter/shell/platform/windows/windows_proc_table.h"
 
 namespace flutter {
 
@@ -35,7 +36,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   //
   // In order for object to render Flutter content the SetEngine method must be
   // called with a valid FlutterWindowsEngine instance.
-  FlutterWindowsView(std::unique_ptr<WindowBindingHandler> window_binding);
+  FlutterWindowsView(
+      std::unique_ptr<WindowBindingHandler> window_binding,
+      std::shared_ptr<WindowsProcTable> windows_proc_table = nullptr);
 
   virtual ~FlutterWindowsView();
 
@@ -365,8 +368,15 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   void SendPointerEventWithData(const FlutterPointerEvent& event_data,
                                 PointerState* state);
 
+  // If true, rendering to the window should synchronize with the vsync
+  // to prevent screen tearing.
+  bool NeedsVsync() const;
+
   // The engine associated with this view.
   FlutterWindowsEngine* engine_ = nullptr;
+
+  // Mocks win32 APIs.
+  std::shared_ptr<WindowsProcTable> windows_proc_table_;
 
   // Keeps track of pointer states in relation to the window.
   std::unordered_map<int32_t, std::unique_ptr<PointerState>> pointer_states_;

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -40,7 +40,6 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD(PointerLocation, GetPrimaryPointerLocation, (), (override));
   MOCK_METHOD(AlertPlatformNodeDelegate*, GetAlertDelegate, (), (override));
   MOCK_METHOD(ui::AXPlatformNodeWin*, GetAlert, (), (override));
-  MOCK_METHOD(bool, NeedsVSync, (), (const override));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowBindingHandler);

--- a/shell/platform/windows/testing/mock_windows_proc_table.h
+++ b/shell/platform/windows/testing/mock_windows_proc_table.h
@@ -21,14 +21,16 @@ class MockWindowsProcTable : public WindowsProcTable {
   MOCK_METHOD(BOOL,
               GetPointerType,
               (UINT32 pointer_id, POINTER_INPUT_TYPE* pointer_type),
-              (override));
+              (const, override));
 
   MOCK_METHOD(LRESULT,
               GetThreadPreferredUILanguages,
               (DWORD, PULONG, PZZWSTR, PULONG),
               (const, override));
 
-  MOCK_METHOD(bool, GetHighContrastEnabled, (), (override));
+  MOCK_METHOD(bool, GetHighContrastEnabled, (), (const, override));
+
+  MOCK_METHOD(bool, DwmIsCompositionEnabled, (), (const, override));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowsProcTable);

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -96,10 +96,6 @@ class WindowBindingHandler {
 
   // Retrieve the alert node.
   virtual ui::AXPlatformNodeWin* GetAlert() = 0;
-
-  // If true, rendering to the window should synchronize with the vsync
-  // to prevent screen tearing.
-  virtual bool NeedsVSync() const = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/windows_proc_table.cc
+++ b/shell/platform/windows/windows_proc_table.cc
@@ -4,6 +4,9 @@
 
 #include "flutter/shell/platform/windows/windows_proc_table.h"
 
+#include <WinUser.h>
+#include <dwmapi.h>
+
 namespace flutter {
 
 WindowsProcTable::WindowsProcTable() {
@@ -17,7 +20,7 @@ WindowsProcTable::~WindowsProcTable() {
 }
 
 BOOL WindowsProcTable::GetPointerType(UINT32 pointer_id,
-                                      POINTER_INPUT_TYPE* pointer_type) {
+                                      POINTER_INPUT_TYPE* pointer_type) const {
   if (!get_pointer_type_.has_value()) {
     return FALSE;
   }
@@ -32,7 +35,7 @@ LRESULT WindowsProcTable::GetThreadPreferredUILanguages(DWORD flags,
   return ::GetThreadPreferredUILanguages(flags, count, languages, length);
 }
 
-bool WindowsProcTable::GetHighContrastEnabled() {
+bool WindowsProcTable::GetHighContrastEnabled() const {
   HIGHCONTRAST high_contrast = {.cbSize = sizeof(HIGHCONTRAST)};
   if (!::SystemParametersInfoW(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST),
                                &high_contrast, 0)) {
@@ -40,6 +43,15 @@ bool WindowsProcTable::GetHighContrastEnabled() {
   }
 
   return high_contrast.dwFlags & HCF_HIGHCONTRASTON;
+}
+
+bool WindowsProcTable::DwmIsCompositionEnabled() const {
+  BOOL composition_enabled;
+  if (SUCCEEDED(::DwmIsCompositionEnabled(&composition_enabled))) {
+    return composition_enabled;
+  }
+
+  return true;
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/windows_proc_table.h
+++ b/shell/platform/windows/windows_proc_table.h
@@ -24,11 +24,12 @@ class WindowsProcTable {
   // Used to react differently to touch or pen inputs. Returns false on failure.
   // Available on Windows 8 and newer, otherwise returns false.
   virtual BOOL GetPointerType(UINT32 pointer_id,
-                              POINTER_INPUT_TYPE* pointer_type);
+                              POINTER_INPUT_TYPE* pointer_type) const;
 
   // Get the preferred languages for the thread, and optionally the process,
   // and system, in that order, depending on the flags.
-  // See
+  //
+  // See:
   // https://learn.microsoft.com/windows/win32/api/winnls/nf-winnls-getthreadpreferreduilanguages
   virtual LRESULT GetThreadPreferredUILanguages(DWORD flags,
                                                 PULONG count,
@@ -38,9 +39,16 @@ class WindowsProcTable {
   // Get whether high contrast is enabled.
   //
   // Available on Windows 8 and newer, otherwise returns false.
-  // See
+  //
+  // See:
   // https://learn.microsoft.com/windows/win32/winauto/high-contrast-parameter
-  virtual bool GetHighContrastEnabled();
+  virtual bool GetHighContrastEnabled() const;
+
+  // Get whether the system compositor, DWM, is enabled.
+  //
+  // See:
+  // https://learn.microsoft.com/windows/win32/api/dwmapi/nf-dwmapi-dwmiscompositionenabled
+  virtual bool DwmIsCompositionEnabled() const;
 
  private:
   using GetPointerType_ = BOOL __stdcall(UINT32 pointerId,


### PR DESCRIPTION
The `FlutterWindowsView` needs the `DwmIsCompositionEnabled` win32 API to check whether it should block presents until the v-blank to prevent screen tearing.

Currently, the view used the `FlutterWindow` to allow mocking this win32 API. However, the window is a complex type with lots of other responsibilities. The `WindowsProcTable` is the new preferred type for mocking win32 API.

Part of https://github.com/flutter/flutter/issues/140626

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
