### PR TITLE
[Impeller] Start and end a frame in the RenderTargetCache for each rendering of an entity in the playgrounds

### DIFF
--- a/impeller/entity/entity_playground.cc
+++ b/impeller/entity/entity_playground.cc
@@ -50,7 +50,10 @@ bool EntityPlayground::OpenPlaygroundHere(Entity entity) {
     return false;
   }
   SinglePassCallback callback = [&](RenderPass& pass) -> bool {
-    return entity.Render(*content_context, pass);
+    content_context->GetRenderTargetCache()->Start();
+    bool result = entity.Render(*content_context, pass);
+    content_context->GetRenderTargetCache()->End();
+    return result;
   };
   return Playground::OpenPlaygroundHere(callback);
 }
@@ -70,7 +73,10 @@ bool EntityPlayground::OpenPlaygroundHere(EntityPlaygroundCallback callback) {
       wireframe = !wireframe;
       content_context.SetWireframe(wireframe);
     }
-    return callback(content_context, pass);
+    content_context.GetRenderTargetCache()->Start();
+    bool result = callback(content_context, pass);
+    content_context.GetRenderTargetCache()->End();
+    return result;
   };
   return Playground::OpenPlaygroundHere(pass_callback);
 }


### PR DESCRIPTION
This fixes the memory leak in the GaussianBlurFilter playground described in https://github.com/flutter/engine/pull/48472