### PR TITLE
[Impeller] Delete unnecessary special casing for Vulkan in framebuffer fetch.

### DIFF
--- a/impeller/entity/shaders/blending/framebuffer_blend.frag
+++ b/impeller/entity/shaders/blending/framebuffer_blend.frag
@@ -16,25 +16,13 @@
 layout(constant_id = 0) const float blend_type = 0;
 layout(constant_id = 1) const float supports_decal = 1;
 
-#ifdef IMPELLER_TARGET_VULKAN
-layout(set = 0,
-       binding = 0,
-       input_attachment_index = 0) uniform subpassInputMS uSub;
+layout(input_attachment_index = 0) uniform subpassInputMS uSub;
 
 vec4 ReadDestination() {
   return (subpassLoad(uSub, 0) + subpassLoad(uSub, 1) + subpassLoad(uSub, 2) +
           subpassLoad(uSub, 3)) /
          vec4(4.0);
 }
-#else
-layout(set = 0,
-       binding = 0,
-       input_attachment_index = 0) uniform subpassInput uSub;
-
-vec4 ReadDestination() {
-  return subpassLoad(uSub);
-}
-#endif  // IMPELLER_TARGET_VULKAN
 
 uniform sampler2D texture_sampler_src;
 


### PR DESCRIPTION
The code generated is functionally identical (http://tinyurl.com/yov6m8ac).