### PR TITLE
[Impeller] turned on validation errors for one golden image test

### DIFF
--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -60,6 +60,12 @@ static const std::vector<std::string> kSkipTests = {
     "impeller_Play_AiksTest_CaptureContext_Vulkan",
 };
 
+/// TODO(https://github.com/flutter/flutter/issues/142017): Turn on validation
+/// for all vulkan tests.
+static const std::vector<std::string> kVulkanValidationTests = {
+    "impeller_Play_AiksTest_CanRenderTextFrame_Vulkan",
+};
+
 namespace {
 std::string GetTestName() {
   std::string suite_name =
@@ -127,13 +133,20 @@ void GoldenPlaygroundTest::SetUp() {
     return;
   }
 
+  bool enable_vulkan_validations = false;
+  std::string test_name = GetTestName();
+  if (std::find(kVulkanValidationTests.begin(), kVulkanValidationTests.end(),
+                test_name) != kVulkanValidationTests.end()) {
+    enable_vulkan_validations = true;
+  }
+
   if (GetParam() == PlaygroundBackend::kMetal) {
     pimpl_->screenshotter = std::make_unique<testing::MetalScreenshotter>();
   } else if (GetParam() == PlaygroundBackend::kVulkan) {
-    pimpl_->screenshotter = std::make_unique<testing::VulkanScreenshotter>();
+    pimpl_->screenshotter = std::make_unique<testing::VulkanScreenshotter>(
+        enable_vulkan_validations);
   }
 
-  std::string test_name = GetTestName();
   if (std::find(kSkipTests.begin(), kSkipTests.end(), test_name) !=
       kSkipTests.end()) {
     GTEST_SKIP_(

--- a/impeller/golden_tests/vulkan_screenshotter.h
+++ b/impeller/golden_tests/vulkan_screenshotter.h
@@ -18,7 +18,7 @@ namespace testing {
 /// playground backend.
 class VulkanScreenshotter : public Screenshotter {
  public:
-  VulkanScreenshotter();
+  VulkanScreenshotter(bool enable_validations);
 
   std::unique_ptr<Screenshot> MakeScreenshot(
       AiksContext& aiks_context,

--- a/impeller/golden_tests/vulkan_screenshotter.h
+++ b/impeller/golden_tests/vulkan_screenshotter.h
@@ -18,7 +18,7 @@ namespace testing {
 /// playground backend.
 class VulkanScreenshotter : public Screenshotter {
  public:
-  VulkanScreenshotter(bool enable_validations);
+  explicit VulkanScreenshotter(bool enable_validations);
 
   std::unique_ptr<Screenshot> MakeScreenshot(
       AiksContext& aiks_context,

--- a/impeller/golden_tests/vulkan_screenshotter.mm
+++ b/impeller/golden_tests/vulkan_screenshotter.mm
@@ -66,8 +66,10 @@ std::unique_ptr<Screenshot> ReadTexture(
 
 VulkanScreenshotter::VulkanScreenshotter() {
   FML_CHECK(::glfwInit() == GLFW_TRUE);
+  PlaygroundSwitches playground_switches;
+  playground_switches.enable_vulkan_validation = true;
   playground_ =
-      PlaygroundImpl::Create(PlaygroundBackend::kVulkan, PlaygroundSwitches{});
+      PlaygroundImpl::Create(PlaygroundBackend::kVulkan, playground_switches);
 }
 
 std::unique_ptr<Screenshot> VulkanScreenshotter::MakeScreenshot(

--- a/impeller/golden_tests/vulkan_screenshotter.mm
+++ b/impeller/golden_tests/vulkan_screenshotter.mm
@@ -64,10 +64,10 @@ std::unique_ptr<Screenshot> ReadTexture(
 }
 }  // namespace
 
-VulkanScreenshotter::VulkanScreenshotter() {
+VulkanScreenshotter::VulkanScreenshotter(bool enable_validations) {
   FML_CHECK(::glfwInit() == GLFW_TRUE);
   PlaygroundSwitches playground_switches;
-  playground_switches.enable_vulkan_validation = true;
+  playground_switches.enable_vulkan_validation = enable_validations;
   playground_ =
       PlaygroundImpl::Create(PlaygroundBackend::kVulkan, playground_switches);
 }


### PR DESCRIPTION
issue https://github.com/flutter/flutter/issues/142017

This just turns on the validations for one test since not everything passes yet with them turned on across the board.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
