### PR TITLE
Fix Shell::Screenshot for Impeller

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -115,7 +115,6 @@ targets:
     timeout: 60
 
   - name: Mac builder_cache
-    bringup: true
     enabled_branches:
       - main
     recipe: engine_v2/cache

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -19,9 +19,6 @@
 #include "flutter/shell/common/serialization_callbacks.h"
 #include "fml/make_copyable.h"
 #include "fml/synchronization/waitable_event.h"
-#include "impeller/aiks/aiks_context.h"
-#include "impeller/core/formats.h"
-#include "impeller/display_list/dl_dispatcher.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkData.h"
 #include "third_party/skia/include/core/SkImage.h"
@@ -38,6 +35,12 @@
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/GrTypes.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+
+#if IMPELLER_SUPPORTS_RENDERING
+#include "impeller/aiks/aiks_context.h"           // nogncheck
+#include "impeller/core/formats.h"                // nogncheck
+#include "impeller/display_list/dl_dispatcher.h"  // nogncheck
+#endif
 
 namespace flutter {
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -908,7 +908,6 @@ ScreenshotLayerTreeAsImageImpeller(
       latch.Signal();
       return;
     }
-    auto buffer_view = impeller::DeviceBuffer::AsBufferView(buffer);
     sk_data = SkData::MakeWithCopy(buffer->OnGetContents(), buffer_desc.size);
 
     latch.Signal();

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "display_list/dl_builder.h"
 #include "flow/frame_timings.h"
 #include "flutter/common/constants.h"
 #include "flutter/common/graphics/persistent_cache.h"
@@ -17,6 +18,10 @@
 #include "flutter/shell/common/base64.h"
 #include "flutter/shell/common/serialization_callbacks.h"
 #include "fml/make_copyable.h"
+#include "fml/synchronization/waitable_event.h"
+#include "impeller/aiks/aiks_context.h"
+#include "impeller/core/formats.h"
+#include "impeller/display_list/dl_dispatcher.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkData.h"
 #include "third_party/skia/include/core/SkImage.h"
@@ -802,38 +807,16 @@ static sk_sp<SkData> ScreenshotLayerTreeAsPicture(
   return recorder.finishRecordingAsPicture()->serialize(&procs);
 }
 
-sk_sp<SkData> Rasterizer::ScreenshotLayerTreeAsImage(
-    flutter::LayerTree* tree,
+static void RenderFrameForScreenshot(
     flutter::CompositorContext& compositor_context,
+    DlCanvas* canvas,
+    flutter::LayerTree* tree,
     GrDirectContext* surface_context,
-    bool compressed) {
-  // Attempt to create a snapshot surface depending on whether we have access
-  // to a valid GPU rendering context.
-  std::unique_ptr<OffscreenSurface> snapshot_surface =
-      std::make_unique<OffscreenSurface>(surface_context, tree->frame_size());
-
-  if (!snapshot_surface->IsValid()) {
-    FML_LOG(ERROR) << "Screenshot: unable to create snapshot surface";
-    return nullptr;
-  }
-
-  // Draw the current layer tree into the snapshot surface.
-  auto* canvas = snapshot_surface->GetCanvas();
-
+    const std::shared_ptr<impeller::AiksContext>& aiks_context) {
   // There is no root surface transformation for the screenshot layer. Reset
   // the matrix to identity.
   SkMatrix root_surface_transformation;
   root_surface_transformation.reset();
-
-  // snapshot_surface->makeImageSnapshot needs the GL context to be set if the
-  // render context is GL. frame->Raster() pops the gl context in platforms
-  // that gl context switching are used. (For example, older iOS that uses GL)
-  // We reset the GL context using the context switch.
-  auto context_switch = surface_->MakeRenderContextCurrent();
-  if (!context_switch->GetResult()) {
-    FML_LOG(ERROR) << "Screenshot: unable to make image screenshot";
-    return nullptr;
-  }
 
   auto frame = compositor_context.AcquireFrame(
       surface_context,              // skia context
@@ -843,18 +826,153 @@ sk_sp<SkData> Rasterizer::ScreenshotLayerTreeAsImage(
       false,                        // instrumentation enabled
       true,                         // render buffer readback supported
       nullptr,                      // thread merger
-      nullptr                       // aiks context
+      aiks_context.get()            // aiks context
   );
   canvas->Clear(DlColor::kTransparent());
   frame->Raster(*tree, true, nullptr);
   canvas->Flush();
+}
 
-  return snapshot_surface->GetRasterData(compressed);
+#if IMPELLER_SUPPORTS_RENDERING
+Rasterizer::ScreenshotFormat ToScreenshotFormat(impeller::PixelFormat format) {
+  switch (format) {
+    case impeller::PixelFormat::kUnknown:
+    case impeller::PixelFormat::kA8UNormInt:
+    case impeller::PixelFormat::kR8UNormInt:
+    case impeller::PixelFormat::kR8G8UNormInt:
+    case impeller::PixelFormat::kR8G8B8A8UNormIntSRGB:
+    case impeller::PixelFormat::kB8G8R8A8UNormIntSRGB:
+    case impeller::PixelFormat::kB10G10R10XRSRGB:
+    case impeller::PixelFormat::kS8UInt:
+    case impeller::PixelFormat::kD24UnormS8Uint:
+    case impeller::PixelFormat::kD32FloatS8UInt:
+    case impeller::PixelFormat::kR32G32B32A32Float:
+    case impeller::PixelFormat::kB10G10R10XR:
+    case impeller::PixelFormat::kB10G10R10A10XR:
+      FML_DCHECK(false);
+      return Rasterizer::ScreenshotFormat::kUnknown;
+    case impeller::PixelFormat::kR8G8B8A8UNormInt:
+      return Rasterizer::ScreenshotFormat::kR8G8B8A8UNormInt;
+    case impeller::PixelFormat::kB8G8R8A8UNormInt:
+      return Rasterizer::ScreenshotFormat::kB8G8R8A8UNormInt;
+    case impeller::PixelFormat::kR16G16B16A16Float:
+      return Rasterizer::ScreenshotFormat::kR16G16B16A16Float;
+  }
+}
+
+static std::pair<sk_sp<SkData>, Rasterizer::ScreenshotFormat>
+ScreenshotLayerTreeAsImageImpeller(
+    const std::shared_ptr<impeller::AiksContext>& aiks_context,
+    flutter::LayerTree* tree,
+    flutter::CompositorContext& compositor_context,
+    bool compressed) {
+  if (compressed) {
+    FML_LOG(ERROR) << "Compressed screenshots not supported for Impeller";
+    return {nullptr, Rasterizer::ScreenshotFormat::kUnknown};
+  }
+
+  DisplayListBuilder builder(SkRect::MakeSize(
+      SkSize::Make(tree->frame_size().fWidth, tree->frame_size().fHeight)));
+
+  RenderFrameForScreenshot(compositor_context, &builder, tree, nullptr,
+                           aiks_context);
+
+  impeller::DlDispatcher dispatcher;
+  builder.Build()->Dispatch(dispatcher);
+  const auto& picture = dispatcher.EndRecordingAsPicture();
+  const auto& image = picture.ToImage(
+      *aiks_context,
+      impeller::ISize(tree->frame_size().fWidth, tree->frame_size().fHeight));
+  const auto& texture = image->GetTexture();
+  impeller::DeviceBufferDescriptor buffer_desc;
+  buffer_desc.storage_mode = impeller::StorageMode::kHostVisible;
+  buffer_desc.size =
+      texture->GetTextureDescriptor().GetByteSizeOfBaseMipLevel();
+  auto impeller_context = aiks_context->GetContext();
+  auto buffer =
+      impeller_context->GetResourceAllocator()->CreateBuffer(buffer_desc);
+  auto command_buffer = impeller_context->CreateCommandBuffer();
+  command_buffer->SetLabel("BlitTextureToBuffer Command Buffer");
+  auto pass = command_buffer->CreateBlitPass();
+  pass->AddCopy(texture, buffer);
+  pass->EncodeCommands(impeller_context->GetResourceAllocator());
+  fml::AutoResetWaitableEvent latch;
+  sk_sp<SkData> sk_data;
+  auto completion = [buffer, &buffer_desc, &sk_data,
+                     &latch](impeller::CommandBuffer::Status status) {
+    if (status != impeller::CommandBuffer::Status::kCompleted) {
+      FML_LOG(ERROR) << "Failed to complete blit pass.";
+      latch.Signal();
+      return;
+    }
+    auto buffer_view = impeller::DeviceBuffer::AsBufferView(buffer);
+    sk_data = SkData::MakeWithCopy(buffer->OnGetContents(), buffer_desc.size);
+
+    latch.Signal();
+  };
+
+  if (!command_buffer->SubmitCommands(completion)) {
+    FML_LOG(ERROR) << "Failed to submit commands.";
+  }
+  latch.Wait();
+  return std::make_pair(
+      sk_data, ToScreenshotFormat(texture->GetTextureDescriptor().format));
+}
+#endif
+
+std::pair<sk_sp<SkData>, Rasterizer::ScreenshotFormat>
+Rasterizer::ScreenshotLayerTreeAsImage(
+    flutter::LayerTree* tree,
+    flutter::CompositorContext& compositor_context,
+    bool compressed) {
+#if IMPELLER_SUPPORTS_RENDERING
+  if (delegate_.GetSettings().enable_impeller) {
+    return ScreenshotLayerTreeAsImageImpeller(GetAiksContext(), tree,
+                                              compositor_context, compressed);
+  }
+#endif  // IMPELLER_SUPPORTS_RENDERING
+
+  GrDirectContext* surface_context = GetGrContext();
+  // Attempt to create a snapshot surface depending on whether we have access
+  // to a valid GPU rendering context.
+  std::unique_ptr<OffscreenSurface> snapshot_surface =
+      std::make_unique<OffscreenSurface>(surface_context, tree->frame_size());
+
+  if (!snapshot_surface->IsValid()) {
+    FML_LOG(ERROR) << "Screenshot: unable to create snapshot surface";
+    return {nullptr, ScreenshotFormat::kUnknown};
+  }
+
+  // Draw the current layer tree into the snapshot surface.
+  DlCanvas* canvas = snapshot_surface->GetCanvas();
+
+  // snapshot_surface->makeImageSnapshot needs the GL context to be set if the
+  // render context is GL. frame->Raster() pops the gl context in platforms
+  // that gl context switching are used. (For example, older iOS that uses GL)
+  // We reset the GL context using the context switch.
+  auto context_switch = surface_->MakeRenderContextCurrent();
+  if (!context_switch->GetResult()) {
+    FML_LOG(ERROR) << "Screenshot: unable to make image screenshot";
+    return {nullptr, ScreenshotFormat::kUnknown};
+  }
+
+  RenderFrameForScreenshot(compositor_context, canvas, tree, surface_context,
+                           nullptr);
+
+  return std::make_pair(snapshot_surface->GetRasterData(compressed),
+                        ScreenshotFormat::kUnknown);
 }
 
 Rasterizer::Screenshot Rasterizer::ScreenshotLastLayerTree(
     Rasterizer::ScreenshotType type,
     bool base64_encode) {
+  if (delegate_.GetSettings().enable_impeller &&
+      type == ScreenshotType::SkiaPicture) {
+    FML_DCHECK(false);
+    FML_LOG(ERROR) << "Last layer tree cannot be screenshotted as a "
+                      "SkiaPicture when using Impeller.";
+    return {};
+  }
   // TODO(dkwingsmt): Support screenshotting all last layer trees
   // when the shell protocol supports multi-views.
   // https://github.com/flutter/flutter/issues/135534
@@ -865,48 +983,49 @@ Rasterizer::Screenshot Rasterizer::ScreenshotLastLayerTree(
     return {};
   }
 
-  sk_sp<SkData> data = nullptr;
+  std::pair<sk_sp<SkData>, ScreenshotFormat> data{nullptr,
+                                                  ScreenshotFormat::kUnknown};
   std::string format;
-
-  GrDirectContext* surface_context =
-      surface_ ? surface_->GetContext() : nullptr;
 
   switch (type) {
     case ScreenshotType::SkiaPicture:
       format = "ScreenshotType::SkiaPicture";
-      data = ScreenshotLayerTreeAsPicture(layer_tree, *compositor_context_);
+      data.first =
+          ScreenshotLayerTreeAsPicture(layer_tree, *compositor_context_);
       break;
     case ScreenshotType::UncompressedImage:
       format = "ScreenshotType::UncompressedImage";
-      data = ScreenshotLayerTreeAsImage(layer_tree, *compositor_context_,
-                                        surface_context, false);
+      data =
+          ScreenshotLayerTreeAsImage(layer_tree, *compositor_context_, false);
       break;
     case ScreenshotType::CompressedImage:
       format = "ScreenshotType::CompressedImage";
-      data = ScreenshotLayerTreeAsImage(layer_tree, *compositor_context_,
-                                        surface_context, true);
+      data = ScreenshotLayerTreeAsImage(layer_tree, *compositor_context_, true);
       break;
     case ScreenshotType::SurfaceData: {
       Surface::SurfaceData surface_data = surface_->GetSurfaceData();
       format = surface_data.pixel_format;
-      data = surface_data.data;
+      data.first = surface_data.data;
       break;
     }
   }
 
-  if (data == nullptr) {
+  if (data.first == nullptr) {
     FML_LOG(ERROR) << "Screenshot data was null.";
     return {};
   }
 
   if (base64_encode) {
-    size_t b64_size = Base64::EncodedSize(data->size());
+    size_t b64_size = Base64::EncodedSize(data.first->size());
     auto b64_data = SkData::MakeUninitialized(b64_size);
-    Base64::Encode(data->data(), data->size(), b64_data->writable_data());
-    return Rasterizer::Screenshot{b64_data, layer_tree->frame_size(), format};
+    Base64::Encode(data.first->data(), data.first->size(),
+                   b64_data->writable_data());
+    return Rasterizer::Screenshot{b64_data, layer_tree->frame_size(), format,
+                                  data.second};
   }
 
-  return Rasterizer::Screenshot{data, layer_tree->frame_size(), format};
+  return Rasterizer::Screenshot{data.first, layer_tree->frame_size(), format,
+                                data.second};
 }
 
 void Rasterizer::SetNextFrameCallback(const fml::closure& callback) {
@@ -977,8 +1096,12 @@ Rasterizer::Screenshot::Screenshot() {}
 
 Rasterizer::Screenshot::Screenshot(sk_sp<SkData> p_data,
                                    SkISize p_size,
-                                   const std::string& p_format)
-    : data(std::move(p_data)), frame_size(p_size), format(p_format) {}
+                                   const std::string& p_format,
+                                   ScreenshotFormat p_pixel_format)
+    : data(std::move(p_data)),
+      frame_size(p_size),
+      format(p_format),
+      pixel_format(p_pixel_format) {}
 
 Rasterizer::Screenshot::Screenshot(const Screenshot& other) = default;
 

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -44,7 +44,7 @@
 namespace impeller {
 class Context;
 class AiksContext;
-enum class PixelFormat { kUnknown };
+enum class PixelFormat : uint8_t { kUnknown };
 }  // namespace impeller
 #endif  // !IMPELLER_SUPPORTS_RENDERING
 

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -25,8 +25,8 @@
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"
 #if IMPELLER_SUPPORTS_RENDERING
-// GN is having trouble understanding how this works in the Fuchsia builds.
 #include "impeller/aiks/aiks_context.h"  // nogncheck
+#include "impeller/core/formats.h"       // nogncheck
 #include "impeller/renderer/context.h"   // nogncheck
 #include "impeller/typographer/backends/skia/typographer_context_skia.h"  // nogncheck
 #endif  // IMPELLER_SUPPORTS_RENDERING
@@ -44,6 +44,7 @@
 namespace impeller {
 class Context;
 class AiksContext;
+enum class PixelFormat { kUnknown };
 }  // namespace impeller
 #endif  // !IMPELLER_SUPPORTS_RENDERING
 
@@ -357,9 +358,10 @@ class Rasterizer final : public SnapshotDelegate,
     SkiaPicture,
 
     //--------------------------------------------------------------------------
-    /// A format used to denote uncompressed image data. This format
+    /// A format used to denote uncompressed image data. For Skia, this format
     /// is 32 bits per pixel, 8 bits per component and
-    /// denoted by the `kN32_SkColorType ` Skia color type.
+    /// denoted by the `kN32_SkColorType ` Skia color type. For Impeller, its
+    /// format is specified in Screenshot::pixel_format.
     ///
     UncompressedImage,
 
@@ -375,6 +377,18 @@ class Rasterizer final : public SnapshotDelegate,
     /// color data, but isn't supported everywhere.
     SurfaceData,
     // NOLINTEND(readability-identifier-naming)
+  };
+
+  // Specifies the format of pixel data in a Screenshot.
+  enum class ScreenshotFormat {
+    // Unknown format, or Skia default.
+    kUnknown,
+    // RGBA 8 bits per channel.
+    kR8G8B8A8UNormInt,
+    // BGRA 8 bits per channel.
+    kB8G8R8A8UNormInt,
+    // RGBA 16 bit floating point per channel.
+    kR16G16B16A16Float,
   };
 
   //----------------------------------------------------------------------------
@@ -401,6 +415,13 @@ class Rasterizer final : public SnapshotDelegate,
     std::string format;
 
     //--------------------------------------------------------------------------
+    /// The pixel format of the data in `data`.
+    ///
+    /// If the impeller backend is not used, this value is always kUnknown and
+    /// the data is in RGBA8888 format.
+    ScreenshotFormat pixel_format = ScreenshotFormat::kUnknown;
+
+    //--------------------------------------------------------------------------
     /// @brief      Creates an empty screenshot
     ///
     Screenshot();
@@ -411,10 +432,12 @@ class Rasterizer final : public SnapshotDelegate,
     /// @param[in]  p_data  The screenshot data
     /// @param[in]  p_size  The screenshot size.
     /// @param[in]  p_format  The screenshot format.
+    /// @param[in]  p_pixel_format  The screenshot format.
     ///
     Screenshot(sk_sp<SkData> p_data,
                SkISize p_size,
-               const std::string& p_format);
+               const std::string& p_format,
+               ScreenshotFormat p_pixel_format);
 
     //--------------------------------------------------------------------------
     /// @brief      The copy constructor for a screenshot.
@@ -663,10 +686,9 @@ class Rasterizer final : public SnapshotDelegate,
     return delegate_.GetIsGpuDisabledSyncSwitch();
   }
 
-  sk_sp<SkData> ScreenshotLayerTreeAsImage(
+  std::pair<sk_sp<SkData>, ScreenshotFormat> ScreenshotLayerTreeAsImage(
       flutter::LayerTree* tree,
       flutter::CompositorContext& compositor_context,
-      GrDirectContext* surface_context,
       bool compressed);
 
   // This method starts with the frame timing recorder at build end. This

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -44,7 +44,6 @@
 namespace impeller {
 class Context;
 class AiksContext;
-enum class PixelFormat : uint8_t { kUnknown };
 }  // namespace impeller
 #endif  // !IMPELLER_SUPPORTS_RENDERING
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -2144,6 +2144,18 @@ void Shell::RemoveView(int64_t view_id) {
 Rasterizer::Screenshot Shell::Screenshot(
     Rasterizer::ScreenshotType screenshot_type,
     bool base64_encode) {
+  if (settings_.enable_impeller) {
+    switch (screenshot_type) {
+      case Rasterizer::ScreenshotType::SkiaPicture:
+        FML_LOG(ERROR)
+            << "Impeller backend cannot produce ScreenshotType::SkiaPicture.";
+        return {};
+      case Rasterizer::ScreenshotType::UncompressedImage:
+      case Rasterizer::ScreenshotType::CompressedImage:
+      case Rasterizer::ScreenshotType::SurfaceData:
+        break;
+    }
+  }
   TRACE_EVENT0("flutter", "Shell::Screenshot");
   fml::AutoResetWaitableEvent latch;
   Rasterizer::Screenshot screenshot;

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -299,8 +299,7 @@ Rasterizer::Screenshot AndroidShellHolder::Screenshot(
     return {nullptr, SkISize::MakeEmpty(), "",
             Rasterizer::ScreenshotFormat::kUnknown};
   }
-  return {shell_->Screenshot(type, base64_encode),
-          Rasterizer::ScreenshotFormat::kR8G8B8A8UNormInt};
+  return shell_->Screenshot(type, base64_encode);
 }
 
 fml::WeakPtr<PlatformViewAndroid> AndroidShellHolder::GetPlatformView() {

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -296,7 +296,8 @@ Rasterizer::Screenshot AndroidShellHolder::Screenshot(
     Rasterizer::ScreenshotType type,
     bool base64_encode) {
   if (!IsValid()) {
-    return {nullptr, SkISize::MakeEmpty(), ""};
+    return {nullptr, SkISize::MakeEmpty(), "",
+            Rasterizer::ScreenshotFormat::kUnknown};
   }
   return {shell_->Screenshot(type, base64_encode),
           Rasterizer::ScreenshotFormat::kR8G8B8A8UNormInt};

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -298,7 +298,8 @@ Rasterizer::Screenshot AndroidShellHolder::Screenshot(
   if (!IsValid()) {
     return {nullptr, SkISize::MakeEmpty(), ""};
   }
-  return shell_->Screenshot(type, base64_encode);
+  return {shell_->Screenshot(type, base64_encode),
+          Rasterizer::ScreenshotFormat::kR8G8B8A8UNormInt};
 }
 
 fml::WeakPtr<PlatformViewAndroid> AndroidShellHolder::GetPlatformView() {

--- a/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
@@ -80,6 +80,7 @@
         @"platform_view_gesture_accept_with_overlapping_platform_views",
     @"--tap-status-bar" : @"tap_status_bar",
     @"--animated-color-square" : @"animated_color_square",
+    @"--solid-blue" : @"solid_blue",
     @"--platform-view-with-continuous-texture" : @"platform_view_with_continuous_texture",
     @"--bogus-font-text" : @"bogus_font_text",
     @"--spawn-engine-works" : @"spawn_engine_works",

--- a/testing/scenario_app/lib/src/scenarios.dart
+++ b/testing/scenario_app/lib/src/scenarios.dart
@@ -14,6 +14,7 @@ import 'locale_initialization.dart';
 import 'platform_view.dart';
 import 'poppable_screen.dart';
 import 'scenario.dart';
+import 'solid_blue.dart';
 import 'texture.dart';
 import 'touches_scenario.dart';
 
@@ -23,6 +24,7 @@ int _viewId = 0;
 
 Map<String, _ScenarioFactory> _scenarios = <String, _ScenarioFactory>{
   'animated_color_square': (FlutterView view) => AnimatedColorSquareScenario(view),
+  'solid_blue': (FlutterView view) => SolidBlueScenario(view),
   'locale_initialization': (FlutterView view) => LocaleInitialization(view),
   'platform_view': (FlutterView view) => PlatformViewScenario(view, id: _viewId++),
   'platform_view_no_overlay_intersection': (FlutterView view) => PlatformViewNoOverlayIntersectionScenario(view, id: _viewId++),

--- a/testing/scenario_app/lib/src/solid_blue.dart
+++ b/testing/scenario_app/lib/src/solid_blue.dart
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'scenario.dart';
+
+/// Fills the screen with a solid blue color.
+class SolidBlueScenario extends Scenario {
+  /// Creates the AnimatedColorSquare scenario.
+  SolidBlueScenario(super.view);
+
+  @override
+  void onBeginFrame(Duration duration) {
+    final SceneBuilder builder = SceneBuilder();
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+
+    canvas.drawPaint(Paint()..color = const Color(0xFF0000FF));
+    final Picture picture = recorder.endRecording();
+
+    builder.addPicture(
+      Offset.zero,
+      picture,
+      willChangeHint: true,
+    );
+    final Scene scene = builder.build();
+    view.render(scene);
+    scene.dispose();
+  }
+}

--- a/testing/scenario_app/lib/src/solid_blue.dart
+++ b/testing/scenario_app/lib/src/solid_blue.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math' as math;
 import 'dart:ui';
 
 import 'scenario.dart';


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/141571

Shell::Screenshot was impelemnted in a Skia-only way and would crash when invoked. Adds test coverage for the breaking path on iOS that ends up calling `FlutterView drawLayer`.