### PR TITLE
[web] fix ==/hashCode/toString for several classes across renderers

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
@@ -120,19 +120,6 @@ class _CkBlurImageFilter extends CkImageFilter {
     borrow(_ref.nativeObject);
   }
 
-  String get _modeString {
-    switch (tileMode) {
-      case ui.TileMode.clamp:
-        return 'clamp';
-      case ui.TileMode.mirror:
-        return 'mirror';
-      case ui.TileMode.repeated:
-        return 'repeated';
-      case ui.TileMode.decal:
-        return 'decal';
-    }
-  }
-
   @override
   bool operator ==(Object other) {
     if (runtimeType != other.runtimeType) {
@@ -149,7 +136,7 @@ class _CkBlurImageFilter extends CkImageFilter {
 
   @override
   String toString() {
-    return 'ImageFilter.blur($sigmaX, $sigmaY, $_modeString)';
+    return 'ImageFilter.blur($sigmaX, $sigmaY, ${tileModeString(tileMode)})';
   }
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -296,6 +296,85 @@ class CkPaint implements ui.Paint {
   void dispose() {
     _ref.dispose();
   }
+
+  // Must be kept in sync with the default in paint.cc.
+  static const double _kStrokeMiterLimitDefault = 4.0;
+
+  // Must be kept in sync with the default in paint.cc.
+  static const int _kColorDefault = 0xFF000000;
+
+  // Must be kept in sync with the default in paint.cc.
+  static final int _kBlendModeDefault = ui.BlendMode.srcOver.index;
+
+  @override
+  String toString() {
+    String resultString = 'Paint()';
+
+    assert(() {
+      final StringBuffer result = StringBuffer();
+      String semicolon = '';
+      result.write('Paint(');
+      if (style == ui.PaintingStyle.stroke) {
+        result.write('$style');
+        if (strokeWidth != 0.0) {
+          result.write(' ${strokeWidth.toStringAsFixed(1)}');
+        } else {
+          result.write(' hairline');
+        }
+        if (strokeCap != ui.StrokeCap.butt) {
+          result.write(' $strokeCap');
+        }
+        if (strokeJoin == ui.StrokeJoin.miter) {
+          if (strokeMiterLimit != _kStrokeMiterLimitDefault) {
+            result.write(' $strokeJoin up to ${strokeMiterLimit.toStringAsFixed(1)}');
+          }
+        } else {
+          result.write(' $strokeJoin');
+        }
+        semicolon = '; ';
+      }
+      if (!isAntiAlias) {
+        result.write('${semicolon}antialias off');
+        semicolon = '; ';
+      }
+      if (color != const ui.Color(_kColorDefault)) {
+        result.write('$semicolon$color');
+        semicolon = '; ';
+      }
+      if (blendMode.index != _kBlendModeDefault) {
+        result.write('$semicolon$blendMode');
+        semicolon = '; ';
+      }
+      if (colorFilter != null) {
+        result.write('${semicolon}colorFilter: $colorFilter');
+        semicolon = '; ';
+      }
+      if (maskFilter != null) {
+        result.write('${semicolon}maskFilter: $maskFilter');
+        semicolon = '; ';
+      }
+      if (filterQuality != ui.FilterQuality.none) {
+        result.write('${semicolon}filterQuality: $filterQuality');
+        semicolon = '; ';
+      }
+      if (shader != null) {
+        result.write('${semicolon}shader: $shader');
+        semicolon = '; ';
+      }
+      if (imageFilter != null) {
+        result.write('${semicolon}imageFilter: $imageFilter');
+        semicolon = '; ';
+      }
+      if (invertColors) {
+        result.write('${semicolon}invert: $invertColors');
+      }
+      result.write(')');
+      resultString = result.toString();
+      return true;
+    }());
+
+    return resultString;
+  }
 }
 
 final Float32List _invertColorMatrix = Float32List.fromList(const <double>[

--- a/lib/web_ui/lib/src/engine/canvaskit/shader.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/shader.dart
@@ -54,6 +54,9 @@ abstract class SimpleCkShader implements CkShader {
   void dispose() {
     _ref.dispose();
   }
+
+  @override
+  String toString() => 'Gradient()';
 }
 
 class CkGradientSweep extends SimpleCkShader implements ui.Gradient {
@@ -133,6 +136,9 @@ class CkGradientLinear extends SimpleCkShader implements ui.Gradient {
       matrix4 != null ? toSkMatrixFromFloat32(matrix4!) : null,
     );
   }
+
+  @override
+  String toString() => 'Gradient()';
 }
 
 class CkGradientRadial extends SimpleCkShader implements ui.Gradient {
@@ -161,6 +167,9 @@ class CkGradientRadial extends SimpleCkShader implements ui.Gradient {
       0,
     );
   }
+
+  @override
+  String toString() => 'Gradient()';
 }
 
 class CkGradientConical extends SimpleCkShader implements ui.Gradient {

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -726,9 +726,11 @@ class CkStrutStyle implements ui.StrutStyle {
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode {
+    final List<String>? fontFamilyFallback = _fontFamilyFallback;
+    return Object.hash(
         _fontFamily,
-        _fontFamilyFallback != null ? Object.hashAll(_fontFamilyFallback) : null,
+        fontFamilyFallback != null ? Object.hashAll(fontFamilyFallback) : null,
         _fontSize,
         _height,
         _leading,
@@ -737,6 +739,7 @@ class CkStrutStyle implements ui.StrutStyle {
         _fontStyle,
         _forceStrutHeight,
       );
+  }
 }
 
 SkFontStyle toSkFontStyle(ui.FontWeight? fontWeight, ui.FontStyle? fontStyle) {

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -728,7 +728,7 @@ class CkStrutStyle implements ui.StrutStyle {
   @override
   int get hashCode => Object.hash(
         _fontFamily,
-        _fontFamilyFallback,
+        _fontFamilyFallback != null ? Object.hashAll(_fontFamilyFallback) : null,
         _fontSize,
         _height,
         _leading,

--- a/lib/web_ui/lib/src/engine/html/painting.dart
+++ b/lib/web_ui/lib/src/engine/html/painting.dart
@@ -96,14 +96,7 @@ class SurfacePaint implements ui.Paint {
   }
 
   @override
-  bool get invertColors {
-    return false;
-  }
-
-  @override
-  set invertColors(bool value) {}
-
-  static const int _defaultPaintColor = 0xFF000000;
+  bool invertColors = false;
 
   @override
   ui.Shader? get shader => _paintData.shader;
@@ -155,25 +148,11 @@ class SurfacePaint implements ui.Paint {
 
   // TODO(ferhat): see https://github.com/flutter/flutter/issues/33605
   @override
-  double get strokeMiterLimit {
-    throw UnsupportedError('SurfacePaint.strokeMiterLimit');
-  }
+  double strokeMiterLimit = 0;
 
+  // TODO(ferhat): Implement ImageFilter, flutter/flutter#35156.
   @override
-  set strokeMiterLimit(double value) {
-
-  }
-
-  @override
-  ui.ImageFilter? get imageFilter {
-    // TODO(ferhat): Implement ImageFilter, flutter/flutter#35156.
-    return null;
-  }
-
-  @override
-  set imageFilter(ui.ImageFilter? value) {
-    // TODO(ferhat): Implement ImageFilter, flutter/flutter#35156
-  }
+  ui.ImageFilter? imageFilter;
 
   // True if Paint instance has used in RecordingCanvas.
   bool _frozen = false;
@@ -186,33 +165,83 @@ class SurfacePaint implements ui.Paint {
     return _paintData;
   }
 
+  // Must be kept in sync with the default in paint.cc.
+  static const double _kStrokeMiterLimitDefault = 4.0;
+
+  // Must be kept in sync with the default in paint.cc.
+  static const int _kColorDefault = 0xFF000000;
+
+  // Must be kept in sync with the default in paint.cc.
+  static final int _kBlendModeDefault = ui.BlendMode.srcOver.index;
+
   @override
   String toString() {
-    final StringBuffer result = StringBuffer();
-    String semicolon = '';
-    result.write('Paint(');
-    if (style == ui.PaintingStyle.stroke) {
-      result.write('$style');
-      if (strokeWidth != 0.0) {
-        result.write(' $strokeWidth');
-      } else {
-        result.write(' hairline');
+    String resultString = 'Paint()';
+
+    assert(() {
+      final StringBuffer result = StringBuffer();
+      String semicolon = '';
+      result.write('Paint(');
+      if (style == ui.PaintingStyle.stroke) {
+        result.write('$style');
+        if (strokeWidth != 0.0) {
+          result.write(' ${strokeWidth.toStringAsFixed(1)}');
+        } else {
+          result.write(' hairline');
+        }
+        if (strokeCap != ui.StrokeCap.butt) {
+          result.write(' $strokeCap');
+        }
+        if (strokeJoin == ui.StrokeJoin.miter) {
+          if (strokeMiterLimit != _kStrokeMiterLimitDefault) {
+            result.write(' $strokeJoin up to ${strokeMiterLimit.toStringAsFixed(1)}');
+          }
+        } else {
+          result.write(' $strokeJoin');
+        }
+        semicolon = '; ';
       }
-      if (strokeCap != ui.StrokeCap.butt) {
-        result.write(' $strokeCap');
+      if (!isAntiAlias) {
+        result.write('${semicolon}antialias off');
+        semicolon = '; ';
       }
-      semicolon = '; ';
-    }
-    if (!isAntiAlias) {
-      result.write('${semicolon}antialias off');
-      semicolon = '; ';
-    }
-    if (color.value != _defaultPaintColor) {
-      result.write('$semicolon$color');
-      semicolon = '; ';
-    }
-    result.write(')');
-    return result.toString();
+      if (color != const ui.Color(_kColorDefault)) {
+        result.write('$semicolon$color');
+        semicolon = '; ';
+      }
+      if (blendMode.index != _kBlendModeDefault) {
+        result.write('$semicolon$blendMode');
+        semicolon = '; ';
+      }
+      if (colorFilter != null) {
+        result.write('${semicolon}colorFilter: $colorFilter');
+        semicolon = '; ';
+      }
+      if (maskFilter != null) {
+        result.write('${semicolon}maskFilter: $maskFilter');
+        semicolon = '; ';
+      }
+      if (filterQuality != ui.FilterQuality.none) {
+        result.write('${semicolon}filterQuality: $filterQuality');
+        semicolon = '; ';
+      }
+      if (shader != null) {
+        result.write('${semicolon}shader: $shader');
+        semicolon = '; ';
+      }
+      if (imageFilter != null) {
+        result.write('${semicolon}imageFilter: $imageFilter');
+        semicolon = '; ';
+      }
+      if (invertColors) {
+        result.write('${semicolon}invert: $invertColors');
+      }
+      result.write(')');
+      resultString = result.toString();
+      return true;
+    }());
+
+    return resultString;
   }
 }
 

--- a/lib/web_ui/lib/src/engine/html/shaders/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader.dart
@@ -63,6 +63,9 @@ abstract class EngineGradient implements ui.Gradient {
 
   @override
   void dispose() {}
+
+  @override
+  String toString() => 'Gradient()';
 }
 
 class GradientSweep extends EngineGradient {
@@ -755,7 +758,7 @@ class _BlurEngineImageFilter extends EngineImageFilter {
 
   @override
   String toString() {
-    return 'ImageFilter.blur($sigmaX, $sigmaY, $tileMode)';
+    return 'ImageFilter.blur($sigmaX, $sigmaY, ${tileModeString(tileMode)})';
   }
 }
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
@@ -172,4 +172,8 @@ class SkwasmPaint extends SkwasmObjectWrapper<RawPaint> implements ui.Paint {
     _invertColors = invertColors;
     _setEffectiveColorFilter();
   }
+
+  // TODO(yjbanov): https://github.com/flutter/flutter/issues/141639
+  @override
+  String toString() => 'Paint()';
 }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -521,31 +521,37 @@ class SkwasmTextStyle implements ui.TextStyle {
 
   @override
   String toString() {
-    final List<String>? fontFamilyFallback = this.fontFamilyFallback;
-    final String? fontFamily = this.fontFamily;
-    return 'TextStyle('
-             'color: ${color ?? "unspecified"}, '
-             'decoration: ${decoration ?? "unspecified"}, '
-             'decorationColor: ${decorationColor ?? "unspecified"}, '
-             'decorationStyle: ${decorationStyle ?? "unspecified"}, '
-             'decorationThickness: ${decorationThickness ?? "unspecified"}, '
-             'fontWeight: ${fontWeight ?? "unspecified"}, '
-             'fontStyle: ${fontStyle ?? "unspecified"}, '
-             'textBaseline: ${textBaseline ?? "unspecified"}, '
-             'fontFamily: ${fontFamily != null && fontFamily.isNotEmpty ? fontFamily : "unspecified"}, '
-             'fontFamilyFallback: ${fontFamilyFallback != null && fontFamilyFallback.isNotEmpty ? fontFamilyFallback : "unspecified"}, '
-             'fontSize: ${fontSize ?? "unspecified"}, '
-             'letterSpacing: ${letterSpacing != null ? "${letterSpacing}x" : "unspecified"}, '
-             'wordSpacing: ${wordSpacing != null ? "${wordSpacing}x" : "unspecified"}, '
-             'height: ${height != null ? "${height}x" : "unspecified"}, '
-             'leadingDistribution: ${leadingDistribution ?? "unspecified"}, '
-             'locale: ${locale ?? "unspecified"}, '
-             'background: ${background ?? "unspecified"}, '
-             'foreground: ${foreground ?? "unspecified"}, '
-             'shadows: ${shadows ?? "unspecified"}, '
-             'fontFeatures: ${fontFeatures ?? "unspecified"}, '
-             'fontVariations: ${fontVariations ?? "unspecified"}'
-           ')';
+    String result = super.toString();
+    assert(() {
+      final List<String>? fontFamilyFallback = this.fontFamilyFallback;
+      final double? fontSize = this.fontSize;
+      final double? height = this.height;
+      result = 'TextStyle('
+          'color: ${color ?? "unspecified"}, '
+          'decoration: ${decoration ?? "unspecified"}, '
+          'decorationColor: ${decorationColor ?? "unspecified"}, '
+          'decorationStyle: ${decorationStyle ?? "unspecified"}, '
+          'decorationThickness: ${decorationThickness ?? "unspecified"}, '
+          'fontWeight: ${fontWeight ?? "unspecified"}, '
+          'fontStyle: ${fontStyle ?? "unspecified"}, '
+          'textBaseline: ${textBaseline ?? "unspecified"}, '
+          'fontFamily: ${fontFamily ?? "unspecified"}, '
+          'fontFamilyFallback: ${fontFamilyFallback != null && fontFamilyFallback.isNotEmpty ? fontFamilyFallback : "unspecified"}, '
+          'fontSize: ${fontSize != null ? fontSize.toStringAsFixed(1) : "unspecified"}, '
+          'letterSpacing: ${letterSpacing != null ? "${letterSpacing}x" : "unspecified"}, '
+          'wordSpacing: ${wordSpacing != null ? "${wordSpacing}x" : "unspecified"}, '
+          'height: ${height != null ? "${height.toStringAsFixed(1)}x" : "unspecified"}, '
+          'leadingDistribution: ${leadingDistribution ?? "unspecified"}, '
+          'locale: ${locale ?? "unspecified"}, '
+          'background: ${background ?? "unspecified"}, '
+          'foreground: ${foreground ?? "unspecified"}, '
+          'shadows: ${shadows ?? "unspecified"}, '
+          'fontFeatures: ${fontFeatures ?? "unspecified"}, '
+          'fontVariations: ${fontVariations ?? "unspecified"}'
+          ')';
+      return true;
+    }());
+    return result;
   }
 }
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -549,17 +549,17 @@ class SkwasmTextStyle implements ui.TextStyle {
   }
 }
 
-class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implements ui.StrutStyle {
+final class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implements ui.StrutStyle {
   factory SkwasmStrutStyle({
     String? fontFamily,
     List<String>? fontFamilyFallback,
     double? fontSize,
     double? height,
-    ui.TextLeadingDistribution? leadingDistribution,
     double? leading,
     ui.FontWeight? fontWeight,
     ui.FontStyle? fontStyle,
     bool? forceStrutHeight,
+    ui.TextLeadingDistribution? leadingDistribution,
   }) {
     final StrutStyleHandle handle = strutStyleCreate();
     if (fontFamily != null || fontFamilyFallback != null) {
@@ -595,13 +595,72 @@ class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implements ui.
     if (forceStrutHeight != null) {
       strutStyleSetForceStrutHeight(handle, forceStrutHeight);
     }
-    return SkwasmStrutStyle._(handle);
+    return SkwasmStrutStyle._(
+      handle,
+      fontFamily,
+      fontFamilyFallback,
+      fontSize,
+      height,
+      leadingDistribution,
+      leading,
+      fontWeight,
+      fontStyle,
+      forceStrutHeight,
+    );
   }
 
-  SkwasmStrutStyle._(StrutStyleHandle handle) : super(handle, _registry);
+  SkwasmStrutStyle._(
+    StrutStyleHandle handle,
+    this._fontFamily,
+    this._fontFamilyFallback,
+    this._fontSize,
+    this._height,
+    this._leadingDistribution,
+    this._leading,
+    this._fontWeight,
+    this._fontStyle,
+    this._forceStrutHeight,
+  ) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawStrutStyle> _registry =
     SkwasmFinalizationRegistry<RawStrutStyle>(strutStyleDispose);
+
+  final String? _fontFamily;
+  final List<String>? _fontFamilyFallback;
+  final double? _fontSize;
+  final double? _height;
+  final double? _leading;
+  final ui.FontWeight? _fontWeight;
+  final ui.FontStyle? _fontStyle;
+  final bool? _forceStrutHeight;
+  final ui.TextLeadingDistribution? _leadingDistribution;
+
+  @override
+  bool operator ==(Object other) {
+    return other is SkwasmStrutStyle &&
+        other._fontFamily == _fontFamily &&
+        other._fontSize == _fontSize &&
+        other._height == _height &&
+        other._leading == _leading &&
+        other._leadingDistribution == _leadingDistribution &&
+        other._fontWeight == _fontWeight &&
+        other._fontStyle == _fontStyle &&
+        other._forceStrutHeight == _forceStrutHeight &&
+        listEquals<String>(other._fontFamilyFallback, _fontFamilyFallback);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    _fontFamily,
+    _fontFamilyFallback != null ? Object.hashAll(_fontFamilyFallback) : null,
+    _fontSize,
+    _height,
+    _leading,
+    _leadingDistribution,
+    _fontWeight,
+    _fontStyle,
+    _forceStrutHeight,
+  );
 }
 
 class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle> implements ui.ParagraphStyle {
@@ -678,13 +737,41 @@ class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle> implem
       skStringFree(localeHandle);
     }
     paragraphStyleSetTextStyle(handle, textStyleHandle);
-    return SkwasmParagraphStyle._(handle, textStyle, fontFamily);
+    return SkwasmParagraphStyle._(
+      handle,
+      textStyle,
+      fontFamily,
+      textAlign,
+      textDirection,
+      fontWeight,
+      fontStyle,
+      maxLines,
+      fontFamily,
+      fontSize,
+      height,
+      textHeightBehavior,
+      strutStyle,
+      ellipsis,
+      locale,
+    );
   }
 
   SkwasmParagraphStyle._(
     ParagraphStyleHandle handle,
     this.textStyle,
-    this.defaultFontFamily
+    this.defaultFontFamily,
+    this._textAlign,
+    this._textDirection,
+    this._fontWeight,
+    this._fontStyle,
+    this._maxLines,
+    this._fontFamily,
+    this._fontSize,
+    this._height,
+    this._textHeightBehavior,
+    this._strutStyle,
+    this._ellipsis,
+    this._locale,
   ) : super(handle, _registry);
 
   static final SkwasmFinalizationRegistry<RawParagraphStyle> _registry =
@@ -692,6 +779,85 @@ class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle> implem
 
   final SkwasmNativeTextStyle textStyle;
   final String? defaultFontFamily;
+
+  final ui.TextAlign? _textAlign;
+  final ui.TextDirection? _textDirection;
+  final ui.FontWeight? _fontWeight;
+  final ui.FontStyle? _fontStyle;
+  final int? _maxLines;
+  final String? _fontFamily;
+  final double? _fontSize;
+  final double? _height;
+  final ui.TextHeightBehavior? _textHeightBehavior;
+  final ui.StrutStyle? _strutStyle;
+  final String? _ellipsis;
+  final ui.Locale? _locale;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is SkwasmParagraphStyle &&
+        other._textAlign == _textAlign &&
+        other._textDirection == _textDirection &&
+        other._fontWeight == _fontWeight &&
+        other._fontStyle == _fontStyle &&
+        other._maxLines == _maxLines &&
+        other._fontFamily == _fontFamily &&
+        other._fontSize == _fontSize &&
+        other._height == _height &&
+        other._textHeightBehavior == _textHeightBehavior &&
+        other._strutStyle == _strutStyle &&
+        other._ellipsis == _ellipsis &&
+        other._locale == _locale;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      _textAlign,
+      _textDirection,
+      _fontWeight,
+      _fontStyle,
+      _maxLines,
+      _fontFamily,
+      _fontSize,
+      _height,
+      _textHeightBehavior,
+      _strutStyle,
+      _ellipsis,
+      _locale,
+    );
+  }
+
+  @override
+  String toString() {
+    String result = super.toString();
+    assert(() {
+      final double? fontSize = _fontSize;
+      final double? height = _height;
+      result = 'ParagraphStyle('
+          'textAlign: ${_textAlign ?? "unspecified"}, '
+          'textDirection: ${_textDirection ?? "unspecified"}, '
+          'fontWeight: ${_fontWeight ?? "unspecified"}, '
+          'fontStyle: ${_fontStyle ?? "unspecified"}, '
+          'maxLines: ${_maxLines ?? "unspecified"}, '
+          'textHeightBehavior: ${_textHeightBehavior ?? "unspecified"}, '
+          'fontFamily: ${_fontFamily ?? "unspecified"}, '
+          'fontSize: ${fontSize != null ? fontSize.toStringAsFixed(1) : "unspecified"}, '
+          'height: ${height != null ? "${height.toStringAsFixed(1)}x" : "unspecified"}, '
+          'strutStyle: ${_strutStyle ?? "unspecified"}, '
+          'ellipsis: ${_ellipsis != null ? '"$_ellipsis"' : "unspecified"}, '
+          'locale: ${_locale ?? "unspecified"}'
+          ')';
+      return true;
+    }());
+    return result;
+  }
 }
 
 class SkwasmParagraphBuilder extends SkwasmObjectWrapper<RawParagraphBuilder> implements ui.ParagraphBuilder {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -650,17 +650,20 @@ final class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implemen
   }
 
   @override
-  int get hashCode => Object.hash(
-    _fontFamily,
-    _fontFamilyFallback != null ? Object.hashAll(_fontFamilyFallback) : null,
-    _fontSize,
-    _height,
-    _leading,
-    _leadingDistribution,
-    _fontWeight,
-    _fontStyle,
-    _forceStrutHeight,
-  );
+  int get hashCode {
+    final List<String>? fontFamilyFallback = _fontFamilyFallback;
+    return Object.hash(
+      _fontFamily,
+      fontFamilyFallback != null ? Object.hashAll(fontFamilyFallback) : null,
+      _fontSize,
+      _height,
+      _leading,
+      _leadingDistribution,
+      _fontWeight,
+      _fontStyle,
+      _forceStrutHeight,
+    );
+  }
 }
 
 class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle> implements ui.ParagraphStyle {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -144,6 +144,9 @@ class SkwasmGradient extends SkwasmNativeShader implements ui.Gradient {
   });
 
   SkwasmGradient._(super.handle);
+
+  @override
+  String toString() => 'Gradient()';
 }
 
 class SkwasmImageShader extends SkwasmNativeShader implements ui.ImageShader {

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -780,6 +780,7 @@ class EngineTextStyle implements ui.TextStyle {
           'letterSpacing: ${letterSpacing != null ? "${letterSpacing}x" : "unspecified"}, '
           'wordSpacing: ${wordSpacing != null ? "${wordSpacing}x" : "unspecified"}, '
           'height: ${height != null ? "${height.toStringAsFixed(1)}x" : "unspecified"}, '
+          'leadingDistribution: ${leadingDistribution ?? "unspecified"}, '
           'locale: ${locale ?? "unspecified"}, '
           'background: ${background ?? "unspecified"}, '
           'foreground: ${foreground ?? "unspecified"}, '

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -501,6 +501,7 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
         other.fontSize == fontSize &&
         other.height == height &&
         other._textHeightBehavior == _textHeightBehavior &&
+        other._strutStyle == _strutStyle &&
         other.ellipsis == ellipsis &&
         other.locale == locale;
   }
@@ -508,17 +509,19 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
   @override
   int get hashCode {
     return Object.hash(
-        textAlign,
-        textDirection,
-        fontWeight,
-        fontStyle,
-        maxLines,
-        fontFamily,
-        fontSize,
-        height,
-        _textHeightBehavior,
-        ellipsis,
-        locale);
+      textAlign,
+      textDirection,
+      fontWeight,
+      fontStyle,
+      maxLines,
+      fontFamily,
+      fontSize,
+      height,
+      _textHeightBehavior,
+      _strutStyle,
+      ellipsis,
+      locale,
+    );
   }
 
   @override
@@ -537,6 +540,7 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
           'fontFamily: ${fontFamily ?? "unspecified"}, '
           'fontSize: ${fontSize != null ? fontSize.toStringAsFixed(1) : "unspecified"}, '
           'height: ${height != null ? "${height.toStringAsFixed(1)}x" : "unspecified"}, '
+          'strutStyle: ${_strutStyle ?? "unspecified"}, '
           'ellipsis: ${ellipsis != null ? '"$ellipsis"' : "unspecified"}, '
           'locale: ${locale ?? "unspecified"}'
           ')';

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -846,9 +846,11 @@ class EngineStrutStyle implements ui.StrutStyle {
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode {
+    final List<String>? fontFamilyFallback = _fontFamilyFallback;
+    return Object.hash(
         _fontFamily,
-        _fontFamilyFallback != null ? Object.hashAll(_fontFamilyFallback) : null,
+        fontFamilyFallback != null ? Object.hashAll(fontFamilyFallback) : null,
         _fontSize,
         _height,
         _leading,
@@ -857,6 +859,7 @@ class EngineStrutStyle implements ui.StrutStyle {
         _fontStyle,
         _forceStrutHeight,
       );
+  }
 }
 
 /// Holds information for a placeholder in a paragraph.

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -848,7 +848,7 @@ class EngineStrutStyle implements ui.StrutStyle {
   @override
   int get hashCode => Object.hash(
         _fontFamily,
-        _fontFamilyFallback,
+        _fontFamilyFallback != null ? Object.hashAll(_fontFamilyFallback) : null,
         _fontSize,
         _height,
         _leading,

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -854,3 +854,17 @@ class LruCache<K extends Object, V extends Object> {
     _itemQueue.removeLast();
   }
 }
+
+/// Returns the VM-compatible string for the tile mode.
+String tileModeString(ui.TileMode tileMode) {
+  switch (tileMode) {
+    case ui.TileMode.clamp:
+      return 'clamp';
+    case ui.TileMode.mirror:
+      return 'mirror';
+    case ui.TileMode.repeated:
+      return 'repeated';
+    case ui.TileMode.decal:
+      return 'decal';
+  }
+}

--- a/lib/web_ui/test/canvaskit/text_test.dart
+++ b/lib/web_ui/test/canvaskit/text_test.dart
@@ -105,23 +105,23 @@ void testMain() {
       test('The default test font is used when a non-test fontFamily is specified', () {
         final String defaultTestFontFamily = testFonts.first;
 
-        expect(CkTextStyle(fontFamily: 'BogusFontFamily').fontFamily, defaultTestFontFamily);
-        expect(CkParagraphStyle(fontFamily: 'BogusFontFamily').getTextStyle().fontFamily, defaultTestFontFamily);
+        expect(CkTextStyle(fontFamily: 'BogusFontFamily').effectiveFontFamily, defaultTestFontFamily);
+        expect(CkParagraphStyle(fontFamily: 'BogusFontFamily').getTextStyle().effectiveFontFamily, defaultTestFontFamily);
         expect(CkStrutStyle(fontFamily: 'BogusFontFamily'), CkStrutStyle(fontFamily: defaultTestFontFamily));
       });
 
       test('The default test font is used when fontFamily is unspecified', () {
         final String defaultTestFontFamily = testFonts.first;
 
-        expect(CkTextStyle().fontFamily, defaultTestFontFamily);
-        expect(CkParagraphStyle().getTextStyle().fontFamily, defaultTestFontFamily);
+        expect(CkTextStyle().effectiveFontFamily, defaultTestFontFamily);
+        expect(CkParagraphStyle().getTextStyle().effectiveFontFamily, defaultTestFontFamily);
         expect(CkStrutStyle(), CkStrutStyle(fontFamily: defaultTestFontFamily));
       });
 
       test('Can specify test fontFamily to use', () {
         for (final String testFont in testFonts) {
-          expect(CkTextStyle(fontFamily: testFont).fontFamily, testFont);
-          expect(CkParagraphStyle(fontFamily: testFont).getTextStyle().fontFamily, testFont);
+          expect(CkTextStyle(fontFamily: testFont).effectiveFontFamily, testFont);
+          expect(CkParagraphStyle(fontFamily: testFont).getTextStyle().effectiveFontFamily, testFont);
         }
       });
     });

--- a/lib/web_ui/test/ui/paint_test.dart
+++ b/lib/web_ui/test/ui/paint_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+import 'utils.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  setUpUnitTests(
+    emulateTesterEnvironment: false,
+    setUpTestViewDimensions: false,
+  );
+
+  test('toString()', () {
+    final ui.Paint paint = ui.Paint();
+    paint.blendMode = ui.BlendMode.darken;
+    paint.style = ui.PaintingStyle.fill;
+    paint.strokeWidth = 1.2;
+    paint.strokeCap = ui.StrokeCap.square;
+    paint.strokeJoin = ui.StrokeJoin.bevel;
+    paint.isAntiAlias = true;
+    paint.color = const ui.Color(0xaabbccdd);
+    paint.invertColors = true;
+    paint.shader = ui.Gradient.linear(
+      const ui.Offset(0.1, 0.2),
+      const ui.Offset(1.5, 1.6),
+      const <ui.Color>[
+        ui.Color(0xaabbccdd),
+        ui.Color(0xbbccddee),
+      ],
+      <double>[0.3, 0.4],
+      ui.TileMode.decal,
+    );
+    paint.maskFilter = const ui.MaskFilter.blur(ui.BlurStyle.normal, 1.7);
+    paint.filterQuality = ui.FilterQuality.high;
+    paint.colorFilter = const ui.ColorFilter.linearToSrgbGamma();
+    paint.strokeMiterLimit = 1.8;
+    paint.imageFilter = ui.ImageFilter.blur(
+      sigmaX: 1.9,
+      sigmaY: 2.1,
+      tileMode: ui.TileMode.mirror,
+    );
+
+    if (!isSkwasm) {
+      expect(
+        paint.toString(),
+        'Paint('
+        'Color(0xaabbccdd); '
+        'BlendMode.darken; '
+        'colorFilter: ColorFilter.linearToSrgbGamma(); '
+        'maskFilter: MaskFilter.blur(BlurStyle.normal, 1.7); '
+        'filterQuality: FilterQuality.high; '
+        'shader: Gradient(); '
+        'imageFilter: ImageFilter.blur(1.9, 2.1, mirror); '
+        'invert: true'
+        ')',
+      );
+    } else {
+      // TODO(yjbanov): https://github.com/flutter/flutter/issues/141639
+      expect(paint.toString(), 'Paint()');
+    }
+  });
+}

--- a/lib/web_ui/test/ui/paragraph_style_test.dart
+++ b/lib/web_ui/test/ui/paragraph_style_test.dart
@@ -1,0 +1,162 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  setUpUnitTests(
+    emulateTesterEnvironment: false,
+    setUpTestViewDimensions: false,
+  );
+
+  test('blanks are equal to each other', () {
+    final ui.ParagraphStyle a = ui.ParagraphStyle();
+    final ui.ParagraphStyle b = ui.ParagraphStyle();
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+  });
+
+  test('each property individually equal', () {
+    for (final String property in _populatorsA.keys) {
+      final _ParagraphStylePropertyPopulator populator = _populatorsA[property]!;
+
+      final _TestParagraphStyleBuilder aBuilder = _TestParagraphStyleBuilder();
+      populator(aBuilder);
+      final ui.ParagraphStyle a = aBuilder.build();
+
+      final _TestParagraphStyleBuilder bBuilder = _TestParagraphStyleBuilder();
+      populator(bBuilder);
+      final ui.ParagraphStyle b = bBuilder.build();
+
+      expect(reason: '$property property is equal', a, b);
+      expect(reason: '$property hashCode is equal', a.hashCode, b.hashCode);
+    }
+  });
+
+  test('each property individually not equal', () {
+    for (final String property in _populatorsA.keys) {
+      final _ParagraphStylePropertyPopulator populatorA = _populatorsA[property]!;
+
+      final _TestParagraphStyleBuilder aBuilder = _TestParagraphStyleBuilder();
+      populatorA(aBuilder);
+      final ui.ParagraphStyle a = aBuilder.build();
+
+      final _ParagraphStylePropertyPopulator populatorB = _populatorsB[property]!;
+      final _TestParagraphStyleBuilder bBuilder = _TestParagraphStyleBuilder();
+      populatorB(bBuilder);
+      final ui.ParagraphStyle b = bBuilder.build();
+
+      expect(reason: '$property property is not equal', a, isNot(b));
+      expect(reason: '$property hashCode is not equal', a.hashCode, isNot(b.hashCode));
+    }
+  });
+
+  test('all properties altogether equal', () {
+    final _TestParagraphStyleBuilder aBuilder = _TestParagraphStyleBuilder();
+    final _TestParagraphStyleBuilder bBuilder = _TestParagraphStyleBuilder();
+
+    for (final String property in _populatorsA.keys) {
+      final _ParagraphStylePropertyPopulator populator = _populatorsA[property]!;
+      populator(aBuilder);
+      populator(bBuilder);
+    }
+
+    final ui.ParagraphStyle a = aBuilder.build();
+    final ui.ParagraphStyle b = bBuilder.build();
+
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+  });
+
+  test('all properties altogether not equal', () {
+    final _TestParagraphStyleBuilder aBuilder = _TestParagraphStyleBuilder();
+    final _TestParagraphStyleBuilder bBuilder = _TestParagraphStyleBuilder();
+
+    for (final String property in _populatorsA.keys) {
+      final _ParagraphStylePropertyPopulator populatorA = _populatorsA[property]!;
+      populatorA(aBuilder);
+
+      final _ParagraphStylePropertyPopulator populatorB = _populatorsB[property]!;
+      populatorB(bBuilder);
+    }
+
+    final ui.ParagraphStyle a = aBuilder.build();
+    final ui.ParagraphStyle b = bBuilder.build();
+
+    expect(a, isNot(b));
+    expect(a.hashCode, isNot(b.hashCode));
+  });
+}
+
+typedef _ParagraphStylePropertyPopulator = void Function(_TestParagraphStyleBuilder builder);
+
+final Map<String, _ParagraphStylePropertyPopulator> _populatorsA = <String, _ParagraphStylePropertyPopulator>{
+  'textAlign': (_TestParagraphStyleBuilder builder) { builder.textAlign = ui.TextAlign.left; },
+  'textDirection': (_TestParagraphStyleBuilder builder) { builder.textDirection = ui.TextDirection.rtl; },
+  'fontWeight': (_TestParagraphStyleBuilder builder) { builder.fontWeight = ui.FontWeight.w400; },
+  'fontStyle': (_TestParagraphStyleBuilder builder) { builder.fontStyle = ui.FontStyle.normal; },
+  'maxLines': (_TestParagraphStyleBuilder builder) { builder.maxLines = 1; },
+  'fontFamily': (_TestParagraphStyleBuilder builder) { builder.fontFamily = 'Arial'; },
+  'fontSize': (_TestParagraphStyleBuilder builder) { builder.fontSize = 12; },
+  'height': (_TestParagraphStyleBuilder builder) { builder.height = 13; },
+  'textHeightBehavior': (_TestParagraphStyleBuilder builder) { builder.textHeightBehavior = const ui.TextHeightBehavior(); },
+  'strutStyle': (_TestParagraphStyleBuilder builder) { builder.strutStyle = ui.StrutStyle(fontFamily: 'Times New Roman'); },
+  'ellipsis': (_TestParagraphStyleBuilder builder) { builder.ellipsis = '...'; },
+  'locale': (_TestParagraphStyleBuilder builder) { builder.locale = const ui.Locale('en', 'US'); },
+};
+
+final Map<String, _ParagraphStylePropertyPopulator> _populatorsB = <String, _ParagraphStylePropertyPopulator>{
+  'textAlign': (_TestParagraphStyleBuilder builder) { builder.textAlign = ui.TextAlign.right; },
+  'textDirection': (_TestParagraphStyleBuilder builder) { builder.textDirection = ui.TextDirection.ltr; },
+  'fontWeight': (_TestParagraphStyleBuilder builder) { builder.fontWeight = ui.FontWeight.w600; },
+  'fontStyle': (_TestParagraphStyleBuilder builder) { builder.fontStyle = ui.FontStyle.italic; },
+  'maxLines': (_TestParagraphStyleBuilder builder) { builder.maxLines = 2; },
+  'fontFamily': (_TestParagraphStyleBuilder builder) { builder.fontFamily = 'Noto'; },
+  'fontSize': (_TestParagraphStyleBuilder builder) { builder.fontSize = 12.1; },
+  'height': (_TestParagraphStyleBuilder builder) { builder.height = 13.1; },
+  'textHeightBehavior': (_TestParagraphStyleBuilder builder) { builder.textHeightBehavior = const ui.TextHeightBehavior(applyHeightToFirstAscent: false); },
+  'strutStyle': (_TestParagraphStyleBuilder builder) { builder.strutStyle = ui.StrutStyle(fontFamily: 'sans-serif'); },
+  'ellipsis': (_TestParagraphStyleBuilder builder) { builder.ellipsis = '___'; },
+  'locale': (_TestParagraphStyleBuilder builder) { builder.locale = const ui.Locale('fr', 'CA'); },
+};
+
+class _TestParagraphStyleBuilder {
+  ui.TextAlign? textAlign;
+  ui.TextDirection? textDirection;
+  ui.FontWeight? fontWeight;
+  ui.FontStyle? fontStyle;
+  int? maxLines;
+  String? fontFamily;
+  double? fontSize;
+  double? height;
+  ui.TextHeightBehavior? textHeightBehavior;
+  ui.StrutStyle? strutStyle;
+  String? ellipsis;
+  ui.Locale? locale;
+
+  ui.ParagraphStyle build() {
+    return ui.ParagraphStyle(
+      textAlign: textAlign,
+      textDirection: textDirection,
+      fontWeight: fontWeight,
+      fontStyle: fontStyle,
+      maxLines: maxLines,
+      fontFamily: fontFamily,
+      fontSize: fontSize,
+      height: height,
+      textHeightBehavior: textHeightBehavior,
+      strutStyle: strutStyle,
+      ellipsis: ellipsis,
+      locale: locale,
+    );
+  }
+}

--- a/lib/web_ui/test/ui/strut_style_test.dart
+++ b/lib/web_ui/test/ui/strut_style_test.dart
@@ -1,0 +1,152 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  setUpUnitTests(
+    emulateTesterEnvironment: false,
+    setUpTestViewDimensions: false,
+  );
+
+  test('blanks are equal to each other', () {
+    final ui.StrutStyle a = ui.StrutStyle();
+    final ui.StrutStyle b = ui.StrutStyle();
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+  });
+
+  test('each property individually equal', () {
+    for (final String property in _populatorsA.keys) {
+      final _StrutStylePropertyPopulator populator = _populatorsA[property]!;
+
+      final _TestStrutStyleBuilder aBuilder = _TestStrutStyleBuilder();
+      populator(aBuilder);
+      final ui.StrutStyle a = aBuilder.build();
+
+      final _TestStrutStyleBuilder bBuilder = _TestStrutStyleBuilder();
+      populator(bBuilder);
+      final ui.StrutStyle b = bBuilder.build();
+
+      expect(reason: '$property property is equal', a, b);
+      expect(reason: '$property hashCode is equal', a.hashCode, b.hashCode);
+    }
+  });
+
+  test('each property individually not equal', () {
+    for (final String property in _populatorsA.keys) {
+      final _StrutStylePropertyPopulator populatorA = _populatorsA[property]!;
+
+      final _TestStrutStyleBuilder aBuilder = _TestStrutStyleBuilder();
+      populatorA(aBuilder);
+      final ui.StrutStyle a = aBuilder.build();
+
+      final _StrutStylePropertyPopulator populatorB = _populatorsB[property]!;
+      final _TestStrutStyleBuilder bBuilder = _TestStrutStyleBuilder();
+      populatorB(bBuilder);
+      final ui.StrutStyle b = bBuilder.build();
+
+      expect(reason: '$property property is not equal', a, isNot(b));
+      expect(reason: '$property hashCode is not equal', a.hashCode, isNot(b.hashCode));
+    }
+  });
+
+  test('all properties altogether equal', () {
+    final _TestStrutStyleBuilder aBuilder = _TestStrutStyleBuilder();
+    final _TestStrutStyleBuilder bBuilder = _TestStrutStyleBuilder();
+
+    for (final String property in _populatorsA.keys) {
+      final _StrutStylePropertyPopulator populator = _populatorsA[property]!;
+      populator(aBuilder);
+      populator(bBuilder);
+    }
+
+    final ui.StrutStyle a = aBuilder.build();
+    final ui.StrutStyle b = bBuilder.build();
+
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+  });
+
+  test('all properties altogether not equal', () {
+    final _TestStrutStyleBuilder aBuilder = _TestStrutStyleBuilder();
+    final _TestStrutStyleBuilder bBuilder = _TestStrutStyleBuilder();
+
+    for (final String property in _populatorsA.keys) {
+      final _StrutStylePropertyPopulator populatorA = _populatorsA[property]!;
+      populatorA(aBuilder);
+
+      final _StrutStylePropertyPopulator populatorB = _populatorsB[property]!;
+      populatorB(bBuilder);
+    }
+
+    final ui.StrutStyle a = aBuilder.build();
+    final ui.StrutStyle b = bBuilder.build();
+
+    expect(a, isNot(b));
+    expect(a.hashCode, isNot(b.hashCode));
+  });
+}
+
+typedef _StrutStylePropertyPopulator = void Function(_TestStrutStyleBuilder builder);
+
+final Map<String, _StrutStylePropertyPopulator> _populatorsA = <String, _StrutStylePropertyPopulator>{
+  'fontFamily': (_TestStrutStyleBuilder builder) { builder.fontFamily = 'Arial'; },
+  // Intentionally do not use const List to make sure Object.hashAll is used to compute hashCode
+  'fontFamilyFallback': (_TestStrutStyleBuilder builder) { builder.fontFamilyFallback = <String>['Roboto']; },
+  'fontSize': (_TestStrutStyleBuilder builder) { builder.fontSize = 12; },
+  'height': (_TestStrutStyleBuilder builder) { builder.height = 13; },
+  'leading': (_TestStrutStyleBuilder builder) { builder.leading = 0.1; },
+  'fontWeight': (_TestStrutStyleBuilder builder) { builder.fontWeight = ui.FontWeight.w400; },
+  'fontStyle': (_TestStrutStyleBuilder builder) { builder.fontStyle = ui.FontStyle.normal; },
+  'forceStrutHeight': (_TestStrutStyleBuilder builder) { builder.forceStrutHeight = false; },
+  'leadingDistribution': (_TestStrutStyleBuilder builder) { builder.leadingDistribution = ui.TextLeadingDistribution.proportional; },
+};
+
+final Map<String, _StrutStylePropertyPopulator> _populatorsB = <String, _StrutStylePropertyPopulator>{
+  'fontFamily': (_TestStrutStyleBuilder builder) { builder.fontFamily = 'Noto'; },
+  // Intentionally do not use const List to make sure Object.hashAll is used to compute hashCode
+  'fontFamilyFallback': (_TestStrutStyleBuilder builder) { builder.fontFamilyFallback = <String>['Verdana']; },
+  'fontSize': (_TestStrutStyleBuilder builder) { builder.fontSize = 12.1; },
+  'height': (_TestStrutStyleBuilder builder) { builder.height = 13.1; },
+  'leading': (_TestStrutStyleBuilder builder) { builder.leading = 0.2; },
+  'fontWeight': (_TestStrutStyleBuilder builder) { builder.fontWeight = ui.FontWeight.w600; },
+  'fontStyle': (_TestStrutStyleBuilder builder) { builder.fontStyle = ui.FontStyle.italic; },
+  'forceStrutHeight': (_TestStrutStyleBuilder builder) { builder.forceStrutHeight = true; },
+  'leadingDistribution': (_TestStrutStyleBuilder builder) { builder.leadingDistribution = ui.TextLeadingDistribution.even; },
+};
+
+class _TestStrutStyleBuilder {
+  String? fontFamily;
+  List<String>? fontFamilyFallback;
+  double? fontSize;
+  double? height;
+  double? leading;
+  ui.FontWeight? fontWeight;
+  ui.FontStyle? fontStyle;
+  bool? forceStrutHeight;
+  ui.TextLeadingDistribution? leadingDistribution;
+
+  ui.StrutStyle build() {
+    return ui.StrutStyle(
+      fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
+      fontSize: fontSize,
+      height: height,
+      leading: leading,
+      fontWeight: fontWeight,
+      fontStyle: fontStyle,
+      forceStrutHeight: forceStrutHeight,
+      leadingDistribution: leadingDistribution,
+    );
+  }
+}

--- a/lib/web_ui/test/ui/text_style_test.dart
+++ b/lib/web_ui/test/ui/text_style_test.dart
@@ -105,6 +105,88 @@ Future<void> testMain() async {
       expect(a.hashCode, isNot(b.hashCode));
     });
   }
+
+  test('toString() with color', () {
+    final _TestTextStyleBuilder builder = _TestTextStyleBuilder();
+
+    for (final String property in _populatorsA.keys) {
+      if (property == 'foreground') {
+        continue;
+      }
+      final _TextStylePropertyPopulator populator = _populatorsA[property]!;
+      populator(builder);
+    }
+
+    final ui.TextStyle style = builder.build();
+
+    expect(
+      style.toString(),
+      'TextStyle('
+      'color: Color(0xff000000), '
+      'decoration: TextDecoration.none, '
+      'decorationColor: Color(0xffaa0000), '
+      'decorationStyle: TextDecorationStyle.solid, '
+      'decorationThickness: ${1.0}, '
+      'fontWeight: FontWeight.w400, '
+      'fontStyle: FontStyle.normal, '
+      'textBaseline: TextBaseline.alphabetic, '
+      'fontFamily: Arial, '
+      'fontFamilyFallback: [Roboto], '
+      'fontSize: 12.0, '
+      'letterSpacing: 1.2x, '
+      'wordSpacing: 2.3x, '
+      'height: 13.0x, '
+      'leadingDistribution: TextLeadingDistribution.proportional, '
+      'locale: en_US, '
+      'background: Paint(), '
+      'foreground: unspecified, '
+      'shadows: [TextShadow(Color(0xff000000), Offset(0.0, 0.0), ${0.0})], '
+      "fontFeatures: [FontFeature('case', 1)], "
+      "fontVariations: [FontVariation('ital', 0.1)]"
+      ')',
+    );
+  });
+
+  test('toString() with foreground', () {
+    final _TestTextStyleBuilder builder = _TestTextStyleBuilder();
+
+    for (final String property in _populatorsA.keys) {
+      if (property == 'color') {
+        continue;
+      }
+      final _TextStylePropertyPopulator populator = _populatorsA[property]!;
+      populator(builder);
+    }
+
+    final ui.TextStyle style = builder.build();
+
+    expect(
+      style.toString(),
+      'TextStyle('
+      'color: unspecified, '
+      'decoration: TextDecoration.none, '
+      'decorationColor: Color(0xffaa0000), '
+      'decorationStyle: TextDecorationStyle.solid, '
+      'decorationThickness: ${1.0}, '
+      'fontWeight: FontWeight.w400, '
+      'fontStyle: FontStyle.normal, '
+      'textBaseline: TextBaseline.alphabetic, '
+      'fontFamily: Arial, '
+      'fontFamilyFallback: [Roboto], '
+      'fontSize: 12.0, '
+      'letterSpacing: 1.2x, '
+      'wordSpacing: 2.3x, '
+      'height: 13.0x, '
+      'leadingDistribution: TextLeadingDistribution.proportional, '
+      'locale: en_US, '
+      'background: Paint(), '
+      'foreground: Paint(), '
+      'shadows: [TextShadow(Color(0xff000000), Offset(0.0, 0.0), ${0.0})], '
+      "fontFeatures: [FontFeature('case', 1)], "
+      "fontVariations: [FontVariation('ital', 0.1)]"
+      ')',
+    );
+  });
 }
 
 typedef _TextStylePropertyPopulator = void Function(_TestTextStyleBuilder builder);

--- a/lib/web_ui/test/ui/text_style_test.dart
+++ b/lib/web_ui/test/ui/text_style_test.dart
@@ -116,6 +116,7 @@ final ui.Paint _foregroundA = ui.Paint();
 final ui.Paint _backgroundB = ui.Paint();
 final ui.Paint _foregroundB = ui.Paint();
 
+// Intentionally do not use const List expressions to make sure Object.hashAll is used to compute hashCode
 final Map<String, _TextStylePropertyPopulator> _populatorsA = <String, _TextStylePropertyPopulator>{
   'color': (_TestTextStyleBuilder builder) { builder.color = const ui.Color(0xff000000); },
   'decoration': (_TestTextStyleBuilder builder) { builder.decoration = ui.TextDecoration.none; },
@@ -140,6 +141,7 @@ final Map<String, _TextStylePropertyPopulator> _populatorsA = <String, _TextStyl
   'fontVariations': (_TestTextStyleBuilder builder) { builder.fontVariations = <ui.FontVariation>[ const ui.FontVariation.italic(0.1)]; },
 };
 
+// Intentionally do not use const List expressions to make sure Object.hashAll is used to compute hashCode
 final Map<String, _TextStylePropertyPopulator> _populatorsB = <String, _TextStylePropertyPopulator>{
   'color': (_TestTextStyleBuilder builder) { builder.color = const ui.Color(0xffbb0000); },
   'decoration': (_TestTextStyleBuilder builder) { builder.decoration = ui.TextDecoration.lineThrough; },

--- a/lib/web_ui/test/ui/text_style_test_env_test.dart
+++ b/lib/web_ui/test/ui/text_style_test_env_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+Future<void> testMain() async {
+  setUpUnitTests(setUpTestViewDimensions: false);
+
+  // Previously the logic that set the effective font family would forget the
+  // original value and would print incorrect value in toString.
+  test('TextStyle remembers original fontFamily value', () {
+    final ui.TextStyle style1 = ui.TextStyle();
+    expect(style1.toString(), contains('fontFamily: unspecified'));
+
+    final ui.TextStyle style2 = ui.TextStyle(
+      fontFamily: 'Hello',
+    );
+    expect(style2.toString(), contains('fontFamily: Hello'));
+  });
+
+  test('ParagraphStyle remembers original fontFamily value', () {
+    final ui.ParagraphStyle style1 = ui.ParagraphStyle();
+    expect(style1.toString(), contains('fontFamily: unspecified'));
+
+    final ui.ParagraphStyle style2 = ui.ParagraphStyle(
+      fontFamily: 'Hello',
+    );
+    expect(style2.toString(), contains('fontFamily: Hello'));
+  });
+}


### PR DESCRIPTION
Fix equality and hash code in `ParagraphStyle` and `StrutStyle` across renderers. Since those classes transitively rely on `Paint` and other classes, also fix those at least to a point that they pass the `test/painting/text_style_test.dart` test on the framework side.