### PR TITLE
[Impeller] fixed colorspace for metal screenshots

### DIFF
--- a/impeller/golden_tests/metal_screenshotter.mm
+++ b/impeller/golden_tests/metal_screenshotter.mm
@@ -37,8 +37,11 @@ std::unique_ptr<Screenshot> MetalScreenshotter::MakeScreenshot(
     return {};
   }
 
-  CIImage* ciImage = [[CIImage alloc] initWithMTLTexture:metal_texture
-                                                 options:@{}];
+  CGColorSpaceRef color_space = CGColorSpaceCreateDeviceRGB();
+  CIImage* ciImage = [[CIImage alloc]
+      initWithMTLTexture:metal_texture
+                 options:@{kCIImageColorSpace : (__bridge id)color_space}];
+  CGColorSpaceRelease(color_space);
   FML_CHECK(ciImage);
 
   std::shared_ptr<Context> context = playground_->GetContext();


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/141903

The golden tests were generating images in the wrong colorspace which left things brighter than they should have been.  This fixes that issue.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
