### PR TITLE
Add use_rbe to gclient variables for Framework Smoke Tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -218,6 +218,9 @@ targets:
     enabled_branches:
       - main
     timeout: 60
+    properties:
+      gclient_variables: >-
+        {"use_rbe": true}
 
   - name: Linux linux_clang_tidy
     recipe: engine_v2/engine_v2


### PR DESCRIPTION
This is to enable rbe support. Part of https://github.com/flutter/flutter/issues/142986