### PR TITLE
Set skia_resolve_filters_before_restore GN arg to true

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -376,6 +376,8 @@ def to_gn_args(args):
   # Skia GN args.
   gn_args['skia_enable_flutter_defines'
          ] = True  # Enable Flutter API guards in Skia.
+  gn_args['skia_resolve_filters_before_restore'
+         ] = True  # Temporary staging flag that requires unit test updates.
   gn_args['skia_use_dng_sdk'] = False  # RAW image handling.
   gn_args['skia_use_sfntly'] = False  # PDF handling dependency.
   gn_args['skia_enable_pdf'] = False  # PDF handling.
@@ -740,6 +742,7 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['target_os'] = 'wasm'
   gn_args['target_cpu'] = 'wasm'
   gn_args['wasm_use_dwarf'] = args.wasm_use_dwarf
+  gn_args['skia_resolve_filters_before_restore'] = True  # Temporary staging
   gn_args['skia_use_angle'] = False
   gn_args['skia_use_dng_sdk'] = False
   gn_args['skia_use_expat'] = False


### PR DESCRIPTION
This is a GN control to add the SK_RESOLVE_FILTERS_BEFORE_RESTORE define that is currently set in Skia's flutter_defines.gni. Flutter's unit tests need to be updated atomically with setting this flag back to false.

This is needed to finish enabling matrix transform optimizations for image filters within SkCanvas, for b/40042615.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
