### PR TITLE
Revert: "Change how OpenGL textures are flipped in the Android embedder"

### DIFF
--- a/shell/platform/android/surface_texture_external_texture.cc
+++ b/shell/platform/android/surface_texture_external_texture.cc
@@ -58,17 +58,11 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
   if (dl_image_) {
     DlAutoCanvasRestore autoRestore(context.canvas, true);
 
-    // The incoming texture is vertically flipped, so we flip it back.
-    //
-    // OpenGL's coordinate system has Positive Y equivalent to up, while Skia's
-    // coordinate system (as well as Impeller's) has Negative Y equvalent to up.
-    {
-      // Move (translate) the origin to the bottom-left corner of the image.
-      context.canvas->Translate(bounds.x(), bounds.y() + bounds.height());
-
-      // No change in the X axis, but we need to flip the Y axis.
-      context.canvas->Scale(1, -1);
-    }
+    // The incoming texture is vertically flipped, so we flip it
+    // back. OpenGL's coordinate system has Positive Y equivalent to up, while
+    // Skia's coordinate system has Negative Y equvalent to up.
+    context.canvas->Translate(bounds.x(), bounds.y() + bounds.height());
+    context.canvas->Scale(bounds.width(), -bounds.height());
 
     if (!transform_.isIdentity()) {
       DlImageColorSource source(dl_image_, DlTileMode::kClamp,
@@ -79,8 +73,7 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
         paintWithShader = *context.paint;
       }
       paintWithShader.setColorSource(&source);
-      context.canvas->DrawRect(SkRect::MakeWH(bounds.width(), bounds.height()),
-                               paintWithShader);
+      context.canvas->DrawRect(SkRect::MakeWH(1, 1), paintWithShader);
     } else {
       context.canvas->DrawImage(dl_image_, {0, 0}, sampling, context.paint);
     }

--- a/shell/platform/android/surface_texture_external_texture_gl.cc
+++ b/shell/platform/android/surface_texture_external_texture_gl.cc
@@ -48,11 +48,8 @@ void SurfaceTextureExternalTextureGL::ProcessFrame(PaintContext& context,
   // Create a
   GrGLTextureInfo textureInfo = {GL_TEXTURE_EXTERNAL_OES, texture_name_,
                                  GL_RGBA8_OES};
-  auto backendTexture = GrBackendTextures::MakeGL(
-      /*width=*/bounds.width(),
-      /*height=*/bounds.height(),
-      /*Mipmapped=*/skgpu::Mipmapped::kNo,
-      /*glInfo=*/textureInfo);
+  auto backendTexture =
+      GrBackendTextures::MakeGL(1, 1, skgpu::Mipmapped::kNo, textureInfo);
   dl_image_ = DlImage::Make(SkImages::BorrowTextureFrom(
       context.gr_context, backendTexture, kTopLeft_GrSurfaceOrigin,
       kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr));


### PR DESCRIPTION
Reverts #49938.

This broke `packages/packages/camera/camera/example`, and unfortunately there is no test (in engine, framework, or packages) that would have caught this. We also suspect (but are not sure) that this is related to an internal customer reported bug as well (b/322750489).

---

Here is the output _pre_-revert:

![image](https://github.com/flutter/engine/assets/168174/0691feec-67a9-45b1-aa8e-1c692d09430b)

Here is the output _post_-revert:

![image](https://github.com/flutter/engine/assets/168174/016dc79a-1e44-48cf-9ba0-a61397f8e637)
