### PR TITLE
Ignore CRLF endings when determining the names of header guards.

### DIFF
--- a/tools/header_guard_check/test/header_file_test.dart
+++ b/tools/header_guard_check/test/header_file_test.dart
@@ -326,6 +326,24 @@ Future<int> main(List<String> args) async {
         expect(headerFile.fix(engineRoot: p.dirname(file.path)), isFalse);
       });
     });
+
+    test('is OK with windows-style CRLF file with a valid header guard', () {
+      final String input = <String>[
+        '#ifndef FLUTTER_FOO_H_',
+        '#define FLUTTER_FOO_H_',
+        '',
+        '// ...',
+        '',
+        '#endif  // FLUTTER_FOO_H_',
+      ].join('\r\n');
+      withTestFile('foo.h', input, (io.File file) {
+        final HeaderFile headerFile = HeaderFile.parse(file.path);
+        expect(headerFile.pragmaOnce, isNull);
+        expect(headerFile.guard!.ifndefValue, 'FLUTTER_FOO_H_');
+        expect(headerFile.guard!.defineValue, 'FLUTTER_FOO_H_');
+        expect(headerFile.guard!.endifValue, 'FLUTTER_FOO_H_');
+      });
+    });
   });
 
   return 0;


### PR DESCRIPTION
Reported by @loic-sharma.

The tl;dr is it should be OK to have `\r\n` (CRLF) endings if the header guard is otherwise correct.

This minor refactor (and test) discounts the existence of `\r` when determining the name of a header guard, i.e.:
```h
#ifndef FLUTTER_MATAN_WHY_H_
```

... is now (correctly) considered a value of `FLUTTER_MATAN_WHY_H_` not `FLUTTER_MATAN_WHY_H_\r`.