### PR TITLE
Replace Fuchsia logging macros (FX_LOG*) with FML logging

### DIFF
--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -61,7 +61,6 @@ template("runner_sources") {
       "$fuchsia_sdk_root/pkg:sys_cpp",
       "$fuchsia_sdk_root/pkg:sys_cpp_testing",
       "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
-      "$fuchsia_sdk_root/pkg:syslog",
       "$fuchsia_sdk_root/pkg:trace",
       "$fuchsia_sdk_root/pkg:vfs_cpp",
       "$fuchsia_sdk_root/pkg:zx",

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -6,7 +6,6 @@
 
 #include <lib/async-loop/loop.h>
 #include <lib/async/default.h>
-#include <lib/syslog/global.h>
 #include <lib/vfs/cpp/pseudo_dir.h>
 #include <sys/stat.h>
 #include <zircon/status.h>
@@ -21,7 +20,6 @@
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
-#include "logging.h"
 #include "runtime/dart/utils/inlines.h"
 #include "runtime/dart/utils/vmservice_object.h"
 #include "service_isolate.h"
@@ -209,7 +207,7 @@ DartRunner::DartRunner(sys::ComponentContext* context) : context_(context) {
   char* error =
       Dart_SetVMFlags(dart_utils::ArraySize(kDartVMArgs), kDartVMArgs);
   if (error) {
-    FX_LOGF(FATAL, LOG_TAG, "Dart_SetVMFlags failed: %s", error);
+    FML_LOG(FATAL) << "Dart_SetVMFlags failed: " << error;
   }
 
   Dart_InitializeParams params = {};
@@ -220,7 +218,7 @@ DartRunner::DartRunner(sys::ComponentContext* context) : context_(context) {
 #else
   if (!dart_utils::MappedResource::LoadFromNamespace(
           nullptr, "/pkg/data/vm_snapshot_data.bin", vm_snapshot_data_)) {
-    FX_LOG(FATAL, LOG_TAG, "Failed to load vm snapshot data");
+    FML_LOG(FATAL) << "Failed to load vm snapshot data";
   }
   params.vm_snapshot_data = vm_snapshot_data_.address();
 #endif
@@ -233,13 +231,13 @@ DartRunner::DartRunner(sys::ComponentContext* context) : context_(context) {
 #endif
   error = Dart_Initialize(&params);
   if (error)
-    FX_LOGF(FATAL, LOG_TAG, "Dart_Initialize failed: %s", error);
+    FML_LOG(FATAL) << "Dart_Initialize failed: " << error;
 }
 
 DartRunner::~DartRunner() {
   char* error = Dart_Cleanup();
   if (error)
-    FX_LOGF(FATAL, LOG_TAG, "Dart_Cleanup failed: %s", error);
+    FML_LOG(FATAL) << "Dart_Cleanup failed: " << error;
 }
 
 void DartRunner::Start(

--- a/shell/platform/fuchsia/dart_runner/dart_test_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_test_component_controller.cc
@@ -5,7 +5,6 @@
 #include "dart_test_component_controller.h"
 
 #include <fcntl.h>
-#include <fml/logging.h>
 #include <fuchsia/test/cpp/fidl.h>
 #include <lib/async-loop/loop.h>
 #include <lib/async/cpp/task.h>
@@ -16,7 +15,6 @@
 #include <lib/fidl/cpp/string.h>
 #include <lib/fpromise/promise.h>
 #include <lib/sys/cpp/service_directory.h>
-#include <lib/syslog/global.h>
 #include <lib/zx/clock.h>
 #include <lib/zx/thread.h>
 #include <sys/stat.h>
@@ -27,6 +25,7 @@
 #include <regex>
 #include <utility>
 
+#include "flutter/fml/logging.h"
 #include "runtime/dart/utils/files.h"
 #include "runtime/dart/utils/handle_exception.h"
 #include "runtime/dart/utils/inlines.h"
@@ -40,7 +39,6 @@
 #include "third_party/tonic/logging/dart_invoke.h"
 
 #include "builtin_libraries.h"
-#include "logging.h"
 
 using tonic::ToDart;
 
@@ -126,15 +124,14 @@ DartTestComponentController::DartTestComponentController(
     binding_.Bind(std::move(controller));
     binding_.set_error_handler([this](zx_status_t status) { Kill(); });
   } else {
-    FX_LOG(ERROR, LOG_TAG,
-           "Fuchsia component controller endpoint is not valid.");
+    FML_LOG(ERROR) << "Fuchsia component controller endpoint is not valid.";
   }
 
   zx_status_t idle_timer_status =
       zx::timer::create(ZX_TIMER_SLACK_LATE, ZX_CLOCK_MONOTONIC, &idle_timer_);
   if (idle_timer_status != ZX_OK) {
-    FX_LOGF(INFO, LOG_TAG, "Idle timer creation failed: %s",
-            zx_status_get_string(idle_timer_status));
+    FML_LOG(INFO) << "Idle timer creation failed: "
+                  << zx_status_get_string(idle_timer_status);
   } else {
     idle_wait_.set_object(idle_timer_.get());
     idle_wait_.set_trigger(ZX_TIMER_SIGNALED);
@@ -165,12 +162,11 @@ void DartTestComponentController::SetUp() {
   }
 
   if (SetUpFromAppSnapshot()) {
-    FX_LOGF(INFO, LOG_TAG, "%s is running from an app snapshot", url_.c_str());
+    FML_LOG(INFO) << url_ << " is running from an app snapshot";
   } else if (SetUpFromKernel()) {
-    FX_LOGF(INFO, LOG_TAG, "%s is running from kernel", url_.c_str());
+    FML_LOG(INFO) << url_ << " is running from kernel";
   } else {
-    FX_LOGF(ERROR, LOG_TAG, "Failed to set up component controller for %s.",
-            url_.c_str());
+    FML_LOG(ERROR) << "Failed to set up component controller for " << url_;
     return;
   }
 
@@ -185,14 +181,14 @@ void DartTestComponentController::SetUp() {
 
 bool DartTestComponentController::CreateAndBindNamespace() {
   if (!start_info_.has_ns()) {
-    FX_LOG(ERROR, LOG_TAG, "Component start info does not have a namespace.");
+    FML_LOG(ERROR) << "Component start info does not have a namespace.";
     return false;
   }
 
   const zx_status_t ns_create_status = fdio_ns_create(&namespace_);
   if (ns_create_status != ZX_OK) {
-    FX_LOGF(ERROR, LOG_TAG, "Failed to create namespace: %s",
-            zx_status_get_string(ns_create_status));
+    FML_LOG(ERROR) << "Failed to create namespace: "
+                   << zx_status_get_string(ns_create_status);
   }
 
   dart_utils::BindTemp(namespace_);
@@ -220,8 +216,8 @@ bool DartTestComponentController::CreateAndBindNamespace() {
     const zx_status_t ns_bind_status =
         fdio_ns_bind(namespace_, path.c_str(), dir.TakeChannel().release());
     if (ns_bind_status != ZX_OK) {
-      FX_LOGF(ERROR, LOG_TAG, "Failed to bind %s to namespace: %s",
-              path.c_str(), zx_status_get_string(ns_bind_status));
+      FML_LOG(ERROR) << "Failed to bind " << path << " to namespace: "
+                     << zx_status_get_string(ns_bind_status);
       return false;
     }
   }
@@ -251,7 +247,7 @@ bool DartTestComponentController::SetUpFromKernel() {
   for (size_t start = 0; start < manifest.size();) {
     size_t end = str.find("\n", start);
     if (end == std::string::npos) {
-      FX_LOG(ERROR, LOG_TAG, "Malformed manifest");
+      FML_LOG(ERROR) << "Malformed manifest";
       return false;
     }
 
@@ -261,8 +257,7 @@ bool DartTestComponentController::SetUpFromKernel() {
     dart_utils::MappedResource kernel;
     if (!dart_utils::MappedResource::LoadFromNamespace(namespace_, path,
                                                        kernel)) {
-      FX_LOGF(ERROR, LOG_TAG, "Cannot load kernel from namespace: %s",
-              path.c_str());
+      FML_LOG(ERROR) << "Cannot load kernel from namespace: " << path;
       return false;
     }
     bool sound_null_safety = Dart_DetectNullSafety(
@@ -276,7 +271,7 @@ bool DartTestComponentController::SetUpFromKernel() {
       result_sound_null_safety = sound_null_safety;
       first_library = false;
     } else if (sound_null_safety != result_sound_null_safety) {
-      FX_LOG(ERROR, LOG_TAG, "Inconsistent sound null safety");
+      FML_LOG(ERROR) << "Inconsistent sound null safety";
       return false;
     }
 
@@ -298,8 +293,8 @@ bool DartTestComponentController::SetUpFromKernel() {
   for (const auto& kernel : kernel_peices_) {
     library = Dart_LoadLibraryFromKernel(kernel.address(), kernel.size());
     if (Dart_IsError(library)) {
-      FX_LOGF(ERROR, LOG_TAG, "Cannot load library from kernel: %s",
-              Dart_GetError(library));
+      FML_LOG(ERROR) << "Cannot load library from kernel: "
+                     << Dart_GetError(library);
       Dart_ExitScope();
       return false;
     }
@@ -308,8 +303,7 @@ bool DartTestComponentController::SetUpFromKernel() {
 
   Dart_Handle result = Dart_FinalizeLoading(false);
   if (Dart_IsError(result)) {
-    FX_LOGF(ERROR, LOG_TAG, "Failed to FinalizeLoading: %s",
-            Dart_GetError(result));
+    FML_LOG(ERROR) << "Failed to FinalizeLoading: " << Dart_GetError(result);
     Dart_ExitScope();
     return false;
   }
@@ -362,7 +356,7 @@ bool DartTestComponentController::CreateIsolate(
       url_.c_str(), label_.c_str(), isolate_snapshot_data,
       isolate_snapshot_instructions, isolate_flags, state, state, &error);
   if (!isolate_) {
-    FX_LOGF(ERROR, LOG_TAG, "Dart_CreateIsolateGroup failed: %s", error);
+    FML_LOG(ERROR) << "Dart_CreateIsolateGroup failed: " << error;
     return false;
   }
 
@@ -550,7 +544,7 @@ fpromise::promise<> DartTestComponentController::RunDartMain() {
   if (error != nullptr) {
     Dart_EnterIsolate(isolate_);
     Dart_ShutdownIsolate();
-    FX_LOGF(ERROR, LOG_TAG, "Unable to make isolate runnable: %s", error);
+    FML_LOG(ERROR) << "Unable to make isolate runnable: " << error;
     free(error);
     return fpromise::make_error_promise();
   }
@@ -565,8 +559,8 @@ fpromise::promise<> DartTestComponentController::RunDartMain() {
       Dart_NewListOfTypeFilled(string_type, Dart_EmptyString(), 0);
 
   if (Dart_IsError(dart_arguments)) {
-    FX_LOGF(ERROR, LOG_TAG, "Failed to allocate Dart arguments list: %s",
-            Dart_GetError(dart_arguments));
+    FML_LOG(ERROR) << "Failed to allocate Dart arguments list: "
+                   << Dart_GetError(dart_arguments);
     Dart_ExitScope();
     return fpromise::make_error_promise();
   }
@@ -574,9 +568,8 @@ fpromise::promise<> DartTestComponentController::RunDartMain() {
   Dart_Handle user_main = Dart_GetField(Dart_RootLibrary(), ToDart("main"));
 
   if (Dart_IsError(user_main)) {
-    FX_LOGF(ERROR, LOG_TAG,
-            "Failed to locate user_main in the root library: %s",
-            Dart_GetError(user_main));
+    FML_LOG(ERROR) << "Failed to locate user_main in the root library: "
+                   << Dart_GetError(user_main);
     Dart_ExitScope();
     return fpromise::make_error_promise();
   }
@@ -584,8 +577,8 @@ fpromise::promise<> DartTestComponentController::RunDartMain() {
   Dart_Handle fuchsia_lib = Dart_LookupLibrary(tonic::ToDart("dart:fuchsia"));
 
   if (Dart_IsError(fuchsia_lib)) {
-    FX_LOGF(ERROR, LOG_TAG, "Failed to locate dart:fuchsia: %s",
-            Dart_GetError(fuchsia_lib));
+    FML_LOG(ERROR) << "Failed to locate dart:fuchsia: "
+                   << Dart_GetError(fuchsia_lib);
     Dart_ExitScope();
     return fpromise::make_error_promise();
   }
@@ -597,7 +590,7 @@ fpromise::promise<> DartTestComponentController::RunDartMain() {
     auto dart_state = tonic::DartState::Current();
     if (!dart_state->has_set_return_code()) {
       // The program hasn't set a return code meaning this exit is unexpected.
-      FX_LOG(ERROR, LOG_TAG, Dart_GetError(main_result));
+      FML_LOG(ERROR) << Dart_GetError(main_result);
       return_code_ = tonic::GetErrorExitCode(main_result);
 
       dart_utils::HandleIfException(runner_incoming_services_, url_,
@@ -657,8 +650,7 @@ void DartTestComponentController::MessageEpilogue(Dart_Handle result) {
   zx_status_t status =
       idle_timer_.set(idle_start_ + kIdleWaitDuration, kIdleSlack);
   if (status != ZX_OK) {
-    FX_LOGF(INFO, LOG_TAG, "Idle timer set failed: %s",
-            zx_status_get_string(status));
+    FML_LOG(INFO) << "Idle timer set failed: " << zx_status_get_string(status);
   }
 }
 
@@ -688,8 +680,8 @@ void DartTestComponentController::OnIdleTimer(async_dispatcher_t* dispatcher,
     // Early wakeup or message pushed idle time forward: reschedule.
     zx_status_t status = idle_timer_.set(deadline, kIdleSlack);
     if (status != ZX_OK) {
-      FX_LOGF(INFO, LOG_TAG, "Idle timer set failed: %s",
-              zx_status_get_string(status));
+      FML_LOG(INFO) << "Idle timer set failed: "
+                    << zx_status_get_string(status);
     }
   }
   wait->Begin(dispatcher);  // ignore errors

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -168,7 +168,6 @@ template("runner_sources") {
              "$fuchsia_sdk_root/pkg:async-loop-cpp",
              "$fuchsia_sdk_root/pkg:fdio",
              "$fuchsia_sdk_root/pkg:fidl_cpp",
-             "$fuchsia_sdk_root/pkg:syslog",
              "$fuchsia_sdk_root/pkg:trace",
              "$fuchsia_sdk_root/pkg:trace-engine",
              "$fuchsia_sdk_root/pkg:trace-provider-so",

--- a/shell/platform/fuchsia/flutter/software_surface.cc
+++ b/shell/platform/fuchsia/flutter/software_surface.cc
@@ -331,10 +331,10 @@ void SoftwareSurface::SignalWritesFinished(
     return;
   }
 
-  dart_utils::Check(surface_read_finished_callback_ == nullptr,
-                    "Attempted to signal a write on the surface when the "
-                    "previous write has not yet been acknowledged by the "
-                    "compositor.");
+  FML_CHECK(surface_read_finished_callback_ == nullptr)
+      << "Attempted to signal a write on the surface when the "
+         "previous write has not yet been acknowledged by the "
+         "compositor.";
   surface_read_finished_callback_ = on_surface_read_finished;
 
   // Sysmem *may* require the cache to be cleared after writes to the surface

--- a/shell/platform/fuchsia/flutter/text_delegate.cc
+++ b/shell/platform/fuchsia/flutter/text_delegate.cc
@@ -141,7 +141,7 @@ void TextDelegate::ActivateIme() {
 }
 
 void TextDelegate::ActivateIme(fuchsia::ui::input::InputMethodAction action) {
-  DEBUG_CHECK(last_text_state_.has_value(), LOG_TAG, "");
+  FML_DCHECK(last_text_state_.has_value());
 
   requested_text_action_ = action;
   text_sync_service_->GetInputMethodEditor(

--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 
+#include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
 #include "runtime/dart/utils/inlines.h"
 #include "third_party/skia/include/core/SkCanvas.h"
@@ -490,10 +491,10 @@ void VulkanSurface::SignalWritesFinished(
     return;
   }
 
-  dart_utils::Check(pending_on_writes_committed_ == nullptr,
-                    "Attempted to signal a write on the surface when the "
-                    "previous write has not yet been acknowledged by the "
-                    "compositor.");
+  FML_CHECK(pending_on_writes_committed_ == nullptr)
+      << "Attempted to signal a write on the surface when the "
+         "previous write has not yet been acknowledged by the "
+         "compositor.";
 
   pending_on_writes_committed_ = on_writes_committed;
 }

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
@@ -7,7 +7,6 @@
 
 #include <lib/async/cpp/time.h>
 #include <lib/async/default.h>
-#include <lib/syslog/global.h>
 
 #include "flutter/flutter_vma/flutter_skia_vma.h"
 #include "flutter/fml/macros.h"

--- a/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -45,10 +45,10 @@ template("make_utils") {
              "$fuchsia_sdk_root/pkg:fdio",
              "$fuchsia_sdk_root/pkg:sys_cpp",
              "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
-             "$fuchsia_sdk_root/pkg:syslog",
              "$fuchsia_sdk_root/pkg:trace",
              "$fuchsia_sdk_root/pkg:vfs_cpp",
              "$fuchsia_sdk_root/pkg:zx",
+             "//flutter/fml",
              "//flutter/third_party/tonic",
            ]
 

--- a/shell/platform/fuchsia/runtime/dart/utils/files.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/files.cc
@@ -5,18 +5,18 @@
 #include "files.h"
 
 #include <fcntl.h>
+#include <unistd.h>
 
 #include <cstdint>
 
-#include "inlines.h"
-#include "logging.h"
+#include "flutter/fml/logging.h"
 
 namespace dart_utils {
 
 namespace {
 
 bool ReadFileDescriptor(int fd, std::string* result) {
-  DEBUG_CHECK(result, LOG_TAG, "");
+  FML_DCHECK(result);
   result->clear();
 
   if (fd < 0) {

--- a/shell/platform/fuchsia/runtime/dart/utils/inlines.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/inlines.h
@@ -5,22 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_INLINES_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_INLINES_H_
 
-#include <lib/syslog/global.h>
-
 namespace dart_utils {
-
-inline void Check(bool condition, const char* tag, const char* message = "") {
-  if (!condition) {
-    FX_LOG(FATAL, tag, message);
-  }
-}
-
-#ifndef NDEBUG
-#define DEBUG_CHECK(condition, tag, message) \
-  dart_utils::Check(condition, tag, message)
-#else
-#define DEBUG_CHECK(condition, tag, message) (true || (condition))
-#endif
 
 template <size_t SIZE, typename T>
 inline size_t ArraySize(T (&array)[SIZE]) {

--- a/shell/platform/fuchsia/runtime/dart/utils/tempfs.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/tempfs.cc
@@ -6,12 +6,11 @@
 
 #include <string_view>
 
-#include <lib/syslog/global.h>
 #include <zircon/errors.h>
 #include <zircon/status.h>
 #include <zircon/syscalls.h>
 
-#include "logging.h"
+#include "flutter/fml/logging.h"
 
 namespace {
 
@@ -28,8 +27,8 @@ void BindTemp(fdio_ns_t* ns) {
   // devfs requires sharing between the service isolate and the app isolates.
   fdio_flat_namespace_t* rootns;
   if (zx_status_t status = fdio_ns_export_root(&rootns); status != ZX_OK) {
-    FX_LOGF(ERROR, LOG_TAG, "Failed to export root ns: %s",
-            zx_status_get_string(status));
+    FML_LOG(ERROR) << "Failed to export root ns: "
+                   << zx_status_get_string(status);
     return;
   }
 
@@ -44,9 +43,8 @@ void BindTemp(fdio_ns_t* ns) {
   if (zx_status_t status = fdio_ns_bind(ns, kTmpPath, tmp_dir_handle);
       status != ZX_OK) {
     zx_handle_close(tmp_dir_handle);
-    FX_LOGF(ERROR, LOG_TAG,
-            "Failed to bind /tmp directory into isolate namespace: %s",
-            zx_status_get_string(status));
+    FML_LOG(ERROR) << "Failed to bind /tmp directory into isolate namespace: "
+                   << zx_status_get_string(status);
   }
 }
 

--- a/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
@@ -11,21 +11,22 @@
 #include <fuchsia/mem/cpp/fidl.h>
 #include <lib/fdio/directory.h>
 #include <lib/fdio/io.h>
-#include <lib/syslog/global.h>
 #include <zircon/status.h>
 
-#include "logging.h"
+#include <ios>
+
+#include "flutter/fml/logging.h"
 
 namespace {
 
 bool VmoFromFd(int fd, bool executable, fuchsia::mem::Buffer* buffer) {
   if (!buffer) {
-    FX_LOG(FATAL, LOG_TAG, "Invalid buffer pointer");
+    FML_LOG(FATAL) << "Invalid buffer pointer";
   }
 
   struct stat stat_struct;
   if (fstat(fd, &stat_struct) == -1) {
-    FX_LOGF(ERROR, LOG_TAG, "fstat failed: %s", strerror(errno));
+    FML_LOG(ERROR) << "fstat failed: " << strerror(errno);
     return false;
   }
 
@@ -38,8 +39,8 @@ bool VmoFromFd(int fd, bool executable, fuchsia::mem::Buffer* buffer) {
   }
 
   if (status != ZX_OK) {
-    FX_LOGF(ERROR, LOG_TAG, "fdio_get_vmo_%s failed: %s",
-            executable ? "exec" : "copy", zx_status_get_string(status));
+    FML_LOG(ERROR) << (executable ? "fdio_get_vmo_exec" : "fdio_get_vmo_copy")
+                   << " failed: " << zx_status_get_string(status);
     return false;
   }
 
@@ -68,9 +69,9 @@ bool VmoFromFilename(const std::string& filename,
   const zx_status_t status =
       fdio_open_fd(filename.c_str(), static_cast<uint32_t>(flags), &fd);
   if (status != ZX_OK) {
-    FX_LOGF(ERROR, LOG_TAG, "fdio_open_fd(\"%s\", %08x) failed: %s",
-            filename.c_str(), static_cast<uint32_t>(flags),
-            zx_status_get_string(status));
+    FML_LOG(ERROR) << "fdio_open_fd(\"" << filename << "\", " << std::hex
+                   << static_cast<uint32_t>(flags)
+                   << ") failed: " << zx_status_get_string(status);
     return false;
   }
   bool result = VmoFromFd(fd, executable, buffer);
@@ -91,9 +92,9 @@ bool VmoFromFilenameAt(int dirfd,
   const zx_status_t status = fdio_open_fd_at(dirfd, filename.c_str(),
                                              static_cast<uint32_t>(flags), &fd);
   if (status != ZX_OK) {
-    FX_LOGF(ERROR, LOG_TAG, "fdio_open_fd_at(%d, \"%s\", %08x) failed: %s",
-            dirfd, filename.c_str(), static_cast<uint32_t>(flags),
-            zx_status_get_string(status));
+    FML_LOG(ERROR) << "fdio_open_fd_at(" << dirfd << ", \"" << filename
+                   << "\", " << std::hex << static_cast<uint32_t>(flags)
+                   << ") failed: " << zx_status_get_string(status);
     return false;
   }
   bool result = VmoFromFd(fd, executable, buffer);

--- a/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
@@ -6,13 +6,12 @@
 
 #include <dirent.h>
 #include <fuchsia/io/cpp/fidl.h>
-#include <lib/syslog/global.h>
 #include <zircon/status.h>
 
 #include <cerrno>
 #include <string>
 
-#include "logging.h"
+#include "flutter/fml/logging.h"
 
 namespace {
 
@@ -40,9 +39,8 @@ void VMServiceObject::GetContents(LazyEntryVector* out_vector) const {
   // the contents of this directory.
   std::vector<std::string> files;
   if (!ReadDirContents(kPortDir, &files)) {
-    FX_LOGF(ERROR, LOG_TAG,
-            "Failed to read Dart VM service port directory '%s': %s", kPortDir,
-            strerror(errno));
+    FML_LOG(ERROR) << "Failed to read Dart VM service port directory '"
+                   << kPortDir << "': " << strerror(errno);
     return;
   }
   for (const auto& file : files) {


### PR DESCRIPTION
This change updates all of the Fuchsia specific logging macros (e.g. FX_LOG*) to use the logging macros provided by the FML library (FML_LOG(...)). This will allow us to migrate to Fuchsia structured logging backend in a future commit.

flutter/flutter#141924

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
