### PR TITLE
Avoid sizing `ImageReaderSurfaceProducer` smaller than 1x1

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -436,8 +436,8 @@ public class FlutterRenderer implements TextureRegistry {
     private boolean ignoringFence = false;
 
     // The requested width and height are updated by setSize.
-    private int requestedWidth = 0;
-    private int requestedHeight = 0;
+    private int requestedWidth = 1;
+    private int requestedHeight = 1;
     // Whenever the requested width and height change we set this to be true so we
     // create a new ImageReader (inside getSurface) with the correct width and height.
     // We use this flag so that we lazily create the ImageReader only when a frame
@@ -676,6 +676,10 @@ public class FlutterRenderer implements TextureRegistry {
 
     @Override
     public void setSize(int width, int height) {
+      // Clamp to a minimum of 1. A 0x0 texture is a runtime exception in ImageReader.
+      width = Math.max(1, width);
+      height = Math.max(1, height);
+
       if (requestedWidth == width && requestedHeight == height) {
         // No size change.
         return;

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -626,7 +626,7 @@ public class FlutterRendererTest {
   public void ImageReaderSurfaceProducerClampsWidthAndHeightTo1() {
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
     FlutterRenderer.ImageReaderSurfaceProducer texture =
-            flutterRenderer.new ImageReaderSurfaceProducer(0);
+        flutterRenderer.new ImageReaderSurfaceProducer(0);
 
     // Default values.
     assertEquals(texture.getWidth(), 1);

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -621,6 +621,25 @@ public class FlutterRendererTest {
     assertEquals(0, texture.numImages());
   }
 
+  // A 0x0 ImageReader is a runtime error.
+  @Test
+  public void ImageReaderSurfaceProducerClampsWidthAndHeightTo1() {
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+            flutterRenderer.new ImageReaderSurfaceProducer(0);
+
+    // Default values.
+    assertEquals(texture.getWidth(), 1);
+    assertEquals(texture.getHeight(), 1);
+
+    // Try setting width and height to 0.
+    texture.setSize(0, 0);
+
+    // Expect clamp to 1.
+    assertEquals(texture.getWidth(), 1);
+    assertEquals(texture.getHeight(), 1);
+  }
+
   @Test
   public void SurfaceTextureSurfaceProducerCreatesAConnectedTexture() {
     // Force creating a SurfaceTextureSurfaceProducer regardless of Android API version.

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -635,6 +635,9 @@ public class FlutterRendererTest {
     // Try setting width and height to 0.
     texture.setSize(0, 0);
 
+    // Ensure we can still create/get a surface without an exception being raised.
+    assertNotNull(texture.getSurface());
+
     // Expect clamp to 1.
     assertEquals(texture.getWidth(), 1);
     assertEquals(texture.getHeight(), 1);


### PR DESCRIPTION
Partial fix towards https://github.com/flutter/flutter/issues/142082.

This fixes OpenGLES + SurfaceProducer, but not Vulkan + SurfaceProducer (that requires VK-specific changes).