### PR TITLE
[Impeller] blur: drop eighth downsample barrier

### DIFF
--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -221,12 +221,17 @@ Scalar GaussianBlurFilterContents::CalculateScale(Scalar sigma) {
   exponent = std::max(-4.0f, exponent);
   Scalar rounded = powf(2.0f, exponent);
   Scalar result = rounded;
-  // Only drop below 1/8 if 1/8 would overflow our kernel.
+  // Extend the range of the 1/8th downsample based on the effective kernel size
+  // for the blur.
   if (rounded < 0.125f) {
     Scalar rounded_plus = powf(2.0f, exponent + 1);
     Scalar blur_radius = CalculateBlurRadius(sigma);
     int kernel_size_plus = (ScaleBlurRadius(blur_radius, rounded_plus) * 2) + 1;
-    result = kernel_size_plus < kMaxKernelSize ? rounded_plus : rounded;
+    // This constant was picked by looking at the results in to make sure no
+    // shimmering was introduced.
+    static constexpr int32_t kEighthDownsampleKernalWidthMax = 41;
+    result = kernel_size_plus <= kEighthDownsampleKernalWidthMax ? rounded_plus
+                                                                 : rounded;
   }
   return result;
 };

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -198,7 +198,8 @@ TEST(GaussianBlurFilterContentsTest, CalculateSigmaValues) {
   EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(4.0f), 1);
   EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(16.0f), 0.25);
   // Hang on to 1/8 as long as possible.
-  EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(100.0f), 0.125);
+  EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(95.0f), 0.125);
+  EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(96.0f), 0.0625);
   // Downsample clamped to 1/16th.
   EXPECT_EQ(GaussianBlurFilterContents::CalculateScale(1024.0f), 0.0625);
 }


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/142990

I pushed this value as low as I dared to go and ended up with a kernel size of 41 (radius 20).

Here is the new downsample rate versus sigma (on a 2x display).

## before
<img width="903" alt="Screenshot 2024-02-06 at 10 28 58 AM" src="https://github.com/flutter/engine/assets/30870216/f94896d3-fe1c-40e5-8ff4-d50bafbd0b5e">

## after
<img width="901" alt="Screenshot 2024-02-06 at 10 26 49 AM" src="https://github.com/flutter/engine/assets/30870216/bc5cced7-b8c4-4597-9dd4-c460b966176b">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
