### PR TITLE
Tool that audits GitHub for checks that appear to fail at a high rate

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -240,6 +240,7 @@ vars = {
   "upstream_vector_math": "https://github.com/google/vector_math.dart.git",
   "upstream_VulkanMemoryAllocator": "https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git",
   "upstream_watcher": "https://github.com/dart-lang/watcher.git",
+  "upstream_web": "https://github.com/dart-lang/web.git",
   "upstream_web_socket_channel": "https://github.com/dart-lang/web_socket_channel.git",
   "upstream_webdev": "https://github.com/dart-lang/webdev.git",
   "upstream_webkit_inspection_protocol": "https://github.com/google/webkit_inspection_protocol.dart.git",
@@ -493,6 +494,9 @@ deps = {
 
   'src/third_party/dart/third_party/pkg/watcher':
    Var('dart_git') + '/watcher.git' + '@' + Var('dart_watcher_rev'),
+
+  'src/third_party/dart/third_party/pkg/web':
+   Var('dart_git') + '/web.git@393ed8301ceb1c0557dd1916c17d16c0a3a73003',
 
   'src/third_party/dart/third_party/pkg/web_socket_channel':
    Var('dart_git') + '/web_socket_channel.git@5241175e7c66271850d6e75fb9ec90068f9dd3c4',

--- a/tools/github_commit_audit/.gitignore
+++ b/tools/github_commit_audit/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the file ".github_token".
+.github_token

--- a/tools/github_commit_audit/README.md
+++ b/tools/github_commit_audit/README.md
@@ -19,10 +19,20 @@ Either:
 
 ```bash
 # Assuming you're in the root of the repository.
-dart ./tools/header_guard_check/bin/main.dart
+dart ./tools/github_commit_audit/bin/main.dart
 ```
 
 ## Options
 
 - `--help`: Show help message.
 - `--repo`: The repository to audit. Defaults to `flutter/engine`.
+- `--include-label`: Skip PRs that don't have this label.
+- `--exclude-label`: Skip PRs that have this label.
+
+## Examples
+
+```bash
+dart ./tools/github_commit_audit/bin/main.dart \
+  --repo flutter/engine \
+  --exclude-label "platform-web"
+```

--- a/tools/github_commit_audit/README.md
+++ b/tools/github_commit_audit/README.md
@@ -7,6 +7,8 @@ Specifically, it reports how many commits have failed checks. This tool can be
 used to "audit" if the reported flakiness of a repository seems to be
 undercounted.
 
+This is a "for fun" tool. PRs welcome.
+
 ## Usage
 
 This tool uses a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
@@ -17,9 +19,43 @@ Either:
 - Create a file called `.github_token` in the package root (i.e. next to this
   README) with the token.
 
-```bash
+```shell
 # Assuming you're in the root of the repository.
 dart ./tools/github_commit_audit/bin/main.dart
+```
+
+... will give output similar to:
+
+```txt
+Summary:
+  - Linux Framework Smoke Tests: 56/126 (0.44)
+  - Linux linux_license: 52/126 (0.41)
+  - Linux linux_host_engine: 41/126 (0.33)
+  - Linux Fuchsia FEMU: 41/126 (0.33)
+  - Linux Web Framework tests: 23/71 (0.32)
+  - Linux linux_web_engine: 39/126 (0.31)
+  - Linux linux_fuchsia: 37/122 (0.30)
+  - Linux linux_android_emulator_tests: 20/66 (0.30)
+  - Linux linux_unopt: 38/126 (0.30)
+  - Linux mac_unopt: 37/126 (0.29)
+  - Mac mac_host_engine: 36/126 (0.29)
+  - Windows windows_unopt: 31/126 (0.25)
+  - Linux linux_android_debug_engine: 27/126 (0.21)
+  - Linux linux_clang_tidy: 21/99 (0.21)
+  - Windows windows_host_engine: 25/126 (0.20)
+  - Mac mac_ios_engine: 20/126 (0.16)
+  - Mac mac_clang_tidy: 15/103 (0.15)
+  - Linux linux_android_aot_engine: 16/126 (0.13)
+  - Windows windows_android_aot_engine: 15/126 (0.12)
+  - Windows windows_arm_host_engine: 13/126 (0.10)
+  - Linux linux_host_desktop_engine: 11/126 (0.09)
+  - Linux mac_android_aot_engine: 10/126 (0.08)
+  - Linux linux_arm_host_engine: 9/126 (0.07)
+  - triage: 0/127 (0.00)
+  - ci.yaml validation: 0/118 (0.00)
+  - cla/google: 0/117 (0.00)
+  - Vulnerability scanning: 0/109 (0.00)
+  - Extract Dependencies: 0/109 (0.00)
 ```
 
 ## Options

--- a/tools/github_commit_audit/README.md
+++ b/tools/github_commit_audit/README.md
@@ -1,0 +1,28 @@
+# `github_commit_audit`
+
+An _experimental_ (read: not used on CI) tool to audit commits in a GitHub
+repository.
+
+Specifically, it reports how many commits have failed checks. This tool can be
+used to "audit" if the reported flakiness of a repository seems to be
+undercounted.
+
+## Usage
+
+This tool uses a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
+
+Either:
+
+- Set a `GITHUB_TOKEN` environment variable
+- Create a file called `.github_token` in the package root (i.e. next to this
+  README) with the token.
+
+```bash
+# Assuming you're in the root of the repository.
+dart ./tools/header_guard_check/bin/main.dart
+```
+
+## Options
+
+- `--help`: Show help message.
+- `--repo`: The repository to audit. Defaults to `flutter/engine`.

--- a/tools/github_commit_audit/bin/main.dart
+++ b/tools/github_commit_audit/bin/main.dart
@@ -1,0 +1,183 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+
+void main(List<String> args) async {
+  // Look for a personal access token.
+  final String token = _getPersonalAccessToken();
+
+  // Print the last 10 pull requests for the flutter/flutter repository.
+  final List<int> pullRequests = await _fetchPullRequests(
+    token: token,
+    repository: 'flutter/engine',
+    max: 100,
+  );
+
+  // Create map of every check name to the number of times it has run and failed.
+  final Map<String, int> checkCounts = <String, int>{};
+  final Map<String, int> failedCheckCounts = <String, int>{};
+
+  // For each PR, access the checks API to get the status of the commit.
+  for (final int pullRequest in pullRequests) {
+    final List<String> commits = await _fetchCommits(
+      token: token,
+      repository: 'flutter/engine',
+      pullRequest: pullRequest,
+    );
+    for (final String commit in commits) {
+      final List<(String name, String? status)> statuses = await _fetchCommitStatus(
+        token: token,
+        repository: 'flutter/engine',
+        commit: commit,
+      );
+      print('PR $pullRequest commit $commit');
+      for (final (String name, String? status) in statuses) {
+        print('  $name: $status');
+      }
+
+      // Count the number of times each check has run and failed.
+      for (final (String name, String? status) in statuses) {
+        checkCounts[name] = (checkCounts[name] ?? 0) + 1;
+        if (status == 'failure') {
+          failedCheckCounts[name] = (failedCheckCounts[name] ?? 0) + 1;
+        }
+      }
+    }
+  }
+
+  // Print the results, for each check, print the number of times it has run and failed and the failure rate.
+  for (final String name in checkCounts.keys.toList()..sort()) {
+    final int count = checkCounts[name]!;
+    final int failedCount = failedCheckCounts[name] ?? 0;
+    final double failureRate = count == 0 ? 0.0 : failedCount / count;
+    print('$name: $failedCount/$count (${failureRate.toStringAsFixed(2)})');
+  }
+}
+
+
+/// Returns the personal access token from the environment or a file.
+///
+/// The personal access token is used to authenticate with the GitHub API.
+///
+/// If no token is found an error is thrown.
+String _getPersonalAccessToken() {
+  String? token = io.Platform.environment['GITHUB_TOKEN'];
+  if (token == null) {
+    // Find a file called .github_token relative to this script.
+    final String self = io.File.fromUri(io.Platform.script).absolute.parent.path;
+    final io.File tokenFile = io.File(p.join(p.dirname(self), '.github_token'));
+    if (tokenFile.existsSync()) {
+      token = tokenFile.readAsStringSync().trim();
+    }
+  }
+  if (token == null) {
+    throw StateError(
+        'No GitHub token found. Set a GITHUB_TOKEN environment variable or '
+        'create a .github_token file in the same directory of the '
+        'github_commit_audit package (i.e. next to the README).');
+  }
+  return token;
+}
+
+/// Fetches the last N pull requests for the given repository.
+Future<List<int>> _fetchPullRequests({
+  required String token,
+  required String repository,
+  int max = 10,
+}) async {
+  final http.Client client = http.Client();
+  try {
+    final Uri url = Uri.https('api.github.com', '/repos/$repository/pulls', <String, String>{
+      'per_page': '$max',
+    });
+    final http.Response response = await client.get(
+      url,
+      headers: <String, String>{
+        'Authorization': 'token $token',
+        'Accept': 'application/vnd.github.v3+json',
+      },
+    );
+    if (response.statusCode != 200) {
+      throw StateError('Failed to fetch pull requests: ${response.body}');
+    }
+    final List<Object?> json = jsonDecode(response.body) as List<Object?>;
+    // Filter out PRs that have a label of 'platform-web'.
+    return json.map<int>((Object? pr) {
+      final Map<String, Object?> prMap = pr! as Map<String, Object?>;
+      final List<Object?> labels = prMap['labels']! as List<Object?>;
+      if (!labels.any((Object? label) => (label! as Map<String, Object?>)['name'] == 'platform-web')) {
+        return -1;
+      }
+      return prMap['number']! as int;
+    }).where((int pr) => pr != -1).toList();
+    // return json.map<int>((Object? pr) {
+    //   return (pr! as Map<String, Object?>)['number']! as int;
+    // }).toList();
+  } finally {
+    client.close();
+  }
+}
+
+/// Fetches every commit for the given pull request.
+Future<List<String>> _fetchCommits({
+  required String token,
+  required String repository,
+  required int pullRequest,
+}) async {
+  final http.Client client = http.Client();
+  try {
+    final Uri url = Uri.https('api.github.com', '/repos/$repository/pulls/$pullRequest/commits');
+    final http.Response response = await client.get(
+      url,
+      headers: <String, String>{
+        'Authorization': 'token $token',
+        'Accept': 'application/vnd.github.v3+json',
+      },
+    );
+    if (response.statusCode != 200) {
+      throw StateError('Failed to fetch commits: ${response.body}');
+    }
+    final List<Object?> json = jsonDecode(response.body) as List<Object?>;
+    return json.map<String>((Object? commit) {
+      return (commit! as Map<String, Object?>)['sha']! as String;
+    }).toList();
+  } finally {
+    client.close();
+  }
+}
+
+/// Fetches the name and status of each check for the given commit.
+Future<List<(String, String?)>> _fetchCommitStatus({
+  required String token,
+  required String repository,
+  required String commit,
+}) async {
+  final http.Client client = http.Client();
+  try {
+    final Uri url = Uri.https('api.github.com', '/repos/$repository/commits/$commit/check-runs');
+    final http.Response response = await client.get(
+      url,
+      headers: <String, String>{
+        'Authorization': 'token $token',
+        'Accept': 'application/vnd.github.v3+json',
+      },
+    );
+    if (response.statusCode != 200) {
+      throw StateError('Failed to fetch commit status: ${response.body}');
+    }
+    final Map<String, Object?> json = jsonDecode(response.body) as Map<String, Object?>;
+    final List<Object?> checks = json['check_runs']! as List<Object?>;
+    return checks.map((Object? check) {
+      final Map<String, Object?> checkMap = check! as Map<String, Object?>;
+      return (checkMap['name']! as String, checkMap['conclusion'] as String?);
+    }).toList();
+  } finally {
+    client.close();
+  }
+}

--- a/tools/github_commit_audit/bin/main.dart
+++ b/tools/github_commit_audit/bin/main.dart
@@ -5,6 +5,8 @@
 import 'dart:convert';
 import 'dart:io' as io;
 
+import 'package:args/args.dart';
+import 'package:github_commit_audit/src/github_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
@@ -12,51 +14,51 @@ void main(List<String> args) async {
   // Look for a personal access token.
   final String token = _getPersonalAccessToken();
 
-  // Print the last 10 pull requests for the flutter/flutter repository.
-  final List<int> pullRequests = await _fetchPullRequests(
-    token: token,
-    repository: 'flutter/engine',
-    max: 100,
-  );
-
-  // Create map of every check name to the number of times it has run and failed.
-  final Map<String, int> checkCounts = <String, int>{};
-  final Map<String, int> failedCheckCounts = <String, int>{};
-
-  // For each PR, access the checks API to get the status of the commit.
-  for (final int pullRequest in pullRequests) {
-    final List<String> commits = await _fetchCommits(
-      token: token,
-      repository: 'flutter/engine',
-      pullRequest: pullRequest,
+  // Determine what repository to fetch pull requests from.
+  final ArgParser parser = ArgParser()
+    ..addOption(
+      'repository',
+      abbr: 'r',
+      defaultsTo: 'flutter/engine',
+      help: 'The repository to fetch pull requests from.',
+    )
+    ..addOption(
+      'max',
+      help: 'The maximum number of most recently updated pull requests to fetch.',
+      defaultsTo: '100',
+      valueHelp: '1 to 100',
     );
-    for (final String commit in commits) {
-      final List<(String name, String? status)> statuses = await _fetchCommitStatus(
-        token: token,
-        repository: 'flutter/engine',
-        commit: commit,
-      );
-      print('PR $pullRequest commit $commit');
-      for (final (String name, String? status) in statuses) {
-        print('  $name: $status');
-      }
 
-      // Count the number of times each check has run and failed.
-      for (final (String name, String? status) in statuses) {
-        checkCounts[name] = (checkCounts[name] ?? 0) + 1;
-        if (status == 'failure') {
-          failedCheckCounts[name] = (failedCheckCounts[name] ?? 0) + 1;
+  final ArgResults results = parser.parse(args);
+  final String repository = results['repository'] as String;
+  final int max = int.parse(results['max'] as String);
+
+  // Create a client.
+  final http.Client client = http.Client();
+  try {
+    final GithubClient github = GithubClient(client, token: token);
+
+    // Fetch some pull requests.
+    final List<PullRequest> pullRequests = await github.fetchPullRequests(repository, max: max).toList();
+
+    // Debug: Print the names of the pull requests.
+    for (final PullRequest pr in pullRequests) {
+      print('PR #${pr.number}: ${pr.title}');
+
+      // Fetch the commits for the pull request.
+      final List<PullRequestCommit> commits = await github.fetchCommits(repository, pr.number).toList();
+      for (final PullRequestCommit commit in commits) {
+        print('  - ${commit.sha}');
+
+        // Fetch the statuses for the commit.
+        final List<PullRequestCommitCheck> statuses = await github.fetchCommitStatus(repository, commit.sha).toList();
+        for (final PullRequestCommitCheck status in statuses) {
+          print('    - ${status.name}: ${status.conclusion?.name ?? 'null'}');
         }
       }
     }
-  }
-
-  // Print the results, for each check, print the number of times it has run and failed and the failure rate.
-  for (final String name in checkCounts.keys.toList()..sort()) {
-    final int count = checkCounts[name]!;
-    final int failedCount = failedCheckCounts[name] ?? 0;
-    final double failureRate = count == 0 ? 0.0 : failedCount / count;
-    print('$name: $failedCount/$count (${failureRate.toStringAsFixed(2)})');
+  } finally {
+    client.close();
   }
 }
 
@@ -83,101 +85,4 @@ String _getPersonalAccessToken() {
         'github_commit_audit package (i.e. next to the README).');
   }
   return token;
-}
-
-/// Fetches the last N pull requests for the given repository.
-Future<List<int>> _fetchPullRequests({
-  required String token,
-  required String repository,
-  int max = 10,
-}) async {
-  final http.Client client = http.Client();
-  try {
-    final Uri url = Uri.https('api.github.com', '/repos/$repository/pulls', <String, String>{
-      'per_page': '$max',
-    });
-    final http.Response response = await client.get(
-      url,
-      headers: <String, String>{
-        'Authorization': 'token $token',
-        'Accept': 'application/vnd.github.v3+json',
-      },
-    );
-    if (response.statusCode != 200) {
-      throw StateError('Failed to fetch pull requests: ${response.body}');
-    }
-    final List<Object?> json = jsonDecode(response.body) as List<Object?>;
-    // Filter out PRs that have a label of 'platform-web'.
-    return json.map<int>((Object? pr) {
-      final Map<String, Object?> prMap = pr! as Map<String, Object?>;
-      final List<Object?> labels = prMap['labels']! as List<Object?>;
-      if (!labels.any((Object? label) => (label! as Map<String, Object?>)['name'] == 'platform-web')) {
-        return -1;
-      }
-      return prMap['number']! as int;
-    }).where((int pr) => pr != -1).toList();
-    // return json.map<int>((Object? pr) {
-    //   return (pr! as Map<String, Object?>)['number']! as int;
-    // }).toList();
-  } finally {
-    client.close();
-  }
-}
-
-/// Fetches every commit for the given pull request.
-Future<List<String>> _fetchCommits({
-  required String token,
-  required String repository,
-  required int pullRequest,
-}) async {
-  final http.Client client = http.Client();
-  try {
-    final Uri url = Uri.https('api.github.com', '/repos/$repository/pulls/$pullRequest/commits');
-    final http.Response response = await client.get(
-      url,
-      headers: <String, String>{
-        'Authorization': 'token $token',
-        'Accept': 'application/vnd.github.v3+json',
-      },
-    );
-    if (response.statusCode != 200) {
-      throw StateError('Failed to fetch commits: ${response.body}');
-    }
-    final List<Object?> json = jsonDecode(response.body) as List<Object?>;
-    return json.map<String>((Object? commit) {
-      return (commit! as Map<String, Object?>)['sha']! as String;
-    }).toList();
-  } finally {
-    client.close();
-  }
-}
-
-/// Fetches the name and status of each check for the given commit.
-Future<List<(String, String?)>> _fetchCommitStatus({
-  required String token,
-  required String repository,
-  required String commit,
-}) async {
-  final http.Client client = http.Client();
-  try {
-    final Uri url = Uri.https('api.github.com', '/repos/$repository/commits/$commit/check-runs');
-    final http.Response response = await client.get(
-      url,
-      headers: <String, String>{
-        'Authorization': 'token $token',
-        'Accept': 'application/vnd.github.v3+json',
-      },
-    );
-    if (response.statusCode != 200) {
-      throw StateError('Failed to fetch commit status: ${response.body}');
-    }
-    final Map<String, Object?> json = jsonDecode(response.body) as Map<String, Object?>;
-    final List<Object?> checks = json['check_runs']! as List<Object?>;
-    return checks.map((Object? check) {
-      final Map<String, Object?> checkMap = check! as Map<String, Object?>;
-      return (checkMap['name']! as String, checkMap['conclusion'] as String?);
-    }).toList();
-  } finally {
-    client.close();
-  }
 }

--- a/tools/github_commit_audit/bin/main.dart
+++ b/tools/github_commit_audit/bin/main.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:args/args.dart';
@@ -27,11 +26,70 @@ void main(List<String> args) async {
       help: 'The maximum number of most recently updated pull requests to fetch.',
       defaultsTo: '100',
       valueHelp: '1 to 100',
+    )
+    ..addMultiOption(
+      'include-label',
+      help: 'Include pull requests with the given label.',
+      valueHelp: 'label',
+    )
+    ..addMultiOption(
+      'exclude-label',
+      help: 'Exclude pull requests with the given label.',
+      valueHelp: 'label',
+    )
+    ..addFlag(
+      'verbose',
+      abbr: 'v',
+      help: 'Print verbose output.',
+    )
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      help: 'Print this usage information.',
     );
 
   final ArgResults results = parser.parse(args);
   final String repository = results['repository'] as String;
   final int max = int.parse(results['max'] as String);
+  final List<String> includeLabels = List<String>.from(results['include-label'] as List<Object?>);
+  final List<String> excludeLabels = List<String>.from(results['exclude-label'] as List<Object?>);
+  final bool verbose = results['verbose'] as bool;
+  final bool help = results['help'] as bool;
+
+  if (help) {
+    print('Usage: github_commit_audit [options]');
+    print(parser.usage);
+    return;
+  }
+
+  // Can have either include or exclude labels, but not both.
+  if (includeLabels.isNotEmpty && excludeLabels.isNotEmpty) {
+    print('Cannot have both include and exclude labels.');
+    io.exitCode = 1;
+    return;
+  }
+
+  bool shouldSkipBasedOnLabel(Iterable<String> labels) {
+    if (includeLabels.isNotEmpty) {
+      return !labels.any(includeLabels.contains);
+    }
+    if (excludeLabels.isNotEmpty) {
+      return labels.any(excludeLabels.contains);
+    }
+    return false;
+  }
+
+  void vprint(Object? object) {
+    if (verbose) {
+      print(object);
+    }
+  }
+
+  // Count how many times a check has run.
+  final Map<String, int> checkCounts = <String, int>{};
+
+  // Count how many times a check has explicitly failed.
+  final Map<String, int> checkFailures = <String, int>{};
 
   // Create a client.
   final http.Client client = http.Client();
@@ -42,24 +100,65 @@ void main(List<String> args) async {
     final List<PullRequest> pullRequests = await github.fetchPullRequests(repository, max: max).toList();
 
     // Debug: Print the names of the pull requests.
+    int i = 1;
     for (final PullRequest pr in pullRequests) {
-      print('PR #${pr.number}: ${pr.title}');
+      if (shouldSkipBasedOnLabel(pr.labels)) {
+        vprint('[Skipping] PR #${pr.number}: ${pr.title}');
+        continue;
+      }
+
+      print('[${i++}/${pullRequests.length}] PR #${pr.number}: ${pr.title}');
 
       // Fetch the commits for the pull request.
       final List<PullRequestCommit> commits = await github.fetchCommits(repository, pr.number).toList();
       for (final PullRequestCommit commit in commits) {
-        print('  - ${commit.sha}');
+        vprint('  - ${commit.sha}');
 
         // Fetch the statuses for the commit.
         final List<PullRequestCommitCheck> statuses = await github.fetchCommitStatus(repository, commit.sha).toList();
         for (final PullRequestCommitCheck status in statuses) {
-          print('    - ${status.name}: ${status.conclusion?.name ?? 'null'}');
+          vprint('    - ${status.name}: ${status.conclusion?.name ?? 'null'}');
+          checkCounts[status.name] = (checkCounts[status.name] ?? 0) + 1;
+          if (status.conclusion == CheckRunConclusion.failure) {
+            checkFailures[status.name] = (checkFailures[status.name] ?? 0) + 1;
+          }
         }
       }
     }
   } finally {
     client.close();
   }
+
+  // Print the check counts sorted by a ratio of highest failures.
+  final List<_Summary> summaries = <_Summary>[];
+  for (final String name in checkCounts.keys) {
+    summaries.add(_Summary(
+      name: name,
+      runCount: checkCounts[name]!,
+      failureCount: checkFailures[name] ?? 0,
+    ));
+  }
+
+  summaries.sort((_Summary a, _Summary b) => b.failureRatio.compareTo(a.failureRatio));
+
+  print('Summary:');
+  for (final _Summary summary in summaries) {
+    print('  - ${summary.name}: ${summary.failureCount}/${summary.runCount} (${summary.failureRatio.toStringAsFixed(2)})');
+  }
+}
+
+final class _Summary {
+  const _Summary({
+    required this.name,
+    required this.runCount,
+    required this.failureCount,
+  });
+
+  final String name;
+  final int runCount;
+  final int failureCount;
+
+  double get failureRatio => failureCount / runCount;
 }
 
 

--- a/tools/github_commit_audit/bin/main.dart
+++ b/tools/github_commit_audit/bin/main.dart
@@ -38,8 +38,8 @@ void main(List<String> args) async {
       valueHelp: 'label',
     )
     ..addFlag(
-      'skip-failed-newer-commit-available',
-      help: 'Skip failed checks with an output summary that contains "Newer commit available".',
+      'skip-failed-intentional-failures',
+      help: 'Skip failed checks with an output summary such as "Newer commit available".',
       defaultsTo: true,
     )
     ..addFlag(
@@ -58,7 +58,7 @@ void main(List<String> args) async {
   final int max = int.parse(results['max'] as String);
   final List<String> includeLabels = List<String>.from(results['include-label'] as List<Object?>);
   final List<String> excludeLabels = List<String>.from(results['exclude-label'] as List<Object?>);
-  final bool skipFailedNewerCommitAvailable = results['skip-failed-newer-commit-available'] as bool;
+  final bool skipFailedIntentionalFailures = results['skip-failed-intentional-failures'] as bool;
   final bool verbose = results['verbose'] as bool;
   final bool help = results['help'] as bool;
 
@@ -127,9 +127,8 @@ void main(List<String> args) async {
           checkCounts[status.name] = (checkCounts[status.name] ?? 0) + 1;
 
           if (status.conclusion == CheckRunConclusion.failure) {
-            // If the output contains "Newer commit available", skip it.
-            if (skipFailedNewerCommitAvailable && (status.output.summary?.contains('Newer commit available') ?? false)) {
-              vprint('      - Skipping due to "Newer commit available"');
+            final String summary = status.output.summary ?? '';
+            if (skipFailedIntentionalFailures && summary.contains('(canceled)')) {
               continue;
             }
             checkFailures[status.name] = (checkFailures[status.name] ?? 0) + 1;

--- a/tools/github_commit_audit/bin/main.dart
+++ b/tools/github_commit_audit/bin/main.dart
@@ -16,7 +16,7 @@ void main(List<String> args) async {
   // Determine what repository to fetch pull requests from.
   final ArgParser parser = ArgParser()
     ..addOption(
-      'repository',
+      'repo',
       abbr: 'r',
       defaultsTo: 'flutter/engine',
       help: 'The repository to fetch pull requests from.',
@@ -49,7 +49,7 @@ void main(List<String> args) async {
     );
 
   final ArgResults results = parser.parse(args);
-  final String repository = results['repository'] as String;
+  final String repository = results['repo'] as String;
   final int max = int.parse(results['max'] as String);
   final List<String> includeLabels = List<String>.from(results['include-label'] as List<Object?>);
   final List<String> excludeLabels = List<String>.from(results['exclude-label'] as List<Object?>);

--- a/tools/github_commit_audit/lib/src/github_client.dart
+++ b/tools/github_commit_audit/lib/src/github_client.dart
@@ -215,7 +215,7 @@ enum CheckRunConclusion {
   /// Parses a check run conclusion from a JSON string.
   ///
   /// Returns `null` if the value is not a recognized conclusion (still valid).
-  static CheckRunConclusion? fromJson(String value) {
+  static CheckRunConclusion? fromJson(String? value) {
     switch (value) {
       case 'success':
         return CheckRunConclusion.success;
@@ -251,7 +251,7 @@ final class PullRequestCommitCheck {
     return PullRequestCommitCheck(
       url: json['html_url']! as String,
       name: json['name']! as String,
-      conclusion: CheckRunConclusion.fromJson(json['conclusion']! as String),
+      conclusion: CheckRunConclusion.fromJson(json['conclusion'] as String?),
       startedAt: json['started_at'] == null
           ? null
           : DateTime.parse(json['started_at']! as String),

--- a/tools/github_commit_audit/lib/src/github_client.dart
+++ b/tools/github_commit_audit/lib/src/github_client.dart
@@ -235,7 +235,37 @@ enum CheckRunConclusion {
   }
 }
 
+/// ...
+@immutable
+final class PullRequestCommitCheckoutput {
+  /// Creates a pull request commit check output with the given properties.
+  const PullRequestCommitCheckoutput({
+    required this.title,
+    required this.summary,
+    required this.text,
+  });
+
+  /// Parses a pull request commit check output from a JSON map.
+  factory PullRequestCommitCheckoutput.fromJson(Map<String, Object?> json) {
+    return PullRequestCommitCheckoutput(
+      title: json['title'] as String?,
+      summary: json['summary'] as String?,
+      text: json['text'] as String?,
+    );
+  }
+
+  /// ...
+  final String? title;
+
+  /// ...
+  final String? summary;
+
+  /// ...
+  final String? text;
+}
+
 /// https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference
+@immutable
 final class PullRequestCommitCheck {
   /// Creates a pull request commit check with the given properties.
   const PullRequestCommitCheck({
@@ -244,6 +274,7 @@ final class PullRequestCommitCheck {
     required this.conclusion,
     required this.startedAt,
     required this.completedAt,
+    required this.output,
   });
 
   /// Parses a pull request commit check from a JSON map.
@@ -258,6 +289,7 @@ final class PullRequestCommitCheck {
       completedAt: json['completed_at'] == null
           ? null
           : DateTime.parse(json['completed_at']! as String),
+      output: PullRequestCommitCheckoutput.fromJson(json['output']! as Map<String, Object?>),
     );
   }
 
@@ -275,4 +307,7 @@ final class PullRequestCommitCheck {
 
   /// When the check was completed.
   final DateTime? completedAt;
+
+  /// Output of the check run.
+  final PullRequestCommitCheckoutput output;
 }

--- a/tools/github_commit_audit/lib/src/github_client.dart
+++ b/tools/github_commit_audit/lib/src/github_client.dart
@@ -1,0 +1,135 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+
+/// A minimal GitHub client that can fetch pull requests and commit statuses.
+final class GithubClient {
+  /// Creates a new GitHub client that uses the given [client] to make requests.
+  const GithubClient(this._client, {required String token})
+      : _token = 'token $token';
+
+  final http.Client _client;
+  final String _token;
+
+  Future<Object> _fetchJson(Uri url) async {
+    final http.Response response = await _client.get(url, headers: <String, String>{
+      'Accept': 'application/vnd.github.v3+json',
+      'Authorization': _token,
+    });
+    if (response.statusCode != 200) {
+      throw StateError('Failed to fetch $url: ${response.statusCode} ${response.reasonPhrase}');
+    }
+    return json.decode(response.body) as Object;
+  }
+
+  /// Returns up to [max] pull requests for the given [repository].
+  ///
+  /// Pull requests are sorted by their last update time (most recent first).
+  ///
+  /// ## Optional parameters
+  ///
+  /// - [base]: The base branch to compare the pull requests against.
+  ///   Defaults to 'main'.
+  /// - [max]: The maximum number of pull requests to fetch.
+  ///   Defaults to 100, which is also the maximum.
+  Stream<PullRequest> fetchPullRequests(
+    String repository, {
+    String base = 'main',
+    int max = 100,
+    PullRequestState? state,
+  }) async* {
+    RangeError.checkValueInInterval(max, 1, 100, 'max');
+    final Uri url = Uri.https(
+      'api.github.com',
+      '/repos/$repository/pulls',
+      <String, String>{
+        'base': base,
+        'state': state?.name ?? 'all',
+      },
+    );
+    final List<Object> json = (_fetchJson(url) as List<Object>).cast<Object>();
+    for (final Object pr in json) {
+      yield PullRequest.fromJson(pr as Map<String, Object?>);
+    }
+  }
+}
+
+/// https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28
+@immutable
+final class PullRequest {
+  /// Creates a pull request with the given properties.
+  const PullRequest({
+    required this.url,
+    required this.number,
+    required this.state,
+    required this.title,
+    required this.labels,
+    required this.isDraft,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  /// Parses a pull request from a JSON map.
+  factory PullRequest.fromJson(Map<String, Object?> json) {
+    return PullRequest(
+      url: json['url']! as String,
+      number: json['number']! as int,
+      state: PullRequestState.fromJson(json['state']! as String),
+      title: json['title']! as String,
+      labels: (json['labels']! as List<Object?>).cast<String>().toSet(),
+      isDraft: json['draft']! as bool,
+      createdAt: DateTime.parse(json['created_at']! as String),
+      updatedAt: DateTime.parse(json['updated_at']! as String),
+    );
+  }
+
+  /// The pull request URL.
+  final String url;
+
+  /// The pull request number.
+  final int number;
+
+  /// The pull request state.
+  final PullRequestState state;
+
+  /// The pull request title.
+  final String title;
+
+  /// Labels associated with the pull request.
+  final Set<String> labels;
+
+  /// Whether the pull request is a draft.
+  final bool isDraft;
+
+  /// When the pull request was created.
+  final DateTime createdAt;
+
+  /// When the pull request was last updated.
+  final DateTime updatedAt;
+}
+
+/// The state of a pull request.
+enum PullRequestState {
+  /// The pull request is open (including draft pull requests).
+  open,
+
+  /// The pull request is closed (including merged or declined pull requests).
+  closed;
+
+  /// Parses a pull request state from a JSON string.
+  factory PullRequestState.fromJson(String value) {
+    switch (value) {
+      case 'open':
+        return PullRequestState.open;
+      case 'closed':
+        return PullRequestState.closed;
+      default:
+        throw ArgumentError.value(value, 'value', 'Invalid pull request state');
+    }
+  }
+}

--- a/tools/github_commit_audit/lib/src/github_client.dart
+++ b/tools/github_commit_audit/lib/src/github_client.dart
@@ -17,12 +17,14 @@ final class GithubClient {
   final String _token;
 
   Future<Object> _fetchJson(Uri url) async {
-    final http.Response response = await _client.get(url, headers: <String, String>{
+    final http.Response response =
+        await _client.get(url, headers: <String, String>{
       'Accept': 'application/vnd.github.v3+json',
       'Authorization': _token,
     });
     if (response.statusCode != 200) {
-      throw StateError('Failed to fetch $url: ${response.statusCode} ${response.reasonPhrase}');
+      throw StateError(
+          'Failed to fetch $url: ${response.statusCode} ${response.reasonPhrase}');
     }
     return json.decode(response.body) as Object;
   }
@@ -52,9 +54,36 @@ final class GithubClient {
         'state': state?.name ?? 'all',
       },
     );
-    final List<Object> json = (_fetchJson(url) as List<Object>).cast<Object>();
+    final List<Object> json =
+        (await _fetchJson(url) as List<Object?>).cast<Object>();
     for (final Object pr in json) {
       yield PullRequest.fromJson(pr as Map<String, Object?>);
+    }
+  }
+
+  /// Fetches every commit for the given pull request.
+  Stream<PullRequestCommit> fetchCommits(
+      String repository, int pullRequest) async* {
+    final Uri url = Uri.https(
+        'api.github.com', '/repos/$repository/pulls/$pullRequest/commits');
+    final List<Object> json =
+        (await _fetchJson(url) as List<Object?>).cast<Object>();
+    for (final Object commit in json) {
+      yield PullRequestCommit.fromJson(commit as Map<String, Object?>);
+    }
+  }
+
+  /// Fetches the name and status of each check for the given commit.
+  Stream<PullRequestCommitCheck> fetchCommitStatus(
+      String repository, String commit) async* {
+    final Uri url = Uri.https(
+        'api.github.com', '/repos/$repository/commits/$commit/check-runs');
+    final Map<String, Object> json =
+        (await _fetchJson(url) as Map<String, Object?>).cast<String, Object>();
+    final List<Object?> checks = json['check_runs']! as List<Object?>;
+    for (final Object? check in checks) {
+      final Map<String, Object?> checkMap = check! as Map<String, Object?>;
+      yield PullRequestCommitCheck.fromJson(checkMap);
     }
   }
 }
@@ -81,7 +110,9 @@ final class PullRequest {
       number: json['number']! as int,
       state: PullRequestState.fromJson(json['state']! as String),
       title: json['title']! as String,
-      labels: (json['labels']! as List<Object?>).cast<String>().toSet(),
+      labels: (json['labels']! as List<Object?>).map<String>((Object? label) {
+        return (label! as Map<String, Object?>)['name']! as String;
+      }).toSet(),
       isDraft: json['draft']! as bool,
       createdAt: DateTime.parse(json['created_at']! as String),
       updatedAt: DateTime.parse(json['updated_at']! as String),
@@ -132,4 +163,113 @@ enum PullRequestState {
         throw ArgumentError.value(value, 'value', 'Invalid pull request state');
     }
   }
+}
+
+/// https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-commits-on-a-pull-request
+@immutable
+final class PullRequestCommit {
+  /// Creates a pull request commit with the given properties.
+  const PullRequestCommit({
+    required this.url,
+    required this.sha,
+    required this.message,
+  });
+
+  /// Parses a pull request commit from a JSON map.
+  factory PullRequestCommit.fromJson(Map<String, Object?> json) {
+    return PullRequestCommit(
+      url: (json['commit']! as Map<String, Object?>)['url']! as String,
+      sha: json['sha']! as String,
+      message: (json['commit']! as Map<String, Object?>)['message']! as String,
+    );
+  }
+
+  /// The URL of the commit.
+  final String url;
+
+  /// The SHA of the commit.
+  final String sha;
+
+  /// The commit message.
+  final String message;
+}
+
+/// Possible conclusions for a check run.
+enum CheckRunConclusion {
+  /// The check run succeeded.
+  success,
+
+  /// The check run failed.
+  failure,
+
+  /// The check run was neutral.
+  neutral,
+
+  /// The check run was cancelled.
+  cancelled,
+
+  /// The check run timed out.
+  timedOut,
+
+  /// The check run has an action required.
+  actionRequired;
+
+  /// Parses a check run conclusion from a JSON string.
+  ///
+  /// Returns `null` if the value is not a recognized conclusion (still valid).
+  static CheckRunConclusion? fromJson(String value) {
+    switch (value) {
+      case 'success':
+        return CheckRunConclusion.success;
+      case 'failure':
+        return CheckRunConclusion.failure;
+      case 'neutral':
+        return CheckRunConclusion.neutral;
+      case 'cancelled':
+        return CheckRunConclusion.cancelled;
+      case 'timed_out':
+        return CheckRunConclusion.timedOut;
+      case 'action_required':
+        return CheckRunConclusion.actionRequired;
+      default:
+        return null;
+    }
+  }
+}
+
+/// https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference
+final class PullRequestCommitCheck {
+  /// Creates a pull request commit check with the given properties.
+  const PullRequestCommitCheck({
+    required this.name,
+    required this.conclusion,
+    required this.startedAt,
+    required this.completedAt,
+  });
+
+  /// Parses a pull request commit check from a JSON map.
+  factory PullRequestCommitCheck.fromJson(Map<String, Object?> json) {
+    return PullRequestCommitCheck(
+      name: json['name']! as String,
+      conclusion: CheckRunConclusion.fromJson(json['conclusion']! as String),
+      startedAt: json['started_at'] == null
+          ? null
+          : DateTime.parse(json['started_at']! as String),
+      completedAt: json['completed_at'] == null
+          ? null
+          : DateTime.parse(json['completed_at']! as String),
+    );
+  }
+
+  /// The name of the check.
+  final String name;
+
+  /// The conclusion of the check, if available.
+  final CheckRunConclusion? conclusion;
+
+  /// When the check was started.
+  final DateTime? startedAt;
+
+  /// When the check was completed.
+  final DateTime? completedAt;
 }

--- a/tools/github_commit_audit/pubspec.yaml
+++ b/tools/github_commit_audit/pubspec.yaml
@@ -35,11 +35,29 @@ dependency_overrides:
     path: ../../../third_party/dart/third_party/pkg/async
   async_helper:
     path: ../../../third_party/dart/pkg/async_helper
+  collection:
+    path: ../../../third_party/dart/third_party/pkg/collection
   expect:
     path: ../../../third_party/dart/pkg/expect
+  http:
+    path: ../../../third_party/dart/third_party/pkg/http/pkgs/http
+  http_parser:
+    path: ../../../third_party/dart/third_party/pkg/http_parser
+  path:
+    path: ../../../third_party/dart/third_party/pkg/path
   litetest:
     path: ../../testing/litetest
   meta:
     path: ../../../third_party/dart/pkg/meta
   smith:
     path: ../../../third_party/dart/pkg/smith
+  source_span:
+    path: ../../../third_party/dart/third_party/pkg/source_span
+  string_scanner:
+    path: ../../../third_party/dart/third_party/pkg/string_scanner
+  term_glyph:
+    path: ../../../third_party/dart/third_party/pkg/term_glyph
+  typed_data:
+    path: ../../../third_party/dart/third_party/pkg/typed_data
+  web:
+    path: ../../../third_party/dart/third_party/pkg/web

--- a/tools/github_commit_audit/pubspec.yaml
+++ b/tools/github_commit_audit/pubspec.yaml
@@ -1,0 +1,45 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+name: header_guard_check
+publish_to: none
+
+# Do not add any dependencies that require more than what is provided in
+# //third_party/dart/pkg or //third_party/dart/third_party/pkg.
+# In particular, package:test is not usable here.
+
+# If you do add packages here, make sure you can run `pub get --offline`, and
+# check the .packages and .package_config to make sure all the paths are
+# relative to this directory into //third_party/dart
+
+environment:
+  sdk: '>=3.2.0-0 <4.0.0'
+
+dependencies:
+  args: any
+  http: any
+  meta: any
+  path: any
+
+dev_dependencies:
+  async_helper: any
+  expect: any
+  litetest: any
+  smith: any
+
+dependency_overrides:
+  args:
+    path: ../../../third_party/dart/third_party/pkg/args
+  async:
+    path: ../../../third_party/dart/third_party/pkg/async
+  async_helper:
+    path: ../../../third_party/dart/pkg/async_helper
+  expect:
+    path: ../../../third_party/dart/pkg/expect
+  litetest:
+    path: ../../testing/litetest
+  meta:
+    path: ../../../third_party/dart/pkg/meta
+  smith:
+    path: ../../../third_party/dart/pkg/smith

--- a/tools/github_commit_audit/pubspec.yaml
+++ b/tools/github_commit_audit/pubspec.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-name: header_guard_check
+name: github_commit_audit
 publish_to: none
 
 # Do not add any dependencies that require more than what is provided in

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -39,6 +39,7 @@ ALL_PACKAGES = [
     os.path.join(ENGINE_DIR, 'tools', 'const_finder'),
     os.path.join(ENGINE_DIR, 'tools', 'gen_web_locale_keymap'),
     os.path.join(ENGINE_DIR, 'tools', 'githooks'),
+    os.path.join(ENGINE_DIR, 'tools', 'git_commit_audit'),
     os.path.join(ENGINE_DIR, 'tools', 'golden_tests_harvester'),
     os.path.join(ENGINE_DIR, 'tools', 'header_guard_check'),
     os.path.join(ENGINE_DIR, 'tools', 'licenses'),

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -39,7 +39,7 @@ ALL_PACKAGES = [
     os.path.join(ENGINE_DIR, 'tools', 'const_finder'),
     os.path.join(ENGINE_DIR, 'tools', 'gen_web_locale_keymap'),
     os.path.join(ENGINE_DIR, 'tools', 'githooks'),
-    os.path.join(ENGINE_DIR, 'tools', 'git_commit_audit'),
+    os.path.join(ENGINE_DIR, 'tools', 'github_commit_audit'),
     os.path.join(ENGINE_DIR, 'tools', 'golden_tests_harvester'),
     os.path.join(ENGINE_DIR, 'tools', 'header_guard_check'),
     os.path.join(ENGINE_DIR, 'tools', 'licenses'),


### PR DESCRIPTION
This is just for showing my work/data exploration.

If we think this is useful enough to check-in, I'm happy to merge it (though I'm not going to bother writing tests for something that we won't use on CI).

## Example Usage

```shell
# See https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
GITHUB_TOKEN="..." \
  ./prebuilts/macos-arm64/dart-sdk/bin/dart tools/github_commit_audit/bin/main.dart \
  --repo flutter/engine \
  --max 100 \
  --exclude-label platform-web
```

... produces output such as:

```txt
...

Summary:
  - Linux Framework Smoke Tests: 56/126 (0.44)
  - Linux linux_license: 53/126 (0.42)
  - Linux linux_host_engine: 41/126 (0.33)
  - Linux Fuchsia FEMU: 41/126 (0.33)
  - Linux Web Framework tests: 23/71 (0.32)
  - Linux linux_web_engine: 39/126 (0.31)
  - Linux linux_fuchsia: 37/122 (0.30)
  - Linux linux_unopt: 38/126 (0.30)
  - Linux linux_android_emulator_tests: 20/67 (0.30)
  - Linux mac_unopt: 37/126 (0.29)
  - Mac mac_host_engine: 37/126 (0.29)
  - Windows windows_unopt: 31/126 (0.25)
  - Linux linux_android_debug_engine: 27/126 (0.21)
  - Linux linux_clang_tidy: 21/99 (0.21)
  - Windows windows_host_engine: 26/126 (0.21)
  - Mac mac_ios_engine: 20/126 (0.16)
  - Mac mac_clang_tidy: 15/103 (0.15)
  - Linux linux_android_aot_engine: 16/126 (0.13)
  - Windows windows_android_aot_engine: 15/126 (0.12)
  - Windows windows_arm_host_engine: 13/126 (0.10)
  - Linux linux_host_desktop_engine: 11/126 (0.09)
  - Linux mac_android_aot_engine: 10/126 (0.08)
  - Linux linux_arm_host_engine: 9/126 (0.07)
  - Vulnerability scanning: 0/110 (0.00)
  - triage: 0/127 (0.00)
  - Extract Dependencies: 0/110 (0.00)
  - cla/google: 0/117 (0.00)
  - ci.yaml validation: 0/118 (0.00)
```

This suggests, but is not authoritative, that ~30% of `Linux linux_web_engine` builds fail on PRs that aren't labeled `platform-web`. Compare that with, say, `Linux linux_arm_host_engine` (7%).

I'm happy to make minor changes to the script to make it more useful, or can also accept PRs.