### PR TITLE
[Impeller] Replace stencil pipeline ops with enum.

### DIFF
--- a/impeller/entity/contents/checkerboard_contents.cc
+++ b/impeller/entity/contents/checkerboard_contents.cc
@@ -25,8 +25,7 @@ bool CheckerboardContents::Render(const ContentContext& renderer,
 
   auto options = OptionsFromPass(pass);
   options.blend_mode = BlendMode::kSourceOver;
-  options.stencil_compare = CompareFunction::kAlways;  // Ignore all clips.
-  options.stencil_operation = StencilOperation::kKeep;
+  options.stencil_mode = ContentContextOptions::StencilMode::kIgnore;
   options.primitive_type = PrimitiveType::kTriangleStrip;
 
   VertexBufferBuilder<typename VS::PerVertexData> vtx_builder;

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -89,8 +89,8 @@ bool ClipContents::Render(const ContentContext& renderer,
     {
       pass.SetCommandLabel("Difference Clip (Increment)");
 
-      options.stencil_compare = CompareFunction::kEqual;
-      options.stencil_operation = StencilOperation::kIncrementClamp;
+      options.stencil_mode =
+          ContentContextOptions::StencilMode::kLegacyClipIncrement;
 
       auto points = Rect::MakeSize(pass.GetRenderTargetSize()).GetPoints();
       auto vertices =
@@ -113,14 +113,14 @@ bool ClipContents::Render(const ContentContext& renderer,
       pass.SetCommandLabel("Difference Clip (Punch)");
       pass.SetStencilReference(entity.GetClipDepth() + 1);
 
-      options.stencil_compare = CompareFunction::kEqual;
-      options.stencil_operation = StencilOperation::kDecrementClamp;
+      options.stencil_mode =
+          ContentContextOptions::StencilMode::kLegacyClipDecrement;
     }
   } else {
     pass.SetCommandLabel("Intersect Clip");
 
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
 
   auto geometry_result = geometry_->GetPositionBuffer(renderer, entity, pass);
@@ -179,8 +179,7 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
   pass.SetCommandLabel("Restore Clip");
   auto options = OptionsFromPass(pass);
   options.blend_mode = BlendMode::kDestination;
-  options.stencil_compare = CompareFunction::kLess;
-  options.stencil_operation = StencilOperation::kSetToReferenceValue;
+  options.stencil_mode = ContentContextOptions::StencilMode::kLegacyClipRestore;
   options.primitive_type = PrimitiveType::kTriangleStrip;
   pass.SetPipeline(renderer.GetClipPipeline(options));
   pass.SetStencilReference(entity.GetClipDepth());

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -95,8 +95,8 @@ bool ConicalGradientContents::RenderSSBO(const ContentContext& renderer,
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
 
@@ -165,8 +165,8 @@ bool ConicalGradientContents::RenderTexture(const ContentContext& renderer,
 
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
   pass.SetPipeline(renderer.GetConicalGradientFillPipeline(options));

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -96,8 +96,8 @@ bool LinearGradientContents::RenderTexture(const ContentContext& renderer,
 
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
 
@@ -159,8 +159,8 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
 

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -94,8 +94,8 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
 
@@ -154,8 +154,8 @@ bool RadialGradientContents::RenderTexture(const ContentContext& renderer,
 
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
 

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -89,8 +89,8 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
       GetGeometry()->GetPositionBuffer(renderer, entity, pass);
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
 

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -57,8 +57,8 @@ bool SolidColorContents::Render(const ContentContext& renderer,
 
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
 
   options.primitive_type = geometry_result.type;

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -102,8 +102,8 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
 
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
 
@@ -163,8 +163,8 @@ bool SweepGradientContents::RenderTexture(const ContentContext& renderer,
 
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
 

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -158,7 +158,7 @@ bool TextureContents::Render(const ContentContext& renderer,
 
   auto pipeline_options = OptionsFromPassAndEntity(pass, entity);
   if (!stencil_enabled_) {
-    pipeline_options.stencil_compare = CompareFunction::kAlways;
+    pipeline_options.stencil_mode = ContentContextOptions::StencilMode::kIgnore;
   }
   pipeline_options.primitive_type = PrimitiveType::kTriangleStrip;
 

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -153,8 +153,8 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
 
   auto options = OptionsFromPassAndEntity(pass, entity);
   if (geometry_result.prevent_overdraw) {
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
   }
   options.primitive_type = geometry_result.type;
 

--- a/impeller/renderer/compute_subgroup_unittests.cc
+++ b/impeller/renderer/compute_subgroup_unittests.cc
@@ -143,8 +143,9 @@ TEST_P(ComputeSubgroupTest, PathPlayground) {
         pass.GetRenderTarget().GetStencilAttachment().has_value();
     options.blend_mode = BlendMode::kSourceIn;
     options.primitive_type = PrimitiveType::kTriangleStrip;
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
 
     pass.SetPipeline(renderer.GetSolidFillPipeline(options));
 
@@ -340,8 +341,9 @@ TEST_P(ComputeSubgroupTest, LargePath) {
         pass.GetRenderTarget().GetStencilAttachment().has_value();
     options.blend_mode = BlendMode::kSourceIn;
     options.primitive_type = PrimitiveType::kTriangleStrip;
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
 
     pass.SetPipeline(renderer.GetSolidFillPipeline(options));
 
@@ -418,8 +420,9 @@ TEST_P(ComputeSubgroupTest, QuadAndCubicInOnePath) {
         pass.GetRenderTarget().GetStencilAttachment().has_value();
     options.blend_mode = BlendMode::kSourceIn;
     options.primitive_type = PrimitiveType::kTriangleStrip;
-    options.stencil_compare = CompareFunction::kEqual;
-    options.stencil_operation = StencilOperation::kIncrementClamp;
+
+    options.stencil_mode =
+        ContentContextOptions::StencilMode::kLegacyClipIncrement;
 
     pass.SetPipeline(renderer.GetSolidFillPipeline(options));
 


### PR DESCRIPTION
Depends on https://github.com/flutter/engine/pull/49828.

No semantic change.

Also adds/documents stencil configurations that are needed for StC. Operations for the current stencil stack are labeled as "legacy".