### PR TITLE
[web] Leave blob URLs untouched in TT policy.

### DIFF
--- a/lib/web_ui/flutter_js/src/trusted_types.js
+++ b/lib/web_ui/flutter_js/src/trusted_types.js
@@ -20,6 +20,11 @@ export class FlutterTrustedTypesPolicy {
     if (window.trustedTypes) {
       this.policy = trustedTypes.createPolicy(policyName, {
         createScriptURL: function (url) {
+          // Return blob urls without manipulating them
+          if (url.startsWith('blob:')) {
+            return url;
+          }
+          // Validate other urls
           const parsed = new URL(url, window.location);
           const file = parsed.pathname.split("/").pop();
           const matches = patterns.some((pattern) => pattern.test(file));


### PR DESCRIPTION
Very simple tweak to flutter.js that allows blob URLs to be used as entrypointUrls when loading flutter (this is needed by dartpad)

## Testing

I had to test this locally by spinning up a flutter app with something like:

```html
<script>
  let initSrc = `let actualMain = document.createElement("script");
document.head.appendChild(actualMain);
actualMain.id = "injected_from_a_blob";
actualMain.src = "main.dart.js";`;
  let blobInit = new Blob([...initSrc]);
  let blobUrl = URL.createObjectURL(blobInit);
</script>
<script>
  window.addEventListener('load', function(ev) {
    // Download main.dart.js
    _flutter.loader.loadEntrypoint({
      entrypointUrl: blobUrl,
      onEntrypointLoaded: function(engineInitializer) {
        engineInitializer.autoStart();
      }
    });
  });
</script>
```

## Issues

* Fixes https://github.com/flutter/flutter/issues/141329

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
