### PR TITLE
[Android] Fix KeyEmbedderResponder throws a NullPointerException

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
@@ -398,9 +398,11 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
             ? null
             : message -> {
               Boolean handled = false;
-              message.rewind();
-              if (message.capacity() != 0) {
-                handled = message.get() != 0;
+              if (message != null) {
+                message.rewind();
+                if (message.capacity() != 0) {
+                  handled = message.get() != 0;
+                }
               }
               onKeyEventHandledCallback.onKeyEventHandled(handled);
             };

--- a/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
@@ -8,6 +8,7 @@ import android.view.InputDevice;
 import android.view.KeyEvent;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import io.flutter.Log;
 import io.flutter.embedding.android.KeyboardMap.PressingGoal;
 import io.flutter.embedding.android.KeyboardMap.TogglingGoal;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -403,6 +404,8 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
                 if (message.capacity() != 0) {
                   handled = message.get() != 0;
                 }
+              } else {
+                Log.w(TAG, "A null reply was received when sending a key event to the framework.");
               }
               onKeyEventHandledCallback.onKeyEventHandled(handled);
             };


### PR DESCRIPTION
## Description

This PR fixes a `NullPointerException` thrown from `KeyEmbedderResponder` when pressing a key during a hot restart (at this time the framework might not be ready and null reply is sent back).

## Related Issue

Fixes https://github.com/flutter/flutter/issues/141662.

## Tests

Adds 1 test.