### PR TITLE
DNS: Disable Goma for mac builds

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -11,7 +11,8 @@
                 "--runtime-mode",
                 "debug",
                 "--simulator",
-                "--no-lto"
+                "--no-lto",
+                "--no-goma"
             ],
             "name": "ios_debug_sim",
             "ninja": {
@@ -34,7 +35,8 @@
                 "debug",
                 "--simulator",
                 "--simulator-cpu=arm64",
-                "--no-lto"
+                "--no-lto",
+                "--no-goma"
             ],
             "name": "ios_debug_sim_arm64",
             "ninja": {
@@ -54,7 +56,8 @@
             "gn": [
                 "--ios",
                 "--runtime-mode",
-                "debug"
+                "debug",
+                "--no-goma"
             ],
             "name": "ios_debug",
             "ninja": {
@@ -77,7 +80,8 @@
             "gn": [
                 "--ios",
                 "--runtime-mode",
-                "profile"
+                "profile",
+                "--no-goma"
             ],
             "name": "ios_profile",
             "ninja": {
@@ -101,7 +105,8 @@
             "gn": [
                 "--ios",
                 "--runtime-mode",
-                "release"
+                "release",
+                "--no-goma"
             ],
             "name": "ios_release",
             "ninja": {
@@ -129,7 +134,8 @@
                 "debug",
                 "--simulator",
                 "--no-lto",
-                "--darwin-extension-safe"
+                "--darwin-extension-safe",
+                "--no-goma"
             ],
             "name": "ios_debug_sim_extension_safe",
             "ninja": {
@@ -153,7 +159,8 @@
                 "--simulator",
                 "--simulator-cpu=arm64",
                 "--no-lto",
-                "--darwin-extension-safe"
+                "--darwin-extension-safe",
+                "--no-goma"
             ],
             "name": "ios_debug_sim_arm64_extension_safe",
             "ninja": {
@@ -174,7 +181,8 @@
                 "--ios",
                 "--runtime-mode",
                 "debug",
-                "--darwin-extension-safe"
+                "--darwin-extension-safe",
+                "--no-goma"
             ],
             "name": "ios_debug_extension_safe",
             "ninja": {
@@ -198,7 +206,8 @@
                 "--ios",
                 "--runtime-mode",
                 "profile",
-                "--darwin-extension-safe"
+                "--darwin-extension-safe",
+                "--no-goma"
             ],
             "name": "ios_profile_extension_safe",
             "ninja": {
@@ -223,7 +232,8 @@
                 "--ios",
                 "--runtime-mode",
                 "release",
-                "--darwin-extension-safe"
+                "--darwin-extension-safe",
+                "--no-goma"
             ],
             "name": "ios_release_extension_safe",
             "ninja": {

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -24,7 +24,8 @@
                 "--unoptimized",
                 "--no-lto",
                 "--prebuilt-dart-sdk",
-                "--enable-impeller-3d"
+                "--enable-impeller-3d",
+                "--no-goma"
             ],
             "name": "host_debug_unopt",
             "ninja": {
@@ -82,7 +83,8 @@
                 "--runtime-mode",
                 "debug",
                 "--simulator",
-                "--no-lto"
+                "--no-lto",
+                "--no-goma"
             ],
             "name": "ios_debug_sim",
             "ninja": {
@@ -142,7 +144,8 @@
                "--prebuilt-dart-sdk",
                "--force-mac-arm64",
                "--mac-cpu",
-               "arm64"
+               "arm64",
+               "--no-goma"
             ],
             "name": "host_debug_unopt_arm64",
             "ninja": {
@@ -191,7 +194,8 @@
                 "--no-lto",
                 "--force-mac-arm64",
                 "--simulator-cpu",
-                "arm64"
+                "arm64",
+                "--no-goma"
             ],
             "name": "ios_debug_sim_arm64",
             "ninja": {
@@ -262,7 +266,8 @@
                 "--force-mac-arm64",
                 "--simulator-cpu",
                 "arm64",
-                "--darwin-extension-safe"
+                "--darwin-extension-safe",
+                "--no-goma"
             ],
             "name": "ios_debug_sim_arm64_extension_safe",
             "ninja": {


### PR DESCRIPTION
This is to try to tickle a clang crasher by running it a lot more.