### PR TITLE
[Windows] Add README

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -366,6 +366,7 @@
 ../../../flutter/shell/platform/glfw/client_wrapper/plugin_registrar_glfw_unittests.cc
 ../../../flutter/shell/platform/glfw/client_wrapper/testing
 ../../../flutter/shell/platform/linux/testing
+../../../flutter/shell/platform/windows/README.md
 ../../../flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc
 ../../../flutter/shell/platform/windows/client_wrapper/dart_project_unittests.cc
 ../../../flutter/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc

--- a/shell/platform/windows/README.md
+++ b/shell/platform/windows/README.md
@@ -1,0 +1,38 @@
+# Windows Platform Embedder
+
+This code is the glue between the Flutter engine and the Windows platform.
+It is responsible for:
+
+1. Launching the Flutter engine.
+2. Providing a view for the Flutter engine to render into.
+3. Dispatching events to the Flutter engine.
+
+> [!CAUTION]
+> This is a best effort attempt to document the Windows embedder. It is not
+> guaranteed to be up to date or complete. If you find a discrepancy, please
+> [send a pull request](https://github.com/flutter/engine/compare)!
+
+See also:
+
+1. [Flutter tool's Windows logic](https://github.com/flutter/flutter/tree/master/packages/flutter_tools/lib/src/windows) - Builds and runs Flutter Windows apps on
+the command line.
+1. [Windows app template](https://github.com/flutter/flutter/tree/master/packages/flutter_tools/templates/app_shared/windows.tmpl) - The entrypoint for Flutter Windows app. This
+launches the Windows embedder.
+1. [`#hackers-desktop` Discord channel](https://discord.com/channels/608014603317936148/608020180177780791)
+
+## Developing
+
+See:
+
+1. [Setting up the Engine development environment](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment)
+2. [Compiling for Windows](https://github.com/flutter/flutter/wiki/Compiling-the-engine#compiling-for-windows)
+3. [Debugging Windows builds with Visual Studio](https://github.com/flutter/flutter/wiki/Debugging-the-engine#debugging-windows-builds-with-visual-studio)
+
+### Notable files
+
+Some notable files include:
+
+1. [`flutter_windows_engine.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_windows_engine.h) - Connects the Windows embedder to the Flutter engine.
+1. [`flutter_windows_view.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_windows_view.h) - The logic that for a Flutter view
+1. [`flutter_window.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_window.h) - Integrates a Flutter  view with Windows (using a win32 child window).
+1. [`//shell/platform/embedder/embedder.h`](https://github.com/flutter/engine/blob/main/shell/platform/embedder/embedder.h) - The API boundary between the Windows embedder and the Flutter engine.

--- a/shell/platform/windows/README.md
+++ b/shell/platform/windows/README.md
@@ -18,6 +18,7 @@ See also:
 the command line.
 1. [Windows app template](https://github.com/flutter/flutter/tree/master/packages/flutter_tools/templates/app_shared/windows.tmpl) - The entrypoint for Flutter Windows app. This
 launches the Windows embedder.
+1. [`platform-windows` GitHub issues label](https://github.com/flutter/flutter/issues?q=is%3Aopen+label%3Aplatform-windows+sort%3Aupdated-desc)
 1. [`#hackers-desktop` Discord channel](https://discord.com/channels/608014603317936148/608020180177780791)
 
 ## Developing

--- a/shell/platform/windows/README.md
+++ b/shell/platform/windows/README.md
@@ -37,6 +37,6 @@ See:
 Some notable files include:
 
 1. [`flutter_windows_engine.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_windows_engine.h) - Connects the Windows embedder to the Flutter engine.
-1. [`flutter_windows_view.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_windows_view.h) - The logic for a Flutter view
+1. [`flutter_windows_view.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_windows_view.h) - The logic for a Flutter view.
 1. [`flutter_window.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_window.h) - Integrates a Flutter view with Windows (using a win32 child window).
 1. [`//shell/platform/embedder/embedder.h`](https://github.com/flutter/engine/blob/main/shell/platform/embedder/embedder.h) - The API boundary between the Windows embedder and the Flutter engine.

--- a/shell/platform/windows/README.md
+++ b/shell/platform/windows/README.md
@@ -33,6 +33,6 @@ See:
 Some notable files include:
 
 1. [`flutter_windows_engine.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_windows_engine.h) - Connects the Windows embedder to the Flutter engine.
-1. [`flutter_windows_view.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_windows_view.h) - The logic that for a Flutter view
-1. [`flutter_window.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_window.h) - Integrates a Flutter  view with Windows (using a win32 child window).
+1. [`flutter_windows_view.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_windows_view.h) - The logic for a Flutter view
+1. [`flutter_window.h`](https://github.com/flutter/engine/blob/main/shell/platform/windows/flutter_window.h) - Integrates a Flutter view with Windows (using a win32 child window).
 1. [`//shell/platform/embedder/embedder.h`](https://github.com/flutter/engine/blob/main/shell/platform/embedder/embedder.h) - The API boundary between the Windows embedder and the Flutter engine.

--- a/shell/platform/windows/README.md
+++ b/shell/platform/windows/README.md
@@ -7,6 +7,9 @@ It is responsible for:
 2. Providing a view for the Flutter engine to render into.
 3. Dispatching events to the Flutter engine.
 
+For more information on embedders, see the
+[Flutter architectural overview](https://docs.flutter.dev/resources/architectural-overview).
+
 > [!CAUTION]
 > This is a best effort attempt to document the Windows embedder. It is not
 > guaranteed to be up to date or complete. If you find a discrepancy, please


### PR DESCRIPTION
[Link to preview](https://github.com/loic-sharma/flutter-engine/blob/windows_readme/shell/platform/windows/README.md)

Inspired by the Android README @matanlurey added here: https://github.com/flutter/engine/tree/main/shell/platform/android#readme

This gives people quick pointers that might be useful when starting their Windows journey.