### PR TITLE
[Impeller] Allow playgrounds to use SwiftShader via a flag.

### DIFF
--- a/impeller/playground/BUILD.gn
+++ b/impeller/playground/BUILD.gn
@@ -15,6 +15,10 @@ impeller_component("playground") {
     "switches.h",
     "widgets.cc",
     "widgets.h",
+
+    # Swiftshader is Vulkan backend specific but the utilities are not.
+    "backend/vulkan/swiftshader_utilities.cc",
+    "backend/vulkan/swiftshader_utilities.h",
   ]
 
   deps = [ "../renderer/backend" ]

--- a/impeller/playground/backend/vulkan/swiftshader_utilities.cc
+++ b/impeller/playground/backend/vulkan/swiftshader_utilities.cc
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/impeller/playground/backend/vulkan/swiftshader_utilities.h"
+
+#include <cstdlib>
+
+#include "flutter/fml/file.h"
+#include "flutter/fml/logging.h"
+#include "flutter/fml/paths.h"
+
+namespace impeller {
+
+static void FindSwiftShaderICDAtKnownPaths() {
+  static constexpr const char* kSwiftShaderICDJSON = "vk_swiftshader_icd.json";
+  static constexpr const char* kVulkanICDFileNamesEnvVariableKey =
+      "VK_ICD_FILENAMES";
+  const auto executable_directory_path =
+      fml::paths::GetExecutableDirectoryPath();
+  FML_CHECK(executable_directory_path.first);
+  const auto executable_directory =
+      fml::OpenDirectory(executable_directory_path.second.c_str(), false,
+                         fml::FilePermission::kRead);
+  FML_CHECK(executable_directory.is_valid());
+  if (fml::FileExists(executable_directory, kSwiftShaderICDJSON)) {
+    const auto icd_path = fml::paths::JoinPaths(
+        {executable_directory_path.second, kSwiftShaderICDJSON});
+    auto result = setenv(kVulkanICDFileNamesEnvVariableKey,  //
+                         icd_path.c_str(),                   //
+                         1                                   // overwrite
+    );
+    FML_CHECK(result == 0)
+        << "Could not set the environment variable to use SwiftShader.";
+  } else {
+    FML_CHECK(false)
+        << "Was asked to use SwiftShader but could not find the installable "
+           "client driver (ICD) for the locally built SwiftShader.";
+  }
+}
+
+void SetupSwiftshaderOnce(bool use_swiftshader) {
+  static bool swiftshader_preference = false;
+  static std::once_flag sOnceInitializer;
+  std::call_once(sOnceInitializer, [use_swiftshader]() {
+    if (use_swiftshader) {
+      FindSwiftShaderICDAtKnownPaths();
+      swiftshader_preference = use_swiftshader;
+    }
+  });
+  FML_CHECK(swiftshader_preference == use_swiftshader)
+      << "The option to use SwiftShader in a process can only be set once and "
+         "may be changed later.";
+}
+
+}  // namespace impeller

--- a/impeller/playground/backend/vulkan/swiftshader_utilities.h
+++ b/impeller/playground/backend/vulkan/swiftshader_utilities.h
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_PLAYGROUND_BACKEND_VULKAN_SWIFTSHADER_UTILITIES_H_
+#define FLUTTER_IMPELLER_PLAYGROUND_BACKEND_VULKAN_SWIFTSHADER_UTILITIES_H_
+
+namespace impeller {
+
+//------------------------------------------------------------------------------
+/// @brief      Find and setup the installable client driver for a locally built
+///             SwiftShader at known paths. The option to use SwiftShader can
+///             only be used one in the process. While calling this method
+///             multiple times is fine, specifying a different use_swiftshader
+///             value will trip an assertion.
+///
+/// @warning    This call must be made before any Vulkan contexts are created in
+///             the process.
+///
+/// @param[in]  use_swiftshader  If SwiftShader should be used.
+///
+void SetupSwiftshaderOnce(bool use_swiftshader);
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_PLAYGROUND_BACKEND_VULKAN_SWIFTSHADER_UTILITIES_H_

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -121,10 +121,7 @@ class Playground {
   void SetWindowSize(ISize size);
 
  private:
-  struct GLFWInitializer;
-
   fml::TimeDelta start_time_;
-  std::unique_ptr<GLFWInitializer> glfw_initializer_;
   std::unique_ptr<PlaygroundImpl> impl_;
   std::shared_ptr<Context> context_;
   std::unique_ptr<Renderer> renderer_;

--- a/impeller/playground/switches.cc
+++ b/impeller/playground/switches.cc
@@ -19,6 +19,7 @@ PlaygroundSwitches::PlaygroundSwitches(const fml::CommandLine& args) {
     enable_playground = true;
   }
   enable_vulkan_validation = args.HasOption("enable_vulkan_validation");
+  use_swiftshader = args.HasOption("use_swiftshader");
 }
 
 }  // namespace impeller

--- a/impeller/playground/switches.h
+++ b/impeller/playground/switches.h
@@ -20,6 +20,12 @@ struct PlaygroundSwitches {
   // rendered in the playground.
   std::optional<std::chrono::milliseconds> timeout;
   bool enable_vulkan_validation = false;
+  //----------------------------------------------------------------------------
+  /// Seek a SwiftShader library in known locations and use it when running
+  /// Vulkan. It is a fatal error to provide this option and not have the test
+  /// find a SwiftShader implementation.
+  ///
+  bool use_swiftshader = false;
   bool use_angle = false;
 
   PlaygroundSwitches();


### PR DESCRIPTION
Specifying the `--use_swiftshader` flag will find an setup the SwiftShader ICD in the process. Allows switching between two Vulkan implementation (system and SwiftShader) quickly using a flag.

Following up on https://github.com/flutter/flutter/issues/127070