### PR TITLE
Run all Android `scenario_app` tests, not just the smoke test.

### DIFF
--- a/testing/scenario_app/bin/android_integration_tests.dart
+++ b/testing/scenario_app/bin/android_integration_tests.dart
@@ -33,7 +33,6 @@ void main(List<String> args) async {
       'smoke-test',
       help: 'runs a single test to verify the setup',
       negatable: false,
-      defaultsTo: true,
     );
 
   runZonedGuarded(


### PR DESCRIPTION
I was making sure that I could get at least one test running and passing on CI (as expected), now turn all of them on.