### PR TITLE
Try to get GLES tests running...

### DIFF
--- a/ci/builders/README.md
+++ b/ci/builders/README.md
@@ -300,7 +300,7 @@ configuration.
            "--variant",
            "host_debug_impeller_vulkan",
            "--type",
-           "impeller-vulkan",
+           "impeller",
            "--engine-capture-core-dump"
        ],
        "script": "flutter/testing/run_tests.py",

--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -58,7 +58,7 @@
                         "--variant",
                         "host_debug_impeller_vulkan",
                         "--type",
-                        "impeller-vulkan",
+                        "impeller",
                         "--engine-capture-core-dump"
                     ]
                 }

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1905,7 +1905,8 @@ TEST_P(AiksTest,
   AiksContext renderer(mock_context, nullptr);
   std::shared_ptr<Image> image = picture.ToImage(renderer, {300, 300});
 
-  ASSERT_EQ(spy->render_passes_.size(), 3llu);
+  ASSERT_EQ(spy->render_passes_.size(),
+            GetBackend() == PlaygroundBackend::kOpenGLES ? 4llu : 3llu);
   std::shared_ptr<RenderPass> render_pass = spy->render_passes_[0];
   ASSERT_EQ(render_pass->GetCommands().size(), 0llu);
 }

--- a/impeller/entity/contents/tiled_texture_contents_unittests.cc
+++ b/impeller/entity/contents/tiled_texture_contents_unittests.cc
@@ -76,7 +76,7 @@ TEST_P(EntityTest, TiledTextureContentsRendersWithCorrectPipelineExternalOES) {
 
   ASSERT_EQ(commands.size(), 1u);
   ASSERT_STREQ(commands[0].pipeline->GetDescriptor().GetLabel().c_str(),
-               "TextureFill Pipeline V#1");
+               "TiledTextureFillExternal Pipeline V#1");
 }
 #endif
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2522,9 +2522,9 @@ TEST_P(EntityTest, AdvancedBlendCoverageHintIsNotResetByEntityPass) {
   if (test_allocator->GetDescriptors().size() == 6u) {
     EXPECT_EQ(test_allocator->GetDescriptors()[0].size, ISize(1000, 1000));
     EXPECT_EQ(test_allocator->GetDescriptors()[1].size, ISize(1000, 1000));
+    EXPECT_EQ(test_allocator->GetDescriptors()[2].size, ISize(1000, 1000));
+    EXPECT_EQ(test_allocator->GetDescriptors()[3].size, ISize(1000, 1000));
 
-    EXPECT_EQ(test_allocator->GetDescriptors()[2].size, ISize(200, 200));
-    EXPECT_EQ(test_allocator->GetDescriptors()[3].size, ISize(200, 200));
     EXPECT_EQ(test_allocator->GetDescriptors()[4].size, ISize(200, 200));
     EXPECT_EQ(test_allocator->GetDescriptors()[5].size, ISize(200, 200));
   } else if (test_allocator->GetDescriptors().size() == 9u) {

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -457,6 +457,9 @@ TEST_P(RendererTest, CanRenderInstanced) {
 }
 
 TEST_P(RendererTest, CanBlitTextureToTexture) {
+  if (GetBackend() == PlaygroundBackend::kOpenGLES) {
+    GTEST_SKIP() << "Mipmap test shader not supported on GLES.";
+  }
   auto context = GetContext();
   ASSERT_TRUE(context);
 
@@ -572,6 +575,9 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
 }
 
 TEST_P(RendererTest, CanBlitTextureToBuffer) {
+  if (GetBackend() == PlaygroundBackend::kOpenGLES) {
+    GTEST_SKIP() << "Mipmap test shader not supported on GLES.";
+  }
   auto context = GetContext();
   ASSERT_TRUE(context);
 
@@ -706,6 +712,9 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
 }
 
 TEST_P(RendererTest, CanGenerateMipmaps) {
+  if (GetBackend() == PlaygroundBackend::kOpenGLES) {
+    GTEST_SKIP() << "Mipmap test shader not supported on GLES.";
+  }
   auto context = GetContext();
   ASSERT_TRUE(context);
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -1267,7 +1267,7 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
     )
 
   # Use this type to exclusively run impeller vulkan tests.
-  if 'impeller-vulkan' in types:
+  if 'impeller' in types:
     build_name = args.variant
     try:
       xvfb.start_virtual_x(build_name, build_dir)

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -1266,7 +1266,7 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
         build_dir, engine_filter, args.coverage, args.engine_capture_core_dump
     )
 
-  # Use this type to exclusively run impeller vulkan tests.
+  # Use this type to exclusively run impeller tests.
   if 'impeller' in types:
     build_name = args.variant
     try:
@@ -1275,8 +1275,7 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
           build_dir,
           'impeller_unittests',
           engine_filter,
-          shuffle_flags + ['--gtest_filter=-'
-                           '*/OpenGLES:'],
+          shuffle_flags,
           coverage=args.coverage
       )
     finally:


### PR DESCRIPTION
I plan to fix the GLES fragment program reload issue, but first want to make sure this gets some failures for it.

Added a few skips for shaders that require an extension not available on CI (mipmap related ones).

Updated a couple tests that were failing.