### PR TITLE
[Impeller] Remove RRect blur zero sigma branch.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3481,17 +3481,19 @@ TEST_P(AiksTest, BlurredRectangleWithShader) {
 TEST_P(AiksTest, MaskBlurWithZeroSigmaIsSkipped) {
   Canvas canvas;
 
-  Paint paint = {
-      .color = Color::Blue(),
-      .mask_blur_descriptor =
-          Paint::MaskBlurDescriptor{
-              .style = FilterContents::BlurStyle::kNormal,
-              .sigma = Sigma(0),
-          },
-  };
+  for (Sigma sigma : {Sigma(0), Sigma(-10)}) {
+    Paint paint = {
+        .color = Color::Blue(),
+        .mask_blur_descriptor =
+            Paint::MaskBlurDescriptor{
+                .style = FilterContents::BlurStyle::kNormal,
+                .sigma = sigma,
+            },
+    };
 
-  canvas.DrawCircle({300, 300}, 200, paint);
-  canvas.DrawRect(Rect::MakeLTRB(100, 300, 500, 600), paint);
+    canvas.DrawCircle({300, 300}, 200, paint);
+    canvas.DrawRect(Rect::MakeLTRB(100, 300, 500, 600), paint);
+  }
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -315,8 +315,9 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
       paint.mask_blur_descriptor->style != FilterContents::BlurStyle::kNormal) {
     return false;
   }
-  // A blur sigma that is close to zero should not result in any shadow.
-  if (std::fabs(paint.mask_blur_descriptor->sigma.sigma) <= kEhCloseEnough) {
+  // A blur sigma that is close to zero or negative should not result in any
+  // shadow.
+  if (paint.mask_blur_descriptor->sigma.sigma <= kEhCloseEnough) {
     return false;
   }
 

--- a/impeller/entity/contents/solid_rrect_blur_contents.cc
+++ b/impeller/entity/contents/solid_rrect_blur_contents.cc
@@ -5,6 +5,7 @@
 #include "impeller/entity/contents/solid_rrect_blur_contents.h"
 #include <optional>
 
+#include "impeller/base/validation.h"
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/color.h"
@@ -61,8 +62,13 @@ std::optional<Rect> SolidRRectBlurContents::GetCoverage(
 bool SolidRRectBlurContents::Render(const ContentContext& renderer,
                                     const Entity& entity,
                                     RenderPass& pass) const {
-  // Early return if sigma is close to zero to avoid rendering NaNs.
-  if (!rect_.has_value() || std::fabs(sigma_.sigma) <= kEhCloseEnough) {
+  if (!rect_.has_value()) {
+    return true;
+  }
+  // Early return if sigma is close to zero or negative to avoid rendering NaNs.
+  if (sigma_.sigma <= kEhCloseEnough) {
+    VALIDATION_LOG
+        << "Sigma must not be nearly zero or negative for the RRect blur.";
     return true;
   }
 

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -21,12 +21,6 @@ out f16vec4 frag_color;
 
 const int kSampleCount = 4;
 
-float16_t RRectDistance(vec2 sample_position, vec2 half_size) {
-  vec2 space = abs(sample_position) - half_size + frag_info.corner_radius;
-  return float16_t(length(max(space, 0.0)) + min(max(space.x, space.y), 0.0) -
-                   frag_info.corner_radius);
-}
-
 /// Closed form unidirectional rounded rect blur mask solution using the
 /// analytical Gaussian integral (with approximated erf).
 float RRectBlurX(vec2 sample_position, vec2 half_size) {
@@ -73,9 +67,5 @@ void main() {
   vec2 half_size = frag_info.rect_size * 0.5;
   vec2 sample_position = v_position - half_size;
 
-  if (frag_info.blur_sigma > 0.0) {
-    frag_color *= float16_t(RRectBlur(sample_position, half_size));
-  } else {
-    frag_color *= float16_t(-RRectDistance(sample_position, half_size));
-  }
+  frag_color *= float16_t(RRectBlur(sample_position, half_size));
 }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -5501,7 +5501,7 @@
             "longest_path_cycles": [
               1.53125,
               1.53125,
-              0.484375,
+              0.453125,
               1.5,
               0.0,
               0.25,
@@ -5517,13 +5517,14 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "varying"
+              "arith_total",
+              "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.234375,
-              0.234375,
-              0.078125,
-              0.0625,
+              1.53125,
+              1.53125,
+              0.421875,
+              1.5,
               0.0,
               0.25,
               0.0
@@ -5533,10 +5534,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              1.6749999523162842,
-              1.6749999523162842,
-              0.546875,
-              1.5625,
+              1.53125,
+              1.53125,
+              0.453125,
+              1.5,
               0.0,
               0.25,
               0.0
@@ -5544,7 +5545,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 24,
+          "uniform_registers_used": 20,
           "work_registers_used": 32
         }
       }
@@ -5575,7 +5576,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              2.640000104904175,
+              23.43000030517578,
               1.0,
               0.0
             ],
@@ -5583,13 +5584,13 @@
               "arithmetic"
             ],
             "total_cycles": [
-              10.333333015441895,
+              8.0,
               1.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 3,
+          "uniform_registers_used": 2,
           "work_registers_used": 4
         }
       }
@@ -9254,7 +9255,7 @@
             "longest_path_cycles": [
               1.59375,
               1.59375,
-              0.453125,
+              0.421875,
               1.5,
               0.0,
               0.25,
@@ -9270,13 +9271,14 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "varying"
+              "arith_total",
+              "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.234375,
-              0.234375,
-              0.078125,
-              0.0625,
+              1.59375,
+              1.59375,
+              0.421875,
+              1.5,
               0.0,
               0.25,
               0.0
@@ -9286,10 +9288,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              1.7374999523162842,
-              1.7374999523162842,
-              0.515625,
-              1.5625,
+              1.59375,
+              1.59375,
+              0.421875,
+              1.5,
               0.0,
               0.25,
               0.0
@@ -9297,7 +9299,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 24,
+          "uniform_registers_used": 20,
           "work_registers_used": 32
         }
       }


### PR DESCRIPTION
Pointed out by @flar during a conversation. We don't need to handle this case because we already early return in the Contents when we're close to zero.