### PR TITLE
[Impeller] use string view for labels in more places to defer allocatons.

### DIFF
--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/vulkan/command_encoder_vk.h"
+#include <string>
 
 #include "flutter/fml/closure.h"
 #include "fml/status.h"
@@ -222,12 +223,13 @@ fml::StatusOr<vk::DescriptorSet> CommandEncoderVK::AllocateDescriptorSets(
                                                                       context);
 }
 
-void CommandEncoderVK::PushDebugGroup(const char* label) const {
+void CommandEncoderVK::PushDebugGroup(std::string_view label) const {
   if (!HasValidationLayers()) {
     return;
   }
+  std::string label_copy(label);
   vk::DebugUtilsLabelEXT label_info;
-  label_info.pLabelName = label;
+  label_info.pLabelName = label_copy.c_str();
   if (auto command_buffer = GetCommandBuffer()) {
     command_buffer.beginDebugUtilsLabelEXT(label_info);
   }
@@ -242,17 +244,18 @@ void CommandEncoderVK::PopDebugGroup() const {
   }
 }
 
-void CommandEncoderVK::InsertDebugMarker(const char* label) const {
+void CommandEncoderVK::InsertDebugMarker(std::string_view label) const {
   if (!HasValidationLayers()) {
     return;
   }
+  std::string label_copy(label);
   vk::DebugUtilsLabelEXT label_info;
-  label_info.pLabelName = label;
+  label_info.pLabelName = label_copy.c_str();
   if (auto command_buffer = GetCommandBuffer()) {
     command_buffer.insertDebugUtilsLabelEXT(label_info);
   }
   if (queue_) {
-    queue_->InsertDebugMarker(label);
+    queue_->InsertDebugMarker(label_copy.c_str());
   }
 }
 

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.cc
@@ -227,9 +227,8 @@ void CommandEncoderVK::PushDebugGroup(std::string_view label) const {
   if (!HasValidationLayers()) {
     return;
   }
-  std::string label_copy(label);
   vk::DebugUtilsLabelEXT label_info;
-  label_info.pLabelName = label_copy.c_str();
+  label_info.pLabelName = label.data();
   if (auto command_buffer = GetCommandBuffer()) {
     command_buffer.beginDebugUtilsLabelEXT(label_info);
   }
@@ -248,14 +247,13 @@ void CommandEncoderVK::InsertDebugMarker(std::string_view label) const {
   if (!HasValidationLayers()) {
     return;
   }
-  std::string label_copy(label);
   vk::DebugUtilsLabelEXT label_info;
-  label_info.pLabelName = label_copy.c_str();
+  label_info.pLabelName = label.data();
   if (auto command_buffer = GetCommandBuffer()) {
     command_buffer.insertDebugUtilsLabelEXT(label_info);
   }
   if (queue_) {
-    queue_->InsertDebugMarker(label_copy.c_str());
+    queue_->InsertDebugMarker(label);
   }
 }
 

--- a/impeller/renderer/backend/vulkan/command_encoder_vk.h
+++ b/impeller/renderer/backend/vulkan/command_encoder_vk.h
@@ -76,11 +76,11 @@ class CommandEncoderVK {
 
   vk::CommandBuffer GetCommandBuffer() const;
 
-  void PushDebugGroup(const char* label) const;
+  void PushDebugGroup(std::string_view label) const;
 
   void PopDebugGroup() const;
 
-  void InsertDebugMarker(const char* label) const;
+  void InsertDebugMarker(std::string_view label) const;
 
   fml::StatusOr<vk::DescriptorSet> AllocateDescriptorSets(
       const vk::DescriptorSetLayout& layout,

--- a/impeller/renderer/backend/vulkan/queue_vk.cc
+++ b/impeller/renderer/backend/vulkan/queue_vk.cc
@@ -27,9 +27,8 @@ void QueueVK::InsertDebugMarker(std::string_view label) const {
   if (!HasValidationLayers()) {
     return;
   }
-  std::string label_copy(label);
   vk::DebugUtilsLabelEXT label_info;
-  label_info.pLabelName = label_copy.c_str();
+  label_info.pLabelName = label.data();
   Lock lock(queue_mutex_);
   queue_.insertDebugUtilsLabelEXT(label_info);
 }

--- a/impeller/renderer/backend/vulkan/queue_vk.cc
+++ b/impeller/renderer/backend/vulkan/queue_vk.cc
@@ -23,12 +23,13 @@ vk::Result QueueVK::Submit(const vk::SubmitInfo& submit_info,
   return queue_.submit(submit_info, fence);
 }
 
-void QueueVK::InsertDebugMarker(const char* label) const {
+void QueueVK::InsertDebugMarker(std::string_view label) const {
   if (!HasValidationLayers()) {
     return;
   }
+  std::string label_copy(label);
   vk::DebugUtilsLabelEXT label_info;
-  label_info.pLabelName = label;
+  label_info.pLabelName = label_copy.c_str();
   Lock lock(queue_mutex_);
   queue_.insertDebugUtilsLabelEXT(label_info);
 }

--- a/impeller/renderer/backend/vulkan/queue_vk.h
+++ b/impeller/renderer/backend/vulkan/queue_vk.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "flutter/fml/macros.h"
 #include "impeller/base/thread.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 
@@ -40,7 +39,7 @@ class QueueVK {
   vk::Result Submit(const vk::SubmitInfo& submit_info,
                     const vk::Fence& fence) const;
 
-  void InsertDebugMarker(const char* label) const;
+  void InsertDebugMarker(std::string_view label) const;
 
  private:
   mutable Mutex queue_mutex_;

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -423,8 +423,7 @@ void RenderPassVK::SetPipeline(
 // |RenderPass|
 void RenderPassVK::SetCommandLabel(std::string_view label) {
 #ifdef IMPELLER_DEBUG
-  std::string label_copy(label);
-  command_buffer_->GetEncoder()->PushDebugGroup(label_copy.c_str());
+  command_buffer_->GetEncoder()->PushDebugGroup(label);
   has_label_ = true;
 #endif  // IMPELLER_DEBUG
 }


### PR DESCRIPTION
This improves the performance of command encoding when there is no debugger attached. most labels are const char*, and so by accepting a string_view we can avoid actually creating a string if validations are disabled.