### PR TITLE
[Impeller] Assign incremental clip depth to all entities.

### DIFF
--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -33,8 +33,9 @@ struct CanvasStackEntry {
   // |cull_rect| is conservative screen-space bounds of the clipped output area
   std::optional<Rect> cull_rect;
   size_t clip_depth = 0u;
+  // The number of clips tracked for this canvas stack entry.
+  size_t num_clips = 0u;
   Entity::RenderingMode rendering_mode = Entity::RenderingMode::kDirect;
-  bool contains_clips = false;
 };
 
 enum class PointStyle {
@@ -181,6 +182,7 @@ class Canvas {
  private:
   std::unique_ptr<EntityPass> base_pass_;
   EntityPass* current_pass_ = nullptr;
+  uint64_t current_depth_ = 0u;
   std::deque<CanvasStackEntry> transform_stack_;
   std::optional<Rect> initial_cull_rect_;
 
@@ -191,6 +193,8 @@ class Canvas {
   EntityPass& GetCurrentPass();
 
   size_t GetClipDepth() const;
+
+  void AddEntityToCurrentPass(Entity entity);
 
   void ClipGeometry(const std::shared_ptr<Geometry>& geometry,
                     Entity::ClipOperation clip_op);

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -246,6 +246,7 @@ bool AtlasContents::Render(const ContentContext& renderer,
 
     FS::FragInfo frag_info;
     VS::FrameInfo frame_info;
+    frame_info.depth = entity.GetShaderClipDepth();
 
     auto dst_sampler_descriptor = sampler_descriptor_;
     if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {
@@ -404,6 +405,7 @@ bool AtlasTextureContents::Render(const ContentContext& renderer,
   auto& host_buffer = renderer.GetTransientsBuffer();
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.texture_sampler_y_coord_scale = texture->GetYCoordScale();
   frame_info.alpha = alpha_;
@@ -490,6 +492,7 @@ bool AtlasColorContents::Render(const ContentContext& renderer,
   auto& host_buffer = renderer.GetTransientsBuffer();
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
 
   FS::FragInfo frag_info;

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -79,16 +79,18 @@ bool ClipContents::Render(const ContentContext& renderer,
   using VS = ClipPipeline::VertexShader;
 
   VS::FrameInfo info;
+  info.depth = entity.GetShaderClipDepth();
 
   auto options = OptionsFromPass(pass);
   options.blend_mode = BlendMode::kDestination;
   pass.SetStencilReference(entity.GetClipDepth());
-  options.stencil_compare = CompareFunction::kEqual;
-  options.stencil_operation = StencilOperation::kIncrementClamp;
 
   if (clip_op_ == Entity::ClipOperation::kDifference) {
     {
       pass.SetCommandLabel("Difference Clip (Increment)");
+
+      options.stencil_compare = CompareFunction::kEqual;
+      options.stencil_operation = StencilOperation::kIncrementClamp;
 
       auto points = Rect::MakeSize(pass.GetRenderTargetSize()).GetPoints();
       auto vertices =

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -87,6 +87,7 @@ bool ConicalGradientContents::RenderSSBO(const ContentContext& renderer,
                           DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
@@ -155,6 +156,7 @@ bool ConicalGradientContents::RenderTexture(const ContentContext& renderer,
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = geometry_result.transform;
   frame_info.matrix = GetInverseEffectTransform();
 

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -160,8 +160,9 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
   }
   if (maybe_depth.has_value()) {
     DepthAttachmentDescriptor depth = maybe_depth.value();
-    depth.depth_compare = CompareFunction::kAlways;
-    depth.depth_write_enabled = false;
+    depth.depth_write_enabled = depth_write_enabled;
+    depth.depth_compare = depth_compare;
+    desc.SetDepthStencilAttachmentDescriptor(depth);
   }
 
   desc.SetPrimitiveType(primitive_type);

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -288,11 +288,13 @@ struct PendingCommandBuffers {
 struct ContentContextOptions {
   SampleCount sample_count = SampleCount::kCount1;
   BlendMode blend_mode = BlendMode::kSourceOver;
+  CompareFunction depth_compare = CompareFunction::kAlways;
   CompareFunction stencil_compare = CompareFunction::kEqual;
   StencilOperation stencil_operation = StencilOperation::kKeep;
   PrimitiveType primitive_type = PrimitiveType::kTriangle;
   PixelFormat color_attachment_pixel_format = PixelFormat::kUnknown;
   bool has_depth_stencil_attachments = true;
+  bool depth_write_enabled = false;
   bool wireframe = false;
   bool is_for_rrect_blur_clear = false;
 
@@ -301,6 +303,7 @@ struct ContentContextOptions {
       static_assert(sizeof(o.sample_count) == 1);
       static_assert(sizeof(o.blend_mode) == 1);
       static_assert(sizeof(o.sample_count) == 1);
+      static_assert(sizeof(o.depth_compare) == 1);
       static_assert(sizeof(o.stencil_compare) == 1);
       static_assert(sizeof(o.stencil_operation) == 1);
       static_assert(sizeof(o.primitive_type) == 1);
@@ -309,11 +312,13 @@ struct ContentContextOptions {
       return (o.is_for_rrect_blur_clear ? 1llu : 0llu) << 0 |
              (o.wireframe ? 1llu : 0llu) << 1 |
              (o.has_depth_stencil_attachments ? 1llu : 0llu) << 2 |
+             (o.depth_write_enabled ? 1llu : 0llu) << 3 |
              // enums
-             static_cast<uint64_t>(o.color_attachment_pixel_format) << 16 |
-             static_cast<uint64_t>(o.primitive_type) << 24 |
-             static_cast<uint64_t>(o.stencil_operation) << 32 |
-             static_cast<uint64_t>(o.stencil_compare) << 40 |
+             static_cast<uint64_t>(o.color_attachment_pixel_format) << 8 |
+             static_cast<uint64_t>(o.primitive_type) << 16 |
+             static_cast<uint64_t>(o.stencil_operation) << 24 |
+             static_cast<uint64_t>(o.stencil_compare) << 32 |
+             static_cast<uint64_t>(o.depth_compare) << 40 |
              static_cast<uint64_t>(o.blend_mode) << 48 |
              static_cast<uint64_t>(o.sample_count) << 56;
     }
@@ -324,6 +329,8 @@ struct ContentContextOptions {
                               const ContentContextOptions& rhs) const {
       return lhs.sample_count == rhs.sample_count &&
              lhs.blend_mode == rhs.blend_mode &&
+             lhs.depth_write_enabled == rhs.depth_write_enabled &&
+             lhs.depth_compare == rhs.depth_compare &&
              lhs.stencil_compare == rhs.stencil_compare &&
              lhs.stencil_operation == rhs.stencil_operation &&
              lhs.primitive_type == rhs.primitive_type &&

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -163,6 +163,7 @@ bool FilterContents::Render(const ContentContext& renderer,
   if (!maybe_entity.has_value()) {
     return true;
   }
+  maybe_entity->SetNewClipDepth(entity.GetNewClipDepth());
   return maybe_entity->Render(renderer, pass);
 }
 

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -138,6 +138,7 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
           src_sampler_descriptor);
   FS::BindTextureSamplerSrc(pass, src_snapshot->texture, src_sampler);
 
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform() * src_snapshot->transform;
   frame_info.src_y_coord_scale = src_snapshot->texture->GetYCoordScale();
   VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -90,6 +90,7 @@ bool LinearGradientContents::RenderTexture(const ContentContext& renderer,
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = geometry_result.transform;
   frame_info.matrix = GetInverseEffectTransform();
 
@@ -150,6 +151,7 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
                           DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -86,6 +86,7 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
                           DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
@@ -147,6 +148,7 @@ bool RadialGradientContents::RenderTexture(const ContentContext& renderer,
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = geometry_result.transform;
   frame_info.matrix = GetInverseEffectTransform();
 

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -154,6 +154,7 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
   ///
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = geometry_result.transform;
   VS::BindFrameInfo(pass,
                     renderer.GetTransientsBuffer().EmplaceUniform(frame_info));

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -69,6 +69,7 @@ bool SolidColorContents::Render(const ContentContext& renderer,
   pass.SetStencilReference(entity.GetClipDepth());
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = capture.AddMatrix("Transform", geometry_result.transform);
   frame_info.color = capture.AddColor("Color", GetColor()).Premultiply();
   VS::BindFrameInfo(pass,

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -98,6 +98,7 @@ bool SolidRRectBlurContents::Render(const ContentContext& renderer,
   }
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform() *
                    Matrix::MakeTranslation(positive_rect.GetOrigin());
 

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -93,6 +93,7 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
                           DefaultUniformAlignment());
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform() * entity.GetTransform();
   frame_info.matrix = GetInverseEffectTransform();
 
@@ -156,6 +157,7 @@ bool SweepGradientContents::RenderTexture(const ContentContext& renderer,
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = geometry_result.transform;
   frame_info.matrix = GetInverseEffectTransform();
 

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -95,6 +95,7 @@ bool TextContents::Render(const ContentContext& renderer,
 
   // Common vertex uniforms for all glyphs.
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform();
   frame_info.atlas_size =
       Vector2{static_cast<Scalar>(atlas->GetTexture()->GetSize().width),

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -142,6 +142,7 @@ bool TextureContents::Render(const ContentContext& renderer,
   auto& host_buffer = renderer.GetTransientsBuffer();
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = pass.GetOrthographicTransform() *
                    capture.AddMatrix("Transform", entity.GetTransform());
   frame_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -138,6 +138,7 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
       UsesEmulatedTileMode(renderer.GetDeviceCapabilities());
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = geometry_result.transform;
   frame_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();
   frame_info.alpha = GetOpacityFactor();

--- a/impeller/entity/contents/vertices_contents.cc
+++ b/impeller/entity/contents/vertices_contents.cc
@@ -139,6 +139,7 @@ bool VerticesUVContents::Render(const ContentContext& renderer,
   pass.SetVertexBuffer(std::move(geometry_result.vertex_buffer));
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = geometry_result.transform;
   frame_info.texture_sampler_y_coord_scale =
       snapshot->texture->GetYCoordScale();
@@ -188,6 +189,7 @@ bool VerticesColorContents::Render(const ContentContext& renderer,
   pass.SetVertexBuffer(std::move(geometry_result.vertex_buffer));
 
   VS::FrameInfo frame_info;
+  frame_info.depth = entity.GetShaderClipDepth();
   frame_info.mvp = geometry_result.transform;
   VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));
 

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -5,6 +5,7 @@
 #include "impeller/entity/entity.h"
 
 #include <algorithm>
+#include <limits>
 #include <optional>
 
 #include "impeller/base/validation.h"
@@ -46,6 +47,10 @@ Entity::Entity() = default;
 
 Entity::~Entity() = default;
 
+Entity::Entity(Entity&&) = default;
+
+Entity::Entity(const Entity&) = default;
+
 const Matrix& Entity::GetTransform() const {
   return transform_;
 }
@@ -86,12 +91,26 @@ const std::shared_ptr<Contents>& Entity::GetContents() const {
   return contents_;
 }
 
-void Entity::SetClipDepth(uint32_t depth) {
-  clip_depth_ = depth;
+void Entity::SetClipDepth(uint32_t clip_depth) {
+  clip_depth_ = clip_depth;
 }
 
 uint32_t Entity::GetClipDepth() const {
   return clip_depth_;
+}
+
+void Entity::SetNewClipDepth(uint32_t clip_depth) {
+  new_clip_depth_ = clip_depth;
+}
+
+uint32_t Entity::GetNewClipDepth() const {
+  return new_clip_depth_;
+}
+
+static const Scalar kDepthEpsilon = 1.0f / std::pow(2, 18);
+
+float Entity::GetShaderClipDepth() const {
+  return new_clip_depth_ * kDepthEpsilon;
 }
 
 void Entity::IncrementStencilDepth(uint32_t increment) {

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -71,7 +71,7 @@ class Entity {
 
   ~Entity();
 
-  Entity(Entity&&) = default;
+  Entity(Entity&&);
 
   /// @brief  Get the global transform matrix for this Entity.
   const Matrix& GetTransform() const;
@@ -96,6 +96,12 @@ class Entity {
 
   uint32_t GetClipDepth() const;
 
+  void SetNewClipDepth(uint32_t clip_depth);
+
+  uint32_t GetNewClipDepth() const;
+
+  float GetShaderClipDepth() const;
+
   void SetBlendMode(BlendMode blend_mode);
 
   BlendMode GetBlendMode() const;
@@ -119,12 +125,13 @@ class Entity {
   Entity Clone() const;
 
  private:
-  Entity(const Entity&) = default;
+  Entity(const Entity&);
 
   Matrix transform_;
   std::shared_ptr<Contents> contents_;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   uint32_t clip_depth_ = 0u;
+  uint32_t new_clip_depth_ = 0u;
   mutable Capture capture_;
 };
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -79,6 +79,33 @@ void EntityPass::AddEntity(Entity entity) {
   elements_.emplace_back(std::move(entity));
 }
 
+void EntityPass::PushClip(Entity entity) {
+  elements_.emplace_back(std::move(entity));
+  active_clips_.emplace_back(elements_.size() - 1);
+}
+
+void EntityPass::PopClips(size_t num_clips, uint64_t depth) {
+  if (num_clips > active_clips_.size()) {
+    VALIDATION_LOG
+        << "Attempted to pop more clips than are currently active. Active: "
+        << active_clips_.size() << ", Popped: " << num_clips
+        << ", Depth: " << depth;
+  }
+
+  size_t max = std::min(num_clips, active_clips_.size());
+  for (size_t i = 0; i < max; i++) {
+    FML_DCHECK(active_clips_.back() < elements_.size());
+    Entity* element = std::get_if<Entity>(&elements_[active_clips_.back()]);
+    FML_DCHECK(element);
+    element->SetNewClipDepth(depth);
+    active_clips_.pop_back();
+  }
+}
+
+void EntityPass::PopAllClips(uint64_t depth) {
+  PopClips(active_clips_.size(), depth);
+}
+
 void EntityPass::SetElements(std::vector<Element> elements) {
   elements_ = std::move(elements);
 }
@@ -683,6 +710,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     Entity element_entity;
     Capture subpass_texture_capture =
         capture.CreateChild("Entity (Subpass texture)");
+    element_entity.SetNewClipDepth(subpass->new_clip_depth_);
     element_entity.SetCapture(subpass_texture_capture);
     element_entity.SetContents(std::move(offscreen_texture_contents));
     element_entity.SetClipDepth(subpass->clip_depth_);
@@ -856,6 +884,13 @@ bool EntityPass::OnRender(
     const std::optional<InlinePassContext::RenderPassResult>&
         collapsed_parent_pass) const {
   TRACE_EVENT0("impeller", "EntityPass::OnRender");
+
+  if (!active_clips_.empty()) {
+    VALIDATION_LOG << SPrintF(
+        "EntityPass (Depth=%d) contains one or more clips with an unresolved "
+        "depth value.",
+        pass_depth);
+  }
 
   InlinePassContext pass_context(renderer, pass_target,
                                  GetTotalPassReads(renderer), GetElementCount(),
@@ -1136,6 +1171,8 @@ std::unique_ptr<EntityPass> EntityPass::Clone() const {
 
   auto pass = std::make_unique<EntityPass>();
   pass->SetElements(std::move(new_elements));
+  pass->active_clips_.insert(pass->active_clips_.begin(), active_clips_.begin(),
+                             active_clips_.end());
   pass->backdrop_filter_reads_from_pass_texture_ =
       backdrop_filter_reads_from_pass_texture_;
   pass->advanced_blend_reads_from_pass_texture_ =
@@ -1143,6 +1180,7 @@ std::unique_ptr<EntityPass> EntityPass::Clone() const {
   pass->backdrop_filter_proc_ = backdrop_filter_proc_;
   pass->blend_mode_ = blend_mode_;
   pass->delegate_ = delegate_;
+  pass->new_clip_depth_ = new_clip_depth_;
   // Note: I tried also adding flood clip and bounds limit but one of the
   // two caused rendering in wonderous to break. It's 10:51 PM, and I'm
   // ready to move on.
@@ -1157,8 +1195,16 @@ void EntityPass::SetClipDepth(size_t clip_depth) {
   clip_depth_ = clip_depth;
 }
 
-size_t EntityPass::GetClipDepth() {
+size_t EntityPass::GetClipDepth() const {
   return clip_depth_;
+}
+
+void EntityPass::SetNewClipDepth(size_t clip_depth) {
+  new_clip_depth_ = clip_depth;
+}
+
+uint32_t EntityPass::GetNewClipDepth() const {
+  return new_clip_depth_;
 }
 
 void EntityPass::SetBlendMode(BlendMode blend_mode) {

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -76,6 +76,12 @@ class EntityPass {
   /// @brief Add an entity to the current entity pass.
   void AddEntity(Entity entity);
 
+  void PushClip(Entity entity);
+
+  void PopClips(size_t num_clips, uint64_t depth);
+
+  void PopAllClips(uint64_t depth);
+
   void SetElements(std::vector<Element> elements);
 
   //----------------------------------------------------------------------------
@@ -135,7 +141,11 @@ class EntityPass {
 
   void SetClipDepth(size_t clip_depth);
 
-  size_t GetClipDepth();
+  size_t GetClipDepth() const;
+
+  void SetNewClipDepth(size_t clip_depth);
+
+  uint32_t GetNewClipDepth() const;
 
   void SetBlendMode(BlendMode blend_mode);
 
@@ -297,9 +307,16 @@ class EntityPass {
   /// evaluated and recorded to an `EntityPassTarget` by the `OnRender` method.
   std::vector<Element> elements_;
 
+  /// The stack of currently active clips (during Aiks recording time). Each
+  /// entry is an index into the `elements_` list. The depth value of a clip is
+  /// the max of all the entities it affects, so assignment of the depth value
+  /// is deferred until clip restore or end of the EntityPass.
+  std::vector<size_t> active_clips_;
+
   EntityPass* superpass_ = nullptr;
   Matrix transform_;
   size_t clip_depth_ = 0u;
+  uint32_t new_clip_depth_ = 1u;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   bool flood_clip_ = false;
   bool enable_offscreen_debug_checkerboard_ = false;

--- a/impeller/entity/entity_playground.cc
+++ b/impeller/entity/entity_playground.cc
@@ -30,6 +30,12 @@ bool EntityPlayground::OpenPlaygroundHere(EntityPass& entity_pass) {
     return false;
   }
 
+  // Resolve any lingering tracked clips by assigning an arbitrarily high
+  // number. The number to assign just needs to be at least as high as larger
+  // any previously assigned clip depth in the scene. Normally, Aiks handles
+  // this correctly when wrapping up the base pass as an `impeller::Picture`.
+  entity_pass.PopAllClips(99999);
+
   auto callback = [&](RenderTarget& render_target) -> bool {
     return entity_pass.Render(content_context, render_target);
   };

--- a/impeller/entity/shaders/blending/framebuffer_blend.vert
+++ b/impeller/entity/shaders/blending/framebuffer_blend.vert
@@ -10,6 +10,7 @@
 // impeller/renderer/backend/vulkan/binding_helpers_vk.cc
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
   float src_y_coord_scale;
 }
 frame_info;
@@ -20,7 +21,7 @@ in vec2 src_texture_coords;
 out vec2 v_src_texture_coords;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(vertices, frame_info.depth, 1.0);
   v_src_texture_coords =
       IPRemapCoords(src_texture_coords, frame_info.src_y_coord_scale);
 }

--- a/impeller/entity/shaders/blending/porter_duff_blend.vert
+++ b/impeller/entity/shaders/blending/porter_duff_blend.vert
@@ -7,6 +7,7 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
   float texture_sampler_y_coord_scale;
 }
 frame_info;
@@ -19,7 +20,7 @@ out vec2 v_texture_coords;
 out f16vec4 v_color;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(vertices, frame_info.depth, 1.0);
   v_color = f16vec4(color);
   v_texture_coords =
       IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);

--- a/impeller/entity/shaders/clip.vert
+++ b/impeller/entity/shaders/clip.vert
@@ -6,11 +6,12 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
 }
 frame_info;
 
 in vec2 position;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
 }

--- a/impeller/entity/shaders/glyph_atlas.vert
+++ b/impeller/entity/shaders/glyph_atlas.vert
@@ -7,6 +7,7 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
   mat4 entity_transform;
   vec2 atlas_size;
   vec2 offset;
@@ -79,7 +80,7 @@ void main() {
                     0.0, 1.0);
   }
 
-  gl_Position = frame_info.mvp * position;
+  gl_Position = frame_info.mvp * vec4(position.xy, frame_info.depth, 1.0);
   v_uv = uv_origin + unit_position * uv_size;
   v_text_color = frame_info.text_color;
 }

--- a/impeller/entity/shaders/gradient_fill.vert
+++ b/impeller/entity/shaders/gradient_fill.vert
@@ -7,6 +7,7 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
   mat4 matrix;
 }
 frame_info;
@@ -16,6 +17,6 @@ in vec2 position;
 out vec2 v_position;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
   v_position = IPVec2TransformPosition(frame_info.matrix, position);
 }

--- a/impeller/entity/shaders/position_color.vert
+++ b/impeller/entity/shaders/position_color.vert
@@ -7,6 +7,7 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
 }
 frame_info;
 
@@ -16,6 +17,6 @@ in vec4 color;
 out f16vec4 v_color;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
   v_color = f16vec4(color);
 }

--- a/impeller/entity/shaders/rrect_blur.vert
+++ b/impeller/entity/shaders/rrect_blur.vert
@@ -6,6 +6,7 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
 }
 frame_info;
 
@@ -14,7 +15,7 @@ in vec2 position;
 out vec2 v_position;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
   // The fragment stage uses local coordinates to compute the blur.
   v_position = position;
 }

--- a/impeller/entity/shaders/runtime_effect.vert
+++ b/impeller/entity/shaders/runtime_effect.vert
@@ -6,6 +6,7 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
 }
 frame_info;
 
@@ -16,6 +17,6 @@ in vec2 position;
 out vec2 _fragCoord;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
   _fragCoord = position;
 }

--- a/impeller/entity/shaders/solid_fill.vert
+++ b/impeller/entity/shaders/solid_fill.vert
@@ -6,6 +6,7 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
   f16vec4 color;
 }
 frame_info;
@@ -16,5 +17,5 @@ IMPELLER_MAYBE_FLAT out f16vec4 v_color;
 
 void main() {
   v_color = frame_info.color;
-  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
 }

--- a/impeller/entity/shaders/texture_fill.vert
+++ b/impeller/entity/shaders/texture_fill.vert
@@ -7,6 +7,7 @@
 
 uniform FrameInfo {
   mat4 mvp;
+  float depth;
   float texture_sampler_y_coord_scale;
   float16_t alpha;
 }
@@ -19,7 +20,7 @@ out vec2 v_texture_coords;
 IMPELLER_MAYBE_FLAT out float16_t v_alpha;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
   v_alpha = frame_info.alpha;
   v_texture_coords =
       IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -154,12 +154,12 @@ struct TexImage2DData {
         // only use the stencil component.
         //
         // https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml
+      case PixelFormat::kD24UnormS8Uint:
         internal_format = GL_DEPTH_STENCIL;
         external_format = GL_DEPTH_STENCIL;
         type = GL_UNSIGNED_INT_24_8;
         break;
       case PixelFormat::kUnknown:
-      case PixelFormat::kD24UnormS8Uint:
       case PixelFormat::kD32FloatS8UInt:
       case PixelFormat::kR8UNormInt:
       case PixelFormat::kR8G8UNormInt:

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -2583,7 +2583,7 @@
     "Mali-G78": {
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/gles/clip.vert.gles",
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "type": "Vertex",
       "variants": {
         "Position": {
@@ -2634,7 +2634,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 28,
           "work_registers_used": 32
         }
       }
@@ -2652,7 +2652,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               3.0,
               0.0
             ],
@@ -2665,21 +2665,22 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               3.0,
               0.0
             ],
             "total_bound_pipelines": [
+              "arithmetic",
               "load_store"
             ],
             "total_cycles": [
-              2.6666667461395264,
+              3.0,
               3.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 5,
+          "uniform_registers_used": 7,
           "work_registers_used": 2
         }
       }
@@ -3611,9 +3612,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.515625,
-              0.515625,
-              0.140625,
+              0.390625,
+              0.390625,
+              0.09375,
               0.0,
               4.0,
               0.0
@@ -3630,8 +3631,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.484375,
-              0.484375,
+              0.328125,
+              0.328125,
               0.03125,
               0.0,
               4.0,
@@ -3641,9 +3642,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.737500011920929,
-              0.737500011920929,
-              0.15625,
+              0.546875,
+              0.546875,
+              0.109375,
               0.0,
               4.0,
               0.0
@@ -3651,7 +3652,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 48,
+          "uniform_registers_used": 46,
           "work_registers_used": 32
         },
         "Varying": {
@@ -3702,7 +3703,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 18,
+          "uniform_registers_used": 22,
           "work_registers_used": 16
         }
       }
@@ -3720,7 +3721,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              7.260000228881836,
+              6.929999828338623,
               8.0,
               0.0
             ],
@@ -3733,7 +3734,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              6.269999980926514,
+              5.940000057220459,
               8.0,
               0.0
             ],
@@ -3741,13 +3742,13 @@
               "arithmetic"
             ],
             "total_cycles": [
-              9.333333015441895,
+              9.0,
               8.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 13,
+          "uniform_registers_used": 12,
           "work_registers_used": 3
         }
       }
@@ -3876,7 +3877,7 @@
     "Mali-G78": {
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/gles/gradient_fill.vert.gles",
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "type": "Vertex",
       "variants": {
         "Position": {
@@ -3927,7 +3928,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 30,
+          "uniform_registers_used": 38,
           "work_registers_used": 32
         },
         "Varying": {
@@ -3978,7 +3979,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 18,
+          "uniform_registers_used": 22,
           "work_registers_used": 11
         }
       }
@@ -3996,7 +3997,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              3.299999952316284,
+              3.630000114440918,
               4.0,
               0.0
             ],
@@ -4009,7 +4010,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              3.299999952316284,
+              3.630000114440918,
               4.0,
               0.0
             ],
@@ -4017,14 +4018,14 @@
               "load_store"
             ],
             "total_cycles": [
-              3.3333332538604736,
+              3.6666667461395264,
               4.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 8,
-          "work_registers_used": 2
+          "uniform_registers_used": 10,
+          "work_registers_used": 3
         }
       }
     }
@@ -5102,7 +5103,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 22,
+          "uniform_registers_used": 30,
           "work_registers_used": 32
         },
         "Varying": {
@@ -5153,7 +5154,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 10,
+          "uniform_registers_used": 14,
           "work_registers_used": 12
         }
       }
@@ -5171,7 +5172,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.9700000286102295,
+              3.299999952316284,
               7.0,
               0.0
             ],
@@ -5184,7 +5185,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.9700000286102295,
+              3.299999952316284,
               7.0,
               0.0
             ],
@@ -5192,13 +5193,13 @@
               "load_store"
             ],
             "total_cycles": [
-              3.0,
+              3.3333332538604736,
               7.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 6,
+          "uniform_registers_used": 7,
           "work_registers_used": 2
         }
       }
@@ -5208,7 +5209,7 @@
     "Mali-G78": {
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/gles/position_color.vert.gles",
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "type": "Vertex",
       "variants": {
         "Position": {
@@ -5259,7 +5260,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 28,
           "work_registers_used": 32
         },
         "Varying": {
@@ -5310,7 +5311,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 8,
+          "uniform_registers_used": 12,
           "work_registers_used": 9
         }
       }
@@ -5328,7 +5329,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               5.0,
               0.0
             ],
@@ -5341,7 +5342,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               5.0,
               0.0
             ],
@@ -5349,13 +5350,13 @@
               "load_store"
             ],
             "total_cycles": [
-              2.6666667461395264,
+              3.0,
               5.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 5,
+          "uniform_registers_used": 7,
           "work_registers_used": 2
         }
       }
@@ -5600,7 +5601,7 @@
     "Mali-G78": {
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/gles/rrect_blur.vert.gles",
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "type": "Vertex",
       "variants": {
         "Position": {
@@ -5651,7 +5652,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 28,
           "work_registers_used": 32
         },
         "Varying": {
@@ -5702,7 +5703,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 8,
+          "uniform_registers_used": 12,
           "work_registers_used": 7
         }
       }
@@ -5720,7 +5721,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               4.0,
               0.0
             ],
@@ -5733,7 +5734,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               4.0,
               0.0
             ],
@@ -5741,13 +5742,13 @@
               "load_store"
             ],
             "total_cycles": [
-              2.6666667461395264,
+              3.0,
               4.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 5,
+          "uniform_registers_used": 7,
           "work_registers_used": 2
         }
       }
@@ -5757,7 +5758,7 @@
     "Mali-G78": {
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/gles/runtime_effect.vert.gles",
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "type": "Vertex",
       "variants": {
         "Position": {
@@ -5808,7 +5809,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 28,
           "work_registers_used": 32
         },
         "Varying": {
@@ -5859,7 +5860,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 8,
+          "uniform_registers_used": 12,
           "work_registers_used": 7
         }
       }
@@ -5877,7 +5878,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               4.0,
               0.0
             ],
@@ -5890,7 +5891,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               4.0,
               0.0
             ],
@@ -5898,13 +5899,13 @@
               "load_store"
             ],
             "total_cycles": [
-              2.6666667461395264,
+              3.0,
               4.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 5,
+          "uniform_registers_used": 7,
           "work_registers_used": 2
         }
       }
@@ -6031,7 +6032,7 @@
     "Mali-G78": {
       "core": "Mali-G78",
       "filename": "flutter/impeller/entity/gles/solid_fill.vert.gles",
-      "has_uniform_computation": false,
+      "has_uniform_computation": true,
       "type": "Vertex",
       "variants": {
         "Position": {
@@ -6082,7 +6083,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 24,
+          "uniform_registers_used": 32,
           "work_registers_used": 32
         },
         "Varying": {
@@ -6133,7 +6134,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
+          "uniform_registers_used": 16,
           "work_registers_used": 7
         }
       }
@@ -6151,7 +6152,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               4.0,
               0.0
             ],
@@ -6164,7 +6165,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.640000104904175,
+              2.9700000286102295,
               4.0,
               0.0
             ],
@@ -6172,13 +6173,13 @@
               "load_store"
             ],
             "total_cycles": [
-              2.6666667461395264,
+              3.0,
               4.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 6,
+          "uniform_registers_used": 8,
           "work_registers_used": 2
         }
       }
@@ -6753,7 +6754,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 22,
+          "uniform_registers_used": 30,
           "work_registers_used": 32
         },
         "Varying": {
@@ -6804,7 +6805,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 10,
+          "uniform_registers_used": 14,
           "work_registers_used": 8
         }
       }
@@ -6822,7 +6823,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.9700000286102295,
+              3.299999952316284,
               6.0,
               0.0
             ],
@@ -6835,7 +6836,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.9700000286102295,
+              3.299999952316284,
               6.0,
               0.0
             ],
@@ -6843,13 +6844,13 @@
               "load_store"
             ],
             "total_cycles": [
-              3.0,
+              3.3333332538604736,
               6.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 6,
+          "uniform_registers_used": 7,
           "work_registers_used": 2
         }
       }
@@ -7797,9 +7798,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.5,
-              0.5,
-              0.140625,
+              0.375,
+              0.375,
+              0.109375,
               0.0,
               4.0,
               0.0
@@ -7816,8 +7817,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.46875,
-              0.46875,
+              0.28125,
+              0.28125,
               0.03125,
               0.0,
               4.0,
@@ -7827,9 +7828,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.71875,
-              0.71875,
-              0.15625,
+              0.53125,
+              0.53125,
+              0.125,
               0.0,
               4.0,
               0.0
@@ -7837,7 +7838,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 56,
+          "uniform_registers_used": 50,
           "work_registers_used": 32
         },
         "Varying": {
@@ -7888,7 +7889,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 48,
+          "uniform_registers_used": 38,
           "work_registers_used": 13
         }
       }


### PR DESCRIPTION
- Add depth settings to pipeline variant hash.
- Assign new clip depth to all entities.
- Punt the final depth to all the vertex shaders.
- Add validations to assert all clip depths are resolved.