### PR TITLE
[Impeller] allow non-square corner radii for fast blurs

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -1524,6 +1524,67 @@ TEST_P(AiksTest, FilledRoundRectsRenderCorrectly) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, SolidColorCirclesOvalsRRectsMaskBlurCorrectly) {
+  Canvas canvas;
+  canvas.Scale(GetContentScale());
+  Paint paint;
+  paint.mask_blur_descriptor = Paint::MaskBlurDescriptor{
+      .style = FilterContents::BlurStyle::kNormal,
+      .sigma = Sigma{1},
+  };
+
+  canvas.DrawPaint({.color = Color::White()});
+
+  paint.color = Color::Crimson();
+  Scalar y = 100.0f;
+  for (int i = 0; i < 5; i++) {
+    Scalar x = (i + 1) * 100;
+    Scalar radius = x / 10.0f;
+    canvas.DrawRect(Rect::MakeXYWH(x + 25 - radius / 2, y + radius / 2,  //
+                                   radius, 60.0f - radius),
+                    paint);
+  }
+
+  paint.color = Color::Blue();
+  y += 100.0f;
+  for (int i = 0; i < 5; i++) {
+    Scalar x = (i + 1) * 100;
+    Scalar radius = x / 10.0f;
+    canvas.DrawCircle({x + 25, y + 25}, radius, paint);
+  }
+
+  paint.color = Color::Green();
+  y += 100.0f;
+  for (int i = 0; i < 5; i++) {
+    Scalar x = (i + 1) * 100;
+    Scalar radius = x / 10.0f;
+    canvas.DrawOval(Rect::MakeXYWH(x + 25 - radius / 2, y + radius / 2,  //
+                                   radius, 60.0f - radius),
+                    paint);
+  }
+
+  paint.color = Color::Purple();
+  y += 100.0f;
+  for (int i = 0; i < 5; i++) {
+    Scalar x = (i + 1) * 100;
+    Scalar radius = x / 20.0f;
+    canvas.DrawRRect(Rect::MakeXYWH(x, y, 60.0f, 60.0f),  //
+                     {radius, radius},                    //
+                     paint);
+  }
+
+  paint.color = Color::Orange();
+  y += 100.0f;
+  for (int i = 0; i < 5; i++) {
+    Scalar x = (i + 1) * 100;
+    Scalar radius = x / 20.0f;
+    canvas.DrawRRect(Rect::MakeXYWH(x, y, 60.0f, 60.0f),  //
+                     {radius, 5.0f}, paint);
+  }
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 TEST_P(AiksTest, FilledRoundRectPathsRenderCorrectly) {
   Canvas canvas;
   canvas.Scale(GetContentScale());

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -304,7 +304,7 @@ void Canvas::DrawPaint(const Paint& paint) {
 }
 
 bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
-                                     Scalar corner_radius,
+                                     Size corner_radius,
                                      const Paint& paint) {
   if (paint.color_source.GetType() != ColorSource::Type::kColor ||
       paint.style != Paint::Style::kFill) {
@@ -315,8 +315,8 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
       paint.mask_blur_descriptor->style != FilterContents::BlurStyle::kNormal) {
     return false;
   }
-  // A blur sigma that is close to zero should not result in any shadow.
-  if (std::fabs(paint.mask_blur_descriptor->sigma.sigma) <= kEhCloseEnough) {
+  // A blur sigma that is not positive enough should not result in a blur.
+  if (paint.mask_blur_descriptor->sigma.sigma <= kEhCloseEnough) {
     return false;
   }
 
@@ -360,7 +360,7 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
     return;
   }
 
-  if (AttemptDrawBlurredRRect(rect, 0, paint)) {
+  if (AttemptDrawBlurredRRect(rect, {}, paint)) {
     return;
   }
 
@@ -387,7 +387,7 @@ void Canvas::DrawOval(const Rect& rect, const Paint& paint) {
     return;
   }
 
-  if (AttemptDrawBlurredRRect(rect, 0, paint)) {
+  if (AttemptDrawBlurredRRect(rect, rect.GetSize() * 0.5f, paint)) {
     return;
   }
 
@@ -404,8 +404,7 @@ void Canvas::DrawOval(const Rect& rect, const Paint& paint) {
 void Canvas::DrawRRect(const Rect& rect,
                        const Size& corner_radii,
                        const Paint& paint) {
-  if (corner_radii.IsSquare() &&
-      AttemptDrawBlurredRRect(rect, corner_radii.width, paint)) {
+  if (AttemptDrawBlurredRRect(rect, corner_radii, paint)) {
     return;
   }
 
@@ -434,8 +433,8 @@ void Canvas::DrawCircle(const Point& center,
                         const Paint& paint) {
   Size half_size(radius, radius);
   if (AttemptDrawBlurredRRect(
-          Rect::MakeOriginSize(center - half_size, half_size * 2), radius,
-          paint)) {
+          Rect::MakeOriginSize(center - half_size, half_size * 2),
+          {radius, radius}, paint)) {
     return;
   }
 

--- a/impeller/aiks/canvas.h
+++ b/impeller/aiks/canvas.h
@@ -205,7 +205,7 @@ class Canvas {
   void RestoreClip();
 
   bool AttemptDrawBlurredRRect(const Rect& rect,
-                               Scalar corner_radius,
+                               Size corner_radius,
                                const Paint& paint);
 
   Canvas(const Canvas&) = delete;

--- a/impeller/entity/contents/solid_rrect_blur_contents.h
+++ b/impeller/entity/contents/solid_rrect_blur_contents.h
@@ -28,7 +28,7 @@ class SolidRRectBlurContents final : public Contents {
 
   ~SolidRRectBlurContents() override;
 
-  void SetRRect(std::optional<Rect> rect, Scalar corner_radius = 0);
+  void SetRRect(std::optional<Rect> rect, Size corner_radii = {});
 
   void SetSigma(Sigma sigma);
 
@@ -50,7 +50,7 @@ class SolidRRectBlurContents final : public Contents {
 
  private:
   std::optional<Rect> rect_;
-  Scalar corner_radius_;
+  Size corner_radii_;
   Sigma sigma_;
 
   Color color_;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1752,7 +1752,7 @@ TEST_P(EntityTest, RRectShadowTest) {
         Rect::MakeLTRB(top_left.x, top_left.y, bottom_right.x, bottom_right.y);
 
     auto contents = std::make_unique<SolidRRectBlurContents>();
-    contents->SetRRect(rect, corner_radius);
+    contents->SetRRect(rect, {corner_radius, corner_radius});
     contents->SetColor(color);
     contents->SetSigma(Radius(blur_radius));
 

--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -11,7 +11,7 @@ uniform FragInfo {
   f16vec4 color;
   vec2 rect_size;
   float blur_sigma;
-  float corner_radius;
+  vec2 corner_radii;
 }
 frag_info;
 
@@ -21,28 +21,52 @@ out f16vec4 frag_color;
 
 const int kSampleCount = 4;
 
-float16_t RRectDistance(vec2 sample_position, vec2 half_size) {
-  vec2 space = abs(sample_position) - half_size + frag_info.corner_radius;
-  return float16_t(length(max(space, 0.0)) + min(max(space.x, space.y), 0.0) -
-                   frag_info.corner_radius);
-}
-
 /// Closed form unidirectional rounded rect blur mask solution using the
 /// analytical Gaussian integral (with approximated erf).
 float RRectBlurX(vec2 sample_position, vec2 half_size) {
-  // Compute the X direction distance field (not incorporating the Y distance)
-  // for the rounded rect.
-  float space =
-      min(0.0, half_size.y - frag_info.corner_radius - abs(sample_position.y));
-  float rrect_distance =
-      half_size.x - frag_info.corner_radius +
-      sqrt(max(0.0, frag_info.corner_radius * frag_info.corner_radius -
-                        space * space));
+  // The vertical edge of the rrect consists of a flat portion and a curved
+  // portion, the two of which vary in size depending on the size of the
+  // corner radii, both adding up to half_size.y.
+  // half_size.y - corner_radii.y is the size of the vertical flat
+  // portion of the rrect.
+  // subtracting the absolute value of the Y sample_position will be
+  // negative (and then clamped to 0) for positions that are located
+  // vertically in the flat part of the rrect, and will be the relative
+  // distance from the center of curvature otherwise.
+  float space_y =
+      min(0.0, half_size.y - frag_info.corner_radii.y - abs(sample_position.y));
+  // space is now in the range [0.0, corner_radii.y]. If the y sample was
+  // in the flat portion of the rrect, it will be 0.0
 
-  // Map the linear distance field to the approximate Gaussian integral.
+  // We will now calculate rrect_distance as the distance from the centerline
+  // of the rrect towards the near side of the rrect.
+  // half_size.x - frag_info.corner_radii.x is the size of the horizontal
+  // flat portion of the rrect.
+  // We add to that the X size (space_x) of the curved corner measured at
+  // the indicated Y coordinate we calculated as space_y, such that:
+  //   (space_y / corner_radii.y)^2 + (space_x / corner_radii.x)^2 == 1.0
+  // Since we want the space_x, we rearrange the equation as:
+  //   space_x = corner_radii.x * sqrt(1.0 - (space_y / corner_radii.y)^2)
+  // We need to prevent negative values inside the sqrt which can occur
+  // when the Y sample was beyond the vertical size of the rrect and thus
+  // space_y was larger than corner_radii.y.
+  // The calling function RRectBlur will never provide a Y sample outside
+  // of that range, though, so the max(0.0) is mostly a precaution.
+  float unit_space_y = space_y / frag_info.corner_radii.y;
+  float unit_space_x = sqrt(max(0.0, 1.0 - unit_space_y * unit_space_y));
+  float rrect_distance =
+      half_size.x - frag_info.corner_radii.x * (1.0 - unit_space_x);
+
+  // Now we integrate the Gaussian over the range of the relative positions
+  // of the left and right sides of the rrect relative to the sampling
+  // X coordinate.
   vec2 integral = IPVec2FastGaussianIntegral(
       float(sample_position.x) + vec2(-rrect_distance, rrect_distance),
       float(frag_info.blur_sigma));
+  // integral.y contains the evaluation of the indefinite gaussian integral
+  // function at (X + rrect_distance) and integral.x contains the evaluation
+  // of it at (X - rrect_distance). Subtracting the two produces the
+  // integral result over the range from one to the other.
   return integral.y - integral.x;
 }
 
@@ -51,6 +75,10 @@ float RRectBlur(vec2 sample_position, vec2 half_size) {
   // the kernel center to incorporate 99.7% of the color contribution.
   float half_sampling_range = frag_info.blur_sigma * 3.0;
 
+  // We want to cover the range [Y - half_range, Y + half_range], but we
+  // don't want to sample beyond the edge of the rrect (where the RRectBlurX
+  // function produces bad information and where the real answer at those
+  // locations will be 0.0 anyway).
   float begin_y = max(-half_sampling_range, sample_position.y - half_size.y);
   float end_y = min(half_sampling_range, sample_position.y + half_size.y);
   float interval = (end_y - begin_y) / kSampleCount;
@@ -73,9 +101,5 @@ void main() {
   vec2 half_size = frag_info.rect_size * 0.5;
   vec2 sample_position = v_position - half_size;
 
-  if (frag_info.blur_sigma > 0.0) {
-    frag_color *= float16_t(RRectBlur(sample_position, half_size));
-  } else {
-    frag_color *= float16_t(-RRectDistance(sample_position, half_size));
-  }
+  frag_color *= float16_t(RRectBlur(sample_position, half_size));
 }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -5499,9 +5499,9 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              1.53125,
-              1.53125,
-              0.484375,
+              1.65625,
+              1.65625,
+              0.453125,
               1.5,
               0.0,
               0.25,
@@ -5517,13 +5517,14 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "varying"
+              "arith_total",
+              "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.234375,
-              0.234375,
-              0.078125,
-              0.0625,
+              1.65625,
+              1.65625,
+              0.421875,
+              1.5,
               0.0,
               0.25,
               0.0
@@ -5533,10 +5534,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              1.6749999523162842,
-              1.6749999523162842,
-              0.546875,
-              1.5625,
+              1.65625,
+              1.65625,
+              0.453125,
+              1.5,
               0.0,
               0.25,
               0.0
@@ -5544,7 +5545,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 24,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         }
       }
@@ -5562,7 +5563,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              23.43000030517578,
+              25.739999771118164,
               1.0,
               0.0
             ],
@@ -5575,7 +5576,7 @@
               "arithmetic"
             ],
             "shortest_path_cycles": [
-              2.640000104904175,
+              25.739999771118164,
               1.0,
               0.0
             ],
@@ -5583,7 +5584,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              10.333333015441895,
+              8.333333015441895,
               1.0,
               0.0
             ]
@@ -9252,9 +9253,9 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              1.59375,
-              1.59375,
-              0.453125,
+              1.65625,
+              1.65625,
+              0.421875,
               1.5,
               0.0,
               0.25,
@@ -9270,13 +9271,14 @@
               "texture"
             ],
             "shortest_path_bound_pipelines": [
-              "varying"
+              "arith_total",
+              "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.234375,
-              0.234375,
-              0.078125,
-              0.0625,
+              1.65625,
+              1.65625,
+              0.421875,
+              1.5,
               0.0,
               0.25,
               0.0
@@ -9286,10 +9288,10 @@
               "arith_fma"
             ],
             "total_cycles": [
-              1.7374999523162842,
-              1.7374999523162842,
-              0.515625,
-              1.5625,
+              1.65625,
+              1.65625,
+              0.421875,
+              1.5,
               0.0,
               0.25,
               0.0
@@ -9297,7 +9299,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 24,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         }
       }


### PR DESCRIPTION
Upgrades the fast blur shader to work with round rects and ovals that have different radii in X and Y.

Fixes https://github.com/flutter/flutter/issues/141850
Obsoletes https://github.com/flutter/engine/pull/49989