### PR TITLE
[Impeller] Clear the GPUTracerVK in_frame flag when ending a frame even if the tracer is disabled

### DIFF
--- a/impeller/renderer/backend/vulkan/gpu_tracer_vk.cc
+++ b/impeller/renderer/backend/vulkan/gpu_tracer_vk.cc
@@ -82,6 +82,8 @@ void GPUTracerVK::MarkFrameStart() {
 }
 
 void GPUTracerVK::MarkFrameEnd() {
+  in_frame_ = false;
+
   if (!enabled_) {
     return;
   }
@@ -98,7 +100,6 @@ void GPUTracerVK::MarkFrameEnd() {
   FML_DCHECK(state.pending_buffers == 0u);
   state.pending_buffers = 0;
   state.current_index = 0;
-  in_frame_ = false;
 }
 
 std::unique_ptr<GPUProbe> GPUTracerVK::CreateGPUProbe() {

--- a/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
+++ b/impeller/renderer/backend/vulkan/test/gpu_tracer_unittests.cc
@@ -27,6 +27,22 @@ TEST(GPUTracerVK, CanBeDisabled) {
   ASSERT_FALSE(tracer->IsEnabled());
 }
 
+TEST(GPUTracerVK, DisabledFrameCycle) {
+  auto const context =
+      MockVulkanContextBuilder()
+          .SetSettingsCallback([](ContextVK::Settings& settings) {
+            settings.enable_gpu_tracing = false;
+          })
+          .Build();
+  auto tracer = context->GetGPUTracer();
+
+  // Check that a repeated frame start/end cycle does not fail any assertions.
+  for (int i = 0; i < 2; i++) {
+    tracer->MarkFrameStart();
+    tracer->MarkFrameEnd();
+  }
+}
+
 TEST(GPUTracerVK, CanTraceCmdBuffer) {
   auto const context =
       MockVulkanContextBuilder()


### PR DESCRIPTION
Without this an assertion in GPUTracerVK::MarkFrameStart will fail on the next frame.