### PR TITLE
Simplify PlatformViewRenderTarget interface

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
@@ -1,7 +1,6 @@
 package io.flutter.plugin.platform;
 
 import android.annotation.TargetApi;
-import android.graphics.Canvas;
 import android.graphics.ImageFormat;
 import android.hardware.HardwareBuffer;
 import android.media.Image;
@@ -120,14 +119,6 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
 
   public int getHeight() {
     return this.bufferHeight;
-  }
-
-  public Canvas lockHardwareCanvas() {
-    return getSurface().lockHardwareCanvas();
-  }
-
-  public void unlockCanvasAndPost(Canvas canvas) {
-    getSurface().unlockCanvasAndPost(canvas);
   }
 
   public long getId() {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewRenderTarget.java
@@ -4,7 +4,6 @@
 
 package io.flutter.plugin.platform;
 
-import android.graphics.Canvas;
 import android.view.Surface;
 
 /**
@@ -21,15 +20,6 @@ public interface PlatformViewRenderTarget {
 
   // Returns the currently specified height.
   public int getHeight();
-
-  // Forwards call to Surface returned by getSurface.
-  // NOTE: If this returns null the RenderTarget is "full" and has no room for a
-  // new frame.
-  Canvas lockHardwareCanvas();
-
-  // Forwards call to Surface returned by getSurface.
-  // NOTE: Must be called if lockHardwareCanvas returns a non-null Canvas.
-  void unlockCanvasAndPost(Canvas canvas);
 
   // The id of this render target.
   public long getId();

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -13,6 +13,7 @@ import android.graphics.Matrix;
 import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.view.MotionEvent;
+import android.view.Surface;
 import android.view.View;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
@@ -151,7 +152,8 @@ public class PlatformViewWrapper extends FrameLayout {
       Log.e(TAG, "Platform view cannot be composed without a RenderTarget.");
       return;
     }
-    final Canvas targetCanvas = renderTarget.lockHardwareCanvas();
+    final Surface targetSurface = renderTarget.getSurface();
+    final Canvas targetCanvas = targetSurface.lockHardwareCanvas();
     if (targetCanvas == null) {
       // Cannot render right now.
       invalidate();
@@ -165,7 +167,7 @@ public class PlatformViewWrapper extends FrameLayout {
       // Override the canvas that this subtree of views will use to draw.
       super.draw(targetCanvas);
     } finally {
-      renderTarget.unlockCanvasAndPost(targetCanvas);
+      targetSurface.unlockCanvasAndPost(targetCanvas);
     }
   }
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -968,12 +968,12 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
 
   private static PlatformViewRenderTarget makePlatformViewRenderTarget(
       TextureRegistry textureRegistry) {
-    if (enableSurfaceProducerRenderTarget && Build.VERSION.SDK_INT >= 33) {
+    if (enableSurfaceProducerRenderTarget && Build.VERSION.SDK_INT >= 29) {
       final TextureRegistry.SurfaceProducer textureEntry = textureRegistry.createSurfaceProducer();
       Log.i(TAG, "PlatformView is using SurfaceProducer backend");
       return new SurfaceProducerPlatformViewRenderTarget(textureEntry);
     }
-    if (enableImageRenderTarget && Build.VERSION.SDK_INT >= 33) {
+    if (enableImageRenderTarget && Build.VERSION.SDK_INT >= 29) {
       final TextureRegistry.ImageTextureEntry textureEntry = textureRegistry.createImageTexture();
       Log.i(TAG, "PlatformView is using ImageReader backend");
       return new ImageReaderPlatformViewRenderTarget(textureEntry);

--- a/shell/platform/android/io/flutter/plugin/platform/SurfaceProducerPlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SurfaceProducerPlatformViewRenderTarget.java
@@ -1,7 +1,6 @@
 package io.flutter.plugin.platform;
 
 import android.annotation.TargetApi;
-import android.graphics.Canvas;
 import android.view.Surface;
 import io.flutter.view.TextureRegistry.SurfaceProducer;
 
@@ -27,21 +26,6 @@ public class SurfaceProducerPlatformViewRenderTarget implements PlatformViewRend
   // Returns the currently specified height.
   public int getHeight() {
     return this.producer.getHeight();
-  }
-
-  // Forwards call to Surface returned by getSurface.
-  // NOTE: If this returns null the RenderTarget is "full" and has no room for a
-  // new frame.
-  public Canvas lockHardwareCanvas() {
-    Surface surface = this.producer.getSurface();
-    return surface.lockHardwareCanvas();
-  }
-
-  // Forwards call to Surface returned by getSurface.
-  // NOTE: Must be called if lockHardwareCanvas returns a non-null Canvas.
-  public void unlockCanvasAndPost(Canvas canvas) {
-    Surface surface = this.producer.getSurface();
-    surface.unlockCanvasAndPost(canvas);
   }
 
   // The id of this render target.

--- a/shell/platform/android/test/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTargetTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTargetTest.java
@@ -16,6 +16,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.media.Image;
+import android.view.Surface;
 import android.view.View;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -78,7 +79,9 @@ public class ImageReaderPlatformViewRenderTargetTest {
     assertNull(textureEntry.acquireLatestImage());
 
     // Start rendering a frame.
-    final Canvas targetCanvas = renderTarget.lockHardwareCanvas();
+    final Surface s = renderTarget.getSurface();
+    assertNotNull(s);
+    final Canvas targetCanvas = s.lockHardwareCanvas();
     assertNotNull(targetCanvas);
 
     try {
@@ -89,7 +92,7 @@ public class ImageReaderPlatformViewRenderTargetTest {
       platformView.draw(targetCanvas);
     } finally {
       // Finish rendering a frame.
-      renderTarget.unlockCanvasAndPost(targetCanvas);
+      s.unlockCanvasAndPost(targetCanvas);
     }
 
     // Pump the UI thread task loop. This is needed so that the OnImageAvailable callback

--- a/shell/platform/android/test/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTargetTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTargetTest.java
@@ -59,9 +59,10 @@ public class SurfaceTexturePlatformViewRenderTargetTest {
     platformView.layout(0, 0, size, size);
 
     // Test.
-    final Canvas c = renderTarget.lockHardwareCanvas();
+    final Surface s = renderTarget.getSurface();
+    final Canvas c = s.lockHardwareCanvas();
     platformView.draw(c);
-    renderTarget.unlockCanvasAndPost(c);
+    s.unlockCanvasAndPost(c);
 
     // Verify.
     verify(canvas, times(1)).drawColor(Color.RED);
@@ -88,8 +89,9 @@ public class SurfaceTexturePlatformViewRenderTargetTest {
           }
         };
 
-    final Canvas c = renderTarget.lockHardwareCanvas();
-    renderTarget.unlockCanvasAndPost(c);
+    final Surface s = renderTarget.getSurface();
+    final Canvas c = s.lockHardwareCanvas();
+    s.unlockCanvasAndPost(c);
 
     reset(surface);
     reset(surfaceTexture);


### PR DESCRIPTION
- Enable ImageReader/SurfaceProducer backends for Android >= 29.
- This removes the need for a weird Android 29-specific fix in SurfaceTexturePlatformViewRenderTarget.
- Now that we don't need the weird fix we can simplify the PlatformViewRenderTarget interface.