### PR TITLE
[Windows] Reduce Visual Studio build errors caused by keyboard unit tests

### DIFF
--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -544,9 +544,11 @@ class KeyboardTest : public WindowsTest {
 // Define compound `expect` in macros. If they're defined in functions, the
 // stacktrace wouldn't print where the function is called in the unit tests.
 
-#define EXPECT_CALL_IS_EVENT(_key_call, ...)         \
-  EXPECT_EQ(_key_call.type, KeyCall::kKeyCallOnKey); \
-  EXPECT_EVENT_EQUALS(_key_call.key_event, __VA_ARGS__);
+#define EXPECT_CALL_IS_EVENT(_key_call, _type, _physical, _logical,    \
+                             _character, _synthesized)                 \
+  EXPECT_EQ(_key_call.type, KeyCall::kKeyCallOnKey);                   \
+  EXPECT_EVENT_EQUALS(_key_call.key_event, _type, _physical, _logical, \
+                      _character, _synthesized);
 
 #define EXPECT_CALL_IS_TEXT(_key_call, u16_string)    \
   EXPECT_EQ(_key_call.type, KeyCall::kKeyCallOnText); \

--- a/shell/platform/windows/testing/test_keyboard.h
+++ b/shell/platform/windows/testing/test_keyboard.h
@@ -145,13 +145,17 @@ class MockMessageQueue {
 // Expect the |_target| FlutterKeyEvent has the required properties.
 #define EXPECT_EVENT_EQUALS(_target, _type, _physical, _logical, _character, \
                             _synthesized)                                    \
-  EXPECT_PRED_FORMAT2(_EventEquals, _target,                                 \
-                      (FlutterKeyEvent{                                      \
-                          .type = _type,                                     \
-                          .physical = _physical,                             \
-                          .logical = _logical,                               \
-                          .character = _character,                           \
-                          .synthesized = _synthesized,                       \
-                      }));
+  EXPECT_PRED_FORMAT2(                                                       \
+      _EventEquals, _target,                                                 \
+      (FlutterKeyEvent{                                                      \
+          /* struct_size = */ sizeof(FlutterKeyEvent),                       \
+          /* timestamp = */ 0,                                               \
+          /* type = */ _type,                                                \
+          /* physical = */ _physical,                                        \
+          /* logical = */ _logical,                                          \
+          /* character = */ _character,                                      \
+          /* synthesized = */ _synthesized,                                  \
+          /* device_type = */ kFlutterKeyEventDeviceTypeKeyboard,            \
+      }));
 
 #endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_TEST_KEYBOARD_H_


### PR DESCRIPTION
The `EXPECT_CALL_IS_EVENT` macro used features that are not supported by Visual Studio 2022's intellisense, which results in >130 errors when editing in Visual Studio. These issues only affect the editing experience, building still works as expected.

This change reduces false errors in Visual Studio by making `EXPECT_CALL_IS_EVENT` buildable in Visual Studio.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exexpt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
