### PR TITLE
[Windows] Refactor logic when window resize completes

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -329,7 +329,7 @@ bool AngleSurfaceManager::MakeResourceCurrent() {
                          egl_resource_context_) == EGL_TRUE);
 }
 
-EGLBoolean AngleSurfaceManager::SwapBuffers() {
+bool AngleSurfaceManager::SwapBuffers() {
   return (eglSwapBuffers(egl_display_, render_surface_));
 }
 

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -77,7 +77,7 @@ class AngleSurfaceManager {
 
   // Swaps the front and back buffers of the DX11 swapchain backing surface if
   // not null.
-  EGLBoolean SwapBuffers();
+  virtual bool SwapBuffers();
 
   // Creates a |EGLSurface| from the provided handle.
   EGLSurface CreateSurfaceFromHandle(EGLenum handle_type,

--- a/shell/platform/windows/compositor_opengl.cc
+++ b/shell/platform/windows/compositor_opengl.cc
@@ -154,7 +154,12 @@ bool CompositorOpenGL::Present(const FlutterLayer** layers,
                        GL_NEAREST            // filter
   );
 
-  return engine_->view()->SwapBuffers();
+  if (!engine_->surface_manager()->SwapBuffers()) {
+    return false;
+  }
+
+  engine_->view()->OnFramePresented();
+  return true;
 }
 
 bool CompositorOpenGL::Initialize() {
@@ -188,7 +193,12 @@ bool CompositorOpenGL::ClearSurface() {
   gl_->ClearColor(0.0f, 0.0f, 0.0f, 0.0f);
   gl_->Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
-  return engine_->view()->SwapBuffers();
+  if (!engine_->surface_manager()->SwapBuffers()) {
+    return false;
+  }
+
+  engine_->view()->OnFramePresented();
+  return true;
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/compositor_opengl_unittests.cc
+++ b/shell/platform/windows/compositor_opengl_unittests.cc
@@ -11,6 +11,7 @@
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/testing/engine_modifier.h"
 #include "flutter/shell/platform/windows/testing/flutter_windows_engine_builder.h"
+#include "flutter/shell/platform/windows/testing/mock_angle_surface_manager.h"
 #include "flutter/shell/platform/windows/testing/mock_window_binding_handler.h"
 #include "flutter/shell/platform/windows/testing/windows_test.h"
 #include "gmock/gmock.h"
@@ -56,23 +57,11 @@ const impeller::ProcTableGLES::Resolver kMockResolver = [](const char* name) {
   }
 };
 
-class MockAngleSurfaceManager : public AngleSurfaceManager {
- public:
-  MockAngleSurfaceManager() : AngleSurfaceManager(false) {}
-
-  MOCK_METHOD(bool, MakeCurrent, (), (override));
-
- private:
-  FML_DISALLOW_COPY_AND_ASSIGN(MockAngleSurfaceManager);
-};
-
 class MockFlutterWindowsView : public FlutterWindowsView {
  public:
   MockFlutterWindowsView(std::unique_ptr<WindowBindingHandler> window)
       : FlutterWindowsView(std::move(window)) {}
   virtual ~MockFlutterWindowsView() = default;
-
-  MOCK_METHOD(bool, SwapBuffers, (), (override));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsView);
@@ -163,7 +152,7 @@ TEST_F(CompositorOpenGLTest, Present) {
   const FlutterLayer* layer_ptr = &layer;
 
   EXPECT_CALL(*surface_manager(), MakeCurrent).WillOnce(Return(true));
-  EXPECT_CALL(*view(), SwapBuffers).WillOnce(Return(true));
+  EXPECT_CALL(*surface_manager(), SwapBuffers).WillOnce(Return(true));
   EXPECT_TRUE(compositor.Present(&layer_ptr, 1));
 
   ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
@@ -179,7 +168,7 @@ TEST_F(CompositorOpenGLTest, PresentEmpty) {
   EXPECT_CALL(*surface_manager(), MakeCurrent)
       .Times(2)
       .WillRepeatedly(Return(true));
-  EXPECT_CALL(*view(), SwapBuffers).WillOnce(Return(true));
+  EXPECT_CALL(*surface_manager(), SwapBuffers).WillOnce(Return(true));
   EXPECT_TRUE(compositor.Present(nullptr, 0));
 }
 

--- a/shell/platform/windows/compositor_opengl_unittests.cc
+++ b/shell/platform/windows/compositor_opengl_unittests.cc
@@ -57,16 +57,6 @@ const impeller::ProcTableGLES::Resolver kMockResolver = [](const char* name) {
   }
 };
 
-class MockFlutterWindowsView : public FlutterWindowsView {
- public:
-  MockFlutterWindowsView(std::unique_ptr<WindowBindingHandler> window)
-      : FlutterWindowsView(std::move(window)) {}
-  virtual ~MockFlutterWindowsView() = default;
-
- private:
-  FML_DISALLOW_COPY_AND_ASSIGN(MockFlutterWindowsView);
-};
-
 class CompositorOpenGLTest : public WindowsTest {
  public:
   CompositorOpenGLTest() = default;
@@ -74,7 +64,6 @@ class CompositorOpenGLTest : public WindowsTest {
 
  protected:
   FlutterWindowsEngine* engine() { return engine_.get(); }
-  MockFlutterWindowsView* view() { return view_.get(); }
   MockAngleSurfaceManager* surface_manager() { return surface_manager_; }
 
   void UseHeadlessEngine() {
@@ -95,14 +84,14 @@ class CompositorOpenGLTest : public WindowsTest {
     EXPECT_CALL(*window.get(), SetView).Times(1);
     EXPECT_CALL(*window.get(), GetWindowHandle).WillRepeatedly(Return(nullptr));
 
-    view_ = std::make_unique<MockFlutterWindowsView>(std::move(window));
+    view_ = std::make_unique<FlutterWindowsView>(std::move(window));
 
     engine_->SetView(view_.get());
   }
 
  private:
   std::unique_ptr<FlutterWindowsEngine> engine_;
-  std::unique_ptr<MockFlutterWindowsView> view_;
+  std::unique_ptr<FlutterWindowsView> view_;
   MockAngleSurfaceManager* surface_manager_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(CompositorOpenGLTest);

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -168,10 +168,6 @@ float FlutterWindow::GetDpiScale() {
   return static_cast<float>(GetCurrentDPI()) / static_cast<float>(base_dpi);
 }
 
-bool FlutterWindow::IsVisible() {
-  return IsWindowVisible(GetWindowHandle());
-}
-
 PhysicalWindowBounds FlutterWindow::GetPhysicalWindowBounds() {
   return {GetCurrentWidth(), GetCurrentHeight()};
 }

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -159,9 +159,6 @@ class FlutterWindow : public KeyboardManager::WindowDelegate,
   virtual float GetDpiScale() override;
 
   // |FlutterWindowBindingHandler|
-  virtual bool IsVisible() override;
-
-  // |FlutterWindowBindingHandler|
   virtual PhysicalWindowBounds GetPhysicalWindowBounds() override;
 
   // |FlutterWindowBindingHandler|

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -66,7 +66,6 @@ class MockFlutterWindow : public FlutterWindow {
   MOCK_METHOD(void, OnSetCursor, (), (override));
   MOCK_METHOD(float, GetScrollOffsetMultiplier, (), (override));
   MOCK_METHOD(float, GetDpiScale, (), (override));
-  MOCK_METHOD(bool, IsVisible, (), (override));
   MOCK_METHOD(void, UpdateCursorRect, (const Rect&), (override));
   MOCK_METHOD(void, OnResetImeComposing, (), (override));
   MOCK_METHOD(UINT, Win32DispatchMessage, (UINT, WPARAM, LPARAM), (override));

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -62,17 +62,6 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // Tells the engine to generate a new frame
   void ForceRedraw();
 
-  // Swap the view's surface buffers. Must be called on the engine's raster
-  // thread. Returns true if the buffers were swapped.
-  //
-  // |OnFrameGenerated| or |OnEmptyFrameGenerated| must be called before this
-  // method.
-  //
-  // If the view is resizing, this returns false if the frame is not the target
-  // size. Otherwise, it unblocks the platform thread and blocks the raster
-  // thread until the v-blank.
-  virtual bool SwapBuffers();
-
   // Callback to clear a previously presented software bitmap.
   virtual bool ClearSoftwareBitmap();
 
@@ -102,6 +91,11 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // This resizes the surface if a resize is pending and |width| and
   // |height| match the target size.
   bool OnFrameGenerated(size_t width, size_t height);
+
+  // Called on the raster thread after |CompositorOpenGL| presents a frame.
+  //
+  // This completes a view resize if one is pending.
+  virtual void OnFramePresented();
 
   // Sets the cursor that should be used when the mouse is over the Flutter
   // content. See mouse_cursor.dart for the values and meanings of cursor_name.

--- a/shell/platform/windows/testing/mock_angle_surface_manager.h
+++ b/shell/platform/windows/testing/mock_angle_surface_manager.h
@@ -25,6 +25,8 @@ class MockAngleSurfaceManager : public AngleSurfaceManager {
   MOCK_METHOD(bool, ClearCurrent, (), (override));
   MOCK_METHOD(void, SetVSyncEnabled, (bool), (override));
 
+  MOCK_METHOD(bool, SwapBuffers, (), (override));
+
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockAngleSurfaceManager);
 };

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -22,7 +22,6 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD(void, SetView, (WindowBindingHandlerDelegate * view), (override));
   MOCK_METHOD(HWND, GetWindowHandle, (), (override));
   MOCK_METHOD(float, GetDpiScale, (), (override));
-  MOCK_METHOD(bool, IsVisible, (), (override));
   MOCK_METHOD(PhysicalWindowBounds, GetPhysicalWindowBounds, (), (override));
   MOCK_METHOD(void,
               UpdateFlutterCursor,

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -51,9 +51,6 @@ class WindowBindingHandler {
   // Returns the scale factor for the backing window.
   virtual float GetDpiScale() = 0;
 
-  // Returns whether the HWND is currently visible.
-  virtual bool IsVisible() = 0;
-
   // Returns the bounds of the backing window in physical pixels.
   virtual PhysicalWindowBounds GetPhysicalWindowBounds() = 0;
 


### PR DESCRIPTION
Changes:

1. Moves surface buffer swapping from `FlutterWindowsView` to `CompositorOpenGL`
1. Renames `FlutterWindowsView::SwapBuffers` to `FlutterWindowsView::OnFramePresented`
2. Previously, if a resize was pending and the window was not visible Windows would unblock the platform thread before swapping buffers. This trick aimed to reduce the time the platform thread was blocked as swapping buffers previously waited until the v-blank. This logic was removed as swapping buffers no longer waits until the v-blank.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
