### PR TITLE
Revert "Add gclient_variables back for linux_license and fix the excluded files"

### DIFF
--- a/ci/builders/standalone/linux_license.json
+++ b/ci/builders/standalone/linux_license.json
@@ -4,9 +4,6 @@
         "os=Linux"
     ],
     "cas_archive": false,
-    "gclient_variables": {
-        "download_android_deps": false
-    },
     "name": "licenses",
     "tests": [
         {

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -1749,6 +1749,7 @@
 ../../../third_party/abseil-cpp/create_lts.py
 ../../../third_party/abseil-cpp/generate_def_files.py
 ../../../third_party/abseil-cpp/roll_abseil.py
+../../../third_party/android_embedding_dependencies
 ../../../third_party/android_tools
 ../../../third_party/angle/.clang-format
 ../../../third_party/angle/.git
@@ -2641,6 +2642,7 @@
 ../../../third_party/freetype2/vms_make.com
 ../../../third_party/google_fonts_for_unit_tests
 ../../../third_party/googletest
+../../../third_party/gradle
 ../../../third_party/harfbuzz/.ci/requirements.txt
 ../../../third_party/harfbuzz/.clang-format
 ../../../third_party/harfbuzz/.editorconfig
@@ -2841,6 +2843,7 @@
 ../../../third_party/icu/source/tools/toolutil/sources.txt
 ../../../third_party/icu/source/tools/tzcode/Makefile.in
 ../../../third_party/icu/source/tools/tzcode/readme.txt
+../../../third_party/java
 ../../../third_party/libcxx/.clang-format
 ../../../third_party/libcxx/.clang-tidy
 ../../../third_party/libcxx/.git


### PR DESCRIPTION
Reverts flutter/engine#49775

The autorollers create PRs with this flag set to true (the default). This breaks the license check on autoroller PRs since the autorollers are trying to add back the entries in the excluded files list.