### PR TITLE
[Impeller] move bindings off of command while recording.

### DIFF
--- a/impeller/entity/contents/test/contents_test_helpers.h
+++ b/impeller/entity/contents/test/contents_test_helpers.h
@@ -5,22 +5,26 @@
 #ifndef FLUTTER_IMPELLER_ENTITY_CONTENTS_TEST_CONTENTS_TEST_HELPERS_H_
 #define FLUTTER_IMPELLER_ENTITY_CONTENTS_TEST_CONTENTS_TEST_HELPERS_H_
 
-#include "impeller/renderer/command.h"
+#include "impeller/core/shader_types.h"
+#include "impeller/renderer/render_pass.h"
 
 namespace impeller {
 
 /// @brief Retrieve the [VertInfo] struct data from the provided [command].
 template <typename T>
-typename T::VertInfo* GetVertInfo(const Command& command) {
-  auto resource = std::find_if(command.vertex_bindings.buffers.begin(),
-                               command.vertex_bindings.buffers.end(),
-                               [](const BufferAndUniformSlot& data) {
-                                 return data.slot.ext_res_0 == 0u;
+typename T::VertInfo* GetVertInfo(
+    const BoundCommand& command,
+    const std::vector<BoundBuffer>& bound_buffers) {
+  const auto& end =
+      bound_buffers.begin() + command.buffer_offset + command.buffer_length;
+  auto resource = std::find_if(bound_buffers.begin() + command.buffer_offset,
+                               end, [](const BoundBuffer& data) {
+                                 return data.slot.ext_res_0 == 0u &&
+                                        data.stage == ShaderStage::kVertex;
                                });
-  if (resource == command.vertex_bindings.buffers.end()) {
+  if (resource == end) {
     return nullptr;
   }
-
   auto data =
       (resource->view.resource.contents + resource->view.resource.range.offset);
   return reinterpret_cast<typename T::VertInfo*>(data);
@@ -28,13 +32,17 @@ typename T::VertInfo* GetVertInfo(const Command& command) {
 
 /// @brief Retrieve the [FragInfo] struct data from the provided [command].
 template <typename T>
-typename T::FragInfo* GetFragInfo(const Command& command) {
-  auto resource = std::find_if(command.fragment_bindings.buffers.begin(),
-                               command.fragment_bindings.buffers.end(),
-                               [](const BufferAndUniformSlot& data) {
-                                 return data.slot.ext_res_0 == 0u;
+typename T::FragInfo* GetFragInfo(
+    const BoundCommand& command,
+    const std::vector<BoundBuffer>& bound_buffers) {
+  const auto& end =
+      bound_buffers.begin() + command.buffer_offset + command.buffer_length;
+  auto resource = std::find_if(bound_buffers.begin() + command.buffer_offset,
+                               end, [](const BoundBuffer& data) {
+                                 return data.slot.ext_res_0 == 0u &&
+                                        data.stage == ShaderStage::kFragment;
                                });
-  if (resource == command.fragment_bindings.buffers.end()) {
+  if (resource == end) {
     return nullptr;
   }
 

--- a/impeller/entity/contents/tiled_texture_contents_unittests.cc
+++ b/impeller/entity/contents/tiled_texture_contents_unittests.cc
@@ -9,6 +9,7 @@
 #include "impeller/entity/contents/tiled_texture_contents.h"
 #include "impeller/entity/entity_playground.h"
 #include "impeller/playground/playground_test.h"
+#include "impeller/renderer/render_pass.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
 namespace impeller {
@@ -37,7 +38,7 @@ TEST_P(EntityTest, TiledTextureContentsRendersWithCorrectPipeline) {
   auto render_pass = buffer->CreateRenderPass(render_target);
 
   ASSERT_TRUE(contents.Render(*GetContentContext(), {}, *render_pass));
-  const std::vector<Command>& commands = render_pass->GetCommands();
+  const std::vector<BoundCommand>& commands = render_pass->GetCommands();
 
   ASSERT_EQ(commands.size(), 1u);
   ASSERT_STREQ(commands[0].pipeline->GetDescriptor().GetLabel().c_str(),

--- a/impeller/entity/contents/tiled_texture_contents_unittests.cc
+++ b/impeller/entity/contents/tiled_texture_contents_unittests.cc
@@ -73,7 +73,7 @@ TEST_P(EntityTest, TiledTextureContentsRendersWithCorrectPipelineExternalOES) {
   auto render_pass = buffer->CreateRenderPass(render_target);
 
   ASSERT_TRUE(contents.Render(*GetContentContext(), {}, *render_pass));
-  const std::vector<Command>& commands = render_pass->GetCommands();
+  const std::vector<BoundCommand>& commands = render_pass->GetCommands();
 
   ASSERT_EQ(commands.size(), 1u);
   ASSERT_STREQ(commands[0].pipeline->GetDescriptor().GetLabel().c_str(),

--- a/impeller/entity/contents/vertices_contents_unittests.cc
+++ b/impeller/entity/contents/vertices_contents_unittests.cc
@@ -69,7 +69,7 @@ TEST_P(EntityTest, RendersDstPerColorWithAlpha) {
   ASSERT_TRUE(contents->Render(*content_context, entity, *render_pass));
 
   const auto& cmd = render_pass->GetCommands()[0];
-  auto* frag_uniforms = GetFragInfo<FS>(cmd);
+  auto* frag_uniforms = GetFragInfo<FS>(cmd, render_pass->GetBoundBuffers());
 
   ASSERT_EQ(frag_uniforms->alpha, 0.5);
 }

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "flutter/fml/macros.h"
 #include "impeller/core/shader_types.h"
 #include "impeller/renderer/backend/gles/gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
@@ -38,8 +37,12 @@ class BufferBindingsGLES {
 
   bool BindUniformData(const ProcTableGLES& gl,
                        Allocator& transients_allocator,
-                       const Bindings& vertex_bindings,
-                       const Bindings& fragment_bindings);
+                       const std::vector<BoundBuffer>& bound_buffers,
+                       size_t buffer_offset,
+                       size_t buffer_length,
+                       const std::vector<BoundTexture>& bound_textures,
+                       size_t texture_offset,
+                       size_t texture_length);
 
   bool UnbindVertexAttributes(const ProcTableGLES& gl) const;
 
@@ -71,10 +74,13 @@ class BufferBindingsGLES {
                          Allocator& transients_allocator,
                          const BufferResource& buffer);
 
-  std::optional<size_t> BindTextures(const ProcTableGLES& gl,
-                                     const Bindings& bindings,
-                                     ShaderStage stage,
-                                     size_t unit_start_index = 0);
+  std::optional<size_t> BindTextures(
+      const ProcTableGLES& gl,
+      const std::vector<BoundTexture>& bound_textures,
+      size_t offset,
+      size_t length,
+      ShaderStage stage,
+      size_t unit_start_index = 0);
 
   BufferBindingsGLES(const BufferBindingsGLES&) = delete;
 

--- a/impeller/renderer/backend/gles/render_pass_gles.h
+++ b/impeller/renderer/backend/gles/render_pass_gles.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "flutter/fml/macros.h"
 #include "flutter/impeller/renderer/backend/gles/reactor_gles.h"
 #include "flutter/impeller/renderer/render_pass.h"
 

--- a/impeller/renderer/backend/metal/compute_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.mm
@@ -224,14 +224,14 @@ bool ComputePassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
         ComputePipelineMTL::Cast(*command.pipeline)
             .GetMTLComputePipelineState());
 
-    for (const BufferAndUniformSlot& buffer : command.bindings.buffers) {
+    for (const BoundBuffer& buffer : command.bindings.bound_buffers) {
       if (!Bind(pass_bindings, *allocator, buffer.slot.ext_res_0,
                 buffer.view.resource)) {
         return false;
       }
     }
 
-    for (const TextureAndSampler& data : command.bindings.sampled_images) {
+    for (const BoundTexture& data : command.bindings.bound_textures) {
       if (!Bind(pass_bindings, data.slot.texture_index, *data.sampler,
                 *data.texture.resource)) {
         return false;

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -406,24 +406,6 @@ static bool Bind(PassBindingsCache& pass,
 bool RenderPassMTL::EncodeCommands(const std::shared_ptr<Allocator>& allocator,
                                    id<MTLRenderCommandEncoder> encoder) const {
   PassBindingsCache pass_bindings(encoder);
-  // auto bind_stage_resources = [&allocator, &pass_bindings](
-  //                                 const Bindings& bindings,
-  //                                 ShaderStage stage) -> bool {
-  //   for (const BoundBuffer& buffer : bindings.bound_buffers) {
-  //     if (!Bind(pass_bindings, *allocator, stage, buffer.slot.ext_res_0,
-  //               buffer.view.resource)) {
-  //       return false;
-  //     }
-  //   }
-  //   for (const BoundTexture& data : bindings.bound_textures) {
-  //     if (!Bind(pass_bindings, stage, data.slot.texture_index, *data.sampler,
-  //               *data.texture.resource)) {
-  //       return false;
-  //     }
-  //   }
-  //   return true;
-  // };
-
   const auto target_sample_count = render_target_.GetSampleCount();
 
   fml::closure pop_debug_marker = [encoder]() { [encoder popDebugGroup]; };

--- a/impeller/renderer/backend/vulkan/binding_helpers_vk.h
+++ b/impeller/renderer/backend/vulkan/binding_helpers_vk.h
@@ -11,7 +11,7 @@
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
 #include "impeller/renderer/command.h"
-#include "impeller/renderer/compute_command.h"
+#include "impeller/renderer/compute_pass.h"
 #include "impeller/renderer/render_pass.h"
 
 namespace impeller {
@@ -27,7 +27,9 @@ fml::StatusOr<std::vector<vk::DescriptorSet>> AllocateAndBindDescriptorSets(
 fml::StatusOr<std::vector<vk::DescriptorSet>> AllocateAndBindDescriptorSets(
     const ContextVK& context,
     const std::shared_ptr<CommandEncoderVK>& encoder,
-    const std::vector<ComputeCommand>& commands);
+    const std::vector<BoundComputeCommand>& commands,
+    const std::vector<BoundBuffer>& bound_buffers,
+    const std::vector<BoundTexture>& bound_textures);
 
 }  // namespace impeller
 

--- a/impeller/renderer/backend/vulkan/binding_helpers_vk.h
+++ b/impeller/renderer/backend/vulkan/binding_helpers_vk.h
@@ -12,13 +12,16 @@
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
 #include "impeller/renderer/command.h"
 #include "impeller/renderer/compute_command.h"
+#include "impeller/renderer/render_pass.h"
 
 namespace impeller {
 
 fml::StatusOr<std::vector<vk::DescriptorSet>> AllocateAndBindDescriptorSets(
     const ContextVK& context,
     const std::shared_ptr<CommandEncoderVK>& encoder,
-    const std::vector<Command>& commands,
+    const std::vector<BoundCommand>& commands,
+    const std::vector<BoundBuffer>& bound_buffers,
+    const std::vector<BoundTexture>& bound_textures,
     const TextureVK& input_attachment);
 
 fml::StatusOr<std::vector<vk::DescriptorSet>> AllocateAndBindDescriptorSets(

--- a/impeller/renderer/backend/vulkan/compute_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/compute_pass_vk.cc
@@ -44,7 +44,7 @@ static bool UpdateBindingLayouts(const Bindings& bindings,
 
   barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
 
-  for (const TextureAndSampler& data : bindings.sampled_images) {
+  for (const BoundTexture& data : bindings.bound_textures) {
     if (!TextureVK::Cast(*data.texture.resource).SetLayout(barrier)) {
       return false;
     }

--- a/impeller/renderer/backend/vulkan/compute_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/compute_pass_vk.cc
@@ -33,8 +33,9 @@ void ComputePassVK::OnSetLabel(const std::string& label) {
   label_ = label;
 }
 
-static bool UpdateBindingLayouts(const Bindings& bindings,
-                                 const vk::CommandBuffer& buffer) {
+static bool UpdateBindingLayouts(
+    const std::vector<BoundTexture>& bound_textures,
+    const vk::CommandBuffer& buffer) {
   BarrierVK barrier;
   barrier.cmd_buffer = buffer;
   barrier.src_access = vk::AccessFlagBits::eTransferWrite;
@@ -44,23 +45,8 @@ static bool UpdateBindingLayouts(const Bindings& bindings,
 
   barrier.new_layout = vk::ImageLayout::eShaderReadOnlyOptimal;
 
-  for (const BoundTexture& data : bindings.bound_textures) {
+  for (const BoundTexture& data : bound_textures) {
     if (!TextureVK::Cast(*data.texture.resource).SetLayout(barrier)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-static bool UpdateBindingLayouts(const ComputeCommand& command,
-                                 const vk::CommandBuffer& buffer) {
-  return UpdateBindingLayouts(command.bindings, buffer);
-}
-
-static bool UpdateBindingLayouts(const std::vector<ComputeCommand>& commands,
-                                 const vk::CommandBuffer& buffer) {
-  for (const ComputeCommand& command : commands) {
-    if (!UpdateBindingLayouts(command, buffer)) {
       return false;
     }
   }
@@ -97,12 +83,12 @@ bool ComputePassVK::OnEncodeCommands(const Context& context,
   }
   auto cmd_buffer = encoder->GetCommandBuffer();
 
-  if (!UpdateBindingLayouts(commands_, cmd_buffer)) {
+  if (!UpdateBindingLayouts(bound_textures_, cmd_buffer)) {
     VALIDATION_LOG << "Could not update binding layouts for compute pass.";
     return false;
   }
-  auto desc_sets_result =
-      AllocateAndBindDescriptorSets(vk_context, encoder, commands_);
+  auto desc_sets_result = AllocateAndBindDescriptorSets(
+      vk_context, encoder, commands_, bound_buffers_, bound_textures_);
   if (!desc_sets_result.ok()) {
     return false;
   }

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -6,7 +6,6 @@
 #define FLUTTER_IMPELLER_RENDERER_COMMAND_H_
 
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -59,21 +58,27 @@ using BufferResource = Resource<BufferView>;
 using TextureResource = Resource<std::shared_ptr<const Texture>>;
 
 /// @brief combines the texture, sampler and sampler slot information.
-struct TextureAndSampler {
+struct BoundTexture {
+  ShaderStage stage;
   SampledImageSlot slot;
   TextureResource texture;
   std::shared_ptr<const Sampler> sampler;
 };
 
 /// @brief combines the buffer resource and its uniform slot information.
-struct BufferAndUniformSlot {
+struct BoundBuffer {
+  ShaderStage stage;
   ShaderUniformSlot slot;
   BufferResource view;
 };
 
+static const size_t kMaxBindings = 16;
+
 struct Bindings {
-  std::vector<TextureAndSampler> sampled_images;
-  std::vector<BufferAndUniformSlot> buffers;
+  std::array<BoundTexture, kMaxBindings> bound_textures;
+  size_t texture_offset = 0u;
+  std::array<BoundBuffer, kMaxBindings> bound_buffers;
+  size_t buffer_offset = 0u;
 };
 
 //------------------------------------------------------------------------------
@@ -96,15 +101,10 @@ struct Command : public ResourceBinder {
   ///
   std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline;
   //----------------------------------------------------------------------------
-  /// The buffer, texture, and sampler bindings used by the vertex pipeline
+  /// The buffer, texture, and sampler bindings used by the  pipeline
   /// stage.
   ///
-  Bindings vertex_bindings;
-  //----------------------------------------------------------------------------
-  /// The buffer, texture, and sampler bindings used by the fragment pipeline
-  /// stage.
-  ///
-  Bindings fragment_bindings;
+  Bindings bindings;
 
 #ifdef IMPELLER_DEBUG
   //----------------------------------------------------------------------------

--- a/impeller/renderer/compute_pass.cc
+++ b/impeller/renderer/compute_pass.cc
@@ -43,7 +43,28 @@ bool ComputePass::AddCommand(ComputeCommand command) {
     return false;
   }
 
-  commands_.emplace_back(std::move(command));
+  auto buffer_offset = bound_buffers_.size();
+  auto buffer_length = command.bindings.buffer_offset;
+  auto texture_offset = bound_textures_.size();
+  auto texture_length = command.bindings.texture_offset;
+
+  for (auto i = 0u; i < buffer_length; i++) {
+    bound_buffers_.push_back(std::move(command.bindings.bound_buffers[i]));
+  }
+  for (auto i = 0u; i < texture_length; i++) {
+    bound_textures_.push_back(std::move(command.bindings.bound_textures[i]));
+  }
+
+  commands_.emplace_back(BoundComputeCommand{
+      .pipeline = std::move(command.pipeline),
+      .buffer_offset = buffer_offset,
+      .buffer_length = buffer_length,
+      .texture_offset = texture_offset,
+      .texture_length = texture_length,
+#ifdef IMPELLER_DEBUG
+      .label = std::move(command.label)
+#endif  // IMPELLER_DEBUG
+  });
   return true;
 }
 

--- a/impeller/renderer/compute_pass.h
+++ b/impeller/renderer/compute_pass.h
@@ -7,12 +7,25 @@
 
 #include <string>
 
+#include "impeller/renderer/command.h"
 #include "impeller/renderer/compute_command.h"
 
 namespace impeller {
 
 class HostBuffer;
 class Allocator;
+
+struct BoundComputeCommand {
+  std::shared_ptr<Pipeline<ComputePipelineDescriptor>> pipeline;
+  /// Offset and length into a per-render pass binding vector.
+  size_t buffer_offset;
+  size_t buffer_length;
+  size_t texture_offset;
+  size_t texture_length;
+#ifdef IMPELLER_DEBUG
+  std::string label;
+#endif  // IMPELLER_DEBUG
+};
 
 //------------------------------------------------------------------------------
 /// @brief      Compute passes encode compute shader into the underlying command
@@ -57,7 +70,9 @@ class ComputePass {
 
  protected:
   const std::weak_ptr<const Context> context_;
-  std::vector<ComputeCommand> commands_;
+  std::vector<BoundComputeCommand> commands_;
+  std::vector<BoundBuffer> bound_buffers_;
+  std::vector<BoundTexture> bound_textures_;
 
   explicit ComputePass(std::weak_ptr<const Context> context);
 

--- a/impeller/renderer/compute_pass.h
+++ b/impeller/renderer/compute_pass.h
@@ -6,10 +6,7 @@
 #define FLUTTER_IMPELLER_RENDERER_COMPUTE_PASS_H_
 
 #include <string>
-#include <variant>
 
-#include "impeller/core/device_buffer.h"
-#include "impeller/core/texture.h"
 #include "impeller/renderer/compute_command.h"
 
 namespace impeller {

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -85,8 +85,33 @@ bool RenderPass::AddCommand(Command&& command) {
     // an error either.
     return true;
   }
+  auto buffer_offset = bound_buffers_.size();
+  auto texture_offset = bound_textures_.size();
+  auto buffer_length = command.bindings.buffer_offset;
+  auto texture_length = command.bindings.texture_offset;
+  for (auto i = 0u; i < command.bindings.texture_offset; i++) {
+    bound_textures_.push_back(std::move(command.bindings.bound_textures[i]));
+  }
+  for (auto i = 0u; i < command.bindings.buffer_offset; i++) {
+    bound_buffers_.push_back(std::move(command.bindings.bound_buffers[i]));
+  }
 
-  commands_.emplace_back(std::move(command));
+  commands_.emplace_back(BoundCommand{
+      .pipeline = std::move(command.pipeline),
+      .buffer_offset = buffer_offset,
+      .buffer_length = buffer_length,
+      .texture_offset = texture_offset,
+      .texture_length = texture_length,
+#ifdef IMPELLER_DEBUG
+      .label = std::move(command.label),
+#endif  // IMPELLER_DEBUG
+      .stencil_reference = command.stencil_reference,
+      .base_vertex = command.base_vertex,
+      .viewport = command.viewport,
+      .scissor = command.scissor,
+      .instance_count = command.instance_count,
+      .vertex_buffer = std::move(command.vertex_buffer),
+  });
   return true;
 }
 

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -17,6 +17,27 @@ namespace impeller {
 class HostBuffer;
 class Allocator;
 
+/// @brief A Command object with the bindings recorded elsewhere.
+struct BoundCommand {
+  std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline;
+
+  /// Offset and length into a per-render pass binding vector.
+  size_t buffer_offset;
+  size_t buffer_length;
+  size_t texture_offset;
+  size_t texture_length;
+
+#ifdef IMPELLER_DEBUG
+  std::string label;
+#endif  // IMPELLER_DEBUG
+  uint32_t stencil_reference = 0u;
+  uint64_t base_vertex = 0u;
+  std::optional<Viewport> viewport;
+  std::optional<IRect> scissor;
+  size_t instance_count = 1u;
+  VertexBuffer vertex_buffer;
+};
+
 //------------------------------------------------------------------------------
 /// @brief      Render passes encode render commands directed as one specific
 ///             render target into an underlying command buffer.
@@ -75,7 +96,25 @@ class RenderPass {
   ///
   /// @details    Visible for testing.
   ///
-  const std::vector<Command>& GetCommands() const { return commands_; }
+  const std::vector<BoundCommand>& GetCommands() const { return commands_; }
+
+  //----------------------------------------------------------------------------
+  /// @brief      Accessor for the current bound buffers.
+  ///
+  /// @details    Visible for testing.
+  ///
+  const std::vector<BoundBuffer>& GetBoundBuffers() const {
+    return bound_buffers_;
+  }
+
+  //----------------------------------------------------------------------------
+  /// @brief      Accessor for the current bound textures.
+  ///
+  /// @details    Visible for testing.
+  ///
+  const std::vector<BoundTexture>& GetBoundTextures() const {
+    return bound_textures_;
+  }
 
   //----------------------------------------------------------------------------
   /// @brief      The sample count of the attached render target.
@@ -102,7 +141,9 @@ class RenderPass {
   const ISize render_target_size_;
   const RenderTarget render_target_;
   std::shared_ptr<HostBuffer> transients_buffer_;
-  std::vector<Command> commands_;
+  std::vector<BoundCommand> commands_;
+  std::vector<BoundBuffer> bound_buffers_;
+  std::vector<BoundTexture> bound_textures_;
   const Matrix orthographic_;
 
   RenderPass(std::weak_ptr<const Context> context, const RenderTarget& target);

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -13,6 +13,7 @@
 #include "impeller/core/shader_types.h"
 #include "impeller/core/vertex_buffer.h"
 #include "impeller/geometry/color.h"
+#include "impeller/renderer/command.h"
 #include "impeller/renderer/pipeline_library.h"
 #include "impeller/renderer/sampler_library.h"
 #include "tonic/converter/dart_converter.h"
@@ -395,8 +396,7 @@ void InternalFlutterGpu_RenderPass_ClearBindings(
     flutter::gpu::RenderPass* wrapper) {
   auto& command = wrapper->GetCommand();
   command.vertex_buffer = {};
-  command.vertex_bindings = {};
-  command.fragment_bindings = {};
+  command.bindings = impeller::Bindings{};
 }
 
 void InternalFlutterGpu_RenderPass_SetColorBlendEnable(


### PR DESCRIPTION
Because of the massive size of the cmd object, this is actually a huge performance regression


![image](https://github.com/flutter/engine/assets/8975114/4a1945ef-65b2-4c50-a629-8c4692a66122)

