### PR TITLE
Make screen reader announcement append a non-breaking space every other message.

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/accessibility.dart
+++ b/lib/web_ui/lib/src/engine/semantics/accessibility.dart
@@ -51,6 +51,15 @@ class AccessibilityAnnouncements {
   /// accouncements assertively.
   final DomHTMLElement _assertiveElement;
 
+  /// Whether to append a non-breaking space to the end of the message
+  /// before outputting it.
+  ///
+  /// It's used to work around a VoiceOver bug where announcing the same message
+  /// repeatedly results in subsequent messages not being announced despite the
+  /// fact that the previous announcement was already removed from the DOM a
+  /// long while back. See https://github.com/flutter/flutter/issues/142250.
+  bool _appendSpace = false;
+
   /// Looks up the element used to announce messages of the given [assertiveness].
   DomHTMLElement ariaLiveElementFor(Assertiveness assertiveness) {
     switch (assertiveness) {
@@ -84,7 +93,9 @@ class AccessibilityAnnouncements {
     final DomHTMLElement ariaLiveElement = ariaLiveElementFor(assertiveness);
 
     final DomHTMLDivElement messageElement = createDomHTMLDivElement();
-    messageElement.text = message;
+    // See the doc-comment for [_appendSpace] for the rationale.
+    messageElement.text = _appendSpace ? '$message\u00A0' : message;
+    _appendSpace = !_appendSpace;
     ariaLiveElement.append(messageElement);
     Timer(liveMessageDuration, () => messageElement.remove());
   }

--- a/lib/web_ui/test/engine/semantics/semantics_announcement_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_announcement_test.dart
@@ -91,18 +91,35 @@ void testMain() {
       expectNoMessages();
     });
 
-    test('Rapid-fire messages are each announced.', () async {
+    test('Rapid-fire messages are each announced', () async {
       sendAnnouncementMessage(message: 'Hello');
       expectMessages(polite: 'Hello');
 
       await Future<void>.delayed(liveMessageDuration * 0.5);
       sendAnnouncementMessage(message: 'There');
-      expectMessages(polite: 'HelloThere');
+      expectMessages(polite: 'HelloThere\u00A0');
 
       await Future<void>.delayed(liveMessageDuration * 0.6);
-      expectMessages(polite: 'There');
+      expectMessages(polite: 'There\u00A0');
 
       await Future<void>.delayed(liveMessageDuration * 0.5);
+      expectNoMessages();
+    });
+
+    test('Repeated announcements are modified to ensure screen readers announce them', () async {
+      sendAnnouncementMessage(message: 'Hello');
+      expectMessages(polite: 'Hello');
+      await Future<void>.delayed(liveMessageDuration);
+      expectNoMessages();
+
+      sendAnnouncementMessage(message: 'Hello');
+      expectMessages(polite: 'Hello\u00A0');
+      await Future<void>.delayed(liveMessageDuration);
+      expectNoMessages();
+
+      sendAnnouncementMessage(message: 'Hello');
+      expectMessages(polite: 'Hello');
+      await Future<void>.delayed(liveMessageDuration);
       expectNoMessages();
     });
 


### PR DESCRIPTION
This fixes an issue when the same message was sent to the screen reader again and was not subsequently announced by VoiceOver despite the prior message having long been removed from the DOM.

Fixes https://github.com/flutter/flutter/issues/142250

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
