### PR TITLE
Delete trace event from DeviceBufferVK

### DIFF
--- a/impeller/renderer/backend/vulkan/device_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.cc
@@ -31,7 +31,6 @@ uint8_t* DeviceBufferVK::OnGetContents() const {
 bool DeviceBufferVK::OnCopyHostBuffer(const uint8_t* source,
                                       Range source_range,
                                       size_t offset) {
-  TRACE_EVENT0("impeller", "CopyToDeviceBuffer");
   uint8_t* dest = OnGetContents();
 
   if (!dest) {


### PR DESCRIPTION
We don't have this in the GLES or MTL backends, and it's showing up in profiling.
