### PR TITLE
[ios] Fix memory leak in ChildClippingView

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,5 @@ Twin Sun, LLC <google-contrib@twinsunsolutions.com>
 Qixing Cao <qixing.cao.83@gmail.com>
 LinXunFeng <linxunfeng@yeah.net>
 Amir Panahandeh <amirpanahandeh@gmail.com>
+Rulong Chen（陈汝龙）<rulong.crl@alibaba-inc.com>
+

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -246,6 +246,17 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
   XCTAssertTrue([childClippingView pointInside:CGPointMake(199, 199) withEvent:nil]);
 }
 
+- (void)testReleasesBackdropFilterSubviewsOnChildClippingViewDealloc {
+  __weak NSMutableArray<UIVisualEffectView*>* weakBackdropFilterSubviews = nil;
+  @autoreleasepool {
+    ChildClippingView* clipping_view = [[ChildClippingView alloc] initWithFrame:CGRectZero];
+    weakBackdropFilterSubviews = clipping_view.backdropFilterSubviews;
+    XCTAssertNotNil(weakBackdropFilterSubviews);
+    clipping_view = nil;
+  }
+  XCTAssertNil(weakBackdropFilterSubviews);
+}
+
 - (void)testApplyBackdropFilter {
   flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
   auto thread_task_runner = CreateNewThread("FlutterPlatformViewsTest");

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -120,6 +120,8 @@
 // filters.
 - (void)applyBlurBackdropFilters:(NSArray<PlatformViewFilter*>*)filters;
 
+// For testing only.
+- (NSMutableArray*)backdropFilterSubviews;
 @end
 
 namespace flutter {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -236,7 +236,7 @@ static BOOL _preparedOnce = NO;
 
 - (NSMutableArray*)backdropFilterSubviews {
   if (!_backdropFilterSubviews) {
-    _backdropFilterSubviews = [[[NSMutableArray alloc] init] retain];
+    _backdropFilterSubviews = [[NSMutableArray alloc] init];
   }
   return _backdropFilterSubviews;
 }


### PR DESCRIPTION
This fixes the memory leak in `ChildClippingView`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
