### PR TITLE
[Fuchsia] Redo - Use chromium test-scripts to download images and execute tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -196,6 +196,8 @@ targets:
       config_name: linux_fuchsia
     drone_dimensions:
       - os=Linux
+    dimensions:
+      kvm: "1"
     # TODO(https://github.com/flutter/flutter/issues/138559): Re-enable/delete.
     # runIfNot:
     #   - lib/web_ui/**

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ app.*.symbols
 
 # RBE support configurations and scripts vended from CIPD
 /build/rbe
+
+# The test-scripts from Chromium and managed by DEPS and gclient.
+/tools/fuchsia/test_scripts

--- a/DEPS
+++ b/DEPS
@@ -255,7 +255,7 @@ vars = {
   # The version / instance id of the cipd:chromium/fuchsia/test-scripts which
   # will be used altogether with fuchsia-sdk to setup the build / test
   # environment.
-  'fuchsia_test_scripts_version': 'xMcCltDynP2JMZNUekFtV24vCnjgz_J3SZIN-4FbUKQC',
+  'fuchsia_test_scripts_version': 'MXOVCk7s_1bZ8hJZ5M5DgS_9i8FeSjYojkSGY8zpnxQC',
 }
 
 gclient_gn_args_file = 'src/third_party/dart/build/config/gclient_args.gni'

--- a/ci/builders/linux_fuchsia.json
+++ b/ci/builders/linux_fuchsia.json
@@ -77,7 +77,7 @@
                 {
                     "name": "Upload to Symbol Server for arch: arm64",
                     "language": "python3",
-		    "contexts": ["depot_tools_on_path"],
+                    "contexts": ["depot_tools_on_path"],
                     "script": "flutter/tools/fuchsia/upload_to_symbol_server.py",
                     "parameters": [
                         "--symbol-dir",
@@ -138,10 +138,12 @@
         {
             "drone_dimensions": [
                 "device_type=none",
+                "kvm=1",
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "run_fuchsia_emu": true
             },
             "gn": [
                 "--fuchsia",
@@ -163,7 +165,7 @@
                 {
                     "name": "Upload to Symbol Server for arch: x64",
                     "language": "python3",
-		    "contexts": ["depot_tools_on_path"],
+                    "contexts": ["depot_tools_on_path"],
                     "script": "flutter/tools/fuchsia/upload_to_symbol_server.py",
                     "parameters": [
                         "--symbol-dir",
@@ -171,6 +173,14 @@
                         "--engine-version",
                         "${REVISION}",
                         "--upload"
+                    ]
+                },
+                {
+                    "name": "x64 emulator based tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py"
                     ]
                 }
             ]

--- a/testing/fuchsia/run_tests.py
+++ b/testing/fuchsia/run_tests.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2013, the Flutter project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE file.
+
+import argparse
+import os
+import sys
+
+# The imports are coming from fuchsia/test_scripts and pylint cannot find them
+# without setting a global init-hook which is less favorable.
+# But this file will be executed as part of the CI, its correctness of importing
+# is guaranteed.
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), '../../tools/fuchsia/test_scripts/test/'
+    )
+)
+
+# pylint: disable=import-error, wrong-import-position
+import run_test
+from run_executable_test import ExecutableTestRunner
+from test_runner import TestRunner
+
+# This file is expected to be executed from src/.
+
+
+# TODO(https://github.com/flutter/flutter/issues/140179): Execute all the tests
+# in
+# https://github.com/flutter/engine/blob/main/testing/fuchsia/test_suites.yaml
+# and avoid hardcoded paths.
+def _get_test_runner(runner_args: argparse.Namespace, *_) -> TestRunner:
+  return ExecutableTestRunner(
+      runner_args.out_dir, [],
+      'fuchsia-pkg://fuchsia.com/dart_runner_tests#meta/dart_runner_tests.cm',
+      runner_args.target_id, 'codecoverage', '/tmp/log',
+      ['../out/fuchsia_debug_x64/dart_runner_tests.far'], None
+  )
+
+
+# TODO(https://github.com/flutter/flutter/issues/140179): Respect build
+# configurations.
+if __name__ == '__main__':
+  try:
+    os.remove('../out/fuchsia_debug_x64/dart_runner_tests.far')
+  except FileNotFoundError:
+    pass
+  os.symlink(
+      'dart_runner_tests-0.far',
+      '../out/fuchsia_debug_x64/dart_runner_tests.far'
+  )
+  sys.argv.append('--out-dir=out/fuchsia_debug_x64')
+  # The 'flutter-test-type' is a place holder and has no specific meaning; the
+  # _get_test_runner is overrided.
+  sys.argv.append('flutter-test-type')
+  run_test._get_test_runner = _get_test_runner  # pylint: disable=protected-access
+  sys.exit(run_test.main())

--- a/testing/fuchsia/run_tests.py
+++ b/testing/fuchsia/run_tests.py
@@ -35,7 +35,7 @@ def _get_test_runner(runner_args: argparse.Namespace, *_) -> TestRunner:
   return ExecutableTestRunner(
       runner_args.out_dir, [],
       'fuchsia-pkg://fuchsia.com/dart_runner_tests#meta/dart_runner_tests.cm',
-      runner_args.target_id, 'codecoverage', '/tmp/log',
+      runner_args.target_id, None, '/tmp/log',
       ['out/fuchsia_debug_x64/dart_runner_tests.far'], None
   )
 

--- a/testing/fuchsia/run_tests.py
+++ b/testing/fuchsia/run_tests.py
@@ -36,7 +36,7 @@ def _get_test_runner(runner_args: argparse.Namespace, *_) -> TestRunner:
       runner_args.out_dir, [],
       'fuchsia-pkg://fuchsia.com/dart_runner_tests#meta/dart_runner_tests.cm',
       runner_args.target_id, 'codecoverage', '/tmp/log',
-      ['../out/fuchsia_debug_x64/dart_runner_tests.far'], None
+      ['out/fuchsia_debug_x64/dart_runner_tests.far'], None
   )
 
 
@@ -44,12 +44,12 @@ def _get_test_runner(runner_args: argparse.Namespace, *_) -> TestRunner:
 # configurations.
 if __name__ == '__main__':
   try:
-    os.remove('../out/fuchsia_debug_x64/dart_runner_tests.far')
+    os.remove('out/fuchsia_debug_x64/dart_runner_tests.far')
   except FileNotFoundError:
     pass
   os.symlink(
       'dart_runner_tests-0.far',
-      '../out/fuchsia_debug_x64/dart_runner_tests.far'
+      'out/fuchsia_debug_x64/dart_runner_tests.far'
   )
   sys.argv.append('--out-dir=out/fuchsia_debug_x64')
   # The 'flutter-test-type' is a place holder and has no specific meaning; the

--- a/testing/fuchsia/run_tests.py
+++ b/testing/fuchsia/run_tests.py
@@ -21,10 +21,11 @@ sys.path.insert(
 
 # pylint: disable=import-error, wrong-import-position
 import run_test
+from common import DIR_SRC_ROOT
 from run_executable_test import ExecutableTestRunner
 from test_runner import TestRunner
 
-# This file is expected to be executed from src/.
+OUT_DIR = os.path.join(DIR_SRC_ROOT, 'out/fuchsia_debug_x64')
 
 
 # TODO(https://github.com/flutter/flutter/issues/140179): Execute all the tests
@@ -33,10 +34,10 @@ from test_runner import TestRunner
 # and avoid hardcoded paths.
 def _get_test_runner(runner_args: argparse.Namespace, *_) -> TestRunner:
   return ExecutableTestRunner(
-      runner_args.out_dir, [],
+      OUT_DIR, [],
       'fuchsia-pkg://fuchsia.com/dart_runner_tests#meta/dart_runner_tests.cm',
       runner_args.target_id, None, '/tmp/log',
-      ['out/fuchsia_debug_x64/dart_runner_tests.far'], None
+      [os.path.join(OUT_DIR, 'dart_runner_tests.far')], None
   )
 
 
@@ -44,13 +45,13 @@ def _get_test_runner(runner_args: argparse.Namespace, *_) -> TestRunner:
 # configurations.
 if __name__ == '__main__':
   try:
-    os.remove('out/fuchsia_debug_x64/dart_runner_tests.far')
+    os.remove(os.path.join(OUT_DIR, 'dart_runner_tests.far'))
   except FileNotFoundError:
     pass
   os.symlink(
-      'dart_runner_tests-0.far', 'out/fuchsia_debug_x64/dart_runner_tests.far'
+      'dart_runner_tests-0.far', os.path.join(OUT_DIR, 'dart_runner_tests.far')
   )
-  sys.argv.append('--out-dir=out/fuchsia_debug_x64')
+  sys.argv.append('--out-dir=' + OUT_DIR)
   # The 'flutter-test-type' is a place holder and has no specific meaning; the
   # _get_test_runner is overrided.
   sys.argv.append('flutter-test-type')

--- a/testing/fuchsia/run_tests.py
+++ b/testing/fuchsia/run_tests.py
@@ -25,6 +25,8 @@ from common import DIR_SRC_ROOT
 from run_executable_test import ExecutableTestRunner
 from test_runner import TestRunner
 
+# TODO(https://github.com/flutter/flutter/issues/140179): Respect build
+# configurations.
 OUT_DIR = os.path.join(DIR_SRC_ROOT, 'out/fuchsia_debug_x64')
 
 
@@ -41,8 +43,6 @@ def _get_test_runner(runner_args: argparse.Namespace, *_) -> TestRunner:
   )
 
 
-# TODO(https://github.com/flutter/flutter/issues/140179): Respect build
-# configurations.
 if __name__ == '__main__':
   try:
     os.remove(os.path.join(OUT_DIR, 'dart_runner_tests.far'))

--- a/testing/fuchsia/run_tests.py
+++ b/testing/fuchsia/run_tests.py
@@ -48,8 +48,7 @@ if __name__ == '__main__':
   except FileNotFoundError:
     pass
   os.symlink(
-      'dart_runner_tests-0.far',
-      'out/fuchsia_debug_x64/dart_runner_tests.far'
+      'dart_runner_tests-0.far', 'out/fuchsia_debug_x64/dart_runner_tests.far'
   )
   sys.argv.append('--out-dir=out/fuchsia_debug_x64')
   # The 'flutter-test-type' is a place holder and has no specific meaning; the

--- a/tools/fuchsia/with_envs.py
+++ b/tools/fuchsia/with_envs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) 2013, the Flutter project authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE file.
+
+import os
+import platform
+import subprocess
+import sys
+
+sys.path.insert(
+    0,
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), 'test_scripts/test/')
+    )
+)
+
+from common import catch_sigterm, wait_for_sigterm
+
+
+def Main():
+  """
+    Executes the test-scripts with required environment variables. It acts like
+    /usr/bin/env, but provides some extra functionality to dynamically set up
+    the environment variables.
+    """
+  # Ensures the signals can be correctly forwarded to the subprocesses.
+  catch_sigterm()
+
+  os.environ['SRC_ROOT'] = os.path.abspath(
+      os.path.join(os.path.dirname(__file__), '../../../')
+  )
+  # Flutter uses a different repo structure and fuchsia sdk is not in the
+  # third_party/, so images root and sdk root need to be explicitly set.
+  os.environ['FUCHSIA_IMAGES_ROOT'] = os.path.join(
+      os.environ['SRC_ROOT'], 'fuchsia/images/'
+  )
+
+  assert platform.system() == 'Linux', 'Unsupported OS ' + platform.system()
+  os.environ['FUCHSIA_SDK_ROOT'] = os.path.join(
+      os.environ['SRC_ROOT'], 'fuchsia/sdk/linux/'
+  )
+
+  with subprocess.Popen(sys.argv[1:]) as proc:
+    try:
+      proc.wait()
+    except:
+      # Use terminate / SIGTERM to allow the subprocess exiting cleanly.
+      proc.terminate()
+    return proc.returncode
+
+
+if __name__ == '__main__':
+  sys.exit(Main())


### PR DESCRIPTION
This change is a redo of https://github.com/flutter/engine/pull/49847.

https://github.com/zijiehe-google-com/engine/compare/4530942..main should show the diff between this and the original change; mainly fixes the https://github.com/flutter/flutter/issues/141907.

Following paragraph is copied from the original change.

This change can be executed from buildroot by

```
python3 flutter/tools/fuchsia/with_envs.py flutter/testing/fuchsia/run_tests.py
```

Bug: https://github.com/flutter/flutter/issues/140179

- [V] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [V] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [V] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [V] I listed at least one issue that this PR fixes in the description above.
- [V] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [V] I updated/added relevant documentation (doc comments with `///`).
- [V] I signed the [CLA].
- [V] All existing and new tests are passing.