### PR TITLE
Manually revert TLHC optimizations, holding on to width/height changes.

### DIFF
--- a/shell/platform/android/android_shell_holder_unittests.cc
+++ b/shell/platform/android/android_shell_holder_unittests.cc
@@ -35,10 +35,6 @@ class MockPlatformViewAndroidJNI : public PlatformViewAndroidJNI {
               SurfaceTextureAttachToGLContext,
               (JavaLocalRef surface_texture, int textureId),
               (override));
-  MOCK_METHOD(bool,
-              SurfaceTextureShouldUpdate,
-              (JavaLocalRef surface_texture),
-              (override));
   MOCK_METHOD(void,
               SurfaceTextureUpdateTexImage,
               (JavaLocalRef surface_texture),

--- a/shell/platform/android/image_external_texture.cc
+++ b/shell/platform/android/image_external_texture.cc
@@ -26,9 +26,11 @@ void ImageExternalTexture::Paint(PaintContext& context,
     return;
   }
   Attach(context);
-  const bool should_process_frame = !freeze;
+  const bool should_process_frame =
+      (!freeze && new_frame_ready_) || dl_image_ == nullptr;
   if (should_process_frame) {
     ProcessFrame(context, bounds);
+    new_frame_ready_ = false;
   }
   if (dl_image_) {
     context.canvas->DrawImageRect(
@@ -46,7 +48,7 @@ void ImageExternalTexture::Paint(PaintContext& context,
 
 // Implementing flutter::Texture.
 void ImageExternalTexture::MarkNewFrameAvailable() {
-  // NOOP.
+  new_frame_ready_ = true;
 }
 
 // Implementing flutter::Texture.

--- a/shell/platform/android/image_external_texture.h
+++ b/shell/platform/android/image_external_texture.h
@@ -61,6 +61,7 @@ class ImageExternalTexture : public flutter::Texture {
 
   enum class AttachmentState { kUninitialized, kAttached, kDetached };
   AttachmentState state_ = AttachmentState::kUninitialized;
+  bool new_frame_ready_ = false;
 
   sk_sp<flutter::DlImage> dl_image_;
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -951,16 +951,6 @@ public class FlutterJNI {
 
   private native void nativeMarkTextureFrameAvailable(long nativeShellHolderId, long textureId);
 
-  /** Schedule the engine to draw a frame but does not invalidate the layout tree. */
-  @UiThread
-  public void scheduleFrame() {
-    ensureRunningOnMainThread();
-    ensureAttachedToNative();
-    nativeScheduleFrame(nativeShellHolderId);
-  }
-
-  private native void nativeScheduleFrame(long nativeShellHolderId);
-
   /**
    * Unregisters a texture that was registered with {@link #registerTexture(long,
    * SurfaceTextureWrapper)}.

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -16,12 +16,13 @@ import android.media.ImageReader;
 import android.os.Build;
 import android.os.Handler;
 import android.view.Surface;
-
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-
+import io.flutter.Log;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.view.TextureRegistry;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
@@ -31,10 +32,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
-
-import io.flutter.Log;
-import io.flutter.embedding.engine.FlutterJNI;
-import io.flutter.view.TextureRegistry;
 
 /**
  * Represents the rendering responsibilities of a {@code FlutterEngine}.
@@ -50,1206 +47,1149 @@ import io.flutter.view.TextureRegistry;
  * io.flutter.embedding.android.FlutterTextureView} are implementations of {@link RenderSurface}.
  */
 public class FlutterRenderer implements TextureRegistry {
-    /**
-     * Whether to always use GL textures for {@link FlutterRenderer#createSurfaceProducer()}.
-     *
-     * <p>This is a debug-only API intended for local development. For example, when using a newer
-     * Android device (that normally would use {@link ImageReaderSurfaceProducer}, but wanting to
-     * test the OpenGLES/{@link SurfaceTextureSurfaceProducer} code branch. This flag has undefined
-     * behavior if set to true while running in a Vulkan (Impeller) context.
-     */
-    @VisibleForTesting
-    static boolean debugForceSurfaceProducerGlTextures = false;
+  /**
+   * Whether to always use GL textures for {@link FlutterRenderer#createSurfaceProducer()}.
+   *
+   * <p>This is a debug-only API intended for local development. For example, when using a newer
+   * Android device (that normally would use {@link ImageReaderSurfaceProducer}, but wanting to test
+   * the OpenGLES/{@link SurfaceTextureSurfaceProducer} code branch. This flag has undefined
+   * behavior if set to true while running in a Vulkan (Impeller) context.
+   */
+  @VisibleForTesting static boolean debugForceSurfaceProducerGlTextures = false;
 
-    private static final String TAG = "FlutterRenderer";
+  private static final String TAG = "FlutterRenderer";
 
-    @NonNull
-    private final FlutterJNI flutterJNI;
-    @NonNull
-    private final AtomicLong nextTextureId = new AtomicLong(0L);
-    @Nullable
-    private Surface surface;
-    private boolean isDisplayingFlutterUi = false;
-    private int isRenderingToImageViewCount = 0;
-    private final Handler handler = new Handler();
+  @NonNull private final FlutterJNI flutterJNI;
+  @NonNull private final AtomicLong nextTextureId = new AtomicLong(0L);
+  @Nullable private Surface surface;
+  private boolean isDisplayingFlutterUi = false;
+  private int isRenderingToImageViewCount = 0;
+  private final Handler handler = new Handler();
 
-    @NonNull
-    private final Set<WeakReference<TextureRegistry.OnTrimMemoryListener>> onTrimMemoryListeners =
-            new HashSet<>();
+  @NonNull
+  private final Set<WeakReference<TextureRegistry.OnTrimMemoryListener>> onTrimMemoryListeners =
+      new HashSet<>();
 
-    @NonNull
-    private final FlutterUiDisplayListener flutterUiDisplayListener =
-            new FlutterUiDisplayListener() {
-                @Override
-                public void onFlutterUiDisplayed() {
-                    isDisplayingFlutterUi = true;
-                }
-
-                @Override
-                public void onFlutterUiNoLongerDisplayed() {
-                    isDisplayingFlutterUi = false;
-                }
-            };
-
-    public FlutterRenderer(@NonNull FlutterJNI flutterJNI) {
-        this.flutterJNI = flutterJNI;
-        this.flutterJNI.addIsDisplayingFlutterUiListener(flutterUiDisplayListener);
-    }
-
-    /**
-     * Returns true if this {@code FlutterRenderer} is painting pixels to an Android {@code View}
-     * hierarchy, false otherwise.
-     */
-    public boolean isDisplayingFlutterUi() {
-        return isDisplayingFlutterUi;
-    }
-
-    /**
-     * Informs the renderer whether the surface it is rendering to is backend by a {@code
-     * FlutterImageView}, which requires additional synchonization in the Vulkan backend.
-     */
-    public void SetRenderingToImageView(boolean value) {
-        if (value) {
-            isRenderingToImageViewCount++;
-        } else {
-            isRenderingToImageViewCount--;
+  @NonNull
+  private final FlutterUiDisplayListener flutterUiDisplayListener =
+      new FlutterUiDisplayListener() {
+        @Override
+        public void onFlutterUiDisplayed() {
+          isDisplayingFlutterUi = true;
         }
-        flutterJNI.SetIsRenderingToImageView(isRenderingToImageViewCount > 0);
-    }
 
-    /**
-     * Adds a listener that is invoked whenever this {@code FlutterRenderer} starts and stops
-     * painting pixels to an Android {@code View} hierarchy.
-     */
-    public void addIsDisplayingFlutterUiListener(@NonNull FlutterUiDisplayListener listener) {
-        flutterJNI.addIsDisplayingFlutterUiListener(listener);
-
-        if (isDisplayingFlutterUi) {
-            listener.onFlutterUiDisplayed();
+        @Override
+        public void onFlutterUiNoLongerDisplayed() {
+          isDisplayingFlutterUi = false;
         }
-    }
+      };
 
-    /**
-     * Removes a listener added via {@link
-     * #addIsDisplayingFlutterUiListener(FlutterUiDisplayListener)}.
-     */
-    public void removeIsDisplayingFlutterUiListener(@NonNull FlutterUiDisplayListener listener) {
-        flutterJNI.removeIsDisplayingFlutterUiListener(listener);
-    }
+  public FlutterRenderer(@NonNull FlutterJNI flutterJNI) {
+    this.flutterJNI = flutterJNI;
+    this.flutterJNI.addIsDisplayingFlutterUiListener(flutterUiDisplayListener);
+  }
 
-    private void clearDeadListeners() {
-        final Iterator<WeakReference<OnTrimMemoryListener>> iterator =
-                onTrimMemoryListeners.iterator();
-        while (iterator.hasNext()) {
-            WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
-            final OnTrimMemoryListener listener = listenerRef.get();
-            if (listener == null) {
-                iterator.remove();
+  /**
+   * Returns true if this {@code FlutterRenderer} is painting pixels to an Android {@code View}
+   * hierarchy, false otherwise.
+   */
+  public boolean isDisplayingFlutterUi() {
+    return isDisplayingFlutterUi;
+  }
+
+  /**
+   * Informs the renderer whether the surface it is rendering to is backend by a {@code
+   * FlutterImageView}, which requires additional synchonization in the Vulkan backend.
+   */
+  public void SetRenderingToImageView(boolean value) {
+    if (value) {
+      isRenderingToImageViewCount++;
+    } else {
+      isRenderingToImageViewCount--;
+    }
+    flutterJNI.SetIsRenderingToImageView(isRenderingToImageViewCount > 0);
+  }
+
+  /**
+   * Adds a listener that is invoked whenever this {@code FlutterRenderer} starts and stops painting
+   * pixels to an Android {@code View} hierarchy.
+   */
+  public void addIsDisplayingFlutterUiListener(@NonNull FlutterUiDisplayListener listener) {
+    flutterJNI.addIsDisplayingFlutterUiListener(listener);
+
+    if (isDisplayingFlutterUi) {
+      listener.onFlutterUiDisplayed();
+    }
+  }
+
+  /**
+   * Removes a listener added via {@link
+   * #addIsDisplayingFlutterUiListener(FlutterUiDisplayListener)}.
+   */
+  public void removeIsDisplayingFlutterUiListener(@NonNull FlutterUiDisplayListener listener) {
+    flutterJNI.removeIsDisplayingFlutterUiListener(listener);
+  }
+
+  private void clearDeadListeners() {
+    final Iterator<WeakReference<OnTrimMemoryListener>> iterator = onTrimMemoryListeners.iterator();
+    while (iterator.hasNext()) {
+      WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
+      final OnTrimMemoryListener listener = listenerRef.get();
+      if (listener == null) {
+        iterator.remove();
+      }
+    }
+  }
+
+  /** Adds a listener that is invoked when a memory pressure warning was forward. */
+  @VisibleForTesting
+  /* package */ void addOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
+    // Purge dead listener to avoid accumulating.
+    clearDeadListeners();
+    onTrimMemoryListeners.add(new WeakReference<>(listener));
+  }
+
+  /**
+   * Removes a {@link OnTrimMemoryListener} that was added with {@link
+   * #addOnTrimMemoryListener(OnTrimMemoryListener)}.
+   */
+  @VisibleForTesting
+  /* package */ void removeOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
+    for (WeakReference<OnTrimMemoryListener> listenerRef : onTrimMemoryListeners) {
+      if (listenerRef.get() == listener) {
+        onTrimMemoryListeners.remove(listenerRef);
+        break;
+      }
+    }
+  }
+
+  // ------ START TextureRegistry IMPLEMENTATION -----
+
+  /**
+   * Creates and returns a new external texture {@link SurfaceProducer} managed by the Flutter
+   * engine that is also made available to Flutter code.
+   */
+  @NonNull
+  @Override
+  public SurfaceProducer createSurfaceProducer() {
+    // Prior to Impeller, Flutter on Android *only* ran on OpenGLES (via Skia). That meant that
+    // plugins (i.e. end-users) either explicitly created a SurfaceTexture (via
+    // createX/registerX) or an ImageTexture (via createX/registerX).
+    //
+    // In an Impeller world, which for the first time uses (if available) a Vulkan rendering
+    // backend, it is no longer possible (at least not trivially) to render an OpenGLES-provided
+    // texture (SurfaceTexture) in a Vulkan context.
+    //
+    // This function picks the "best" rendering surface based on the Android runtime, and
+    // provides a consumer-agnostic SurfaceProducer (which in turn vends a Surface), and has
+    // plugins (i.e. end-users) use the Surface instead, letting us "hide" the consumer-side
+    // of the implementation.
+    //
+    // tl;dr: If ImageTexture is available, we use it, otherwise we use a SurfaceTexture.
+    // Coincidentally, if ImageTexture is available, we are also on an Android version that is
+    // running Vulkan, so we don't have to worry about it not being supported.
+    final long id = nextTextureId.getAndIncrement();
+    final SurfaceProducer entry;
+    if (!debugForceSurfaceProducerGlTextures && Build.VERSION.SDK_INT >= 29) {
+      final ImageReaderSurfaceProducer producer = new ImageReaderSurfaceProducer(id);
+      registerImageTexture(id, producer);
+      Log.v(TAG, "New ImageReaderSurfaceProducer ID: " + id);
+      entry = producer;
+    } else {
+      final SurfaceTextureSurfaceProducer producer =
+          new SurfaceTextureSurfaceProducer(id, handler, flutterJNI);
+      registerSurfaceTexture(id, producer.getSurfaceTexture());
+      Log.v(TAG, "New SurfaceTextureSurfaceProducer ID: " + id);
+      entry = producer;
+    }
+    return entry;
+  }
+
+  /**
+   * Creates and returns a new {@link SurfaceTexture} managed by the Flutter engine that is also
+   * made available to Flutter code.
+   */
+  @NonNull
+  @Override
+  public SurfaceTextureEntry createSurfaceTexture() {
+    Log.v(TAG, "Creating a SurfaceTexture.");
+    final SurfaceTexture surfaceTexture = new SurfaceTexture(0);
+    return registerSurfaceTexture(surfaceTexture);
+  }
+
+  /**
+   * Registers and returns a {@link SurfaceTexture} managed by the Flutter engine that is also made
+   * available to Flutter code.
+   */
+  @NonNull
+  @Override
+  public SurfaceTextureEntry registerSurfaceTexture(@NonNull SurfaceTexture surfaceTexture) {
+    return registerSurfaceTexture(nextTextureId.getAndIncrement(), surfaceTexture);
+  }
+
+  /**
+   * Similar to {@link FlutterRenderer#registerSurfaceTexture} but with an existing @{code
+   * textureId}.
+   *
+   * @param surfaceTexture Surface texture to wrap.
+   * @param textureId A texture ID already created that should be assigned to the surface texture.
+   */
+  @NonNull
+  private SurfaceTextureEntry registerSurfaceTexture(
+      long textureId, @NonNull SurfaceTexture surfaceTexture) {
+    surfaceTexture.detachFromGLContext();
+    final SurfaceTextureRegistryEntry entry =
+        new SurfaceTextureRegistryEntry(textureId, surfaceTexture);
+    Log.v(TAG, "New SurfaceTexture ID: " + entry.id());
+    registerTexture(entry.id(), entry.textureWrapper());
+    addOnTrimMemoryListener(entry);
+    return entry;
+  }
+
+  @NonNull
+  @Override
+  public ImageTextureEntry createImageTexture() {
+    final ImageTextureRegistryEntry entry =
+        new ImageTextureRegistryEntry(nextTextureId.getAndIncrement());
+    Log.v(TAG, "New ImageTextureEntry ID: " + entry.id());
+    registerImageTexture(entry.id(), entry);
+    return entry;
+  }
+
+  @Override
+  public void onTrimMemory(int level) {
+    final Iterator<WeakReference<OnTrimMemoryListener>> iterator = onTrimMemoryListeners.iterator();
+    while (iterator.hasNext()) {
+      WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
+      final OnTrimMemoryListener listener = listenerRef.get();
+      if (listener != null) {
+        listener.onTrimMemory(level);
+      } else {
+        // Purge cleared refs to avoid accumulating a lot of dead listener
+        iterator.remove();
+      }
+    }
+  }
+
+  final class SurfaceTextureRegistryEntry
+      implements TextureRegistry.SurfaceTextureEntry, TextureRegistry.OnTrimMemoryListener {
+    private final long id;
+    @NonNull private final SurfaceTextureWrapper textureWrapper;
+    private boolean released;
+    @Nullable private OnTrimMemoryListener trimMemoryListener;
+    @Nullable private OnFrameConsumedListener frameConsumedListener;
+
+    SurfaceTextureRegistryEntry(long id, @NonNull SurfaceTexture surfaceTexture) {
+      this.id = id;
+      Runnable onFrameConsumed =
+          () -> {
+            if (frameConsumedListener != null) {
+              frameConsumedListener.onFrameConsumed();
             }
-        }
-    }
+          };
+      this.textureWrapper = new SurfaceTextureWrapper(surfaceTexture, onFrameConsumed);
 
-    /** Adds a listener that is invoked when a memory pressure warning was forward. */
-    @VisibleForTesting
-    /* package */ void addOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
-        // Purge dead listener to avoid accumulating.
-        clearDeadListeners();
-        onTrimMemoryListeners.add(new WeakReference<>(listener));
-    }
-
-    /**
-     * Removes a {@link OnTrimMemoryListener} that was added with {@link
-     * #addOnTrimMemoryListener(OnTrimMemoryListener)}.
-     */
-    @VisibleForTesting
-    /* package */ void removeOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
-        for (WeakReference<OnTrimMemoryListener> listenerRef : onTrimMemoryListeners) {
-            if (listenerRef.get() == listener) {
-                onTrimMemoryListeners.remove(listenerRef);
-                break;
+      // Even though we make sure to unregister the callback before releasing, as of
+      // Android O, SurfaceTexture has a data race when accessing the callback, so the
+      // callback may still be called by a stale reference after released==true and
+      // mNativeView==null.
+      SurfaceTexture.OnFrameAvailableListener onFrameListener =
+          texture -> {
+            if (released || !flutterJNI.isAttached()) {
+              // Even though we make sure to unregister the callback before releasing, as of
+              // Android O, SurfaceTexture has a data race when accessing the callback, so the
+              // callback may still be called by a stale reference after released==true and
+              // mNativeView==null.
+              return;
             }
-        }
-    }
-
-    // ------ START TextureRegistry IMPLEMENTATION -----
-
-    /**
-     * Creates and returns a new external texture {@link SurfaceProducer} managed by the Flutter
-     * engine that is also made available to Flutter code.
-     */
-    @NonNull
-    @Override
-    public SurfaceProducer createSurfaceProducer() {
-        // Prior to Impeller, Flutter on Android *only* ran on OpenGLES (via Skia). That meant that
-        // plugins (i.e. end-users) either explicitly created a SurfaceTexture (via
-        // createX/registerX) or an ImageTexture (via createX/registerX).
-        //
-        // In an Impeller world, which for the first time uses (if available) a Vulkan rendering
-        // backend, it is no longer possible (at least not trivially) to render an OpenGLES-provided
-        // texture (SurfaceTexture) in a Vulkan context.
-        //
-        // This function picks the "best" rendering surface based on the Android runtime, and
-        // provides a consumer-agnostic SurfaceProducer (which in turn vends a Surface), and has
-        // plugins (i.e. end-users) use the Surface instead, letting us "hide" the consumer-side
-        // of the implementation.
-        //
-        // tl;dr: If ImageTexture is available, we use it, otherwise we use a SurfaceTexture.
-        // Coincidentally, if ImageTexture is available, we are also on an Android version that is
-        // running Vulkan, so we don't have to worry about it not being supported.
-        final long id = nextTextureId.getAndIncrement();
-        final SurfaceProducer entry;
-        if (!debugForceSurfaceProducerGlTextures && Build.VERSION.SDK_INT >= 29) {
-            final ImageReaderSurfaceProducer producer = new ImageReaderSurfaceProducer(id);
-            registerImageTexture(id, producer);
-            Log.v(TAG, "New ImageReaderSurfaceProducer ID: " + id);
-            entry = producer;
-        } else {
-            final SurfaceTextureSurfaceProducer producer =
-                    new SurfaceTextureSurfaceProducer(id, handler, flutterJNI);
-            registerSurfaceTexture(id, producer.getSurfaceTexture());
-            Log.v(TAG, "New SurfaceTextureSurfaceProducer ID: " + id);
-            entry = producer;
-        }
-        return entry;
-    }
-
-    /**
-     * Creates and returns a new {@link SurfaceTexture} managed by the Flutter engine that is also
-     * made available to Flutter code.
-     */
-    @NonNull
-    @Override
-    public SurfaceTextureEntry createSurfaceTexture() {
-        Log.v(TAG, "Creating a SurfaceTexture.");
-        final SurfaceTexture surfaceTexture = new SurfaceTexture(0);
-        return registerSurfaceTexture(surfaceTexture);
-    }
-
-    /**
-     * Registers and returns a {@link SurfaceTexture} managed by the Flutter engine that is also
-     * made available to Flutter code.
-     */
-    @NonNull
-    @Override
-    public SurfaceTextureEntry registerSurfaceTexture(@NonNull SurfaceTexture surfaceTexture) {
-        return registerSurfaceTexture(nextTextureId.getAndIncrement(), surfaceTexture);
-    }
-
-    /**
-     * Similar to {@link FlutterRenderer#registerSurfaceTexture} but with an existing @{code
-     * textureId}.
-     *
-     * @param surfaceTexture Surface texture to wrap.
-     * @param textureId A texture ID already created that should be assigned to the surface texture.
-     */
-    @NonNull
-    private SurfaceTextureEntry registerSurfaceTexture(
-            long textureId, @NonNull SurfaceTexture surfaceTexture) {
-        surfaceTexture.detachFromGLContext();
-        final SurfaceTextureRegistryEntry entry =
-                new SurfaceTextureRegistryEntry(textureId, surfaceTexture);
-        Log.v(TAG, "New SurfaceTexture ID: " + entry.id());
-        registerTexture(entry.id(), entry.textureWrapper());
-        addOnTrimMemoryListener(entry);
-        return entry;
-    }
-
-    @NonNull
-    @Override
-    public ImageTextureEntry createImageTexture() {
-        final ImageTextureRegistryEntry entry =
-                new ImageTextureRegistryEntry(nextTextureId.getAndIncrement());
-        Log.v(TAG, "New ImageTextureEntry ID: " + entry.id());
-        registerImageTexture(entry.id(), entry);
-        return entry;
+            markTextureFrameAvailable(id);
+          };
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        // The callback relies on being executed on the UI thread (unsynchronised read
+        // of
+        // mNativeView
+        // and also the engine code check for platform thread in
+        // Shell::OnPlatformViewMarkTextureFrameAvailable),
+        // so we explicitly pass a Handler for the current thread.
+        this.surfaceTexture().setOnFrameAvailableListener(onFrameListener, new Handler());
+      } else {
+        // Android documentation states that the listener can be called on an arbitrary
+        // thread.
+        // But in practice, versions of Android that predate the newer API will call the
+        // listener
+        // on the thread where the SurfaceTexture was constructed.
+        this.surfaceTexture().setOnFrameAvailableListener(onFrameListener);
+      }
     }
 
     @Override
     public void onTrimMemory(int level) {
-        final Iterator<WeakReference<OnTrimMemoryListener>> iterator =
-                onTrimMemoryListeners.iterator();
-        while (iterator.hasNext()) {
-            WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
-            final OnTrimMemoryListener listener = listenerRef.get();
-            if (listener != null) {
-                listener.onTrimMemory(level);
-            } else {
-                // Purge cleared refs to avoid accumulating a lot of dead listener
-                iterator.remove();
-            }
-        }
+      if (trimMemoryListener != null) {
+        trimMemoryListener.onTrimMemory(level);
+      }
     }
 
-    final class SurfaceTextureRegistryEntry
-            implements TextureRegistry.SurfaceTextureEntry, TextureRegistry.OnTrimMemoryListener {
-        private final long id;
-        @NonNull
-        private final SurfaceTextureWrapper textureWrapper;
-        private boolean released;
-        @Nullable
-        private OnTrimMemoryListener trimMemoryListener;
-        @Nullable
-        private OnFrameConsumedListener frameConsumedListener;
-
-        SurfaceTextureRegistryEntry(long id, @NonNull SurfaceTexture surfaceTexture) {
-            this.id = id;
-            Runnable onFrameConsumed = () -> {
-                if (frameConsumedListener != null) {
-                    frameConsumedListener.onFrameConsumed();
-                }
-            };
-            this.textureWrapper = new SurfaceTextureWrapper(surfaceTexture, onFrameConsumed);
-
-            // Even though we make sure to unregister the callback before releasing, as of
-            // Android O, SurfaceTexture has a data race when accessing the callback, so the
-            // callback may still be called by a stale reference after released==true and
-            // mNativeView==null.
-            SurfaceTexture.OnFrameAvailableListener onFrameListener = texture -> {
-                if (released || !flutterJNI.isAttached()) {
-                    // Even though we make sure to unregister the callback before releasing, as of
-                    // Android O, SurfaceTexture has a data race when accessing the callback, so the
-                    // callback may still be called by a stale reference after released==true and
-                    // mNativeView==null.
-                    return;
-                }
-                markTextureFrameAvailable(id);
-            };
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                // The callback relies on being executed on the UI thread (unsynchronised read
-                // of
-                // mNativeView
-                // and also the engine code check for platform thread in
-                // Shell::OnPlatformViewMarkTextureFrameAvailable),
-                // so we explicitly pass a Handler for the current thread.
-                this.surfaceTexture().setOnFrameAvailableListener(onFrameListener, new Handler());
-            } else {
-                // Android documentation states that the listener can be called on an arbitrary
-                // thread.
-                // But in practice, versions of Android that predate the newer API will call the
-                // listener
-                // on the thread where the SurfaceTexture was constructed.
-                this.surfaceTexture().setOnFrameAvailableListener(onFrameListener);
-            }
-        }
-
-        @Override
-        public void onTrimMemory(int level) {
-            if (trimMemoryListener != null) {
-                trimMemoryListener.onTrimMemory(level);
-            }
-        }
-
-        private void removeListener() {
-            removeOnTrimMemoryListener(this);
-        }
-
-        @NonNull
-        public SurfaceTextureWrapper textureWrapper() {
-            return textureWrapper;
-        }
-
-        @Override
-        @NonNull
-        public SurfaceTexture surfaceTexture() {
-            return textureWrapper.surfaceTexture();
-        }
-
-        @Override
-        public long id() {
-            return id;
-        }
-
-        @Override
-        public void release() {
-            if (released) {
-                return;
-            }
-            Log.v(TAG, "Releasing a SurfaceTexture (" + id + ").");
-            textureWrapper.release();
-            unregisterTexture(id);
-            removeListener();
-            released = true;
-        }
-
-        @Override
-        protected void finalize() throws Throwable {
-            try {
-                if (released) {
-                    return;
-                }
-
-                handler.post(new TextureFinalizerRunnable(id, flutterJNI));
-            } finally {
-                super.finalize();
-            }
-        }
-
-        @Override
-        public void setOnFrameConsumedListener(@Nullable OnFrameConsumedListener listener) {
-            frameConsumedListener = listener;
-        }
-
-        @Override
-        public void setOnTrimMemoryListener(@Nullable OnTrimMemoryListener listener) {
-            trimMemoryListener = listener;
-        }
+    private void removeListener() {
+      removeOnTrimMemoryListener(this);
     }
 
-    static final class TextureFinalizerRunnable implements Runnable {
-        private final long id;
-        private final FlutterJNI flutterJNI;
-
-        TextureFinalizerRunnable(long id, @NonNull FlutterJNI flutterJNI) {
-            this.id = id;
-            this.flutterJNI = flutterJNI;
-        }
-
-        @Override
-        public void run() {
-            if (!flutterJNI.isAttached()) {
-                return;
-            }
-            Log.v(TAG, "Releasing a Texture (" + id + ").");
-            flutterJNI.unregisterTexture(id);
-        }
+    @NonNull
+    public SurfaceTextureWrapper textureWrapper() {
+      return textureWrapper;
     }
 
-    @Keep
-    @TargetApi(29)
-    final class ImageReaderSurfaceProducer
-            implements TextureRegistry.SurfaceProducer, TextureRegistry.ImageConsumer {
-        private static final String TAG = "ImageReaderSurfaceProducer";
-        private static final int MAX_IMAGES = 4;
+    @Override
+    @NonNull
+    public SurfaceTexture surfaceTexture() {
+      return textureWrapper.surfaceTexture();
+    }
 
-        private final long id;
+    @Override
+    public long id() {
+      return id;
+    }
 
-        private boolean released;
-        private boolean ignoringFence = false;
+    @Override
+    public void release() {
+      if (released) {
+        return;
+      }
+      Log.v(TAG, "Releasing a SurfaceTexture (" + id + ").");
+      textureWrapper.release();
+      unregisterTexture(id);
+      removeListener();
+      released = true;
+    }
 
-        // The requested width and height are updated by setSize.
-        private int requestedWidth = 1;
-        private int requestedHeight = 1;
-
-        /** Internal class: state held per image produced by image readers. */
-        private class PerImage {
-            public final ImageReader reader;
-            public final Image image;
-
-            public PerImage(ImageReader reader, Image image) {
-                this.reader = reader;
-                this.image = image;
-            }
-
-            /** Call close when you are done with an the image. */
-            public void close() {
-                this.image.close();
-                maybeCloseReader(reader);
-            }
+    @Override
+    protected void finalize() throws Throwable {
+      try {
+        if (released) {
+          return;
         }
 
-        // Active image reader.
-        private ImageReader activeReader;
-        // Set of image readers that should be closed.
-        private final Set<ImageReader> readersToClose = new HashSet<>();
-        // Last image produced. We keep this around until a new image is produced or the
-        // consumer consumes this image.
-        private PerImage lastProducedImage;
-        // Last image consumed. We only close this at the next image consumption point to avoid
-        // a race condition with the raster thread accessing an image we closed.
-        private PerImage lastConsumedImage;
+        handler.post(new TextureFinalizerRunnable(id, flutterJNI));
+      } finally {
+        super.finalize();
+      }
+    }
 
-        private final Handler onImageAvailableHandler = new Handler();
-        private final ImageReader.OnImageAvailableListener onImageAvailableListener = reader -> {
-            Image image = null;
-            try {
-                image = reader.acquireLatestImage();
-            } catch (IllegalStateException e) {
-                Log.e(TAG, "onImageAvailable acquireLatestImage failed: " + e);
-            }
-            if (image == null) {
-                return;
-            }
-            onImage(new PerImage(reader, image));
+    @Override
+    public void setOnFrameConsumedListener(@Nullable OnFrameConsumedListener listener) {
+      frameConsumedListener = listener;
+    }
+
+    @Override
+    public void setOnTrimMemoryListener(@Nullable OnTrimMemoryListener listener) {
+      trimMemoryListener = listener;
+    }
+  }
+
+  static final class TextureFinalizerRunnable implements Runnable {
+    private final long id;
+    private final FlutterJNI flutterJNI;
+
+    TextureFinalizerRunnable(long id, @NonNull FlutterJNI flutterJNI) {
+      this.id = id;
+      this.flutterJNI = flutterJNI;
+    }
+
+    @Override
+    public void run() {
+      if (!flutterJNI.isAttached()) {
+        return;
+      }
+      Log.v(TAG, "Releasing a Texture (" + id + ").");
+      flutterJNI.unregisterTexture(id);
+    }
+  }
+
+  @Keep
+  @TargetApi(29)
+  final class ImageReaderSurfaceProducer
+      implements TextureRegistry.SurfaceProducer, TextureRegistry.ImageConsumer {
+    private static final String TAG = "ImageReaderSurfaceProducer";
+    private static final int MAX_IMAGES = 4;
+
+    private final long id;
+
+    private boolean released;
+    private boolean ignoringFence = false;
+
+    // The requested width and height are updated by setSize.
+    private int requestedWidth = 1;
+    private int requestedHeight = 1;
+
+    /** Internal class: state held per image produced by image readers. */
+    private class PerImage {
+      public final ImageReader reader;
+      public final Image image;
+
+      public PerImage(ImageReader reader, Image image) {
+        this.reader = reader;
+        this.image = image;
+      }
+
+      /** Call close when you are done with an the image. */
+      public void close() {
+        this.image.close();
+        maybeCloseReader(reader);
+      }
+    }
+
+    // Active image reader.
+    private ImageReader activeReader;
+    // Set of image readers that should be closed.
+    private final Set<ImageReader> readersToClose = new HashSet<>();
+    // Last image produced. We keep this around until a new image is produced or the
+    // consumer consumes this image.
+    private PerImage lastProducedImage;
+    // Last image consumed. We only close this at the next image consumption point to avoid
+    // a race condition with the raster thread accessing an image we closed.
+    private PerImage lastConsumedImage;
+
+    private final Handler onImageAvailableHandler = new Handler();
+    private final ImageReader.OnImageAvailableListener onImageAvailableListener =
+        reader -> {
+          Image image = null;
+          try {
+            image = reader.acquireLatestImage();
+          } catch (IllegalStateException e) {
+            Log.e(TAG, "onImageAvailable acquireLatestImage failed: " + e);
+          }
+          if (image == null) {
+            return;
+          }
+          onImage(new PerImage(reader, image));
         };
 
-        ImageReaderSurfaceProducer(long id) {
-            this.id = id;
-        }
-
-        @Override
-        public long id() {
-            return id;
-        }
-
-        private void releaseInternal() {
-            released = true;
-            if (this.lastProducedImage != null) {
-                this.lastProducedImage.close();
-                this.lastProducedImage = null;
-            }
-            if (this.lastConsumedImage != null) {
-                this.lastConsumedImage.close();
-                this.lastConsumedImage = null;
-            }
-            for (ImageReader reader : readersToClose) {
-                reader.close();
-            }
-            readersToClose.clear();
-            if (this.activeReader != null) {
-                this.activeReader.close();
-                this.activeReader = null;
-            }
-        }
-
-        @Override
-        public void release() {
-            if (released) {
-                return;
-            }
-            releaseInternal();
-            unregisterTexture(id);
-        }
-
-        @Override
-        public void setSize(int width, int height) {
-            if (requestedWidth == width && requestedHeight == height) {
-                // No size change.
-                return;
-            }
-            this.requestedHeight = height;
-            this.requestedWidth = width;
-            synchronized (this) {
-                if (this.activeReader != null) {
-                    // Schedule the old activeReader to be closed.
-                    readersToClose.add(this.activeReader);
-                    this.activeReader = null;
-                }
-            }
-        }
-
-        @Override
-        public int getWidth() {
-            return this.requestedWidth;
-        }
-
-        @Override
-        public int getHeight() {
-            return this.requestedHeight;
-        }
-
-        @Override
-        public Surface getSurface() {
-            maybeCreateReader();
-            return activeReader.getSurface();
-        }
-
-        @Override
-        @TargetApi(29)
-        public Image acquireLatestImage() {
-            PerImage r;
-            PerImage toClose;
-            synchronized (this) {
-                r = this.lastProducedImage;
-                this.lastProducedImage = null;
-                toClose = this.lastConsumedImage;
-                this.lastConsumedImage = r;
-            }
-            if (toClose != null) {
-                toClose.close();
-            }
-            if (r == null) {
-                return null;
-            }
-            maybeWaitOnFence(r.image);
-            return r.image;
-        }
-
-        private void maybeCloseReader(ImageReader reader) {
-            synchronized (this) {
-                if (!readersToClose.contains(reader)) {
-                    return;
-                }
-                if (this.lastConsumedImage != null && this.lastConsumedImage.reader == reader) {
-                    // There is still a consumed image in flight for this reader. Don't close.
-                    return;
-                }
-                if (this.lastProducedImage != null && this.lastProducedImage.reader == reader) {
-                    // There is still a pending image for this reader. Don't close.
-                    return;
-                }
-                readersToClose.remove(reader);
-            }
-            // Close the reader.
-            reader.close();
-        }
-
-        private void maybeCreateReader() {
-            synchronized (this) {
-                if (this.activeReader != null) {
-                    return;
-                }
-                this.activeReader = createImageReader();
-            }
-        }
-
-        /** Invoked for each method that is available. */
-        private void onImage(PerImage image) {
-            if (released) {
-                return;
-            }
-            PerImage toClose;
-            synchronized (this) {
-                if (this.readersToClose.contains(image.reader)) {
-                    Log.i(TAG, "Skipped frame because resize is in flight.");
-                    image.close();
-                    return;
-                }
-                toClose = this.lastProducedImage;
-                this.lastProducedImage = image;
-            }
-            // Close the previously pushed buffer.
-            if (toClose != null) {
-                Log.i(TAG, "Dropping rendered frame that was not acquired in time.");
-                toClose.close();
-            }
-            // Mark that we have a new frame available. Eventually the raster thread will
-            // call acquireLatestImage.
-            markTextureFrameAvailable(id);
-        }
-
-        @TargetApi(33)
-        private void waitOnFence(Image image) {
-            try {
-                SyncFence fence = image.getFence();
-                boolean signaled = fence.awaitForever();
-                if (!signaled) {
-                    Log.e(TAG, "acquireLatestImage image's fence was never signalled.");
-                }
-            } catch (IOException e) {
-                // Drop.
-            }
-        }
-
-        private void maybeWaitOnFence(Image image) {
-            if (image == null) {
-                return;
-            }
-            if (ignoringFence) {
-                return;
-            }
-            if (Build.VERSION.SDK_INT >= 33) {
-                // The fence API is only available on Android >= 33.
-                waitOnFence(image);
-                return;
-            }
-            // Log once per ImageTextureEntry.
-            ignoringFence = true;
-            Log.w(TAG, "ImageTextureEntry can't wait on the fence on Android < 33");
-        }
-
-<<<<<<< HEAD
-        ImageReaderSurfaceProducer(long id) {
-            this.id = id;
-        }
-
-        @Override
-        public long id() {
-            return id;
-        }
-
-        @Override
-        public void release() {
-            if (released) {
-                return;
-            }
-            releaseInternal();
-            unregisterTexture(id);
-        }
-
-        @Override
-        public void setSize(int width, int height) {
-            // Clamp to a minimum of 1. A 0x0 texture is a runtime exception in ImageReader.
-            width = Math.max(1, width);
-            height = Math.max(1, height);
-
-            if (requestedWidth == width && requestedHeight == height) {
-                // No size change.
-                return;
-            }
-            this.createNewReader = true;
-            this.requestedHeight = height;
-            this.requestedWidth = width;
-        }
-
-        @Override
-        public int getWidth() {
-            return this.requestedWidth;
-        }
-
-        @Override
-        public int getHeight() {
-            return this.requestedHeight;
-        }
-
-        @Override
-        public Surface getSurface() {
-            PerImageReader pir = getActiveReader();
-            return pir.reader.getSurface();
-        }
-
-        @Override
-        public void scheduleFrame() {
-            if (VERBOSE_LOGS) {
-                long now = System.nanoTime();
-                if (lastScheduleTime != 0) {
-                    long delta = now - lastScheduleTime;
-                    Log.v(TAG, "scheduleFrame delta=" + deltaMillis(delta));
-                }
-                lastScheduleTime = now;
-            }
-            scheduleEngineFrame();
-        }
-
-        @Override
-        @TargetApi(29)
-        public Image acquireLatestImage() {
-            PerImage r = dequeueImage();
-            if (r == null) {
-                return null;
-            }
-            maybeWaitOnFence(r.image);
-            return r.image;
-        }
-
-        private PerImageReader getActiveReader() {
-            synchronized (lock) {
-                if (createNewReader) {
-                    createNewReader = false;
-                    // Create a new ImageReader and add it to the queue.
-                    return getOrCreatePerImageReader(createImageReader());
-                }
-                return imageReaderQueue.peekLast();
-            }
-        }
-
-=======
->>>>>>> parent of dd32ff12b98 (Reland Optimizations for TLHC frame rate and jank (#50065))
-        @Override
-        protected void finalize() throws Throwable {
-            try {
-                if (released) {
-                    return;
-                }
-                releaseInternal();
-                handler.post(new TextureFinalizerRunnable(id, flutterJNI));
-            } finally {
-                super.finalize();
-            }
-        }
-
-        @TargetApi(33)
-        private ImageReader createImageReader33() {
-            final ImageReader.Builder builder =
-                    new ImageReader.Builder(requestedWidth, requestedHeight);
-            // Allow for double buffering.
-            builder.setMaxImages(MAX_IMAGES);
-            // Use PRIVATE image format so that we can support video decoding.
-            // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our
-            // ability to read back texture data. If we don't always want to use it, how do
-            // we
-            // decide when to use it or not? Perhaps PlatformViews can indicate if they may
-            // contain
-            // DRM'd content.
-            // I need to investigate how PRIVATE impacts our ability to take screenshots or
-            // capture
-            // the output of Flutter application.
-            builder.setImageFormat(ImageFormat.PRIVATE);
-            // Hint that consumed images will only be read by GPU.
-            builder.setUsage(HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
-            final ImageReader reader = builder.build();
-            reader.setOnImageAvailableListener(
-                    this.onImageAvailableListener, onImageAvailableHandler);
-            return reader;
-        }
-
-        @TargetApi(29)
-        private ImageReader createImageReader29() {
-            final ImageReader reader = ImageReader.newInstance(requestedWidth, requestedHeight,
-                    ImageFormat.PRIVATE, MAX_IMAGES, HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
-            reader.setOnImageAvailableListener(
-                    this.onImageAvailableListener, onImageAvailableHandler);
-            return reader;
-        }
-
-        private ImageReader createImageReader() {
-            if (Build.VERSION.SDK_INT >= 33) {
-                return createImageReader33();
-            } else if (Build.VERSION.SDK_INT >= 29) {
-                return createImageReader29();
-            }
-            throw new UnsupportedOperationException(
-                    "ImageReaderPlatformViewRenderTarget requires API version 29+");
-        }
-
-        @VisibleForTesting
-        public void disableFenceForTest() {
-            // Roboelectric's implementation of SyncFence is borked.
-            ignoringFence = true;
-        }
-
-        @VisibleForTesting
-        public int readersToCloseSize() {
-            return readersToClose.size();
-        }
+    ImageReaderSurfaceProducer(long id) {
+      this.id = id;
     }
 
-    @Keep
-    final class ImageTextureRegistryEntry
-            implements TextureRegistry.ImageTextureEntry, TextureRegistry.ImageConsumer {
-        private static final String TAG = "ImageTextureRegistryEntry";
-        private final long id;
-        private boolean released;
-        private boolean ignoringFence = false;
-        private Image image;
-
-        ImageTextureRegistryEntry(long id) {
-            this.id = id;
-        }
-
-        @Override
-        public long id() {
-            return id;
-        }
-
-        @Override
-        @TargetApi(19)
-        public void release() {
-            if (released) {
-                return;
-            }
-            released = true;
-            if (image != null) {
-                image.close();
-                image = null;
-            }
-            unregisterTexture(id);
-        }
-
-        @Override
-        @TargetApi(19)
-        public void pushImage(Image image) {
-            if (released) {
-                return;
-            }
-            Image toClose;
-            synchronized (this) {
-                toClose = this.image;
-                this.image = image;
-            }
-            // Close the previously pushed buffer.
-            if (toClose != null) {
-                Log.e(TAG, "Dropping PlatformView Frame");
-                toClose.close();
-            }
-            if (image != null) {
-                // Mark that we have a new frame available.
-                markTextureFrameAvailable(id);
-            }
-        }
-
-        @TargetApi(33)
-        private void waitOnFence(Image image) {
-            try {
-                SyncFence fence = image.getFence();
-                boolean signaled = fence.awaitForever();
-                if (!signaled) {
-                    Log.e(TAG, "acquireLatestImage image's fence was never signalled.");
-                }
-            } catch (IOException e) {
-                // Drop.
-            }
-        }
-
-        @TargetApi(29)
-        private void maybeWaitOnFence(Image image) {
-            if (image == null) {
-                return;
-            }
-            if (ignoringFence) {
-                return;
-            }
-            if (Build.VERSION.SDK_INT >= 33) {
-                // The fence API is only available on Android >= 33.
-                waitOnFence(image);
-                return;
-            }
-            // Log once per ImageTextureEntry.
-            ignoringFence = true;
-            Log.w(TAG, "ImageTextureEntry can't wait on the fence on Android < 33");
-        }
-
-        @Override
-        @TargetApi(29)
-        public Image acquireLatestImage() {
-            Image r;
-            synchronized (this) {
-                r = this.image;
-                this.image = null;
-            }
-            maybeWaitOnFence(r);
-            return r;
-        }
-
-        @Override
-        @TargetApi(19)
-        protected void finalize() throws Throwable {
-            try {
-                if (released) {
-                    return;
-                }
-                if (image != null) {
-                    // Be sure to finalize any cached image.
-                    image.close();
-                    image = null;
-                }
-                released = true;
-                handler.post(new TextureFinalizerRunnable(id, flutterJNI));
-            } finally {
-                super.finalize();
-            }
-        }
+    @Override
+    public long id() {
+      return id;
     }
-    // ------ END TextureRegistry IMPLEMENTATION ----
+
+    private void releaseInternal() {
+      released = true;
+      if (this.lastProducedImage != null) {
+        this.lastProducedImage.close();
+        this.lastProducedImage = null;
+      }
+      if (this.lastConsumedImage != null) {
+        this.lastConsumedImage.close();
+        this.lastConsumedImage = null;
+      }
+      for (ImageReader reader : readersToClose) {
+        reader.close();
+      }
+      readersToClose.clear();
+      if (this.activeReader != null) {
+        this.activeReader.close();
+        this.activeReader = null;
+      }
+    }
+
+    @Override
+    public void release() {
+      if (released) {
+        return;
+      }
+      releaseInternal();
+      unregisterTexture(id);
+    }
+
+    @Override
+    public void setSize(int width, int height) {
+      // Clamp to a minimum of 1. A 0x0 texture is a runtime exception in ImageReader.
+      width = Math.max(1, width);
+      height = Math.max(1, height);
+      if (requestedWidth == width && requestedHeight == height) {
+        // No size change.
+        return;
+      }
+      this.requestedHeight = height;
+      this.requestedWidth = width;
+      synchronized (this) {
+        if (this.activeReader != null) {
+          // Schedule the old activeReader to be closed.
+          readersToClose.add(this.activeReader);
+          this.activeReader = null;
+        }
+      }
+    }
+
+    @Override
+    public int getWidth() {
+      return this.requestedWidth;
+    }
+
+    @Override
+    public int getHeight() {
+      return this.requestedHeight;
+    }
+
+    @Override
+    public Surface getSurface() {
+      maybeCreateReader();
+      return activeReader.getSurface();
+    }
+
+    @Override
+    @TargetApi(29)
+    public Image acquireLatestImage() {
+      PerImage r;
+      PerImage toClose;
+      synchronized (this) {
+        r = this.lastProducedImage;
+        this.lastProducedImage = null;
+        toClose = this.lastConsumedImage;
+        this.lastConsumedImage = r;
+      }
+      if (toClose != null) {
+        toClose.close();
+      }
+      if (r == null) {
+        return null;
+      }
+      maybeWaitOnFence(r.image);
+      return r.image;
+    }
+
+    private void maybeCloseReader(ImageReader reader) {
+      synchronized (this) {
+        if (!readersToClose.contains(reader)) {
+          return;
+        }
+        if (this.lastConsumedImage != null && this.lastConsumedImage.reader == reader) {
+          // There is still a consumed image in flight for this reader. Don't close.
+          return;
+        }
+        if (this.lastProducedImage != null && this.lastProducedImage.reader == reader) {
+          // There is still a pending image for this reader. Don't close.
+          return;
+        }
+        readersToClose.remove(reader);
+      }
+      // Close the reader.
+      reader.close();
+    }
+
+    private void maybeCreateReader() {
+      synchronized (this) {
+        if (this.activeReader != null) {
+          return;
+        }
+        this.activeReader = createImageReader();
+      }
+    }
+
+    /** Invoked for each method that is available. */
+    private void onImage(PerImage image) {
+      if (released) {
+        return;
+      }
+      PerImage toClose;
+      synchronized (this) {
+        if (this.readersToClose.contains(image.reader)) {
+          Log.i(TAG, "Skipped frame because resize is in flight.");
+          image.close();
+          return;
+        }
+        toClose = this.lastProducedImage;
+        this.lastProducedImage = image;
+      }
+      // Close the previously pushed buffer.
+      if (toClose != null) {
+        Log.i(TAG, "Dropping rendered frame that was not acquired in time.");
+        toClose.close();
+      }
+      // Mark that we have a new frame available. Eventually the raster thread will
+      // call acquireLatestImage.
+      markTextureFrameAvailable(id);
+    }
+
+    @TargetApi(33)
+    private void waitOnFence(Image image) {
+      try {
+        SyncFence fence = image.getFence();
+        boolean signaled = fence.awaitForever();
+        if (!signaled) {
+          Log.e(TAG, "acquireLatestImage image's fence was never signalled.");
+        }
+      } catch (IOException e) {
+        // Drop.
+      }
+    }
+
+    private void maybeWaitOnFence(Image image) {
+      if (image == null) {
+        return;
+      }
+      if (ignoringFence) {
+        return;
+      }
+      if (Build.VERSION.SDK_INT >= 33) {
+        // The fence API is only available on Android >= 33.
+        waitOnFence(image);
+        return;
+      }
+      // Log once per ImageTextureEntry.
+      ignoringFence = true;
+      Log.w(TAG, "ImageTextureEntry can't wait on the fence on Android < 33");
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+      try {
+        if (released) {
+          return;
+        }
+        releaseInternal();
+        handler.post(new TextureFinalizerRunnable(id, flutterJNI));
+      } finally {
+        super.finalize();
+      }
+    }
+
+    @TargetApi(33)
+    private ImageReader createImageReader33() {
+      final ImageReader.Builder builder = new ImageReader.Builder(requestedWidth, requestedHeight);
+      // Allow for double buffering.
+      builder.setMaxImages(MAX_IMAGES);
+      // Use PRIVATE image format so that we can support video decoding.
+      // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our
+      // ability to read back texture data. If we don't always want to use it, how do
+      // we
+      // decide when to use it or not? Perhaps PlatformViews can indicate if they may
+      // contain
+      // DRM'd content.
+      // I need to investigate how PRIVATE impacts our ability to take screenshots or
+      // capture
+      // the output of Flutter application.
+      builder.setImageFormat(ImageFormat.PRIVATE);
+      // Hint that consumed images will only be read by GPU.
+      builder.setUsage(HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
+      final ImageReader reader = builder.build();
+      reader.setOnImageAvailableListener(this.onImageAvailableListener, onImageAvailableHandler);
+      return reader;
+    }
+
+    @TargetApi(29)
+    private ImageReader createImageReader29() {
+      final ImageReader reader =
+          ImageReader.newInstance(
+              requestedWidth,
+              requestedHeight,
+              ImageFormat.PRIVATE,
+              MAX_IMAGES,
+              HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
+      reader.setOnImageAvailableListener(this.onImageAvailableListener, onImageAvailableHandler);
+      return reader;
+    }
+
+    private ImageReader createImageReader() {
+      if (Build.VERSION.SDK_INT >= 33) {
+        return createImageReader33();
+      } else if (Build.VERSION.SDK_INT >= 29) {
+        return createImageReader29();
+      }
+      throw new UnsupportedOperationException(
+          "ImageReaderPlatformViewRenderTarget requires API version 29+");
+    }
+
+    @VisibleForTesting
+    public void disableFenceForTest() {
+      // Roboelectric's implementation of SyncFence is borked.
+      ignoringFence = true;
+    }
+
+    @VisibleForTesting
+    public int readersToCloseSize() {
+      return readersToClose.size();
+    }
+  }
+
+  @Keep
+  final class ImageTextureRegistryEntry
+      implements TextureRegistry.ImageTextureEntry, TextureRegistry.ImageConsumer {
+    private static final String TAG = "ImageTextureRegistryEntry";
+    private final long id;
+    private boolean released;
+    private boolean ignoringFence = false;
+    private Image image;
+
+    ImageTextureRegistryEntry(long id) {
+      this.id = id;
+    }
+
+    @Override
+    public long id() {
+      return id;
+    }
+
+    @Override
+    @TargetApi(19)
+    public void release() {
+      if (released) {
+        return;
+      }
+      released = true;
+      if (image != null) {
+        image.close();
+        image = null;
+      }
+      unregisterTexture(id);
+    }
+
+    @Override
+    @TargetApi(19)
+    public void pushImage(Image image) {
+      if (released) {
+        return;
+      }
+      Image toClose;
+      synchronized (this) {
+        toClose = this.image;
+        this.image = image;
+      }
+      // Close the previously pushed buffer.
+      if (toClose != null) {
+        Log.e(TAG, "Dropping PlatformView Frame");
+        toClose.close();
+      }
+      if (image != null) {
+        // Mark that we have a new frame available.
+        markTextureFrameAvailable(id);
+      }
+    }
+
+    @TargetApi(33)
+    private void waitOnFence(Image image) {
+      try {
+        SyncFence fence = image.getFence();
+        boolean signaled = fence.awaitForever();
+        if (!signaled) {
+          Log.e(TAG, "acquireLatestImage image's fence was never signalled.");
+        }
+      } catch (IOException e) {
+        // Drop.
+      }
+    }
+
+    @TargetApi(29)
+    private void maybeWaitOnFence(Image image) {
+      if (image == null) {
+        return;
+      }
+      if (ignoringFence) {
+        return;
+      }
+      if (Build.VERSION.SDK_INT >= 33) {
+        // The fence API is only available on Android >= 33.
+        waitOnFence(image);
+        return;
+      }
+      // Log once per ImageTextureEntry.
+      ignoringFence = true;
+      Log.w(TAG, "ImageTextureEntry can't wait on the fence on Android < 33");
+    }
+
+    @Override
+    @TargetApi(29)
+    public Image acquireLatestImage() {
+      Image r;
+      synchronized (this) {
+        r = this.image;
+        this.image = null;
+      }
+      maybeWaitOnFence(r);
+      return r;
+    }
+
+    @Override
+    @TargetApi(19)
+    protected void finalize() throws Throwable {
+      try {
+        if (released) {
+          return;
+        }
+        if (image != null) {
+          // Be sure to finalize any cached image.
+          image.close();
+          image = null;
+        }
+        released = true;
+        handler.post(new TextureFinalizerRunnable(id, flutterJNI));
+      } finally {
+        super.finalize();
+      }
+    }
+  }
+  // ------ END TextureRegistry IMPLEMENTATION ----
+
+  /**
+   * Notifies Flutter that the given {@code surface} was created and is available for Flutter
+   * rendering.
+   *
+   * <p>If called more than once, the current native resources are released. This can be undesired
+   * if the Engine expects to reuse this surface later. For example, this is true when platform
+   * views are displayed in a frame, and then removed in the next frame.
+   *
+   * <p>To avoid releasing the current surface resources, set {@code keepCurrentSurface} to true.
+   *
+   * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
+   * android.view.TextureView.SurfaceTextureListener}
+   *
+   * @param surface The render surface.
+   * @param onlySwap True if the current active surface should not be detached.
+   */
+  public void startRenderingToSurface(@NonNull Surface surface, boolean onlySwap) {
+    if (!onlySwap) {
+      // Stop rendering to the surface releases the associated native resources, which
+      // causes a glitch when toggling between rendering to an image view (hybrid
+      // composition) and
+      // rendering directly to a Surface or Texture view. For more,
+      // https://github.com/flutter/flutter/issues/95343
+      stopRenderingToSurface();
+    }
+
+    this.surface = surface;
+
+    if (onlySwap) {
+      // In the swap case we are just swapping the surface that we render to.
+      flutterJNI.onSurfaceWindowChanged(surface);
+    } else {
+      // In the non-swap case we are creating a new surface to render to.
+      flutterJNI.onSurfaceCreated(surface);
+    }
+  }
+
+  /**
+   * Swaps the {@link Surface} used to render the current frame.
+   *
+   * <p>In hybrid composition, the root surfaces changes from {@link
+   * android.view.SurfaceHolder#getSurface()} to {@link android.media.ImageReader#getSurface()} when
+   * a platform view is in the current frame.
+   */
+  public void swapSurface(@NonNull Surface surface) {
+    this.surface = surface;
+    flutterJNI.onSurfaceWindowChanged(surface);
+  }
+
+  /**
+   * Notifies Flutter that a {@code surface} previously registered with {@link
+   * #startRenderingToSurface(Surface, boolean)} has changed size to the given {@code width} and
+   * {@code height}.
+   *
+   * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
+   * android.view.TextureView.SurfaceTextureListener}
+   */
+  public void surfaceChanged(int width, int height) {
+    flutterJNI.onSurfaceChanged(width, height);
+  }
+
+  /**
+   * Notifies Flutter that a {@code surface} previously registered with {@link
+   * #startRenderingToSurface(Surface, boolean)} has been destroyed and needs to be released and
+   * cleaned up on the Flutter side.
+   *
+   * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
+   * android.view.TextureView.SurfaceTextureListener}
+   */
+  public void stopRenderingToSurface() {
+    if (surface != null) {
+      flutterJNI.onSurfaceDestroyed();
+
+      // TODO(mattcarroll): the source of truth for this call should be FlutterJNI,
+      // which is where
+      // the call to onFlutterUiDisplayed() comes from. However, no such native
+      // callback exists yet,
+      // so until the engine and FlutterJNI are configured to call us back when
+      // rendering stops,
+      // we will manually monitor that change here.
+      if (isDisplayingFlutterUi) {
+        flutterUiDisplayListener.onFlutterUiNoLongerDisplayed();
+      }
+
+      isDisplayingFlutterUi = false;
+      surface = null;
+    }
+  }
+
+  /**
+   * Notifies Flutter that the viewport metrics, e.g. window height and width, have changed.
+   *
+   * <p>If the width, height, or devicePixelRatio are less than or equal to 0, this update is
+   * ignored.
+   *
+   * @param viewportMetrics The metrics to send to the Dart application.
+   */
+  public void setViewportMetrics(@NonNull ViewportMetrics viewportMetrics) {
+    // We might get called with just the DPR if width/height aren't available yet.
+    // Just ignore, as it will get called again when width/height are set.
+    if (!viewportMetrics.validate()) {
+      return;
+    }
+    Log.v(
+        TAG,
+        "Setting viewport metrics\n"
+            + "Size: "
+            + viewportMetrics.width
+            + " x "
+            + viewportMetrics.height
+            + "\n"
+            + "Padding - L: "
+            + viewportMetrics.viewPaddingLeft
+            + ", T: "
+            + viewportMetrics.viewPaddingTop
+            + ", R: "
+            + viewportMetrics.viewPaddingRight
+            + ", B: "
+            + viewportMetrics.viewPaddingBottom
+            + "\n"
+            + "Insets - L: "
+            + viewportMetrics.viewInsetLeft
+            + ", T: "
+            + viewportMetrics.viewInsetTop
+            + ", R: "
+            + viewportMetrics.viewInsetRight
+            + ", B: "
+            + viewportMetrics.viewInsetBottom
+            + "\n"
+            + "System Gesture Insets - L: "
+            + viewportMetrics.systemGestureInsetLeft
+            + ", T: "
+            + viewportMetrics.systemGestureInsetTop
+            + ", R: "
+            + viewportMetrics.systemGestureInsetRight
+            + ", B: "
+            + viewportMetrics.systemGestureInsetRight
+            + "\n"
+            + "Display Features: "
+            + viewportMetrics.displayFeatures.size());
+
+    int[] displayFeaturesBounds = new int[viewportMetrics.displayFeatures.size() * 4];
+    int[] displayFeaturesType = new int[viewportMetrics.displayFeatures.size()];
+    int[] displayFeaturesState = new int[viewportMetrics.displayFeatures.size()];
+    for (int i = 0; i < viewportMetrics.displayFeatures.size(); i++) {
+      DisplayFeature displayFeature = viewportMetrics.displayFeatures.get(i);
+      displayFeaturesBounds[4 * i] = displayFeature.bounds.left;
+      displayFeaturesBounds[4 * i + 1] = displayFeature.bounds.top;
+      displayFeaturesBounds[4 * i + 2] = displayFeature.bounds.right;
+      displayFeaturesBounds[4 * i + 3] = displayFeature.bounds.bottom;
+      displayFeaturesType[i] = displayFeature.type.encodedValue;
+      displayFeaturesState[i] = displayFeature.state.encodedValue;
+    }
+
+    flutterJNI.setViewportMetrics(
+        viewportMetrics.devicePixelRatio,
+        viewportMetrics.width,
+        viewportMetrics.height,
+        viewportMetrics.viewPaddingTop,
+        viewportMetrics.viewPaddingRight,
+        viewportMetrics.viewPaddingBottom,
+        viewportMetrics.viewPaddingLeft,
+        viewportMetrics.viewInsetTop,
+        viewportMetrics.viewInsetRight,
+        viewportMetrics.viewInsetBottom,
+        viewportMetrics.viewInsetLeft,
+        viewportMetrics.systemGestureInsetTop,
+        viewportMetrics.systemGestureInsetRight,
+        viewportMetrics.systemGestureInsetBottom,
+        viewportMetrics.systemGestureInsetLeft,
+        viewportMetrics.physicalTouchSlop,
+        displayFeaturesBounds,
+        displayFeaturesType,
+        displayFeaturesState);
+  }
+
+  // TODO(mattcarroll): describe the native behavior that this invokes
+  // TODO(mattcarroll): determine if this is nullable or nonnull
+  public Bitmap getBitmap() {
+    return flutterJNI.getBitmap();
+  }
+
+  // TODO(mattcarroll): describe the native behavior that this invokes
+  public void dispatchPointerDataPacket(@NonNull ByteBuffer buffer, int position) {
+    flutterJNI.dispatchPointerDataPacket(buffer, position);
+  }
+
+  // TODO(mattcarroll): describe the native behavior that this invokes
+  private void registerTexture(long textureId, @NonNull SurfaceTextureWrapper textureWrapper) {
+    flutterJNI.registerTexture(textureId, textureWrapper);
+  }
+
+  private void registerImageTexture(
+      long textureId, @NonNull TextureRegistry.ImageConsumer imageTexture) {
+    flutterJNI.registerImageTexture(textureId, imageTexture);
+  }
+
+  // TODO(mattcarroll): describe the native behavior that this invokes
+  private void markTextureFrameAvailable(long textureId) {
+    flutterJNI.markTextureFrameAvailable(textureId);
+  }
+
+  // TODO(mattcarroll): describe the native behavior that this invokes
+  private void unregisterTexture(long textureId) {
+    flutterJNI.unregisterTexture(textureId);
+  }
+
+  // TODO(mattcarroll): describe the native behavior that this invokes
+  public boolean isSoftwareRenderingEnabled() {
+    return flutterJNI.getIsSoftwareRenderingEnabled();
+  }
+
+  // TODO(mattcarroll): describe the native behavior that this invokes
+  public void setAccessibilityFeatures(int flags) {
+    flutterJNI.setAccessibilityFeatures(flags);
+  }
+
+  // TODO(mattcarroll): describe the native behavior that this invokes
+  public void setSemanticsEnabled(boolean enabled) {
+    flutterJNI.setSemanticsEnabled(enabled);
+  }
+
+  // TODO(mattcarroll): describe the native behavior that this invokes
+  public void dispatchSemanticsAction(
+      int nodeId, int action, @Nullable ByteBuffer args, int argsPosition) {
+    flutterJNI.dispatchSemanticsAction(nodeId, action, args, argsPosition);
+  }
+
+  /**
+   * Mutable data structure that holds all viewport metrics properties that Flutter cares about.
+   *
+   * <p>All distance measurements, e.g., width, height, padding, viewInsets, are measured in device
+   * pixels, not logical pixels.
+   */
+  public static final class ViewportMetrics {
+    /** A value that indicates the setting has not been set. */
+    public static final int unsetValue = -1;
+
+    public float devicePixelRatio = 1.0f;
+    public int width = 0;
+    public int height = 0;
+    public int viewPaddingTop = 0;
+    public int viewPaddingRight = 0;
+    public int viewPaddingBottom = 0;
+    public int viewPaddingLeft = 0;
+    public int viewInsetTop = 0;
+    public int viewInsetRight = 0;
+    public int viewInsetBottom = 0;
+    public int viewInsetLeft = 0;
+    public int systemGestureInsetTop = 0;
+    public int systemGestureInsetRight = 0;
+    public int systemGestureInsetBottom = 0;
+    public int systemGestureInsetLeft = 0;
+    public int physicalTouchSlop = unsetValue;
 
     /**
-     * Notifies Flutter that the given {@code surface} was created and is available for Flutter
-     * rendering.
+     * Whether this instance contains valid metrics for the Flutter application.
      *
-     * <p>If called more than once, the current native resources are released. This can be undesired
-     * if the Engine expects to reuse this surface later. For example, this is true when platform
-     * views are displayed in a frame, and then removed in the next frame.
-     *
-     * <p>To avoid releasing the current surface resources, set {@code keepCurrentSurface} to true.
-     *
-     * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
-     * android.view.TextureView.SurfaceTextureListener}
-     *
-     * @param surface The render surface.
-     * @param onlySwap True if the current active surface should not be detached.
+     * @return True if width, height, and devicePixelRatio are > 0; false otherwise.
      */
-    public void startRenderingToSurface(@NonNull Surface surface, boolean onlySwap) {
-        if (!onlySwap) {
-            // Stop rendering to the surface releases the associated native resources, which
-            // causes a glitch when toggling between rendering to an image view (hybrid
-            // composition) and
-            // rendering directly to a Surface or Texture view. For more,
-            // https://github.com/flutter/flutter/issues/95343
-            stopRenderingToSurface();
-        }
-
-        this.surface = surface;
-
-        if (onlySwap) {
-            // In the swap case we are just swapping the surface that we render to.
-            flutterJNI.onSurfaceWindowChanged(surface);
-        } else {
-            // In the non-swap case we are creating a new surface to render to.
-            flutterJNI.onSurfaceCreated(surface);
-        }
+    boolean validate() {
+      return width > 0 && height > 0 && devicePixelRatio > 0;
     }
+
+    public List<DisplayFeature> displayFeatures = new ArrayList<>();
+  }
+
+  /**
+   * Description of a physical feature on the display.
+   *
+   * <p>A display feature is a distinctive physical attribute located within the display panel of
+   * the device. It can intrude into the application window space and create a visual distortion,
+   * visual or touch discontinuity, make some area invisible or create a logical divider or
+   * separation in the screen space.
+   *
+   * <p>Based on {@link androidx.window.layout.DisplayFeature}, with added support for cutouts.
+   */
+  public static final class DisplayFeature {
+    public final Rect bounds;
+    public final DisplayFeatureType type;
+    public final DisplayFeatureState state;
+
+    public DisplayFeature(Rect bounds, DisplayFeatureType type, DisplayFeatureState state) {
+      this.bounds = bounds;
+      this.type = type;
+      this.state = state;
+    }
+
+    public DisplayFeature(Rect bounds, DisplayFeatureType type) {
+      this.bounds = bounds;
+      this.type = type;
+      this.state = DisplayFeatureState.UNKNOWN;
+    }
+  }
+
+  /**
+   * Types of display features that can appear on the viewport.
+   *
+   * <p>Some, like {@link #FOLD}, can be reported without actually occluding the screen. They are
+   * useful for knowing where the display is bent or has a crease. The {@link DisplayFeature#bounds}
+   * can be 0-width in such cases.
+   */
+  public enum DisplayFeatureType {
+    /**
+     * Type of display feature not yet known to Flutter. This can happen if WindowManager is updated
+     * with new types. The {@link DisplayFeature#bounds} is the only known property.
+     */
+    UNKNOWN(0),
 
     /**
-     * Swaps the {@link Surface} used to render the current frame.
-     *
-     * <p>In hybrid composition, the root surfaces changes from {@link
-     * android.view.SurfaceHolder#getSurface()} to {@link android.media.ImageReader#getSurface()}
-     * when a platform view is in the current frame.
+     * A fold in the flexible display that does not occlude the screen. Corresponds to {@link
+     * androidx.window.layout.FoldingFeature.OcclusionType#NONE}
      */
-    public void swapSurface(@NonNull Surface surface) {
-        this.surface = surface;
-        flutterJNI.onSurfaceWindowChanged(surface);
-    }
+    FOLD(1),
 
     /**
-     * Notifies Flutter that a {@code surface} previously registered with {@link
-     * #startRenderingToSurface(Surface, boolean)} has changed size to the given {@code width} and
-     * {@code height}.
-     *
-     * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
-     * android.view.TextureView.SurfaceTextureListener}
+     * Splits the display in two separate panels that can fold. Occludes the screen. Corresponds to
+     * {@link androidx.window.layout.FoldingFeature.OcclusionType#FULL}
      */
-    public void surfaceChanged(int width, int height) {
-        flutterJNI.onSurfaceChanged(width, height);
-    }
+    HINGE(2),
 
     /**
-     * Notifies Flutter that a {@code surface} previously registered with {@link
-     * #startRenderingToSurface(Surface, boolean)} has been destroyed and needs to be released and
-     * cleaned up on the Flutter side.
-     *
-     * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
-     * android.view.TextureView.SurfaceTextureListener}
+     * Area of the screen that usually houses cameras or sensors. Occludes the screen. Corresponds
+     * to {@link android.view.DisplayCutout}
      */
-    public void stopRenderingToSurface() {
-        if (surface != null) {
-            flutterJNI.onSurfaceDestroyed();
+    CUTOUT(3);
 
-            // TODO(mattcarroll): the source of truth for this call should be FlutterJNI,
-            // which is where
-            // the call to onFlutterUiDisplayed() comes from. However, no such native
-            // callback exists yet,
-            // so until the engine and FlutterJNI are configured to call us back when
-            // rendering stops,
-            // we will manually monitor that change here.
-            if (isDisplayingFlutterUi) {
-                flutterUiDisplayListener.onFlutterUiNoLongerDisplayed();
-            }
+    public final int encodedValue;
 
-            isDisplayingFlutterUi = false;
-            surface = null;
-        }
+    DisplayFeatureType(int encodedValue) {
+      this.encodedValue = encodedValue;
     }
+  }
+
+  /**
+   * State of the display feature.
+   *
+   * <p>For foldables, the state is the posture. For cutouts, this property is {@link #UNKNOWN}
+   */
+  public enum DisplayFeatureState {
+    /** The display feature is a cutout or this state is new and not yet known to Flutter. */
+    UNKNOWN(0),
 
     /**
-     * Notifies Flutter that the viewport metrics, e.g. window height and width, have changed.
-     *
-     * <p>If the width, height, or devicePixelRatio are less than or equal to 0, this update is
-     * ignored.
-     *
-     * @param viewportMetrics The metrics to send to the Dart application.
+     * The foldable device is completely open. The screen space that is presented to the user is
+     * flat. Corresponds to {@link androidx.window.layout.FoldingFeature.State#FLAT}
      */
-    public void setViewportMetrics(@NonNull ViewportMetrics viewportMetrics) {
-        // We might get called with just the DPR if width/height aren't available yet.
-        // Just ignore, as it will get called again when width/height are set.
-        if (!viewportMetrics.validate()) {
-            return;
-        }
-        Log.v(TAG,
-                "Setting viewport metrics\n"
-                        + "Size: " + viewportMetrics.width + " x " + viewportMetrics.height + "\n"
-                        + "Padding - L: " + viewportMetrics.viewPaddingLeft
-                        + ", T: " + viewportMetrics.viewPaddingTop
-                        + ", R: " + viewportMetrics.viewPaddingRight
-                        + ", B: " + viewportMetrics.viewPaddingBottom + "\n"
-                        + "Insets - L: " + viewportMetrics.viewInsetLeft + ", T: "
-                        + viewportMetrics.viewInsetTop + ", R: " + viewportMetrics.viewInsetRight
-                        + ", B: " + viewportMetrics.viewInsetBottom + "\n"
-                        + "System Gesture Insets - L: " + viewportMetrics.systemGestureInsetLeft
-                        + ", T: " + viewportMetrics.systemGestureInsetTop
-                        + ", R: " + viewportMetrics.systemGestureInsetRight
-                        + ", B: " + viewportMetrics.systemGestureInsetRight + "\n"
-                        + "Display Features: " + viewportMetrics.displayFeatures.size());
-
-        int[] displayFeaturesBounds = new int[viewportMetrics.displayFeatures.size() * 4];
-        int[] displayFeaturesType = new int[viewportMetrics.displayFeatures.size()];
-        int[] displayFeaturesState = new int[viewportMetrics.displayFeatures.size()];
-        for (int i = 0; i < viewportMetrics.displayFeatures.size(); i++) {
-            DisplayFeature displayFeature = viewportMetrics.displayFeatures.get(i);
-            displayFeaturesBounds[4 * i] = displayFeature.bounds.left;
-            displayFeaturesBounds[4 * i + 1] = displayFeature.bounds.top;
-            displayFeaturesBounds[4 * i + 2] = displayFeature.bounds.right;
-            displayFeaturesBounds[4 * i + 3] = displayFeature.bounds.bottom;
-            displayFeaturesType[i] = displayFeature.type.encodedValue;
-            displayFeaturesState[i] = displayFeature.state.encodedValue;
-        }
-
-        flutterJNI.setViewportMetrics(viewportMetrics.devicePixelRatio, viewportMetrics.width,
-                viewportMetrics.height, viewportMetrics.viewPaddingTop,
-                viewportMetrics.viewPaddingRight, viewportMetrics.viewPaddingBottom,
-                viewportMetrics.viewPaddingLeft, viewportMetrics.viewInsetTop,
-                viewportMetrics.viewInsetRight, viewportMetrics.viewInsetBottom,
-                viewportMetrics.viewInsetLeft, viewportMetrics.systemGestureInsetTop,
-                viewportMetrics.systemGestureInsetRight, viewportMetrics.systemGestureInsetBottom,
-                viewportMetrics.systemGestureInsetLeft, viewportMetrics.physicalTouchSlop,
-                displayFeaturesBounds, displayFeaturesType, displayFeaturesState);
-    }
-
-    // TODO(mattcarroll): describe the native behavior that this invokes
-    // TODO(mattcarroll): determine if this is nullable or nonnull
-    public Bitmap getBitmap() {
-        return flutterJNI.getBitmap();
-    }
-
-    // TODO(mattcarroll): describe the native behavior that this invokes
-    public void dispatchPointerDataPacket(@NonNull ByteBuffer buffer, int position) {
-        flutterJNI.dispatchPointerDataPacket(buffer, position);
-    }
-
-    // TODO(mattcarroll): describe the native behavior that this invokes
-    private void registerTexture(long textureId, @NonNull SurfaceTextureWrapper textureWrapper) {
-        flutterJNI.registerTexture(textureId, textureWrapper);
-    }
-
-    private void registerImageTexture(
-            long textureId, @NonNull TextureRegistry.ImageConsumer imageTexture) {
-        flutterJNI.registerImageTexture(textureId, imageTexture);
-    }
-
-    // TODO(mattcarroll): describe the native behavior that this invokes
-    private void markTextureFrameAvailable(long textureId) {
-        flutterJNI.markTextureFrameAvailable(textureId);
-    }
-
-    // TODO(mattcarroll): describe the native behavior that this invokes
-    private void unregisterTexture(long textureId) {
-        flutterJNI.unregisterTexture(textureId);
-    }
-
-    // TODO(mattcarroll): describe the native behavior that this invokes
-    public boolean isSoftwareRenderingEnabled() {
-        return flutterJNI.getIsSoftwareRenderingEnabled();
-    }
-
-    // TODO(mattcarroll): describe the native behavior that this invokes
-    public void setAccessibilityFeatures(int flags) {
-        flutterJNI.setAccessibilityFeatures(flags);
-    }
-
-    // TODO(mattcarroll): describe the native behavior that this invokes
-    public void setSemanticsEnabled(boolean enabled) {
-        flutterJNI.setSemanticsEnabled(enabled);
-    }
-
-    // TODO(mattcarroll): describe the native behavior that this invokes
-    public void dispatchSemanticsAction(
-            int nodeId, int action, @Nullable ByteBuffer args, int argsPosition) {
-        flutterJNI.dispatchSemanticsAction(nodeId, action, args, argsPosition);
-    }
+    POSTURE_FLAT(1),
 
     /**
-     * Mutable data structure that holds all viewport metrics properties that Flutter cares about.
-     *
-     * <p>All distance measurements, e.g., width, height, padding, viewInsets, are measured in
-     * device pixels, not logical pixels.
+     * The foldable device's hinge is in an intermediate position between opened and closed state.
+     * There is a non-flat angle between parts of the flexible screen or between physical display
+     * panels. Corresponds to {@link androidx.window.layout.FoldingFeature.State#HALF_OPENED}
      */
-    public static final class ViewportMetrics {
-        /** A value that indicates the setting has not been set. */
-        public static final int unsetValue = -1;
+    POSTURE_HALF_OPENED(2);
 
-        public float devicePixelRatio = 1.0f;
-        public int width = 0;
-        public int height = 0;
-        public int viewPaddingTop = 0;
-        public int viewPaddingRight = 0;
-        public int viewPaddingBottom = 0;
-        public int viewPaddingLeft = 0;
-        public int viewInsetTop = 0;
-        public int viewInsetRight = 0;
-        public int viewInsetBottom = 0;
-        public int viewInsetLeft = 0;
-        public int systemGestureInsetTop = 0;
-        public int systemGestureInsetRight = 0;
-        public int systemGestureInsetBottom = 0;
-        public int systemGestureInsetLeft = 0;
-        public int physicalTouchSlop = unsetValue;
+    public final int encodedValue;
 
-        /**
-         * Whether this instance contains valid metrics for the Flutter application.
-         *
-         * @return True if width, height, and devicePixelRatio are > 0; false otherwise.
-         */
-        boolean validate() {
-            return width > 0 && height > 0 && devicePixelRatio > 0;
-        }
-
-        public List<DisplayFeature> displayFeatures = new ArrayList<>();
+    DisplayFeatureState(int encodedValue) {
+      this.encodedValue = encodedValue;
     }
-
-    /**
-     * Description of a physical feature on the display.
-     *
-     * <p>A display feature is a distinctive physical attribute located within the display panel of
-     * the device. It can intrude into the application window space and create a visual distortion,
-     * visual or touch discontinuity, make some area invisible or create a logical divider or
-     * separation in the screen space.
-     *
-     * <p>Based on {@link androidx.window.layout.DisplayFeature}, with added support for cutouts.
-     */
-    public static final class DisplayFeature {
-        public final Rect bounds;
-        public final DisplayFeatureType type;
-        public final DisplayFeatureState state;
-
-        public DisplayFeature(Rect bounds, DisplayFeatureType type, DisplayFeatureState state) {
-            this.bounds = bounds;
-            this.type = type;
-            this.state = state;
-        }
-
-        public DisplayFeature(Rect bounds, DisplayFeatureType type) {
-            this.bounds = bounds;
-            this.type = type;
-            this.state = DisplayFeatureState.UNKNOWN;
-        }
-    }
-
-    /**
-     * Types of display features that can appear on the viewport.
-     *
-     * <p>Some, like {@link #FOLD}, can be reported without actually occluding the screen. They are
-     * useful for knowing where the display is bent or has a crease. The {@link
-     * DisplayFeature#bounds} can be 0-width in such cases.
-     */
-    public enum DisplayFeatureType {
-        /**
-         * Type of display feature not yet known to Flutter. This can happen if WindowManager is
-         * updated with new types. The {@link DisplayFeature#bounds} is the only known property.
-         */
-        UNKNOWN(0),
-
-        /**
-         * A fold in the flexible display that does not occlude the screen. Corresponds to {@link
-         * androidx.window.layout.FoldingFeature.OcclusionType#NONE}
-         */
-        FOLD(1),
-
-        /**
-         * Splits the display in two separate panels that can fold. Occludes the screen. Corresponds
-         * to
-         * {@link androidx.window.layout.FoldingFeature.OcclusionType#FULL}
-         */
-        HINGE(2),
-
-        /**
-         * Area of the screen that usually houses cameras or sensors. Occludes the screen.
-         * Corresponds to {@link android.view.DisplayCutout}
-         */
-        CUTOUT(3);
-
-        public final int encodedValue;
-
-        DisplayFeatureType(int encodedValue) {
-            this.encodedValue = encodedValue;
-        }
-    }
-
-    /**
-     * State of the display feature.
-     *
-     * <p>For foldables, the state is the posture. For cutouts, this property is {@link #UNKNOWN}
-     */
-    public enum DisplayFeatureState {
-        /** The display feature is a cutout or this state is new and not yet known to Flutter. */
-        UNKNOWN(0),
-
-        /**
-         * The foldable device is completely open. The screen space that is presented to the user is
-         * flat. Corresponds to {@link androidx.window.layout.FoldingFeature.State#FLAT}
-         */
-        POSTURE_FLAT(1),
-
-        /**
-         * The foldable device's hinge is in an intermediate position between opened and closed
-         * state. There is a non-flat angle between parts of the flexible screen or between physical
-         * display panels. Corresponds to {@link
-         * androidx.window.layout.FoldingFeature.State#HALF_OPENED}
-         */
-        POSTURE_HALF_OPENED(2);
-
-        public final int encodedValue;
-
-        DisplayFeatureState(int encodedValue) {
-            this.encodedValue = encodedValue;
-        }
-    }
+  }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -16,24 +16,25 @@ import android.media.ImageReader;
 import android.os.Build;
 import android.os.Handler;
 import android.view.Surface;
+
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import io.flutter.Log;
-import io.flutter.embedding.engine.FlutterJNI;
-import io.flutter.view.TextureRegistry;
+
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+
+import io.flutter.Log;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.view.TextureRegistry;
 
 /**
  * Represents the rendering responsibilities of a {@code FlutterEngine}.
@@ -49,1260 +50,1206 @@ import java.util.concurrent.atomic.AtomicLong;
  * io.flutter.embedding.android.FlutterTextureView} are implementations of {@link RenderSurface}.
  */
 public class FlutterRenderer implements TextureRegistry {
-  /**
-   * Whether to always use GL textures for {@link FlutterRenderer#createSurfaceProducer()}.
-   *
-   * <p>This is a debug-only API intended for local development. For example, when using a newer
-   * Android device (that normally would use {@link ImageReaderSurfaceProducer}, but wanting to test
-   * the OpenGLES/{@link SurfaceTextureSurfaceProducer} code branch. This flag has undefined
-   * behavior if set to true while running in a Vulkan (Impeller) context.
-   */
-  @VisibleForTesting static boolean debugForceSurfaceProducerGlTextures = false;
+    /**
+     * Whether to always use GL textures for {@link FlutterRenderer#createSurfaceProducer()}.
+     *
+     * <p>This is a debug-only API intended for local development. For example, when using a newer
+     * Android device (that normally would use {@link ImageReaderSurfaceProducer}, but wanting to
+     * test the OpenGLES/{@link SurfaceTextureSurfaceProducer} code branch. This flag has undefined
+     * behavior if set to true while running in a Vulkan (Impeller) context.
+     */
+    @VisibleForTesting
+    static boolean debugForceSurfaceProducerGlTextures = false;
 
-  private static final String TAG = "FlutterRenderer";
+    private static final String TAG = "FlutterRenderer";
 
-  @NonNull private final FlutterJNI flutterJNI;
-  @NonNull private final AtomicLong nextTextureId = new AtomicLong(0L);
-  @Nullable private Surface surface;
-  private boolean isDisplayingFlutterUi = false;
-  private int isRenderingToImageViewCount = 0;
-  private final Handler handler = new Handler();
+    @NonNull
+    private final FlutterJNI flutterJNI;
+    @NonNull
+    private final AtomicLong nextTextureId = new AtomicLong(0L);
+    @Nullable
+    private Surface surface;
+    private boolean isDisplayingFlutterUi = false;
+    private int isRenderingToImageViewCount = 0;
+    private final Handler handler = new Handler();
 
-  @NonNull
-  private final Set<WeakReference<TextureRegistry.OnTrimMemoryListener>> onTrimMemoryListeners =
-      new HashSet<>();
+    @NonNull
+    private final Set<WeakReference<TextureRegistry.OnTrimMemoryListener>> onTrimMemoryListeners =
+            new HashSet<>();
 
-  @NonNull
-  private final FlutterUiDisplayListener flutterUiDisplayListener =
-      new FlutterUiDisplayListener() {
-        @Override
-        public void onFlutterUiDisplayed() {
-          isDisplayingFlutterUi = true;
+    @NonNull
+    private final FlutterUiDisplayListener flutterUiDisplayListener =
+            new FlutterUiDisplayListener() {
+                @Override
+                public void onFlutterUiDisplayed() {
+                    isDisplayingFlutterUi = true;
+                }
+
+                @Override
+                public void onFlutterUiNoLongerDisplayed() {
+                    isDisplayingFlutterUi = false;
+                }
+            };
+
+    public FlutterRenderer(@NonNull FlutterJNI flutterJNI) {
+        this.flutterJNI = flutterJNI;
+        this.flutterJNI.addIsDisplayingFlutterUiListener(flutterUiDisplayListener);
+    }
+
+    /**
+     * Returns true if this {@code FlutterRenderer} is painting pixels to an Android {@code View}
+     * hierarchy, false otherwise.
+     */
+    public boolean isDisplayingFlutterUi() {
+        return isDisplayingFlutterUi;
+    }
+
+    /**
+     * Informs the renderer whether the surface it is rendering to is backend by a {@code
+     * FlutterImageView}, which requires additional synchonization in the Vulkan backend.
+     */
+    public void SetRenderingToImageView(boolean value) {
+        if (value) {
+            isRenderingToImageViewCount++;
+        } else {
+            isRenderingToImageViewCount--;
         }
+        flutterJNI.SetIsRenderingToImageView(isRenderingToImageViewCount > 0);
+    }
 
-        @Override
-        public void onFlutterUiNoLongerDisplayed() {
-          isDisplayingFlutterUi = false;
+    /**
+     * Adds a listener that is invoked whenever this {@code FlutterRenderer} starts and stops
+     * painting pixels to an Android {@code View} hierarchy.
+     */
+    public void addIsDisplayingFlutterUiListener(@NonNull FlutterUiDisplayListener listener) {
+        flutterJNI.addIsDisplayingFlutterUiListener(listener);
+
+        if (isDisplayingFlutterUi) {
+            listener.onFlutterUiDisplayed();
         }
-      };
-
-  public FlutterRenderer(@NonNull FlutterJNI flutterJNI) {
-    this.flutterJNI = flutterJNI;
-    this.flutterJNI.addIsDisplayingFlutterUiListener(flutterUiDisplayListener);
-  }
-
-  /**
-   * Returns true if this {@code FlutterRenderer} is painting pixels to an Android {@code View}
-   * hierarchy, false otherwise.
-   */
-  public boolean isDisplayingFlutterUi() {
-    return isDisplayingFlutterUi;
-  }
-
-  /**
-   * Informs the renderer whether the surface it is rendering to is backend by a {@code
-   * FlutterImageView}, which requires additional synchonization in the Vulkan backend.
-   */
-  public void SetRenderingToImageView(boolean value) {
-    if (value) {
-      isRenderingToImageViewCount++;
-    } else {
-      isRenderingToImageViewCount--;
     }
-    flutterJNI.SetIsRenderingToImageView(isRenderingToImageViewCount > 0);
-  }
 
-  /**
-   * Adds a listener that is invoked whenever this {@code FlutterRenderer} starts and stops painting
-   * pixels to an Android {@code View} hierarchy.
-   */
-  public void addIsDisplayingFlutterUiListener(@NonNull FlutterUiDisplayListener listener) {
-    flutterJNI.addIsDisplayingFlutterUiListener(listener);
-
-    if (isDisplayingFlutterUi) {
-      listener.onFlutterUiDisplayed();
+    /**
+     * Removes a listener added via {@link
+     * #addIsDisplayingFlutterUiListener(FlutterUiDisplayListener)}.
+     */
+    public void removeIsDisplayingFlutterUiListener(@NonNull FlutterUiDisplayListener listener) {
+        flutterJNI.removeIsDisplayingFlutterUiListener(listener);
     }
-  }
 
-  /**
-   * Removes a listener added via {@link
-   * #addIsDisplayingFlutterUiListener(FlutterUiDisplayListener)}.
-   */
-  public void removeIsDisplayingFlutterUiListener(@NonNull FlutterUiDisplayListener listener) {
-    flutterJNI.removeIsDisplayingFlutterUiListener(listener);
-  }
-
-  private void clearDeadListeners() {
-    final Iterator<WeakReference<OnTrimMemoryListener>> iterator = onTrimMemoryListeners.iterator();
-    while (iterator.hasNext()) {
-      WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
-      final OnTrimMemoryListener listener = listenerRef.get();
-      if (listener == null) {
-        iterator.remove();
-      }
-    }
-  }
-
-  /** Adds a listener that is invoked when a memory pressure warning was forward. */
-  @VisibleForTesting
-  /* package */ void addOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
-    // Purge dead listener to avoid accumulating.
-    clearDeadListeners();
-    onTrimMemoryListeners.add(new WeakReference<>(listener));
-  }
-
-  /**
-   * Removes a {@link OnTrimMemoryListener} that was added with {@link
-   * #addOnTrimMemoryListener(OnTrimMemoryListener)}.
-   */
-  @VisibleForTesting
-  /* package */ void removeOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
-    for (WeakReference<OnTrimMemoryListener> listenerRef : onTrimMemoryListeners) {
-      if (listenerRef.get() == listener) {
-        onTrimMemoryListeners.remove(listenerRef);
-        break;
-      }
-    }
-  }
-
-  // ------ START TextureRegistry IMPLEMENTATION -----
-
-  /**
-   * Creates and returns a new external texture {@link SurfaceProducer} managed by the Flutter
-   * engine that is also made available to Flutter code.
-   */
-  @NonNull
-  @Override
-  public SurfaceProducer createSurfaceProducer() {
-    // Prior to Impeller, Flutter on Android *only* ran on OpenGLES (via Skia). That
-    // meant that
-    // plugins (i.e. end-users) either explicitly created a SurfaceTexture (via
-    // createX/registerX) or an ImageTexture (via createX/registerX).
-    //
-    // In an Impeller world, which for the first time uses (if available) a Vulkan
-    // rendering
-    // backend, it is no longer possible (at least not trivially) to render an
-    // OpenGLES-provided
-    // texture (SurfaceTexture) in a Vulkan context.
-    //
-    // This function picks the "best" rendering surface based on the Android
-    // runtime, and
-    // provides a consumer-agnostic SurfaceProducer (which in turn vends a Surface),
-    // and has
-    // plugins (i.e. end-users) use the Surface instead, letting us "hide" the
-    // consumer-side
-    // of the implementation.
-    //
-    // tl;dr: If ImageTexture is available, we use it, otherwise we use a
-    // SurfaceTexture.
-    // Coincidentally, if ImageTexture is available, we are also on an Android
-    // version that is
-    // running Vulkan, so we don't have to worry about it not being supported.
-    final long id = nextTextureId.getAndIncrement();
-    final SurfaceProducer entry;
-    if (!debugForceSurfaceProducerGlTextures && Build.VERSION.SDK_INT >= 29) {
-      final ImageReaderSurfaceProducer producer = new ImageReaderSurfaceProducer(id);
-      registerImageTexture(id, producer);
-      Log.v(TAG, "New ImageReaderSurfaceProducer ID: " + id);
-      entry = producer;
-    } else {
-      final SurfaceTextureSurfaceProducer producer =
-          new SurfaceTextureSurfaceProducer(id, handler, flutterJNI);
-      registerSurfaceTexture(id, producer.getSurfaceTexture());
-      Log.v(TAG, "New SurfaceTextureSurfaceProducer ID: " + id);
-      entry = producer;
-    }
-    return entry;
-  }
-
-  /**
-   * Creates and returns a new {@link SurfaceTexture} managed by the Flutter engine that is also
-   * made available to Flutter code.
-   */
-  @NonNull
-  @Override
-  public SurfaceTextureEntry createSurfaceTexture() {
-    Log.v(TAG, "Creating a SurfaceTexture.");
-    final SurfaceTexture surfaceTexture = new SurfaceTexture(0);
-    return registerSurfaceTexture(surfaceTexture);
-  }
-
-  /**
-   * Registers and returns a {@link SurfaceTexture} managed by the Flutter engine that is also made
-   * available to Flutter code.
-   */
-  @NonNull
-  @Override
-  public SurfaceTextureEntry registerSurfaceTexture(@NonNull SurfaceTexture surfaceTexture) {
-    return registerSurfaceTexture(nextTextureId.getAndIncrement(), surfaceTexture);
-  }
-
-  /**
-   * Similar to {@link FlutterRenderer#registerSurfaceTexture} but with an existing @{code
-   * textureId}.
-   *
-   * @param surfaceTexture Surface texture to wrap.
-   * @param textureId A texture ID already created that should be assigned to the surface texture.
-   */
-  @NonNull
-  private SurfaceTextureEntry registerSurfaceTexture(
-      long textureId, @NonNull SurfaceTexture surfaceTexture) {
-    surfaceTexture.detachFromGLContext();
-    final SurfaceTextureRegistryEntry entry =
-        new SurfaceTextureRegistryEntry(textureId, surfaceTexture);
-    Log.v(TAG, "New SurfaceTexture ID: " + entry.id());
-    registerTexture(entry.id(), entry.textureWrapper());
-    addOnTrimMemoryListener(entry);
-    return entry;
-  }
-
-  @NonNull
-  @Override
-  public ImageTextureEntry createImageTexture() {
-    final ImageTextureRegistryEntry entry =
-        new ImageTextureRegistryEntry(nextTextureId.getAndIncrement());
-    Log.v(TAG, "New ImageTextureEntry ID: " + entry.id());
-    registerImageTexture(entry.id(), entry);
-    return entry;
-  }
-
-  @Override
-  public void onTrimMemory(int level) {
-    final Iterator<WeakReference<OnTrimMemoryListener>> iterator = onTrimMemoryListeners.iterator();
-    while (iterator.hasNext()) {
-      WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
-      final OnTrimMemoryListener listener = listenerRef.get();
-      if (listener != null) {
-        listener.onTrimMemory(level);
-      } else {
-        // Purge cleared refs to avoid accumulating a lot of dead listener
-        iterator.remove();
-      }
-    }
-  }
-
-  final class SurfaceTextureRegistryEntry
-      implements TextureRegistry.SurfaceTextureEntry, TextureRegistry.OnTrimMemoryListener {
-    private final long id;
-    @NonNull private final SurfaceTextureWrapper textureWrapper;
-    private boolean released;
-    @Nullable private OnTrimMemoryListener trimMemoryListener;
-    @Nullable private OnFrameConsumedListener frameConsumedListener;
-
-    SurfaceTextureRegistryEntry(long id, @NonNull SurfaceTexture surfaceTexture) {
-      this.id = id;
-      Runnable onFrameConsumed =
-          () -> {
-            if (frameConsumedListener != null) {
-              frameConsumedListener.onFrameConsumed();
+    private void clearDeadListeners() {
+        final Iterator<WeakReference<OnTrimMemoryListener>> iterator =
+                onTrimMemoryListeners.iterator();
+        while (iterator.hasNext()) {
+            WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
+            final OnTrimMemoryListener listener = listenerRef.get();
+            if (listener == null) {
+                iterator.remove();
             }
-          };
-      this.textureWrapper = new SurfaceTextureWrapper(surfaceTexture, onFrameConsumed);
+        }
+    }
 
-      // Even though we make sure to unregister the callback before releasing, as of
-      // Android O, SurfaceTexture has a data race when accessing the callback, so the
-      // callback may still be called by a stale reference after released==true and
-      // mNativeView==null.
-      SurfaceTexture.OnFrameAvailableListener onFrameListener =
-          texture -> {
-            if (released || !flutterJNI.isAttached()) {
-              // Even though we make sure to unregister the callback before releasing, as of
-              // Android O, SurfaceTexture has a data race when accessing the callback, so the
-              // callback may still be called by a stale reference after released==true and
-              // mNativeView==null.
-              return;
+    /** Adds a listener that is invoked when a memory pressure warning was forward. */
+    @VisibleForTesting
+    /* package */ void addOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
+        // Purge dead listener to avoid accumulating.
+        clearDeadListeners();
+        onTrimMemoryListeners.add(new WeakReference<>(listener));
+    }
+
+    /**
+     * Removes a {@link OnTrimMemoryListener} that was added with {@link
+     * #addOnTrimMemoryListener(OnTrimMemoryListener)}.
+     */
+    @VisibleForTesting
+    /* package */ void removeOnTrimMemoryListener(@NonNull OnTrimMemoryListener listener) {
+        for (WeakReference<OnTrimMemoryListener> listenerRef : onTrimMemoryListeners) {
+            if (listenerRef.get() == listener) {
+                onTrimMemoryListeners.remove(listenerRef);
+                break;
             }
-            textureWrapper.markDirty();
-            scheduleEngineFrame();
-          };
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        // The callback relies on being executed on the UI thread (unsynchronised read
-        // of
-        // mNativeView
-        // and also the engine code check for platform thread in
-        // Shell::OnPlatformViewMarkTextureFrameAvailable),
-        // so we explicitly pass a Handler for the current thread.
-        this.surfaceTexture().setOnFrameAvailableListener(onFrameListener, new Handler());
-      } else {
-        // Android documentation states that the listener can be called on an arbitrary
-        // thread.
-        // But in practice, versions of Android that predate the newer API will call the
-        // listener
-        // on the thread where the SurfaceTexture was constructed.
-        this.surfaceTexture().setOnFrameAvailableListener(onFrameListener);
-      }
+        }
+    }
+
+    // ------ START TextureRegistry IMPLEMENTATION -----
+
+    /**
+     * Creates and returns a new external texture {@link SurfaceProducer} managed by the Flutter
+     * engine that is also made available to Flutter code.
+     */
+    @NonNull
+    @Override
+    public SurfaceProducer createSurfaceProducer() {
+        // Prior to Impeller, Flutter on Android *only* ran on OpenGLES (via Skia). That meant that
+        // plugins (i.e. end-users) either explicitly created a SurfaceTexture (via
+        // createX/registerX) or an ImageTexture (via createX/registerX).
+        //
+        // In an Impeller world, which for the first time uses (if available) a Vulkan rendering
+        // backend, it is no longer possible (at least not trivially) to render an OpenGLES-provided
+        // texture (SurfaceTexture) in a Vulkan context.
+        //
+        // This function picks the "best" rendering surface based on the Android runtime, and
+        // provides a consumer-agnostic SurfaceProducer (which in turn vends a Surface), and has
+        // plugins (i.e. end-users) use the Surface instead, letting us "hide" the consumer-side
+        // of the implementation.
+        //
+        // tl;dr: If ImageTexture is available, we use it, otherwise we use a SurfaceTexture.
+        // Coincidentally, if ImageTexture is available, we are also on an Android version that is
+        // running Vulkan, so we don't have to worry about it not being supported.
+        final long id = nextTextureId.getAndIncrement();
+        final SurfaceProducer entry;
+        if (!debugForceSurfaceProducerGlTextures && Build.VERSION.SDK_INT >= 29) {
+            final ImageReaderSurfaceProducer producer = new ImageReaderSurfaceProducer(id);
+            registerImageTexture(id, producer);
+            Log.v(TAG, "New ImageReaderSurfaceProducer ID: " + id);
+            entry = producer;
+        } else {
+            final SurfaceTextureSurfaceProducer producer =
+                    new SurfaceTextureSurfaceProducer(id, handler, flutterJNI);
+            registerSurfaceTexture(id, producer.getSurfaceTexture());
+            Log.v(TAG, "New SurfaceTextureSurfaceProducer ID: " + id);
+            entry = producer;
+        }
+        return entry;
+    }
+
+    /**
+     * Creates and returns a new {@link SurfaceTexture} managed by the Flutter engine that is also
+     * made available to Flutter code.
+     */
+    @NonNull
+    @Override
+    public SurfaceTextureEntry createSurfaceTexture() {
+        Log.v(TAG, "Creating a SurfaceTexture.");
+        final SurfaceTexture surfaceTexture = new SurfaceTexture(0);
+        return registerSurfaceTexture(surfaceTexture);
+    }
+
+    /**
+     * Registers and returns a {@link SurfaceTexture} managed by the Flutter engine that is also
+     * made available to Flutter code.
+     */
+    @NonNull
+    @Override
+    public SurfaceTextureEntry registerSurfaceTexture(@NonNull SurfaceTexture surfaceTexture) {
+        return registerSurfaceTexture(nextTextureId.getAndIncrement(), surfaceTexture);
+    }
+
+    /**
+     * Similar to {@link FlutterRenderer#registerSurfaceTexture} but with an existing @{code
+     * textureId}.
+     *
+     * @param surfaceTexture Surface texture to wrap.
+     * @param textureId A texture ID already created that should be assigned to the surface texture.
+     */
+    @NonNull
+    private SurfaceTextureEntry registerSurfaceTexture(
+            long textureId, @NonNull SurfaceTexture surfaceTexture) {
+        surfaceTexture.detachFromGLContext();
+        final SurfaceTextureRegistryEntry entry =
+                new SurfaceTextureRegistryEntry(textureId, surfaceTexture);
+        Log.v(TAG, "New SurfaceTexture ID: " + entry.id());
+        registerTexture(entry.id(), entry.textureWrapper());
+        addOnTrimMemoryListener(entry);
+        return entry;
+    }
+
+    @NonNull
+    @Override
+    public ImageTextureEntry createImageTexture() {
+        final ImageTextureRegistryEntry entry =
+                new ImageTextureRegistryEntry(nextTextureId.getAndIncrement());
+        Log.v(TAG, "New ImageTextureEntry ID: " + entry.id());
+        registerImageTexture(entry.id(), entry);
+        return entry;
     }
 
     @Override
     public void onTrimMemory(int level) {
-      if (trimMemoryListener != null) {
-        trimMemoryListener.onTrimMemory(level);
-      }
+        final Iterator<WeakReference<OnTrimMemoryListener>> iterator =
+                onTrimMemoryListeners.iterator();
+        while (iterator.hasNext()) {
+            WeakReference<OnTrimMemoryListener> listenerRef = iterator.next();
+            final OnTrimMemoryListener listener = listenerRef.get();
+            if (listener != null) {
+                listener.onTrimMemory(level);
+            } else {
+                // Purge cleared refs to avoid accumulating a lot of dead listener
+                iterator.remove();
+            }
+        }
     }
 
-    private void removeListener() {
-      removeOnTrimMemoryListener(this);
-    }
+    final class SurfaceTextureRegistryEntry
+            implements TextureRegistry.SurfaceTextureEntry, TextureRegistry.OnTrimMemoryListener {
+        private final long id;
+        @NonNull
+        private final SurfaceTextureWrapper textureWrapper;
+        private boolean released;
+        @Nullable
+        private OnTrimMemoryListener trimMemoryListener;
+        @Nullable
+        private OnFrameConsumedListener frameConsumedListener;
 
-    @NonNull
-    public SurfaceTextureWrapper textureWrapper() {
-      return textureWrapper;
-    }
+        SurfaceTextureRegistryEntry(long id, @NonNull SurfaceTexture surfaceTexture) {
+            this.id = id;
+            Runnable onFrameConsumed = () -> {
+                if (frameConsumedListener != null) {
+                    frameConsumedListener.onFrameConsumed();
+                }
+            };
+            this.textureWrapper = new SurfaceTextureWrapper(surfaceTexture, onFrameConsumed);
 
-    @Override
-    @NonNull
-    public SurfaceTexture surfaceTexture() {
-      return textureWrapper.surfaceTexture();
-    }
-
-    @Override
-    public long id() {
-      return id;
-    }
-
-    @Override
-    public void release() {
-      if (released) {
-        return;
-      }
-      Log.v(TAG, "Releasing a SurfaceTexture (" + id + ").");
-      textureWrapper.release();
-      unregisterTexture(id);
-      removeListener();
-      released = true;
-    }
-
-    @Override
-    protected void finalize() throws Throwable {
-      try {
-        if (released) {
-          return;
+            // Even though we make sure to unregister the callback before releasing, as of
+            // Android O, SurfaceTexture has a data race when accessing the callback, so the
+            // callback may still be called by a stale reference after released==true and
+            // mNativeView==null.
+            SurfaceTexture.OnFrameAvailableListener onFrameListener = texture -> {
+                if (released || !flutterJNI.isAttached()) {
+                    // Even though we make sure to unregister the callback before releasing, as of
+                    // Android O, SurfaceTexture has a data race when accessing the callback, so the
+                    // callback may still be called by a stale reference after released==true and
+                    // mNativeView==null.
+                    return;
+                }
+                markTextureFrameAvailable(id);
+            };
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                // The callback relies on being executed on the UI thread (unsynchronised read
+                // of
+                // mNativeView
+                // and also the engine code check for platform thread in
+                // Shell::OnPlatformViewMarkTextureFrameAvailable),
+                // so we explicitly pass a Handler for the current thread.
+                this.surfaceTexture().setOnFrameAvailableListener(onFrameListener, new Handler());
+            } else {
+                // Android documentation states that the listener can be called on an arbitrary
+                // thread.
+                // But in practice, versions of Android that predate the newer API will call the
+                // listener
+                // on the thread where the SurfaceTexture was constructed.
+                this.surfaceTexture().setOnFrameAvailableListener(onFrameListener);
+            }
         }
 
-        handler.post(new TextureFinalizerRunnable(id, flutterJNI));
-      } finally {
-        super.finalize();
-      }
+        @Override
+        public void onTrimMemory(int level) {
+            if (trimMemoryListener != null) {
+                trimMemoryListener.onTrimMemory(level);
+            }
+        }
+
+        private void removeListener() {
+            removeOnTrimMemoryListener(this);
+        }
+
+        @NonNull
+        public SurfaceTextureWrapper textureWrapper() {
+            return textureWrapper;
+        }
+
+        @Override
+        @NonNull
+        public SurfaceTexture surfaceTexture() {
+            return textureWrapper.surfaceTexture();
+        }
+
+        @Override
+        public long id() {
+            return id;
+        }
+
+        @Override
+        public void release() {
+            if (released) {
+                return;
+            }
+            Log.v(TAG, "Releasing a SurfaceTexture (" + id + ").");
+            textureWrapper.release();
+            unregisterTexture(id);
+            removeListener();
+            released = true;
+        }
+
+        @Override
+        protected void finalize() throws Throwable {
+            try {
+                if (released) {
+                    return;
+                }
+
+                handler.post(new TextureFinalizerRunnable(id, flutterJNI));
+            } finally {
+                super.finalize();
+            }
+        }
+
+        @Override
+        public void setOnFrameConsumedListener(@Nullable OnFrameConsumedListener listener) {
+            frameConsumedListener = listener;
+        }
+
+        @Override
+        public void setOnTrimMemoryListener(@Nullable OnTrimMemoryListener listener) {
+            trimMemoryListener = listener;
+        }
     }
 
-    @Override
-    public void setOnFrameConsumedListener(@Nullable OnFrameConsumedListener listener) {
-      frameConsumedListener = listener;
+    static final class TextureFinalizerRunnable implements Runnable {
+        private final long id;
+        private final FlutterJNI flutterJNI;
+
+        TextureFinalizerRunnable(long id, @NonNull FlutterJNI flutterJNI) {
+            this.id = id;
+            this.flutterJNI = flutterJNI;
+        }
+
+        @Override
+        public void run() {
+            if (!flutterJNI.isAttached()) {
+                return;
+            }
+            Log.v(TAG, "Releasing a Texture (" + id + ").");
+            flutterJNI.unregisterTexture(id);
+        }
     }
 
-    @Override
-    public void setOnTrimMemoryListener(@Nullable OnTrimMemoryListener listener) {
-      trimMemoryListener = listener;
-    }
-  }
+    @Keep
+    @TargetApi(29)
+    final class ImageReaderSurfaceProducer
+            implements TextureRegistry.SurfaceProducer, TextureRegistry.ImageConsumer {
+        private static final String TAG = "ImageReaderSurfaceProducer";
+        private static final int MAX_IMAGES = 4;
 
-  static final class TextureFinalizerRunnable implements Runnable {
-    private final long id;
-    private final FlutterJNI flutterJNI;
+        private final long id;
 
-    TextureFinalizerRunnable(long id, @NonNull FlutterJNI flutterJNI) {
-      this.id = id;
-      this.flutterJNI = flutterJNI;
-    }
+        private boolean released;
+        private boolean ignoringFence = false;
 
-    @Override
-    public void run() {
-      if (!flutterJNI.isAttached()) {
-        return;
-      }
-      Log.v(TAG, "Releasing a Texture (" + id + ").");
-      flutterJNI.unregisterTexture(id);
-    }
-  }
+        // The requested width and height are updated by setSize.
+        private int requestedWidth = 1;
+        private int requestedHeight = 1;
 
-  // Keep a queue of ImageReaders.
-  // Each ImageReader holds acquired Images.
-  // When we acquire the next image, close any ImageReaders that don't have any
-  // more pending images.
-  @Keep
-  @TargetApi(29)
-  final class ImageReaderSurfaceProducer
-      implements TextureRegistry.SurfaceProducer, TextureRegistry.ImageConsumer {
-    private static final String TAG = "ImageReaderSurfaceProducer";
-    private static final int MAX_IMAGES = 4;
+        /** Internal class: state held per image produced by image readers. */
+        private class PerImage {
+            public final ImageReader reader;
+            public final Image image;
 
-    // Flip when debugging to see verbose logs.
-    private static final boolean VERBOSE_LOGS = false;
+            public PerImage(ImageReader reader, Image image) {
+                this.reader = reader;
+                this.image = image;
+            }
 
-    private final long id;
+            /** Call close when you are done with an the image. */
+            public void close() {
+                this.image.close();
+                maybeCloseReader(reader);
+            }
+        }
 
-    private boolean released;
-    // Will be true in tests and on Android API < 33.
-    private boolean ignoringFence = false;
+        // Active image reader.
+        private ImageReader activeReader;
+        // Set of image readers that should be closed.
+        private final Set<ImageReader> readersToClose = new HashSet<>();
+        // Last image produced. We keep this around until a new image is produced or the
+        // consumer consumes this image.
+        private PerImage lastProducedImage;
+        // Last image consumed. We only close this at the next image consumption point to avoid
+        // a race condition with the raster thread accessing an image we closed.
+        private PerImage lastConsumedImage;
 
-    // The requested width and height are updated by setSize.
-    private int requestedWidth = 1;
-    private int requestedHeight = 1;
-    // Whenever the requested width and height change we set this to be true so we
-    // create a new ImageReader (inside getSurface) with the correct width and height.
-    // We use this flag so that we lazily create the ImageReader only when a frame
-    // will be produced at that size.
-    private boolean createNewReader = true;
-
-    // State held to track latency of various stages.
-    private long lastDequeueTime = 0;
-    private long lastQueueTime = 0;
-    private long lastScheduleTime = 0;
-
-    private Object lock = new Object();
-    // REQUIRED: The following fields must only be accessed when lock is held.
-    private final LinkedList<PerImageReader> imageReaderQueue = new LinkedList<PerImageReader>();
-    private final HashMap<ImageReader, PerImageReader> perImageReaders =
-        new HashMap<ImageReader, PerImageReader>();
-
-    /** Internal class: state held per Image produced by ImageReaders. */
-    private class PerImage {
-      public final Image image;
-      public final long queuedTime;
-
-      public PerImage(Image image, long queuedTime) {
-        this.image = image;
-        this.queuedTime = queuedTime;
-      }
-    }
-
-    /** Internal class: state held per ImageReader. */
-    private class PerImageReader {
-      public final ImageReader reader;
-      private final LinkedList<PerImage> imageQueue = new LinkedList<PerImage>();
-
-      private final ImageReader.OnImageAvailableListener onImageAvailableListener =
-          reader -> {
+        private final Handler onImageAvailableHandler = new Handler();
+        private final ImageReader.OnImageAvailableListener onImageAvailableListener = reader -> {
             Image image = null;
             try {
-              image = reader.acquireLatestImage();
+                image = reader.acquireLatestImage();
             } catch (IllegalStateException e) {
-              Log.e(TAG, "onImageAvailable acquireLatestImage failed: " + e);
-            }
-            if (released) {
-              return;
+                Log.e(TAG, "onImageAvailable acquireLatestImage failed: " + e);
             }
             if (image == null) {
-              return;
+                return;
             }
-            onImage(reader, image);
-          };
+            onImage(new PerImage(reader, image));
+        };
 
-      public PerImageReader(ImageReader reader) {
-        this.reader = reader;
-        reader.setOnImageAvailableListener(onImageAvailableListener, new Handler());
-      }
-
-      PerImage queueImage(Image image) {
-        PerImage perImage = new PerImage(image, System.nanoTime());
-        imageQueue.add(perImage);
-        // If we fall too far behind we will skip some frames.
-        while (imageQueue.size() > 2) {
-          PerImage r = imageQueue.removeFirst();
-          r.image.close();
+        ImageReaderSurfaceProducer(long id) {
+            this.id = id;
         }
-        return perImage;
-      }
 
-      PerImage dequeueImage() {
-        if (imageQueue.size() == 0) {
-          return null;
+        @Override
+        public long id() {
+            return id;
         }
-        PerImage r = imageQueue.removeFirst();
-        return r;
-      }
 
-      /** returns true if we can prune this reader */
-      boolean canPrune() {
-        return imageQueue.size() == 0;
-      }
-
-      void close() {
-        reader.close();
-        imageQueue.clear();
-      }
-    }
-
-    double deltaMillis(long deltaNanos) {
-      double ms = (double) deltaNanos / (double) 1000000.0;
-      return ms;
-    }
-
-    PerImageReader getOrCreatePerImageReader(ImageReader reader) {
-      PerImageReader r = perImageReaders.get(reader);
-      if (r == null) {
-        r = new PerImageReader(reader);
-        perImageReaders.put(reader, r);
-        imageReaderQueue.add(r);
-      }
-      return r;
-    }
-
-    void pruneImageReaderQueue() {
-      // Prune nodes from the head of the ImageReader queue.
-      while (imageReaderQueue.size() > 1) {
-        PerImageReader r = imageReaderQueue.peekFirst();
-        if (!r.canPrune()) {
-          // No more ImageReaders can be pruned this round.
-          break;
-        }
-        imageReaderQueue.removeFirst();
-        perImageReaders.remove(r.reader);
-        r.close();
-      }
-    }
-
-    void onImage(ImageReader reader, Image image) {
-      PerImage queuedImage = null;
-      synchronized (lock) {
-        PerImageReader perReader = getOrCreatePerImageReader(reader);
-        queuedImage = perReader.queueImage(image);
-      }
-      if (queuedImage == null) {
-        return;
-      }
-      if (VERBOSE_LOGS) {
-        if (lastQueueTime != 0) {
-          long now = System.nanoTime();
-          long queueDelta = now - lastQueueTime;
-          Log.i(
-              TAG,
-              "enqueued image="
-                  + queuedImage.image.hashCode()
-                  + " queueDelta="
-                  + deltaMillis(queueDelta));
-          lastQueueTime = now;
-        } else {
-          lastQueueTime = System.nanoTime();
-        }
-      }
-      scheduleEngineFrame();
-    }
-
-    PerImage dequeueImage() {
-      PerImage r = null;
-      synchronized (lock) {
-        for (PerImageReader reader : imageReaderQueue) {
-          r = reader.dequeueImage();
-          if (r == null) {
-            // This reader is probably about to get pruned.
-            continue;
-          }
-          if (VERBOSE_LOGS) {
-            if (lastDequeueTime != 0) {
-              long now = System.nanoTime();
-              long dequeueDelta = now - lastDequeueTime;
-              long queuedFor = now - r.queuedTime;
-              long scheduleDelay = now - lastScheduleTime;
-              Log.i(
-                  TAG,
-                  "dequeued image="
-                      + r.image.hashCode()
-                      + " queuedFor= "
-                      + deltaMillis(queuedFor)
-                      + " dequeueDelta="
-                      + deltaMillis(dequeueDelta)
-                      + " scheduleDelay="
-                      + deltaMillis(scheduleDelay));
-              lastDequeueTime = now;
-            } else {
-              lastDequeueTime = System.nanoTime();
+        private void releaseInternal() {
+            released = true;
+            if (this.lastProducedImage != null) {
+                this.lastProducedImage.close();
+                this.lastProducedImage = null;
             }
-          }
-          // We have dequeued the first image.
-          break;
+            if (this.lastConsumedImage != null) {
+                this.lastConsumedImage.close();
+                this.lastConsumedImage = null;
+            }
+            for (ImageReader reader : readersToClose) {
+                reader.close();
+            }
+            readersToClose.clear();
+            if (this.activeReader != null) {
+                this.activeReader.close();
+                this.activeReader = null;
+            }
         }
-        pruneImageReaderQueue();
-      }
-      return r;
-    }
 
-    private void releaseInternal() {
-      released = true;
-      for (PerImageReader pir : perImageReaders.values()) {
-        pir.close();
-      }
-      perImageReaders.clear();
-      imageReaderQueue.clear();
-    }
-
-    @TargetApi(33)
-    private void waitOnFence(Image image) {
-      try {
-        SyncFence fence = image.getFence();
-        boolean signaled = fence.awaitForever();
-        if (!signaled) {
-          Log.e(TAG, "acquireLatestImage image's fence was never signalled.");
+        @Override
+        public void release() {
+            if (released) {
+                return;
+            }
+            releaseInternal();
+            unregisterTexture(id);
         }
-      } catch (IOException e) {
-        // Drop.
-      }
-    }
 
-    private void maybeWaitOnFence(Image image) {
-      if (image == null) {
-        return;
-      }
-      if (ignoringFence) {
-        return;
-      }
-      if (Build.VERSION.SDK_INT >= 33) {
-        // The fence API is only available on Android >= 33.
-        waitOnFence(image);
-        return;
-      }
-      // Log once per ImageTextureEntry.
-      ignoringFence = true;
-      Log.w(TAG, "ImageTextureEntry can't wait on the fence on Android < 33");
-    }
-
-    ImageReaderSurfaceProducer(long id) {
-      this.id = id;
-    }
-
-    @Override
-    public long id() {
-      return id;
-    }
-
-    @Override
-    public void release() {
-      if (released) {
-        return;
-      }
-      releaseInternal();
-      unregisterTexture(id);
-    }
-
-    @Override
-    public void setSize(int width, int height) {
-      // Clamp to a minimum of 1. A 0x0 texture is a runtime exception in ImageReader.
-      width = Math.max(1, width);
-      height = Math.max(1, height);
-
-      if (requestedWidth == width && requestedHeight == height) {
-        // No size change.
-        return;
-      }
-      this.createNewReader = true;
-      this.requestedHeight = height;
-      this.requestedWidth = width;
-    }
-
-    @Override
-    public int getWidth() {
-      return this.requestedWidth;
-    }
-
-    @Override
-    public int getHeight() {
-      return this.requestedHeight;
-    }
-
-    @Override
-    public Surface getSurface() {
-      PerImageReader pir = getActiveReader();
-      return pir.reader.getSurface();
-    }
-
-    @Override
-    public void scheduleFrame() {
-      if (VERBOSE_LOGS) {
-        long now = System.nanoTime();
-        if (lastScheduleTime != 0) {
-          long delta = now - lastScheduleTime;
-          Log.v(TAG, "scheduleFrame delta=" + deltaMillis(delta));
+        @Override
+        public void setSize(int width, int height) {
+            if (requestedWidth == width && requestedHeight == height) {
+                // No size change.
+                return;
+            }
+            this.requestedHeight = height;
+            this.requestedWidth = width;
+            synchronized (this) {
+                if (this.activeReader != null) {
+                    // Schedule the old activeReader to be closed.
+                    readersToClose.add(this.activeReader);
+                    this.activeReader = null;
+                }
+            }
         }
-        lastScheduleTime = now;
-      }
-      scheduleEngineFrame();
-    }
 
-    @Override
-    @TargetApi(29)
-    public Image acquireLatestImage() {
-      PerImage r = dequeueImage();
-      if (r == null) {
-        return null;
-      }
-      maybeWaitOnFence(r.image);
-      return r.image;
-    }
-
-    private PerImageReader getActiveReader() {
-      synchronized (lock) {
-        if (createNewReader) {
-          createNewReader = false;
-          // Create a new ImageReader and add it to the queue.
-          return getOrCreatePerImageReader(createImageReader());
+        @Override
+        public int getWidth() {
+            return this.requestedWidth;
         }
-        return imageReaderQueue.peekLast();
-      }
-    }
 
-    @Override
-    protected void finalize() throws Throwable {
-      try {
-        if (released) {
-          return;
+        @Override
+        public int getHeight() {
+            return this.requestedHeight;
         }
-        releaseInternal();
-        handler.post(new TextureFinalizerRunnable(id, flutterJNI));
-      } finally {
-        super.finalize();
-      }
-    }
 
-    @TargetApi(33)
-    private ImageReader createImageReader33() {
-      final ImageReader.Builder builder = new ImageReader.Builder(requestedWidth, requestedHeight);
-      // Allow for double buffering.
-      builder.setMaxImages(MAX_IMAGES);
-      // Use PRIVATE image format so that we can support video decoding.
-      // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our
-      // ability to read back texture data. If we don't always want to use it, how do
-      // we
-      // decide when to use it or not? Perhaps PlatformViews can indicate if they may
-      // contain
-      // DRM'd content.
-      // I need to investigate how PRIVATE impacts our ability to take screenshots or
-      // capture
-      // the output of Flutter application.
-      builder.setImageFormat(ImageFormat.PRIVATE);
-      // Hint that consumed images will only be read by GPU.
-      builder.setUsage(HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
-      final ImageReader reader = builder.build();
-      return reader;
-    }
-
-    @TargetApi(29)
-    private ImageReader createImageReader29() {
-      final ImageReader reader =
-          ImageReader.newInstance(
-              requestedWidth,
-              requestedHeight,
-              ImageFormat.PRIVATE,
-              MAX_IMAGES,
-              HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
-      return reader;
-    }
-
-    private ImageReader createImageReader() {
-      if (Build.VERSION.SDK_INT >= 33) {
-        return createImageReader33();
-      } else if (Build.VERSION.SDK_INT >= 29) {
-        return createImageReader29();
-      }
-      throw new UnsupportedOperationException(
-          "ImageReaderPlatformViewRenderTarget requires API version 29+");
-    }
-
-    @VisibleForTesting
-    public void disableFenceForTest() {
-      // Roboelectric's implementation of SyncFence is borked.
-      ignoringFence = true;
-    }
-
-    @VisibleForTesting
-    public int numImageReaders() {
-      synchronized (lock) {
-        return imageReaderQueue.size();
-      }
-    }
-
-    @VisibleForTesting
-    public int numImages() {
-      int r = 0;
-      synchronized (lock) {
-        for (PerImageReader reader : imageReaderQueue) {
-          r += reader.imageQueue.size();
+        @Override
+        public Surface getSurface() {
+            maybeCreateReader();
+            return activeReader.getSurface();
         }
-      }
-      return r;
-    }
-  }
 
-  @Keep
-  final class ImageTextureRegistryEntry
-      implements TextureRegistry.ImageTextureEntry, TextureRegistry.ImageConsumer {
-    private static final String TAG = "ImageTextureRegistryEntry";
-    private final long id;
-    private boolean released;
-    private boolean ignoringFence = false;
-    private Image image;
-
-    ImageTextureRegistryEntry(long id) {
-      this.id = id;
-    }
-
-    @Override
-    public long id() {
-      return id;
-    }
-
-    @Override
-    @TargetApi(19)
-    public void release() {
-      if (released) {
-        return;
-      }
-      released = true;
-      if (image != null) {
-        image.close();
-        image = null;
-      }
-      unregisterTexture(id);
-    }
-
-    @Override
-    @TargetApi(19)
-    public void pushImage(Image image) {
-      if (released) {
-        return;
-      }
-      Image toClose;
-      synchronized (this) {
-        toClose = this.image;
-        this.image = image;
-      }
-      // Close the previously pushed buffer.
-      if (toClose != null) {
-        Log.e(TAG, "Dropping PlatformView Frame");
-        toClose.close();
-      }
-      if (image != null) {
-        scheduleEngineFrame();
-      }
-    }
-
-    @TargetApi(33)
-    private void waitOnFence(Image image) {
-      try {
-        SyncFence fence = image.getFence();
-        boolean signaled = fence.awaitForever();
-        if (!signaled) {
-          Log.e(TAG, "acquireLatestImage image's fence was never signalled.");
+        @Override
+        @TargetApi(29)
+        public Image acquireLatestImage() {
+            PerImage r;
+            PerImage toClose;
+            synchronized (this) {
+                r = this.lastProducedImage;
+                this.lastProducedImage = null;
+                toClose = this.lastConsumedImage;
+                this.lastConsumedImage = r;
+            }
+            if (toClose != null) {
+                toClose.close();
+            }
+            if (r == null) {
+                return null;
+            }
+            maybeWaitOnFence(r.image);
+            return r.image;
         }
-      } catch (IOException e) {
-        // Drop.
-      }
-    }
 
-    @TargetApi(29)
-    private void maybeWaitOnFence(Image image) {
-      if (image == null) {
-        return;
-      }
-      if (ignoringFence) {
-        return;
-      }
-      if (Build.VERSION.SDK_INT >= 33) {
-        // The fence API is only available on Android >= 33.
-        waitOnFence(image);
-        return;
-      }
-      // Log once per ImageTextureEntry.
-      ignoringFence = true;
-      Log.w(TAG, "ImageTextureEntry can't wait on the fence on Android < 33");
-    }
-
-    @Override
-    @TargetApi(29)
-    public Image acquireLatestImage() {
-      Image r;
-      synchronized (this) {
-        r = this.image;
-        this.image = null;
-      }
-      maybeWaitOnFence(r);
-      return r;
-    }
-
-    @Override
-    @TargetApi(19)
-    protected void finalize() throws Throwable {
-      try {
-        if (released) {
-          return;
+        private void maybeCloseReader(ImageReader reader) {
+            synchronized (this) {
+                if (!readersToClose.contains(reader)) {
+                    return;
+                }
+                if (this.lastConsumedImage != null && this.lastConsumedImage.reader == reader) {
+                    // There is still a consumed image in flight for this reader. Don't close.
+                    return;
+                }
+                if (this.lastProducedImage != null && this.lastProducedImage.reader == reader) {
+                    // There is still a pending image for this reader. Don't close.
+                    return;
+                }
+                readersToClose.remove(reader);
+            }
+            // Close the reader.
+            reader.close();
         }
-        if (image != null) {
-          // Be sure to finalize any cached image.
-          image.close();
-          image = null;
+
+        private void maybeCreateReader() {
+            synchronized (this) {
+                if (this.activeReader != null) {
+                    return;
+                }
+                this.activeReader = createImageReader();
+            }
         }
-        released = true;
-        handler.post(new TextureFinalizerRunnable(id, flutterJNI));
-      } finally {
-        super.finalize();
-      }
+
+        /** Invoked for each method that is available. */
+        private void onImage(PerImage image) {
+            if (released) {
+                return;
+            }
+            PerImage toClose;
+            synchronized (this) {
+                if (this.readersToClose.contains(image.reader)) {
+                    Log.i(TAG, "Skipped frame because resize is in flight.");
+                    image.close();
+                    return;
+                }
+                toClose = this.lastProducedImage;
+                this.lastProducedImage = image;
+            }
+            // Close the previously pushed buffer.
+            if (toClose != null) {
+                Log.i(TAG, "Dropping rendered frame that was not acquired in time.");
+                toClose.close();
+            }
+            // Mark that we have a new frame available. Eventually the raster thread will
+            // call acquireLatestImage.
+            markTextureFrameAvailable(id);
+        }
+
+        @TargetApi(33)
+        private void waitOnFence(Image image) {
+            try {
+                SyncFence fence = image.getFence();
+                boolean signaled = fence.awaitForever();
+                if (!signaled) {
+                    Log.e(TAG, "acquireLatestImage image's fence was never signalled.");
+                }
+            } catch (IOException e) {
+                // Drop.
+            }
+        }
+
+        private void maybeWaitOnFence(Image image) {
+            if (image == null) {
+                return;
+            }
+            if (ignoringFence) {
+                return;
+            }
+            if (Build.VERSION.SDK_INT >= 33) {
+                // The fence API is only available on Android >= 33.
+                waitOnFence(image);
+                return;
+            }
+            // Log once per ImageTextureEntry.
+            ignoringFence = true;
+            Log.w(TAG, "ImageTextureEntry can't wait on the fence on Android < 33");
+        }
+
+<<<<<<< HEAD
+        ImageReaderSurfaceProducer(long id) {
+            this.id = id;
+        }
+
+        @Override
+        public long id() {
+            return id;
+        }
+
+        @Override
+        public void release() {
+            if (released) {
+                return;
+            }
+            releaseInternal();
+            unregisterTexture(id);
+        }
+
+        @Override
+        public void setSize(int width, int height) {
+            // Clamp to a minimum of 1. A 0x0 texture is a runtime exception in ImageReader.
+            width = Math.max(1, width);
+            height = Math.max(1, height);
+
+            if (requestedWidth == width && requestedHeight == height) {
+                // No size change.
+                return;
+            }
+            this.createNewReader = true;
+            this.requestedHeight = height;
+            this.requestedWidth = width;
+        }
+
+        @Override
+        public int getWidth() {
+            return this.requestedWidth;
+        }
+
+        @Override
+        public int getHeight() {
+            return this.requestedHeight;
+        }
+
+        @Override
+        public Surface getSurface() {
+            PerImageReader pir = getActiveReader();
+            return pir.reader.getSurface();
+        }
+
+        @Override
+        public void scheduleFrame() {
+            if (VERBOSE_LOGS) {
+                long now = System.nanoTime();
+                if (lastScheduleTime != 0) {
+                    long delta = now - lastScheduleTime;
+                    Log.v(TAG, "scheduleFrame delta=" + deltaMillis(delta));
+                }
+                lastScheduleTime = now;
+            }
+            scheduleEngineFrame();
+        }
+
+        @Override
+        @TargetApi(29)
+        public Image acquireLatestImage() {
+            PerImage r = dequeueImage();
+            if (r == null) {
+                return null;
+            }
+            maybeWaitOnFence(r.image);
+            return r.image;
+        }
+
+        private PerImageReader getActiveReader() {
+            synchronized (lock) {
+                if (createNewReader) {
+                    createNewReader = false;
+                    // Create a new ImageReader and add it to the queue.
+                    return getOrCreatePerImageReader(createImageReader());
+                }
+                return imageReaderQueue.peekLast();
+            }
+        }
+
+=======
+>>>>>>> parent of dd32ff12b98 (Reland Optimizations for TLHC frame rate and jank (#50065))
+        @Override
+        protected void finalize() throws Throwable {
+            try {
+                if (released) {
+                    return;
+                }
+                releaseInternal();
+                handler.post(new TextureFinalizerRunnable(id, flutterJNI));
+            } finally {
+                super.finalize();
+            }
+        }
+
+        @TargetApi(33)
+        private ImageReader createImageReader33() {
+            final ImageReader.Builder builder =
+                    new ImageReader.Builder(requestedWidth, requestedHeight);
+            // Allow for double buffering.
+            builder.setMaxImages(MAX_IMAGES);
+            // Use PRIVATE image format so that we can support video decoding.
+            // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our
+            // ability to read back texture data. If we don't always want to use it, how do
+            // we
+            // decide when to use it or not? Perhaps PlatformViews can indicate if they may
+            // contain
+            // DRM'd content.
+            // I need to investigate how PRIVATE impacts our ability to take screenshots or
+            // capture
+            // the output of Flutter application.
+            builder.setImageFormat(ImageFormat.PRIVATE);
+            // Hint that consumed images will only be read by GPU.
+            builder.setUsage(HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
+            final ImageReader reader = builder.build();
+            reader.setOnImageAvailableListener(
+                    this.onImageAvailableListener, onImageAvailableHandler);
+            return reader;
+        }
+
+        @TargetApi(29)
+        private ImageReader createImageReader29() {
+            final ImageReader reader = ImageReader.newInstance(requestedWidth, requestedHeight,
+                    ImageFormat.PRIVATE, MAX_IMAGES, HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
+            reader.setOnImageAvailableListener(
+                    this.onImageAvailableListener, onImageAvailableHandler);
+            return reader;
+        }
+
+        private ImageReader createImageReader() {
+            if (Build.VERSION.SDK_INT >= 33) {
+                return createImageReader33();
+            } else if (Build.VERSION.SDK_INT >= 29) {
+                return createImageReader29();
+            }
+            throw new UnsupportedOperationException(
+                    "ImageReaderPlatformViewRenderTarget requires API version 29+");
+        }
+
+        @VisibleForTesting
+        public void disableFenceForTest() {
+            // Roboelectric's implementation of SyncFence is borked.
+            ignoringFence = true;
+        }
+
+        @VisibleForTesting
+        public int readersToCloseSize() {
+            return readersToClose.size();
+        }
     }
-  }
-  // ------ END TextureRegistry IMPLEMENTATION ----
 
-  /**
-   * Notifies Flutter that the given {@code surface} was created and is available for Flutter
-   * rendering.
-   *
-   * <p>If called more than once, the current native resources are released. This can be undesired
-   * if the Engine expects to reuse this surface later. For example, this is true when platform
-   * views are displayed in a frame, and then removed in the next frame.
-   *
-   * <p>To avoid releasing the current surface resources, set {@code keepCurrentSurface} to true.
-   *
-   * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
-   * android.view.TextureView.SurfaceTextureListener}
-   *
-   * @param surface The render surface.
-   * @param onlySwap True if the current active surface should not be detached.
-   */
-  public void startRenderingToSurface(@NonNull Surface surface, boolean onlySwap) {
-    if (!onlySwap) {
-      // Stop rendering to the surface releases the associated native resources, which
-      // causes a glitch when toggling between rendering to an image view (hybrid
-      // composition) and
-      // rendering directly to a Surface or Texture view. For more,
-      // https://github.com/flutter/flutter/issues/95343
-      stopRenderingToSurface();
+    @Keep
+    final class ImageTextureRegistryEntry
+            implements TextureRegistry.ImageTextureEntry, TextureRegistry.ImageConsumer {
+        private static final String TAG = "ImageTextureRegistryEntry";
+        private final long id;
+        private boolean released;
+        private boolean ignoringFence = false;
+        private Image image;
+
+        ImageTextureRegistryEntry(long id) {
+            this.id = id;
+        }
+
+        @Override
+        public long id() {
+            return id;
+        }
+
+        @Override
+        @TargetApi(19)
+        public void release() {
+            if (released) {
+                return;
+            }
+            released = true;
+            if (image != null) {
+                image.close();
+                image = null;
+            }
+            unregisterTexture(id);
+        }
+
+        @Override
+        @TargetApi(19)
+        public void pushImage(Image image) {
+            if (released) {
+                return;
+            }
+            Image toClose;
+            synchronized (this) {
+                toClose = this.image;
+                this.image = image;
+            }
+            // Close the previously pushed buffer.
+            if (toClose != null) {
+                Log.e(TAG, "Dropping PlatformView Frame");
+                toClose.close();
+            }
+            if (image != null) {
+                // Mark that we have a new frame available.
+                markTextureFrameAvailable(id);
+            }
+        }
+
+        @TargetApi(33)
+        private void waitOnFence(Image image) {
+            try {
+                SyncFence fence = image.getFence();
+                boolean signaled = fence.awaitForever();
+                if (!signaled) {
+                    Log.e(TAG, "acquireLatestImage image's fence was never signalled.");
+                }
+            } catch (IOException e) {
+                // Drop.
+            }
+        }
+
+        @TargetApi(29)
+        private void maybeWaitOnFence(Image image) {
+            if (image == null) {
+                return;
+            }
+            if (ignoringFence) {
+                return;
+            }
+            if (Build.VERSION.SDK_INT >= 33) {
+                // The fence API is only available on Android >= 33.
+                waitOnFence(image);
+                return;
+            }
+            // Log once per ImageTextureEntry.
+            ignoringFence = true;
+            Log.w(TAG, "ImageTextureEntry can't wait on the fence on Android < 33");
+        }
+
+        @Override
+        @TargetApi(29)
+        public Image acquireLatestImage() {
+            Image r;
+            synchronized (this) {
+                r = this.image;
+                this.image = null;
+            }
+            maybeWaitOnFence(r);
+            return r;
+        }
+
+        @Override
+        @TargetApi(19)
+        protected void finalize() throws Throwable {
+            try {
+                if (released) {
+                    return;
+                }
+                if (image != null) {
+                    // Be sure to finalize any cached image.
+                    image.close();
+                    image = null;
+                }
+                released = true;
+                handler.post(new TextureFinalizerRunnable(id, flutterJNI));
+            } finally {
+                super.finalize();
+            }
+        }
     }
-
-    this.surface = surface;
-
-    if (onlySwap) {
-      // In the swap case we are just swapping the surface that we render to.
-      flutterJNI.onSurfaceWindowChanged(surface);
-    } else {
-      // In the non-swap case we are creating a new surface to render to.
-      flutterJNI.onSurfaceCreated(surface);
-    }
-  }
-
-  /**
-   * Swaps the {@link Surface} used to render the current frame.
-   *
-   * <p>In hybrid composition, the root surfaces changes from {@link
-   * android.view.SurfaceHolder#getSurface()} to {@link android.media.ImageReader#getSurface()} when
-   * a platform view is in the current frame.
-   */
-  public void swapSurface(@NonNull Surface surface) {
-    this.surface = surface;
-    flutterJNI.onSurfaceWindowChanged(surface);
-  }
-
-  /**
-   * Notifies Flutter that a {@code surface} previously registered with {@link
-   * #startRenderingToSurface(Surface, boolean)} has changed size to the given {@code width} and
-   * {@code height}.
-   *
-   * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
-   * android.view.TextureView.SurfaceTextureListener}
-   */
-  public void surfaceChanged(int width, int height) {
-    flutterJNI.onSurfaceChanged(width, height);
-  }
-
-  /**
-   * Notifies Flutter that a {@code surface} previously registered with {@link
-   * #startRenderingToSurface(Surface, boolean)} has been destroyed and needs to be released and
-   * cleaned up on the Flutter side.
-   *
-   * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
-   * android.view.TextureView.SurfaceTextureListener}
-   */
-  public void stopRenderingToSurface() {
-    if (surface != null) {
-      flutterJNI.onSurfaceDestroyed();
-
-      // TODO(mattcarroll): the source of truth for this call should be FlutterJNI,
-      // which is where
-      // the call to onFlutterUiDisplayed() comes from. However, no such native
-      // callback exists yet,
-      // so until the engine and FlutterJNI are configured to call us back when
-      // rendering stops,
-      // we will manually monitor that change here.
-      if (isDisplayingFlutterUi) {
-        flutterUiDisplayListener.onFlutterUiNoLongerDisplayed();
-      }
-
-      isDisplayingFlutterUi = false;
-      surface = null;
-    }
-  }
-
-  /**
-   * Notifies Flutter that the viewport metrics, e.g. window height and width, have changed.
-   *
-   * <p>If the width, height, or devicePixelRatio are less than or equal to 0, this update is
-   * ignored.
-   *
-   * @param viewportMetrics The metrics to send to the Dart application.
-   */
-  public void setViewportMetrics(@NonNull ViewportMetrics viewportMetrics) {
-    // We might get called with just the DPR if width/height aren't available yet.
-    // Just ignore, as it will get called again when width/height are set.
-    if (!viewportMetrics.validate()) {
-      return;
-    }
-    Log.v(
-        TAG,
-        "Setting viewport metrics\n"
-            + "Size: "
-            + viewportMetrics.width
-            + " x "
-            + viewportMetrics.height
-            + "\n"
-            + "Padding - L: "
-            + viewportMetrics.viewPaddingLeft
-            + ", T: "
-            + viewportMetrics.viewPaddingTop
-            + ", R: "
-            + viewportMetrics.viewPaddingRight
-            + ", B: "
-            + viewportMetrics.viewPaddingBottom
-            + "\n"
-            + "Insets - L: "
-            + viewportMetrics.viewInsetLeft
-            + ", T: "
-            + viewportMetrics.viewInsetTop
-            + ", R: "
-            + viewportMetrics.viewInsetRight
-            + ", B: "
-            + viewportMetrics.viewInsetBottom
-            + "\n"
-            + "System Gesture Insets - L: "
-            + viewportMetrics.systemGestureInsetLeft
-            + ", T: "
-            + viewportMetrics.systemGestureInsetTop
-            + ", R: "
-            + viewportMetrics.systemGestureInsetRight
-            + ", B: "
-            + viewportMetrics.systemGestureInsetRight
-            + "\n"
-            + "Display Features: "
-            + viewportMetrics.displayFeatures.size());
-
-    int[] displayFeaturesBounds = new int[viewportMetrics.displayFeatures.size() * 4];
-    int[] displayFeaturesType = new int[viewportMetrics.displayFeatures.size()];
-    int[] displayFeaturesState = new int[viewportMetrics.displayFeatures.size()];
-    for (int i = 0; i < viewportMetrics.displayFeatures.size(); i++) {
-      DisplayFeature displayFeature = viewportMetrics.displayFeatures.get(i);
-      displayFeaturesBounds[4 * i] = displayFeature.bounds.left;
-      displayFeaturesBounds[4 * i + 1] = displayFeature.bounds.top;
-      displayFeaturesBounds[4 * i + 2] = displayFeature.bounds.right;
-      displayFeaturesBounds[4 * i + 3] = displayFeature.bounds.bottom;
-      displayFeaturesType[i] = displayFeature.type.encodedValue;
-      displayFeaturesState[i] = displayFeature.state.encodedValue;
-    }
-
-    flutterJNI.setViewportMetrics(
-        viewportMetrics.devicePixelRatio,
-        viewportMetrics.width,
-        viewportMetrics.height,
-        viewportMetrics.viewPaddingTop,
-        viewportMetrics.viewPaddingRight,
-        viewportMetrics.viewPaddingBottom,
-        viewportMetrics.viewPaddingLeft,
-        viewportMetrics.viewInsetTop,
-        viewportMetrics.viewInsetRight,
-        viewportMetrics.viewInsetBottom,
-        viewportMetrics.viewInsetLeft,
-        viewportMetrics.systemGestureInsetTop,
-        viewportMetrics.systemGestureInsetRight,
-        viewportMetrics.systemGestureInsetBottom,
-        viewportMetrics.systemGestureInsetLeft,
-        viewportMetrics.physicalTouchSlop,
-        displayFeaturesBounds,
-        displayFeaturesType,
-        displayFeaturesState);
-  }
-
-  // TODO(mattcarroll): describe the native behavior that this invokes
-  // TODO(mattcarroll): determine if this is nullable or nonnull
-  public Bitmap getBitmap() {
-    return flutterJNI.getBitmap();
-  }
-
-  // TODO(mattcarroll): describe the native behavior that this invokes
-  public void dispatchPointerDataPacket(@NonNull ByteBuffer buffer, int position) {
-    flutterJNI.dispatchPointerDataPacket(buffer, position);
-  }
-
-  // TODO(mattcarroll): describe the native behavior that this invokes
-  private void registerTexture(long textureId, @NonNull SurfaceTextureWrapper textureWrapper) {
-    flutterJNI.registerTexture(textureId, textureWrapper);
-  }
-
-  private void registerImageTexture(
-      long textureId, @NonNull TextureRegistry.ImageConsumer imageTexture) {
-    flutterJNI.registerImageTexture(textureId, imageTexture);
-  }
-
-  private void scheduleEngineFrame() {
-    flutterJNI.scheduleFrame();
-  }
-
-  // TODO(mattcarroll): describe the native behavior that this invokes
-  private void markTextureFrameAvailable(long textureId) {
-    flutterJNI.markTextureFrameAvailable(textureId);
-  }
-
-  // TODO(mattcarroll): describe the native behavior that this invokes
-  private void unregisterTexture(long textureId) {
-    flutterJNI.unregisterTexture(textureId);
-  }
-
-  // TODO(mattcarroll): describe the native behavior that this invokes
-  public boolean isSoftwareRenderingEnabled() {
-    return flutterJNI.getIsSoftwareRenderingEnabled();
-  }
-
-  // TODO(mattcarroll): describe the native behavior that this invokes
-  public void setAccessibilityFeatures(int flags) {
-    flutterJNI.setAccessibilityFeatures(flags);
-  }
-
-  // TODO(mattcarroll): describe the native behavior that this invokes
-  public void setSemanticsEnabled(boolean enabled) {
-    flutterJNI.setSemanticsEnabled(enabled);
-  }
-
-  // TODO(mattcarroll): describe the native behavior that this invokes
-  public void dispatchSemanticsAction(
-      int nodeId, int action, @Nullable ByteBuffer args, int argsPosition) {
-    flutterJNI.dispatchSemanticsAction(nodeId, action, args, argsPosition);
-  }
-
-  /**
-   * Mutable data structure that holds all viewport metrics properties that Flutter cares about.
-   *
-   * <p>All distance measurements, e.g., width, height, padding, viewInsets, are measured in device
-   * pixels, not logical pixels.
-   */
-  public static final class ViewportMetrics {
-    /** A value that indicates the setting has not been set. */
-    public static final int unsetValue = -1;
-
-    public float devicePixelRatio = 1.0f;
-    public int width = 0;
-    public int height = 0;
-    public int viewPaddingTop = 0;
-    public int viewPaddingRight = 0;
-    public int viewPaddingBottom = 0;
-    public int viewPaddingLeft = 0;
-    public int viewInsetTop = 0;
-    public int viewInsetRight = 0;
-    public int viewInsetBottom = 0;
-    public int viewInsetLeft = 0;
-    public int systemGestureInsetTop = 0;
-    public int systemGestureInsetRight = 0;
-    public int systemGestureInsetBottom = 0;
-    public int systemGestureInsetLeft = 0;
-    public int physicalTouchSlop = unsetValue;
+    // ------ END TextureRegistry IMPLEMENTATION ----
 
     /**
-     * Whether this instance contains valid metrics for the Flutter application.
+     * Notifies Flutter that the given {@code surface} was created and is available for Flutter
+     * rendering.
      *
-     * @return True if width, height, and devicePixelRatio are > 0; false otherwise.
+     * <p>If called more than once, the current native resources are released. This can be undesired
+     * if the Engine expects to reuse this surface later. For example, this is true when platform
+     * views are displayed in a frame, and then removed in the next frame.
+     *
+     * <p>To avoid releasing the current surface resources, set {@code keepCurrentSurface} to true.
+     *
+     * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
+     * android.view.TextureView.SurfaceTextureListener}
+     *
+     * @param surface The render surface.
+     * @param onlySwap True if the current active surface should not be detached.
      */
-    boolean validate() {
-      return width > 0 && height > 0 && devicePixelRatio > 0;
+    public void startRenderingToSurface(@NonNull Surface surface, boolean onlySwap) {
+        if (!onlySwap) {
+            // Stop rendering to the surface releases the associated native resources, which
+            // causes a glitch when toggling between rendering to an image view (hybrid
+            // composition) and
+            // rendering directly to a Surface or Texture view. For more,
+            // https://github.com/flutter/flutter/issues/95343
+            stopRenderingToSurface();
+        }
+
+        this.surface = surface;
+
+        if (onlySwap) {
+            // In the swap case we are just swapping the surface that we render to.
+            flutterJNI.onSurfaceWindowChanged(surface);
+        } else {
+            // In the non-swap case we are creating a new surface to render to.
+            flutterJNI.onSurfaceCreated(surface);
+        }
     }
 
-    public List<DisplayFeature> displayFeatures = new ArrayList<>();
-  }
-
-  /**
-   * Description of a physical feature on the display.
-   *
-   * <p>A display feature is a distinctive physical attribute located within the display panel of
-   * the device. It can intrude into the application window space and create a visual distortion,
-   * visual or touch discontinuity, make some area invisible or create a logical divider or
-   * separation in the screen space.
-   *
-   * <p>Based on {@link androidx.window.layout.DisplayFeature}, with added support for cutouts.
-   */
-  public static final class DisplayFeature {
-    public final Rect bounds;
-    public final DisplayFeatureType type;
-    public final DisplayFeatureState state;
-
-    public DisplayFeature(Rect bounds, DisplayFeatureType type, DisplayFeatureState state) {
-      this.bounds = bounds;
-      this.type = type;
-      this.state = state;
+    /**
+     * Swaps the {@link Surface} used to render the current frame.
+     *
+     * <p>In hybrid composition, the root surfaces changes from {@link
+     * android.view.SurfaceHolder#getSurface()} to {@link android.media.ImageReader#getSurface()}
+     * when a platform view is in the current frame.
+     */
+    public void swapSurface(@NonNull Surface surface) {
+        this.surface = surface;
+        flutterJNI.onSurfaceWindowChanged(surface);
     }
 
-    public DisplayFeature(Rect bounds, DisplayFeatureType type) {
-      this.bounds = bounds;
-      this.type = type;
-      this.state = DisplayFeatureState.UNKNOWN;
+    /**
+     * Notifies Flutter that a {@code surface} previously registered with {@link
+     * #startRenderingToSurface(Surface, boolean)} has changed size to the given {@code width} and
+     * {@code height}.
+     *
+     * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
+     * android.view.TextureView.SurfaceTextureListener}
+     */
+    public void surfaceChanged(int width, int height) {
+        flutterJNI.onSurfaceChanged(width, height);
     }
-  }
-
-  /**
-   * Types of display features that can appear on the viewport.
-   *
-   * <p>Some, like {@link #FOLD}, can be reported without actually occluding the screen. They are
-   * useful for knowing where the display is bent or has a crease. The {@link DisplayFeature#bounds}
-   * can be 0-width in such cases.
-   */
-  public enum DisplayFeatureType {
-    /**
-     * Type of display feature not yet known to Flutter. This can happen if WindowManager is updated
-     * with new types. The {@link DisplayFeature#bounds} is the only known property.
-     */
-    UNKNOWN(0),
 
     /**
-     * A fold in the flexible display that does not occlude the screen. Corresponds to {@link
-     * androidx.window.layout.FoldingFeature.OcclusionType#NONE}
+     * Notifies Flutter that a {@code surface} previously registered with {@link
+     * #startRenderingToSurface(Surface, boolean)} has been destroyed and needs to be released and
+     * cleaned up on the Flutter side.
+     *
+     * <p>See {@link android.view.SurfaceHolder.Callback} and {@link
+     * android.view.TextureView.SurfaceTextureListener}
      */
-    FOLD(1),
+    public void stopRenderingToSurface() {
+        if (surface != null) {
+            flutterJNI.onSurfaceDestroyed();
 
-    /**
-     * Splits the display in two separate panels that can fold. Occludes the screen. Corresponds to
-     * {@link androidx.window.layout.FoldingFeature.OcclusionType#FULL}
-     */
-    HINGE(2),
+            // TODO(mattcarroll): the source of truth for this call should be FlutterJNI,
+            // which is where
+            // the call to onFlutterUiDisplayed() comes from. However, no such native
+            // callback exists yet,
+            // so until the engine and FlutterJNI are configured to call us back when
+            // rendering stops,
+            // we will manually monitor that change here.
+            if (isDisplayingFlutterUi) {
+                flutterUiDisplayListener.onFlutterUiNoLongerDisplayed();
+            }
 
-    /**
-     * Area of the screen that usually houses cameras or sensors. Occludes the screen. Corresponds
-     * to {@link android.view.DisplayCutout}
-     */
-    CUTOUT(3);
-
-    public final int encodedValue;
-
-    DisplayFeatureType(int encodedValue) {
-      this.encodedValue = encodedValue;
+            isDisplayingFlutterUi = false;
+            surface = null;
+        }
     }
-  }
-
-  /**
-   * State of the display feature.
-   *
-   * <p>For foldables, the state is the posture. For cutouts, this property is {@link #UNKNOWN}
-   */
-  public enum DisplayFeatureState {
-    /** The display feature is a cutout or this state is new and not yet known to Flutter. */
-    UNKNOWN(0),
 
     /**
-     * The foldable device is completely open. The screen space that is presented to the user is
-     * flat. Corresponds to {@link androidx.window.layout.FoldingFeature.State#FLAT}
+     * Notifies Flutter that the viewport metrics, e.g. window height and width, have changed.
+     *
+     * <p>If the width, height, or devicePixelRatio are less than or equal to 0, this update is
+     * ignored.
+     *
+     * @param viewportMetrics The metrics to send to the Dart application.
      */
-    POSTURE_FLAT(1),
+    public void setViewportMetrics(@NonNull ViewportMetrics viewportMetrics) {
+        // We might get called with just the DPR if width/height aren't available yet.
+        // Just ignore, as it will get called again when width/height are set.
+        if (!viewportMetrics.validate()) {
+            return;
+        }
+        Log.v(TAG,
+                "Setting viewport metrics\n"
+                        + "Size: " + viewportMetrics.width + " x " + viewportMetrics.height + "\n"
+                        + "Padding - L: " + viewportMetrics.viewPaddingLeft
+                        + ", T: " + viewportMetrics.viewPaddingTop
+                        + ", R: " + viewportMetrics.viewPaddingRight
+                        + ", B: " + viewportMetrics.viewPaddingBottom + "\n"
+                        + "Insets - L: " + viewportMetrics.viewInsetLeft + ", T: "
+                        + viewportMetrics.viewInsetTop + ", R: " + viewportMetrics.viewInsetRight
+                        + ", B: " + viewportMetrics.viewInsetBottom + "\n"
+                        + "System Gesture Insets - L: " + viewportMetrics.systemGestureInsetLeft
+                        + ", T: " + viewportMetrics.systemGestureInsetTop
+                        + ", R: " + viewportMetrics.systemGestureInsetRight
+                        + ", B: " + viewportMetrics.systemGestureInsetRight + "\n"
+                        + "Display Features: " + viewportMetrics.displayFeatures.size());
 
-    /**
-     * The foldable device's hinge is in an intermediate position between opened and closed state.
-     * There is a non-flat angle between parts of the flexible screen or between physical display
-     * panels. Corresponds to {@link androidx.window.layout.FoldingFeature.State#HALF_OPENED}
-     */
-    POSTURE_HALF_OPENED(2);
+        int[] displayFeaturesBounds = new int[viewportMetrics.displayFeatures.size() * 4];
+        int[] displayFeaturesType = new int[viewportMetrics.displayFeatures.size()];
+        int[] displayFeaturesState = new int[viewportMetrics.displayFeatures.size()];
+        for (int i = 0; i < viewportMetrics.displayFeatures.size(); i++) {
+            DisplayFeature displayFeature = viewportMetrics.displayFeatures.get(i);
+            displayFeaturesBounds[4 * i] = displayFeature.bounds.left;
+            displayFeaturesBounds[4 * i + 1] = displayFeature.bounds.top;
+            displayFeaturesBounds[4 * i + 2] = displayFeature.bounds.right;
+            displayFeaturesBounds[4 * i + 3] = displayFeature.bounds.bottom;
+            displayFeaturesType[i] = displayFeature.type.encodedValue;
+            displayFeaturesState[i] = displayFeature.state.encodedValue;
+        }
 
-    public final int encodedValue;
-
-    DisplayFeatureState(int encodedValue) {
-      this.encodedValue = encodedValue;
+        flutterJNI.setViewportMetrics(viewportMetrics.devicePixelRatio, viewportMetrics.width,
+                viewportMetrics.height, viewportMetrics.viewPaddingTop,
+                viewportMetrics.viewPaddingRight, viewportMetrics.viewPaddingBottom,
+                viewportMetrics.viewPaddingLeft, viewportMetrics.viewInsetTop,
+                viewportMetrics.viewInsetRight, viewportMetrics.viewInsetBottom,
+                viewportMetrics.viewInsetLeft, viewportMetrics.systemGestureInsetTop,
+                viewportMetrics.systemGestureInsetRight, viewportMetrics.systemGestureInsetBottom,
+                viewportMetrics.systemGestureInsetLeft, viewportMetrics.physicalTouchSlop,
+                displayFeaturesBounds, displayFeaturesType, displayFeaturesState);
     }
-  }
+
+    // TODO(mattcarroll): describe the native behavior that this invokes
+    // TODO(mattcarroll): determine if this is nullable or nonnull
+    public Bitmap getBitmap() {
+        return flutterJNI.getBitmap();
+    }
+
+    // TODO(mattcarroll): describe the native behavior that this invokes
+    public void dispatchPointerDataPacket(@NonNull ByteBuffer buffer, int position) {
+        flutterJNI.dispatchPointerDataPacket(buffer, position);
+    }
+
+    // TODO(mattcarroll): describe the native behavior that this invokes
+    private void registerTexture(long textureId, @NonNull SurfaceTextureWrapper textureWrapper) {
+        flutterJNI.registerTexture(textureId, textureWrapper);
+    }
+
+    private void registerImageTexture(
+            long textureId, @NonNull TextureRegistry.ImageConsumer imageTexture) {
+        flutterJNI.registerImageTexture(textureId, imageTexture);
+    }
+
+    // TODO(mattcarroll): describe the native behavior that this invokes
+    private void markTextureFrameAvailable(long textureId) {
+        flutterJNI.markTextureFrameAvailable(textureId);
+    }
+
+    // TODO(mattcarroll): describe the native behavior that this invokes
+    private void unregisterTexture(long textureId) {
+        flutterJNI.unregisterTexture(textureId);
+    }
+
+    // TODO(mattcarroll): describe the native behavior that this invokes
+    public boolean isSoftwareRenderingEnabled() {
+        return flutterJNI.getIsSoftwareRenderingEnabled();
+    }
+
+    // TODO(mattcarroll): describe the native behavior that this invokes
+    public void setAccessibilityFeatures(int flags) {
+        flutterJNI.setAccessibilityFeatures(flags);
+    }
+
+    // TODO(mattcarroll): describe the native behavior that this invokes
+    public void setSemanticsEnabled(boolean enabled) {
+        flutterJNI.setSemanticsEnabled(enabled);
+    }
+
+    // TODO(mattcarroll): describe the native behavior that this invokes
+    public void dispatchSemanticsAction(
+            int nodeId, int action, @Nullable ByteBuffer args, int argsPosition) {
+        flutterJNI.dispatchSemanticsAction(nodeId, action, args, argsPosition);
+    }
+
+    /**
+     * Mutable data structure that holds all viewport metrics properties that Flutter cares about.
+     *
+     * <p>All distance measurements, e.g., width, height, padding, viewInsets, are measured in
+     * device pixels, not logical pixels.
+     */
+    public static final class ViewportMetrics {
+        /** A value that indicates the setting has not been set. */
+        public static final int unsetValue = -1;
+
+        public float devicePixelRatio = 1.0f;
+        public int width = 0;
+        public int height = 0;
+        public int viewPaddingTop = 0;
+        public int viewPaddingRight = 0;
+        public int viewPaddingBottom = 0;
+        public int viewPaddingLeft = 0;
+        public int viewInsetTop = 0;
+        public int viewInsetRight = 0;
+        public int viewInsetBottom = 0;
+        public int viewInsetLeft = 0;
+        public int systemGestureInsetTop = 0;
+        public int systemGestureInsetRight = 0;
+        public int systemGestureInsetBottom = 0;
+        public int systemGestureInsetLeft = 0;
+        public int physicalTouchSlop = unsetValue;
+
+        /**
+         * Whether this instance contains valid metrics for the Flutter application.
+         *
+         * @return True if width, height, and devicePixelRatio are > 0; false otherwise.
+         */
+        boolean validate() {
+            return width > 0 && height > 0 && devicePixelRatio > 0;
+        }
+
+        public List<DisplayFeature> displayFeatures = new ArrayList<>();
+    }
+
+    /**
+     * Description of a physical feature on the display.
+     *
+     * <p>A display feature is a distinctive physical attribute located within the display panel of
+     * the device. It can intrude into the application window space and create a visual distortion,
+     * visual or touch discontinuity, make some area invisible or create a logical divider or
+     * separation in the screen space.
+     *
+     * <p>Based on {@link androidx.window.layout.DisplayFeature}, with added support for cutouts.
+     */
+    public static final class DisplayFeature {
+        public final Rect bounds;
+        public final DisplayFeatureType type;
+        public final DisplayFeatureState state;
+
+        public DisplayFeature(Rect bounds, DisplayFeatureType type, DisplayFeatureState state) {
+            this.bounds = bounds;
+            this.type = type;
+            this.state = state;
+        }
+
+        public DisplayFeature(Rect bounds, DisplayFeatureType type) {
+            this.bounds = bounds;
+            this.type = type;
+            this.state = DisplayFeatureState.UNKNOWN;
+        }
+    }
+
+    /**
+     * Types of display features that can appear on the viewport.
+     *
+     * <p>Some, like {@link #FOLD}, can be reported without actually occluding the screen. They are
+     * useful for knowing where the display is bent or has a crease. The {@link
+     * DisplayFeature#bounds} can be 0-width in such cases.
+     */
+    public enum DisplayFeatureType {
+        /**
+         * Type of display feature not yet known to Flutter. This can happen if WindowManager is
+         * updated with new types. The {@link DisplayFeature#bounds} is the only known property.
+         */
+        UNKNOWN(0),
+
+        /**
+         * A fold in the flexible display that does not occlude the screen. Corresponds to {@link
+         * androidx.window.layout.FoldingFeature.OcclusionType#NONE}
+         */
+        FOLD(1),
+
+        /**
+         * Splits the display in two separate panels that can fold. Occludes the screen. Corresponds
+         * to
+         * {@link androidx.window.layout.FoldingFeature.OcclusionType#FULL}
+         */
+        HINGE(2),
+
+        /**
+         * Area of the screen that usually houses cameras or sensors. Occludes the screen.
+         * Corresponds to {@link android.view.DisplayCutout}
+         */
+        CUTOUT(3);
+
+        public final int encodedValue;
+
+        DisplayFeatureType(int encodedValue) {
+            this.encodedValue = encodedValue;
+        }
+    }
+
+    /**
+     * State of the display feature.
+     *
+     * <p>For foldables, the state is the posture. For cutouts, this property is {@link #UNKNOWN}
+     */
+    public enum DisplayFeatureState {
+        /** The display feature is a cutout or this state is new and not yet known to Flutter. */
+        UNKNOWN(0),
+
+        /**
+         * The foldable device is completely open. The screen space that is presented to the user is
+         * flat. Corresponds to {@link androidx.window.layout.FoldingFeature.State#FLAT}
+         */
+        POSTURE_FLAT(1),
+
+        /**
+         * The foldable device's hinge is in an intermediate position between opened and closed
+         * state. There is a non-flat angle between parts of the flexible screen or between physical
+         * display panels. Corresponds to {@link
+         * androidx.window.layout.FoldingFeature.State#HALF_OPENED}
+         */
+        POSTURE_HALF_OPENED(2);
+
+        public final int encodedValue;
+
+        DisplayFeatureState(int encodedValue) {
+            this.encodedValue = encodedValue;
+        }
+    }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java
@@ -81,9 +81,4 @@ final class SurfaceTextureSurfaceProducer
     }
     return surface;
   }
-
-  @Override
-  public void scheduleFrame() {
-    flutterJNI.markTextureFrameAvailable(id);
-  }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
@@ -22,7 +22,6 @@ public class SurfaceTextureWrapper {
   private boolean released;
   private boolean attached;
   private Runnable onFrameConsumed;
-  private boolean newFrameAvailable = false;
 
   public SurfaceTextureWrapper(@NonNull SurfaceTexture surfaceTexture) {
     this(surfaceTexture, null);
@@ -48,23 +47,10 @@ public class SurfaceTextureWrapper {
     return surfaceTexture;
   }
 
-  public void markDirty() {
-    synchronized (this) {
-      newFrameAvailable = true;
-    }
-  }
-
-  public boolean shouldUpdate() {
-    synchronized (this) {
-      return newFrameAvailable;
-    }
-  }
-
   // Called by native.
   @SuppressWarnings("unused")
   public void updateTexImage() {
     synchronized (this) {
-      newFrameAvailable = false;
       if (!released) {
         surfaceTexture.updateTexImage();
         if (onFrameConsumed != null) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewRenderTarget.java
@@ -32,7 +32,4 @@ public interface PlatformViewRenderTarget {
 
   // Returns the Surface to be rendered on to.
   public Surface getSurface();
-
-  // Schedules a frame to be drawn.
-  public default void scheduleFrame() {}
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -167,7 +167,6 @@ public class PlatformViewWrapper extends FrameLayout {
       // Override the canvas that this subtree of views will use to draw.
       super.draw(targetCanvas);
     } finally {
-      renderTarget.scheduleFrame();
       targetSurface.unlockCanvasAndPost(targetCanvas);
     }
   }

--- a/shell/platform/android/io/flutter/plugin/platform/SurfaceProducerPlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SurfaceProducerPlatformViewRenderTarget.java
@@ -48,8 +48,4 @@ public class SurfaceProducerPlatformViewRenderTarget implements PlatformViewRend
   public Surface getSurface() {
     return this.producer.getSurface();
   }
-
-  public void scheduleFrame() {
-    this.producer.scheduleFrame();
-  }
 }

--- a/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -94,8 +94,6 @@ public interface TextureRegistry {
      * @return a Surface to use for a drawing target for various APIs.
      */
     Surface getSurface();
-
-    void scheduleFrame();
   };
 
   /** A registry entry for a managed SurfaceTexture. */

--- a/shell/platform/android/jni/jni_mock.h
+++ b/shell/platform/android/jni/jni_mock.h
@@ -49,11 +49,6 @@ class JNIMock final : public PlatformViewAndroidJNI {
               (JavaLocalRef surface_texture, int textureId),
               (override));
 
-  MOCK_METHOD(bool,
-              SurfaceTextureShouldUpdate,
-              (JavaLocalRef surface_texture),
-              (override));
-
   MOCK_METHOD(void,
               SurfaceTextureUpdateTexImage,
               (JavaLocalRef surface_texture),

--- a/shell/platform/android/jni/platform_view_android_jni.h
+++ b/shell/platform/android/jni/platform_view_android_jni.h
@@ -92,11 +92,6 @@ class PlatformViewAndroidJNI {
                                                int textureId) = 0;
 
   //----------------------------------------------------------------------------
-  /// @brief      Returns true if surface_texture should be updated.
-  ///
-  virtual bool SurfaceTextureShouldUpdate(JavaLocalRef surface_texture) = 0;
-
-  //----------------------------------------------------------------------------
   /// @brief      Updates the texture image to the most recent frame from the
   ///             image stream.
   ///

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -111,8 +111,6 @@ static jmethodID g_java_weak_reference_get_method = nullptr;
 
 static jmethodID g_attach_to_gl_context_method = nullptr;
 
-static jmethodID g_surface_texture_wrapper_should_update = nullptr;
-
 static jmethodID g_update_tex_image_method = nullptr;
 
 static jmethodID g_get_transform_matrix_method = nullptr;
@@ -523,10 +521,6 @@ static void MarkTextureFrameAvailable(JNIEnv* env,
       static_cast<int64_t>(texture_id));
 }
 
-static void ScheduleFrame(JNIEnv* env, jobject jcaller, jlong shell_holder) {
-  ANDROID_SHELL_HOLDER->GetPlatformView()->ScheduleFrame();
-}
-
 static void InvokePlatformMessageResponseCallback(JNIEnv* env,
                                                   jobject jcaller,
                                                   jlong shell_holder,
@@ -802,15 +796,11 @@ bool RegisterApi(JNIEnv* env) {
           .fnPtr = reinterpret_cast<void*>(&MarkTextureFrameAvailable),
       },
       {
-          .name = "nativeScheduleFrame",
-          .signature = "(J)V",
-          .fnPtr = reinterpret_cast<void*>(&ScheduleFrame),
-      },
-      {
           .name = "nativeUnregisterTexture",
           .signature = "(JJ)V",
           .fnPtr = reinterpret_cast<void*>(&UnregisterTexture),
       },
+
       // Methods for Dart callback functionality.
       {
           .name = "nativeLookupCallbackInformation",
@@ -1169,15 +1159,6 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
     return false;
   }
 
-  g_surface_texture_wrapper_should_update =
-      env->GetMethodID(g_texture_wrapper_class->obj(), "shouldUpdate", "()Z");
-
-  if (g_surface_texture_wrapper_should_update == nullptr) {
-    FML_LOG(ERROR)
-        << "Could not locate SurfaceTextureWrapper.shouldUpdate method";
-    return false;
-  }
-
   g_update_tex_image_method =
       env->GetMethodID(g_texture_wrapper_class->obj(), "updateTexImage", "()V");
 
@@ -1470,29 +1451,6 @@ void PlatformViewAndroidJNIImpl::SurfaceTextureAttachToGLContext(
                       g_attach_to_gl_context_method, textureId);
 
   FML_CHECK(fml::jni::CheckException(env));
-}
-
-bool PlatformViewAndroidJNIImpl::SurfaceTextureShouldUpdate(
-    JavaLocalRef surface_texture) {
-  JNIEnv* env = fml::jni::AttachCurrentThread();
-
-  if (surface_texture.is_null()) {
-    return false;
-  }
-
-  fml::jni::ScopedJavaLocalRef<jobject> surface_texture_local_ref(
-      env, env->CallObjectMethod(surface_texture.obj(),
-                                 g_java_weak_reference_get_method));
-  if (surface_texture_local_ref.is_null()) {
-    return false;
-  }
-
-  jboolean shouldUpdate = env->CallBooleanMethod(
-      surface_texture_local_ref.obj(), g_surface_texture_wrapper_should_update);
-
-  FML_CHECK(fml::jni::CheckException(env));
-
-  return shouldUpdate;
 }
 
 void PlatformViewAndroidJNIImpl::SurfaceTextureUpdateTexImage(

--- a/shell/platform/android/platform_view_android_jni_impl.h
+++ b/shell/platform/android/platform_view_android_jni_impl.h
@@ -45,8 +45,6 @@ class PlatformViewAndroidJNIImpl final : public PlatformViewAndroidJNI {
   void SurfaceTextureAttachToGLContext(JavaLocalRef surface_texture,
                                        int textureId) override;
 
-  bool SurfaceTextureShouldUpdate(JavaLocalRef surface_texture) override;
-
   void SurfaceTextureUpdateTexImage(JavaLocalRef surface_texture) override;
 
   void SurfaceTextureGetTransformMatrix(JavaLocalRef surface_texture,

--- a/shell/platform/android/surface_texture_external_texture.h
+++ b/shell/platform/android/surface_texture_external_texture.h
@@ -40,7 +40,6 @@ class SurfaceTextureExternalTexture : public flutter::Texture {
   virtual void Detach();
 
   void Attach(int gl_tex_id);
-  bool ShouldUpdate();
   void Update();
 
   enum class AttachmentState { kUninitialized, kAttached, kDetached };
@@ -49,6 +48,7 @@ class SurfaceTextureExternalTexture : public flutter::Texture {
   fml::jni::ScopedJavaGlobalRef<jobject> surface_texture_;
   AttachmentState state_ = AttachmentState::kUninitialized;
   SkMatrix transform_;
+  bool new_frame_ready_ = false;
   sk_sp<flutter::DlImage> dl_image_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(SurfaceTextureExternalTexture);

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -511,7 +511,7 @@ public class FlutterRendererTest {
   }
 
   @Test
-  public void ImageReaderSurfaceProducerDoesNotDropFramesWhenResizeInflight() {
+  public void ImageReaderSurfaceProducerSkipsFramesWhenResizeInflight() {
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
     FlutterRenderer.ImageReaderSurfaceProducer texture =
         flutterRenderer.new ImageReaderSurfaceProducer(0);
@@ -533,15 +533,15 @@ public class FlutterRendererTest {
     // Resize.
     texture.setSize(4, 4);
 
-    // Let callbacks run. The rendered frame will manifest here.
+    // Let callbacks run.
     shadowOf(Looper.getMainLooper()).idle();
 
-    // We acquired the frame produced above.
-    assertNotNull(texture.acquireLatestImage());
+    // We should not get a new frame because the produced frame was for the previous size.
+    assertNull(texture.acquireLatestImage());
   }
 
   @Test
-  public void ImageReaderSurfaceProducerImageReadersAndImagesCount() {
+  public void ImageReaderSurfaceProducerHandlesLateFrameWhenResizeInflight() {
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
     FlutterRenderer.ImageReaderSurfaceProducer texture =
         flutterRenderer.new ImageReaderSurfaceProducer(0);
@@ -563,9 +563,6 @@ public class FlutterRendererTest {
     // Let callbacks run, this will produce a single frame.
     shadowOf(Looper.getMainLooper()).idle();
 
-    assertEquals(1, texture.numImageReaders());
-    assertEquals(1, texture.numImages());
-
     // Resize.
     texture.setSize(4, 4);
 
@@ -577,8 +574,15 @@ public class FlutterRendererTest {
     // Let callbacks run.
     shadowOf(Looper.getMainLooper()).idle();
 
-    assertEquals(1, texture.numImageReaders());
-    assertEquals(2, texture.numImages());
+    // We will acquire a frame that is the old size.
+    Image produced = texture.acquireLatestImage();
+    assertNotNull(produced);
+    assertEquals(produced.getWidth(), 1);
+    assertEquals(produced.getHeight(), 1);
+
+    // We will still have one pending reader to be closed.
+    // If we didn't we would have closed the reader that owned the image we just acquired.
+    assertEquals(1, texture.readersToCloseSize());
 
     // Render a new frame with the current size.
     surface = texture.getSurface();
@@ -590,35 +594,11 @@ public class FlutterRendererTest {
     // Let callbacks run.
     shadowOf(Looper.getMainLooper()).idle();
 
-    assertEquals(2, texture.numImageReaders());
-    assertEquals(3, texture.numImages());
+    // Acquire the new image.
+    assertNotNull(texture.acquireLatestImage());
 
-    // Acquire first frame.
-    Image produced = texture.acquireLatestImage();
-    assertNotNull(produced);
-    assertEquals(1, produced.getWidth());
-    assertEquals(1, produced.getHeight());
-    assertEquals(2, texture.numImageReaders());
-    assertEquals(2, texture.numImages());
-    // Acquire second frame. This should result in closing the first ImageReader.
-    produced = texture.acquireLatestImage();
-    assertNotNull(produced);
-    assertEquals(1, produced.getWidth());
-    assertEquals(1, produced.getHeight());
-    assertEquals(1, texture.numImageReaders());
-    assertEquals(1, texture.numImages());
-    // Acquire third frame. We should not close the active ImageReader.
-    produced = texture.acquireLatestImage();
-    assertNotNull(produced);
-    assertEquals(4, produced.getWidth());
-    assertEquals(4, produced.getHeight());
-    assertEquals(1, texture.numImageReaders());
-    assertEquals(0, texture.numImages());
-
-    // Returns null image when no more images are queued.
-    assertNull(texture.acquireLatestImage());
-    assertEquals(1, texture.numImageReaders());
-    assertEquals(0, texture.numImages());
+    // We will have no pending readers to close.
+    assertEquals(0, texture.readersToCloseSize());
   }
 
   // A 0x0 ImageReader is a runtime error.

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -1614,8 +1614,6 @@ public class PlatformViewsControllerTest {
               public Surface getSurface() {
                 return null;
               }
-
-              public void scheduleFrame() {}
             };
           }
         };


### PR DESCRIPTION
Reverts https://github.com/flutter/engine/pull/50065 due to https://github.com/flutter/flutter/issues/142459.

[Discord](https://discord.com/channels/608014603317936148/608020293944082452/1201589744690270338):

> It looks like the failing tests are the resize tests for webview_flutter and google_maps_flutter
I can reproduce the failure locally for: https://github.com/flutter/packages/blob/main/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart#L296

I manually merged this to keep https://github.com/flutter/engine/pull/50066.