### PR TITLE
Fix incorrect FML_VLOG() severity usage

### DIFF
--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -545,7 +545,7 @@ const std::string& ComponentV2::GetDebugLabel() const {
 }
 
 void ComponentV2::Kill() {
-  FML_VLOG(-1) << "received Kill event";
+  FML_VLOG(1) << "received Kill event";
 
   // From the documentation for ComponentController, ZX_OK should be sent when
   // the ComponentController receives a termination request. However, if the
@@ -582,7 +582,7 @@ void ComponentV2::KillWithEpitaph(zx_status_t epitaph_status) {
 }
 
 void ComponentV2::Stop() {
-  FML_VLOG(-1) << "received Stop event";
+  FML_VLOG(1) << "received Stop event";
 
   // TODO(fxb/89162): Any other cleanup logic we should do that's appropriate
   // for Stop but not for Kill?
@@ -617,8 +617,8 @@ void ComponentV2::OnEngineTerminate(const Engine* shell_holder) {
   shell_holders_.erase(found);
 
   if (shell_holders_.empty()) {
-    FML_VLOG(-1) << "Killing component because all shell holders have been "
-                    "terminated.";
+    FML_VLOG(1) << "Killing component because all shell holders have been "
+                   "terminated.";
     Kill();
     // WARNING: Don't do anything past this point because the delegate may have
     // collected this instance via the termination callback.

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -611,7 +611,7 @@ void Engine::Initialize(
     ZX_ASSERT(runner_services->Connect(
                   memory_pressure_provider_.NewRequest()) == ZX_OK);
 
-    FML_VLOG(-1) << "Registering memorypressure watcher";
+    FML_VLOG(1) << "Registering memorypressure watcher";
 
     // Register for changes, which will make the request for the initial
     // memory level.
@@ -647,12 +647,12 @@ void Engine::Initialize(
         FML_LOG(WARNING) << "Got intl Profile without locales";
       }
       auto message = MakeLocalizationPlatformMessage(profile);
-      FML_VLOG(-1) << "Sending LocalizationPlatformMessage";
+      FML_VLOG(1) << "Sending LocalizationPlatformMessage";
       weak->shell_->GetPlatformView()->DispatchPlatformMessage(
           std::move(message));
     };
 
-    FML_VLOG(-1) << "Requesting intl Profile";
+    FML_VLOG(1) << "Requesting intl Profile";
 
     // Make the initial request
     intl_property_provider_->GetProfile(get_profile_callback);
@@ -660,7 +660,7 @@ void Engine::Initialize(
     // And register for changes
     intl_property_provider_.events().OnChange = [this, runner_services,
                                                  get_profile_callback]() {
-      FML_VLOG(-1) << fuchsia::intl::PropertyProvider::Name_ << ": OnChange";
+      FML_VLOG(1) << fuchsia::intl::PropertyProvider::Name_ << ": OnChange";
       runner_services->Connect(intl_property_provider_.NewRequest());
       intl_property_provider_->GetProfile(get_profile_callback);
     };

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
@@ -114,7 +114,7 @@ class FlutterEmbedderTest : public ::loop_fixture::RealLoop,
  public:
   FlutterEmbedderTest()
       : realm_builder_(component_testing::RealmBuilder::Create()) {
-    FML_VLOG(-1) << "Setting up base realm";
+    FML_VLOG(1) << "Setting up base realm";
     SetUpRealmBase();
 
     // Post a "just in case" quit task, if the test hangs.


### PR DESCRIPTION
The FML_VLOG() macros are designed to use a positive integers, since they pass -severity to the LogMessage constructor. The negative severity can also cause some surprising behavior with log filtering. This change update usages of FML_VLOG(-1) to FML_VLOG(1).

flutter/flutter#141924

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
