### PR TITLE
Download android deps when checking licenses.

### DIFF
--- a/ci/builders/standalone/linux_license.json
+++ b/ci/builders/standalone/linux_license.json
@@ -4,9 +4,6 @@
         "os=Linux"
     ],
     "cas_archive": false,
-    "gclient_variables": {
-        "download_android_deps": false
-    },
     "name": "licenses",
     "tests": [
         {


### PR DESCRIPTION
PRs like https://github.com/flutter/engine/pull/49797 are failing.

cc @jonahwilliams 