### PR TITLE
More correctly name methods regarding event loop that are currently named microtask

### DIFF
--- a/fml/task_source.cc
+++ b/fml/task_source.cc
@@ -28,7 +28,7 @@ void TaskSource::RegisterTask(const DelayedTask& task) {
     case TaskSourceGrade::kUnspecified:
       primary_task_queue_.push(task);
       break;
-    case TaskSourceGrade::kDartMicroTasks:
+    case TaskSourceGrade::kDartEventLoop:
       secondary_task_queue_.push(task);
       break;
   }
@@ -42,7 +42,7 @@ void TaskSource::PopTask(TaskSourceGrade grade) {
     case TaskSourceGrade::kUnspecified:
       primary_task_queue_.pop();
       break;
-    case TaskSourceGrade::kDartMicroTasks:
+    case TaskSourceGrade::kDartEventLoop:
       secondary_task_queue_.pop();
       break;
   }

--- a/fml/task_source_grade.h
+++ b/fml/task_source_grade.h
@@ -17,8 +17,8 @@ enum class TaskSourceGrade {
   /// interaction.
   kUserInteraction,
   /// This `TaskSourceGrade` indicates that a task corresponds to servicing a
-  /// dart micro task. These aren't critical to user interaction.
-  kDartMicroTasks,
+  /// dart event loop task. These aren't critical to user interaction.
+  kDartEventLoop,
   /// The absence of a specialized `TaskSourceGrade`.
   kUnspecified,
 };

--- a/fml/task_source_unittests.cc
+++ b/fml/task_source_unittests.cc
@@ -29,7 +29,7 @@ TEST(TaskSourceTests, MultipleTaskGrades) {
   task_source.RegisterTask(
       {2, [] {}, ChronoTicksSinceEpoch(), TaskSourceGrade::kUserInteraction});
   task_source.RegisterTask(
-      {3, [] {}, ChronoTicksSinceEpoch(), TaskSourceGrade::kDartMicroTasks});
+      {3, [] {}, ChronoTicksSinceEpoch(), TaskSourceGrade::kDartEventLoop});
   ASSERT_EQ(task_source.GetNumPendingTasks(), 3u);
 }
 
@@ -55,7 +55,7 @@ TEST(TaskSourceTests, SimpleOrderingMultiTaskHeaps) {
   auto time_stamp = ChronoTicksSinceEpoch();
   int value = 0;
   task_source.RegisterTask(
-      {1, [&] { value = 1; }, time_stamp, TaskSourceGrade::kDartMicroTasks});
+      {1, [&] { value = 1; }, time_stamp, TaskSourceGrade::kDartEventLoop});
   task_source.RegisterTask({2, [&] { value = 7; },
                             time_stamp + fml::TimeDelta::FromMilliseconds(1),
                             TaskSourceGrade::kUserInteraction});
@@ -75,7 +75,7 @@ TEST(TaskSourceTests, OrderingMultiTaskHeapsSecondaryPaused) {
   auto time_stamp = ChronoTicksSinceEpoch();
   int value = 0;
   task_source.RegisterTask(
-      {1, [&] { value = 1; }, time_stamp, TaskSourceGrade::kDartMicroTasks});
+      {1, [&] { value = 1; }, time_stamp, TaskSourceGrade::kDartEventLoop});
   task_source.RegisterTask({2, [&] { value = 7; },
                             time_stamp + fml::TimeDelta::FromMilliseconds(1),
                             TaskSourceGrade::kUserInteraction});

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -413,7 +413,7 @@ void DartIsolate::SetMessageHandlingTaskRunner(
           TRACE_EVENT0("flutter", "DartIsolate::HandleMessage");
           task();
         },
-        fml::TimePoint::Now(), fml::TaskSourceGrade::kDartMicroTasks);
+        fml::TimePoint::Now(), fml::TaskSourceGrade::kDartEventLoop);
 #endif
   });
 }

--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -112,7 +112,7 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
   if (callback) {
     const uint64_t flow_identifier = fml::tracing::TraceNonce();
     if (pause_secondary_tasks) {
-      PauseDartMicroTasks();
+      PauseDartEventLoopTasks();
     }
 
     // The base trace ensures that flows have a root to begin from if one does
@@ -142,7 +142,7 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
           callback(std::move(frame_timings_recorder));
           TRACE_FLOW_END("flutter", kVsyncFlowName, flow_identifier);
           if (pause_secondary_tasks) {
-            ResumeDartMicroTasks(ui_task_queue_id);
+            ResumeDartEventLoopTasks(ui_task_queue_id);
           }
         });
   }
@@ -152,13 +152,13 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
   }
 }
 
-void VsyncWaiter::PauseDartMicroTasks() {
+void VsyncWaiter::PauseDartEventLoopTasks() {
   auto ui_task_queue_id = task_runners_.GetUITaskRunner()->GetTaskQueueId();
   auto task_queues = fml::MessageLoopTaskQueues::GetInstance();
   task_queues->PauseSecondarySource(ui_task_queue_id);
 }
 
-void VsyncWaiter::ResumeDartMicroTasks(fml::TaskQueueId ui_task_queue_id) {
+void VsyncWaiter::ResumeDartEventLoopTasks(fml::TaskQueueId ui_task_queue_id) {
   auto task_queues = fml::MessageLoopTaskQueues::GetInstance();
   task_queues->ResumeSecondarySource(ui_task_queue_id);
 }

--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -79,8 +79,8 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
   Callback callback_;
   std::unordered_map<uintptr_t, fml::closure> secondary_callbacks_;
 
-  void PauseDartMicroTasks();
-  static void ResumeDartMicroTasks(fml::TaskQueueId ui_task_queue_id);
+  void PauseDartEventLoopTasks();
+  static void ResumeDartEventLoopTasks(fml::TaskQueueId ui_task_queue_id);
 
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiter);
 };

--- a/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -4345,7 +4345,7 @@ TEST_F(EmbedderTest, ObjectsPostedViaPortsServicedOnSecondaryTaskHeap) {
     trampoline = [&](Dart_Handle handle) {
       ASSERT_TRUE(tonic::DartConverter<bool>::FromDart(handle));
       auto task_grade = fml::MessageLoopTaskQueues::GetCurrentTaskSourceGrade();
-      EXPECT_EQ(task_grade, fml::TaskSourceGrade::kDartMicroTasks);
+      EXPECT_EQ(task_grade, fml::TaskSourceGrade::kDartEventLoop);
       event.Signal();
     };
     ASSERT_EQ(FlutterEnginePostDartObject(engine.get(), port, &object),


### PR DESCRIPTION
Flutter implements the UI isolates message via posting to a UI task queue. That task queue has a primary and a secondary queue. The

* primary is used for running tasks resulated to framework (e.g. draw frame)
* secondary is used to run Dart event loop messages (e.g. received data on a socket)

The Dart semantics requires running microtasks before processing the next event loop message.

The way flutter implements by attaching an observer to the secondary queue. Every time a task from the queue is run, all observers are run and one of them is going to run pending microtasks.

In some situations the engine pauses the dart event loop. The terminology used in the code is "microtask" when in reality what it means is "event loop".

=> This PR changes this terminology to reflect what actually happens.