### PR TITLE
Refactor macOS trackpad gesture tracking

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -995,6 +995,12 @@ TEST_F(FlutterViewControllerTest, testViewControllerIsReleased) {
   EXPECT_EQ(last_event.device_kind, kFlutterPointerDeviceKindTrackpad);
   EXPECT_EQ(last_event.signal_kind, kFlutterPointerSignalKindNone);
 
+  // Test that stray NSEventPhaseCancelled event does not crash
+  called = false;
+  [viewController rotateWithEvent:flutter::testing::MockGestureEvent(NSEventTypeRotate,
+                                                                     NSEventPhaseCancelled, 0, 0)];
+  EXPECT_FALSE(called);
+
   return true;
 }
 


### PR DESCRIPTION
The AppKit state machine was not well understood before. Sometimes the engine would leave orphan PanZoomStart after a certain sequences including NSEventPhaseMayBegin

Now track each gesture's specific phase instead of boolean true/false which doesn't really accurately represent the system state.

Fixes https://github.com/flutter/flutter/issues/140730
FIxes https://github.com/flutter/flutter/issues/136622

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
