### PR TITLE
Move `copyPixelsFromBuffer` to a background thread.

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterImageViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterImageViewTest.java
@@ -1,0 +1,57 @@
+package io.flutter.embedding.android;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.hardware.HardwareBuffer;
+import android.media.Image;
+import android.media.Image.Plane;
+import android.media.ImageReader;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+@Config(manifest = Config.NONE)
+@RunWith(AndroidJUnit4.class)
+@TargetApi(30)
+public class FlutterImageViewTest {
+  private final Context ctx = ApplicationProvider.getApplicationContext();
+
+  @Test
+  public void acquireLatestImage() {
+    final ImageReader mockReader = mock(ImageReader.class);
+    final Image mockImage = mock(Image.class);
+    final HardwareBuffer mockHardwareBuffer = mock(HardwareBuffer.class);
+    final Bitmap mockBitmap = mock(Bitmap.class);
+    final FlutterImageView imageView =
+        spy(new FlutterImageView(ctx, mockReader, FlutterImageView.SurfaceKind.background));
+
+    when(mockReader.getMaxImages()).thenReturn(2);
+    when(mockReader.acquireLatestImage()).thenReturn(mockImage);
+    when(mockImage.getPlanes()).thenReturn(new Plane[0]);
+    when(mockImage.getHardwareBuffer()).thenReturn(mockHardwareBuffer);
+    when(mockHardwareBuffer.getUsage()).thenReturn(HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
+    when(imageView.convertImageToBitmap(mockImage)).thenReturn(mockBitmap);
+
+    final FlutterJNI jni = mock(FlutterJNI.class);
+    imageView.attachToRenderer(new FlutterRenderer(jni));
+    doNothing().when(imageView).invalidate();
+
+    assertFalse(imageView.acquireLatestImage());
+
+    // Simulate the next frame available.
+    imageView.onImageAvailable(mockReader);
+    assertTrue(imageView.acquireLatestImage());
+  }
+}


### PR DESCRIPTION
Move the time-consuming `copyPixelsFromBuffer` function to a background thread to avoid blocking the UI thread. At the same time, remove the unnecessary `currentImage` member.



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
