### PR TITLE
[Impeller] Wire up Angle use to a command line flag and enable it by default on macOS.

### DIFF
--- a/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -76,19 +76,12 @@ PlaygroundImplGLES::PlaygroundImplGLES(PlaygroundSwitches switches)
   ::glfwDefaultWindowHints();
 
 #if FML_OS_MACOSX
-  if (use_angle_) {
-    ::glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
-    ::glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
-    ::glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
-    ::glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
-  } else {
-    ::glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
-  }
-#else   // FML_OS_MACOSX
+  FML_CHECK(use_angle_) << "Must use Angle on macOS for OpenGL ES.";
+  ::glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+#endif  // FML_OS_MACOSX
   ::glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
   ::glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
   ::glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
-#endif  // FML_OS_MACOSX
   ::glfwWindowHint(GLFW_RED_BITS, 8);
   ::glfwWindowHint(GLFW_GREEN_BITS, 8);
   ::glfwWindowHint(GLFW_BLUE_BITS, 8);

--- a/impeller/playground/switches.cc
+++ b/impeller/playground/switches.cc
@@ -6,6 +6,8 @@
 
 #include <cstdlib>
 
+#include "flutter/fml/build_config.h"
+
 namespace impeller {
 
 PlaygroundSwitches::PlaygroundSwitches() = default;
@@ -20,6 +22,11 @@ PlaygroundSwitches::PlaygroundSwitches(const fml::CommandLine& args) {
   }
   enable_vulkan_validation = args.HasOption("enable_vulkan_validation");
   use_swiftshader = args.HasOption("use_swiftshader");
+  use_angle = args.HasOption("use_angle");
+#if FML_OS_MACOSX
+  // OpenGL on macOS is busted and deprecated. Use Angle there by default.
+  use_angle = true;
+#endif  // FML_OS_MACOSX
 }
 
 }  // namespace impeller

--- a/impeller/playground/switches.h
+++ b/impeller/playground/switches.h
@@ -26,6 +26,11 @@ struct PlaygroundSwitches {
   /// find a SwiftShader implementation.
   ///
   bool use_swiftshader = false;
+  /// Attempt to use Angle on the system instead of the available OpenGL ES
+  /// implementation. This is on-by-default on macOS due to the broken-ness in
+  /// the deprecated OpenGL implementation. On other platforms, it this opt-in
+  /// via the flag with the system OpenGL ES implementation used by fault.
+  ///
   bool use_angle = false;
 
   PlaygroundSwitches();


### PR DESCRIPTION
Similar to --use_swiftshader in https://github.com/flutter/engine/pull/50298.