### PR TITLE
[Impeller] Remove unused define.

### DIFF
--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -123,8 +123,4 @@ impeller_component("vulkan") {
     "//third_party/vulkan-deps/vulkan-headers/src:vulkan_headers",
     "//third_party/vulkan_memory_allocator",
   ]
-
-  if (impeller_enable_vulkan_validation_layers) {
-    defines = [ "IMPELLER_ENABLE_VULKAN_VALIDATION_LAYERS" ]
-  }
 }


### PR DESCRIPTION
This define isn't used in a C++ TU. Only the build scripts (in `//flutter/shell/platform/android/BUILD.gn`) use the flag to decide whether to package the validation layers.

Remove the define that no one uses.
