### PR TITLE
[Impeller] Allow multiple --runtime-stage-* parameters to impellerc

### DIFF
--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -69,13 +69,16 @@ static bool OutputIPLR(
   }
 
   for (const auto& platform : switches.PlatformsToCompile()) {
+    if (platform == TargetPlatform::kSkSL) {
+      // Already handled above.
+      continue;
+    }
     SourceOptions options = switches.CreateSourceOptions(platform);
 
     // Invoke the compiler and generate reflection data for a single shader.
 
     Reflector::Options reflector_options =
         CreateReflectorOptions(options, switches);
-    FML_LOG(ERROR) << "WHAT?!?";
     Compiler compiler(source_file_mapping, options, reflector_options);
     if (!compiler.IsValid()) {
       std::cerr << "Compilation failed." << std::endl;
@@ -271,7 +274,6 @@ bool Main(const fml::CommandLine& command_line) {
   Reflector::Options reflector_options =
       CreateReflectorOptions(options, switches);
 
-  FML_LOG(ERROR) << "Here!!";
   Compiler compiler(source_file_mapping, options, reflector_options);
   if (!compiler.IsValid()) {
     std::cerr << "Compilation failed." << std::endl;

--- a/impeller/compiler/impellerc_main.cc
+++ b/impeller/compiler/impellerc_main.cc
@@ -20,20 +20,31 @@
 namespace impeller {
 namespace compiler {
 
+static Reflector::Options CreateReflectorOptions(const SourceOptions& options,
+                                                 const Switches& switches) {
+  Reflector::Options reflector_options;
+  reflector_options.target_platform = options.target_platform;
+  reflector_options.entry_point_name = options.entry_point_name;
+  reflector_options.shader_name =
+      InferShaderNameFromPath(switches.source_file_name);
+  reflector_options.header_file_name = Utf8FromPath(
+      std::filesystem::path{switches.reflection_header_name}.filename());
+  return reflector_options;
+}
+
 /// Run the shader compiler to geneate SkSL reflection data.
 /// If there is an error, prints error text and returns `nullptr`.
 static std::shared_ptr<RuntimeStageData::Shader> CompileSkSL(
     std::shared_ptr<fml::Mapping> source_file_mapping,
-    SourceOptions& options,
-    Reflector::Options& reflector_options) {
-  SourceOptions sksl_options = options;
-  sksl_options.target_platform = TargetPlatform::kSkSL;
+    const Switches& switches) {
+  auto options = switches.CreateSourceOptions(TargetPlatform::kSkSL);
 
-  Reflector::Options sksl_reflector_options = reflector_options;
+  Reflector::Options sksl_reflector_options =
+      CreateReflectorOptions(options, switches);
   sksl_reflector_options.target_platform = TargetPlatform::kSkSL;
 
-  Compiler sksl_compiler = Compiler(std::move(source_file_mapping),
-                                    sksl_options, sksl_reflector_options);
+  Compiler sksl_compiler =
+      Compiler(std::move(source_file_mapping), options, sksl_reflector_options);
   if (!sksl_compiler.IsValid()) {
     std::cerr << "Compilation to SkSL failed." << std::endl;
     std::cerr << sksl_compiler.GetErrorMessages() << std::endl;
@@ -42,26 +53,74 @@ static std::shared_ptr<RuntimeStageData::Shader> CompileSkSL(
   return sksl_compiler.GetReflector()->GetRuntimeStageShaderData();
 }
 
-/// Outputs artifacts for a single compiler invocation and option configuration.
-/// If there is an error, prints error text and returns `false`.
-static bool OutputArtifacts(Compiler& compiler,
-                            Switches& switches,
-                            std::shared_ptr<fml::Mapping> source_file_mapping,
-                            SourceOptions& options,
-                            Reflector::Options& reflector_options) {
-  // --------------------------------------------------------------------------
-  /// 1. Invoke the compiler to generate SkSL if needed.
-  ///
+static bool OutputIPLR(
+    const Switches& switches,
+    const std::shared_ptr<fml::Mapping>& source_file_mapping) {
+  FML_DCHECK(switches.iplr);
 
+  RuntimeStageData stages;
   std::shared_ptr<RuntimeStageData::Shader> sksl_shader;
-  if (switches.iplr && TargetPlatformBundlesSkSL(switches.target_platform)) {
-    sksl_shader =
-        CompileSkSL(std::move(source_file_mapping), options, reflector_options);
+  if (TargetPlatformBundlesSkSL(switches.SelectDefaultTargetPlatform())) {
+    sksl_shader = CompileSkSL(source_file_mapping, switches);
     if (!sksl_shader) {
       return false;
     }
+    stages.AddShader(sksl_shader);
   }
 
+  for (const auto& platform : switches.PlatformsToCompile()) {
+    SourceOptions options = switches.CreateSourceOptions(platform);
+
+    // Invoke the compiler and generate reflection data for a single shader.
+
+    Reflector::Options reflector_options =
+        CreateReflectorOptions(options, switches);
+    FML_LOG(ERROR) << "WHAT?!?";
+    Compiler compiler(source_file_mapping, options, reflector_options);
+    if (!compiler.IsValid()) {
+      std::cerr << "Compilation failed." << std::endl;
+      std::cerr << compiler.GetErrorMessages() << std::endl;
+      return false;
+    }
+
+    auto reflector = compiler.GetReflector();
+    if (reflector == nullptr) {
+      std::cerr << "Could not create reflector." << std::endl;
+      return false;
+    }
+
+    auto stage_data = reflector->GetRuntimeStageShaderData();
+    if (!stage_data) {
+      std::cerr << "Runtime stage information was nil." << std::endl;
+      return false;
+    }
+
+    stages.AddShader(stage_data);
+  }
+
+  auto stage_data_mapping = switches.json_format ? stages.CreateJsonMapping()
+                                                 : stages.CreateMapping();
+  if (!stage_data_mapping) {
+    std::cerr << "Runtime stage data could not be created." << std::endl;
+    return false;
+  }
+  if (!fml::WriteAtomically(*switches.working_directory,                  //
+                            Utf8FromPath(switches.sl_file_name).c_str(),  //
+                            *stage_data_mapping                           //
+                            )) {
+    std::cerr << "Could not write file to " << switches.sl_file_name
+              << std::endl;
+    return false;
+  }
+  // Tools that consume the runtime stage data expect the access mode to
+  // be 0644.
+  if (!SetPermissiveAccess(switches.sl_file_name)) {
+    return false;
+  }
+  return true;
+}
+
+static bool OutputSLFile(const Compiler& compiler, const Switches& switches) {
   // --------------------------------------------------------------------------
   /// 2. Output the source file. When in IPLR/RuntimeStage mode, output the
   ///    serialized IPLR flatbuffer.
@@ -69,75 +128,19 @@ static bool OutputArtifacts(Compiler& compiler,
 
   auto sl_file_name = std::filesystem::absolute(
       std::filesystem::current_path() / switches.sl_file_name);
-  if (switches.iplr) {
-    auto reflector = compiler.GetReflector();
-    if (reflector == nullptr) {
-      std::cerr << "Could not create reflector." << std::endl;
-      return false;
-    }
-    auto stage_data = reflector->GetRuntimeStageShaderData();
-    if (!stage_data) {
-      std::cerr << "Runtime stage information was nil." << std::endl;
-      return false;
-    }
-    RuntimeStageData stages;
-    if (sksl_shader) {
-      stages.AddShader(RuntimeStageBackend::kSkSL, sksl_shader);
-    }
-    switch (switches.target_platform) {
-      case TargetPlatform::kUnknown:
-      case TargetPlatform::kMetalDesktop:
-      case TargetPlatform::kMetalIOS:
-      case TargetPlatform::kOpenGLES:
-      case TargetPlatform::kOpenGLDesktop:
-      case TargetPlatform::kVulkan:
-        std::cerr << "TargetPlatform "
-                  << TargetPlatformToString(switches.target_platform)
-                  << " not supported for IPLR.";
-        return false;
-      case TargetPlatform::kRuntimeStageMetal:
-        stages.AddShader(RuntimeStageBackend::kMetal, stage_data);
-        break;
-      case TargetPlatform::kRuntimeStageGLES:
-        stages.AddShader(RuntimeStageBackend::kOpenGLES, stage_data);
-        break;
-      case TargetPlatform::kRuntimeStageVulkan:
-        stages.AddShader(RuntimeStageBackend::kVulkan, stage_data);
-        break;
-      case TargetPlatform::kSkSL:
-        // Already handled above.
-        break;
-    }
-
-    auto stage_data_mapping = options.json_format ? stages.CreateJsonMapping()
-                                                  : stages.CreateMapping();
-    if (!stage_data_mapping) {
-      std::cerr << "Runtime stage data could not be created." << std::endl;
-      return false;
-    }
-    if (!fml::WriteAtomically(*switches.working_directory,         //
-                              Utf8FromPath(sl_file_name).c_str(),  //
-                              *stage_data_mapping                  //
-                              )) {
-      std::cerr << "Could not write file to " << switches.sl_file_name
-                << std::endl;
-      return false;
-    }
-    // Tools that consume the runtime stage data expect the access mode to
-    // be 0644.
-    if (!SetPermissiveAccess(sl_file_name)) {
-      return false;
-    }
-  } else {
-    if (!fml::WriteAtomically(*switches.working_directory,
-                              Utf8FromPath(sl_file_name).c_str(),
-                              *compiler.GetSLShaderSource())) {
-      std::cerr << "Could not write file to " << switches.sl_file_name
-                << std::endl;
-      return false;
-    }
+  if (!fml::WriteAtomically(*switches.working_directory,
+                            Utf8FromPath(sl_file_name).c_str(),
+                            *compiler.GetSLShaderSource())) {
+    std::cerr << "Could not write file to " << switches.sl_file_name
+              << std::endl;
+    return false;
   }
+  return true;
+}
 
+static bool OutputReflectionData(const Compiler& compiler,
+                                 const Switches& switches,
+                                 const SourceOptions& options) {
   // --------------------------------------------------------------------------
   /// 3. Output shader reflection data.
   ///    May include a JSON file, a C++ header, and/or a C++ TU.
@@ -184,14 +187,17 @@ static bool OutputArtifacts(Compiler& compiler,
       }
     }
   }
+  return true;
+}
 
+static bool OutputDepfile(const Compiler& compiler, const Switches& switches) {
   // --------------------------------------------------------------------------
   /// 4. Output a depfile.
   ///
 
   if (!switches.depfile_path.empty()) {
     std::string result_file;
-    switch (switches.target_platform) {
+    switch (switches.SelectDefaultTargetPlatform()) {
       case TargetPlatform::kMetalDesktop:
       case TargetPlatform::kMetalIOS:
       case TargetPlatform::kOpenGLES:
@@ -234,31 +240,11 @@ bool Main(const fml::CommandLine& command_line) {
     Switches::PrintHelp(std::cerr);
     return false;
   }
-  SourceOptions options;
-  options.target_platform = switches.target_platform;
-  options.source_language = switches.source_language;
-  if (switches.input_type == SourceType::kUnknown) {
-    options.type = SourceTypeFromFileName(switches.source_file_name);
-  } else {
-    options.type = switches.input_type;
-  }
-  options.working_directory = switches.working_directory;
-  options.file_name = switches.source_file_name;
-  options.include_dirs = switches.include_directories;
-  options.defines = switches.defines;
-  options.entry_point_name = EntryPointFunctionNameFromSourceName(
-      switches.source_file_name, options.type, options.source_language,
-      switches.entry_point);
-  options.json_format = switches.json_format;
-  options.gles_language_version = switches.gles_language_version;
-  options.metal_version = switches.metal_version;
-  options.use_half_textures = switches.use_half_textures;
-  options.require_framebuffer_fetch = switches.require_framebuffer_fetch;
 
   if (!switches.shader_bundle.empty()) {
     // Invoke the compiler multiple times to build a shader bundle with the
     // given shader_bundle spec.
-    return GenerateShaderBundle(switches, options);
+    return GenerateShaderBundle(switches);
   }
 
   std::shared_ptr<fml::FileMapping> source_file_mapping =
@@ -268,17 +254,24 @@ bool Main(const fml::CommandLine& command_line) {
     return false;
   }
 
-  // Invoke the compiler and generate reflection data for a single shader or
-  // runtime stage IPLR.
+  if (switches.iplr && !OutputIPLR(switches, source_file_mapping)) {
+    return false;
+  }
 
-  Reflector::Options reflector_options;
-  reflector_options.target_platform = switches.target_platform;
-  reflector_options.entry_point_name = options.entry_point_name;
-  reflector_options.shader_name =
-      InferShaderNameFromPath(switches.source_file_name);
-  reflector_options.header_file_name = Utf8FromPath(
-      std::filesystem::path{switches.reflection_header_name}.filename());
+  // Create at least one compiler to output the SL file, reflection data, and a
+  // depfile.
+  // TODO(dnfield): This seems off. We should more explicitly handle how we
+  // generate reflection and depfile data for the runtime stage case.
+  // https://github.com/flutter/flutter/issues/140841
 
+  SourceOptions options = switches.CreateSourceOptions();
+
+  // Invoke the compiler and generate reflection data for a single shader.
+
+  Reflector::Options reflector_options =
+      CreateReflectorOptions(options, switches);
+
+  FML_LOG(ERROR) << "Here!!";
   Compiler compiler(source_file_mapping, options, reflector_options);
   if (!compiler.IsValid()) {
     std::cerr << "Compilation failed." << std::endl;
@@ -296,8 +289,15 @@ bool Main(const fml::CommandLine& command_line) {
     return false;
   }
 
-  if (!OutputArtifacts(compiler, switches, std::move(source_file_mapping),
-                       options, reflector_options)) {
+  if (!switches.iplr && !OutputSLFile(compiler, switches)) {
+    return false;
+  }
+
+  if (!OutputReflectionData(compiler, switches, options)) {
+    return false;
+  }
+
+  if (!OutputDepfile(compiler, switches)) {
     return false;
   }
 

--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -58,9 +58,9 @@ class Reflector {
   };
 
   Reflector(Options options,
-            std::shared_ptr<const spirv_cross::ParsedIR> ir,
-            std::shared_ptr<fml::Mapping> shader_data,
-            CompilerBackend compiler);
+            const std::shared_ptr<const spirv_cross::ParsedIR>& ir,
+            const std::shared_ptr<fml::Mapping>& shader_data,
+            const CompilerBackend& compiler);
 
   ~Reflector();
 

--- a/impeller/compiler/runtime_stage_data.cc
+++ b/impeller/compiler/runtime_stage_data.cc
@@ -23,10 +23,10 @@ RuntimeStageData::RuntimeStageData() = default;
 
 RuntimeStageData::~RuntimeStageData() = default;
 
-void RuntimeStageData::AddShader(RuntimeStageBackend backend,
-                                 const std::shared_ptr<Shader>& data) {
-  FML_DCHECK(data_.find(backend) == data_.end());
-  data_[backend] = data;
+void RuntimeStageData::AddShader(const std::shared_ptr<Shader>& data) {
+  FML_DCHECK(data);
+  FML_DCHECK(data_.find(data->backend) == data_.end());
+  data_[data->backend] = data;
 }
 
 static std::optional<fb::Stage> ToStage(spv::ExecutionModel stage) {

--- a/impeller/compiler/runtime_stage_data.cc
+++ b/impeller/compiler/runtime_stage_data.cc
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 
+#include "fml/backtrace.h"
 #include "impeller/core/runtime_types.h"
 #include "inja/inja.hpp"
 

--- a/impeller/compiler/runtime_stage_data.h
+++ b/impeller/compiler/runtime_stage_data.h
@@ -51,6 +51,7 @@ class RuntimeStageData {
     std::vector<UniformDescription> uniforms;
     std::vector<InputDescription> inputs;
     std::shared_ptr<fml::Mapping> shader;
+    RuntimeStageBackend backend;
 
     Shader(const Shader&) = delete;
     Shader& operator=(const Shader&) = delete;
@@ -60,8 +61,7 @@ class RuntimeStageData {
 
   ~RuntimeStageData();
 
-  void AddShader(RuntimeStageBackend backend,
-                 const std::shared_ptr<Shader>& data);
+  void AddShader(const std::shared_ptr<Shader>& data);
 
   std::unique_ptr<fb::RuntimeStagesT> CreateFlatbuffer() const;
 

--- a/impeller/compiler/shader_bundle.h
+++ b/impeller/compiler/shader_bundle.h
@@ -24,12 +24,12 @@ std::optional<ShaderBundleConfig> ParseShaderBundleConfig(
 ///         directly.
 std::optional<fb::ShaderBundleT> GenerateShaderBundleFlatbuffer(
     const std::string& bundle_config_json,
-    SourceOptions& options);
+    const SourceOptions& options);
 
 /// @brief  Parses the JSON shader bundle configuration and invokes the
 ///         compiler multiple times to produce a shader bundle flatbuffer, which
 ///         is then output to the `sl` file.
-bool GenerateShaderBundle(Switches& switches, SourceOptions& options);
+bool GenerateShaderBundle(Switches& switches);
 
 }  // namespace compiler
 }  // namespace impeller

--- a/impeller/compiler/switches.h
+++ b/impeller/compiler/switches.h
@@ -12,13 +12,14 @@
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/unique_fd.h"
 #include "impeller/compiler/include_dir.h"
+#include "impeller/compiler/source_options.h"
 #include "impeller/compiler/types.h"
 
 namespace impeller {
 namespace compiler {
 
-struct Switches {
-  TargetPlatform target_platform = TargetPlatform::kUnknown;
+class Switches {
+ public:
   std::shared_ptr<fml::UniqueFD> working_directory = nullptr;
   std::vector<IncludeDir> include_directories = {};
   std::string source_file_name = "";
@@ -51,7 +52,22 @@ struct Switches {
 
   bool AreValid(std::ostream& explain) const;
 
+  /// A vector containing at least one valid platform.
+  std::vector<TargetPlatform> PlatformsToCompile() const;
+  TargetPlatform SelectDefaultTargetPlatform() const;
+
+  // Creates source options from these switches for the specified
+  // TargetPlatform. Uses SelectDefaultTargetPlatform if not specified.
+  SourceOptions CreateSourceOptions(
+      std::optional<TargetPlatform> target_platform = std::nullopt) const;
+
   static void PrintHelp(std::ostream& stream);
+
+ private:
+  // Use |SelectDefaultTargetPlatform|.
+  TargetPlatform target_platform_ = TargetPlatform::kUnknown;
+  // Use |PlatformsToCompile|.
+  std::vector<TargetPlatform> runtime_stages_ = {};
 };
 
 }  // namespace compiler

--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -61,13 +61,11 @@ impellerc("runtime_stages") {
   ]
   sl_file_extension = "iplr"
 
-  # TODO(dnfield): Make impellerc able to bundle multiple non-SkSL shaders.
-  # https://github.com/flutter/flutter/issues/140817
-  if (is_ios || is_mac) {
-    shader_target_flag = "--runtime-stage-metal"
-  } else {
-    shader_target_flag = "--runtime-stage-gles"
-  }
+  shader_target_flags = [
+    "--runtime-stage-metal",
+    "--runtime-stage-gles",
+  ]
+
   iplr = true
 }
 
@@ -132,7 +130,7 @@ impellerc("flutter_gpu_shaders") {
     "flutter_gpu_texture.frag",
     "flutter_gpu_texture.vert",
   ]
-  shader_target_flag = "--runtime-stage-metal"
+  shader_target_flags = [ "--runtime-stage-metal" ]
   shader_bundle = "{\"UnlitFragment\": {\"type\": \"fragment\", \"file\": \"../../flutter/impeller/fixtures/flutter_gpu_unlit.frag\"}, \"UnlitVertex\": {\"type\": \"vertex\", \"file\": \"../../flutter/impeller/fixtures/flutter_gpu_unlit.vert\"}, \"TextureFragment\": {\"type\": \"fragment\", \"file\": \"../../flutter/impeller/fixtures/flutter_gpu_texture.frag\"}, \"TextureVertex\": {\"type\": \"vertex\", \"file\": \"../../flutter/impeller/fixtures/flutter_gpu_texture.vert\"}}"
   shader_bundle_output = "playground.shaderbundle"
 }

--- a/impeller/runtime_stage/runtime_stage_unittests.cc
+++ b/impeller/runtime_stage/runtime_stage_unittests.cc
@@ -9,6 +9,7 @@
 #include "flutter/testing/testing.h"
 #include "impeller/base/allocation.h"
 #include "impeller/base/validation.h"
+#include "impeller/core/runtime_types.h"
 #include "impeller/core/shader_types.h"
 #include "impeller/playground/playground.h"
 #include "impeller/renderer/pipeline_descriptor.h"
@@ -275,6 +276,21 @@ TEST_P(RuntimeStageTest, CanCreatePipelineFromRuntimeStage) {
   desc.SetStencilPixelFormat(stencil_fmt);
   auto pipeline = GetContext()->GetPipelineLibrary()->GetPipeline(desc).Get();
   ASSERT_NE(pipeline, nullptr);
+}
+
+TEST_P(RuntimeStageTest, ContainsExpectedShaderTypes) {
+  auto stages = OpenAssetAsRuntimeStage("ink_sparkle.frag.iplr");
+  // Right now, SkSL gets implicitly bundled regardless of what the build rule
+  // for this test requested. After
+  // https://github.com/flutter/flutter/issues/138919, this may require a build
+  // rule change or a new test.
+  EXPECT_TRUE(stages[RuntimeStageBackend::kSkSL]);
+
+  EXPECT_TRUE(stages[RuntimeStageBackend::kOpenGLES]);
+  EXPECT_TRUE(stages[RuntimeStageBackend::kMetal]);
+  // TODO(dnfield): Flip this when
+  // https://github.com/flutter/flutter/issues/122823 is fixed.
+  EXPECT_FALSE(stages[RuntimeStageBackend::kVulkan]);
 }
 
 }  // namespace testing

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -280,7 +280,7 @@ template("_impellerc") {
 }
 
 # Required: shaders                 The list of shaders inputs to compile.
-# Required: shader_target_flag      The target flag to append. Valid options:
+# Required: shader_target_flags     The target flag(s) to append. Valid options:
 #                                       --sksl
 #                                       --metal-ios
 #                                       --metal-desktop
@@ -288,6 +288,7 @@ template("_impellerc") {
 #                                       --opengl-desktop
 #                                       --vulkan
 #                                       --runtime-stage-metal
+#                                       --runtime-stage-gles
 # Required: sl_file_extension       The file extension to use for output files.
 #                                   Not required for --shader_bundle mode.
 # Optional: iplr                    Causes --sl output to be in iplr/runtime
@@ -305,7 +306,7 @@ template("_impellerc") {
 #                                   flatbuffer.
 template("impellerc") {
   assert(defined(invoker.shaders), "Impeller shaders must be specified.")
-  assert(defined(invoker.shader_target_flag),
+  assert(defined(invoker.shader_target_flags),
          "The flag to impellerc for target selection must be specified.")
   assert(defined(invoker.sl_file_extension) || defined(invoker.shader_bundle),
          "The extension of the SL file must be specified (metal, glsl, etc..).")
@@ -315,7 +316,10 @@ template("impellerc") {
         "When shader_bundle is specified, shader_output_bundle must also be specified.")
   }
 
-  sksl = invoker.shader_target_flag == "--sksl"
+  sksl = false
+  foreach(shader_target_flag, invoker.shader_target_flags) {
+    sksl = shader_target_flag == "--sksl"
+  }
   iplr = false
   if (defined(invoker.iplr) && invoker.iplr) {
     iplr = invoker.iplr
@@ -347,13 +351,10 @@ template("impellerc") {
       generated_dir = "$target_gen_dir"
     }
 
-    shader_target_flag = invoker.shader_target_flag
+    shader_target_flags = invoker.shader_target_flags
 
     shader_lib_dir = rebase_path("//flutter/impeller/compiler/shader_lib")
-    args = [
-      "--include=$shader_lib_dir",
-      "$shader_target_flag",
-    ]
+    args = [ "--include=$shader_lib_dir" ] + shader_target_flags
 
     # When we're in single invocation mode, we can't use source enumeration.
     if (!single_invocation) {
@@ -414,7 +415,7 @@ template("impellerc") {
 
       outputs = [ sl_output ]
     } else if (sksl) {
-      # When SkSL is selected as the `shader_target_flag`, don't generate
+      # When SkSL is selected as a `shader_target_flags`, don't generate
       # C++ reflection state. Nothing needs to use it and it's likely invalid
       # given the special cases when generating SkSL.
       # Note that this configuration is orthogonal to the "--iplr" flag
@@ -536,13 +537,13 @@ template("_impeller_shaders_metal") {
     metal_version = metal_version
     sl_file_extension = "metal"
     use_half_textures = use_half_textures
-    shader_target_flag = ""
+    shader_target_flags = []
     defines = [ "IMPELLER_TARGET_METAL" ]
     if (is_ios) {
-      shader_target_flag = "--metal-ios"
+      shader_target_flags += [ "--metal-ios" ]
       defines += [ "IMPELLER_TARGET_METAL_IOS" ]
     } else if (is_mac) {
-      shader_target_flag = "--metal-desktop"
+      shader_target_flags = [ "--metal-desktop" ]
       defines += [ "IMPELLER_TARGET_METAL_DESKTOP" ]
     } else {
       assert(false, "Metal not supported on this platform.")
@@ -631,9 +632,9 @@ template("_impeller_shaders_gles") {
       intermediates_subdir = "gles"
     }
     if (is_mac) {
-      shader_target_flag = "--opengl-desktop"
+      shader_target_flags = [ "--opengl-desktop" ]
     } else {
-      shader_target_flag = "--opengl-es"
+      shader_target_flags = [ "--opengl-es" ]
     }
 
     defines = [ "IMPELLER_TARGET_OPENGLES" ]
@@ -710,7 +711,7 @@ template("_impeller_shaders_vk") {
 
       intermediates_subdir = "vk"
     }
-    shader_target_flag = "--vulkan"
+    shader_target_flags = [ "--vulkan" ]
 
     defines = [ "IMPELLER_TARGET_VULKAN" ]
   }

--- a/lib/ui/fixtures/shaders/BUILD.gn
+++ b/lib/ui/fixtures/shaders/BUILD.gn
@@ -18,7 +18,7 @@ if (enable_unittests) {
 
   impellerc("ink_sparkle") {
     shaders = [ "//flutter/impeller/fixtures/ink_sparkle.frag" ]
-    shader_target_flag = "--sksl"
+    shader_target_flags = [ "--sksl" ]
     intermediates_subdir = "iplr"
     sl_file_extension = "iplr"
     iplr = true
@@ -26,7 +26,7 @@ if (enable_unittests) {
 
   impellerc("ink_sparkle_web") {
     shaders = [ "//flutter/impeller/fixtures/ink_sparkle.frag" ]
-    shader_target_flag = "--sksl"
+    shader_target_flags = [ "--sksl" ]
     intermediates_subdir = "iplr-json"
     sl_file_extension = "iplr"
     iplr = true
@@ -38,7 +38,10 @@ if (enable_unittests) {
       "//flutter/impeller/fixtures/ordering/shader_with_samplers.frag",
       "//flutter/third_party/test_shaders/selman/glow_shader.frag",
     ]
-    shader_target_flag = "--runtime-stage-metal"
+    shader_target_flags = [
+      "--runtime-stage-metal",
+      "--runtime-stage-gles",
+    ]
     intermediates_subdir = "iplr-remap"
     sl_file_extension = "iplr"
     iplr = true

--- a/lib/ui/fixtures/shaders/general_shaders/BUILD.gn
+++ b/lib/ui/fixtures/shaders/general_shaders/BUILD.gn
@@ -26,7 +26,7 @@ if (enable_unittests) {
 
   impellerc("compile_general_shaders") {
     shaders = test_shaders
-    shader_target_flag = "--sksl"
+    shader_target_flags = [ "--sksl" ]
     intermediates_subdir = "iplr"
     sl_file_extension = "iplr"
     iplr = true

--- a/lib/ui/fixtures/shaders/supported_glsl_op_shaders/BUILD.gn
+++ b/lib/ui/fixtures/shaders/supported_glsl_op_shaders/BUILD.gn
@@ -50,7 +50,7 @@ if (enable_unittests) {
 
   impellerc("compile_supported_glsl_shaders") {
     shaders = test_shaders
-    shader_target_flag = "--sksl"
+    shader_target_flags = [ "--sksl" ]
     intermediates_subdir = "iplr"
     sl_file_extension = "iplr"
     iplr = true

--- a/lib/ui/fixtures/shaders/supported_op_shaders/BUILD.gn
+++ b/lib/ui/fixtures/shaders/supported_op_shaders/BUILD.gn
@@ -46,7 +46,7 @@ if (enable_unittests) {
 
   impellerc("compile_supported_op_shaders") {
     shaders = test_shaders
-    shader_target_flag = "--sksl"
+    shader_target_flags = [ "--sksl" ]
     intermediates_subdir = "iplr"
     sl_file_extension = "iplr"
     iplr = true


### PR DESCRIPTION
This patch will be important for Android/Vulkan, where we'll need to bundle GLES, Vulkan, and SkSL (at least for now).

I've refactored impellerc_main to break up some of the larger methods into more granular ones.

I've also changed the way that the `IPLR` output works so that we create as many compilers as runtime stages requested.

We still are in a weird situation where we create one "Default" compiler for the reflection data and depfile. I don't think that needs to be addressed in this patch, but we should do something about this. I've talked a little with @bdero and @jonahwilliams - it will probably involve something like making the generated reflection data a bit more flexible than it currently is so that it can more ergonomically capture different platform anomalies - we could do this either by having a compiler type that is explicitly for generating reflection data rather than using one arbitrary one and making the reflector try to be platform agnostic. I've filed a couple TODOs related to this and linked them in the patch.

Fixes https://github.com/flutter/flutter/issues/140817