### PR TITLE
Remove `gclient_variables` from `linux_license.json`

### DIFF
--- a/ci/builders/standalone/linux_license.json
+++ b/ci/builders/standalone/linux_license.json
@@ -4,9 +4,6 @@
         "os=Linux"
     ],
     "cas_archive": false,
-    "gclient_variables": {
-        "download_android_deps": false
-    },
     "name": "licenses",
     "tests": [
         {


### PR DESCRIPTION
The `gclient_variables` has never been used and this is to unblock a recipes CL: https://flutter-review.googlesource.com/c/recipes/+/53902

Part of https://github.com/flutter/flutter/issues/141461