### PR TITLE
Re-Re-land Manually revert TLHC optimizations

### DIFF
--- a/shell/platform/android/android_shell_holder_unittests.cc
+++ b/shell/platform/android/android_shell_holder_unittests.cc
@@ -35,6 +35,10 @@ class MockPlatformViewAndroidJNI : public PlatformViewAndroidJNI {
               SurfaceTextureAttachToGLContext,
               (JavaLocalRef surface_texture, int textureId),
               (override));
+  MOCK_METHOD(bool,
+              SurfaceTextureShouldUpdate,
+              (JavaLocalRef surface_texture),
+              (override));
   MOCK_METHOD(void,
               SurfaceTextureUpdateTexImage,
               (JavaLocalRef surface_texture),

--- a/shell/platform/android/image_external_texture.cc
+++ b/shell/platform/android/image_external_texture.cc
@@ -26,11 +26,9 @@ void ImageExternalTexture::Paint(PaintContext& context,
     return;
   }
   Attach(context);
-  const bool should_process_frame =
-      (!freeze && new_frame_ready_) || dl_image_ == nullptr;
+  const bool should_process_frame = !freeze;
   if (should_process_frame) {
     ProcessFrame(context, bounds);
-    new_frame_ready_ = false;
   }
   if (dl_image_) {
     context.canvas->DrawImageRect(
@@ -48,7 +46,7 @@ void ImageExternalTexture::Paint(PaintContext& context,
 
 // Implementing flutter::Texture.
 void ImageExternalTexture::MarkNewFrameAvailable() {
-  new_frame_ready_ = true;
+  // NOOP.
 }
 
 // Implementing flutter::Texture.

--- a/shell/platform/android/image_external_texture.h
+++ b/shell/platform/android/image_external_texture.h
@@ -61,7 +61,6 @@ class ImageExternalTexture : public flutter::Texture {
 
   enum class AttachmentState { kUninitialized, kAttached, kDetached };
   AttachmentState state_ = AttachmentState::kUninitialized;
-  bool new_frame_ready_ = false;
 
   sk_sp<flutter::DlImage> dl_image_;
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -951,6 +951,16 @@ public class FlutterJNI {
 
   private native void nativeMarkTextureFrameAvailable(long nativeShellHolderId, long textureId);
 
+  /** Schedule the engine to draw a frame but does not invalidate the layout tree. */
+  @UiThread
+  public void scheduleFrame() {
+    ensureRunningOnMainThread();
+    ensureAttachedToNative();
+    nativeScheduleFrame(nativeShellHolderId);
+  }
+
+  private native void nativeScheduleFrame(long nativeShellHolderId);
+
   /**
    * Unregisters a texture that was registered with {@link #registerTexture(long,
    * SurfaceTextureWrapper)}.

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java
@@ -81,4 +81,9 @@ final class SurfaceTextureSurfaceProducer
     }
     return surface;
   }
+
+  @Override
+  public void scheduleFrame() {
+    flutterJNI.markTextureFrameAvailable(id);
+  }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
@@ -22,6 +22,7 @@ public class SurfaceTextureWrapper {
   private boolean released;
   private boolean attached;
   private Runnable onFrameConsumed;
+  private boolean newFrameAvailable = false;
 
   public SurfaceTextureWrapper(@NonNull SurfaceTexture surfaceTexture) {
     this(surfaceTexture, null);
@@ -47,10 +48,23 @@ public class SurfaceTextureWrapper {
     return surfaceTexture;
   }
 
+  public void markDirty() {
+    synchronized (this) {
+      newFrameAvailable = true;
+    }
+  }
+
+  public boolean shouldUpdate() {
+    synchronized (this) {
+      return newFrameAvailable;
+    }
+  }
+
   // Called by native.
   @SuppressWarnings("unused")
   public void updateTexImage() {
     synchronized (this) {
+      newFrameAvailable = false;
       if (!released) {
         surfaceTexture.updateTexImage();
         if (onFrameConsumed != null) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewRenderTarget.java
@@ -32,4 +32,7 @@ public interface PlatformViewRenderTarget {
 
   // Returns the Surface to be rendered on to.
   public Surface getSurface();
+
+  // Schedules a frame to be drawn.
+  public default void scheduleFrame() {}
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -167,6 +167,7 @@ public class PlatformViewWrapper extends FrameLayout {
       // Override the canvas that this subtree of views will use to draw.
       super.draw(targetCanvas);
     } finally {
+      renderTarget.scheduleFrame();
       targetSurface.unlockCanvasAndPost(targetCanvas);
     }
   }

--- a/shell/platform/android/io/flutter/plugin/platform/SurfaceProducerPlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SurfaceProducerPlatformViewRenderTarget.java
@@ -48,4 +48,8 @@ public class SurfaceProducerPlatformViewRenderTarget implements PlatformViewRend
   public Surface getSurface() {
     return this.producer.getSurface();
   }
+
+  public void scheduleFrame() {
+    this.producer.scheduleFrame();
+  }
 }

--- a/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -94,6 +94,8 @@ public interface TextureRegistry {
      * @return a Surface to use for a drawing target for various APIs.
      */
     Surface getSurface();
+
+    void scheduleFrame();
   };
 
   /** A registry entry for a managed SurfaceTexture. */

--- a/shell/platform/android/jni/jni_mock.h
+++ b/shell/platform/android/jni/jni_mock.h
@@ -49,6 +49,11 @@ class JNIMock final : public PlatformViewAndroidJNI {
               (JavaLocalRef surface_texture, int textureId),
               (override));
 
+  MOCK_METHOD(bool,
+              SurfaceTextureShouldUpdate,
+              (JavaLocalRef surface_texture),
+              (override));
+
   MOCK_METHOD(void,
               SurfaceTextureUpdateTexImage,
               (JavaLocalRef surface_texture),

--- a/shell/platform/android/jni/platform_view_android_jni.h
+++ b/shell/platform/android/jni/platform_view_android_jni.h
@@ -92,6 +92,11 @@ class PlatformViewAndroidJNI {
                                                int textureId) = 0;
 
   //----------------------------------------------------------------------------
+  /// @brief      Returns true if surface_texture should be updated.
+  ///
+  virtual bool SurfaceTextureShouldUpdate(JavaLocalRef surface_texture) = 0;
+
+  //----------------------------------------------------------------------------
   /// @brief      Updates the texture image to the most recent frame from the
   ///             image stream.
   ///

--- a/shell/platform/android/platform_view_android_jni_impl.h
+++ b/shell/platform/android/platform_view_android_jni_impl.h
@@ -45,6 +45,8 @@ class PlatformViewAndroidJNIImpl final : public PlatformViewAndroidJNI {
   void SurfaceTextureAttachToGLContext(JavaLocalRef surface_texture,
                                        int textureId) override;
 
+  bool SurfaceTextureShouldUpdate(JavaLocalRef surface_texture) override;
+
   void SurfaceTextureUpdateTexImage(JavaLocalRef surface_texture) override;
 
   void SurfaceTextureGetTransformMatrix(JavaLocalRef surface_texture,

--- a/shell/platform/android/surface_texture_external_texture.cc
+++ b/shell/platform/android/surface_texture_external_texture.cc
@@ -37,7 +37,7 @@ void SurfaceTextureExternalTexture::OnGrContextCreated() {
 }
 
 void SurfaceTextureExternalTexture::MarkNewFrameAvailable() {
-  new_frame_ready_ = true;
+  // NOOP.
 }
 
 void SurfaceTextureExternalTexture::Paint(PaintContext& context,
@@ -48,10 +48,9 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
     return;
   }
   const bool should_process_frame =
-      (!freeze && new_frame_ready_) || dl_image_ == nullptr;
+      !freeze || ShouldUpdate() || dl_image_ == nullptr;
   if (should_process_frame) {
     ProcessFrame(context, bounds);
-    new_frame_ready_ = false;
   }
   FML_CHECK(state_ == AttachmentState::kAttached);
 
@@ -109,6 +108,11 @@ void SurfaceTextureExternalTexture::Attach(int gl_tex_id) {
   jni_facade_->SurfaceTextureAttachToGLContext(
       fml::jni::ScopedJavaLocalRef<jobject>(surface_texture_), gl_tex_id);
   state_ = AttachmentState::kAttached;
+}
+
+bool SurfaceTextureExternalTexture::ShouldUpdate() {
+  return jni_facade_->SurfaceTextureShouldUpdate(
+      fml::jni::ScopedJavaLocalRef<jobject>(surface_texture_));
 }
 
 void SurfaceTextureExternalTexture::Update() {

--- a/shell/platform/android/surface_texture_external_texture.h
+++ b/shell/platform/android/surface_texture_external_texture.h
@@ -40,6 +40,7 @@ class SurfaceTextureExternalTexture : public flutter::Texture {
   virtual void Detach();
 
   void Attach(int gl_tex_id);
+  bool ShouldUpdate();
   void Update();
 
   enum class AttachmentState { kUninitialized, kAttached, kDetached };
@@ -48,7 +49,6 @@ class SurfaceTextureExternalTexture : public flutter::Texture {
   fml::jni::ScopedJavaGlobalRef<jobject> surface_texture_;
   AttachmentState state_ = AttachmentState::kUninitialized;
   SkMatrix transform_;
-  bool new_frame_ready_ = false;
   sk_sp<flutter::DlImage> dl_image_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(SurfaceTextureExternalTexture);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -1614,6 +1614,8 @@ public class PlatformViewsControllerTest {
               public Surface getSurface() {
                 return null;
               }
+
+              public void scheduleFrame() {}
             };
           }
         };


### PR DESCRIPTION
- ImageReaderSurfaceProducer no longer drops frames when the producer and the consumers are up to two frames out of sync.
- Have the native C++ side of the Android external textures check if a new frame has been pushed and that the texture needs to be updated. This avoids having to schedule a task on the raster thread for each updated texture.
- Notify the engine earlier that a frame is needed when updating a TLHC texture.
- Re-land fix: Don't close the last dequeued from image reader until the dequeued image is no longer used.