### PR TITLE
Exclude the Dart SDK sdk/lib/svg/dart2js directory from the license crawl

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -2521,6 +2521,7 @@
 ../../../third_party/dart/sdk/lib/html/doc
 ../../../third_party/dart/sdk/lib/libraries.json
 ../../../third_party/dart/sdk/lib/libraries.yaml
+../../../third_party/dart/sdk/lib/svg/dart2js
 ../../../third_party/dart/sdk/lib/vmservice_libraries.json
 ../../../third_party/dart/sdk/lib/vmservice_libraries.yaml
 ../../../third_party/dart/sdk/version

--- a/ci/licenses_golden/licenses_dart
+++ b/ci/licenses_golden/licenses_dart
@@ -1,4 +1,4 @@
-Signature: 070d855e9daf0706a6209be7505b27e1
+Signature: bfe079de7a6c5c5c2ce1f7e9837a17ac
 
 ====================================================================================================
 LIBRARY: dart
@@ -857,7 +857,6 @@ ORIGIN: ../../../third_party/dart/sdk/lib/io/secure_server_socket.dart + ../../.
 ORIGIN: ../../../third_party/dart/sdk/lib/isolate/isolate.dart + ../../../third_party/dart/LICENSE
 ORIGIN: ../../../third_party/dart/sdk/lib/math/math.dart + ../../../third_party/dart/LICENSE
 ORIGIN: ../../../third_party/dart/sdk/lib/math/random.dart + ../../../third_party/dart/LICENSE
-ORIGIN: ../../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart + ../../../third_party/dart/LICENSE
 ORIGIN: ../../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart + ../../../third_party/dart/LICENSE
 ORIGIN: ../../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart + ../../../third_party/dart/LICENSE
 ORIGIN: ../../../third_party/dart/sdk/lib/web_sql/dart2js/web_sql_dart2js.dart + ../../../third_party/dart/LICENSE
@@ -1225,7 +1224,6 @@ FILE: ../../../third_party/dart/sdk/lib/io/secure_server_socket.dart
 FILE: ../../../third_party/dart/sdk/lib/isolate/isolate.dart
 FILE: ../../../third_party/dart/sdk/lib/math/math.dart
 FILE: ../../../third_party/dart/sdk/lib/math/random.dart
-FILE: ../../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/web_sql/dart2js/web_sql_dart2js.dart

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: b0fbe71c20bdf5b2a1c163281b1f90de
+Signature: f835ab00d16b708da196110898b39ac6
 

--- a/tools/licenses/lib/paths.dart
+++ b/tools/licenses/lib/paths.dart
@@ -136,6 +136,7 @@ final Set<String> skippedPaths = <String>{
   r'third_party/dart/runtime/docs',
   r'third_party/dart/runtime/vm/service',
   r'third_party/dart/sdk/lib/html/doc',
+  r'third_party/dart/sdk/lib/svg/dart2js', // generated from other sources
   r'third_party/dart/third_party/binary_size', // not linked in
   r'third_party/dart/third_party/binaryen', // not linked in
   r'third_party/dart/third_party/d3', // Siva says "that is the charting library used by the binary size tool"


### PR DESCRIPTION
This directory contains a file that is generated from other sources.

It is causing problems for the license script because it contains multiple copyright messages and one of the messages is partially included in the header region parsed by the script.