### PR TITLE
CP: Use Mac M1s or x86 wherever possible. (#49540)

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -28,8 +28,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -54,8 +53,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -80,8 +78,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -107,8 +104,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -134,7 +130,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
+                "os=Mac-12|Mac-13",
                 "cpu=x86"
             ],
             "gn": [
@@ -160,8 +156,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -187,8 +182,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -214,8 +208,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",
@@ -242,8 +235,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-12",
-                "cpu=x86"
+                "os=Mac-12|Mac-13"
             ],
             "gn": [
                 "--ios",


### PR DESCRIPTION
Arch type was fixed to x86 because release candidate branches didn't have rosetta installed. Rosetta was enabled on December unblocking the use of M1 machines in most of mac ios sub-builds.

Bug: https://github.com/flutter/flutter/issues/133207

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
