### PR TITLE
Round SkRects in ClipRectContainsPlatformViewBoundingRect

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -45,7 +45,13 @@ static bool ClipRectContainsPlatformViewBoundingRect(const SkRect& clip_rect,
                                                      const SkRect& platformview_boundingrect,
                                                      const SkMatrix& transform_matrix) {
   SkRect transformed_rect = transform_matrix.mapRect(clip_rect);
-  return transformed_rect.contains(platformview_boundingrect);
+
+  // Tolerate floating point errors when comparing flow clipping view bounds
+  // and quartz platform view bounds. Round to integers.
+  SkIRect transformed_rect_rounded = transformed_rect.round();
+  SkIRect platformview_boundingrect_rounded = platformview_boundingrect.round();
+
+  return transformed_rect_rounded.contains(platformview_boundingrect_rounded);
 }
 
 // Determines if the `clipRRect` from a clipRRect mutator contains the

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -47,11 +47,8 @@ static bool ClipRectContainsPlatformViewBoundingRect(const SkRect& clip_rect,
   SkRect transformed_rect = transform_matrix.mapRect(clip_rect);
 
   // Tolerate floating point errors when comparing flow clipping view bounds
-  // and quartz platform view bounds. Round to integers.
-  SkIRect transformed_rect_rounded = transformed_rect.round();
-  SkIRect platformview_boundingrect_rounded = platformview_boundingrect.round();
-
-  return transformed_rect_rounded.contains(platformview_boundingrect_rounded);
+  // and quartz platform view bounds. Round platform view to integers.
+  return transformed_rect.roundOut().contains(platformview_boundingrect);
 }
 
 // Determines if the `clipRRect` from a clipRRect mutator contains the

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		0AC232F724BA71D300A85907 /* FlutterEngineTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterEngineTest.mm; sourceTree = "<group>"; };
 		0AC2330324BA71D300A85907 /* accessibility_bridge_test.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = accessibility_bridge_test.mm; sourceTree = "<group>"; };
 		0AC2330B24BA71D300A85907 /* FlutterTextInputPluginTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterTextInputPluginTest.mm; sourceTree = "<group>"; };
-		0AC2330F24BA71D300A85907 /* FlutterBinaryMessengerRelayTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterBinaryMessengerRelayTest.mm; sourceTree = "<group>"; };
 		0AC2331024BA71D300A85907 /* connection_collection_test.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = connection_collection_test.mm; sourceTree = "<group>"; };
 		0AC2331224BA71D300A85907 /* FlutterEnginePlatformViewTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterEnginePlatformViewTest.mm; sourceTree = "<group>"; };
 		0AC2331924BA71D300A85907 /* FlutterPluginAppLifeCycleDelegateTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterPluginAppLifeCycleDelegateTest.mm; sourceTree = "<group>"; };
@@ -72,7 +71,6 @@
 		3DD7D38C27D2B81000DA365C /* FlutterUndoManagerPluginTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterUndoManagerPluginTest.mm; sourceTree = "<group>"; };
 		689EC1E2281B30D3008FEB58 /* FlutterSpellCheckPluginTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterSpellCheckPluginTest.mm; sourceTree = "<group>"; };
 		68B6091227F62F990036AC78 /* VsyncWaiterIosTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VsyncWaiterIosTest.mm; sourceTree = "<group>"; };
-		73F12C22288F92FF00AFC3A6 /* FlutterViewControllerTest_mrc.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterViewControllerTest_mrc.mm; sourceTree = "<group>"; };
 		D2D361A52B234EAC0018964E /* FlutterMetalLayerTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterMetalLayerTest.mm; sourceTree = "<group>"; };
 		F7521D7226BB671E005F15C5 /* libios_test_flutter.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libios_test_flutter.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libios_test_flutter.dylib"; sourceTree = "<group>"; };
 		F7521D7526BB673E005F15C5 /* libocmock_shared.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libocmock_shared.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libocmock_shared.dylib"; sourceTree = "<group>"; };
@@ -109,12 +107,10 @@
 				0AC232F724BA71D300A85907 /* FlutterEngineTest.mm */,
 				0AC2330324BA71D300A85907 /* accessibility_bridge_test.mm */,
 				0AC2330B24BA71D300A85907 /* FlutterTextInputPluginTest.mm */,
-				0AC2330F24BA71D300A85907 /* FlutterBinaryMessengerRelayTest.mm */,
 				0AC2331024BA71D300A85907 /* connection_collection_test.mm */,
 				0AC2331224BA71D300A85907 /* FlutterEnginePlatformViewTest.mm */,
 				0AC2331924BA71D300A85907 /* FlutterPluginAppLifeCycleDelegateTest.mm */,
 				0AC2332124BA71D300A85907 /* FlutterViewControllerTest.mm */,
-				73F12C22288F92FF00AFC3A6 /* FlutterViewControllerTest_mrc.mm */,
 				D2D361A52B234EAC0018964E /* FlutterMetalLayerTest.mm */,
 			);
 			name = Source;


### PR DESCRIPTION
Platform view clip mutators are being applied when the platform view scrolls off screen.  This was due to floating point errors comparing the bounds of the platform view with the bounds of the clip view.

https://github.com/flutter/engine/blob/373b1ec35b74c80f5ab450e9365e884cc87b971c/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm#L44-L48

Example:

Clip rect:
```
(fLeft = 135, fTop = 17.2308426, fRight = 1305, fBottom = 2240.23096)
```
Platform view rect:
```
(fLeft = 135, fTop = 17.230835, fRight = 1035, fBottom = 767.230835)
```
The clip rect should be larger than the platform view rect and therefore no clipping should happen.  The left and top should be equal, and the right and bottom clip is greater than the platform view.  However, because the top 17.2308426 > 17.230835 the rect is _not_ larger (for the clip rect to contain the platform view, left and top must be <= and right and bottom must be >=), then clipping happens, causing an expensive `-[FlutterClippingMaskView drawRect:]` call.  Handle this by rounding the rect bounds during the fast-path `ClipRectContainsPlatformViewBoundingRect` check.

Fixes https://github.com/flutter/flutter/issues/142828
See also https://github.com/flutter/engine/pull/37434 and https://github.com/flutter/engine/pull/20050

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
