### PR TITLE
[Impeller] add missing barrier to compute tessellator.

### DIFF
--- a/impeller/renderer/compute_tessellator.cc
+++ b/impeller/renderer/compute_tessellator.cc
@@ -145,6 +145,7 @@ ComputeTessellator::Status ComputeTessellator::Tessellate(
         context->GetPipelineLibrary()->GetPipeline(pipeline_desc).Get();
     FML_DCHECK(compute_pipeline);
 
+    pass->AddBufferMemoryBarrier();
     pass->SetPipeline(compute_pipeline);
     pass->SetCommandLabel("Compute Stroke");
 


### PR DESCRIPTION
Fixes the flake on ToT

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8757792078669575121/+/u/test:_Host_Tests_for_host_debug_unopt/stdout
