### PR TITLE
[web] make TextStyle implementations consistent

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -226,6 +226,11 @@ class CkTextStyle implements ui.TextStyle {
     List<ui.FontFeature>? fontFeatures,
     List<ui.FontVariation>? fontVariations,
   }) {
+    assert(
+      color == null || foreground == null,
+      'Cannot provide both a color and a foreground\n'
+      'The color argument is just a shorthand for "foreground: Paint()..color = color".',
+    );
     return CkTextStyle._(
       color,
       decoration,
@@ -471,6 +476,98 @@ class CkTextStyle implements ui.TextStyle {
 
     return canvasKit.TextStyle(properties);
   }();
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is CkTextStyle
+        && other.color == color
+        && other.decoration == decoration
+        && other.decorationColor == decorationColor
+        && other.decorationStyle == decorationStyle
+        && other.fontWeight == fontWeight
+        && other.fontStyle == fontStyle
+        && other.textBaseline == textBaseline
+        && other.leadingDistribution == leadingDistribution
+        && other.fontFamily == fontFamily
+        && other.fontSize == fontSize
+        && other.letterSpacing == letterSpacing
+        && other.wordSpacing == wordSpacing
+        && other.height == height
+        && other.decorationThickness == decorationThickness
+        && other.locale == locale
+        && other.background == background
+        && other.foreground == foreground
+        && listEquals<ui.Shadow>(other.shadows, shadows)
+        && listEquals<String>(other.fontFamilyFallback, fontFamilyFallback)
+        && listEquals<ui.FontFeature>(other.fontFeatures, fontFeatures)
+        && listEquals<ui.FontVariation>(other.fontVariations, fontVariations);
+  }
+
+  @override
+  int get hashCode {
+    final List<ui.Shadow>? shadows = this.shadows;
+    final List<ui.FontFeature>? fontFeatures = this.fontFeatures;
+    final List<ui.FontVariation>? fontVariations = this.fontVariations;
+    final List<String>? fontFamilyFallback = this.fontFamilyFallback;
+    return Object.hash(
+      color,
+      decoration,
+      decorationColor,
+      decorationStyle,
+      fontWeight,
+      fontStyle,
+      textBaseline,
+      leadingDistribution,
+      fontFamily,
+      fontFamilyFallback == null ? null : Object.hashAll(fontFamilyFallback),
+      fontSize,
+      letterSpacing,
+      wordSpacing,
+      height,
+      locale,
+      background,
+      foreground,
+      shadows == null ? null : Object.hashAll(shadows),
+      decorationThickness,
+      // Object.hash goes up to 20 arguments, but we have 21
+      Object.hash(
+        fontFeatures == null ? null : Object.hashAll(fontFeatures),
+        fontVariations == null ? null : Object.hashAll(fontVariations),
+      )
+    );
+  }
+
+  @override
+  String toString() {
+    final List<String>? fontFamilyFallback = this.fontFamilyFallback;
+    final String? fontFamily = this.fontFamily;
+    return 'TextStyle('
+             'color: ${color ?? "unspecified"}, '
+             'decoration: ${decoration ?? "unspecified"}, '
+             'decorationColor: ${decorationColor ?? "unspecified"}, '
+             'decorationStyle: ${decorationStyle ?? "unspecified"}, '
+             'decorationThickness: ${decorationThickness ?? "unspecified"}, '
+             'fontWeight: ${fontWeight ?? "unspecified"}, '
+             'fontStyle: ${fontStyle ?? "unspecified"}, '
+             'textBaseline: ${textBaseline ?? "unspecified"}, '
+             'fontFamily: ${fontFamily != null && fontFamily.isNotEmpty ? fontFamily : "unspecified"}, '
+             'fontFamilyFallback: ${fontFamilyFallback != null && fontFamilyFallback.isNotEmpty ? fontFamilyFallback : "unspecified"}, '
+             'fontSize: ${fontSize ?? "unspecified"}, '
+             'letterSpacing: ${letterSpacing != null ? "${letterSpacing}x" : "unspecified"}, '
+             'wordSpacing: ${wordSpacing != null ? "${wordSpacing}x" : "unspecified"}, '
+             'height: ${height != null ? "${height}x" : "unspecified"}, '
+             'leadingDistribution: ${leadingDistribution ?? "unspecified"}, '
+             'locale: ${locale ?? "unspecified"}, '
+             'background: ${background ?? "unspecified"}, '
+             'foreground: ${foreground ?? "unspecified"}, '
+             'shadows: ${shadows ?? "unspecified"}, '
+             'fontFeatures: ${fontFeatures ?? "unspecified"}, '
+             'fontVariations: ${fontVariations ?? "unspecified"}'
+           ')';
+  }
 }
 
 class CkStrutStyle implements ui.StrutStyle {

--- a/lib/web_ui/lib/src/engine/html/renderer.dart
+++ b/lib/web_ui/lib/src/engine/html/renderer.dart
@@ -258,6 +258,7 @@ class HtmlRenderer implements Renderer {
     letterSpacing: letterSpacing,
     wordSpacing: wordSpacing,
     height: height,
+    leadingDistribution: leadingDistribution,
     locale: locale,
     background: background,
     foreground: foreground,

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -317,7 +317,11 @@ class SkwasmTextStyle implements ui.TextStyle {
     this.shadows,
     this.fontFeatures,
     this.fontVariations,
-  });
+  }) : assert(
+        color == null || foreground == null,
+        'Cannot provide both a color and a foreground\n'
+        'The color argument is just a shorthand for "foreground: Paint()..color = color".',
+       );
 
   void applyToNative(SkwasmNativeTextStyle style) {
     final TextStyleHandle handle = style.handle;
@@ -451,6 +455,98 @@ class SkwasmTextStyle implements ui.TextStyle {
   final List<ui.Shadow>? shadows;
   final List<ui.FontFeature>? fontFeatures;
   final List<ui.FontVariation>? fontVariations;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is SkwasmTextStyle
+        && other.color == color
+        && other.decoration == decoration
+        && other.decorationColor == decorationColor
+        && other.decorationStyle == decorationStyle
+        && other.fontWeight == fontWeight
+        && other.fontStyle == fontStyle
+        && other.textBaseline == textBaseline
+        && other.leadingDistribution == leadingDistribution
+        && other.fontFamily == fontFamily
+        && other.fontSize == fontSize
+        && other.letterSpacing == letterSpacing
+        && other.wordSpacing == wordSpacing
+        && other.height == height
+        && other.decorationThickness == decorationThickness
+        && other.locale == locale
+        && other.background == background
+        && other.foreground == foreground
+        && listEquals<ui.Shadow>(other.shadows, shadows)
+        && listEquals<String>(other.fontFamilyFallback, fontFamilyFallback)
+        && listEquals<ui.FontFeature>(other.fontFeatures, fontFeatures)
+        && listEquals<ui.FontVariation>(other.fontVariations, fontVariations);
+  }
+
+  @override
+  int get hashCode {
+    final List<ui.Shadow>? shadows = this.shadows;
+    final List<ui.FontFeature>? fontFeatures = this.fontFeatures;
+    final List<ui.FontVariation>? fontVariations = this.fontVariations;
+    final List<String>? fontFamilyFallback = this.fontFamilyFallback;
+    return Object.hash(
+      color,
+      decoration,
+      decorationColor,
+      decorationStyle,
+      fontWeight,
+      fontStyle,
+      textBaseline,
+      leadingDistribution,
+      fontFamily,
+      fontFamilyFallback == null ? null : Object.hashAll(fontFamilyFallback),
+      fontSize,
+      letterSpacing,
+      wordSpacing,
+      height,
+      locale,
+      background,
+      foreground,
+      shadows == null ? null : Object.hashAll(shadows),
+      decorationThickness,
+      // Object.hash goes up to 20 arguments, but we have 21
+      Object.hash(
+        fontFeatures == null ? null : Object.hashAll(fontFeatures),
+        fontVariations == null ? null : Object.hashAll(fontVariations),
+      )
+    );
+  }
+
+  @override
+  String toString() {
+    final List<String>? fontFamilyFallback = this.fontFamilyFallback;
+    final String? fontFamily = this.fontFamily;
+    return 'TextStyle('
+             'color: ${color ?? "unspecified"}, '
+             'decoration: ${decoration ?? "unspecified"}, '
+             'decorationColor: ${decorationColor ?? "unspecified"}, '
+             'decorationStyle: ${decorationStyle ?? "unspecified"}, '
+             'decorationThickness: ${decorationThickness ?? "unspecified"}, '
+             'fontWeight: ${fontWeight ?? "unspecified"}, '
+             'fontStyle: ${fontStyle ?? "unspecified"}, '
+             'textBaseline: ${textBaseline ?? "unspecified"}, '
+             'fontFamily: ${fontFamily != null && fontFamily.isNotEmpty ? fontFamily : "unspecified"}, '
+             'fontFamilyFallback: ${fontFamilyFallback != null && fontFamilyFallback.isNotEmpty ? fontFamilyFallback : "unspecified"}, '
+             'fontSize: ${fontSize ?? "unspecified"}, '
+             'letterSpacing: ${letterSpacing != null ? "${letterSpacing}x" : "unspecified"}, '
+             'wordSpacing: ${wordSpacing != null ? "${wordSpacing}x" : "unspecified"}, '
+             'height: ${height != null ? "${height}x" : "unspecified"}, '
+             'leadingDistribution: ${leadingDistribution ?? "unspecified"}, '
+             'locale: ${locale ?? "unspecified"}, '
+             'background: ${background ?? "unspecified"}, '
+             'foreground: ${foreground ?? "unspecified"}, '
+             'shadows: ${shadows ?? "unspecified"}, '
+             'fontFeatures: ${fontFeatures ?? "unspecified"}, '
+             'fontVariations: ${fontVariations ?? "unspecified"}'
+           ')';
+  }
 }
 
 class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implements ui.StrutStyle {

--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -431,6 +431,7 @@ abstract class StyleNode {
         letterSpacing: _letterSpacing,
         wordSpacing: _wordSpacing,
         height: _height,
+        leadingDistribution: _leadingDistribution,
         locale: _locale,
         background: _background,
         foreground: _foreground,
@@ -456,6 +457,7 @@ abstract class StyleNode {
   double? get _letterSpacing;
   double? get _wordSpacing;
   double? get _height;
+  ui.TextLeadingDistribution? get _leadingDistribution;
   ui.Locale? get _locale;
   ui.Paint? get _background;
   ui.Paint? get _foreground;
@@ -520,6 +522,9 @@ class ChildStyleNode extends StyleNode {
 
   @override
   double? get _height => style.height ?? parent._height;
+
+  @override
+  ui.TextLeadingDistribution? get _leadingDistribution => style.leadingDistribution ?? parent._leadingDistribution;
 
   @override
   ui.Locale? get _locale => style.locale ?? parent._locale;
@@ -597,6 +602,9 @@ class RootStyleNode extends StyleNode {
 
   @override
   double? get _height => paragraphStyle.height;
+
+  @override
+  ui.TextLeadingDistribution? get _leadingDistribution => null;
 
   @override
   ui.Locale? get _locale => paragraphStyle.locale;

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -568,6 +568,7 @@ class EngineTextStyle implements ui.TextStyle {
     required double? letterSpacing,
     required double? wordSpacing,
     required double? height,
+    required ui.TextLeadingDistribution? leadingDistribution,
     required ui.Locale? locale,
     required ui.Paint? background,
     required ui.Paint? foreground,
@@ -595,6 +596,7 @@ class EngineTextStyle implements ui.TextStyle {
     this.letterSpacing,
     this.wordSpacing,
     this.height,
+    this.leadingDistribution,
     this.locale,
     this.background,
     this.foreground,
@@ -640,6 +642,7 @@ class EngineTextStyle implements ui.TextStyle {
   final double? letterSpacing;
   final double? wordSpacing;
   final double? height;
+  final ui.TextLeadingDistribution? leadingDistribution;
   final ui.Locale? locale;
   final ui.Paint? background;
   final ui.Paint? foreground;
@@ -688,101 +691,114 @@ class EngineTextStyle implements ui.TextStyle {
     );
   }
 
-  EngineTextStyle copyWith({
-    ui.Color? color,
-    ui.TextDecoration? decoration,
-    ui.Color? decorationColor,
-    ui.TextDecorationStyle? decorationStyle,
-    double? decorationThickness,
-    ui.FontWeight? fontWeight,
-    ui.FontStyle? fontStyle,
-    ui.TextBaseline? textBaseline,
-    String? fontFamily,
-    List<String>? fontFamilyFallback,
-    double? fontSize,
-    double? letterSpacing,
-    double? wordSpacing,
-    double? height,
-    ui.Locale? locale,
-    ui.Paint? background,
-    ui.Paint? foreground,
-    List<ui.Shadow>? shadows,
-    List<ui.FontFeature>? fontFeatures,
-    List<ui.FontVariation>? fontVariations,
-  }) {
-    return EngineTextStyle(
-      color: color ?? this.color,
-      decoration: decoration ?? this.decoration,
-      decorationColor: decorationColor ?? this.decorationColor,
-      decorationStyle: decorationStyle ?? this.decorationStyle,
-      decorationThickness: decorationThickness ?? this.decorationThickness,
-      fontWeight: fontWeight ?? this.fontWeight,
-      fontStyle: fontStyle ?? this.fontStyle,
-      textBaseline: textBaseline ?? this.textBaseline,
-      fontFamily: fontFamily ?? this.fontFamily,
-      fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
-      fontSize: fontSize ?? this.fontSize,
-      letterSpacing: letterSpacing ?? this.letterSpacing,
-      wordSpacing: wordSpacing ?? this.wordSpacing,
-      height: height ?? this.height,
-      locale: locale ?? this.locale,
-      background: background ?? this.background,
-      foreground: foreground ?? this.foreground,
-      shadows: shadows ?? this.shadows,
-      fontFeatures: fontFeatures ?? this.fontFeatures,
-      fontVariations: fontVariations ?? this.fontVariations,
-    );
-  }
+  // EngineTextStyle copyWith({
+  //   ui.Color? color,
+  //   ui.TextDecoration? decoration,
+  //   ui.Color? decorationColor,
+  //   ui.TextDecorationStyle? decorationStyle,
+  //   double? decorationThickness,
+  //   ui.FontWeight? fontWeight,
+  //   ui.FontStyle? fontStyle,
+  //   ui.TextBaseline? textBaseline,
+  //   String? fontFamily,
+  //   List<String>? fontFamilyFallback,
+  //   double? fontSize,
+  //   double? letterSpacing,
+  //   double? wordSpacing,
+  //   double? height,
+  //   ui.Locale? locale,
+  //   ui.Paint? background,
+  //   ui.Paint? foreground,
+  //   List<ui.Shadow>? shadows,
+  //   List<ui.FontFeature>? fontFeatures,
+  //   List<ui.FontVariation>? fontVariations,
+  // }) {
+  //   return EngineTextStyle(
+  //     color: color ?? this.color,
+  //     decoration: decoration ?? this.decoration,
+  //     decorationColor: decorationColor ?? this.decorationColor,
+  //     decorationStyle: decorationStyle ?? this.decorationStyle,
+  //     decorationThickness: decorationThickness ?? this.decorationThickness,
+  //     fontWeight: fontWeight ?? this.fontWeight,
+  //     fontStyle: fontStyle ?? this.fontStyle,
+  //     textBaseline: textBaseline ?? this.textBaseline,
+  //     fontFamily: fontFamily ?? this.fontFamily,
+  //     fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
+  //     fontSize: fontSize ?? this.fontSize,
+  //     letterSpacing: letterSpacing ?? this.letterSpacing,
+  //     wordSpacing: wordSpacing ?? this.wordSpacing,
+  //     height: height ?? this.height,
+  //     locale: locale ?? this.locale,
+  //     background: background ?? this.background,
+  //     foreground: foreground ?? this.foreground,
+  //     shadows: shadows ?? this.shadows,
+  //     fontFeatures: fontFeatures ?? this.fontFeatures,
+  //     fontVariations: fontVariations ?? this.fontVariations,
+  //   );
+  // }
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) {
       return true;
     }
-    if (other.runtimeType != runtimeType) {
-      return false;
-    }
-    return other is EngineTextStyle &&
-        other.color == color &&
-        other.decoration == decoration &&
-        other.decorationColor == decorationColor &&
-        other.decorationStyle == decorationStyle &&
-        other.fontWeight == fontWeight &&
-        other.fontStyle == fontStyle &&
-        other.textBaseline == textBaseline &&
-        other.fontFamily == fontFamily &&
-        other.fontSize == fontSize &&
-        other.letterSpacing == letterSpacing &&
-        other.wordSpacing == wordSpacing &&
-        other.height == height &&
-        other.locale == locale &&
-        other.background == background &&
-        other.foreground == foreground &&
-        listEquals<ui.Shadow>(other.shadows, shadows) &&
-        listEquals<String>(other.fontFamilyFallback, fontFamilyFallback);
+    return other is EngineTextStyle
+        && other.color == color
+        && other.decoration == decoration
+        && other.decorationColor == decorationColor
+        && other.decorationStyle == decorationStyle
+        && other.fontWeight == fontWeight
+        && other.fontStyle == fontStyle
+        && other.textBaseline == textBaseline
+        && other.leadingDistribution == leadingDistribution
+        && other.fontFamily == fontFamily
+        && other.fontSize == fontSize
+        && other.letterSpacing == letterSpacing
+        && other.wordSpacing == wordSpacing
+        && other.height == height
+        && other.decorationThickness == decorationThickness
+        && other.locale == locale
+        && other.background == background
+        && other.foreground == foreground
+        && listEquals<ui.Shadow>(other.shadows, shadows)
+        && listEquals<String>(other.fontFamilyFallback, fontFamilyFallback)
+        && listEquals<ui.FontFeature>(other.fontFeatures, fontFeatures)
+        && listEquals<ui.FontVariation>(other.fontVariations, fontVariations);
   }
 
   @override
-  int get hashCode => Object.hash(
-        color,
-        decoration,
-        decorationColor,
-        decorationStyle,
-        decorationThickness,
-        fontWeight,
-        fontStyle,
-        textBaseline,
-        fontFamily,
-        fontFamilyFallback,
-        fontSize,
-        letterSpacing,
-        wordSpacing,
-        height,
-        locale,
-        background,
-        foreground,
-        shadows,
-      );
+  int get hashCode {
+    final List<ui.Shadow>? shadows = this.shadows;
+    final List<ui.FontFeature>? fontFeatures = this.fontFeatures;
+    final List<ui.FontVariation>? fontVariations = this.fontVariations;
+    final List<String>? fontFamilyFallback = this.fontFamilyFallback;
+    return Object.hash(
+      color,
+      decoration,
+      decorationColor,
+      decorationStyle,
+      fontWeight,
+      fontStyle,
+      textBaseline,
+      leadingDistribution,
+      fontFamily,
+      fontFamilyFallback == null ? null : Object.hashAll(fontFamilyFallback),
+      fontSize,
+      letterSpacing,
+      wordSpacing,
+      height,
+      locale,
+      background,
+      foreground,
+      shadows == null ? null : Object.hashAll(shadows),
+      decorationThickness,
+      // Object.hash goes up to 20 arguments, but we have 21
+      Object.hash(
+        fontFeatures == null ? null : Object.hashAll(fontFeatures),
+        fontVariations == null ? null : Object.hashAll(fontVariations),
+      )
+    );
+  }
 
   @override
   String toString() {

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -691,52 +691,6 @@ class EngineTextStyle implements ui.TextStyle {
     );
   }
 
-  // EngineTextStyle copyWith({
-  //   ui.Color? color,
-  //   ui.TextDecoration? decoration,
-  //   ui.Color? decorationColor,
-  //   ui.TextDecorationStyle? decorationStyle,
-  //   double? decorationThickness,
-  //   ui.FontWeight? fontWeight,
-  //   ui.FontStyle? fontStyle,
-  //   ui.TextBaseline? textBaseline,
-  //   String? fontFamily,
-  //   List<String>? fontFamilyFallback,
-  //   double? fontSize,
-  //   double? letterSpacing,
-  //   double? wordSpacing,
-  //   double? height,
-  //   ui.Locale? locale,
-  //   ui.Paint? background,
-  //   ui.Paint? foreground,
-  //   List<ui.Shadow>? shadows,
-  //   List<ui.FontFeature>? fontFeatures,
-  //   List<ui.FontVariation>? fontVariations,
-  // }) {
-  //   return EngineTextStyle(
-  //     color: color ?? this.color,
-  //     decoration: decoration ?? this.decoration,
-  //     decorationColor: decorationColor ?? this.decorationColor,
-  //     decorationStyle: decorationStyle ?? this.decorationStyle,
-  //     decorationThickness: decorationThickness ?? this.decorationThickness,
-  //     fontWeight: fontWeight ?? this.fontWeight,
-  //     fontStyle: fontStyle ?? this.fontStyle,
-  //     textBaseline: textBaseline ?? this.textBaseline,
-  //     fontFamily: fontFamily ?? this.fontFamily,
-  //     fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
-  //     fontSize: fontSize ?? this.fontSize,
-  //     letterSpacing: letterSpacing ?? this.letterSpacing,
-  //     wordSpacing: wordSpacing ?? this.wordSpacing,
-  //     height: height ?? this.height,
-  //     locale: locale ?? this.locale,
-  //     background: background ?? this.background,
-  //     foreground: foreground ?? this.foreground,
-  //     shadows: shadows ?? this.shadows,
-  //     fontFeatures: fontFeatures ?? this.fontFeatures,
-  //     fontVariations: fontVariations ?? this.fontVariations,
-  //   );
-  // }
-
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) {

--- a/lib/web_ui/test/html/text/layout_fragmenter_test.dart
+++ b/lib/web_ui/test/html/text/layout_fragmenter_test.dart
@@ -287,3 +287,53 @@ List<_Fragment> split(CanvasParagraph paragraph) {
 List<LayoutFragment> computeLayoutFragments(CanvasParagraph paragraph) {
   return LayoutFragmenter(paragraph.plainText, paragraph.spans).fragment();
 }
+
+extension _EngineTextStyle on EngineTextStyle {
+  EngineTextStyle copyWith({
+    Color? color,
+    TextDecoration? decoration,
+    Color? decorationColor,
+    TextDecorationStyle? decorationStyle,
+    double? decorationThickness,
+    FontWeight? fontWeight,
+    FontStyle? fontStyle,
+    TextBaseline? textBaseline,
+    String? fontFamily,
+    List<String>? fontFamilyFallback,
+    double? fontSize,
+    double? letterSpacing,
+    double? wordSpacing,
+    double? height,
+    TextLeadingDistribution? leadingDistribution,
+    Locale? locale,
+    Paint? background,
+    Paint? foreground,
+    List<Shadow>? shadows,
+    List<FontFeature>? fontFeatures,
+    List<FontVariation>? fontVariations,
+  }) {
+    return EngineTextStyle(
+      color: color ?? this.color,
+      decoration: decoration ?? this.decoration,
+      decorationColor: decorationColor ?? this.decorationColor,
+      decorationStyle: decorationStyle ?? this.decorationStyle,
+      decorationThickness: decorationThickness ?? this.decorationThickness,
+      fontWeight: fontWeight ?? this.fontWeight,
+      fontStyle: fontStyle ?? this.fontStyle,
+      textBaseline: textBaseline ?? this.textBaseline,
+      fontFamily: fontFamily ?? this.fontFamily,
+      fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
+      fontSize: fontSize ?? this.fontSize,
+      letterSpacing: letterSpacing ?? this.letterSpacing,
+      wordSpacing: wordSpacing ?? this.wordSpacing,
+      height: height ?? this.height,
+      leadingDistribution: leadingDistribution,
+      locale: locale ?? this.locale,
+      background: background ?? this.background,
+      foreground: foreground ?? this.foreground,
+      shadows: shadows ?? this.shadows,
+      fontFeatures: fontFeatures ?? this.fontFeatures,
+      fontVariations: fontVariations ?? this.fontVariations,
+    );
+  }
+}

--- a/lib/web_ui/test/ui/text_style_test.dart
+++ b/lib/web_ui/test/ui/text_style_test.dart
@@ -1,0 +1,215 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  setUpUnitTests(
+    emulateTesterEnvironment: false,
+    setUpTestViewDimensions: false,
+  );
+
+  test('blanks are equal to each other', () {
+    final ui.TextStyle a = ui.TextStyle();
+    final ui.TextStyle b = ui.TextStyle();
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+  });
+
+  test('each property individually equal', () {
+    for (final String property in _populatorsA.keys) {
+      final _TextStylePropertyPopulator populator = _populatorsA[property]!;
+
+      final _TestTextStyleBuilder aBuilder = _TestTextStyleBuilder();
+      populator(aBuilder);
+      final ui.TextStyle a = aBuilder.build();
+
+      final _TestTextStyleBuilder bBuilder = _TestTextStyleBuilder();
+      populator(bBuilder);
+      final ui.TextStyle b = bBuilder.build();
+
+      expect(reason: '$property property is equal', a, b);
+      expect(reason: '$property hashCode is equal', a.hashCode, b.hashCode);
+    }
+  });
+
+  test('each property individually not equal', () {
+    for (final String property in _populatorsA.keys) {
+      final _TextStylePropertyPopulator populatorA = _populatorsA[property]!;
+
+      final _TestTextStyleBuilder aBuilder = _TestTextStyleBuilder();
+      populatorA(aBuilder);
+      final ui.TextStyle a = aBuilder.build();
+
+      final _TextStylePropertyPopulator populatorB = _populatorsB[property]!;
+      final _TestTextStyleBuilder bBuilder = _TestTextStyleBuilder();
+      populatorB(bBuilder);
+      final ui.TextStyle b = bBuilder.build();
+
+      expect(reason: '$property property is not equal', a, isNot(b));
+      expect(reason: '$property hashCode is not equal', a.hashCode, isNot(b.hashCode));
+    }
+  });
+
+  // `color` and `foreground` cannot be used at the same time, so each test skips
+  // one or the other to be able to test all variations.
+  for (final String skipProperty in const <String>['color', 'foreground']) {
+    test('all properties (except $skipProperty) altogether equal', () {
+      final _TestTextStyleBuilder aBuilder = _TestTextStyleBuilder();
+      final _TestTextStyleBuilder bBuilder = _TestTextStyleBuilder();
+
+      for (final String property in _populatorsA.keys) {
+        if (property == skipProperty) {
+          continue;
+        }
+        final _TextStylePropertyPopulator populator = _populatorsA[property]!;
+        populator(aBuilder);
+        populator(bBuilder);
+      }
+
+      final ui.TextStyle a = aBuilder.build();
+      final ui.TextStyle b = bBuilder.build();
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('all properties (except $skipProperty) altogether not equal', () {
+      final _TestTextStyleBuilder aBuilder = _TestTextStyleBuilder();
+      final _TestTextStyleBuilder bBuilder = _TestTextStyleBuilder();
+
+      for (final String property in _populatorsA.keys) {
+        if (property == skipProperty) {
+          continue;
+        }
+        final _TextStylePropertyPopulator populatorA = _populatorsA[property]!;
+        populatorA(aBuilder);
+
+        final _TextStylePropertyPopulator populatorB = _populatorsB[property]!;
+        populatorB(bBuilder);
+      }
+
+      final ui.TextStyle a = aBuilder.build();
+      final ui.TextStyle b = bBuilder.build();
+
+      expect(a, isNot(b));
+      expect(a.hashCode, isNot(b.hashCode));
+    });
+  }
+}
+
+typedef _TextStylePropertyPopulator = void Function(_TestTextStyleBuilder builder);
+
+// Paint equality is based on identity, so all the paints below are different,
+// even though they express the same paint.
+final ui.Paint _backgroundA = ui.Paint();
+final ui.Paint _foregroundA = ui.Paint();
+final ui.Paint _backgroundB = ui.Paint();
+final ui.Paint _foregroundB = ui.Paint();
+
+final Map<String, _TextStylePropertyPopulator> _populatorsA = <String, _TextStylePropertyPopulator>{
+  'color': (_TestTextStyleBuilder builder) { builder.color = const ui.Color(0xff000000); },
+  'decoration': (_TestTextStyleBuilder builder) { builder.decoration = ui.TextDecoration.none; },
+  'decorationColor': (_TestTextStyleBuilder builder) { builder.decorationColor = const ui.Color(0xffaa0000); },
+  'decorationStyle': (_TestTextStyleBuilder builder) { builder.decorationStyle = ui.TextDecorationStyle.solid; },
+  'decorationThickness': (_TestTextStyleBuilder builder) { builder.decorationThickness = 1.0; },
+  'fontWeight': (_TestTextStyleBuilder builder) { builder.fontWeight = ui.FontWeight.w400; },
+  'fontStyle': (_TestTextStyleBuilder builder) { builder.fontStyle = ui.FontStyle.normal; },
+  'textBaseline': (_TestTextStyleBuilder builder) { builder.textBaseline = ui.TextBaseline.alphabetic; },
+  'fontFamily': (_TestTextStyleBuilder builder) { builder.fontFamily = 'Arial'; },
+  'fontFamilyFallback': (_TestTextStyleBuilder builder) { builder.fontFamilyFallback = <String>['Roboto']; },
+  'fontSize': (_TestTextStyleBuilder builder) { builder.fontSize = 12; },
+  'letterSpacing': (_TestTextStyleBuilder builder) { builder.letterSpacing = 1.2; },
+  'wordSpacing': (_TestTextStyleBuilder builder) { builder.wordSpacing = 2.3; },
+  'height': (_TestTextStyleBuilder builder) { builder.height = 13; },
+  'leadingDistribution': (_TestTextStyleBuilder builder) { builder.leadingDistribution = ui.TextLeadingDistribution.proportional; },
+  'locale': (_TestTextStyleBuilder builder) { builder.locale = const ui.Locale('en', 'US'); },
+  'background': (_TestTextStyleBuilder builder) { builder.background = _backgroundA; },
+  'foreground': (_TestTextStyleBuilder builder) { builder.foreground = _foregroundA; },
+  'shadows': (_TestTextStyleBuilder builder) { builder.shadows = <ui.Shadow>[const ui.Shadow()]; },
+  'fontFeatures': (_TestTextStyleBuilder builder) { builder.fontFeatures = <ui.FontFeature>[const ui.FontFeature.caseSensitiveForms()]; },
+  'fontVariations': (_TestTextStyleBuilder builder) { builder.fontVariations = <ui.FontVariation>[ const ui.FontVariation.italic(0.1)]; },
+};
+
+final Map<String, _TextStylePropertyPopulator> _populatorsB = <String, _TextStylePropertyPopulator>{
+  'color': (_TestTextStyleBuilder builder) { builder.color = const ui.Color(0xffbb0000); },
+  'decoration': (_TestTextStyleBuilder builder) { builder.decoration = ui.TextDecoration.lineThrough; },
+  'decorationColor': (_TestTextStyleBuilder builder) { builder.decorationColor = const ui.Color(0xffcc0000); },
+  'decorationStyle': (_TestTextStyleBuilder builder) { builder.decorationStyle = ui.TextDecorationStyle.dotted; },
+  'decorationThickness': (_TestTextStyleBuilder builder) { builder.decorationThickness = 1.4; },
+  'fontWeight': (_TestTextStyleBuilder builder) { builder.fontWeight = ui.FontWeight.w600; },
+  'fontStyle': (_TestTextStyleBuilder builder) { builder.fontStyle = ui.FontStyle.italic; },
+  'textBaseline': (_TestTextStyleBuilder builder) { builder.textBaseline = ui.TextBaseline.ideographic; },
+  'fontFamily': (_TestTextStyleBuilder builder) { builder.fontFamily = 'Noto'; },
+  'fontFamilyFallback': (_TestTextStyleBuilder builder) { builder.fontFamilyFallback = <String>['Verdana']; },
+  'fontSize': (_TestTextStyleBuilder builder) { builder.fontSize = 12.1; },
+  'letterSpacing': (_TestTextStyleBuilder builder) { builder.letterSpacing = 1.25; },
+  'wordSpacing': (_TestTextStyleBuilder builder) { builder.wordSpacing = 2.35; },
+  'height': (_TestTextStyleBuilder builder) { builder.height = 13.1; },
+  'leadingDistribution': (_TestTextStyleBuilder builder) { builder.leadingDistribution = ui.TextLeadingDistribution.even; },
+  'locale': (_TestTextStyleBuilder builder) { builder.locale = const ui.Locale('fr', 'CA'); },
+  'background': (_TestTextStyleBuilder builder) { builder.background = _backgroundB; },
+  'foreground': (_TestTextStyleBuilder builder) { builder.foreground = _foregroundB; },
+  'shadows': (_TestTextStyleBuilder builder) { builder.shadows = <ui.Shadow>[const ui.Shadow(blurRadius: 5)]; },
+  'fontFeatures': (_TestTextStyleBuilder builder) { builder.fontFeatures = <ui.FontFeature>[const ui.FontFeature.alternative(2)]; },
+  'fontVariations': (_TestTextStyleBuilder builder) { builder.fontVariations = <ui.FontVariation>[ const ui.FontVariation.italic(0.4)]; },
+};
+
+class _TestTextStyleBuilder {
+  ui.Color? color;
+  ui.TextDecoration? decoration;
+  ui.Color? decorationColor;
+  ui.TextDecorationStyle? decorationStyle;
+  double? decorationThickness;
+  ui.FontWeight? fontWeight;
+  ui.FontStyle? fontStyle;
+  ui.TextBaseline? textBaseline;
+  String? fontFamily;
+  List<String>? fontFamilyFallback;
+  double? fontSize;
+  double? letterSpacing;
+  double? wordSpacing;
+  double? height;
+  ui.TextLeadingDistribution? leadingDistribution;
+  ui.Locale? locale;
+  ui.Paint? background;
+  ui.Paint? foreground;
+  List<ui.Shadow>? shadows;
+  List<ui.FontFeature>? fontFeatures;
+  List<ui.FontVariation>? fontVariations;
+
+  ui.TextStyle build() {
+    return ui.TextStyle(
+      color: color,
+      decoration: decoration,
+      decorationColor: decorationColor,
+      decorationStyle: decorationStyle,
+      decorationThickness: decorationThickness,
+      fontWeight: fontWeight,
+      fontStyle: fontStyle,
+      textBaseline: textBaseline,
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
+      fontSize: fontSize,
+      letterSpacing: letterSpacing,
+      wordSpacing: wordSpacing,
+      height: height,
+      leadingDistribution: leadingDistribution,
+      locale: locale,
+      background: background,
+      foreground: foreground,
+      shadows: shadows,
+      fontFeatures: fontFeatures,
+      fontVariations: fontVariations,
+    );
+  }
+}


### PR DESCRIPTION
Make TextStyle implementations consistent across web renderers and consistent with the mobile implementation. This will allow us to unskip `test/painting/text_style_test.dart` on the framework side.