### PR TITLE
Report display sizes in physical pixels on MacOS

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -834,13 +834,14 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
     CGDirectDisplayID displayID =
         static_cast<CGDirectDisplayID>([screen.deviceDescription[@"NSScreenNumber"] integerValue]);
 
+    double devicePixelRatio = screen.backingScaleFactor;
     FlutterEngineDisplay display;
     display.struct_size = sizeof(display);
     display.display_id = displayID;
     display.single_display = false;
-    display.width = static_cast<size_t>(screen.frame.size.width);
-    display.height = static_cast<size_t>(screen.frame.size.height);
-    display.device_pixel_ratio = screen.backingScaleFactor;
+    display.width = static_cast<size_t>(screen.frame.size.width) * devicePixelRatio;
+    display.height = static_cast<size_t>(screen.frame.size.height) * devicePixelRatio;
+    display.device_pixel_ratio = devicePixelRatio;
 
     CVDisplayLinkRef displayLinkRef = nil;
     CVReturn error = CVDisplayLinkCreateWithCGDisplay(displayID, &displayLinkRef);

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -824,13 +824,17 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
   [self updateDisplayConfig];
 }
 
+- (NSArray<NSScreen*>*)screens {
+  return [NSScreen screens];
+}
+
 - (void)updateDisplayConfig {
   if (!_engine) {
     return;
   }
 
   std::vector<FlutterEngineDisplay> displays;
-  for (NSScreen* screen : [NSScreen screens]) {
+  for (NSScreen* screen : [self screens]) {
     CGDirectDisplayID displayID =
         static_cast<CGDirectDisplayID>([screen.deviceDescription[@"NSScreenNumber"] integerValue]);
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -1189,6 +1189,8 @@ TEST_F(FlutterEngineTest, DisplaySizeIsInPhysicalPixel) {
       }));
   EXPECT_TRUE([engine runWithEntrypoint:@"main"]);
   EXPECT_TRUE(updated);
+  [engine shutDownEngine];
+  engine = nil;
 }
 
 }  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -219,11 +219,6 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
  * Returns an array of screen objects representing all of the screens available on the system.
  */
 - (NSArray<NSScreen*>*)screens;
-
-/**
- * Reads information about the available displays from the platform.
- */
-- (void)updateDisplayConfig;
 @end
 
 @interface FlutterEngine (Tests)

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -215,6 +215,15 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
 - (void)announceAccessibilityMessage:(NSString*)message
                         withPriority:(NSAccessibilityPriorityLevel)priority;
 
+/**
+ * Returns an array of screen objects representing all of the screens available on the system.
+ */
+- (NSArray<NSScreen*>*)screens;
+
+/**
+ * Reads information about the available displays from the platform.
+ */
+- (void)updateDisplayConfig;
 @end
 
 @interface FlutterEngine (Tests)


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/142629

`Display.size`'s [documentation](https://main-api.flutter.dev/flutter/dart-ui/Display/size.html) says (emphasize mine):

> The **physical** size of this display.

But we have actually been reporting the size in logical pixels - up until now!