### PR TITLE
[Impeller] In advanced blends, unpremultiply and apply src_input_alpha only if there is no foreground color

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -138,6 +138,28 @@ TEST_P(AiksTest, CanRenderColorFilterWithInvertColorsDrawPaint) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }
 
+TEST_P(AiksTest, CanRenderAdvancedBlendColorFilterWithSaveLayer) {
+  Canvas canvas;
+
+  Rect layer_rect = Rect::MakeXYWH(0, 0, 500, 500);
+  canvas.ClipRect(layer_rect);
+
+  canvas.SaveLayer(
+      {
+          .color_filter = ColorFilter::MakeBlend(BlendMode::kDifference,
+                                                 Color(0, 1, 0, 0.5)),
+      },
+      layer_rect);
+
+  Paint paint;
+  canvas.DrawPaint({.color = Color::Black()});
+  canvas.DrawRect(Rect::MakeXYWH(100, 100, 300, 300),
+                  {.color = Color::White()});
+  canvas.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
+}
+
 namespace {
 bool GenerateMipmap(const std::shared_ptr<Context>& context,
                     std::shared_ptr<Texture> texture,

--- a/impeller/entity/shaders/blending/advanced_blend.frag
+++ b/impeller/entity/shaders/blending/advanced_blend.frag
@@ -41,13 +41,15 @@ void main() {
                                  v_dst_texture_coords  // texture coordinates
                                  ));
   dst *= blend_info.dst_input_alpha;
-  f16vec4 src = IPHalfUnpremultiply(
-      blend_info.color_factor > 0.0hf
-          ? blend_info.color
-          : Sample(texture_sampler_src,  // sampler
-                   v_src_texture_coords  // texture coordinates
-                   ));
-  src *= blend_info.src_input_alpha;
+  f16vec4 src = blend_info.color_factor > 0.0hf
+                    ? blend_info.color
+                    : IPHalfUnpremultiply(Sample(
+                          texture_sampler_src,  // sampler
+                          v_src_texture_coords  // texture coordinates
+                          ));
+  if (blend_info.color_factor == 0.0hf) {
+    src.a *= blend_info.src_input_alpha;
+  }
 
   f16vec3 blend_result = AdvancedBlend(dst.rgb, src.rgb, int(blend_type));
 

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -12,7 +12,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 0,
+          "fp16_arithmetic": 2,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -20,8 +20,8 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.625,
-              0.625,
+              0.578125,
+              0.578125,
               0.21875,
               0.125,
               0.0,
@@ -42,10 +42,10 @@
               "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.625,
-              0.625,
-              0.234375,
-              0.125,
+              0.53125,
+              0.53125,
+              0.203125,
+              0.0625,
               0.0,
               0.25,
               0.25
@@ -55,8 +55,8 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.625,
-              0.625,
+              0.578125,
+              0.578125,
               0.296875,
               0.125,
               0.0,
@@ -66,8 +66,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 10,
-          "work_registers_used": 24
+          "uniform_registers_used": 12,
+          "work_registers_used": 25
         }
       }
     }
@@ -1423,7 +1423,7 @@
       "uses_late_zs_update": false,
       "variants": {
         "Main": {
-          "fp16_arithmetic": 0,
+          "fp16_arithmetic": 2,
           "has_stack_spilling": false,
           "performance": {
             "longest_path_bound_pipelines": [
@@ -1431,8 +1431,8 @@
               "arith_fma"
             ],
             "longest_path_cycles": [
-              0.625,
-              0.625,
+              0.578125,
+              0.578125,
               0.265625,
               0.125,
               0.0,
@@ -1453,10 +1453,10 @@
               "arith_fma"
             ],
             "shortest_path_cycles": [
-              0.625,
-              0.625,
-              0.25,
-              0.125,
+              0.53125,
+              0.53125,
+              0.21875,
+              0.0625,
               0.0,
               0.25,
               0.25
@@ -1466,8 +1466,8 @@
               "arith_fma"
             ],
             "total_cycles": [
-              0.625,
-              0.625,
+              0.578125,
+              0.578125,
               0.34375,
               0.125,
               0.0,
@@ -1477,8 +1477,8 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
-          "work_registers_used": 22
+          "uniform_registers_used": 14,
+          "work_registers_used": 23
         }
       }
     },
@@ -1495,7 +1495,7 @@
               "arithmetic"
             ],
             "longest_path_cycles": [
-              3.630000114440918,
+              4.289999961853027,
               2.0,
               2.0
             ],
@@ -1516,7 +1516,7 @@
               "arithmetic"
             ],
             "total_cycles": [
-              4.0,
+              4.666666507720947,
               2.0,
               2.0
             ]

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -44,7 +44,7 @@ FONT_SUBSET_DIR = os.path.join(BUILDROOT_DIR, 'flutter', 'tools', 'font_subset')
 ENCODING = 'UTF-8'
 
 # This number must be updated when adding new golden tests to impeller.
-_NUM_EXPECTED_GENERATED_IMPELLER_GOLDEN_FILES = 551
+_NUM_EXPECTED_GENERATED_IMPELLER_GOLDEN_FILES = 554
 
 logger = logging.getLogger(__name__)
 logger_handler = logging.StreamHandler()


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/142620