### PR TITLE
Fix iOS password autofill prompt dismissal causes layout to resize

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1520,6 +1520,15 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   BOOL keyboardAnimationIsCompounding =
       self.keyboardAnimationIsShowing == keyboardWillShow && _keyboardAnimationVSyncClient != nil;
 
+  // Avoid triggering startKeyBoardAnimation when keyboard notifications are triggered
+  // by the dismissal of password autofill prompt. When this happens, there is
+  // no keyboard on the screen and FlutterTextInputViewAccessibilityHider is nil.
+  FlutterTextInputPlugin* textInputPlugin = self.engine.textInputPlugin;
+  UIView* textInputHider = [[textInputPlugin textInputView] superview];
+  if (keyboardWillShow && textInputHider == nil) {
+    return;
+  }
+
   // Mark keyboard as showing or hiding.
   self.keyboardAnimationIsShowing = keyboardWillShow;
 


### PR DESCRIPTION
fixes [Save password prompt dismiss is pushing UI up and down](https://github.com/flutter/flutter/issues/112281)

### Code sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      debugShowCheckedModeBanner: false,
      home: HomePage(),
    );
  }
}

class HomePage extends StatefulWidget {
  const HomePage({super.key});

  @override
  State<HomePage> createState() => _HomePageState();
}

class _HomePageState extends State<HomePage> {
  final TextEditingController controller1 = TextEditingController();
  final TextEditingController controller2 = TextEditingController();

  @override
  void dispose() {
    controller1.dispose();
    controller2.dispose();
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold( // Replace Scaffold with Material to fix glitch.
      body: Center(
        child: Column(
          mainAxisSize: MainAxisSize.min,
          children: <Widget>[
            const Text('Login (Without Scaffold)'),
            AutofillGroup(
              child: Column(
                children: <Widget>[
                  TextField(
                    controller: controller1,
                    autofillHints: const <String>[AutofillHints.username],
                  ),
                  TextField(
                    controller: controller2,
                    autofillHints: const <String>[AutofillHints.password],
                  ),
                ],
              ),
            ),
          ],
        ),
      ),
    );
  }
}
```

</details>

### Before


https://github.com/flutter/engine/assets/48603081/dfe36616-e1dd-4c6c-95b0-e4bd89bd3a6a


### After


https://github.com/flutter/engine/assets/48603081/cfb15252-10cd-4521-a1ef-2cace0004588



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
