### PR TITLE
When building clang-tidy commands, filter out the sed command that may be appended to each compile command

### DIFF
--- a/tools/clang_tidy/lib/src/command.dart
+++ b/tools/clang_tidy/lib/src/command.dart
@@ -58,6 +58,9 @@ class Command {
   static final RegExp _pathRegex = RegExp(r'\S*clang/bin/clang');
   static final RegExp _argRegex = RegExp(r'-MF \S*');
 
+  // Filter out any extra commands that were appended to the compile command.
+  static final RegExp _extraCommandRegex = RegExp(r'&&.*$');
+
   String? _tidyArgs;
 
   /// The command line arguments of the command.
@@ -66,6 +69,7 @@ class Command {
       String result = command;
       result = result.replaceAll(_pathRegex, '');
       result = result.replaceAll(_argRegex, '');
+      result = result.replaceAll(_extraCommandRegex, '');
       return result;
     })();
   }

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -575,5 +575,16 @@ Future<int> main(List<String> args) async {
     expect(lintAction, equals(LintAction.lint));
   });
 
+  test('Command filters out sed command after a compile command', () {
+    final Command command = Command.fromMap(<String, String>{
+        'directory': '/unused',
+        'command':
+          '../../buildtools/mac-x64/clang/bin/clang filename '
+          "&& sed -i 's@/b/f/w@../..@g' filename",
+        'file': 'unused',
+    });
+    expect(command.tidyArgs.trim(), 'filename');
+  });
+
   return 0;
 }


### PR DESCRIPTION
See https://github.com/flutter/engine/pull/49542