### PR TITLE
[Impeller] Support binding multiple vertex buffer views.

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -207,7 +207,7 @@ bool TextContents::Render(const ContentContext& renderer,
       });
 
   cmd.BindVertices({
-      .vertex_buffer = buffer_view,
+      .vertex_buffers = {buffer_view},
       .index_buffer = {},
       .vertex_count = vertex_count,
       .index_type = IndexType::kNone,

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -207,7 +207,7 @@ bool TextContents::Render(const ContentContext& renderer,
       });
 
   cmd.BindVertices({
-      .vertex_buffers = {buffer_view},
+      .vertex_buffers = buffer_view,
       .index_buffer = {},
       .vertex_count = vertex_count,
       .index_type = IndexType::kNone,

--- a/impeller/entity/geometry/cover_geometry.cc
+++ b/impeller/entity/geometry/cover_geometry.cc
@@ -20,10 +20,10 @@ GeometryResult CoverGeometry::GetPositionBuffer(const ContentContext& renderer,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffer = host_buffer.Emplace(
+              .vertex_buffers = {host_buffer.Emplace(
                   rect.GetTransformedPoints(entity.GetTransform().Invert())
                       .data(),
-                  8 * sizeof(float), alignof(float)),
+                  8 * sizeof(float), alignof(float))},
               .index_buffer = host_buffer.Emplace(
                   kRectIndicies, 4 * sizeof(uint16_t), alignof(uint16_t)),
               .vertex_count = 4,

--- a/impeller/entity/geometry/cover_geometry.cc
+++ b/impeller/entity/geometry/cover_geometry.cc
@@ -20,10 +20,10 @@ GeometryResult CoverGeometry::GetPositionBuffer(const ContentContext& renderer,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffers = {host_buffer.Emplace(
+              .vertex_buffers = host_buffer.Emplace(
                   rect.GetTransformedPoints(entity.GetTransform().Invert())
                       .data(),
-                  8 * sizeof(float), alignof(float))},
+                  8 * sizeof(float), alignof(float)),
               .index_buffer = host_buffer.Emplace(
                   kRectIndicies, 4 * sizeof(uint16_t), alignof(uint16_t)),
               .vertex_count = 4,

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -22,8 +22,8 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
     auto points = renderer.GetTessellator()->TessellateConvex(
         path_, entity.GetTransform().GetMaxBasisLength());
 
-    vertex_buffer.vertex_buffers = {host_buffer.Emplace(
-        points.data(), points.size() * sizeof(Point), alignof(Point))};
+    vertex_buffer.vertex_buffers = host_buffer.Emplace(
+        points.data(), points.size() * sizeof(Point), alignof(Point));
     vertex_buffer.index_buffer = {}, vertex_buffer.vertex_count = points.size();
     vertex_buffer.index_type = IndexType::kNone;
 
@@ -40,8 +40,8 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
       [&vertex_buffer, &host_buffer](
           const float* vertices, size_t vertices_count, const uint16_t* indices,
           size_t indices_count) {
-        vertex_buffer.vertex_buffers = {host_buffer.Emplace(
-            vertices, vertices_count * sizeof(float) * 2, alignof(float))};
+        vertex_buffer.vertex_buffers = host_buffer.Emplace(
+            vertices, vertices_count * sizeof(float) * 2, alignof(float));
         if (indices != nullptr) {
           vertex_buffer.index_buffer = host_buffer.Emplace(
               indices, indices_count * sizeof(uint16_t), alignof(uint16_t));

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -22,8 +22,8 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
     auto points = renderer.GetTessellator()->TessellateConvex(
         path_, entity.GetTransform().GetMaxBasisLength());
 
-    vertex_buffer.vertex_buffer = host_buffer.Emplace(
-        points.data(), points.size() * sizeof(Point), alignof(Point));
+    vertex_buffer.vertex_buffers = {host_buffer.Emplace(
+        points.data(), points.size() * sizeof(Point), alignof(Point))};
     vertex_buffer.index_buffer = {}, vertex_buffer.vertex_count = points.size();
     vertex_buffer.index_type = IndexType::kNone;
 
@@ -40,8 +40,8 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
       [&vertex_buffer, &host_buffer](
           const float* vertices, size_t vertices_count, const uint16_t* indices,
           size_t indices_count) {
-        vertex_buffer.vertex_buffer = host_buffer.Emplace(
-            vertices, vertices_count * sizeof(float) * 2, alignof(float));
+        vertex_buffer.vertex_buffers = {host_buffer.Emplace(
+            vertices, vertices_count * sizeof(float) * 2, alignof(float))};
         if (indices != nullptr) {
           vertex_buffer.index_buffer = host_buffer.Emplace(
               indices, indices_count * sizeof(uint16_t), alignof(uint16_t));

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -34,23 +34,18 @@ GeometryResult Geometry::ComputePositionGeometry(
       .type = generator.GetTriangleType(),
       .vertex_buffer =
           {
-              .vertex_buffers =
-                  {
-                      renderer.GetTransientsBuffer().Emplace(
-                          count * sizeof(VT), alignof(VT),
-                          [&generator](uint8_t* buffer) {
-                            auto vertices = reinterpret_cast<VT*>(buffer);
-                            generator.GenerateVertices(
-                                [&vertices](const Point& p) {
-                                  *vertices++ = {
-                                      .position = p,
-                                  };
-                                });
-                            FML_DCHECK(vertices ==
-                                       reinterpret_cast<VT*>(buffer) +
-                                           generator.GetVertexCount());
-                          }),
-                  },
+              .vertex_buffers = renderer.GetTransientsBuffer().Emplace(
+                  count * sizeof(VT), alignof(VT),
+                  [&generator](uint8_t* buffer) {
+                    auto vertices = reinterpret_cast<VT*>(buffer);
+                    generator.GenerateVertices([&vertices](const Point& p) {
+                      *vertices++ = {
+                          .position = p,
+                      };
+                    });
+                    FML_DCHECK(vertices == reinterpret_cast<VT*>(buffer) +
+                                               generator.GetVertexCount());
+                  }),
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
@@ -73,24 +68,20 @@ GeometryResult Geometry::ComputePositionUVGeometry(
       .type = generator.GetTriangleType(),
       .vertex_buffer =
           {
-              .vertex_buffers =
-                  {
-                      renderer.GetTransientsBuffer().Emplace(
-                          count * sizeof(VT), alignof(VT),
-                          [&generator, &uv_transform](uint8_t* buffer) {
-                            auto vertices = reinterpret_cast<VT*>(buffer);
-                            generator.GenerateVertices(
-                                [&vertices, &uv_transform](const Point& p) {  //
-                                  *vertices++ = {
-                                      .position = p,
-                                      .texture_coords = uv_transform * p,
-                                  };
-                                });
-                            FML_DCHECK(vertices ==
-                                       reinterpret_cast<VT*>(buffer) +
-                                           generator.GetVertexCount());
-                          }),
-                  },
+              .vertex_buffers = renderer.GetTransientsBuffer().Emplace(
+                  count * sizeof(VT), alignof(VT),
+                  [&generator, &uv_transform](uint8_t* buffer) {
+                    auto vertices = reinterpret_cast<VT*>(buffer);
+                    generator.GenerateVertices(
+                        [&vertices, &uv_transform](const Point& p) {  //
+                          *vertices++ = {
+                              .position = p,
+                              .texture_coords = uv_transform * p,
+                          };
+                        });
+                    FML_DCHECK(vertices == reinterpret_cast<VT*>(buffer) +
+                                               generator.GetVertexCount());
+                  }),
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
@@ -141,8 +132,8 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffers = {host_buffer.Emplace(
-                  data.data(), 16 * sizeof(float), alignof(float))},
+              .vertex_buffers = host_buffer.Emplace(
+                  data.data(), 16 * sizeof(float), alignof(float)),
               .vertex_count = 4,
               .index_type = IndexType::kNone,
           },

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -34,18 +34,23 @@ GeometryResult Geometry::ComputePositionGeometry(
       .type = generator.GetTriangleType(),
       .vertex_buffer =
           {
-              .vertex_buffer = renderer.GetTransientsBuffer().Emplace(
-                  count * sizeof(VT), alignof(VT),
-                  [&generator](uint8_t* buffer) {
-                    auto vertices = reinterpret_cast<VT*>(buffer);
-                    generator.GenerateVertices([&vertices](const Point& p) {
-                      *vertices++ = {
-                          .position = p,
-                      };
-                    });
-                    FML_DCHECK(vertices == reinterpret_cast<VT*>(buffer) +
-                                               generator.GetVertexCount());
-                  }),
+              .vertex_buffers =
+                  {
+                      renderer.GetTransientsBuffer().Emplace(
+                          count * sizeof(VT), alignof(VT),
+                          [&generator](uint8_t* buffer) {
+                            auto vertices = reinterpret_cast<VT*>(buffer);
+                            generator.GenerateVertices(
+                                [&vertices](const Point& p) {
+                                  *vertices++ = {
+                                      .position = p,
+                                  };
+                                });
+                            FML_DCHECK(vertices ==
+                                       reinterpret_cast<VT*>(buffer) +
+                                           generator.GetVertexCount());
+                          }),
+                  },
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
@@ -68,20 +73,24 @@ GeometryResult Geometry::ComputePositionUVGeometry(
       .type = generator.GetTriangleType(),
       .vertex_buffer =
           {
-              .vertex_buffer = renderer.GetTransientsBuffer().Emplace(
-                  count * sizeof(VT), alignof(VT),
-                  [&generator, &uv_transform](uint8_t* buffer) {
-                    auto vertices = reinterpret_cast<VT*>(buffer);
-                    generator.GenerateVertices(
-                        [&vertices, &uv_transform](const Point& p) {  //
-                          *vertices++ = {
-                              .position = p,
-                              .texture_coords = uv_transform * p,
-                          };
-                        });
-                    FML_DCHECK(vertices == reinterpret_cast<VT*>(buffer) +
-                                               generator.GetVertexCount());
-                  }),
+              .vertex_buffers =
+                  {
+                      renderer.GetTransientsBuffer().Emplace(
+                          count * sizeof(VT), alignof(VT),
+                          [&generator, &uv_transform](uint8_t* buffer) {
+                            auto vertices = reinterpret_cast<VT*>(buffer);
+                            generator.GenerateVertices(
+                                [&vertices, &uv_transform](const Point& p) {  //
+                                  *vertices++ = {
+                                      .position = p,
+                                      .texture_coords = uv_transform * p,
+                                  };
+                                });
+                            FML_DCHECK(vertices ==
+                                       reinterpret_cast<VT*>(buffer) +
+                                           generator.GetVertexCount());
+                          }),
+                  },
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
@@ -132,8 +141,8 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffer = host_buffer.Emplace(
-                  data.data(), 16 * sizeof(float), alignof(float)),
+              .vertex_buffers = {host_buffer.Emplace(
+                  data.data(), 16 * sizeof(float), alignof(float))},
               .vertex_count = 4,
               .index_type = IndexType::kNone,
           },

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -100,7 +100,7 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffers = {vertex_buffer},
+              .vertex_buffers = vertex_buffer,
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
@@ -153,7 +153,7 @@ GeometryResult LineGeometry::GetPositionUVBuffer(Rect texture_coverage,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffers = {vertex_buffer},
+              .vertex_buffers = vertex_buffer,
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -100,7 +100,7 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffer = vertex_buffer,
+              .vertex_buffers = {vertex_buffer},
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },
@@ -153,7 +153,7 @@ GeometryResult LineGeometry::GetPositionUVBuffer(Rect texture_coverage,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffer = vertex_buffer,
+              .vertex_buffers = {vertex_buffer},
               .vertex_count = count,
               .index_type = IndexType::kNone,
           },

--- a/impeller/entity/geometry/point_field_geometry.cc
+++ b/impeller/entity/geometry/point_field_geometry.cc
@@ -233,7 +233,7 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
 
   return {
       .type = PrimitiveType::kTriangle,
-      .vertex_buffer = {.vertex_buffer = output,
+      .vertex_buffer = {.vertex_buffers = {output},
                         .vertex_count = total,
                         .index_type = IndexType::kNone},
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),

--- a/impeller/entity/geometry/rect_geometry.cc
+++ b/impeller/entity/geometry/rect_geometry.cc
@@ -16,8 +16,8 @@ GeometryResult RectGeometry::GetPositionBuffer(const ContentContext& renderer,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffers = {host_buffer.Emplace(
-                  rect_.GetPoints().data(), 8 * sizeof(float), alignof(float))},
+              .vertex_buffers = host_buffer.Emplace(
+                  rect_.GetPoints().data(), 8 * sizeof(float), alignof(float)),
               .vertex_count = 4,
               .index_type = IndexType::kNone,
           },

--- a/impeller/entity/geometry/rect_geometry.cc
+++ b/impeller/entity/geometry/rect_geometry.cc
@@ -16,8 +16,8 @@ GeometryResult RectGeometry::GetPositionBuffer(const ContentContext& renderer,
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer =
           {
-              .vertex_buffer = host_buffer.Emplace(
-                  rect_.GetPoints().data(), 8 * sizeof(float), alignof(float)),
+              .vertex_buffers = {host_buffer.Emplace(
+                  rect_.GetPoints().data(), 8 * sizeof(float), alignof(float))},
               .vertex_count = 4,
               .index_type = IndexType::kNone,
           },

--- a/impeller/entity/geometry/vertices_geometry.cc
+++ b/impeller/entity/geometry/vertices_geometry.cc
@@ -141,8 +141,8 @@ GeometryResult VerticesGeometry::GetPositionBuffer(
       .type = GetPrimitiveType(),
       .vertex_buffer =
           {
-              .vertex_buffer = {.buffer = buffer,
-                                .range = Range{0, total_vtx_bytes}},
+              .vertex_buffers = BufferView{.buffer = buffer,
+                                           .range = Range{0, total_vtx_bytes}},
               .index_buffer = {.buffer = buffer,
                                .range =
                                    Range{total_vtx_bytes, total_idx_bytes}},
@@ -199,8 +199,8 @@ GeometryResult VerticesGeometry::GetPositionColorBuffer(
       .type = GetPrimitiveType(),
       .vertex_buffer =
           {
-              .vertex_buffer = {.buffer = buffer,
-                                .range = Range{0, total_vtx_bytes}},
+              .vertex_buffers = BufferView{.buffer = buffer,
+                                           .range = Range{0, total_vtx_bytes}},
               .index_buffer = {.buffer = buffer,
                                .range =
                                    Range{total_vtx_bytes, total_idx_bytes}},
@@ -269,8 +269,8 @@ GeometryResult VerticesGeometry::GetPositionUVBuffer(
       .type = GetPrimitiveType(),
       .vertex_buffer =
           {
-              .vertex_buffer = {.buffer = buffer,
-                                .range = Range{0, total_vtx_bytes}},
+              .vertex_buffers = BufferView{.buffer = buffer,
+                                           .range = Range{0, total_vtx_bytes}},
               .index_buffer = {.buffer = buffer,
                                .range =
                                    Range{total_vtx_bytes, total_idx_bytes}},

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -252,7 +252,7 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
             vertex_buffer_offset + pcmd->VtxOffset * sizeof(ImDrawVert);
 
         impeller::VertexBuffer vertex_buffer;
-        vertex_buffer.vertex_buffer = {
+        vertex_buffer.vertex_buffers = impeller::BufferView{
             .buffer = buffer,
             .range = impeller::Range(vb_start, draw_list_vtx_bytes - vb_start)};
         vertex_buffer.index_buffer = {

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -23,26 +23,35 @@ bool BufferBindingsGLES::RegisterVertexStageInput(
     const ProcTableGLES& gl,
     const std::vector<ShaderStageIOSlot>& p_inputs,
     const std::vector<ShaderStageBufferLayout>& layouts) {
-  std::vector<VertexAttribPointer> vertex_attrib_arrays;
-  for (auto i = 0u; i < p_inputs.size(); i++) {
-    const auto& input = p_inputs[i];
-    const auto& layout = layouts[input.binding];
-    VertexAttribPointer attrib;
-    attrib.index = input.location;
-    // Component counts must be 1, 2, 3 or 4. Do that validation now.
-    if (input.vec_size < 1u || input.vec_size > 4u) {
-      return false;
+  std::vector<std::vector<VertexAttribPointer>> vertex_attrib_arrays(
+      layouts.size());
+  // Every layout corresponds to a vertex binding.
+  // As we record, separate the attributes into buckets for each layout in
+  // ascending order. We do this because later on, we'll need to associate each
+  // of the attributes with bound buffers corresponding to the binding.
+  for (auto layout_i = 0u; layout_i < layouts.size(); layout_i++) {
+    const auto& layout = layouts[layout_i];
+    for (const auto& input : p_inputs) {
+      if (input.binding != layout_i) {
+        continue;
+      }
+      VertexAttribPointer attrib;
+      attrib.index = input.location;
+      // Component counts must be 1, 2, 3 or 4. Do that validation now.
+      if (input.vec_size < 1u || input.vec_size > 4u) {
+        return false;
+      }
+      attrib.size = input.vec_size;
+      auto type = ToVertexAttribType(input.type);
+      if (!type.has_value()) {
+        return false;
+      }
+      attrib.type = type.value();
+      attrib.normalized = GL_FALSE;
+      attrib.offset = input.offset;
+      attrib.stride = layout.stride;
+      vertex_attrib_arrays[layout_i].push_back(attrib);
     }
-    attrib.size = input.vec_size;
-    auto type = ToVertexAttribType(input.type);
-    if (!type.has_value()) {
-      return false;
-    }
-    attrib.type = type.value();
-    attrib.normalized = GL_FALSE;
-    attrib.offset = input.offset;
-    attrib.stride = layout.stride;
-    vertex_attrib_arrays.emplace_back(attrib);
   }
   vertex_attrib_arrays_ = std::move(vertex_attrib_arrays);
   return true;
@@ -126,8 +135,13 @@ bool BufferBindingsGLES::ReadUniformsBindings(const ProcTableGLES& gl,
 }
 
 bool BufferBindingsGLES::BindVertexAttributes(const ProcTableGLES& gl,
+                                              size_t binding,
                                               size_t vertex_offset) const {
-  for (const auto& array : vertex_attrib_arrays_) {
+  if (binding >= vertex_attrib_arrays_.size()) {
+    return false;
+  }
+
+  for (const auto& array : vertex_attrib_arrays_[binding]) {
     gl.EnableVertexAttribArray(array.index);
     gl.VertexAttribPointer(array.index,       // index
                            array.size,        // size (must be 1, 2, 3, or 4)
@@ -174,8 +188,11 @@ bool BufferBindingsGLES::BindUniformData(const ProcTableGLES& gl,
 
 bool BufferBindingsGLES::UnbindVertexAttributes(const ProcTableGLES& gl) const {
   for (const auto& array : vertex_attrib_arrays_) {
-    gl.DisableVertexAttribArray(array.index);
+    for (const auto& attribute : array) {
+      gl.DisableVertexAttribArray(attribute.index);
+    }
   }
+
   return true;
 }
 

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.h
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.h
@@ -33,6 +33,7 @@ class BufferBindingsGLES {
   bool ReadUniformsBindings(const ProcTableGLES& gl, GLuint program);
 
   bool BindVertexAttributes(const ProcTableGLES& gl,
+                            size_t binding,
                             size_t vertex_offset) const;
 
   bool BindUniformData(const ProcTableGLES& gl,
@@ -54,7 +55,7 @@ class BufferBindingsGLES {
     GLsizei stride = 0u;
     GLsizei offset = 0u;
   };
-  std::vector<VertexAttribPointer> vertex_attrib_arrays_;
+  std::vector<std::vector<VertexAttribPointer>> vertex_attrib_arrays_;
 
   std::unordered_map<std::string, GLint> uniform_locations_;
 

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -367,7 +367,7 @@ static void SetViewportAndScissor(const Command& command,
 static bool AppendVertexBuffer(
     CommandEncoderVK& encoder,
     std::vector<vk::Buffer>& vertex_buffers,
-    std::vector<vk::DeviceSize> vertex_buffer_offsets,
+    std::vector<vk::DeviceSize>& vertex_buffer_offsets,
     const BufferView& vertex_buffer_view) {
   if (!vertex_buffer_view) {
     return false;
@@ -454,7 +454,7 @@ static bool EncodeCommand(const Context& context,
     }
   }
 
-  // Bind the vertex buffer.
+  // Bind the vertex buffers.
   cmd_buffer.bindVertexBuffers(0u, vertex_buffers.size(), vertex_buffers.data(),
                                vertex_buffer_offsets.data());
 

--- a/impeller/renderer/compute_subgroup_unittests.cc
+++ b/impeller/renderer/compute_subgroup_unittests.cc
@@ -156,7 +156,7 @@ TEST_P(ComputeSubgroupTest, PathPlayground) {
                      ->count;
 
     cmd.BindVertices(
-        VertexBuffer{.vertex_buffer = vertex_buffer->AsBufferView(),
+        VertexBuffer{.vertex_buffers = {vertex_buffer->AsBufferView()},
                      .vertex_count = count,
                      .index_type = IndexType::kNone});
 
@@ -358,7 +358,7 @@ TEST_P(ComputeSubgroupTest, LargePath) {
                      ->count;
 
     cmd.BindVertices(
-        VertexBuffer{.vertex_buffer = vertex_buffer->AsBufferView(),
+        VertexBuffer{.vertex_buffers = {vertex_buffer->AsBufferView()},
                      .vertex_count = count,
                      .index_type = IndexType::kNone});
 
@@ -441,7 +441,7 @@ TEST_P(ComputeSubgroupTest, QuadAndCubicInOnePath) {
                      ->count;
 
     cmd.BindVertices(
-        VertexBuffer{.vertex_buffer = vertex_buffer->AsBufferView(),
+        VertexBuffer{.vertex_buffers = {vertex_buffer->AsBufferView()},
                      .vertex_count = count,
                      .index_type = IndexType::kNone});
 

--- a/impeller/renderer/compute_subgroup_unittests.cc
+++ b/impeller/renderer/compute_subgroup_unittests.cc
@@ -156,7 +156,7 @@ TEST_P(ComputeSubgroupTest, PathPlayground) {
                      ->count;
 
     cmd.BindVertices(
-        VertexBuffer{.vertex_buffers = {vertex_buffer->AsBufferView()},
+        VertexBuffer{.vertex_buffers = vertex_buffer->AsBufferView(),
                      .vertex_count = count,
                      .index_type = IndexType::kNone});
 
@@ -358,7 +358,7 @@ TEST_P(ComputeSubgroupTest, LargePath) {
                      ->count;
 
     cmd.BindVertices(
-        VertexBuffer{.vertex_buffers = {vertex_buffer->AsBufferView()},
+        VertexBuffer{.vertex_buffers = vertex_buffer->AsBufferView(),
                      .vertex_count = count,
                      .index_type = IndexType::kNone});
 
@@ -441,7 +441,7 @@ TEST_P(ComputeSubgroupTest, QuadAndCubicInOnePath) {
                      ->count;
 
     cmd.BindVertices(
-        VertexBuffer{.vertex_buffers = {vertex_buffer->AsBufferView()},
+        VertexBuffer{.vertex_buffers = vertex_buffer->AsBufferView(),
                      .vertex_count = count,
                      .index_type = IndexType::kNone});
 

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -8,6 +8,7 @@
 #include "impeller/core/formats.h"
 #include "impeller/core/host_buffer.h"
 #include "impeller/core/sampler_descriptor.h"
+#include "impeller/core/shader_types.h"
 #include "impeller/fixtures/array.frag.h"
 #include "impeller/fixtures/array.vert.h"
 #include "impeller/fixtures/box_fade.frag.h"
@@ -32,6 +33,7 @@
 #include "impeller/renderer/render_target.h"
 #include "impeller/renderer/renderer.h"
 #include "impeller/renderer/vertex_buffer_builder.h"
+#include "impeller/renderer/vertex_descriptor.h"
 #include "impeller/tessellator/tessellator.h"
 #include "third_party/imgui/imgui.h"
 
@@ -127,23 +129,44 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
   desc->SetCullMode(CullMode::kBackFace);
   desc->SetWindingOrder(WindingOrder::kCounterClockwise);
   desc->SetSampleCount(SampleCount::kCount4);
-  desc->SetStencilAttachmentDescriptors(std::nullopt);
+  desc->ClearStencilAttachments();
+
+  // Setup the vertex layout to take two bindings. The first for positions and
+  // the second for colors.
+  auto vertex_desc = std::make_shared<VertexDescriptor>();
+  ShaderStageIOSlot position_slot = VS::kInputPosition;
+  ShaderStageIOSlot color_slot = VS::kInputColor;
+  position_slot.binding = 0;
+  position_slot.offset = 0;
+  color_slot.binding = 1;
+  color_slot.offset = 0;
+  const std::vector<ShaderStageIOSlot> io_slots = {position_slot, color_slot};
+  const std::vector<ShaderStageBufferLayout> layouts = {
+      ShaderStageBufferLayout{.stride = 12u, .binding = 0},
+      ShaderStageBufferLayout{.stride = 16u, .binding = 1}};
+  vertex_desc->SetStageInputs(io_slots, layouts);
+  desc->SetVertexDescriptor(std::move(vertex_desc));
+
   auto pipeline =
       context->GetPipelineLibrary()->GetPipeline(std::move(desc)).Get();
   ASSERT_TRUE(pipeline);
 
   struct Cube {
-    VS::PerVertexData vertices[8] = {
+    Vector3 positions[8] = {
         // -Z
-        {{-1, -1, -1}, Color::Red()},
-        {{1, -1, -1}, Color::Yellow()},
-        {{1, 1, -1}, Color::Green()},
-        {{-1, 1, -1}, Color::Blue()},
+        {-1, -1, -1},
+        {1, -1, -1},
+        {1, 1, -1},
+        {-1, 1, -1},
         // +Z
-        {{-1, -1, 1}, Color::Green()},
-        {{1, -1, 1}, Color::Blue()},
-        {{1, 1, 1}, Color::Red()},
-        {{-1, 1, 1}, Color::Yellow()},
+        {-1, -1, 1},
+        {1, -1, 1},
+        {1, 1, 1},
+        {-1, 1, 1},
+    };
+    Color colors[8] = {
+        Color::Red(),   Color::Yellow(), Color::Green(), Color::Blue(),
+        Color::Green(), Color::Blue(),   Color::Red(),   Color::Yellow(),
     };
     uint16_t indices[36] = {
         1, 5, 2, 2, 5, 6,  // +X
@@ -159,9 +182,12 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
   {
     auto device_buffer = context->GetResourceAllocator()->CreateBufferWithCopy(
         reinterpret_cast<uint8_t*>(&cube), sizeof(cube));
-    vertex_buffer.vertex_buffers = BufferView{
-        .buffer = device_buffer,
-        .range = Range(offsetof(Cube, vertices), sizeof(Cube::vertices))};
+    vertex_buffer.vertex_buffers = std::vector<BufferView>{
+        {.buffer = device_buffer,
+         .range = Range(offsetof(Cube, positions), sizeof(Cube::positions))},
+        {.buffer = device_buffer,
+         .range = Range(offsetof(Cube, colors), sizeof(Cube::colors))},
+    };
     vertex_buffer.index_buffer = {
         .buffer = device_buffer,
         .range = Range(offsetof(Cube, indices), sizeof(Cube::indices))};

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -159,7 +159,7 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
   {
     auto device_buffer = context->GetResourceAllocator()->CreateBufferWithCopy(
         reinterpret_cast<uint8_t*>(&cube), sizeof(cube));
-    vertex_buffer.vertex_buffer = {
+    vertex_buffer.vertex_buffers = BufferView{
         .buffer = device_buffer,
         .range = Range(offsetof(Cube, vertices), sizeof(Cube::vertices))};
     vertex_buffer.index_buffer = {

--- a/impeller/renderer/vertex_buffer_builder.h
+++ b/impeller/renderer/vertex_buffer_builder.h
@@ -83,7 +83,7 @@ class VertexBufferBuilder {
 
   VertexBuffer CreateVertexBuffer(HostBuffer& host_buffer) const {
     VertexBuffer buffer;
-    buffer.vertex_buffer = CreateVertexBufferView(host_buffer);
+    buffer.vertex_buffers = {CreateVertexBufferView(host_buffer)};
     buffer.index_buffer = CreateIndexBufferView(host_buffer);
     buffer.vertex_count = GetIndexCount();
     buffer.index_type = GetIndexType();
@@ -93,7 +93,7 @@ class VertexBufferBuilder {
   VertexBuffer CreateVertexBuffer(Allocator& device_allocator) const {
     VertexBuffer buffer;
     // This can be merged into a single allocation.
-    buffer.vertex_buffer = CreateVertexBufferView(device_allocator);
+    buffer.vertex_buffers = {CreateVertexBufferView(device_allocator)};
     buffer.index_buffer = CreateIndexBufferView(device_allocator);
     buffer.vertex_count = GetIndexCount();
     buffer.index_type = GetIndexType();

--- a/impeller/renderer/vertex_buffer_builder.h
+++ b/impeller/renderer/vertex_buffer_builder.h
@@ -83,7 +83,7 @@ class VertexBufferBuilder {
 
   VertexBuffer CreateVertexBuffer(HostBuffer& host_buffer) const {
     VertexBuffer buffer;
-    buffer.vertex_buffers = {CreateVertexBufferView(host_buffer)};
+    buffer.vertex_buffers = CreateVertexBufferView(host_buffer);
     buffer.index_buffer = CreateIndexBufferView(host_buffer);
     buffer.vertex_count = GetIndexCount();
     buffer.index_type = GetIndexType();
@@ -93,7 +93,7 @@ class VertexBufferBuilder {
   VertexBuffer CreateVertexBuffer(Allocator& device_allocator) const {
     VertexBuffer buffer;
     // This can be merged into a single allocation.
-    buffer.vertex_buffers = {CreateVertexBufferView(device_allocator)};
+    buffer.vertex_buffers = CreateVertexBufferView(device_allocator);
     buffer.index_buffer = CreateIndexBufferView(device_allocator);
     buffer.vertex_count = GetIndexCount();
     buffer.index_type = GetIndexType();

--- a/impeller/scene/geometry.cc
+++ b/impeller/scene/geometry.cc
@@ -108,7 +108,8 @@ std::shared_ptr<Geometry> Geometry::MakeFromFlatbuffer(
   }
 
   VertexBuffer vertex_buffer = {
-      .vertex_buffer = {.buffer = buffer, .range = Range(0, vertices_bytes)},
+      .vertex_buffers =
+          BufferView{.buffer = buffer, .range = Range(0, vertices_bytes)},
       .index_buffer = {.buffer = buffer,
                        .range = Range(vertices_bytes, indices_bytes)},
       .vertex_count = mesh.indices()->count(),

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -235,10 +235,10 @@ static void BindVertexBuffer(flutter::gpu::RenderPass* wrapper,
                              int length_in_bytes,
                              int vertex_count) {
   auto& vertex_buffer = wrapper->GetVertexBuffer();
-  vertex_buffer.vertex_buffers = {impeller::BufferView{
+  vertex_buffer.vertex_buffers = impeller::BufferView{
       .buffer = buffer,
       .range = impeller::Range(offset_in_bytes, length_in_bytes),
-  }};
+  };
   // If the index type is set, then the `vertex_count` becomes the index
   // count... So don't overwrite the count if it's already been set when binding
   // the index buffer.

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -235,10 +235,10 @@ static void BindVertexBuffer(flutter::gpu::RenderPass* wrapper,
                              int length_in_bytes,
                              int vertex_count) {
   auto& vertex_buffer = wrapper->GetVertexBuffer();
-  vertex_buffer.vertex_buffer = impeller::BufferView{
+  vertex_buffer.vertex_buffers = {impeller::BufferView{
       .buffer = buffer,
       .range = impeller::Range(offset_in_bytes, length_in_bytes),
-  };
+  }};
   // If the index type is set, then the `vertex_count` becomes the index
   // count... So don't overwrite the count if it's already been set when binding
   // the index buffer.


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/116168.

Makes it possible for us to use arbitrary vertex layouts, including SoA layouts with attributes stored in different DeviceBuffers.