### PR TITLE
[Windows] Move DWM flush to Windows proc table for mocking

### DIFF
--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -185,12 +185,6 @@ void FlutterWindow::SetFlutterCursor(HCURSOR cursor) {
   ::SetCursor(current_cursor_);
 }
 
-void FlutterWindow::OnWindowResized() {
-  // Blocking the raster thread until DWM flushes alleviates glitches where
-  // previous size surface is stretched over current size view.
-  DwmFlush();
-}
-
 void FlutterWindow::OnDpiScale(unsigned int dpi) {};
 
 // When DesktopWindow notifies that a WM_Size message has come in

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -171,9 +171,6 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
   virtual void SetFlutterCursor(HCURSOR cursor) override;
 
   // |FlutterWindowBindingHandler|
-  virtual void OnWindowResized() override;
-
-  // |FlutterWindowBindingHandler|
   virtual bool OnBitmapSurfaceCleared() override;
 
   // |FlutterWindowBindingHandler|

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -613,7 +613,11 @@ bool FlutterWindowsView::SwapBuffers() {
       resize_status_ = ResizeState::kDone;
       lock.unlock();
       resize_cv_.notify_all();
-      binding_handler_->OnWindowResized();
+
+      // Blocking the raster thread until DWM flushes alleviates glitches where
+      // previous size surface is stretched over current size view.
+      windows_proc_table_->DwmFlush();
+
       if (!visible) {
         swap_buffers_result = engine_->surface_manager()->SwapBuffers();
       }

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -23,7 +23,6 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD(HWND, GetWindowHandle, (), (override));
   MOCK_METHOD(float, GetDpiScale, (), (override));
   MOCK_METHOD(bool, IsVisible, (), (override));
-  MOCK_METHOD(void, OnWindowResized, (), (override));
   MOCK_METHOD(PhysicalWindowBounds, GetPhysicalWindowBounds, (), (override));
   MOCK_METHOD(void,
               UpdateFlutterCursor,

--- a/shell/platform/windows/testing/mock_windows_proc_table.h
+++ b/shell/platform/windows/testing/mock_windows_proc_table.h
@@ -32,6 +32,8 @@ class MockWindowsProcTable : public WindowsProcTable {
 
   MOCK_METHOD(bool, DwmIsCompositionEnabled, (), (const, override));
 
+  MOCK_METHOD(HRESULT, DwmFlush, (), (const, override));
+
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowsProcTable);
 };

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -57,9 +57,6 @@ class WindowBindingHandler {
   // Returns the bounds of the backing window in physical pixels.
   virtual PhysicalWindowBounds GetPhysicalWindowBounds() = 0;
 
-  // Invoked after the window has been resized.
-  virtual void OnWindowResized() = 0;
-
   // Sets the cursor that should be used when the mouse is over the Flutter
   // content. See mouse_cursor.dart for the values and meanings of cursor_name.
   virtual void UpdateFlutterCursor(const std::string& cursor_name) = 0;

--- a/shell/platform/windows/windows_proc_table.cc
+++ b/shell/platform/windows/windows_proc_table.cc
@@ -54,4 +54,8 @@ bool WindowsProcTable::DwmIsCompositionEnabled() const {
   return true;
 }
 
+HRESULT WindowsProcTable::DwmFlush() const {
+  return ::DwmFlush();
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/windows_proc_table.h
+++ b/shell/platform/windows/windows_proc_table.h
@@ -50,6 +50,13 @@ class WindowsProcTable {
   // https://learn.microsoft.com/windows/win32/api/dwmapi/nf-dwmapi-dwmiscompositionenabled
   virtual bool DwmIsCompositionEnabled() const;
 
+  // Issues a flush call that blocks the caller until all of the outstanding
+  // surface updates have been made.
+  //
+  // See:
+  // https://learn.microsoft.com/windows/win32/api/dwmapi/nf-dwmapi-dwmflush
+  virtual HRESULT DwmFlush() const;
+
  private:
   using GetPointerType_ = BOOL __stdcall(UINT32 pointerId,
                                          POINTER_INPUT_TYPE* pointerType);


### PR DESCRIPTION
The `FlutterWindowsView` uses the `DwmFlush` win32 API to prevent artifacts during window resizing.

Currently, the view used the `FlutterWindow` to allow mocking this win32 API. However, the window is a complex type with lots of other responsibilities. The `WindowsProcTable` is the new preferred type for mocking win32 API.

Part of https://github.com/flutter/flutter/issues/140626

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
