### PR TITLE
[web] Do not wipe the PlatformViewManager when disposing of a view.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -658,8 +658,7 @@ class HtmlViewEmbedder {
 
   /// Disposes the state of this view embedder.
   void dispose() {
-    final Iterable<int> allViews = _viewClipChains.keys;
-    disposeViews(allViews);
+    disposeViews(_viewClipChains.keys.toList());
     _context = EmbedderFrameContext();
     _currentCompositionParams.clear();
     debugCleanupSvgClipPaths();

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -410,8 +410,7 @@ class HtmlViewEmbedder {
       // are going to be added back. Moving rather than removing and re-adding
       // the view helps it maintain state.
       disposeViews(diffResult.viewsToRemove
-          .where((int view) => !diffResult.viewsToAdd.contains(view))
-          .toSet());
+          .where((int view) => !diffResult.viewsToAdd.contains(view)));
       _activeCompositionOrder.addAll(_compositionOrder);
       unusedViews.removeAll(_compositionOrder);
 
@@ -510,7 +509,7 @@ class HtmlViewEmbedder {
     );
   }
 
-  void disposeViews(Set<int> viewsToDispose) {
+  void disposeViews(Iterable<int> viewsToDispose) {
     for (final int viewId in viewsToDispose) {
       // Remove viewId from the _viewClipChains Map, and then from the DOM.
       final ViewClipChain? clipChain = _viewClipChains.remove(viewId);
@@ -659,7 +658,7 @@ class HtmlViewEmbedder {
 
   /// Disposes the state of this view embedder.
   void dispose() {
-    final Set<int> allViews = PlatformViewManager.instance.getKnownPlatformViewIds();
+    final Iterable<int> allViews = _viewClipChains.keys;
     disposeViews(allViews);
     _context = EmbedderFrameContext();
     _currentCompositionParams.clear();

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -659,7 +659,7 @@ class HtmlViewEmbedder {
 
   /// Disposes the state of this view embedder.
   void dispose() {
-    final Set<int> allViews = PlatformViewManager.instance.debugClear();
+    final Set<int> allViews = PlatformViewManager.instance.getKnownPlatformViewIds();
     disposeViews(allViews);
     _context = EmbedderFrameContext();
     _currentCompositionParams.clear();

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -658,7 +658,7 @@ class HtmlViewEmbedder {
 
   /// Disposes the state of this view embedder.
   void dispose() {
-    disposeViews(_viewClipChains.keys.toList());
+    disposeViews(_viewClipChains.keys);
     _context = EmbedderFrameContext();
     _currentCompositionParams.clear();
     debugCleanupSvgClipPaths();

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -212,18 +212,13 @@ class PlatformViewManager {
   /// component.
   bool isVisible(int viewId) => !isInvisible(viewId);
 
-  /// Returns the set of know view ids, so they can be cleaned up.
-  Set<int> getKnownPlatformViewIds() => _contents.keys.toSet();
-
   /// Clears the state. Used in tests.
-  Set<int> debugClear() {
-    final Set<int> result = _contents.keys.toSet();
-    result.forEach(clearPlatformView);
+  void debugClear() {
+    _contents.keys.toList().forEach(clearPlatformView);
     _factories.clear();
     _contents.clear();
     _invisibleViews.clear();
     _viewIdToType.clear();
-    return result;
   }
 }
 

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -212,9 +212,10 @@ class PlatformViewManager {
   /// component.
   bool isVisible(int viewId) => !isInvisible(viewId);
 
-  /// Clears the state. Used in tests.
-  ///
   /// Returns the set of know view ids, so they can be cleaned up.
+  Set<int> getKnownPlatformViewIds() => _contents.keys.toSet();
+
+  /// Clears the state. Used in tests.
   Set<int> debugClear() {
     final Set<int> result = _contents.keys.toSet();
     result.forEach(clearPlatformView);

--- a/lib/web_ui/test/canvaskit/multi_view_test.dart
+++ b/lib/web_ui/test/canvaskit/multi_view_test.dart
@@ -6,6 +6,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../common/matchers.dart';
 import 'common.dart';
@@ -67,6 +68,29 @@ void testMain() {
         CanvasKitRenderer.instance.debugGetRasterizerForView(view),
         isNull,
       );
+    });
+
+    // Issue https://github.com/flutter/flutter/issues/142094
+    test('does not reset platform view factories when disposing a view', () async {
+      expect(PlatformViewManager.instance.knowsViewType('self-test'), isFalse);
+
+      final EngineFlutterView view = EngineFlutterView(
+          EnginePlatformDispatcher.instance, createDomElement('multi-view'));
+      EnginePlatformDispatcher.instance.viewManager.registerView(view);
+      expect(
+        CanvasKitRenderer.instance.debugGetRasterizerForView(view),
+        isNotNull,
+      );
+
+      EnginePlatformDispatcher.instance.viewManager
+          .disposeAndUnregisterView(view.viewId);
+      expect(
+        CanvasKitRenderer.instance.debugGetRasterizerForView(view),
+        isNull,
+      );
+
+      expect(PlatformViewManager.instance.knowsViewType(ui_web.PlatformViewRegistry.defaultVisibleViewType), isTrue);
+      expect(PlatformViewManager.instance.knowsViewType(ui_web.PlatformViewRegistry.defaultInvisibleViewType), isTrue);
     });
   });
 }


### PR DESCRIPTION
When a view gets disposed of, its rasterizer completely clears up the singleton `PlatformViewManager`. Particularly, it removes all registered platform view factories.

This is wrong because the remaining PlatformViews on the page cannot be re-rendered, and the default Platform View factories (used by `pointer_interceptor`, for example), disappear.

This PR attempts to preserve the `dispose` logic of the canvaskit rasterizer, without using the `debugClear` method of the `PlatformViewManager` (which is supposedly test-only).

## Issues

* Fixes https://github.com/flutter/flutter/issues/142094

## Tests

* Added unit-test
* Deployed demo app: https://dit-maps-tests.web.app

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
