### PR TITLE
[Impeller] Respect resolving store actions in the Vulkan backend.

### DIFF
--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -314,18 +314,39 @@ constexpr vk::AttachmentLoadOp ToVKAttachmentLoadOp(LoadAction load_action) {
   FML_UNREACHABLE();
 }
 
-constexpr vk::AttachmentStoreOp ToVKAttachmentStoreOp(
-    StoreAction store_action) {
+constexpr vk::AttachmentStoreOp ToVKAttachmentStoreOp(StoreAction store_action,
+                                                      bool is_resolve_texture) {
   switch (store_action) {
     case StoreAction::kStore:
+      // Both MSAA and resolve textures need to be stored. A resolve is NOT
+      // performed.
       return vk::AttachmentStoreOp::eStore;
     case StoreAction::kDontCare:
+      // Both MSAA and resolve textures can be discarded. A resolve is NOT
+      // performed.
       return vk::AttachmentStoreOp::eDontCare;
     case StoreAction::kMultisampleResolve:
+      // The resolve texture is stored but the MSAA texture can be discarded. A
+      // resolve IS performed.
+      return is_resolve_texture ? vk::AttachmentStoreOp::eStore
+                                : vk::AttachmentStoreOp::eDontCare;
     case StoreAction::kStoreAndMultisampleResolve:
-      return vk::AttachmentStoreOp::eDontCare;
+      // Both MSAA and resolve textures need to be stored. A resolve IS
+      // performed.
+      return vk::AttachmentStoreOp::eStore;
   }
+  FML_UNREACHABLE();
+}
 
+constexpr bool StoreActionPerformsResolve(StoreAction store_action) {
+  switch (store_action) {
+    case StoreAction::kDontCare:
+    case StoreAction::kStore:
+      return false;
+    case StoreAction::kMultisampleResolve:
+    case StoreAction::kStoreAndMultisampleResolve:
+      return true;
+  }
   FML_UNREACHABLE();
 }
 


### PR DESCRIPTION
Earlier, the Vulkan backend would perform a resolve as long as store the main texture had a non-unit sample count. This completely ignored StoreAction::kMultisampleResolve and StoreAction::kStoreAndMultisampleResolve which the Metal backend correctly expects.

Fixes https://github.com/flutter/flutter/issues/142947