### PR TITLE
Make `shell/platform/android` IDE-friendly, and add documentation

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -271,12 +271,12 @@
 ../../../flutter/shell/common/vsync_waiter_unittests.cc
 ../../../flutter/shell/gpu/gpu_surface_metal_impeller_unittests.mm
 ../../../flutter/shell/platform/android/.gitignore
-./../../flutter/shell/platform/android/README.md
+../../../flutter/shell/platform/android/README.md
 ../../../flutter/shell/platform/android/android_context_gl_impeller_unittests.cc
 ../../../flutter/shell/platform/android/android_context_gl_unittests.cc
 ../../../flutter/shell/platform/android/android_shell_holder_unittests.cc
 ../../../flutter/shell/platform/android/apk_asset_provider_unittests.cc
-./../../flutter/shell/platform/android/build.gradle
+../../../flutter/shell/platform/android/build.gradle
 ../../../flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
 ../../../flutter/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
 ../../../flutter/shell/platform/android/flutter_shell_native_unittests.cc

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -271,13 +271,16 @@
 ../../../flutter/shell/common/vsync_waiter_unittests.cc
 ../../../flutter/shell/gpu/gpu_surface_metal_impeller_unittests.mm
 ../../../flutter/shell/platform/android/.gitignore
+./../../flutter/shell/platform/android/README.md
 ../../../flutter/shell/platform/android/android_context_gl_impeller_unittests.cc
 ../../../flutter/shell/platform/android/android_context_gl_unittests.cc
 ../../../flutter/shell/platform/android/android_shell_holder_unittests.cc
 ../../../flutter/shell/platform/android/apk_asset_provider_unittests.cc
+./../../flutter/shell/platform/android/build.gradle
 ../../../flutter/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
 ../../../flutter/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
 ../../../flutter/shell/platform/android/flutter_shell_native_unittests.cc
+../../../flutter/shell/platform/android/gradle.properties
 ../../../flutter/shell/platform/android/jni/jni_mock_unittest.cc
 ../../../flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
 ../../../flutter/shell/platform/android/platform_view_android_unittests.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -6324,6 +6324,7 @@ ORIGIN: ../../../flutter/shell/platform/android/image_external_texture.h + ../..
 ORIGIN: ../../../flutter/shell/platform/android/image_external_texture_gl.cc + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/android/image_external_texture_gl.h + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/android/image_external_texture_vk.h + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/shell/platform/android/io/flutter/BuildConfig.java + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/android/io/flutter/FlutterInjector.java + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/android/io/flutter/Log.java + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/shell/platform/android/io/flutter/app/FlutterActivity.java + ../../../flutter/LICENSE
@@ -9141,6 +9142,7 @@ FILE: ../../../flutter/shell/platform/android/image_external_texture_gl.cc
 FILE: ../../../flutter/shell/platform/android/image_external_texture_gl.h
 FILE: ../../../flutter/shell/platform/android/image_external_texture_vk.cc
 FILE: ../../../flutter/shell/platform/android/image_external_texture_vk.h
+FILE: ../../../flutter/shell/platform/android/io/flutter/BuildConfig.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/FlutterInjector.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/Log.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterActivity.java

--- a/shell/platform/android/README.md
+++ b/shell/platform/android/README.md
@@ -1,0 +1,111 @@
+# Android Platform Embedder
+
+Android embedder for Flutter, including Java [`io.flutter`](io/flutter/) sources
+and Android specific engine-side C++.
+
+This code provides the glue between the Flutter engine and the Android platform,
+and is responsible for:
+
+- Initializing the Flutter engine.
+- Providing a platform view for the Flutter engine to render into.
+- Dispatching events to the Flutter engine.
+
+> [!CAUTION]
+> This is a best effort attempt to document the Android embedder. It is not
+> guaranteed to be up to date or complete. If you find a discrepancy, please
+> [send a pull request](https://github.com/flutter/engine/compare)!
+
+See also:
+
+- [`../../tools/android_lint/bin/main.dart`](../../../tools/android_lint/bin/main.dart)
+- [Android Platform Views](https://github.com/flutter/flutter/wiki/Android-Platform-Views)
+- [Hosting native Android views in your Flutter app with Platform Views](https://docs.flutter.dev/platform-integration/android/platform-views)
+- [Testing Android Changes in the Devicelab on an Emulator](https://github.com/flutter/flutter/wiki/Testing-Android-Changes-in-the-Devicelab-on-an-Emulator)
+- [Texture Layer Hybrid Composition](https://github.com/flutter/flutter/wiki/Texture-Layer-Hybrid-Composition)
+
+## Developing
+
+How to edit and contribute to the Android embedder.
+
+> ![TIP]
+> This guide assumes you already have a working Engine development environment:
+>
+> - [Setting up the Engine development environment](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment)
+> - [Compiling for Android](https://github.com/flutter/flutter/wiki/Compiling-the-engine#compiling-for-android-from-macos-or-linux)
+>
+> You should also have a working Android development environment:
+>
+> - [Android Studio](https://developer.android.com/studio)
+> - [Install Flutter > Test Drive](https://docs.flutter.dev/get-started/test-drive?tab=androidstudio)
+>
+> _It is also recommended (but not required) to install
+> [Visual Studio Code](https://code.visualstudio.com/)._
+
+Depending on what you are trying to do, you may need to edit the Java code in
+[`io.flutter`](io/flutter/) or the C++ code in [`shell/platform/android`](./),
+sometimes both. Let's start with the C++ code, as it is more similar to
+developing for other platforms or platform-agnostic parts of the engine.
+
+### Editing C++ code
+
+The C++ code for the Android embedder is located in
+[`shell/platform/android`](./) and subdirectories.
+
+Some notable files include:
+
+- [`context/android_context.h`](./context/android_context.h): Holds state that
+  is shared across Android surfaces.
+- [`jni/platform_view_android_jni.h`](./jni/platform_view_android_jni.h): Allows
+  calling Java code running in the JVM.
+- [`AndroidManifest.xml`](./AndroidManifest.xml): Used by [`android_lint`](../../../tools/android_lint/).
+- [`BUILD.gn`](./BUILD.gn): Used by GN to build the C++-side embedder tests and
+  the `flutter.jar` file for the engine.
+- [`ndk_helpers.h`](./ndk_helpers.h): Helper functions for dynamically loading
+  and calling Android NDK (C/C++) functions.
+- [`platform_view_android.h`](./platform_view_android.h): The main entry point
+  for the Android embedder.
+
+See [VSCode with C/C++ Intellisense](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment#vscode-with-cc-intellisense-cc)
+for how to use the [`clangd`](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) extension to get C++ code
+completion:
+
+![Example](https://github.com/flutter/flutter/assets/168174/8a75dd27-66e1-4c4f-88af-667a73b909b6)
+
+> ![NOTE] > `--compile-commands-dir` must point to an Android build output:
+>
+> ```json
+> {
+>   /* ... */
+>   "clangd.path": "buildtools/mac-arm64/clang/bin/clangd",
+>   "clangd.arguments": ["--compile-commands-dir=out/android_debug_unopt_arm64"]
+>   /* ... */
+> }
+> ```
+>
+> ... but remember to change it back when editing other parts of the engine.
+
+### Editing Java code
+
+The Java code for the Android embedder is located in
+[`io/flutter/`](io/flutter/) and subdirectories.
+
+The tests are located in [`test/io/flutter/`](test/io/flutter/), and the test
+runner in [`test_runner`](test_runner/).
+
+Some notable files include:
+
+- [`io/flutter/embedding/android/FlutterActivity.java`](io/flutter/embedding/android/FlutterActivity.java):
+  An activity that displays a full-screen Flutter UI.
+- [`io/flutter/embedding/engine/FlutterJNI.java`](io/flutter/embedding/engine/FlutterJNI.java):
+  The Java interface for the C++ engine.
+- [`io/flutter/view/TextureRegistry.java`](io/flutter/view/TextureRegistry.java):
+  Registry of backend textures used by a Flutter View.
+
+It is non-trivial to get a working IDE setup for editing Java code in the
+Flutter engine. Some developers have had success [using VSCode as an IDE for the Android Embedding](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment#using-vscode-as-an-ide-for-the-android-embedding-java),
+but the following instructions are for if that doesn't work, or you want to use
+Android Studio.
+
+## Building
+
+## Testing

--- a/shell/platform/android/README.md
+++ b/shell/platform/android/README.md
@@ -73,7 +73,7 @@ completion:
 
 > ![NOTE] > `--compile-commands-dir` must point to an Android build output:
 >
-> ```json
+> ```jsonc
 > {
 >   /* ... */
 >   "clangd.path": "buildtools/mac-arm64/clang/bin/clangd",

--- a/shell/platform/android/README.md
+++ b/shell/platform/android/README.md
@@ -104,8 +104,39 @@ Some notable files include:
 It is non-trivial to get a working IDE setup for editing Java code in the
 Flutter engine. Some developers have had success [using VSCode as an IDE for the Android Embedding](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment#using-vscode-as-an-ide-for-the-android-embedding-java),
 but the following instructions are for if that doesn't work, or you want to use
-Android Studio.
+Android Studio:
 
-## Building
+1. Open `shell/platform/android` in Android Studio.
+1. Configure the following:
 
-## Testing
+   - [`Preferences | Build, Execution, Deployment | Gradle-Android Compiler`](jetbrains://AndroidStudio/settings?name=Build%2C+Execution%2C+Deployment--Gradle-Android+Compiler)
+
+     Command-line Options:
+
+     ```txt
+     -Pbuild_dir="/tmp/build_dir" -Pflutter_jar="$ENGINE/src/out/android_debug_unopt_arm64/flutter.jar"
+     ```
+
+   - [`Preferences | Build, Execution, Deployment | Build Tools | Gradle`](jetbrains://AndroidStudio/settings?name=Build%2C+Execution%2C+Deployment--Build+Tools--Gradle)
+
+     Distribution of `Local Installation` with:
+
+     ```txt
+     $ENGINE/src/third_party/gradle
+     ```
+
+     Gradle SDK using Android Studio (path depends on your machine):
+
+     ```txt
+     /Applications/Android Studio.app/Contents/jbr/Contents/Home
+     ```
+
+1. Sync Gradle.
+
+   ![Example](https://github.com/flutter/flutter/assets/168174/02fe0e6f-f0c4-47b2-8dae-9aa0b9520503)
+
+At this point you should be able to open Java files in Android Studio and get
+code completion in the `io/flutter` folder (additional, undocumented work is
+required for `test/io/flutter`). For example, `FlutterJNI.java`:
+
+![Example](https://github.com/flutter/flutter/assets/168174/387550d4-eab7-4097-9da3-7713a6ec4da7)

--- a/shell/platform/android/build.gradle
+++ b/shell/platform/android/build.gradle
@@ -20,12 +20,7 @@ repositories {
 apply plugin: "com.android.library"
 
 android {
-    compileSdk 31
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+    compileSdk 34
 
     sourceSets {
         main {

--- a/shell/platform/android/build.gradle
+++ b/shell/platform/android/build.gradle
@@ -34,4 +34,3 @@ android {
 dependencies {
     implementation 'androidx.annotation:annotation-jvm:1.7.1'
 }
-

--- a/shell/platform/android/build.gradle
+++ b/shell/platform/android/build.gradle
@@ -1,0 +1,42 @@
+// This file only exists to provide IDE support to Android Studio.
+//
+// See ./README.md for details.
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:7.0.4"
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+apply plugin: "com.android.library"
+
+android {
+    compileSdk 31
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs './'
+            java.include './io.flutter/**'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.annotation:annotation-jvm:1.7.1'
+}
+

--- a/shell/platform/android/gradle.properties
+++ b/shell/platform/android/gradle.properties
@@ -1,0 +1,5 @@
+# This file only exists to provide IDE support to Android Studio.
+#
+# See ./README.md for details.
+android.useAndroidX=true
+android.enableJetifier=true

--- a/shell/platform/android/io/flutter/BuildConfig.java
+++ b/shell/platform/android/io/flutter/BuildConfig.java
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// THIS FILE IS REPLACED WITH AN AUTO_GENERATED FILE (AND EXISTS JUST FOR IDE SUPPORT).
+// DO NOT EDIT THE VALUES HERE - SEE $flutter_root/tools/gen_android_buildconfig.py
+package io.flutter;
+
+public final class BuildConfig {
+  private BuildConfig() {{}}
+  public final static boolean DEBUG = false;
+  public final static boolean PROFILE = false;
+  public final static boolean RELEASE = false;
+  public final static boolean JIT_RELEASE = false;
+}

--- a/shell/platform/android/io/flutter/BuildConfig.java
+++ b/shell/platform/android/io/flutter/BuildConfig.java
@@ -7,9 +7,13 @@
 package io.flutter;
 
 public final class BuildConfig {
-  private BuildConfig() {{}}
-  public final static boolean DEBUG = false;
-  public final static boolean PROFILE = false;
-  public final static boolean RELEASE = false;
-  public final static boolean JIT_RELEASE = false;
+  private BuildConfig() {
+    {
+    }
+  }
+
+  public static final boolean DEBUG = false;
+  public static final boolean PROFILE = false;
+  public static final boolean RELEASE = false;
+  public static final boolean JIT_RELEASE = false;
 }

--- a/shell/platform/android/io/flutter/Log.java
+++ b/shell/platform/android/io/flutter/Log.java
@@ -8,7 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
- * Port of {@link android.util.Log} that only logs in {@link io.flutter.BuildConfig#DEBUG} mode and
+ * Port of {@link android.util.Log} that only logs in {@value io.flutter.BuildConfig#DEBUG} mode and
  * internally filters logs based on a {@link #logLevel}.
  */
 public class Log {

--- a/shell/platform/android/test_runner/.gitignore
+++ b/shell/platform/android/test_runner/.gitignore
@@ -1,1 +1,2 @@
 .gradle
+local.properties


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/141043.

Nothing in this change should impact:

- End-user apps
- Testing and/or CI

I've added what I believe is the minimum required to get a reasonable Android Studio experience with the `shell/platform/android` folder. More could definitely be done, but this unblocks me (i.e. https://github.com/flutter/flutter/issues/139702) and adds instructions for the next person.

_I'm open to suggestions on how to improve this further, but unless they are critical, I'd rather land this as-is and review your PRs tweaking my documentation further (I have limited time to work exclusively on docs)._

---

Example after this:

![image](https://github.com/flutter/engine/assets/168174/97dfd46b-b617-4bb5-9144-0802d88e2864)