### PR TITLE
Disable surface producer

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -151,7 +151,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
 
   private static boolean enableImageRenderTarget = true;
 
-  private static boolean enableSurfaceProducerRenderTarget = true;
+  private static boolean enableSurfaceProducerRenderTarget = false;
 
   private final PlatformViewsChannel.PlatformViewsHandler channelHandler =
       new PlatformViewsChannel.PlatformViewsHandler() {


### PR DESCRIPTION
Disables the surface producer code paths in beta because of a bug that impacts some platform views (e.g. https://github.com/flutter/flutter/issues/142952). 

Cherry picking the correct fix is too complicated as it is multiple dependent PRs with lots of conflicts.

This PR just disables the code path for the beta.