### PR TITLE
Avoid static construction of non-trivial objects

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,7 +27,8 @@ Checks: >-
   performance-move-const-arg,
   performance-move-constructor-init,
   performance-unnecessary-copy-initialization,
-  performance-unnecessary-value-param
+  performance-unnecessary-value-param,
+  fuchsia-statically-constructed-objects
 
 CheckOptions:
   - key: modernize-use-default-member-init.UseAssignment

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -97,7 +97,10 @@ source_set("flow") {
     "//flutter/third_party/txt",
   ]
 
-  deps = [ "//flutter/skia" ]
+  deps = [
+    "//flutter/skia",
+    "//third_party/abseil-cpp/absl/base:no_destructor",
+  ]
 
   if (impeller_supports_rendering) {
     deps += [


### PR DESCRIPTION
Style guide: https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables

See https://github.com/flutter/flutter/issues/142835

I expect this to fail on CI right now, want to see if I can get them all or just create a burn down for this rule.