### PR TITLE
[Impeller] Do not emit metadata for structs that are not part of the shader's interface

### DIFF
--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -142,6 +142,14 @@ TEST_P(CompilerTest, SkSLTextureLookUpOrderOfOperations) {
                      "flutter_FragCoord.xy));") != -1);
 }
 
+TEST_P(CompilerTest, CanCompileStructs) {
+  if (GetParam() != TargetPlatform::kSkSL) {
+    GTEST_SKIP() << "Only supported on SkSL";
+  }
+  ASSERT_TRUE(CanCompileAndReflect("struct_internal.frag",
+                                   SourceType::kFragmentShader));
+}
+
 #define INSTANTIATE_TARGET_PLATFORM_TEST_SUITE_P(suite_name)               \
   INSTANTIATE_TEST_SUITE_P(                                                \
       suite_name, CompilerTest,                                            \

--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -101,6 +101,7 @@ test_fixtures("file_fixtures") {
     "stage1.comp",
     "stage2.comp",
     "struct_def_bug.vert",
+    "struct_internal.frag",
     "table_mountain_nx.png",
     "table_mountain_ny.png",
     "table_mountain_nz.png",

--- a/impeller/fixtures/struct_internal.frag
+++ b/impeller/fixtures/struct_internal.frag
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+out vec4 frag_color;
+
+struct TestStruct {
+  float a;
+  float b;
+  float c;
+};
+
+void main() {
+  TestStruct ts = TestStruct(1.0, 0.5, 0.25);
+  frag_color = vec4(ts.c, ts.b, ts.a, 1.0);
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/138404