### PR TITLE
[Impeller] Fix blown stack due to always out of date window dimensions on high-dpi devices.

### DIFF
--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -158,8 +158,8 @@ std::unique_ptr<Surface> PlaygroundImplVK::AcquireSurfaceFrame(
 
   int width = 0;
   int height = 0;
-  ::glfwGetWindowSize(reinterpret_cast<GLFWwindow*>(handle_.get()), &width,
-                      &height);
+  ::glfwGetFramebufferSize(reinterpret_cast<GLFWwindow*>(handle_.get()), &width,
+                           &height);
   size_ = ISize{width, height};
   surface_context_vk->UpdateSurfaceSize(ISize{width, height});
 


### PR DESCRIPTION
This regression was introduced in https://github.com/flutter/engine/commit/89077a09c7f0d5691f7f5ed060481dc81dea74d0 which made it so that the updated surface size would be provided to the swapchain impl out-of-band instead of being inferred from the surface properties (to avoid a lag between the reports of the two).

However, the playgrounds used the window size to report the updated size. This is fine where the window scale is 1. But fails on high-dpi devices. The patch replaces the call to get the window size with an equivalent call to get the framebuffer size.

The failure was a blown stack due to a new swapchain impl being created over and over again because the size was always out of date.

Fixes https://github.com/flutter/flutter/issues/142833