### PR TITLE
Resize the RenderTarget before creating and passing its Surface to the VirtualDisplay

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTarget.java
@@ -4,8 +4,6 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE;
 
 import android.annotation.TargetApi;
 import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.PorterDuff;
 import android.graphics.SurfaceTexture;
 import android.os.Build;
 import android.view.Surface;
@@ -64,7 +62,7 @@ public class SurfaceTexturePlatformViewRenderTarget implements PlatformViewRende
       };
 
   private void recreateSurfaceIfNeeded() {
-    if (!shouldRecreateSurfaceForLowMemory) {
+    if (surface != null && !shouldRecreateSurfaceForLowMemory) {
       return;
     }
     if (surface != null) {
@@ -79,27 +77,6 @@ public class SurfaceTexturePlatformViewRenderTarget implements PlatformViewRende
     return new Surface(surfaceTexture);
   }
 
-  private void init() {
-    if (bufferWidth > 0 && bufferHeight > 0) {
-      surfaceTexture.setDefaultBufferSize(bufferWidth, bufferHeight);
-    }
-    if (surface != null) {
-      surface.release();
-      surface = null;
-    }
-    surface = createSurface();
-
-    // Fill the entire canvas with a transparent color.
-    // As a result, the background color of the platform view container is displayed
-    // to the user until the platform view draws its first frame.
-    final Canvas canvas = lockHardwareCanvas();
-    try {
-      canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
-    } finally {
-      unlockCanvasAndPost(canvas);
-    }
-  }
-
   /** Implementation of PlatformViewRenderTarget */
   public SurfaceTexturePlatformViewRenderTarget(SurfaceTextureEntry surfaceTextureEntry) {
     if (Build.VERSION.SDK_INT < 23) {
@@ -111,7 +88,6 @@ public class SurfaceTexturePlatformViewRenderTarget implements PlatformViewRende
     this.surfaceTexture = surfaceTextureEntry.surfaceTexture();
     surfaceTextureEntry.setOnFrameConsumedListener(frameConsumedListener);
     surfaceTextureEntry.setOnTrimMemoryListener(trimMemoryListener);
-    init();
   }
 
   public Canvas lockHardwareCanvas() {

--- a/shell/platform/android/test/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTargetTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTargetTest.java
@@ -12,7 +12,6 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.PorterDuff;
 import android.graphics.SurfaceTexture;
 import android.view.Surface;
 import android.view.View;
@@ -26,34 +25,6 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class SurfaceTexturePlatformViewRenderTargetTest {
   private final Context ctx = ApplicationProvider.getApplicationContext();
-
-  @Test
-  public void create_clearsTexture() {
-    final Canvas canvas = mock(Canvas.class);
-    final Surface surface = mock(Surface.class);
-    when(surface.lockHardwareCanvas()).thenReturn(canvas);
-    when(surface.isValid()).thenReturn(true);
-    final SurfaceTexture surfaceTexture = mock(SurfaceTexture.class);
-    final SurfaceTextureEntry surfaceTextureEntry = mock(SurfaceTextureEntry.class);
-    when(surfaceTextureEntry.surfaceTexture()).thenReturn(surfaceTexture);
-    when(surfaceTexture.isReleased()).thenReturn(false);
-
-    // Test.
-    final SurfaceTexturePlatformViewRenderTarget renderTarget =
-        new SurfaceTexturePlatformViewRenderTarget(surfaceTextureEntry) {
-          @Override
-          protected Surface createSurface() {
-            return surface;
-          }
-        };
-
-    // Verify.
-    verify(surface, times(1)).lockHardwareCanvas();
-    verify(surface, times(1)).unlockCanvasAndPost(canvas);
-    verify(canvas, times(1)).drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
-    verifyNoMoreInteractions(surface);
-    verifyNoMoreInteractions(canvas);
-  }
 
   @Test
   public void viewDraw_writesToBuffer() {
@@ -93,10 +64,9 @@ public class SurfaceTexturePlatformViewRenderTargetTest {
     renderTarget.unlockCanvasAndPost(c);
 
     // Verify.
-    verify(canvas, times(1)).drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
     verify(canvas, times(1)).drawColor(Color.RED);
-    verify(surface, times(2)).lockHardwareCanvas();
-    verify(surface, times(2)).unlockCanvasAndPost(canvas);
+    verify(surface, times(1)).lockHardwareCanvas();
+    verify(surface, times(1)).unlockCanvasAndPost(canvas);
     verifyNoMoreInteractions(surface);
   }
 
@@ -117,6 +87,9 @@ public class SurfaceTexturePlatformViewRenderTargetTest {
             return surface;
           }
         };
+
+    final Canvas c = renderTarget.lockHardwareCanvas();
+    renderTarget.unlockCanvasAndPost(c);
 
     reset(surface);
     reset(surfaceTexture);


### PR DESCRIPTION
This change ensures that we first set the default buffer size on the underlying SurfaceTexture before creating the Surface for it.

This fixes a bug that only occurs on Android devices running 28 or older: see https://github.com/flutter/flutter/issues/141068.

This also removes some unnecessary init code and cleans up tests.