### PR TITLE
[Flutter GPU] Fix playground shader paths.

### DIFF
--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -132,7 +132,8 @@ impellerc("flutter_gpu_shaders") {
     "flutter_gpu_texture.vert",
   ]
 
-  shader_bundle = "{\"UnlitFragment\": {\"type\": \"fragment\", \"file\": \"../../flutter/impeller/fixtures/flutter_gpu_unlit.frag\"}, \"UnlitVertex\": {\"type\": \"vertex\", \"file\": \"../../flutter/impeller/fixtures/flutter_gpu_unlit.vert\"}, \"TextureFragment\": {\"type\": \"fragment\", \"file\": \"../../flutter/impeller/fixtures/flutter_gpu_texture.frag\"}, \"TextureVertex\": {\"type\": \"vertex\", \"file\": \"../../flutter/impeller/fixtures/flutter_gpu_texture.vert\"}}"
+  fixtures = rebase_path("//flutter/impeller/fixtures")
+  shader_bundle = "{\"UnlitFragment\": {\"type\": \"fragment\", \"file\": \"${fixtures}/flutter_gpu_unlit.frag\"}, \"UnlitVertex\": {\"type\": \"vertex\", \"file\": \"${fixtures}/flutter_gpu_unlit.vert\"}, \"TextureFragment\": {\"type\": \"fragment\", \"file\": \"${fixtures}/flutter_gpu_texture.frag\"}, \"TextureVertex\": {\"type\": \"vertex\", \"file\": \"${fixtures}/flutter_gpu_texture.vert\"}}"
   shader_bundle_output = "playground.shaderbundle"
 }
 

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -315,7 +315,7 @@ template("impellerc") {
   if (defined(invoker.shader_bundle)) {
     assert(
         defined(invoker.shader_bundle_output),
-        "When shader_bundle is specified, shader_output_bundle must also be specified.")
+        "When shader_bundle is specified, shader_bundle_output must also be specified.")
   }
 
   if (defined(invoker.shader_target_flags)) {


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/140969.

Makes the shader paths absolute to prevent issues caused by the working directory differing across build environments.