### PR TITLE
Skip flaky test on mac in http_disallow_http_connections_test.dart

### DIFF
--- a/testing/dart/http_disallow_http_connections_test.dart
+++ b/testing/dart/http_disallow_http_connections_test.dart
@@ -91,7 +91,7 @@ void main() {
         zoneValues: <dynamic, dynamic>{#flutter.io.allow_http: mockTrue});
       expect(mockFalse.checked, isTrue);
     });
-  });
+  }, skip: Platform.isMacOS); // https://github.com/flutter/flutter/issues/141149
 
   test('testWithLoopback', () async {
     await bindServerAndTest('127.0.0.1', (HttpClient httpClient, Uri uri) async {


### PR DESCRIPTION
Related https://github.com/flutter/flutter/issues/141149
