### PR TITLE
[fuchsia] Add libbackend_fuchsia_globals.so to common_libs

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -935,7 +935,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': 'CGyrUgA1M1yFx5N5C1aFQ_Q4Y5uP_FhxctN_UCZ9BugC'
+        'version': 'Wgogr8K1YZdo7yOnnGHWa2NBIvSTD6v8JIwlA8m-4oUC'
        }
      ],
      'condition': 'host_os == "linux" and not download_fuchsia_sdk',

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -1344,6 +1344,7 @@
 ../../../fuchsia/sdk/linux/pkg/async_patterns_cpp/meta.json
 ../../../fuchsia/sdk/linux/pkg/async_patterns_testing_cpp/include/lib/async_patterns/testing
 ../../../fuchsia/sdk/linux/pkg/async_patterns_testing_cpp/meta.json
+../../../fuchsia/sdk/linux/pkg/backend_fuchsia_globals/meta.json
 ../../../fuchsia/sdk/linux/pkg/component_incoming_cpp/meta.json
 ../../../fuchsia/sdk/linux/pkg/component_outgoing_cpp/meta.json
 ../../../fuchsia/sdk/linux/pkg/driver_component_cpp/meta.json

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: cf4e16ff9b0a1f5ec7a15cb4b7c4ce35
+Signature: fb5772ead7fffa7c3c625e5b37bac308
 
 ====================================================================================================
 LIBRARY: fuchsia_sdk
@@ -7,6 +7,7 @@ TYPE: LicenseType.apache
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/VkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/VkLayer_khronos_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libheapdump_instrumentation.so
@@ -17,6 +18,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libheapdump_instrumentation.so
@@ -187,6 +189,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/VkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/VkLayer_khronos_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libheapdump_instrumentation.so
@@ -197,6 +200,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libheapdump_instrumentation.so
@@ -367,6 +371,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/riscv64/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/VkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/VkLayer_khronos_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libheapdump_instrumentation.so
@@ -377,6 +382,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libheapdump_instrumentation.so
@@ -546,6 +552,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/data/config/symbol_index/config.json
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libheapdump_instrumentation.so
@@ -556,6 +563,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libheapdump_instrumentation.so
@@ -722,6 +730,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libheapdump_instrumentation.so
@@ -732,6 +741,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libheapdump_instrumentation.so
@@ -898,6 +908,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libheapdump_instrumentation.so
@@ -908,6 +919,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libheapdump_instrumentation.so
@@ -1074,6 +1086,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libheapdump_instrumentation.so
@@ -1084,6 +1097,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libheapdump_instrumentation.so
@@ -1250,6 +1264,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libheapdump_instrumentation.so
@@ -1260,6 +1275,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libheapdump_instrumentation.so
@@ -1426,6 +1442,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libheapdump_instrumentation.so
@@ -1436,6 +1453,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libheapdump_instrumentation.so
@@ -1602,6 +1620,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libheapdump_instrumentation.so
@@ -1612,6 +1631,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libheapdump_instrumentation.so
@@ -1778,6 +1798,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libheapdump_instrumentation.so
@@ -1788,6 +1809,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libheapdump_instrumentation.so
@@ -1954,6 +1976,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libheapdump_instrumentation.so
@@ -1964,6 +1987,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libheapdump_instrumentation.so
@@ -2130,6 +2154,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libheapdump_instrumentation.so
@@ -2140,6 +2165,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libheapdump_instrumentation.so
@@ -2306,6 +2332,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libheapdump_instrumentation.so
@@ -2316,6 +2343,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libheapdump_instrumentation.so
@@ -2482,6 +2510,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libheapdump_instrumentation.so
@@ -2492,6 +2521,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libheapdump_instrumentation.so
@@ -2658,6 +2688,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libheapdump_instrumentation.so
@@ -2668,6 +2699,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libheapdump_instrumentation.so
@@ -2834,6 +2866,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libheapdump_instrumentation.so
@@ -2844,6 +2877,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libheapdump_instrumentation.so
@@ -3010,6 +3044,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libheapdump_instrumentation.so
@@ -3020,6 +3055,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libheapdump_instrumentation.so
@@ -3198,6 +3234,7 @@ FILE: ../../../fuchsia/sdk/linux/packages/realm_builder_server/riscv64-api-1/rel
 FILE: ../../../fuchsia/sdk/linux/packages/realm_builder_server/x64-api-1/release/content_checklist_path
 FILE: ../../../fuchsia/sdk/linux/packages/realm_builder_server/x64-api-1/release/package_manifest.json
 FILE: ../../../fuchsia/sdk/linux/pkg/async-default/async-default.ifs
+FILE: ../../../fuchsia/sdk/linux/pkg/backend_fuchsia_globals/backend_fuchsia_globals.ifs
 FILE: ../../../fuchsia/sdk/linux/pkg/driver_runtime_shared_lib/driver_runtime.ifs
 FILE: ../../../fuchsia/sdk/linux/pkg/fdio/fdio.ifs
 FILE: ../../../fuchsia/sdk/linux/pkg/heapdump_instrumentation/heapdump_instrumentation.ifs
@@ -5517,6 +5554,7 @@ TYPE: LicenseType.bsd
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/VkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/VkLayer_khronos_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libheapdump_instrumentation.so
@@ -5527,6 +5565,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libheapdump_instrumentation.so
@@ -5697,6 +5736,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/VkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/VkLayer_khronos_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libheapdump_instrumentation.so
@@ -5707,6 +5747,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libheapdump_instrumentation.so
@@ -5877,6 +5918,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/riscv64/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/VkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/VkLayer_khronos_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libheapdump_instrumentation.so
@@ -5887,6 +5929,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libheapdump_instrumentation.so
@@ -6056,6 +6099,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/data/config/symbol_index/config.json
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libheapdump_instrumentation.so
@@ -6066,6 +6110,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libheapdump_instrumentation.so
@@ -6232,6 +6277,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libheapdump_instrumentation.so
@@ -6242,6 +6288,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libheapdump_instrumentation.so
@@ -6408,6 +6455,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libheapdump_instrumentation.so
@@ -6418,6 +6466,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libheapdump_instrumentation.so
@@ -6584,6 +6633,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libheapdump_instrumentation.so
@@ -6594,6 +6644,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libheapdump_instrumentation.so
@@ -6760,6 +6811,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libheapdump_instrumentation.so
@@ -6770,6 +6822,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libheapdump_instrumentation.so
@@ -6936,6 +6989,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libheapdump_instrumentation.so
@@ -6946,6 +7000,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libheapdump_instrumentation.so
@@ -7112,6 +7167,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libheapdump_instrumentation.so
@@ -7122,6 +7178,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libheapdump_instrumentation.so
@@ -7288,6 +7345,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libheapdump_instrumentation.so
@@ -7298,6 +7356,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libheapdump_instrumentation.so
@@ -7464,6 +7523,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libheapdump_instrumentation.so
@@ -7474,6 +7534,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libheapdump_instrumentation.so
@@ -7640,6 +7701,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libheapdump_instrumentation.so
@@ -7650,6 +7712,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libheapdump_instrumentation.so
@@ -7816,6 +7879,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libheapdump_instrumentation.so
@@ -7826,6 +7890,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libheapdump_instrumentation.so
@@ -7992,6 +8057,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libheapdump_instrumentation.so
@@ -8002,6 +8068,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libheapdump_instrumentation.so
@@ -8168,6 +8235,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libheapdump_instrumentation.so
@@ -8178,6 +8246,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libheapdump_instrumentation.so
@@ -8344,6 +8413,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libheapdump_instrumentation.so
@@ -8354,6 +8424,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libheapdump_instrumentation.so
@@ -8520,6 +8591,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libheapdump_instrumentation.so
@@ -8530,6 +8602,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libheapdump_instrumentation.so
@@ -8708,6 +8781,7 @@ FILE: ../../../fuchsia/sdk/linux/packages/realm_builder_server/riscv64-api-1/rel
 FILE: ../../../fuchsia/sdk/linux/packages/realm_builder_server/x64-api-1/release/content_checklist_path
 FILE: ../../../fuchsia/sdk/linux/packages/realm_builder_server/x64-api-1/release/package_manifest.json
 FILE: ../../../fuchsia/sdk/linux/pkg/async-default/async-default.ifs
+FILE: ../../../fuchsia/sdk/linux/pkg/backend_fuchsia_globals/backend_fuchsia_globals.ifs
 FILE: ../../../fuchsia/sdk/linux/pkg/driver_runtime_shared_lib/driver_runtime.ifs
 FILE: ../../../fuchsia/sdk/linux/pkg/fdio/fdio.ifs
 FILE: ../../../fuchsia/sdk/linux/pkg/heapdump_instrumentation/heapdump_instrumentation.ifs
@@ -9798,6 +9872,7 @@ ORIGIN: ../../../fuchsia/sdk/linux/obj/x64-api-16/sysroot/include/zircon/boot/cr
 ORIGIN: ../../../fuchsia/sdk/linux/obj/x64-api-16/sysroot/include/zircon/string_view.h + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/obj/x64-api-16/sysroot/include/zircon/syscalls-next.h + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/obj/x64-api-16/sysroot/include/zircon/testonly-syscalls.h + ../../../fuchsia/sdk/linux/LICENSE
+ORIGIN: ../../../fuchsia/sdk/linux/pkg/backend_fuchsia_globals/include/lib/syslog/cpp/logging_backend_fuchsia_globals.h + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/pkg/driver_component_cpp/include/lib/driver/component/cpp/internal/start_args.h + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/pkg/driver_component_cpp/include/lib/driver/component/cpp/internal/symbols.h + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/pkg/driver_incoming_cpp/include/lib/driver/incoming/cpp/namespace.h + ../../../fuchsia/sdk/linux/LICENSE
@@ -10047,6 +10122,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/sysroot/include/zircon/boot/cras
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/sysroot/include/zircon/string_view.h
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/sysroot/include/zircon/syscalls-next.h
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/sysroot/include/zircon/testonly-syscalls.h
+FILE: ../../../fuchsia/sdk/linux/pkg/backend_fuchsia_globals/include/lib/syslog/cpp/logging_backend_fuchsia_globals.h
 FILE: ../../../fuchsia/sdk/linux/pkg/driver_component_cpp/include/lib/driver/component/cpp/internal/start_args.h
 FILE: ../../../fuchsia/sdk/linux/pkg/driver_component_cpp/include/lib/driver/component/cpp/internal/symbols.h
 FILE: ../../../fuchsia/sdk/linux/pkg/driver_incoming_cpp/include/lib/driver/incoming/cpp/namespace.h
@@ -11127,6 +11203,7 @@ ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.audio/ring_buffer_forma
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.network/history.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.inspect/inspect_sink.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.io/symlink.fidl + ../../../fuchsia/sdk/linux/LICENSE
+ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.kernel/framebuffer-resource.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.kernel/iommu-resource.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.lowpan.thread/feature.fidl + ../../../fuchsia/sdk/linux/LICENSE
 ORIGIN: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.routes/ipv4.fidl + ../../../fuchsia/sdk/linux/LICENSE
@@ -11209,6 +11286,7 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.audio/ring_buffer_format.
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.network/history.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.inspect/inspect_sink.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.io/symlink.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.kernel/framebuffer-resource.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.kernel/iommu-resource.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.lowpan.thread/feature.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.routes/ipv4.fidl
@@ -11305,6 +11383,7 @@ TYPE: LicenseType.mit
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/VkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/VkLayer_khronos_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libheapdump_instrumentation.so
@@ -11315,6 +11394,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libheapdump_instrumentation.so
@@ -11485,6 +11565,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/VkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/VkLayer_khronos_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libheapdump_instrumentation.so
@@ -11495,6 +11576,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/riscv64/lib/libheapdump_instrumentation.so
@@ -11665,6 +11747,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/riscv64/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/VkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/VkLayer_khronos_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libheapdump_instrumentation.so
@@ -11675,6 +11758,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libheapdump_instrumentation.so
@@ -11844,6 +11928,7 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/data/config/symbol_index/config.json
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libheapdump_instrumentation.so
@@ -11854,6 +11939,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/lib/libheapdump_instrumentation.so
@@ -12020,6 +12106,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-12/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libheapdump_instrumentation.so
@@ -12030,6 +12117,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/lib/libheapdump_instrumentation.so
@@ -12196,6 +12284,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-13/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libheapdump_instrumentation.so
@@ -12206,6 +12295,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/lib/libheapdump_instrumentation.so
@@ -12372,6 +12462,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-14/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libheapdump_instrumentation.so
@@ -12382,6 +12473,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/lib/libheapdump_instrumentation.so
@@ -12548,6 +12640,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-15/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libheapdump_instrumentation.so
@@ -12558,6 +12651,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/lib/libheapdump_instrumentation.so
@@ -12724,6 +12818,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/arm64-api-16/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libheapdump_instrumentation.so
@@ -12734,6 +12829,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/lib/libheapdump_instrumentation.so
@@ -12900,6 +12996,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-12/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libheapdump_instrumentation.so
@@ -12910,6 +13007,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/lib/libheapdump_instrumentation.so
@@ -13076,6 +13174,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-13/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libheapdump_instrumentation.so
@@ -13086,6 +13185,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/lib/libheapdump_instrumentation.so
@@ -13252,6 +13352,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-14/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libheapdump_instrumentation.so
@@ -13262,6 +13363,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/lib/libheapdump_instrumentation.so
@@ -13428,6 +13530,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-15/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libheapdump_instrumentation.so
@@ -13438,6 +13541,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/lib/libheapdump_instrumentation.so
@@ -13604,6 +13708,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/riscv64-api-16/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libheapdump_instrumentation.so
@@ -13614,6 +13719,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/lib/libheapdump_instrumentation.so
@@ -13780,6 +13886,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-12/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libheapdump_instrumentation.so
@@ -13790,6 +13897,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/lib/libheapdump_instrumentation.so
@@ -13956,6 +14064,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-13/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libheapdump_instrumentation.so
@@ -13966,6 +14075,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/lib/libheapdump_instrumentation.so
@@ -14132,6 +14242,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-14/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libheapdump_instrumentation.so
@@ -14142,6 +14253,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/lib/libheapdump_instrumentation.so
@@ -14308,6 +14420,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/sysroot/lib/libpthread.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/sysroot/lib/librt.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-15/sysroot/lib/libzircon.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libheapdump_instrumentation.so
@@ -14318,6 +14431,7 @@ FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libtrace-provider-so.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/dist/libvulkan.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libasync-default.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libasync-loop-default.a
+FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libbackend_fuchsia_globals.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libdriver_runtime.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libfdio.so
 FILE: ../../../fuchsia/sdk/linux/obj/x64-api-16/lib/libheapdump_instrumentation.so
@@ -14496,6 +14610,7 @@ FILE: ../../../fuchsia/sdk/linux/packages/realm_builder_server/riscv64-api-1/rel
 FILE: ../../../fuchsia/sdk/linux/packages/realm_builder_server/x64-api-1/release/content_checklist_path
 FILE: ../../../fuchsia/sdk/linux/packages/realm_builder_server/x64-api-1/release/package_manifest.json
 FILE: ../../../fuchsia/sdk/linux/pkg/async-default/async-default.ifs
+FILE: ../../../fuchsia/sdk/linux/pkg/backend_fuchsia_globals/backend_fuchsia_globals.ifs
 FILE: ../../../fuchsia/sdk/linux/pkg/driver_runtime_shared_lib/driver_runtime.ifs
 FILE: ../../../fuchsia/sdk/linux/pkg/fdio/fdio.ifs
 FILE: ../../../fuchsia/sdk/linux/pkg/heapdump_instrumentation/heapdump_instrumentation.ifs

--- a/tools/fuchsia/fuchsia_libs.gni
+++ b/tools/fuchsia/fuchsia_libs.gni
@@ -45,6 +45,10 @@ common_libs = [
     path = rebase_path("$fuchsia_sdk_dist")
   },
   {
+    name = "libbackend_fuchsia_globals.so"
+    path = rebase_path("$fuchsia_sdk_dist")
+  },
+  {
     name = "libvulkan.so"
     path = rebase_path("$fuchsia_sdk_dist")
   },


### PR DESCRIPTION
The libbackend_fuchsia_globals.so is now required by libsyslog.so, so include it in the list of Fuchsia common_libs.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

b/315973146

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.