### PR TITLE
Flutter GPU: Add GpuContext.createHostBuffer

### DIFF
--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -21,7 +21,7 @@ void instantiateDefaultContext() {
 
 @pragma('vm:entry-point')
 void canEmplaceHostBuffer() {
-  final gpu.HostBuffer hostBuffer = gpu.HostBuffer(gpu.gpuContext);
+  final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
 
   final gpu.BufferView view0 = hostBuffer
       .emplace(Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData());
@@ -216,7 +216,7 @@ void uniformBindFailsForInvalidHostBufferOffset() {
   final gpu.RenderPipeline pipeline = createUnlitRenderPipeline();
   encoder.bindPipeline(pipeline);
 
-  final gpu.HostBuffer transients = gpu.HostBuffer(gpu.gpuContext);
+  final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
   final gpu.BufferView vertInfoData = transients.emplace(float32(<double>[
     1, 0, 0, 0, // mvp
     0, 1, 0, 0, // mvp
@@ -262,7 +262,7 @@ void canCreateRenderPassAndSubmit() {
   encoder.setColorBlendEnable(true);
   encoder.setColorBlendEquation(gpu.ColorBlendEquation());
 
-  final gpu.HostBuffer transients = gpu.HostBuffer(gpu.gpuContext);
+  final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
   final gpu.BufferView vertices = transients.emplace(float32(<double>[
     -0.5, -0.5, //
     0.5, 0.5, //

--- a/lib/gpu/lib/src/buffer.dart
+++ b/lib/gpu/lib/src/buffer.dart
@@ -135,7 +135,7 @@ base class DeviceBuffer extends NativeFieldWrapperClass1 with Buffer {
 /// and automatically inserts padding between emplaced data if necessary.
 base class HostBuffer extends NativeFieldWrapperClass1 with Buffer {
   /// Creates a new HostBuffer.
-  HostBuffer(GpuContext gpuContext) {
+  HostBuffer._initialize(GpuContext gpuContext) {
     _initialize(gpuContext);
   }
 

--- a/lib/gpu/lib/src/context.dart
+++ b/lib/gpu/lib/src/context.dart
@@ -69,6 +69,10 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     return result.isValid ? result : null;
   }
 
+  HostBuffer createHostBuffer() {
+    return HostBuffer._initialize(this);
+  }
+
   /// Allocates a new texture in GPU-resident memory.
   ///
   /// Returns [null] if the [Texture] creation failed.


### PR DESCRIPTION
Just a quick fix to use the same pattern as other GpuContext derivative things.