### PR TITLE
[Impeller] use const std::unique_ptr ref for Sampler type.

### DIFF
--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -1364,7 +1364,7 @@ std::vector<Reflector::BindPrototype> Reflector::ReflectBindPrototypes(
         .argument_name = "texture",
     });
     proto.args.push_back(BindPrototypeArgument{
-        .type_name = "std::shared_ptr<const Sampler>",
+        .type_name = "const Sampler&",
         .argument_name = "sampler",
     });
   }

--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -1364,7 +1364,7 @@ std::vector<Reflector::BindPrototype> Reflector::ReflectBindPrototypes(
         .argument_name = "texture",
     });
     proto.args.push_back(BindPrototypeArgument{
-        .type_name = "const Sampler&",
+        .type_name = "const std::unique_ptr<const Sampler>&",
         .argument_name = "sampler",
     });
   }

--- a/impeller/core/resource_binder.h
+++ b/impeller/core/resource_binder.h
@@ -34,7 +34,7 @@ struct ResourceBinder {
                             const SampledImageSlot& slot,
                             const ShaderMetadata& metadata,
                             std::shared_ptr<const Texture> texture,
-                            std::shared_ptr<const Sampler> sampler) = 0;
+                            const Sampler& sampler) = 0;
 };
 
 }  // namespace impeller

--- a/impeller/core/resource_binder.h
+++ b/impeller/core/resource_binder.h
@@ -34,7 +34,7 @@ struct ResourceBinder {
                             const SampledImageSlot& slot,
                             const ShaderMetadata& metadata,
                             std::shared_ptr<const Texture> texture,
-                            const Sampler& sampler) = 0;
+                            const std::unique_ptr<const Sampler>& sampler) = 0;
 };
 
 }  // namespace impeller

--- a/impeller/core/sampler.h
+++ b/impeller/core/sampler.h
@@ -31,8 +31,19 @@ class Sampler {
   Sampler& operator=(const Sampler&) = delete;
 };
 
+/// @brief A sampler subclass to be returned in the result of a lost device
+//         or other failure to allocate a sampler object.
+class InvalidSampler : public Sampler {
+ public:
+  explicit InvalidSampler(SamplerDescriptor desc) : Sampler(std::move(desc)) {}
+
+  ~InvalidSampler() = default;
+
+  bool IsValid() const override { return false; }
+};
+
 using SamplerMap = std::unordered_map<SamplerDescriptor,
-                                      std::shared_ptr<const Sampler>,
+                                      std::unique_ptr<const Sampler>,
                                       ComparableHash<SamplerDescriptor>,
                                       ComparableEqual<SamplerDescriptor>>;
 

--- a/impeller/core/sampler.h
+++ b/impeller/core/sampler.h
@@ -16,8 +16,6 @@ class Sampler {
  public:
   virtual ~Sampler();
 
-  virtual bool IsValid() const = 0;
-
   const SamplerDescriptor& GetDescriptor() const;
 
  protected:
@@ -29,17 +27,6 @@ class Sampler {
   Sampler(const Sampler&) = delete;
 
   Sampler& operator=(const Sampler&) = delete;
-};
-
-/// @brief A sampler subclass to be returned in the result of a lost device
-//         or other failure to allocate a sampler object.
-class InvalidSampler : public Sampler {
- public:
-  explicit InvalidSampler(SamplerDescriptor desc) : Sampler(std::move(desc)) {}
-
-  ~InvalidSampler() = default;
-
-  bool IsValid() const override { return false; }
 };
 
 using SamplerMap = std::unordered_map<SamplerDescriptor,

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -252,7 +252,7 @@ bool AtlasContents::Render(const ContentContext& renderer,
       dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
       dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
     }
-    const Sampler& dst_sampler =
+    const std::unique_ptr<const Sampler>& dst_sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(
             dst_sampler_descriptor);
     FS::BindTextureSamplerDst(pass, texture_, dst_sampler);

--- a/impeller/entity/contents/atlas_contents.cc
+++ b/impeller/entity/contents/atlas_contents.cc
@@ -252,8 +252,9 @@ bool AtlasContents::Render(const ContentContext& renderer,
       dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
       dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
     }
-    auto dst_sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-        dst_sampler_descriptor);
+    const Sampler& dst_sampler =
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler(
+            dst_sampler_descriptor);
     FS::BindTextureSamplerDst(pass, texture_, dst_sampler);
     frame_info.texture_sampler_y_coord_scale = texture_->GetYCoordScale();
 

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -179,7 +179,7 @@ static std::optional<Entity> AdvancedBlend(
       dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
       dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
     }
-    const Sampler& dst_sampler =
+    const std::unique_ptr<const Sampler>& dst_sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(
             dst_sampler_descriptor);
     FS::BindTextureSamplerDst(pass, dst_snapshot->texture, dst_sampler);
@@ -202,7 +202,7 @@ static std::optional<Entity> AdvancedBlend(
         src_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
         src_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
       }
-      const Sampler& src_sampler =
+      const std::unique_ptr<const Sampler>& src_sampler =
           renderer.GetContext()->GetSamplerLibrary()->GetSampler(
               src_sampler_descriptor);
       blend_info.color_factor = 0;
@@ -353,7 +353,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
       dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
       dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
     }
-    const Sampler& dst_sampler =
+    const std::unique_ptr<const Sampler>& dst_sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(
             dst_sampler_descriptor);
     FS::BindTextureSamplerDst(pass, dst_snapshot->texture, dst_sampler);
@@ -476,7 +476,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
       dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
       dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
     }
-    const Sampler& dst_sampler =
+    const std::unique_ptr<const Sampler>& dst_sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler(
             dst_sampler_descriptor);
     FS::BindTextureSamplerDst(pass, dst_snapshot->texture, dst_sampler);
@@ -574,7 +574,7 @@ static std::optional<Entity> PipelineBlend(
         return false;
       }
 
-      const Sampler& sampler =
+      const std::unique_ptr<const Sampler>& sampler =
           renderer.GetContext()->GetSamplerLibrary()->GetSampler(
               input->sampler_descriptor);
       FS::BindTextureSamplerSrc(pass, input->texture, sampler);

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -179,8 +179,9 @@ static std::optional<Entity> AdvancedBlend(
       dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
       dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
     }
-    auto dst_sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-        dst_sampler_descriptor);
+    const Sampler& dst_sampler =
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler(
+            dst_sampler_descriptor);
     FS::BindTextureSamplerDst(pass, dst_snapshot->texture, dst_sampler);
     frame_info.dst_y_coord_scale = dst_snapshot->texture->GetYCoordScale();
     blend_info.dst_input_alpha =
@@ -201,8 +202,9 @@ static std::optional<Entity> AdvancedBlend(
         src_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
         src_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
       }
-      auto src_sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-          src_sampler_descriptor);
+      const Sampler& src_sampler =
+          renderer.GetContext()->GetSamplerLibrary()->GetSampler(
+              src_sampler_descriptor);
       blend_info.color_factor = 0;
       blend_info.src_input_alpha = src_snapshot->opacity;
       FS::BindTextureSamplerSrc(pass, src_snapshot->texture, src_sampler);
@@ -351,8 +353,9 @@ std::optional<Entity> BlendFilterContents::CreateForegroundAdvancedBlend(
       dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
       dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
     }
-    auto dst_sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-        dst_sampler_descriptor);
+    const Sampler& dst_sampler =
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler(
+            dst_sampler_descriptor);
     FS::BindTextureSamplerDst(pass, dst_snapshot->texture, dst_sampler);
     frame_info.dst_y_coord_scale = dst_snapshot->texture->GetYCoordScale();
     blend_info.dst_input_alpha =
@@ -473,8 +476,9 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
       dst_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
       dst_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
     }
-    auto dst_sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-        dst_sampler_descriptor);
+    const Sampler& dst_sampler =
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler(
+            dst_sampler_descriptor);
     FS::BindTextureSamplerDst(pass, dst_snapshot->texture, dst_sampler);
     frame_info.texture_sampler_y_coord_scale =
         dst_snapshot->texture->GetYCoordScale();
@@ -570,8 +574,9 @@ static std::optional<Entity> PipelineBlend(
         return false;
       }
 
-      auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-          input->sampler_descriptor);
+      const Sampler& sampler =
+          renderer.GetContext()->GetSamplerLibrary()->GetSampler(
+              input->sampler_descriptor);
       FS::BindTextureSamplerSrc(pass, input->texture, sampler);
 
       auto size = input->texture->GetSize();

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -123,7 +123,8 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
     VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));
 
-    auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
+    const Sampler& sampler =
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
     FS::BindTextureSampler(pass, input_snapshot->texture, sampler);
 
     return pass.Draw().ok();

--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -123,7 +123,7 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
     VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));
 
-    const Sampler& sampler =
+    const std::unique_ptr<const Sampler>& sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
     FS::BindTextureSampler(pass, input_snapshot->texture, sampler);
 

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -96,7 +96,8 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
         absorb_opacity == ColorFilterContents::AbsorbOpacity::kYes
             ? input_snapshot->opacity
             : 1.0f;
-    auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
+    const Sampler& sampler =
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
     FS::BindInputTexture(pass, input_snapshot->texture, sampler);
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
 

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -96,7 +96,7 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
         absorb_opacity == ColorFilterContents::AbsorbOpacity::kYes
             ? input_snapshot->opacity
             : 1.0f;
-    const Sampler& sampler =
+    const std::unique_ptr<const Sampler>& sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
     FS::BindInputTexture(pass, input_snapshot->texture, sampler);
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -77,7 +77,7 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
             ? input_snapshot->opacity
             : 1.0f;
 
-    const Sampler& sampler =
+    const std::unique_ptr<const Sampler>& sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
     FS::BindInputTexture(pass, input_snapshot->texture, sampler);
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -77,7 +77,8 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
             ? input_snapshot->opacity
             : 1.0f;
 
-    auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
+    const Sampler& sampler =
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
     FS::BindInputTexture(pass, input_snapshot->texture, sampler);
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
     VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -111,7 +111,8 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
         break;
     }
 
-    auto sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
+    const Sampler& sampler =
+        renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
     FS::BindYTexture(pass, y_input_snapshot->texture, sampler);
     FS::BindUvTexture(pass, uv_input_snapshot->texture, sampler);
 

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -111,7 +111,7 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
         break;
     }
 
-    const Sampler& sampler =
+    const std::unique_ptr<const Sampler>& sampler =
         renderer.GetContext()->GetSamplerLibrary()->GetSampler({});
     FS::BindYTexture(pass, y_input_snapshot->texture, sampler);
     FS::BindUvTexture(pass, uv_input_snapshot->texture, sampler);

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -132,8 +132,9 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
     src_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
     src_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
   }
-  auto src_sampler = renderer.GetContext()->GetSamplerLibrary()->GetSampler(
-      src_sampler_descriptor);
+  const Sampler& src_sampler =
+      renderer.GetContext()->GetSamplerLibrary()->GetSampler(
+          src_sampler_descriptor);
   FS::BindTextureSamplerSrc(pass, src_snapshot->texture, src_sampler);
 
   frame_info.mvp = pass.GetOrthographicTransform() * src_snapshot->transform;

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -132,7 +132,7 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
     src_sampler_descriptor.width_address_mode = SamplerAddressMode::kDecal;
     src_sampler_descriptor.height_address_mode = SamplerAddressMode::kDecal;
   }
-  const Sampler& src_sampler =
+  const std::unique_ptr<const Sampler>& src_sampler =
       renderer.GetContext()->GetSamplerLibrary()->GetSampler(
           src_sampler_descriptor);
   FS::BindTextureSamplerSrc(pass, src_snapshot->texture, src_sampler);

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -254,7 +254,7 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
         FML_DCHECK(sampler_index < texture_inputs_.size());
         auto& input = texture_inputs_[sampler_index];
 
-        auto sampler =
+        const Sampler& sampler =
             context->GetSamplerLibrary()->GetSampler(input.sampler_descriptor);
 
         SampledImageSlot image_slot;

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -254,7 +254,7 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
         FML_DCHECK(sampler_index < texture_inputs_.size());
         auto& input = texture_inputs_[sampler_index];
 
-        const Sampler& sampler =
+        const std::unique_ptr<const Sampler>& sampler =
             context->GetSamplerLibrary()->GetSampler(input.sampler_descriptor);
 
         SampledImageSlot image_slot;

--- a/impeller/entity/contents/test/recording_render_pass.cc
+++ b/impeller/entity/contents/test/recording_render_pass.cc
@@ -103,12 +103,13 @@ bool RecordingRenderPass::BindResource(
 }
 
 // |RenderPass|
-bool RecordingRenderPass::BindResource(ShaderStage stage,
-                                       DescriptorType type,
-                                       const SampledImageSlot& slot,
-                                       const ShaderMetadata& metadata,
-                                       std::shared_ptr<const Texture> texture,
-                                       const Sampler& sampler) {
+bool RecordingRenderPass::BindResource(
+    ShaderStage stage,
+    DescriptorType type,
+    const SampledImageSlot& slot,
+    const ShaderMetadata& metadata,
+    std::shared_ptr<const Texture> texture,
+    const std::unique_ptr<const Sampler>& sampler) {
   pending_.BindResource(stage, type, slot, metadata, texture, sampler);
   return delegate_->BindResource(stage, type, slot, metadata, texture, sampler);
 }

--- a/impeller/entity/contents/test/recording_render_pass.cc
+++ b/impeller/entity/contents/test/recording_render_pass.cc
@@ -108,7 +108,7 @@ bool RecordingRenderPass::BindResource(ShaderStage stage,
                                        const SampledImageSlot& slot,
                                        const ShaderMetadata& metadata,
                                        std::shared_ptr<const Texture> texture,
-                                       std::shared_ptr<const Sampler> sampler) {
+                                       const Sampler& sampler) {
   pending_.BindResource(stage, type, slot, metadata, texture, sampler);
   return delegate_->BindResource(stage, type, slot, metadata, texture, sampler);
 }

--- a/impeller/entity/contents/test/recording_render_pass.h
+++ b/impeller/entity/contents/test/recording_render_pass.h
@@ -66,7 +66,7 @@ class RecordingRenderPass : public RenderPass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    std::shared_ptr<const Sampler> sampler) override;
+                    const Sampler& sampler) override;
 
   // |RenderPass|
   void OnSetLabel(std::string label) override;

--- a/impeller/entity/contents/test/recording_render_pass.h
+++ b/impeller/entity/contents/test/recording_render_pass.h
@@ -66,7 +66,7 @@ class RecordingRenderPass : public RenderPass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    const Sampler& sampler) override;
+                    const std::unique_ptr<const Sampler>& sampler) override;
 
   // |RenderPass|
   void OnSetLabel(std::string label) override;

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -36,13 +36,14 @@
 #include "impeller/renderer/render_pass.h"
 
 struct ImGui_ImplImpeller_Data {
-  explicit ImGui_ImplImpeller_Data(const impeller::Sampler& p_sampler)
+  explicit ImGui_ImplImpeller_Data(
+      const std::unique_ptr<const impeller::Sampler>& p_sampler)
       : sampler(p_sampler) {}
 
   std::shared_ptr<impeller::Context> context;
   std::shared_ptr<impeller::Texture> font_texture;
   std::shared_ptr<impeller::Pipeline<impeller::PipelineDescriptor>> pipeline;
-  const impeller::Sampler& sampler;
+  const std::unique_ptr<const impeller::Sampler>& sampler;
 };
 
 static ImGui_ImplImpeller_Data* ImGui_ImplImpeller_GetBackendData() {

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -36,10 +36,13 @@
 #include "impeller/renderer/render_pass.h"
 
 struct ImGui_ImplImpeller_Data {
+  explicit ImGui_ImplImpeller_Data(const impeller::Sampler& p_sampler)
+      : sampler(p_sampler) {}
+
   std::shared_ptr<impeller::Context> context;
   std::shared_ptr<impeller::Texture> font_texture;
   std::shared_ptr<impeller::Pipeline<impeller::PipelineDescriptor>> pipeline;
-  std::shared_ptr<const impeller::Sampler> sampler;
+  const impeller::Sampler& sampler;
 };
 
 static ImGui_ImplImpeller_Data* ImGui_ImplImpeller_GetBackendData() {
@@ -56,7 +59,8 @@ bool ImGui_ImplImpeller_Init(
             "Already initialized a renderer backend!");
 
   // Setup backend capabilities flags
-  auto* bd = new ImGui_ImplImpeller_Data();
+  auto* bd =
+      new ImGui_ImplImpeller_Data(context->GetSamplerLibrary()->GetSampler({}));
   io.BackendRendererUserData = reinterpret_cast<void*>(bd);
   io.BackendRendererName = "imgui_impl_impeller";
   io.BackendFlags |=
@@ -105,8 +109,6 @@ bool ImGui_ImplImpeller_Init(
     bd->pipeline =
         context->GetPipelineLibrary()->GetPipeline(std::move(desc)).Get();
     IM_ASSERT(bd->pipeline != nullptr && "Could not create ImGui pipeline.");
-
-    bd->sampler = context->GetSamplerLibrary()->GetSampler({});
     IM_ASSERT(bd->pipeline != nullptr && "Could not create ImGui sampler.");
   }
 

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -381,7 +381,7 @@ std::optional<size_t> BufferBindingsGLES::BindTextures(
     /// If there is a sampler for the texture at the same index, configure the
     /// bound texture using that sampler.
     ///
-    const auto& sampler_gles = SamplerGLES::Cast(*data.sampler);
+    const auto& sampler_gles = SamplerGLES::Cast(data.sampler);
     if (!sampler_gles.ConfigureBoundTexture(texture_gles, gl)) {
       return std::nullopt;
     }

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -381,7 +381,7 @@ std::optional<size_t> BufferBindingsGLES::BindTextures(
     /// If there is a sampler for the texture at the same index, configure the
     /// bound texture using that sampler.
     ///
-    const auto& sampler_gles = SamplerGLES::Cast(data.sampler);
+    const auto& sampler_gles = SamplerGLES::Cast(*data.sampler);
     if (!sampler_gles.ConfigureBoundTexture(texture_gles, gl)) {
       return std::nullopt;
     }

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -4,8 +4,6 @@
 
 #include "impeller/renderer/backend/gles/sampler_gles.h"
 
-#include <iostream>
-
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/gles/formats_gles.h"
@@ -17,10 +15,6 @@ namespace impeller {
 SamplerGLES::SamplerGLES(SamplerDescriptor desc) : Sampler(std::move(desc)) {}
 
 SamplerGLES::~SamplerGLES() = default;
-
-bool SamplerGLES::IsValid() const {
-  return true;
-}
 
 static GLint ToParam(MinMagFilter minmag_filter,
                      std::optional<MipFilter> mip_filter = std::nullopt) {
@@ -74,10 +68,6 @@ static GLint ToAddressMode(SamplerAddressMode mode,
 
 bool SamplerGLES::ConfigureBoundTexture(const TextureGLES& texture,
                                         const ProcTableGLES& gl) const {
-  if (!IsValid()) {
-    return false;
-  }
-
   if (texture.NeedsMipmapGeneration()) {
     VALIDATION_LOG
         << "Texture mip count is > 1, but the mipmap has not been generated. "

--- a/impeller/renderer/backend/gles/sampler_gles.h
+++ b/impeller/renderer/backend/gles/sampler_gles.h
@@ -28,9 +28,6 @@ class SamplerGLES final : public Sampler,
 
   explicit SamplerGLES(SamplerDescriptor desc);
 
-  // |Sampler|
-  bool IsValid() const override;
-
   SamplerGLES(const SamplerGLES&) = delete;
 
   SamplerGLES& operator=(const SamplerGLES&) = delete;

--- a/impeller/renderer/backend/gles/sampler_library_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_library_gles.cc
@@ -11,6 +11,8 @@
 
 namespace impeller {
 
+static const std::unique_ptr<const Sampler> kNullSampler = nullptr;
+
 SamplerLibraryGLES::SamplerLibraryGLES(bool supports_decal_sampler_address_mode)
     : supports_decal_sampler_address_mode_(
           supports_decal_sampler_address_mode) {}
@@ -19,23 +21,23 @@ SamplerLibraryGLES::SamplerLibraryGLES(bool supports_decal_sampler_address_mode)
 SamplerLibraryGLES::~SamplerLibraryGLES() = default;
 
 // |SamplerLibrary|
-const Sampler& SamplerLibraryGLES::GetSampler(SamplerDescriptor descriptor) {
+const std::unique_ptr<const Sampler>& SamplerLibraryGLES::GetSampler(
+    SamplerDescriptor descriptor) {
   if (!supports_decal_sampler_address_mode_ &&
       (descriptor.width_address_mode == SamplerAddressMode::kDecal ||
        descriptor.height_address_mode == SamplerAddressMode::kDecal ||
        descriptor.depth_address_mode == SamplerAddressMode::kDecal)) {
     VALIDATION_LOG << "SamplerAddressMode::kDecal is not supported by the "
                       "current OpenGLES backend.";
-    return invalid_sampler_;
+    return kNullSampler;
   }
 
   auto found = samplers_.find(descriptor);
   if (found != samplers_.end()) {
-    return *found->second.get();
+    return found->second;
   }
-  return *(samplers_[descriptor] =
-               std::unique_ptr<SamplerGLES>(new SamplerGLES(descriptor)))
-              .get();
+  return (samplers_[descriptor] =
+              std::unique_ptr<SamplerGLES>(new SamplerGLES(descriptor)));
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/sampler_library_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_library_gles.cc
@@ -19,23 +19,23 @@ SamplerLibraryGLES::SamplerLibraryGLES(bool supports_decal_sampler_address_mode)
 SamplerLibraryGLES::~SamplerLibraryGLES() = default;
 
 // |SamplerLibrary|
-std::shared_ptr<const Sampler> SamplerLibraryGLES::GetSampler(
-    SamplerDescriptor descriptor) {
+const Sampler& SamplerLibraryGLES::GetSampler(SamplerDescriptor descriptor) {
   if (!supports_decal_sampler_address_mode_ &&
       (descriptor.width_address_mode == SamplerAddressMode::kDecal ||
        descriptor.height_address_mode == SamplerAddressMode::kDecal ||
        descriptor.depth_address_mode == SamplerAddressMode::kDecal)) {
     VALIDATION_LOG << "SamplerAddressMode::kDecal is not supported by the "
                       "current OpenGLES backend.";
-    return nullptr;
+    return invalid_sampler_;
   }
 
   auto found = samplers_.find(descriptor);
   if (found != samplers_.end()) {
-    return found->second;
+    return *found->second.get();
   }
-  return samplers_[descriptor] =
-             std::shared_ptr<SamplerGLES>(new SamplerGLES(descriptor));
+  return *(samplers_[descriptor] =
+               std::unique_ptr<SamplerGLES>(new SamplerGLES(descriptor)))
+              .get();
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/sampler_library_gles.h
+++ b/impeller/renderer/backend/gles/sampler_library_gles.h
@@ -21,12 +21,12 @@ class SamplerLibraryGLES final : public SamplerLibrary {
   friend class ContextGLES;
 
   SamplerMap samplers_;
-  InvalidSampler invalid_sampler_ = InvalidSampler({});
 
   SamplerLibraryGLES();
 
   // |SamplerLibrary|
-  const Sampler& GetSampler(SamplerDescriptor descriptor) override;
+  const std::unique_ptr<const Sampler>& GetSampler(
+      SamplerDescriptor descriptor) override;
 
   bool supports_decal_sampler_address_mode_ = false;
 

--- a/impeller/renderer/backend/gles/sampler_library_gles.h
+++ b/impeller/renderer/backend/gles/sampler_library_gles.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_SAMPLER_LIBRARY_GLES_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_SAMPLER_LIBRARY_GLES_H_
 
+#include "impeller/core/sampler.h"
 #include "impeller/core/sampler_descriptor.h"
 #include "impeller/renderer/sampler_library.h"
 
@@ -20,12 +21,12 @@ class SamplerLibraryGLES final : public SamplerLibrary {
   friend class ContextGLES;
 
   SamplerMap samplers_;
+  InvalidSampler invalid_sampler_ = InvalidSampler({});
 
   SamplerLibraryGLES();
 
   // |SamplerLibrary|
-  std::shared_ptr<const Sampler> GetSampler(
-      SamplerDescriptor descriptor) override;
+  const Sampler& GetSampler(SamplerDescriptor descriptor) override;
 
   bool supports_decal_sampler_address_mode_ = false;
 

--- a/impeller/renderer/backend/metal/compute_pass_mtl.h
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.h
@@ -61,7 +61,7 @@ class ComputePassMTL final : public ComputePass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    std::shared_ptr<const Sampler> sampler) override;
+                    const Sampler& sampler) override;
 
   // |ComputePass|
   bool EncodeCommands() const override;

--- a/impeller/renderer/backend/metal/compute_pass_mtl.h
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.h
@@ -61,7 +61,7 @@ class ComputePassMTL final : public ComputePass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    const Sampler& sampler) override;
+                    const std::unique_ptr<const Sampler>& sampler) override;
 
   // |ComputePass|
   bool EncodeCommands() const override;

--- a/impeller/renderer/backend/metal/compute_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.mm
@@ -98,15 +98,15 @@ bool ComputePassMTL::BindResource(ShaderStage stage,
                                   const SampledImageSlot& slot,
                                   const ShaderMetadata& metadata,
                                   std::shared_ptr<const Texture> texture,
-                                  std::shared_ptr<const Sampler> sampler) {
-  if (!sampler->IsValid() || !texture->IsValid()) {
+                                  const Sampler& sampler) {
+  if (!sampler.IsValid() || !texture->IsValid()) {
     return false;
   }
 
   pass_bindings_cache_.SetTexture(slot.texture_index,
                                   TextureMTL::Cast(*texture).GetMTLTexture());
   pass_bindings_cache_.SetSampler(
-      slot.texture_index, SamplerMTL::Cast(*sampler).GetMTLSamplerState());
+      slot.texture_index, SamplerMTL::Cast(sampler).GetMTLSamplerState());
   return true;
 }
 

--- a/impeller/renderer/backend/metal/compute_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/compute_pass_mtl.mm
@@ -93,20 +93,21 @@ bool ComputePassMTL::BindResource(ShaderStage stage,
 }
 
 // |ComputePass|
-bool ComputePassMTL::BindResource(ShaderStage stage,
-                                  DescriptorType type,
-                                  const SampledImageSlot& slot,
-                                  const ShaderMetadata& metadata,
-                                  std::shared_ptr<const Texture> texture,
-                                  const Sampler& sampler) {
-  if (!sampler.IsValid() || !texture->IsValid()) {
+bool ComputePassMTL::BindResource(
+    ShaderStage stage,
+    DescriptorType type,
+    const SampledImageSlot& slot,
+    const ShaderMetadata& metadata,
+    std::shared_ptr<const Texture> texture,
+    const std::unique_ptr<const Sampler>& sampler) {
+  if (!sampler || !texture->IsValid()) {
     return false;
   }
 
   pass_bindings_cache_.SetTexture(slot.texture_index,
                                   TextureMTL::Cast(*texture).GetMTLTexture());
   pass_bindings_cache_.SetSampler(
-      slot.texture_index, SamplerMTL::Cast(sampler).GetMTLSamplerState());
+      slot.texture_index, SamplerMTL::Cast(*sampler).GetMTLSamplerState());
   return true;
 }
 

--- a/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -109,7 +109,7 @@ class RenderPassMTL final : public RenderPass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    std::shared_ptr<const Sampler> sampler) override;
+                    const Sampler& sampler) override;
 
   RenderPassMTL(const RenderPassMTL&) = delete;
 

--- a/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -109,7 +109,7 @@ class RenderPassMTL final : public RenderPass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    const Sampler& sampler) override;
+                    const std::unique_ptr<const Sampler>& sampler) override;
 
   RenderPassMTL(const RenderPassMTL&) = delete;
 

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -389,8 +389,8 @@ bool RenderPassMTL::BindResource(ShaderStage stage,
                                  const SampledImageSlot& slot,
                                  const ShaderMetadata& metadata,
                                  std::shared_ptr<const Texture> texture,
-                                 std::shared_ptr<const Sampler> sampler) {
-  return Bind(pass_bindings_, stage, slot.texture_index, *sampler, *texture);
+                                 const Sampler& sampler) {
+  return Bind(pass_bindings_, stage, slot.texture_index, sampler, *texture);
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -211,9 +211,9 @@ static bool Bind(PassBindingsCacheMTL& pass,
 static bool Bind(PassBindingsCacheMTL& pass,
                  ShaderStage stage,
                  size_t bind_index,
-                 const Sampler& sampler,
+                 const std::unique_ptr<const Sampler>& sampler,
                  const Texture& texture) {
-  if (!sampler.IsValid() || !texture.IsValid()) {
+  if (!sampler || !texture.IsValid()) {
     return false;
   }
 
@@ -230,7 +230,7 @@ static bool Bind(PassBindingsCacheMTL& pass,
   return pass.SetTexture(stage, bind_index,
                          TextureMTL::Cast(texture).GetMTLTexture()) &&
          pass.SetSampler(stage, bind_index,
-                         SamplerMTL::Cast(sampler).GetMTLSamplerState());
+                         SamplerMTL::Cast(*sampler).GetMTLSamplerState());
 }
 
 // |RenderPass|
@@ -384,12 +384,13 @@ bool RenderPassMTL::BindResource(
 }
 
 // |RenderPass|
-bool RenderPassMTL::BindResource(ShaderStage stage,
-                                 DescriptorType type,
-                                 const SampledImageSlot& slot,
-                                 const ShaderMetadata& metadata,
-                                 std::shared_ptr<const Texture> texture,
-                                 const Sampler& sampler) {
+bool RenderPassMTL::BindResource(
+    ShaderStage stage,
+    DescriptorType type,
+    const SampledImageSlot& slot,
+    const ShaderMetadata& metadata,
+    std::shared_ptr<const Texture> texture,
+    const std::unique_ptr<const Sampler>& sampler) {
   return Bind(pass_bindings_, stage, slot.texture_index, sampler, *texture);
 }
 

--- a/impeller/renderer/backend/metal/sampler_library_mtl.h
+++ b/impeller/renderer/backend/metal/sampler_library_mtl.h
@@ -28,13 +28,13 @@ class SamplerLibraryMTL final
   friend class ContextMTL;
 
   id<MTLDevice> device_ = nullptr;
+  InvalidSampler invalid_sampler_ = InvalidSampler{{}};
   SamplerMap samplers_;
 
   explicit SamplerLibraryMTL(id<MTLDevice> device);
 
   // |SamplerLibrary|
-  std::shared_ptr<const Sampler> GetSampler(
-      SamplerDescriptor descriptor) override;
+  const Sampler& GetSampler(SamplerDescriptor descriptor) override;
 
   SamplerLibraryMTL(const SamplerLibraryMTL&) = delete;
 

--- a/impeller/renderer/backend/metal/sampler_library_mtl.h
+++ b/impeller/renderer/backend/metal/sampler_library_mtl.h
@@ -28,13 +28,13 @@ class SamplerLibraryMTL final
   friend class ContextMTL;
 
   id<MTLDevice> device_ = nullptr;
-  InvalidSampler invalid_sampler_ = InvalidSampler{{}};
   SamplerMap samplers_;
 
   explicit SamplerLibraryMTL(id<MTLDevice> device);
 
   // |SamplerLibrary|
-  const Sampler& GetSampler(SamplerDescriptor descriptor) override;
+  const std::unique_ptr<const Sampler>& GetSampler(
+      SamplerDescriptor descriptor) override;
 
   SamplerLibraryMTL(const SamplerLibraryMTL&) = delete;
 

--- a/impeller/renderer/backend/metal/sampler_mtl.h
+++ b/impeller/renderer/backend/metal/sampler_mtl.h
@@ -32,9 +32,6 @@ class SamplerMTL final : public Sampler,
 
   SamplerMTL(SamplerDescriptor desc, id<MTLSamplerState> state);
 
-  // |Sampler|
-  bool IsValid() const override;
-
   SamplerMTL(const SamplerMTL&) = delete;
 
   SamplerMTL& operator=(const SamplerMTL&) = delete;

--- a/impeller/renderer/backend/metal/sampler_mtl.mm
+++ b/impeller/renderer/backend/metal/sampler_mtl.mm
@@ -7,13 +7,11 @@
 namespace impeller {
 
 SamplerMTL::SamplerMTL(SamplerDescriptor desc, id<MTLSamplerState> state)
-    : Sampler(std::move(desc)), state_(state) {}
+    : Sampler(std::move(desc)), state_(state) {
+  FML_DCHECK(state_);
+}
 
 SamplerMTL::~SamplerMTL() = default;
-
-bool SamplerMTL::IsValid() const {
-  return state_;
-}
 
 id<MTLSamplerState> SamplerMTL::GetMTLSamplerState() const {
   return state_;

--- a/impeller/renderer/backend/vulkan/compute_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/compute_pass_vk.cc
@@ -145,20 +145,21 @@ bool ComputePassVK::BindResource(ShaderStage stage,
 }
 
 // |ResourceBinder|
-bool ComputePassVK::BindResource(ShaderStage stage,
-                                 DescriptorType type,
-                                 const SampledImageSlot& slot,
-                                 const ShaderMetadata& metadata,
-                                 std::shared_ptr<const Texture> texture,
-                                 const Sampler& sampler) {
+bool ComputePassVK::BindResource(
+    ShaderStage stage,
+    DescriptorType type,
+    const SampledImageSlot& slot,
+    const ShaderMetadata& metadata,
+    std::shared_ptr<const Texture> texture,
+    const std::unique_ptr<const Sampler>& sampler) {
   if (bound_image_offset_ >= kMaxBindings) {
     return false;
   }
-  if (!texture->IsValid() || !sampler.IsValid()) {
+  if (!texture->IsValid() || !sampler) {
     return false;
   }
   const TextureVK& texture_vk = TextureVK::Cast(*texture);
-  const SamplerVK& sampler_vk = SamplerVK::Cast(sampler);
+  const SamplerVK& sampler_vk = SamplerVK::Cast(*sampler);
 
   if (!command_buffer_->GetEncoder()->Track(texture)) {
     return false;

--- a/impeller/renderer/backend/vulkan/compute_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/compute_pass_vk.cc
@@ -150,15 +150,17 @@ bool ComputePassVK::BindResource(ShaderStage stage,
                                  const SampledImageSlot& slot,
                                  const ShaderMetadata& metadata,
                                  std::shared_ptr<const Texture> texture,
-                                 std::shared_ptr<const Sampler> sampler) {
+                                 const Sampler& sampler) {
   if (bound_image_offset_ >= kMaxBindings) {
     return false;
   }
+  if (!texture->IsValid() || !sampler.IsValid()) {
+    return false;
+  }
   const TextureVK& texture_vk = TextureVK::Cast(*texture);
-  const SamplerVK& sampler_vk = SamplerVK::Cast(*sampler);
+  const SamplerVK& sampler_vk = SamplerVK::Cast(sampler);
 
-  if (!command_buffer_->GetEncoder()->Track(texture) ||
-      !command_buffer_->GetEncoder()->Track(sampler_vk.GetSharedSampler())) {
+  if (!command_buffer_->GetEncoder()->Track(texture)) {
     return false;
   }
 

--- a/impeller/renderer/backend/vulkan/compute_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/compute_pass_vk.h
@@ -73,7 +73,7 @@ class ComputePassVK final : public ComputePass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    std::shared_ptr<const Sampler> sampler) override;
+                    const Sampler& sampler) override;
 
   bool BindResource(size_t binding,
                     DescriptorType type,

--- a/impeller/renderer/backend/vulkan/compute_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/compute_pass_vk.h
@@ -73,7 +73,7 @@ class ComputePassVK final : public ComputePass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    const Sampler& sampler) override;
+                    const std::unique_ptr<const Sampler>& sampler) override;
 
   bool BindResource(size_t binding,
                     DescriptorType type,

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -637,15 +637,17 @@ bool RenderPassVK::BindResource(ShaderStage stage,
                                 const SampledImageSlot& slot,
                                 const ShaderMetadata& metadata,
                                 std::shared_ptr<const Texture> texture,
-                                std::shared_ptr<const Sampler> sampler) {
+                                const Sampler& sampler) {
   if (bound_buffer_offset_ >= kMaxBindings) {
     return false;
   }
+  if (!texture->IsValid() || !sampler.IsValid()) {
+    return false;
+  }
   const TextureVK& texture_vk = TextureVK::Cast(*texture);
-  const SamplerVK& sampler_vk = SamplerVK::Cast(*sampler);
+  const SamplerVK& sampler_vk = SamplerVK::Cast(sampler);
 
-  if (!command_buffer_->GetEncoder()->Track(texture) ||
-      !command_buffer_->GetEncoder()->Track(sampler_vk.GetSharedSampler())) {
+  if (!command_buffer_->GetEncoder()->Track(texture)) {
     return false;
   }
 

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -637,15 +637,15 @@ bool RenderPassVK::BindResource(ShaderStage stage,
                                 const SampledImageSlot& slot,
                                 const ShaderMetadata& metadata,
                                 std::shared_ptr<const Texture> texture,
-                                const Sampler& sampler) {
+                                const std::unique_ptr<const Sampler>& sampler) {
   if (bound_buffer_offset_ >= kMaxBindings) {
     return false;
   }
-  if (!texture->IsValid() || !sampler.IsValid()) {
+  if (!texture->IsValid() || !sampler) {
     return false;
   }
   const TextureVK& texture_vk = TextureVK::Cast(*texture);
-  const SamplerVK& sampler_vk = SamplerVK::Cast(sampler);
+  const SamplerVK& sampler_vk = SamplerVK::Cast(*sampler);
 
   if (!command_buffer_->GetEncoder()->Track(texture)) {
     return false;

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -106,7 +106,7 @@ class RenderPassVK final : public RenderPass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    std::shared_ptr<const Sampler> sampler) override;
+                    const Sampler& sampler) override;
 
   bool BindResource(size_t binding,
                     DescriptorType type,

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -106,7 +106,7 @@ class RenderPassVK final : public RenderPass {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    const Sampler& sampler) override;
+                    const std::unique_ptr<const Sampler>& sampler) override;
 
   bool BindResource(size_t binding,
                     DescriptorType type,

--- a/impeller/renderer/backend/vulkan/sampler_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/sampler_library_vk.cc
@@ -25,7 +25,7 @@ static const std::unique_ptr<Sampler>& find_thing(
   if (it == map.end()) {
     return kNullSampler;
   } else {
-    return &it->second;
+    return it->second;
   }
 }
 

--- a/impeller/renderer/backend/vulkan/sampler_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/sampler_library_vk.cc
@@ -16,6 +16,19 @@ SamplerLibraryVK::SamplerLibraryVK(
 
 SamplerLibraryVK::~SamplerLibraryVK() = default;
 
+static const std::unique_ptr<Sampler> kNullSampler = nullptr;
+
+static const std::unique_ptr<Sampler>& find_thing(
+    const SamplerMap& map,
+    const SamplerDescriptor& desc) {
+  const auto& it = map.find(desc);
+  if (it == map.end()) {
+    return kNullSampler;
+  } else {
+    return &it->second;
+  }
+}
+
 const Sampler& SamplerLibraryVK::GetSampler(SamplerDescriptor desc) {
   auto found = samplers_.find(desc);
   if (found != samplers_.end()) {

--- a/impeller/renderer/backend/vulkan/sampler_library_vk.h
+++ b/impeller/renderer/backend/vulkan/sampler_library_vk.h
@@ -23,13 +23,13 @@ class SamplerLibraryVK final
   friend class ContextVK;
 
   std::weak_ptr<DeviceHolder> device_holder_;
+  InvalidSampler invalid_sampler_ = InvalidSampler{{}};
   SamplerMap samplers_;
 
   explicit SamplerLibraryVK(const std::weak_ptr<DeviceHolder>& device_holder);
 
   // |SamplerLibrary|
-  std::shared_ptr<const Sampler> GetSampler(
-      SamplerDescriptor descriptor) override;
+  const Sampler& GetSampler(SamplerDescriptor descriptor) override;
 
   SamplerLibraryVK(const SamplerLibraryVK&) = delete;
 

--- a/impeller/renderer/backend/vulkan/sampler_library_vk.h
+++ b/impeller/renderer/backend/vulkan/sampler_library_vk.h
@@ -23,13 +23,13 @@ class SamplerLibraryVK final
   friend class ContextVK;
 
   std::weak_ptr<DeviceHolder> device_holder_;
-  InvalidSampler invalid_sampler_ = InvalidSampler{{}};
   SamplerMap samplers_;
 
   explicit SamplerLibraryVK(const std::weak_ptr<DeviceHolder>& device_holder);
 
   // |SamplerLibrary|
-  const Sampler& GetSampler(SamplerDescriptor descriptor) override;
+  const std::unique_ptr<const Sampler>& GetSampler(
+      SamplerDescriptor descriptor) override;
 
   SamplerLibraryVK(const SamplerLibraryVK&) = delete;
 

--- a/impeller/renderer/backend/vulkan/sampler_vk.cc
+++ b/impeller/renderer/backend/vulkan/sampler_vk.cc
@@ -18,11 +18,6 @@ vk::Sampler SamplerVK::GetSampler() const {
   return *sampler_;
 }
 
-const std::shared_ptr<SharedObjectVKT<vk::Sampler>>&
-SamplerVK::GetSharedSampler() const {
-  return sampler_;
-}
-
 bool SamplerVK::IsValid() const {
   return is_valid_;
 }

--- a/impeller/renderer/backend/vulkan/sampler_vk.cc
+++ b/impeller/renderer/backend/vulkan/sampler_vk.cc
@@ -8,18 +8,12 @@ namespace impeller {
 
 SamplerVK::SamplerVK(SamplerDescriptor desc, vk::UniqueSampler sampler)
     : Sampler(std::move(desc)),
-      sampler_(MakeSharedVK<vk::Sampler>(std::move(sampler))) {
-  is_valid_ = true;
-}
+      sampler_(MakeSharedVK<vk::Sampler>(std::move(sampler))) {}
 
 SamplerVK::~SamplerVK() = default;
 
 vk::Sampler SamplerVK::GetSampler() const {
   return *sampler_;
-}
-
-bool SamplerVK::IsValid() const {
-  return is_valid_;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/sampler_vk.h
+++ b/impeller/renderer/backend/vulkan/sampler_vk.h
@@ -30,9 +30,6 @@ class SamplerVK final : public Sampler, public BackendCast<SamplerVK, Sampler> {
   std::shared_ptr<SharedObjectVKT<vk::Sampler>> sampler_;
   bool is_valid_ = false;
 
-  // |Sampler|
-  bool IsValid() const override;
-
   SamplerVK(const SamplerVK&) = delete;
 
   SamplerVK& operator=(const SamplerVK&) = delete;

--- a/impeller/renderer/backend/vulkan/sampler_vk.h
+++ b/impeller/renderer/backend/vulkan/sampler_vk.h
@@ -24,8 +24,6 @@ class SamplerVK final : public Sampler, public BackendCast<SamplerVK, Sampler> {
 
   vk::Sampler GetSampler() const;
 
-  const std::shared_ptr<SharedObjectVKT<vk::Sampler>>& GetSharedSampler() const;
-
  private:
   friend SamplerLibraryVK;
 

--- a/impeller/renderer/command.cc
+++ b/impeller/renderer/command.cc
@@ -72,8 +72,8 @@ bool Command::BindResource(ShaderStage stage,
                            const SampledImageSlot& slot,
                            const ShaderMetadata& metadata,
                            std::shared_ptr<const Texture> texture,
-                           std::shared_ptr<const Sampler> sampler) {
-  if (!sampler || !sampler->IsValid()) {
+                           const Sampler& sampler) {
+  if (!sampler.IsValid()) {
     return false;
   }
   if (!texture || !texture->IsValid()) {
@@ -85,14 +85,14 @@ bool Command::BindResource(ShaderStage stage,
       vertex_bindings.sampled_images.emplace_back(TextureAndSampler{
           .slot = slot,
           .texture = {&metadata, std::move(texture)},
-          .sampler = std::move(sampler),
+          .sampler = sampler,
       });
       return true;
     case ShaderStage::kFragment:
       fragment_bindings.sampled_images.emplace_back(TextureAndSampler{
           .slot = slot,
           .texture = {&metadata, std::move(texture)},
-          .sampler = std::move(sampler),
+          .sampler = sampler,
       });
       return true;
     case ShaderStage::kCompute:

--- a/impeller/renderer/command.cc
+++ b/impeller/renderer/command.cc
@@ -72,8 +72,8 @@ bool Command::BindResource(ShaderStage stage,
                            const SampledImageSlot& slot,
                            const ShaderMetadata& metadata,
                            std::shared_ptr<const Texture> texture,
-                           const Sampler& sampler) {
-  if (!sampler.IsValid()) {
+                           const std::unique_ptr<const Sampler>& sampler) {
+  if (!sampler) {
     return false;
   }
   if (!texture || !texture->IsValid()) {

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -61,7 +61,7 @@ using TextureResource = Resource<std::shared_ptr<const Texture>>;
 struct TextureAndSampler {
   SampledImageSlot slot;
   TextureResource texture;
-  std::shared_ptr<const Sampler> sampler;
+  const Sampler& sampler;
 };
 
 /// @brief combines the buffer resource and its uniform slot information.
@@ -179,7 +179,7 @@ struct Command : public ResourceBinder {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    std::shared_ptr<const Sampler> sampler) override;
+                    const Sampler& sampler) override;
 
   bool IsValid() const { return pipeline && pipeline->IsValid(); }
 

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -61,7 +61,7 @@ using TextureResource = Resource<std::shared_ptr<const Texture>>;
 struct TextureAndSampler {
   SampledImageSlot slot;
   TextureResource texture;
-  const Sampler& sampler;
+  const std::unique_ptr<const Sampler>& sampler;
 };
 
 /// @brief combines the buffer resource and its uniform slot information.
@@ -179,7 +179,7 @@ struct Command : public ResourceBinder {
                     const SampledImageSlot& slot,
                     const ShaderMetadata& metadata,
                     std::shared_ptr<const Texture> texture,
-                    const Sampler& sampler) override;
+                    const std::unique_ptr<const Sampler>& sampler) override;
 
   bool IsValid() const { return pipeline && pipeline->IsValid(); }
 

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -153,9 +153,9 @@ bool RenderPass::BindResource(ShaderStage stage,
                               const SampledImageSlot& slot,
                               const ShaderMetadata& metadata,
                               std::shared_ptr<const Texture> texture,
-                              std::shared_ptr<const Sampler> sampler) {
+                              const Sampler& sampler) {
   return pending_.BindResource(stage, type, slot, metadata, std::move(texture),
-                               std::move(sampler));
+                               sampler);
 }
 
 }  // namespace impeller

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -153,7 +153,7 @@ bool RenderPass::BindResource(ShaderStage stage,
                               const SampledImageSlot& slot,
                               const ShaderMetadata& metadata,
                               std::shared_ptr<const Texture> texture,
-                              const Sampler& sampler) {
+                              const std::unique_ptr<const Sampler>& sampler) {
   return pending_.BindResource(stage, type, slot, metadata, std::move(texture),
                                sampler);
 }

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -130,7 +130,7 @@ class RenderPass : public ResourceBinder {
                             const SampledImageSlot& slot,
                             const ShaderMetadata& metadata,
                             std::shared_ptr<const Texture> texture,
-                            std::shared_ptr<const Sampler> sampler) override;
+                            const Sampler& sampler) override;
 
   //----------------------------------------------------------------------------
   /// @brief      Encode the recorded commands to the underlying command buffer.

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -125,12 +125,13 @@ class RenderPass : public ResourceBinder {
       BufferView view);
 
   // |ResourceBinder|
-  virtual bool BindResource(ShaderStage stage,
-                            DescriptorType type,
-                            const SampledImageSlot& slot,
-                            const ShaderMetadata& metadata,
-                            std::shared_ptr<const Texture> texture,
-                            const Sampler& sampler) override;
+  virtual bool BindResource(
+      ShaderStage stage,
+      DescriptorType type,
+      const SampledImageSlot& slot,
+      const ShaderMetadata& metadata,
+      std::shared_ptr<const Texture> texture,
+      const std::unique_ptr<const Sampler>& sampler) override;
 
   //----------------------------------------------------------------------------
   /// @brief      Encode the recorded commands to the underlying command buffer.

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -69,8 +69,8 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  auto sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler);
+  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler.IsValid());
 
   auto host_buffer = HostBuffer::Create(context->GetResourceAllocator());
   SinglePassCallback callback = [&](RenderPass& pass) {
@@ -164,8 +164,8 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
     vertex_buffer.index_type = IndexType::k16bit;
   }
 
-  auto sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler);
+  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler.IsValid());
 
   Vector3 euler_angles;
   auto host_buffer = HostBuffer::Create(context->GetResourceAllocator());
@@ -232,8 +232,8 @@ TEST_P(RendererTest, CanRenderMultiplePrimitives) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  auto sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler);
+  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler.IsValid());
 
   auto host_buffer = HostBuffer::Create(context->GetResourceAllocator());
   SinglePassCallback callback = [&](RenderPass& pass) {
@@ -305,8 +305,8 @@ TEST_P(RendererTest, CanRenderToTexture) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  auto sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler);
+  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler.IsValid());
   std::shared_ptr<RenderPass> r2t_pass;
   auto cmd_buffer = context->CreateCommandBuffer();
   ASSERT_TRUE(cmd_buffer);
@@ -472,8 +472,8 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  auto sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler);
+  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler.IsValid());
 
   // Vertex buffer.
   VertexBufferBuilder<VS::PerVertexData> vertex_builder;
@@ -540,7 +540,7 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
         frag_info.lod = 0;
         FS::BindFragInfo(*pass, host_buffer->EmplaceUniform(frag_info));
 
-        auto sampler = context->GetSamplerLibrary()->GetSampler({});
+        auto& sampler = context->GetSamplerLibrary()->GetSampler({});
         FS::BindTex(*pass, texture, sampler);
 
         pass->Draw();
@@ -577,8 +577,8 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  auto sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler);
+  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler.IsValid());
 
   TextureDescriptor texture_desc;
   texture_desc.storage_mode = StorageMode::kHostVisible;
@@ -668,7 +668,7 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
         frag_info.lod = 0;
         FS::BindFragInfo(*pass, host_buffer->EmplaceUniform(frag_info));
 
-        auto sampler = context->GetSamplerLibrary()->GetSampler({});
+        const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
         auto buffer_view = DeviceBuffer::AsBufferView(device_buffer);
         auto texture =
             context->GetResourceAllocator()->CreateTexture(texture_desc);
@@ -795,7 +795,8 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
         SamplerDescriptor sampler_desc;
         sampler_desc.mip_filter = mip_filters[selected_mip_filter];
         sampler_desc.min_filter = min_filters[selected_min_filter];
-        auto sampler = context->GetSamplerLibrary()->GetSampler(sampler_desc);
+        const Sampler& sampler =
+            context->GetSamplerLibrary()->GetSampler(sampler_desc);
         FS::BindTex(*pass, boston, sampler);
 
         pass->Draw();
@@ -830,14 +831,15 @@ TEST_P(RendererTest, TheImpeller) {
   SamplerDescriptor noise_sampler_desc;
   noise_sampler_desc.width_address_mode = SamplerAddressMode::kRepeat;
   noise_sampler_desc.height_address_mode = SamplerAddressMode::kRepeat;
-  auto noise_sampler =
+  const Sampler& noise_sampler =
       context->GetSamplerLibrary()->GetSampler(noise_sampler_desc);
 
   auto cube_map = CreateTextureCubeForFixture(
       {"table_mountain_px.png", "table_mountain_nx.png",
        "table_mountain_py.png", "table_mountain_ny.png",
        "table_mountain_pz.png", "table_mountain_nz.png"});
-  auto cube_map_sampler = context->GetSamplerLibrary()->GetSampler({});
+  const Sampler& cube_map_sampler =
+      context->GetSamplerLibrary()->GetSampler({});
   auto host_buffer = HostBuffer::Create(context->GetResourceAllocator());
 
   SinglePassCallback callback = [&](RenderPass& pass) {
@@ -1132,8 +1134,8 @@ TEST_P(RendererTest, StencilMask) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  auto sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler);
+  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler.IsValid());
 
   static bool mirror = false;
   static int stencil_reference_write = 0xFF;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -69,8 +69,9 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler.IsValid());
+  const std::unique_ptr<const Sampler>& sampler =
+      context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler);
 
   auto host_buffer = HostBuffer::Create(context->GetResourceAllocator());
   SinglePassCallback callback = [&](RenderPass& pass) {
@@ -164,8 +165,9 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
     vertex_buffer.index_type = IndexType::k16bit;
   }
 
-  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler.IsValid());
+  const std::unique_ptr<const Sampler>& sampler =
+      context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler);
 
   Vector3 euler_angles;
   auto host_buffer = HostBuffer::Create(context->GetResourceAllocator());
@@ -232,8 +234,9 @@ TEST_P(RendererTest, CanRenderMultiplePrimitives) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler.IsValid());
+  const std::unique_ptr<const Sampler>& sampler =
+      context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler);
 
   auto host_buffer = HostBuffer::Create(context->GetResourceAllocator());
   SinglePassCallback callback = [&](RenderPass& pass) {
@@ -305,8 +308,10 @@ TEST_P(RendererTest, CanRenderToTexture) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler.IsValid());
+  const std::unique_ptr<const Sampler>& sampler =
+      context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler);
+
   std::shared_ptr<RenderPass> r2t_pass;
   auto cmd_buffer = context->CreateCommandBuffer();
   ASSERT_TRUE(cmd_buffer);
@@ -472,8 +477,9 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler.IsValid());
+  const std::unique_ptr<const Sampler>& sampler =
+      context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler);
 
   // Vertex buffer.
   VertexBufferBuilder<VS::PerVertexData> vertex_builder;
@@ -577,8 +583,9 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler.IsValid());
+  const std::unique_ptr<const Sampler>& sampler =
+      context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler);
 
   TextureDescriptor texture_desc;
   texture_desc.storage_mode = StorageMode::kHostVisible;
@@ -668,7 +675,8 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
         frag_info.lod = 0;
         FS::BindFragInfo(*pass, host_buffer->EmplaceUniform(frag_info));
 
-        const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
+        const std::unique_ptr<const Sampler>& sampler =
+            context->GetSamplerLibrary()->GetSampler({});
         auto buffer_view = DeviceBuffer::AsBufferView(device_buffer);
         auto texture =
             context->GetResourceAllocator()->CreateTexture(texture_desc);
@@ -795,7 +803,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
         SamplerDescriptor sampler_desc;
         sampler_desc.mip_filter = mip_filters[selected_mip_filter];
         sampler_desc.min_filter = min_filters[selected_min_filter];
-        const Sampler& sampler =
+        const std::unique_ptr<const Sampler>& sampler =
             context->GetSamplerLibrary()->GetSampler(sampler_desc);
         FS::BindTex(*pass, boston, sampler);
 
@@ -831,14 +839,14 @@ TEST_P(RendererTest, TheImpeller) {
   SamplerDescriptor noise_sampler_desc;
   noise_sampler_desc.width_address_mode = SamplerAddressMode::kRepeat;
   noise_sampler_desc.height_address_mode = SamplerAddressMode::kRepeat;
-  const Sampler& noise_sampler =
+  const std::unique_ptr<const Sampler>& noise_sampler =
       context->GetSamplerLibrary()->GetSampler(noise_sampler_desc);
 
   auto cube_map = CreateTextureCubeForFixture(
       {"table_mountain_px.png", "table_mountain_nx.png",
        "table_mountain_py.png", "table_mountain_ny.png",
        "table_mountain_pz.png", "table_mountain_nz.png"});
-  const Sampler& cube_map_sampler =
+  const std::unique_ptr<const Sampler>& cube_map_sampler =
       context->GetSamplerLibrary()->GetSampler({});
   auto host_buffer = HostBuffer::Create(context->GetResourceAllocator());
 
@@ -1134,8 +1142,9 @@ TEST_P(RendererTest, StencilMask) {
   auto bridge = CreateTextureForFixture("bay_bridge.jpg");
   auto boston = CreateTextureForFixture("boston.jpg");
   ASSERT_TRUE(bridge && boston);
-  const Sampler& sampler = context->GetSamplerLibrary()->GetSampler({});
-  ASSERT_TRUE(sampler.IsValid());
+  const std::unique_ptr<const Sampler>& sampler =
+      context->GetSamplerLibrary()->GetSampler({});
+  ASSERT_TRUE(sampler);
 
   static bool mirror = false;
   static int stencil_reference_write = 0xFF;

--- a/impeller/renderer/sampler_library.h
+++ b/impeller/renderer/sampler_library.h
@@ -17,10 +17,14 @@ class SamplerLibrary {
   /// @brief Retrieve a backend specific sampler object for the given sampler
   ///        descriptor.
   ///
+  ///        If the descriptor is invalid or there is a loss of rendering
+  ///        context, this method may return a nullptr.
+  ///
   ///        The sampler library implementations must cache this sampler object
   ///        and guarantee that the reference will continue to be valid
   ///        throughout the lifetime of the engine.
-  virtual const Sampler& GetSampler(SamplerDescriptor descriptor) = 0;
+  virtual const std::unique_ptr<const Sampler>& GetSampler(
+      SamplerDescriptor descriptor) = 0;
 
  protected:
   SamplerLibrary();

--- a/impeller/renderer/sampler_library.h
+++ b/impeller/renderer/sampler_library.h
@@ -14,8 +14,13 @@ class SamplerLibrary {
  public:
   virtual ~SamplerLibrary();
 
-  virtual std::shared_ptr<const Sampler> GetSampler(
-      SamplerDescriptor descriptor) = 0;
+  /// @brief Retrieve a backend specific sampler object for the given sampler
+  ///        descriptor.
+  ///
+  ///        The sampler library implementations must cache this sampler object
+  ///        and guarantee that the reference will continue to be valid
+  ///        throughout the lifetime of the engine.
+  virtual const Sampler& GetSampler(SamplerDescriptor descriptor) = 0;
 
  protected:
   SamplerLibrary();

--- a/impeller/renderer/sampler_library.h
+++ b/impeller/renderer/sampler_library.h
@@ -22,7 +22,7 @@ class SamplerLibrary {
   ///
   ///        The sampler library implementations must cache this sampler object
   ///        and guarantee that the reference will continue to be valid
-  ///        throughout the lifetime of the engine.
+  ///        throughout the lifetime of the Impeller context.
   virtual const std::unique_ptr<const Sampler>& GetSampler(
       SamplerDescriptor descriptor) = 0;
 

--- a/impeller/renderer/testing/mocks.h
+++ b/impeller/renderer/testing/mocks.h
@@ -202,7 +202,7 @@ class MockCapabilities : public Capabilities {
 
 class MockSamplerLibrary : public SamplerLibrary {
  public:
-  MOCK_METHOD(const Sampler&,
+  MOCK_METHOD(const std::unique_ptr<const Sampler>&,
               GetSampler,
               (SamplerDescriptor descriptor),
               (override));
@@ -211,7 +211,6 @@ class MockSamplerLibrary : public SamplerLibrary {
 class MockSampler : public Sampler {
  public:
   explicit MockSampler(const SamplerDescriptor& desc) : Sampler(desc) {}
-  MOCK_METHOD(bool, IsValid, (), (const, override));
 };
 
 }  // namespace testing

--- a/impeller/renderer/testing/mocks.h
+++ b/impeller/renderer/testing/mocks.h
@@ -202,7 +202,7 @@ class MockCapabilities : public Capabilities {
 
 class MockSamplerLibrary : public SamplerLibrary {
  public:
-  MOCK_METHOD(std::shared_ptr<const Sampler>,
+  MOCK_METHOD(const Sampler&,
               GetSampler,
               (SamplerDescriptor descriptor),
               (override));

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -448,7 +448,7 @@ bool InternalFlutterGpu_RenderPass_BindTexture(
       flutter::gpu::ToImpellerSamplerAddressMode(width_address_mode);
   sampler_desc.height_address_mode =
       flutter::gpu::ToImpellerSamplerAddressMode(height_address_mode);
-  auto sampler =
+  const impeller::Sampler& sampler =
       wrapper->GetContext()->GetSamplerLibrary()->GetSampler(sampler_desc);
 
   return command.BindResource(

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -448,7 +448,7 @@ bool InternalFlutterGpu_RenderPass_BindTexture(
       flutter::gpu::ToImpellerSamplerAddressMode(width_address_mode);
   sampler_desc.height_address_mode =
       flutter::gpu::ToImpellerSamplerAddressMode(height_address_mode);
-  const impeller::Sampler& sampler =
+  const std::unique_ptr<const impeller::Sampler>& sampler =
       wrapper->GetContext()->GetSamplerLibrary()->GetSampler(sampler_desc);
 
   return command.BindResource(


### PR DESCRIPTION
The backend specific sampler libraries hold a strong reference to the native sampler objects and never clear this cache. As a result of this, we don't theoretically need rendering commands to increment a shared_ptr ref count - instead the sampler library can provide the Sampler object as a const ref and guarantee that it continues to be valid.

This allows us to reduce the amount of refcount ops for commands that use samplers.


Additionally, the sampler library uses nullptr as a sentinel for failing to construct a sampler object. Since sampler already has an isValid member that is checked - we can replace this with a specific invalid object subtype.