### PR TITLE
[Flutter GPU] Track HostBuffer emplacements by offset.

### DIFF
--- a/impeller/renderer/renderer_dart_unittests.cc
+++ b/impeller/renderer/renderer_dart_unittests.cc
@@ -145,6 +145,7 @@ DART_TEST_CASE(textureAsImageThrowsWhenNotShaderReadable);
 
 DART_TEST_CASE(canCreateShaderLibrary);
 DART_TEST_CASE(canReflectUniformStructs);
+DART_TEST_CASE(uniformBindFailsForInvalidHostBufferOffset);
 
 DART_TEST_CASE(canCreateRenderPassAndSubmit);
 

--- a/lib/gpu/host_buffer.cc
+++ b/lib/gpu/host_buffer.cc
@@ -25,7 +25,14 @@ size_t HostBuffer::EmplaceBytes(const tonic::DartByteData& byte_data) {
   auto view =
       host_buffer_->Emplace(byte_data.data(), byte_data.length_in_bytes(),
                             impeller::DefaultUniformAlignment());
+  emplacements_[current_offset_] = view;
+  current_offset_ += view.range.length;
   return view.range.offset;
+}
+
+std::optional<impeller::BufferView> HostBuffer::GetBufferViewForOffset(
+    size_t offset) {
+  return emplacements_[offset];
 }
 
 }  // namespace gpu

--- a/lib/gpu/host_buffer.h
+++ b/lib/gpu/host_buffer.h
@@ -7,6 +7,7 @@
 
 #include "flutter/lib/gpu/export.h"
 #include "flutter/lib/ui/dart_wrapper.h"
+#include "impeller/core/buffer_view.h"
 #include "impeller/core/host_buffer.h"
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 
@@ -26,8 +27,12 @@ class HostBuffer : public RefCountedDartWrappable<HostBuffer> {
 
   size_t EmplaceBytes(const tonic::DartByteData& byte_data);
 
+  std::optional<impeller::BufferView> GetBufferViewForOffset(size_t offset);
+
  private:
+  size_t current_offset_ = 0;
   std::shared_ptr<impeller::HostBuffer> host_buffer_;
+  std::unordered_map<size_t, impeller::BufferView> emplacements_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(HostBuffer);
 };


### PR DESCRIPTION
Make the wrapped HostBuffer wrapper track/look up emplacements using a fake byte offset.

This is a trick to keep Flutter GPU working after https://github.com/flutter/engine/pull/49505 lands. I'll likely swing around and change how `BufferView` works later on. We can simplify a lot by making Flutter GPU `BufferView`s just take `DeviceBuffer` handles.