### PR TITLE
Revert "[Impeller] round up subpass coverage when it is close to (and smaller) than root pass size."

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3928,54 +3928,6 @@ TEST_P(AiksTest, GaussianBlurMipMapImageFilter) {
 #endif
 }
 
-TEST_P(AiksTest, SaveLayersCloseToRootPassSizeAreScaledUp) {
-  Canvas canvas;
-  // Create a subpass with no bounds hint and an entity coverage of (95, 95).
-  canvas.SaveLayer({
-      .color = Color::Black().WithAlpha(0.5),
-  });
-  canvas.DrawRect(Rect::MakeLTRB(0, 0, 10, 10), {.color = Color::Red()});
-  canvas.DrawRect(Rect::MakeLTRB(0, 0, 95, 95), {.color = Color::Blue()});
-  canvas.Restore();
-
-  Picture picture = canvas.EndRecordingAsPicture();
-  std::shared_ptr<RenderTargetCache> cache =
-      std::make_shared<RenderTargetCache>(GetContext()->GetResourceAllocator());
-  AiksContext aiks_context(GetContext(), nullptr, cache);
-  picture.ToImage(aiks_context, {100, 100});
-
-  for (auto it = cache->GetTextureDataBegin(); it != cache->GetTextureDataEnd();
-       ++it) {
-    EXPECT_EQ(it->texture->GetTextureDescriptor().size, ISize(100, 100));
-  }
-}
-
-TEST_P(AiksTest, SaveLayersCloseToRootPassSizeAreNotScaledUpPastBoundsHint) {
-  Canvas canvas;
-  canvas.SaveLayer(
-      {
-          .color = Color::Black().WithAlpha(0.5),
-      },
-      Rect::MakeSize(ISize(95, 95)));
-  canvas.DrawRect(Rect::MakeLTRB(0, 0, 100, 100), {.color = Color::Red()});
-  canvas.DrawRect(Rect::MakeLTRB(50, 50, 150, 150), {.color = Color::Blue()});
-  canvas.Restore();
-
-  Picture picture = canvas.EndRecordingAsPicture();
-  std::shared_ptr<RenderTargetCache> cache =
-      std::make_shared<RenderTargetCache>(GetContext()->GetResourceAllocator());
-  AiksContext aiks_context(GetContext(), nullptr, cache);
-  picture.ToImage(aiks_context, {100, 100});
-
-  // We expect a single 100x100 texture and the rest should be 95x95.
-  EXPECT_EQ(cache->GetTextureDataBegin()->texture->GetTextureDescriptor().size,
-            ISize(100, 100));
-  for (auto it = ++cache->GetTextureDataBegin();
-       it != cache->GetTextureDataEnd(); ++it) {
-    EXPECT_EQ(it->texture->GetTextureDescriptor().size, ISize(95, 95));
-  }
-}
-
 TEST_P(AiksTest, ImageColorSourceEffectTransform) {
   // Compare with https://fiddle.skia.org/c/6cdc5aefb291fda3833b806ca347a885
 

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -157,9 +157,6 @@ class EntityPass {
     required_mip_count_ = mip_count;
   }
 
-  /// @brief Return the local bounds transformed intro screen coordinate space.
-  std::optional<Rect> GetTransformedBoundsLimit() const;
-
   //----------------------------------------------------------------------------
   /// @brief  Computes the coverage of a given subpass. This is used to
   ///         determine the texture size of a given subpass before it's rendered


### PR DESCRIPTION
Reverts flutter/engine#49925

This did not improve benchmarks: https://flutter-flutter-perf.skia.org/e/?queries=device_type%3DPixel_7_Pro%26sub_result%3D90th_percentile_frame_rasterizer_time_millis%26sub_result%3D99th_percentile_frame_rasterizer_time_millis%26sub_result%3Daverage_frame_rasterizer_time_millis%26sub_result%3Dworst_frame_rasterizer_time_millis%26test%3Dnew_gallery_impeller_old_zoom__transition_perf&selected=commit%3D38910%26name%3D%252Carch%253Dintel%252Cbranch%253Dmaster%252Cconfig%253Ddefault%252Cdevice_type%253DPixel_7_Pro%252Cdevice_version%253Dnone%252Chost_type%253Dlinux%252Csub_result%253D99th_percentile_frame_rasterizer_time_millis%252Ctest%253Dnew_gallery_impeller_old_zoom__transition_perf%252C

From follow up investigation: some of the routes hit this optimization, while some did not as the the bounds size seems to depend on the exact contents.