### PR TITLE
Get bounds from RTree in DLBuilder::Build()

### DIFF
--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -76,6 +76,9 @@ sk_sp<DisplayList> DisplayListBuilder::Build() {
   bool is_safe = is_ui_thread_safe_;
   bool affects_transparency = current_layer_->affects_transparent_layer();
 
+  sk_sp<DlRTree> rtree = this->rtree();
+  SkRect bounds = rtree ? rtree->bounds() : this->bounds();
+
   used_ = allocated_ = render_op_count_ = op_index_ = 0;
   nested_bytes_ = nested_op_count_ = 0;
   is_ui_thread_safe_ = true;
@@ -86,8 +89,8 @@ sk_sp<DisplayList> DisplayListBuilder::Build() {
   current_ = DlPaint();
 
   return sk_sp<DisplayList>(new DisplayList(
-      std::move(storage_), bytes, count, nested_bytes, nested_count, bounds(),
-      compatible, is_safe, affects_transparency, rtree()));
+      std::move(storage_), bytes, count, nested_bytes, nested_count, bounds,
+      compatible, is_safe, affects_transparency, std::move(rtree)));
 }
 
 DisplayListBuilder::DisplayListBuilder(const SkRect& cull_rect,

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -277,7 +277,7 @@ struct SetRuntimeEffectColorSourceOp : DLOp {
 struct SetSceneColorSourceOp : DLOp {
   static const auto kType = DisplayListOpType::kSetSceneColorSource;
 
-  SetSceneColorSourceOp(const DlSceneColorSource* source)
+  explicit SetSceneColorSourceOp(const DlSceneColorSource* source)
       : source(source->scene_node(), source->camera_matrix()) {}
 
   const DlSceneColorSource source;


### PR DESCRIPTION
This optimization was discovered when reviewing the bounds accumulation code in DisplayListBuilder. There is trivially wasted work in the `Build()` method that can be easily avoided.

When a Builder is preparing an RTree, it accumulates a list of bounds for every rendering op, but doesn't union them up front. If you ask the Builder for the bounds of the accumulated ops, it will have to union all of the rectangles to produce an answer. But, if you ask the Builder to produce an RTree, that process will implicitly combine all of the rectangles as a side effect of creating the tree structure - and it has a bounds method that can return that result directly.

This change leverages the construction of the RTree to avoid having to union all of the rects twice which can only save time when constructing the majority of DisplayList objects used in a scene.