### PR TITLE
Use clamp sampling mode in external texture.

### DIFF
--- a/shell/platform/android/surface_texture_external_texture.cc
+++ b/shell/platform/android/surface_texture_external_texture.cc
@@ -71,8 +71,8 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
     }
 
     if (!transform_.isIdentity()) {
-      DlImageColorSource source(dl_image_, DlTileMode::kRepeat,
-                                DlTileMode::kRepeat, sampling, &transform_);
+      DlImageColorSource source(dl_image_, DlTileMode::kClamp,
+                                DlTileMode::kClamp, sampling, &transform_);
 
       DlPaint paintWithShader;
       if (context.paint) {


### PR DESCRIPTION
This is a more reasonable default sampling mode.
