### PR TITLE
Use Mac M1s or x86 wherever possible.

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -26,8 +26,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12|Mac-13",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -50,8 +49,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12|Mac-13",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -74,8 +72,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12|Mac-13",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -99,8 +96,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12|Mac-13",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -148,8 +144,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12|Mac-13",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -173,8 +168,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12|Mac-13",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -198,8 +192,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12|Mac-13",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -224,8 +217,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12|Mac-13",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",


### PR DESCRIPTION
Arch type was fixed to x86 because release candidate branches didn't have rosetta installed. Rosetta was enabled on December unblocking the use of M1 machines in most of mac ios sub-builds.

Bug: https://github.com/flutter/flutter/issues/133207

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
