### PR TITLE
[Impeller] RenderPass now provides the Orthographic matrix

### DIFF
--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -277,8 +277,7 @@ bool AtlasContents::Render(const ContentContext& renderer,
 
     FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
 
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform();
+    frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
@@ -409,8 +408,7 @@ bool AtlasTextureContents::Render(const ContentContext& renderer,
   auto& host_buffer = pass.GetTransientsBuffer();
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform();
+  frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.texture_sampler_y_coord_scale = texture->GetYCoordScale();
   frame_info.alpha = alpha_;
 
@@ -497,8 +495,7 @@ bool AtlasColorContents::Render(const ContentContext& renderer,
   auto& host_buffer = pass.GetTransientsBuffer();
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform();
+  frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
 
   FS::FragInfo frag_info;
   frag_info.alpha = alpha_;

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -99,7 +99,7 @@ bool ClipContents::Render(const ContentContext& renderer,
               .CreateVertexBuffer(pass.GetTransientsBuffer());
       cmd.BindVertices(std::move(vertices));
 
-      info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+      info.mvp = pass.GetOrthographicTransform();
       VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
       options.primitive_type = PrimitiveType::kTriangleStrip;
@@ -200,7 +200,7 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
   cmd.BindVertices(vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
   VS::FrameInfo info;
-  info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+  info.mvp = pass.GetOrthographicTransform();
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(info));
 
   pass.AddCommand(std::move(cmd));

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -89,8 +89,7 @@ bool ConicalGradientContents::RenderSSBO(const ContentContext& renderer,
                           DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform();
+  frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
   Command cmd;

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -212,7 +212,7 @@ static std::optional<Entity> AdvancedBlend(
     auto blend_uniform = host_buffer.EmplaceUniform(blend_info);
     FS::BindBlendInfo(cmd, blend_uniform);
 
-    frame_info.mvp = Matrix::MakeOrthographic(size) *
+    frame_info.mvp = pass.GetOrthographicTransform() *
                      Matrix::MakeTranslation(coverage.GetOrigin() -
                                              subpass_coverage.GetOrigin());
 
@@ -371,8 +371,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
     auto blend_uniform = host_buffer.EmplaceUniform(blend_info);
     FS::BindBlendInfo(cmd, blend_uniform);
 
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform();
+    frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
@@ -496,8 +495,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
 
     FS::BindFragInfo(cmd, host_buffer.EmplaceUniform(frag_info));
 
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform();
+    frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
 
     auto uniform_view = host_buffer.EmplaceUniform(frame_info);
     VS::BindFrameInfo(cmd, uniform_view);
@@ -586,7 +584,7 @@ static std::optional<Entity> PipelineBlend(
       cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
       VS::FrameInfo frame_info;
-      frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+      frame_info.mvp = pass.GetOrthographicTransform() *
                        Matrix::MakeTranslation(-subpass_coverage.GetOrigin()) *
                        input->transform;
       frame_info.texture_sampler_y_coord_scale =

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -112,8 +112,7 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     cmd.stencil_reference = entity.GetClipDepth();
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform();
+    frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();
 

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -77,8 +77,8 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
     cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform() * input_snapshot->transform *
+    frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform() *
+                     input_snapshot->transform *
                      Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -68,8 +68,8 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform() * input_snapshot->transform *
+    frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform() *
+                     input_snapshot->transform *
                      Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -68,8 +68,8 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
     cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform() * input_snapshot->transform *
+    frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform() *
+                     input_snapshot->transform *
                      Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         input_snapshot->texture->GetYCoordScale();

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -96,8 +96,8 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
     cmd.BindVertices(vtx_builder.CreateVertexBuffer(host_buffer));
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform() * y_input_snapshot->transform *
+    frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform() *
+                     y_input_snapshot->transform *
                      Matrix::MakeScale(Vector2(size));
     frame_info.texture_sampler_y_coord_scale =
         y_input_snapshot->texture->GetYCoordScale();

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -138,8 +138,7 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
       src_sampler_descriptor);
   FS::BindTextureSamplerSrc(cmd, src_snapshot->texture, src_sampler);
 
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   src_snapshot->transform;
+  frame_info.mvp = pass.GetOrthographicTransform() * src_snapshot->transform;
   frame_info.src_y_coord_scale = src_snapshot->texture->GetYCoordScale();
   VS::BindFrameInfo(cmd, host_buffer.EmplaceUniform(frame_info));
 

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -151,8 +151,7 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
                           DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform();
+  frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
   Command cmd;

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -88,8 +88,7 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
                           DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform();
+  frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
   Command cmd;

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -109,8 +109,7 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
   cmd.BindVertices(vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform() *
+  frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform() *
                    Matrix::MakeTranslation(positive_rect.GetOrigin());
   VS::BindFrameInfo(cmd, pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -94,8 +94,7 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
                           DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform();
+  frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
   Command cmd;

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -109,7 +109,7 @@ bool TextContents::Render(const ContentContext& renderer,
 
   // Common vertex uniforms for all glyphs.
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize());
+  frame_info.mvp = pass.GetOrthographicTransform();
   frame_info.atlas_size =
       Vector2{static_cast<Scalar>(atlas->GetTexture()->GetSize().width),
               static_cast<Scalar>(atlas->GetTexture()->GetSize().height)};

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -142,7 +142,7 @@ bool TextureContents::Render(const ContentContext& renderer,
   auto& host_buffer = pass.GetTransientsBuffer();
 
   VS::FrameInfo frame_info;
-  frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+  frame_info.mvp = pass.GetOrthographicTransform() *
                    capture.AddMatrix("Transform", entity.GetTransform());
   frame_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();
   frame_info.alpha = capture.AddScalar("Alpha", GetOpacity());

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -884,8 +884,7 @@ TEST_P(EntityTest, BlendingModeOptions) {
           vtx_builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
       VS::FrameInfo frame_info;
-      frame_info.mvp =
-          Matrix::MakeOrthographic(pass.GetRenderTargetSize()) * world_matrix;
+      frame_info.mvp = pass.GetOrthographicTransform() * world_matrix;
       frame_info.color = color.Premultiply();
       VS::BindFrameInfo(cmd,
                         pass.GetTransientsBuffer().EmplaceUniform(frame_info));

--- a/impeller/entity/geometry/cover_geometry.cc
+++ b/impeller/entity/geometry/cover_geometry.cc
@@ -29,8 +29,7 @@ GeometryResult CoverGeometry::GetPositionBuffer(const ContentContext& renderer,
               .vertex_count = 4,
               .index_type = IndexType::k16bit,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -30,8 +30,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
     return GeometryResult{
         .type = PrimitiveType::kTriangleStrip,
         .vertex_buffer = vertex_buffer,
-        .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform(),
+        .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
         .prevent_overdraw = false,
     };
   }
@@ -61,8 +60,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
   return GeometryResult{
       .type = PrimitiveType::kTriangle,
       .vertex_buffer = vertex_buffer,
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -97,8 +95,7 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
         .type = PrimitiveType::kTriangleStrip,
         .vertex_buffer =
             vertex_builder.CreateVertexBuffer(pass.GetTransientsBuffer()),
-        .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     entity.GetTransform(),
+        .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
         .prevent_overdraw = false,
     };
   }
@@ -131,8 +128,7 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
       .type = PrimitiveType::kTriangle,
       .vertex_buffer =
           vertex_builder.CreateVertexBuffer(pass.GetTransientsBuffer()),
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -47,8 +47,7 @@ GeometryResult Geometry::ComputePositionGeometry(
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -83,8 +82,7 @@ GeometryResult Geometry::ComputePositionUVGeometry(
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -136,8 +134,7 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
               .vertex_count = 4,
               .index_type = IndexType::kNone,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -104,8 +104,7 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -157,8 +156,7 @@ GeometryResult LineGeometry::GetPositionUVBuffer(Rect texture_coverage,
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/point_field_geometry.cc
+++ b/impeller/entity/geometry/point_field_geometry.cc
@@ -30,8 +30,7 @@ GeometryResult PointFieldGeometry::GetPositionBuffer(
   return {
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer = vtx_builder->CreateVertexBuffer(host_buffer),
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -59,8 +58,7 @@ GeometryResult PointFieldGeometry::GetPositionUVBuffer(
   return {
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer = uv_vtx_builder.CreateVertexBuffer(host_buffer),
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -238,8 +236,7 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
       .vertex_buffer = {.vertex_buffer = output,
                         .vertex_count = total,
                         .index_type = IndexType::kNone},
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/rect_geometry.cc
+++ b/impeller/entity/geometry/rect_geometry.cc
@@ -21,8 +21,7 @@ GeometryResult RectGeometry::GetPositionBuffer(const ContentContext& renderer,
               .vertex_count = 4,
               .index_type = IndexType::kNone,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -460,8 +460,7 @@ GeometryResult StrokePathGeometry::GetPositionBuffer(
   return GeometryResult{
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer = vertex_builder.CreateVertexBuffer(host_buffer),
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = true,
   };
 }
@@ -494,8 +493,7 @@ GeometryResult StrokePathGeometry::GetPositionUVBuffer(
   return GeometryResult{
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer = vertex_builder.CreateVertexBuffer(host_buffer),
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = true,
   };
 }

--- a/impeller/entity/geometry/vertices_geometry.cc
+++ b/impeller/entity/geometry/vertices_geometry.cc
@@ -150,8 +150,7 @@ GeometryResult VerticesGeometry::GetPositionBuffer(
               .index_type =
                   index_count > 0 ? IndexType::k16bit : IndexType::kNone,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -209,8 +208,7 @@ GeometryResult VerticesGeometry::GetPositionColorBuffer(
               .index_type =
                   index_count > 0 ? IndexType::k16bit : IndexType::kNone,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }
@@ -280,8 +278,7 @@ GeometryResult VerticesGeometry::GetPositionUVBuffer(
               .index_type =
                   index_count > 0 ? IndexType::k16bit : IndexType::kNone,
           },
-      .transform = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   entity.GetTransform(),
+      .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .prevent_overdraw = false,
   };
 }

--- a/impeller/renderer/compute_subgroup_unittests.cc
+++ b/impeller/renderer/compute_subgroup_unittests.cc
@@ -160,8 +160,7 @@ TEST_P(ComputeSubgroupTest, PathPlayground) {
 
     VS::FrameInfo frame_info;
     auto world_matrix = Matrix::MakeScale(GetContentScale());
-    frame_info.mvp =
-        Matrix::MakeOrthographic(pass.GetRenderTargetSize()) * world_matrix;
+    frame_info.mvp = pass.GetOrthographicTransform() * world_matrix;
     frame_info.color = Color::Red().Premultiply();
     VS::BindFrameInfo(cmd,
                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));
@@ -363,8 +362,7 @@ TEST_P(ComputeSubgroupTest, LargePath) {
 
     VS::FrameInfo frame_info;
     auto world_matrix = Matrix::MakeScale(GetContentScale());
-    frame_info.mvp =
-        Matrix::MakeOrthographic(pass.GetRenderTargetSize()) * world_matrix;
+    frame_info.mvp = pass.GetOrthographicTransform() * world_matrix;
     frame_info.color = Color::Red().Premultiply();
     VS::BindFrameInfo(cmd,
                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));
@@ -446,8 +444,7 @@ TEST_P(ComputeSubgroupTest, QuadAndCubicInOnePath) {
 
     VS::FrameInfo frame_info;
     auto world_matrix = Matrix::MakeScale(GetContentScale());
-    frame_info.mvp =
-        Matrix::MakeOrthographic(pass.GetRenderTargetSize()) * world_matrix;
+    frame_info.mvp = pass.GetOrthographicTransform() * world_matrix;
     frame_info.color = Color::Red().Premultiply();
     VS::BindFrameInfo(cmd,
                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -14,7 +14,8 @@ RenderPass::RenderPass(std::weak_ptr<const Context> context,
       has_stencil_attachment_(target.GetStencilAttachment().has_value()),
       render_target_size_(target.GetRenderTargetSize()),
       render_target_(target),
-      transients_buffer_() {
+      transients_buffer_(),
+      orthographic_(Matrix::MakeOrthographic(render_target_size_)) {
   auto strong_context = context_.lock();
   FML_DCHECK(strong_context);
   transients_buffer_ = strong_context->GetHostBufferPool().Grab();
@@ -45,6 +46,10 @@ const RenderTarget& RenderPass::GetRenderTarget() const {
 
 ISize RenderPass::GetRenderTargetSize() const {
   return render_target_size_;
+}
+
+const Matrix& RenderPass::GetOrthographicTransform() const {
+  return orthographic_;
 }
 
 HostBuffer& RenderPass::GetTransientsBuffer() {

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -36,6 +36,8 @@ class RenderPass {
 
   ISize GetRenderTargetSize() const;
 
+  const Matrix& GetOrthographicTransform() const;
+
   virtual bool IsValid() const = 0;
 
   void SetLabel(std::string label);
@@ -101,6 +103,7 @@ class RenderPass {
   const RenderTarget render_target_;
   std::shared_ptr<HostBuffer> transients_buffer_;
   std::vector<Command> commands_;
+  const Matrix orthographic_;
 
   RenderPass(std::weak_ptr<const Context> context, const RenderTarget& target);
 

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -96,8 +96,10 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
         vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator()));
 
     VS::UniformBuffer uniforms;
-    uniforms.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                   Matrix::MakeScale(GetContentScale());
+    EXPECT_EQ(pass.GetOrthographicTransform(),
+              Matrix::MakeOrthographic(pass.GetRenderTargetSize()));
+    uniforms.mvp =
+        pass.GetOrthographicTransform() * Matrix::MakeScale(GetContentScale());
     VS::BindUniformBuffer(cmd,
                           pass.GetTransientsBuffer().EmplaceUniform(uniforms));
 
@@ -266,7 +268,9 @@ TEST_P(RendererTest, CanRenderMultiplePrimitives) {
     for (size_t i = 0; i < 1; i++) {
       for (size_t j = 0; j < 1; j++) {
         VS::UniformBuffer uniforms;
-        uniforms.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
+        EXPECT_EQ(pass.GetOrthographicTransform(),
+                  Matrix::MakeOrthographic(pass.GetRenderTargetSize()));
+        uniforms.mvp = pass.GetOrthographicTransform() *
                        Matrix::MakeScale(GetContentScale()) *
                        Matrix::MakeTranslation({i * 50.0f, j * 50.0f, 0.0f});
         VS::BindUniformBuffer(
@@ -438,8 +442,10 @@ TEST_P(RendererTest, CanRenderInstanced) {
 
   ASSERT_TRUE(OpenPlaygroundHere([&](RenderPass& pass) -> bool {
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(pass.GetRenderTargetSize()) *
-                     Matrix::MakeScale(GetContentScale());
+    EXPECT_EQ(pass.GetOrthographicTransform(),
+              Matrix::MakeOrthographic(pass.GetRenderTargetSize()));
+    frame_info.mvp =
+        pass.GetOrthographicTransform() * Matrix::MakeScale(GetContentScale());
     VS::BindFrameInfo(cmd,
                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));
     VS::BindInstanceInfo(
@@ -539,7 +545,9 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
         cmd.BindVertices(vertex_buffer);
 
         VS::FrameInfo frame_info;
-        frame_info.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
+        EXPECT_EQ(pass->GetOrthographicTransform(),
+                  Matrix::MakeOrthographic(pass->GetRenderTargetSize()));
+        frame_info.mvp = pass->GetOrthographicTransform() *
                          Matrix::MakeScale(GetContentScale());
         VS::BindFrameInfo(
             cmd, pass->GetTransientsBuffer().EmplaceUniform(frame_info));
@@ -664,7 +672,9 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
         cmd.BindVertices(vertex_buffer);
 
         VS::FrameInfo frame_info;
-        frame_info.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
+        EXPECT_EQ(pass->GetOrthographicTransform(),
+                  Matrix::MakeOrthographic(pass->GetRenderTargetSize()));
+        frame_info.mvp = pass->GetOrthographicTransform() *
                          Matrix::MakeScale(GetContentScale());
         VS::BindFrameInfo(
             cmd, pass->GetTransientsBuffer().EmplaceUniform(frame_info));
@@ -785,7 +795,9 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
         cmd.BindVertices(vertex_buffer);
 
         VS::FrameInfo frame_info;
-        frame_info.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
+        EXPECT_EQ(pass->GetOrthographicTransform(),
+                  Matrix::MakeOrthographic(pass->GetRenderTargetSize()));
+        frame_info.mvp = pass->GetOrthographicTransform() *
                          Matrix::MakeScale(GetContentScale());
         VS::BindFrameInfo(
             cmd, pass->GetTransientsBuffer().EmplaceUniform(frame_info));
@@ -857,7 +869,8 @@ TEST_P(RendererTest, TheImpeller) {
     cmd.BindVertices(builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
     VS::FrameInfo frame_info;
-    frame_info.mvp = Matrix::MakeOrthographic(size);
+    EXPECT_EQ(pass.GetOrthographicTransform(), Matrix::MakeOrthographic(size));
+    frame_info.mvp = pass.GetOrthographicTransform();
     VS::BindFrameInfo(cmd,
                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
@@ -905,8 +918,9 @@ TEST_P(RendererTest, ArrayUniforms) {
     cmd.BindVertices(builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
     VS::FrameInfo frame_info;
+    EXPECT_EQ(pass.GetOrthographicTransform(), Matrix::MakeOrthographic(size));
     frame_info.mvp =
-        Matrix::MakeOrthographic(size) * Matrix::MakeScale(GetContentScale());
+        pass.GetOrthographicTransform() * Matrix::MakeScale(GetContentScale());
     VS::BindFrameInfo(cmd,
                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
@@ -962,8 +976,9 @@ TEST_P(RendererTest, InactiveUniforms) {
     cmd.BindVertices(builder.CreateVertexBuffer(pass.GetTransientsBuffer()));
 
     VS::FrameInfo frame_info;
+    EXPECT_EQ(pass.GetOrthographicTransform(), Matrix::MakeOrthographic(size));
     frame_info.mvp =
-        Matrix::MakeOrthographic(size) * Matrix::MakeScale(GetContentScale());
+        pass.GetOrthographicTransform() * Matrix::MakeScale(GetContentScale());
     VS::BindFrameInfo(cmd,
                       pass.GetTransientsBuffer().EmplaceUniform(frame_info));
 
@@ -1223,7 +1238,9 @@ TEST_P(RendererTest, StencilMask) {
       cmd.BindVertices(vertex_buffer);
 
       VS::UniformBuffer uniforms;
-      uniforms.mvp = Matrix::MakeOrthographic(pass->GetRenderTargetSize()) *
+      EXPECT_EQ(pass->GetOrthographicTransform(),
+                Matrix::MakeOrthographic(pass->GetRenderTargetSize()));
+      uniforms.mvp = pass->GetOrthographicTransform() *
                      Matrix::MakeScale(GetContentScale());
       if (mirror) {
         uniforms.mvp = Matrix::MakeScale(Vector2(-1, 1)) * uniforms.mvp;


### PR DESCRIPTION
Clients of the `RenderPass` would each compute the Orthographic matrix themselves even though it was the same for the life of a given pass. They can now get a cached version from the `RenderPass` itself.