### PR TITLE
[Impeller] Reland: Switch from transient stencil-only to depth+stencil buffer.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3557,6 +3557,8 @@ TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
       .WillRepeatedly(::testing::Return(false));
   FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultColorFormat);
   FLT_FORWARD(mock_capabilities, old_capabilities, GetDefaultStencilFormat);
+  FLT_FORWARD(mock_capabilities, old_capabilities,
+              GetDefaultDepthStencilFormat);
   FLT_FORWARD(mock_capabilities, old_capabilities, SupportsOffscreenMSAA);
   FLT_FORWARD(mock_capabilities, old_capabilities,
               SupportsImplicitResolvingMSAA);

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -136,7 +136,8 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
   }
   desc.SetColorAttachmentDescriptor(0u, color0);
 
-  if (!has_stencil_attachment) {
+  if (!has_depth_stencil_attachments) {
+    desc.ClearDepthAttachment();
     desc.ClearStencilAttachments();
   }
 

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -285,7 +285,7 @@ struct ContentContextOptions {
   StencilOperation stencil_operation = StencilOperation::kKeep;
   PrimitiveType primitive_type = PrimitiveType::kTriangle;
   PixelFormat color_attachment_pixel_format = PixelFormat::kUnknown;
-  bool has_stencil_attachment = true;
+  bool has_depth_stencil_attachments = true;
   bool wireframe = false;
   bool is_for_rrect_blur_clear = false;
 
@@ -301,7 +301,7 @@ struct ContentContextOptions {
 
       return (o.is_for_rrect_blur_clear ? 1llu : 0llu) << 0 |
              (o.wireframe ? 1llu : 0llu) << 1 |
-             (o.has_stencil_attachment ? 1llu : 0llu) << 2 |
+             (o.has_depth_stencil_attachments ? 1llu : 0llu) << 2 |
              // enums
              static_cast<uint64_t>(o.color_attachment_pixel_format) << 16 |
              static_cast<uint64_t>(o.primitive_type) << 24 |
@@ -322,7 +322,8 @@ struct ContentContextOptions {
              lhs.primitive_type == rhs.primitive_type &&
              lhs.color_attachment_pixel_format ==
                  rhs.color_attachment_pixel_format &&
-             lhs.has_stencil_attachment == rhs.has_stencil_attachment &&
+             lhs.has_depth_stencil_attachments ==
+                 rhs.has_depth_stencil_attachments &&
              lhs.wireframe == rhs.wireframe &&
              lhs.is_for_rrect_blur_clear == rhs.is_for_rrect_blur_clear;
     }

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -21,7 +21,7 @@ ContentContextOptions OptionsFromPass(const RenderPass& pass) {
   ContentContextOptions opts;
   opts.sample_count = pass.GetSampleCount();
   opts.color_attachment_pixel_format = pass.GetRenderTargetPixelFormat();
-  opts.has_stencil_attachment = pass.HasStencilAttachment();
+  opts.has_depth_stencil_attachments = pass.HasStencilAttachment();
   return opts;
 }
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -431,7 +431,8 @@ bool EntityPass::Render(ContentContext& renderer,
   // If a root stencil was provided by the caller, then verify that it has a
   // configuration which can be used to render this pass.
   auto stencil_attachment = root_render_target.GetStencilAttachment();
-  if (stencil_attachment.has_value()) {
+  auto depth_attachment = root_render_target.GetDepthAttachment();
+  if (stencil_attachment.has_value() && depth_attachment.has_value()) {
     auto stencil_texture = stencil_attachment->texture;
     if (!stencil_texture) {
       VALIDATION_LOG << "The root RenderTarget must have a stencil texture.";
@@ -450,7 +451,7 @@ bool EntityPass::Render(ContentContext& renderer,
   // Setup a new root stencil with an optimal configuration if one wasn't
   // provided by the caller.
   else {
-    root_render_target.SetupStencilAttachment(
+    root_render_target.SetupDepthStencilAttachments(
         *renderer.GetContext(), *renderer.GetRenderTargetCache(),
         color0.texture->GetSize(),
         renderer.GetContext()->GetCapabilities()->SupportsOffscreenMSAA(),

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2619,9 +2619,9 @@ TEST_P(EntityTest, SpecializationConstantsAreAppliedToVariants) {
       ContentContext(GetContext(), TypographerContextSkia::Make());
 
   auto default_color_burn = content_context.GetBlendColorBurnPipeline(
-      {.has_stencil_attachment = false});
+      {.has_depth_stencil_attachments = false});
   auto alt_color_burn = content_context.GetBlendColorBurnPipeline(
-      {.has_stencil_attachment = true});
+      {.has_depth_stencil_attachments = true});
 
   ASSERT_NE(default_color_burn, alt_color_burn);
   ASSERT_EQ(default_color_burn->GetDescriptor().GetSpecializationConstants(),
@@ -2690,7 +2690,7 @@ TEST_P(EntityTest, ContentContextOptionsHasReasonableHashFunctions) {
   opts.blend_mode = BlendMode::kColorBurn;
   auto hash_b = ContentContextOptions::Hash{}(opts);
 
-  opts.has_stencil_attachment = false;
+  opts.has_depth_stencil_attachments = false;
   auto hash_c = ContentContextOptions::Hash{}(opts);
 
   opts.primitive_type = PrimitiveType::kPoint;

--- a/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -41,7 +41,7 @@ static std::optional<GLuint> ConfigureFBO(
   gl.BindFramebuffer(fbo_type, fbo);
 
   if (!TextureGLES::Cast(*texture).SetAsFramebufferAttachment(
-          fbo_type, TextureGLES::AttachmentPoint::kColor0)) {
+          fbo_type, TextureGLES::AttachmentType::kColor0)) {
     VALIDATION_LOG << "Could not attach texture to framebuffer.";
     DeleteFBO(gl, fbo, fbo_type);
     return std::nullopt;

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -186,20 +186,20 @@ struct RenderPassData {
 
     if (auto color = TextureGLES::Cast(pass_data.color_attachment.get())) {
       if (!color->SetAsFramebufferAttachment(
-              GL_FRAMEBUFFER, TextureGLES::AttachmentPoint::kColor0)) {
+              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kColor0)) {
         return false;
       }
     }
 
     if (auto depth = TextureGLES::Cast(pass_data.depth_attachment.get())) {
       if (!depth->SetAsFramebufferAttachment(
-              GL_FRAMEBUFFER, TextureGLES::AttachmentPoint::kDepth)) {
+              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kDepth)) {
         return false;
       }
     }
     if (auto stencil = TextureGLES::Cast(pass_data.stencil_attachment.get())) {
       if (!stencil->SetAsFramebufferAttachment(
-              GL_FRAMEBUFFER, TextureGLES::AttachmentPoint::kStencil)) {
+              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kStencil)) {
         return false;
       }
     }

--- a/impeller/renderer/backend/gles/surface_gles.cc
+++ b/impeller/renderer/backend/gles/surface_gles.cc
@@ -40,24 +40,34 @@ std::unique_ptr<Surface> SurfaceGLES::WrapFBO(
   color0.load_action = LoadAction::kClear;
   color0.store_action = StoreAction::kStore;
 
-  TextureDescriptor stencil0_tex;
-  stencil0_tex.type = TextureType::kTexture2D;
-  stencil0_tex.format = color_format;
-  stencil0_tex.size = fbo_size;
-  stencil0_tex.usage =
+  TextureDescriptor depth_stencil_texture_desc;
+  depth_stencil_texture_desc.type = TextureType::kTexture2D;
+  depth_stencil_texture_desc.format = color_format;
+  depth_stencil_texture_desc.size = fbo_size;
+  depth_stencil_texture_desc.usage =
       static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
-  stencil0_tex.sample_count = SampleCount::kCount1;
+  depth_stencil_texture_desc.sample_count = SampleCount::kCount1;
+
+  auto depth_stencil_tex = std::make_shared<TextureGLES>(
+      gl_context.GetReactor(), depth_stencil_texture_desc,
+      TextureGLES::IsWrapped::kWrapped);
+
+  DepthAttachment depth0;
+  depth0.clear_depth = 0;
+  depth0.texture = depth_stencil_tex;
+  depth0.load_action = LoadAction::kClear;
+  depth0.store_action = StoreAction::kDontCare;
 
   StencilAttachment stencil0;
   stencil0.clear_stencil = 0;
-  stencil0.texture = std::make_shared<TextureGLES>(
-      gl_context.GetReactor(), stencil0_tex, TextureGLES::IsWrapped::kWrapped);
+  stencil0.texture = depth_stencil_tex;
   stencil0.load_action = LoadAction::kClear;
   stencil0.store_action = StoreAction::kDontCare;
 
   RenderTarget render_target_desc;
 
   render_target_desc.SetColorAttachment(color0, 0u);
+  render_target_desc.SetDepthAttachment(depth0);
   render_target_desc.SetStencilAttachment(stencil0);
 
 #ifdef IMPELLER_DEBUG

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -41,13 +41,14 @@ class TextureGLES final : public Texture,
 
   [[nodiscard]] bool GenerateMipmap();
 
-  enum class AttachmentPoint {
+  enum class AttachmentType {
     kColor0,
     kDepth,
     kStencil,
   };
-  [[nodiscard]] bool SetAsFramebufferAttachment(GLenum target,
-                                                AttachmentPoint point) const;
+  [[nodiscard]] bool SetAsFramebufferAttachment(
+      GLenum target,
+      AttachmentType attachment_type) const;
 
   Type GetType() const;
 

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -196,7 +196,8 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
     }
   }
 
-  if (auto depth = render_target_.GetDepthAttachment(); depth.has_value()) {
+  auto depth = render_target_.GetDepthAttachment();
+  if (depth.has_value()) {
     depth_stencil_ref = vk::AttachmentReference{
         static_cast<uint32_t>(attachments.size()),
         vk::ImageLayout::eDepthStencilAttachmentOptimal};
@@ -213,8 +214,14 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
         vk::ImageLayout::eDepthStencilAttachmentOptimal};
     attachments.emplace_back(CreateAttachmentDescription(
         stencil.value(), &Attachment::texture, supports_framebuffer_fetch));
-    SetTextureLayout(stencil.value(), attachments.back(), command_buffer,
-                     &Attachment::texture);
+
+    // If the depth and stencil are stored in the same texture, then we've
+    // already inserted a memory barrier to transition this texture as part of
+    // the depth branch above.
+    if (depth.has_value() && depth->texture != stencil->texture) {
+      SetTextureLayout(stencil.value(), attachments.back(), command_buffer,
+                       &Attachment::texture);
+    }
   }
 
   vk::SubpassDescription subpass_desc;

--- a/impeller/renderer/compute_subgroup_unittests.cc
+++ b/impeller/renderer/compute_subgroup_unittests.cc
@@ -140,7 +140,7 @@ TEST_P(ComputeSubgroupTest, PathPlayground) {
     options.sample_count = pass.GetRenderTarget().GetSampleCount();
     options.color_attachment_pixel_format =
         pass.GetRenderTarget().GetRenderTargetPixelFormat();
-    options.has_stencil_attachment =
+    options.has_depth_stencil_attachments =
         pass.GetRenderTarget().GetStencilAttachment().has_value();
     options.blend_mode = BlendMode::kSourceIn;
     options.primitive_type = PrimitiveType::kTriangleStrip;
@@ -337,7 +337,7 @@ TEST_P(ComputeSubgroupTest, LargePath) {
     options.sample_count = pass.GetRenderTarget().GetSampleCount();
     options.color_attachment_pixel_format =
         pass.GetRenderTarget().GetRenderTargetPixelFormat();
-    options.has_stencil_attachment =
+    options.has_depth_stencil_attachments =
         pass.GetRenderTarget().GetStencilAttachment().has_value();
     options.blend_mode = BlendMode::kSourceIn;
     options.primitive_type = PrimitiveType::kTriangleStrip;
@@ -415,7 +415,7 @@ TEST_P(ComputeSubgroupTest, QuadAndCubicInOnePath) {
     options.sample_count = pass.GetRenderTarget().GetSampleCount();
     options.color_attachment_pixel_format =
         pass.GetRenderTarget().GetRenderTargetPixelFormat();
-    options.has_stencil_attachment =
+    options.has_depth_stencil_attachments =
         pass.GetRenderTarget().GetStencilAttachment().has_value();
     options.blend_mode = BlendMode::kSourceIn;
     options.primitive_type = PrimitiveType::kTriangleStrip;

--- a/impeller/renderer/pipeline_builder.h
+++ b/impeller/renderer/pipeline_builder.h
@@ -107,13 +107,22 @@ struct PipelineBuilder {
       desc.SetColorAttachmentDescriptor(0u, color0);
     }
 
+    // Setup default depth buffer descriptions.
+    {
+      DepthAttachmentDescriptor depth0;
+      depth0.depth_compare = CompareFunction::kGreater;
+      desc.SetDepthStencilAttachmentDescriptor(depth0);
+      desc.SetDepthPixelFormat(
+          context.GetCapabilities()->GetDefaultDepthStencilFormat());
+    }
+
     // Setup default stencil buffer descriptions.
     {
       StencilAttachmentDescriptor stencil0;
       stencil0.stencil_compare = CompareFunction::kEqual;
       desc.SetStencilAttachmentDescriptors(stencil0);
       desc.SetStencilPixelFormat(
-          context.GetCapabilities()->GetDefaultStencilFormat());
+          context.GetCapabilities()->GetDefaultDepthStencilFormat());
     }
 
     return true;

--- a/impeller/renderer/pipeline_builder.h
+++ b/impeller/renderer/pipeline_builder.h
@@ -110,7 +110,7 @@ struct PipelineBuilder {
     // Setup default depth buffer descriptions.
     {
       DepthAttachmentDescriptor depth0;
-      depth0.depth_compare = CompareFunction::kGreater;
+      depth0.depth_compare = CompareFunction::kAlways;
       desc.SetDepthStencilAttachmentDescriptor(depth0);
       desc.SetDepthPixelFormat(
           context.GetCapabilities()->GetDefaultDepthStencilFormat());

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -350,6 +350,7 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
     target.SetupDepthStencilAttachments(context, allocator, size, true, label,
                                         stencil_attachment_config.value());
   } else {
+    target.SetDepthAttachment(std::nullopt);
     target.SetStencilAttachment(std::nullopt);
   }
 
@@ -414,9 +415,6 @@ size_t RenderTarget::GetTotalAttachmentCount() const {
     count++;
   }
   if (stencil_.has_value()) {
-    count++;
-  }
-  if (depth_.has_value()) {
     count++;
   }
   return count;

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -9,6 +9,7 @@
 #include "impeller/base/strings.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/allocator.h"
+#include "impeller/core/formats.h"
 #include "impeller/core/texture.h"
 #include "impeller/renderer/context.h"
 

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -255,8 +255,8 @@ RenderTarget RenderTarget::CreateOffscreen(
   target.SetColorAttachment(color0, 0u);
 
   if (stencil_attachment_config.has_value()) {
-    target.SetupStencilAttachment(context, allocator, size, false, label,
-                                  stencil_attachment_config.value());
+    target.SetupDepthStencilAttachments(context, allocator, size, false, label,
+                                        stencil_attachment_config.value());
   } else {
     target.SetStencilAttachment(std::nullopt);
   }
@@ -347,8 +347,8 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   // Create MSAA stencil texture.
 
   if (stencil_attachment_config.has_value()) {
-    target.SetupStencilAttachment(context, allocator, size, true, label,
-                                  stencil_attachment_config.value());
+    target.SetupDepthStencilAttachments(context, allocator, size, true, label,
+                                        stencil_attachment_config.value());
   } else {
     target.SetStencilAttachment(std::nullopt);
   }
@@ -356,34 +356,47 @@ RenderTarget RenderTarget::CreateOffscreenMSAA(
   return target;
 }
 
-void RenderTarget::SetupStencilAttachment(
+void RenderTarget::SetupDepthStencilAttachments(
     const Context& context,
     RenderTargetAllocator& allocator,
     ISize size,
     bool msaa,
     const std::string& label,
     AttachmentConfig stencil_attachment_config) {
-  TextureDescriptor stencil_tex0;
-  stencil_tex0.storage_mode = stencil_attachment_config.storage_mode;
+  TextureDescriptor depth_stencil_texture_desc;
+  depth_stencil_texture_desc.storage_mode =
+      stencil_attachment_config.storage_mode;
   if (msaa) {
-    stencil_tex0.type = TextureType::kTexture2DMultisample;
-    stencil_tex0.sample_count = SampleCount::kCount4;
+    depth_stencil_texture_desc.type = TextureType::kTexture2DMultisample;
+    depth_stencil_texture_desc.sample_count = SampleCount::kCount4;
   }
-  stencil_tex0.format = context.GetCapabilities()->GetDefaultStencilFormat();
-  stencil_tex0.size = size;
-  stencil_tex0.usage =
+  depth_stencil_texture_desc.format =
+      context.GetCapabilities()->GetDefaultDepthStencilFormat();
+  depth_stencil_texture_desc.size = size;
+  depth_stencil_texture_desc.usage =
       static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+
+  auto depth_stencil_texture =
+      allocator.CreateTexture(depth_stencil_texture_desc);
+  if (!depth_stencil_texture) {
+    return;  // Error messages are handled by `Allocator::CreateTexture`.
+  }
+
+  DepthAttachment depth0;
+  depth0.load_action = stencil_attachment_config.load_action;
+  depth0.store_action = stencil_attachment_config.store_action;
+  depth0.clear_depth = 0u;
+  depth0.texture = depth_stencil_texture;
 
   StencilAttachment stencil0;
   stencil0.load_action = stencil_attachment_config.load_action;
   stencil0.store_action = stencil_attachment_config.store_action;
   stencil0.clear_stencil = 0u;
-  stencil0.texture = allocator.CreateTexture(stencil_tex0);
+  stencil0.texture = depth_stencil_texture;
 
-  if (!stencil0.texture) {
-    return;  // Error messages are handled by `Allocator::CreateTexture`.
-  }
-  stencil0.texture->SetLabel(SPrintF("%s Stencil Texture", label.c_str()));
+  stencil0.texture->SetLabel(
+      SPrintF("%s Depth+Stencil Texture", label.c_str()));
+  SetDepthAttachment(std::move(depth0));
   SetStencilAttachment(std::move(stencil0));
 }
 
@@ -401,6 +414,9 @@ size_t RenderTarget::GetTotalAttachmentCount() const {
     count++;
   }
   if (stencil_.has_value()) {
+    count++;
+  }
+  if (depth_.has_value()) {
     count++;
   }
   return count;

--- a/impeller/renderer/render_target.h
+++ b/impeller/renderer/render_target.h
@@ -109,13 +109,13 @@ class RenderTarget final {
 
   bool IsValid() const;
 
-  void SetupStencilAttachment(const Context& context,
-                              RenderTargetAllocator& allocator,
-                              ISize size,
-                              bool msaa,
-                              const std::string& label = "Offscreen",
-                              AttachmentConfig stencil_attachment_config =
-                                  kDefaultStencilAttachmentConfig);
+  void SetupDepthStencilAttachments(const Context& context,
+                                    RenderTargetAllocator& allocator,
+                                    ISize size,
+                                    bool msaa,
+                                    const std::string& label = "Offscreen",
+                                    AttachmentConfig stencil_attachment_config =
+                                        kDefaultStencilAttachmentConfig);
 
   SampleCount GetSampleCount() const;
 

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -1161,9 +1161,9 @@ TEST_P(RendererTest, StencilMask) {
       stencil_config.storage_mode = StorageMode::kHostVisible;
       auto render_target_allocator =
           RenderTargetAllocator(context->GetResourceAllocator());
-      render_target.SetupStencilAttachment(*context, render_target_allocator,
-                                           render_target.GetRenderTargetSize(),
-                                           true, "stencil", stencil_config);
+      render_target.SetupDepthStencilAttachments(
+          *context, render_target_allocator,
+          render_target.GetRenderTargetSize(), true, "stencil", stencil_config);
       // Fill the stencil buffer with an checkerboard pattern.
       const auto target_width = render_target.GetRenderTargetSize().width;
       const auto target_height = render_target.GetRenderTargetSize().height;
@@ -1273,6 +1273,20 @@ TEST_P(RendererTest, CanLookupRenderTargetProperties) {
   EXPECT_EQ(render_pass->GetRenderTargetSize(),
             render_target.GetRenderTargetSize());
   render_pass->EncodeCommands();
+}
+
+TEST_P(RendererTest,
+       RenderTargetCreateOffscreenMSAASetsDefaultDepthStencilFormat) {
+  auto context = GetContext();
+  auto render_target_cache = std::make_shared<RenderTargetAllocator>(
+      GetContext()->GetResourceAllocator());
+
+  RenderTarget render_target = RenderTarget::CreateOffscreenMSAA(
+      *context, *render_target_cache, {100, 100}, /*mip_count=*/1);
+  EXPECT_EQ(render_target.GetDepthAttachment()
+                ->texture->GetTextureDescriptor()
+                .format,
+            GetContext()->GetCapabilities()->GetDefaultDepthStencilFormat());
 }
 
 }  // namespace testing


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/138460.

In preparation for [draw order optimization](https://github.com/flutter/flutter/issues/114402) and [StC](https://github.com/flutter/flutter/issues/123671).

Use a transient depth+stencil texture instead of a stencil-only texture. Doing this in isolation to detect/weed out any bugs with handling the attachment.