### PR TITLE
Remove string field from FlKeyEvent

### DIFF
--- a/shell/platform/linux/fl_key_channel_responder_test.cc
+++ b/shell/platform/linux/fl_key_channel_responder_test.cc
@@ -46,16 +46,11 @@ static FlKeyEvent* fl_key_event_new_by_mock(guint32 time_in_milliseconds,
                                             guint keyval,
                                             guint16 keycode,
                                             int state,
-                                            const char* string,
                                             gboolean is_modifier) {
-  if (_g_key_event.string != nullptr) {
-    g_free(const_cast<char*>(_g_key_event.string));
-  }
   _g_key_event.is_press = is_press;
   _g_key_event.time = time_in_milliseconds;
   _g_key_event.state = state;
   _g_key_event.keyval = keyval;
-  _g_key_event.string = g_strdup(string);
   _g_key_event.keycode = keycode;
   _g_key_event.origin = nullptr;
   _g_key_event.dispose_origin = nullptr;
@@ -77,7 +72,7 @@ TEST(FlKeyChannelResponderTest, SendKeyEvent) {
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04, 0x0, "A", false),
+      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04, 0x0, false),
       responder_callback, loop);
   expected_value =
       "{type: keydown, keymap: linux, scanCode: 4, toolkit: gtk, keyCode: 65, "
@@ -89,7 +84,7 @@ TEST(FlKeyChannelResponderTest, SendKeyEvent) {
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(23456, false, GDK_KEY_A, 0x04, 0x0, "A", false),
+      fl_key_event_new_by_mock(23456, false, GDK_KEY_A, 0x04, 0x0, false),
       responder_callback, loop);
   expected_value =
       "{type: keyup, keymap: linux, scanCode: 4, toolkit: gtk, keyCode: 65, "
@@ -116,8 +111,7 @@ void test_lock_event(guint key_code,
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12345, true, key_code, 0x04, 0x0, nullptr,
-                               false),
+      fl_key_event_new_by_mock(12345, true, key_code, 0x04, 0x0, false),
       responder_callback, loop);
   expected_value = down_expected;
   expected_handled = FALSE;
@@ -129,8 +123,7 @@ void test_lock_event(guint key_code,
   expected_handled = FALSE;
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12346, false, key_code, 0x04, 0x0, nullptr,
-                               false),
+      fl_key_event_new_by_mock(12346, false, key_code, 0x04, 0x0, false),
       responder_callback, loop);
 
   // Blocks here until echo_response_cb is called.
@@ -178,8 +171,7 @@ TEST(FlKeyChannelResponderTest, TestKeyEventHandledByFramework) {
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04, 0x0, nullptr,
-                               false),
+      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04, 0x0, false),
       responder_callback, loop);
   expected_handled = TRUE;
   expected_value =
@@ -204,8 +196,7 @@ TEST(FlKeyChannelResponderTest, UseSpecifiedLogicalKey) {
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04, 0x0, nullptr,
-                               false),
+      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04, 0x0, false),
       responder_callback, loop, 888);
   expected_handled = TRUE;
   expected_value =

--- a/shell/platform/linux/fl_key_embedder_responder_test.cc
+++ b/shell/platform/linux/fl_key_embedder_responder_test.cc
@@ -122,7 +122,6 @@ static FlKeyEvent* fl_key_event_new_by_mock(guint32 time_in_milliseconds,
   _g_key_event.time = time_in_milliseconds;
   _g_key_event.state = state;
   _g_key_event.keyval = keyval;
-  _g_key_event.string = nullptr;
   _g_key_event.keycode = keycode;
   _g_key_event.origin = nullptr;
   _g_key_event.dispose_origin = nullptr;

--- a/shell/platform/linux/fl_key_event.cc
+++ b/shell/platform/linux/fl_key_event.cc
@@ -28,7 +28,6 @@ FlKeyEvent* fl_key_event_new_from_gdk_event(GdkEvent* event) {
   result->keycode = keycode;
   result->keyval = keyval;
   result->state = state;
-  result->string = g_strdup(event->key.string);
   result->group = event->key.group;
   result->origin = event;
   result->dispose_origin = dispose_origin_from_gdk_event;
@@ -37,9 +36,6 @@ FlKeyEvent* fl_key_event_new_from_gdk_event(GdkEvent* event) {
 }
 
 void fl_key_event_dispose(FlKeyEvent* event) {
-  if (event->string != nullptr) {
-    g_free(const_cast<char*>(event->string));
-  }
   if (event->dispose_origin != nullptr) {
     event->dispose_origin(event->origin);
   }
@@ -49,6 +45,5 @@ void fl_key_event_dispose(FlKeyEvent* event) {
 FlKeyEvent* fl_key_event_clone(const FlKeyEvent* event) {
   FlKeyEvent* new_event = g_new(FlKeyEvent, 1);
   *new_event = *event;
-  new_event->string = g_strdup(event->string);
   return new_event;
 }

--- a/shell/platform/linux/fl_key_event.h
+++ b/shell/platform/linux/fl_key_event.h
@@ -41,10 +41,6 @@ typedef struct _FlKeyEvent {
   int state;
   // Keyboard group.
   guint8 group;
-  // String, null-terminated.
-  //
-  // Can be nullptr.
-  const char* string;
   // An opaque pointer to the original event.
   //
   // This is used when dispatching.  For native events, this is #GdkEvent

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -448,7 +448,6 @@ static FlKeyEvent* fl_key_event_new_by_mock(bool is_press,
   event->time = 0;
   event->state = state;
   event->keyval = keyval;
-  event->string = nullptr;
   event->group = group;
   event->keycode = keycode;
   FlKeyEvent* origin_event = fl_key_event_clone_information_only(event);


### PR DESCRIPTION
This field is deprecated in GTK3 [1] and not used in Flutter. It does not exist in GTK4.

[1] https://docs.gtk.org/gdk3/struct.EventKey.html
