### PR TITLE
[web] Fix Scene clip bounds. Trigger resize on DPR Change.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -6136,6 +6136,7 @@ ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/vector_math.dart + ../../../f
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart + ../../../flutter/LICENSE
+ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/display_dpr_stream.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/dom_manager.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart + ../../../flutter/LICENSE
 ORIGIN: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/embedding_strategy.dart + ../../../flutter/LICENSE
@@ -9001,6 +9002,7 @@ FILE: ../../../flutter/lib/web_ui/lib/src/engine/vector_math.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/display_dpr_stream.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/dom_manager.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/embedding_strategy.dart

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -190,6 +190,7 @@ export 'engine/vector_math.dart';
 export 'engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart';
 export 'engine/view_embedder/dimensions_provider/dimensions_provider.dart';
 export 'engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart';
+export 'engine/view_embedder/display_dpr_stream.dart';
 export 'engine/view_embedder/dom_manager.dart';
 export 'engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart';
 export 'engine/view_embedder/embedding_strategy/embedding_strategy.dart';

--- a/lib/web_ui/lib/src/engine/html/scene.dart
+++ b/lib/web_ui/lib/src/engine/html/scene.dart
@@ -45,7 +45,13 @@ class PersistedScene extends PersistedContainerSurface {
 
   @override
   void recomputeTransformAndClip() {
-    // The scene clip is the size of the entire window (Logical pixels).
+    // The scene clip is the size of the entire window **in Logical pixels**.
+    //
+    // Even though the majority of the engine uses `physicalSize`, there are some
+    // bits (like the HTML renderer, or dynamic view sizing) that are implemented
+    // using CSS, and CSS operates in logical pixels.
+    //
+    // See also: [EngineFlutterView.resize].
     final ui.Size bounds = window.physicalSize / window.devicePixelRatio;
     localClipBounds = ui.Rect.fromLTRB(0, 0, bounds.width, bounds.height);
     projectedClip = null;

--- a/lib/web_ui/lib/src/engine/html/scene.dart
+++ b/lib/web_ui/lib/src/engine/html/scene.dart
@@ -45,9 +45,9 @@ class PersistedScene extends PersistedContainerSurface {
 
   @override
   void recomputeTransformAndClip() {
-    // The scene clip is the size of the entire window.
-    final ui.Size screen = window.physicalSize;
-    localClipBounds = ui.Rect.fromLTRB(0, 0, screen.width, screen.height);
+    // The scene clip is the size of the entire window (Logical pixels).
+    final ui.Size bounds = window.physicalSize / window.devicePixelRatio;
+    localClipBounds = ui.Rect.fromLTRB(0, 0, bounds.width, bounds.height);
     projectedClip = null;
   }
 

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider.dart
@@ -6,13 +6,16 @@ import 'dart:async';
 
 import 'package:ui/src/engine/display.dart';
 import 'package:ui/src/engine/dom.dart';
-import 'package:ui/src/engine/view_embedder/display_dpr_stream.dart';
 import 'package:ui/src/engine/window.dart';
 import 'package:ui/ui.dart' as ui show Size;
 
 import 'dimensions_provider.dart';
 
 /// This class provides observable, real-time dimensions of a host element.
+///
+/// This class needs a `Stream` of `devicePixelRatio` changes, like the one
+/// provided by [DisplayDprStream], because html resize observers do not report
+/// DPR changes.
 ///
 /// All the measurements returned from this class are potentially *expensive*,
 /// and should be cached as needed. Every call to every method on this class
@@ -24,9 +27,11 @@ import 'dimensions_provider.dart';
 /// to be effective.
 class CustomElementDimensionsProvider extends DimensionsProvider {
   /// Creates a [CustomElementDimensionsProvider] from a [_hostElement].
-  CustomElementDimensionsProvider(this._hostElement) {
+  CustomElementDimensionsProvider(this._hostElement, {
+    Stream<double>? onDprChange,
+  }) {
     // Send a resize event when the page DPR changes.
-    _dprChangeStreamSubscription = DisplayDprStream.instance.dprChanged.listen((_) {
+    _dprChangeStreamSubscription = onDprChange?.listen((_) {
       _broadcastSize(null);
     });
 

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
@@ -5,11 +5,10 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:ui/src/engine/dom.dart';
 import 'package:ui/src/engine/window.dart';
 import 'package:ui/ui.dart' as ui show Size;
 
-import '../../display.dart';
-import '../../dom.dart';
 import 'custom_element_dimensions_provider.dart';
 import 'full_page_dimensions_provider.dart';
 
@@ -36,12 +35,6 @@ abstract class DimensionsProvider {
     } else {
       return FullPageDimensionsProvider();
     }
-  }
-
-  /// Returns the DPI reported by the browser.
-  double getDevicePixelRatio() {
-    // This is overridable in tests.
-    return EngineFlutterDisplay.instance.devicePixelRatio;
   }
 
   /// Returns the [ui.Size] of the "viewport".

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 import 'package:ui/src/engine/dom.dart';
+import 'package:ui/src/engine/view_embedder/display_dpr_stream.dart';
 import 'package:ui/src/engine/window.dart';
 import 'package:ui/ui.dart' as ui show Size;
 
@@ -31,7 +32,10 @@ abstract class DimensionsProvider {
   /// Creates the appropriate DimensionsProvider depending on the incoming [hostElement].
   factory DimensionsProvider.create({DomElement? hostElement}) {
     if (hostElement != null) {
-      return CustomElementDimensionsProvider(hostElement);
+      return CustomElementDimensionsProvider(
+        hostElement,
+        onDprChange: DisplayDprStream.instance.dprChanged,
+      );
     } else {
       return FullPageDimensionsProvider();
     }

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/dimensions_provider.dart
@@ -50,6 +50,16 @@ abstract class DimensionsProvider {
   );
 
   /// Returns a Stream with the changes to [ui.Size] (when cheap to get).
+  ///
+  /// Currently this Stream always returns `null` measurements because the
+  /// resize event that we use for [FullPageDimensionsProvider] does not contain
+  /// the new size, so users of this Stream everywhere immediately retrieve the
+  /// new `physicalSize` from the window.
+  ///
+  /// The [CustomElementDimensionsProvider] *could* broadcast the new size, but
+  /// to keep both implementations consistent (and their consumers), for now all
+  /// events from this Stream are going to be `null` (until we find a performant
+  /// way to retrieve the dimensions in full-page mode).
   Stream<ui.Size?> get onResize;
 
   /// Whether the [DimensionsProvider] instance has been closed or not.

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:ui/src/engine/browser_detection.dart';
+import 'package:ui/src/engine/display.dart';
 import 'package:ui/src/engine/dom.dart';
 import 'package:ui/src/engine/window.dart';
 import 'package:ui/ui.dart' as ui show Size;
@@ -67,7 +68,7 @@ class FullPageDimensionsProvider extends DimensionsProvider {
     late double windowInnerWidth;
     late double windowInnerHeight;
     final DomVisualViewport? viewport = domWindow.visualViewport;
-    final double devicePixelRatio = getDevicePixelRatio();
+    final double devicePixelRatio = EngineFlutterDisplay.instance.devicePixelRatio;
 
     if (viewport != null) {
       if (operatingSystem == OperatingSystem.iOs) {
@@ -102,7 +103,7 @@ class FullPageDimensionsProvider extends DimensionsProvider {
     double physicalHeight,
     bool isEditingOnMobile,
   ) {
-    final double devicePixelRatio = getDevicePixelRatio();
+    final double devicePixelRatio = EngineFlutterDisplay.instance.devicePixelRatio;
     final DomVisualViewport? viewport = domWindow.visualViewport;
     late double windowInnerHeight;
 

--- a/lib/web_ui/lib/src/engine/view_embedder/display_dpr_stream.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/display_dpr_stream.dart
@@ -1,0 +1,55 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:ui/src/engine/display.dart';
+import 'package:ui/src/engine/dom.dart';
+import 'package:ui/ui.dart' as ui show Display;
+
+/// Determines if high contrast is enabled using media query 'forced-colors: active' for Windows
+class DisplayDprStream {
+  DisplayDprStream(ui.Display display) : _currentDpr = display.devicePixelRatio {
+    // Start listening to DPR changes.
+    _subscribeToMediaQuery();
+  }
+
+  /// A singleton instance of DisplayDprObserver.
+  static DisplayDprStream instance = DisplayDprStream(EngineFlutterDisplay.instance);
+
+  // Last reported value of DPR.
+  double _currentDpr;
+
+  // Controls the [dprChanged] Stream.
+  final StreamController<double> _dprStreamController = StreamController<double>.broadcast();
+
+  // Listens for the `_currentDpr` to change.
+  late DomMediaQueryList _dprMediaQuery;
+
+  // Creates the media query for the latest known DPR value, and adds a change listener to it.
+  void _subscribeToMediaQuery() {
+    _dprMediaQuery = domWindow.matchMedia('(resolution: ${_currentDpr}dppx)');
+    _dprMediaQuery.addEventListenerWithOptions(
+      'change',
+      createDomEventListener(_onDprMediaQueryChange),
+      <String, Object>{
+        'once': true,
+        'passive': true,
+      });
+  }
+
+  // Handler of the 'change' event.
+  //
+  // This calls subscribe again because events are listened to with `once: true`.
+  JSVoid _onDprMediaQueryChange(DomEvent _) {
+    _currentDpr = EngineFlutterDisplay.instance.devicePixelRatio;
+    _dprStreamController.add(_currentDpr);
+    // Re-subscribe...
+    _subscribeToMediaQuery();
+  }
+
+  /// A stream that emits the latest value of [EngineFlutterDisplay.instance.devicePixelRatio].
+  Stream<double> get dprChanged => _dprStreamController.stream;
+}

--- a/lib/web_ui/lib/src/engine/view_embedder/display_dpr_stream.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/display_dpr_stream.dart
@@ -9,14 +9,20 @@ import 'package:ui/src/engine/display.dart';
 import 'package:ui/src/engine/dom.dart';
 import 'package:ui/ui.dart' as ui show Display;
 
-/// Determines if high contrast is enabled using media query 'forced-colors: active' for Windows
+/// Provides a stream of `devicePixelRatio` changes for the given display.
+///
+/// Note that until the Window Management API is generally available, this class
+/// only monitors the global `devicePixelRatio` property, provided by the default
+/// [EngineFlutterDisplay.instance].
+///
+/// See: https://developer.mozilla.org/en-US/docs/Web/API/Window_Management_API
 class DisplayDprStream {
-  DisplayDprStream(ui.Display display) : _display = display, _currentDpr = display.devicePixelRatio {
+  DisplayDprStream(this._display) : _currentDpr = _display.devicePixelRatio {
     // Start listening to DPR changes.
     _subscribeToMediaQuery();
   }
 
-  /// A singleton instance of DisplayDprObserver.
+  /// A singleton instance of DisplayDprStream.
   static DisplayDprStream instance = DisplayDprStream(EngineFlutterDisplay.instance);
 
   // The display object that will provide the DPR information.
@@ -25,10 +31,10 @@ class DisplayDprStream {
   // Last reported value of DPR.
   double _currentDpr;
 
-  // Controls the [dprChanged] Stream.
+  // Controls the [dprChanged] broadcast Stream.
   final StreamController<double> _dprStreamController = StreamController<double>.broadcast();
 
-  // Listens for the `_currentDpr` to change.
+  // Provides a `change` event for the `_currentDpr`.
   late DomMediaQueryList _dprMediaQuery;
 
   // Creates the media query for the latest known DPR value, and adds a change listener to it.

--- a/lib/web_ui/test/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('browser')
-library;
-
 import 'dart:async';
 
 import 'package:test/bootstrap/browser.dart';

--- a/lib/web_ui/test/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/dimensions_provider/custom_element_dimensions_provider_test.dart
@@ -109,23 +109,28 @@ void doTests() {
     });
 
     test('funnels resize events on sizeSource', () async {
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(2.7);
+
       sizeSource
         ..style.width = '100px'
         ..style.height = '100px';
 
-      expect(await provider.onResize.first, const ui.Size(100, 100));
+      expect(provider.onResize.first, completes);
+      expect(provider.computePhysicalSize(), const ui.Size(270, 270));
 
       sizeSource
         ..style.width = '200px'
         ..style.height = '200px';
 
-      expect(await provider.onResize.first, const ui.Size(200, 200));
+      expect(provider.onResize.first, completes);
+      expect(provider.computePhysicalSize(), const ui.Size(540, 540));
 
       sizeSource
         ..style.width = '300px'
         ..style.height = '300px';
 
-      expect(await provider.onResize.first, const ui.Size(300, 300));
+      expect(provider.onResize.first, completes);
+      expect(provider.computePhysicalSize(), const ui.Size(810, 810));
     });
 
     test('funnels DPR change events too', () async {
@@ -140,14 +145,15 @@ void doTests() {
       final CustomElementDimensionsProvider provider = CustomElementDimensionsProvider(sizeSource);
 
       // The size that will be emitted by the provider eventually
-      final Future<ui.Size> newSize = provider.onResize.first;
+      final Future<ui.Size?> newSize = provider.onResize.first;
 
       // Set the mock DPR value
       EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(3.2);
       // Simulate the mediaQuery change event from the browser
       eventTarget.dispatchEvent(createDomEvent('Event', 'change'));
 
-      expect(await newSize, const ui.Size(10, 10) * 3.2);
+      expect(newSize, completes);
+      expect(provider.computePhysicalSize(), const ui.Size(32, 32));
     });
 
     test('closed by onHotRestart', () async {

--- a/lib/web_ui/test/engine/view_embedder/dimensions_provider/dimensions_provider_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/dimensions_provider/dimensions_provider_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('browser')
-library;
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';

--- a/lib/web_ui/test/engine/view_embedder/dimensions_provider/dimensions_provider_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/dimensions_provider/dimensions_provider_test.dart
@@ -31,15 +31,4 @@ void doTests() {
       expect(provider, isA<CustomElementDimensionsProvider>());
     });
   });
-
-  group('getDevicePixelRatio', () {
-    test('Returns the correct pixelRatio', () async {
-      // Override the DPI to something known, but weird...
-      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(33930);
-
-      final DimensionsProvider provider = DimensionsProvider.create();
-
-      expect(provider.getDevicePixelRatio(), 33930);
-    });
-  });
 }

--- a/lib/web_ui/test/engine/view_embedder/dimensions_provider/full_page_dimensions_provider_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/dimensions_provider/full_page_dimensions_provider_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('browser')
-library;
-
 import 'dart:async';
 
 import 'package:test/bootstrap/browser.dart';

--- a/lib/web_ui/test/engine/view_embedder/display_dpr_stream_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/display_dpr_stream_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('browser')
-library;
-
 import 'dart:async';
 
 import 'package:test/bootstrap/browser.dart';

--- a/lib/web_ui/test/engine/view_embedder/display_dpr_stream_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/display_dpr_stream_test.dart
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:async';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => doTests);
+}
+
+void doTests() {
+  final DomEventTarget eventTarget = createDomElement('div');
+
+  group('dprChanged Stream', () {
+    late DisplayDprStream dprStream;
+
+    setUp(() async {
+      dprStream = DisplayDprStream(EngineFlutterDisplay.instance,
+          overrides: DebugDisplayDprStreamOverrides(
+            getMediaQuery: (_) => eventTarget,
+          ));
+    });
+
+    test('funnels display DPR on every mediaQuery "change" event.', () async {
+      final Future<List<double>> dprs = dprStream.dprChanged
+          .take(3)
+          .timeout(const Duration(seconds: 1))
+          .toList();
+
+      // Simulate the events
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(6.9);
+      eventTarget.dispatchEvent(createDomEvent('Event', 'change'));
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(4.2);
+      eventTarget.dispatchEvent(createDomEvent('Event', 'change'));
+      EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(0.71);
+      eventTarget.dispatchEvent(createDomEvent('Event', 'change'));
+
+      expect(await dprs, <double>[6.9, 4.2, 0.71]);
+    });
+  });
+}


### PR DESCRIPTION
The Scene of the HTML renderer is passing incorrect size information to the engine, and when DPR<1, it can result in elements being culled off of the viewport.

In addition to that, when an app is embedded, not all changes in DPR cause a Resize event (only those some of the dimensions fails by a rounding error!), so this PR ensures that all DPR events in embedded trigger a resize event.

### Issues

Fixes https://github.com/flutter/flutter/issues/129182

### Testing

Looking good at: https://dit-astral-test.web.app


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
