### PR TITLE
[Impeller] new blur: clamp downsample scalar to 1/16

### DIFF
--- a/impeller/aiks/BUILD.gn
+++ b/impeller/aiks/BUILD.gn
@@ -98,7 +98,11 @@ template("aiks_unittests_component") {
     testonly = true
     if (defined(invoker.defines)) {
       defines = invoker.defines
+    } else {
+      defines = []
     }
+    defines += [ "_USE_MATH_DEFINES" ]
+
     sources = predefined_sources + additional_sources
     deps = [
       ":aiks",

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -209,7 +209,10 @@ Scalar GaussianBlurFilterContents::CalculateScale(Scalar sigma) {
   }
   Scalar result = 4.0 / sigma;
   // Round to the nearest 1/(2^n) to get the best quality down scaling.
-  Scalar rounded = pow(2.0f, round(log2(result)));
+  Scalar exponent = round(log2f(result));
+  // Don't scale down below 1/16th to preserve signal.
+  exponent = std::max(-4.0f, exponent);
+  Scalar rounded = powf(2.0f, exponent);
   return rounded;
 };
 
@@ -454,8 +457,8 @@ KernelPipeline::FragmentShader::KernelSamples GenerateBlurInfo(
   KernelPipeline::FragmentShader::KernelSamples result;
   result.sample_count =
       ((2 * parameters.blur_radius) / parameters.step_size) + 1;
-  // 32 comes from kernel.glsl.
-  FML_CHECK(result.sample_count < 32);
+  // 48 comes from kernel.glsl.
+  FML_CHECK(result.sample_count < 48);
 
   // Chop off the last samples if the radius >= 3 where they account for < 1.56%
   // of the result.

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -197,7 +197,8 @@ TEST(GaussianBlurFilterContentsTest, CalculateSigmaValues) {
   EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(3.0f), 1);
   EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(4.0f), 1);
   EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(16.0f), 0.25);
-  EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(1024.0f), 4.f / 1024.f);
+  // Downsample clamped to 1/16th.
+  EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(1024.0f), 0.0625);
 }
 
 TEST_P(GaussianBlurFilterContentsTest, RenderCoverageMatchesGetCoverage) {

--- a/impeller/entity/shaders/gaussian_blur/kernel.glsl
+++ b/impeller/entity/shaders/gaussian_blur/kernel.glsl
@@ -16,7 +16,7 @@ struct KernelSample {
 
 uniform KernelSamples {
   int sample_count;
-  KernelSample samples[32];
+  KernelSample samples[48];
 }
 blur_info;
 

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -76,6 +76,7 @@ static const std::vector<std::string> kSkipTests = {
     IMP_AIKSTEST(SceneColorSource),
     IMP_AIKSTEST(SolidStrokesRenderCorrectly),
     IMP_AIKSTEST(TextFrameSubpixelAlignment),
+    IMP_AIKSTEST(GaussianBlurAnimatedBackdrop),
     // TextRotated is flakey and we can't seem to get it to stabilize on Skia
     // Gold.
     IMP_AIKSTEST(TextRotated),


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/142753

The theory here is that once you start throwing away more than 15/16th of the signal it's pretty noticable.  By looking at the blur under different circumstances that seems like a reasonable limit.

There is no automated test for this.  Doing so would be quite involved and would involve evaluating multiple rendered frames.  There is a manual test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
