### PR TITLE
Revert skiping illegal render in Dart

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -308,8 +308,9 @@ class PlatformDispatcher {
     _invoke(onMetricsChanged, _onMetricsChangedZone);
   }
 
-  // The [FlutterView]s for which [FlutterView.render] has already been called
-  // during the current [onBeginFrame]/[onDrawFrame] callback sequence.
+  // A debug-only variable that stores the [FlutterView]s for which
+  // [FlutterView.render] has already been called during the current
+  // [onBeginFrame]/[onDrawFrame] callback sequence.
   //
   // It is null outside the scope of those callbacks indicating that calls to
   // [FlutterView.render] must be ignored. Furthermore, if a given [FlutterView]
@@ -319,9 +320,16 @@ class PlatformDispatcher {
   // Between [onBeginFrame] and [onDrawFrame] the properties value is
   // temporarily stored in `_renderedViewsBetweenCallbacks` so that it survives
   // the gap between the two callbacks.
-  Set<FlutterView>? _renderedViews;
-  // The `_renderedViews` value between `_beginFrame` and `_drawFrame`.
-  Set<FlutterView>? _renderedViewsBetweenCallbacks;
+  //
+  // In release build, this variable is null, and therefore the calling rule is
+  // not enforced. This is because the check might hurt cold startup delay;
+  // see https://github.com/flutter/engine/pull/46919.
+  Set<FlutterView>? _debugRenderedViews;
+  // A debug-only variable that temporarily stores the `_renderedViews` value
+  // between `_beginFrame` and `_drawFrame`.
+  //
+  // In release build, this variable is null.
+  Set<FlutterView>? _debugRenderedViewsBetweenCallbacks;
 
   /// A callback invoked when any view begins a frame.
   ///
@@ -343,9 +351,12 @@ class PlatformDispatcher {
 
   // Called from the engine, via hooks.dart
   void _beginFrame(int microseconds) {
-    assert(_renderedViews == null);
-    assert(_renderedViewsBetweenCallbacks == null);
-    _renderedViews = <FlutterView>{};
+    assert(_debugRenderedViews == null);
+    assert(_debugRenderedViewsBetweenCallbacks == null);
+    assert(() {
+      _debugRenderedViews = <FlutterView>{};
+      return true;
+    }());
 
     _invoke1<Duration>(
       onBeginFrame,
@@ -353,10 +364,13 @@ class PlatformDispatcher {
       Duration(microseconds: microseconds),
     );
 
-    assert(_renderedViews != null);
-    assert(_renderedViewsBetweenCallbacks == null);
-    _renderedViewsBetweenCallbacks = _renderedViews;
-    _renderedViews = null;
+    assert(_debugRenderedViews != null);
+    assert(_debugRenderedViewsBetweenCallbacks == null);
+    assert(() {
+      _debugRenderedViewsBetweenCallbacks = _debugRenderedViews;
+      _debugRenderedViews = null;
+      return true;
+    }());
   }
 
   /// A callback that is invoked for each frame after [onBeginFrame] has
@@ -374,16 +388,22 @@ class PlatformDispatcher {
 
   // Called from the engine, via hooks.dart
   void _drawFrame() {
-    assert(_renderedViews == null);
-    assert(_renderedViewsBetweenCallbacks != null);
-    _renderedViews = _renderedViewsBetweenCallbacks;
-    _renderedViewsBetweenCallbacks = null;
+    assert(_debugRenderedViews == null);
+    assert(_debugRenderedViewsBetweenCallbacks != null);
+    assert(() {
+      _debugRenderedViews = _debugRenderedViewsBetweenCallbacks;
+      _debugRenderedViewsBetweenCallbacks = null;
+      return true;
+    }());
 
     _invoke(onDrawFrame, _onDrawFrameZone);
 
-    assert(_renderedViews != null);
-    assert(_renderedViewsBetweenCallbacks == null);
-    _renderedViews = null;
+    assert(_debugRenderedViews != null);
+    assert(_debugRenderedViewsBetweenCallbacks == null);
+    assert(() {
+      _debugRenderedViews = null;
+      return true;
+    }());
   }
 
   /// A callback that is invoked when pointer data is available.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -373,8 +373,14 @@ class FlutterView {
   ///   painting.
   void render(Scene scene, {Size? size}) {
     // Duplicated calls or calls outside of onBeginFrame/onDrawFrame (indicated
-    // by _renderedViews being null) are ignored. See _renderedViews.
-    final bool validRender = platformDispatcher._renderedViews?.add(this) ?? false;
+    // by _debugRenderedViews being null) are ignored. See _debugRenderedViews.
+    // TODO(dkwingsmt): We should change this skip into an assertion.
+    // https://github.com/flutter/flutter/issues/137073
+    bool validRender = true;
+    assert(() {
+      validRender = platformDispatcher._debugRenderedViews?.add(this) ?? false;
+      return true;
+    }());
     if (validRender) {
       _render(scene as _NativeScene, size?.width ?? physicalSize.width, size?.height ?? physicalSize.height);
     }

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -148,6 +148,7 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree,
   if (frame_timings_recorder_ == nullptr) {
     return;
   }
+
   has_rendered_ = true;
 
   TRACE_EVENT_WITH_FRAME_NUMBER(frame_timings_recorder_, "flutter",

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -143,13 +143,15 @@ void Animator::BeginFrame(
 
 void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree,
                       float device_pixel_ratio) {
-  // Animator::Render should be called after BeginFrame, which is indicated by
-  // frame_timings_recorder_ being non-null. Otherwise, this call is ignored.
-  if (frame_timings_recorder_ == nullptr) {
-    return;
-  }
-
   has_rendered_ = true;
+
+  if (!frame_timings_recorder_) {
+    // Framework can directly call render with a built scene.
+    frame_timings_recorder_ = std::make_unique<FrameTimingsRecorder>();
+    const fml::TimePoint placeholder_time = fml::TimePoint::Now();
+    frame_timings_recorder_->RecordVsync(placeholder_time, placeholder_time);
+    frame_timings_recorder_->RecordBuildStart(placeholder_time);
+  }
 
   TRACE_EVENT_WITH_FRAME_NUMBER(frame_timings_recorder_, "flutter",
                                 "Animator::Render", /*flow_id_count=*/0,

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -58,8 +58,7 @@ class Animator final {
   ///
   ///           This method must be called during a vsync callback, or
   ///           technically, between Animator::BeginFrame and Animator::EndFrame
-  ///           (both private methods). Otherwise, an assertion will be
-  ///           triggered.
+  ///           (both private methods). Otherwise, this call will be ignored.
   ///
   void Render(std::unique_ptr<flutter::LayerTree> layer_tree,
               float device_pixel_ratio);


### PR DESCRIPTION
This PR reverts the following two PRs:
* https://github.com/flutter/engine/pull/47323
* https://github.com/flutter/engine/pull/49266

Effectively, 

| Illegal renders are... | in debug build | in release build |
|----|----|----|
| Before revert | Skipped in Dart | Skipped in Dart |
| After revert | Skipped in Dart | Passed in Dart and rendered in native |

which means that the illegal renders will take effect in release mode, the mode that the benchmarks are performed in.

This is due to a discovery that the revert https://github.com/flutter/engine/pull/49238 did not bring back the performance. We suspect that some other changes after the culprit (https://github.com/flutter/engine/pull/47239) is also responsible for the regression, which narrows down to just one PR, https://github.com/flutter/engine/pull/47323, which also makes sense. By reverting this change, we'll draw a final conclusion whether the regression is caused by illegal renders.

After this revert, the engine is in a temporary state due to the different behaviors between modes. 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
