### PR TITLE
[Windows] Set cursor immediately when framework requests update

### DIFF
--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -177,7 +177,7 @@ PhysicalWindowBounds FlutterWindow::GetPhysicalWindowBounds() {
 }
 
 void FlutterWindow::UpdateFlutterCursor(const std::string& cursor_name) {
-  current_cursor_ = GetCursorByName(cursor_name);
+  SetFlutterCursor(GetCursorByName(cursor_name));
 }
 
 void FlutterWindow::SetFlutterCursor(HCURSOR cursor) {

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -436,5 +436,12 @@ TEST(FlutterWindowTest, PosthumousWindowMessage) {
   EXPECT_GE(msg_count, 1);
 }
 
+TEST(FlutterWindowTest, UpdateCursor) {
+  FlutterWindow win32window(100, 100);
+  win32window.UpdateFlutterCursor("text");
+  HCURSOR cursor = ::GetCursor();
+  EXPECT_EQ(cursor, ::LoadCursor(nullptr, IDC_IBEAM));
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
On Windows, when using a `MouseRegion` widget to change the cursor it is not actually updated until the cursor is moved. This is because the Windows embedder only updates the `current_cursor_` field but does not actually set the cursor until the window receives the `WM_SETCURSOR` message when the mouse moves. This change makes it set the cursor immediately.

Fixes flutter/flutter#76622