### PR TITLE
[Windows] Fix resize crash

### DIFF
--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -597,10 +597,15 @@ void FlutterWindowsView::OnFramePresented() {
   switch (resize_status_) {
     case ResizeState::kResizeStarted:
       // The caller must first call |OnFrameGenerated| or
-      // |OnEmptyFrameGenerated| before calling this method. This status
-      // indicates the caller did not call these methods or ignored their
-      // result.
-      FML_UNREACHABLE();
+      // |OnEmptyFrameGenerated| before calling this method. This
+      // indicates one of the following:
+      //
+      // 1. The caller did not call these methods.
+      // 2. The caller ignored these methods' result.
+      // 3. The platform thread started a resize after the caller called these
+      //    methods. We might have presented a frame of the wrong size to the
+      //    view.
+      return;
     case ResizeState::kFrameGenerated: {
       // A frame was generated for a pending resize.
       // Unblock the platform thread.

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -181,10 +181,9 @@ bool FlutterWindowsView::OnWindowSizeChanged(size_t width, size_t height) {
   SendWindowMetrics(width, height, binding_handler_->GetDpiScale());
 
   if (surface_will_update) {
-    // Block the platform thread until:
-    //   1. |OnEmptyFrameGenerated| is called or |OnFrameGenerated| is called
-    //   with the right size.
-    //   2. |OnFramePresented| is called
+    // Block the platform thread until a frame is presented with the target
+    // size. See |OnFrameGenerated|, |OnEmptyFrameGenerated|, and
+    // |OnFramePresented|.
     return resize_cv_.wait_for(lock, kWindowResizeTimeout,
                                [&resize_status = resize_status_] {
                                  return resize_status == ResizeState::kDone;

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -105,7 +105,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   void SetFlutterCursor(HCURSOR cursor);
 
   // |WindowBindingHandlerDelegate|
-  void OnWindowSizeChanged(size_t width, size_t height) override;
+  bool OnWindowSizeChanged(size_t width, size_t height) override;
 
   // |WindowBindingHandlerDelegate|
   void OnWindowRepaint() override;

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -16,7 +16,7 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
  public:
   MockWindowBindingHandlerDelegate() {}
 
-  MOCK_METHOD(void, OnWindowSizeChanged, (size_t, size_t), (override));
+  MOCK_METHOD(bool, OnWindowSizeChanged, (size_t, size_t), (override));
   MOCK_METHOD(void, OnWindowRepaint, (), (override));
   MOCK_METHOD(void,
               OnPointerMove,

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -24,6 +24,7 @@ class WindowBindingHandlerDelegate {
   // Called by |FlutterWindow| on the platform thread.
   //
   // Returns true if the delegate completed the window resize synchronously.
+  // The return value should only be used for unit testing.
   virtual bool OnWindowSizeChanged(size_t width, size_t height) = 0;
 
   // Notifies delegate that backing window needs to be repainted.

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -20,9 +20,11 @@ class WindowBindingHandlerDelegate {
   using KeyEventCallback = std::function<void(bool)>;
 
   // Notifies delegate that backing window size has changed.
-  // Typically called by currently configured WindowBindingHandler, this is
-  // called on the platform thread.
-  virtual void OnWindowSizeChanged(size_t width, size_t height) = 0;
+  //
+  // Called by |FlutterWindow| on the platform thread.
+  //
+  // Returns true if the delegate completed the window resize synchronously.
+  virtual bool OnWindowSizeChanged(size_t width, size_t height) = 0;
 
   // Notifies delegate that backing window needs to be repainted.
   // Typically called by currently configured WindowBindingHandler.

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -24,7 +24,7 @@ class WindowBindingHandlerDelegate {
   // Called by |FlutterWindow| on the platform thread.
   //
   // Returns true if the delegate completed the window resize synchronously.
-  // The return value should only be used for unit testing.
+  // The return value is exposed for unit testing.
   virtual bool OnWindowSizeChanged(size_t width, size_t height) = 0;
 
   // Notifies delegate that backing window needs to be repainted.


### PR DESCRIPTION
https://github.com/flutter/engine/pull/49872 introduced a crash in debug mode if the platform thread starts a window resize in between `OnFrameGenerated` and `OnFramePresented`.

Fixes https://github.com/flutter/flutter/issues/141855.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
