### PR TITLE
Remove the skia_fontmgr_factory argument from the Web GN configuration

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -792,8 +792,6 @@ def to_gn_wasm_args(args, gn_args):
   gn_args['skia_enable_fontmgr_custom_directory'] = False
   gn_args['skia_enable_fontmgr_custom_embedded'] = True
   gn_args['skia_enable_fontmgr_custom_empty'] = True
-  gn_args['skia_fontmgr_factory'
-         ] = '//flutter/skia:fontmgr_custom_empty_factory'
   gn_args['skia_enable_skshaper'] = True
   gn_args['skia_enable_skparagraph'] = True
   gn_args['skia_canvaskit_force_tracing'] = False


### PR DESCRIPTION
This was removed in Skia (see https://skia.googlesource.com/skia/+/38e85e85079f4140158a8f83c7bbceb7a1ac5ca5)