### PR TITLE
Fix Android `scenario_app` to actually run and block on CI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -54,6 +54,10 @@ targets:
     recipe: engine_v2/engine_v2
     properties:
       config_name: linux_android_emulator
+      dependencies: >-
+        [
+          {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
+        ]
     timeout: 60
     runIf:
       - .ci.yaml
@@ -71,6 +75,10 @@ targets:
     recipe: engine_v2/engine_v2
     properties:
       config_name: linux_android_emulator_api_33
+      dependencies: >-
+        [
+          {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
+        ]
     timeout: 60
     runIf:
       - .ci.yaml

--- a/ci/builders/linux_android_emulator.json
+++ b/ci/builders/linux_android_emulator.json
@@ -17,6 +17,12 @@
                 "--rbe",
                 "--no-goma"
             ],
+            "dependencies": [
+                {
+                    "dependency": "goldctl",
+                    "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
+                }
+            ],
             "name": "android_debug_x64",
             "ninja": {
                 "config": "android_debug_x64",

--- a/ci/builders/linux_android_emulator_api_33.json
+++ b/ci/builders/linux_android_emulator_api_33.json
@@ -17,6 +17,12 @@
                 "--rbe",
                 "--no-goma"
             ],
+            "dependencies": [
+                {
+                    "dependency": "goldctl",
+                    "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
+                }
+            ],
             "name": "android_debug_x64",
             "ninja": {
                 "config": "android_debug_x64",

--- a/shell/platform/android/surface_texture_external_texture.cc
+++ b/shell/platform/android/surface_texture_external_texture.cc
@@ -57,11 +57,17 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
   if (dl_image_) {
     DlAutoCanvasRestore autoRestore(context.canvas, true);
 
-    // The incoming texture is vertically flipped, so we flip it
-    // back. OpenGL's coordinate system has Positive Y equivalent to up, while
-    // Skia's coordinate system has Negative Y equvalent to up.
-    context.canvas->Translate(bounds.x(), bounds.y() + bounds.height());
-    context.canvas->Scale(bounds.width(), -bounds.height());
+    // The incoming texture is vertically flipped, so we flip it back.
+    //
+    // OpenGL's coordinate system has Positive Y equivalent to up, while Skia's
+    // coordinate system (as well as Impeller's) has Negative Y equvalent to up.
+    {
+      // Move (translate) the origin to the bottom-left corner of the image.
+      context.canvas->Translate(bounds.x(), bounds.y() + bounds.height());
+
+      // No change in the X axis, but we need to flip the Y axis.
+      context.canvas->Scale(1, -1);
+    }
 
     if (!transform_.isIdentity()) {
       DlImageColorSource source(dl_image_, DlTileMode::kClamp,
@@ -72,7 +78,8 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
         paintWithShader = *context.paint;
       }
       paintWithShader.setColorSource(&source);
-      context.canvas->DrawRect(SkRect::MakeWH(1, 1), paintWithShader);
+      context.canvas->DrawRect(SkRect::MakeWH(bounds.width(), bounds.height()),
+                               paintWithShader);
     } else {
       context.canvas->DrawImage(dl_image_, {0, 0}, sampling, context.paint);
     }

--- a/shell/platform/android/surface_texture_external_texture.cc
+++ b/shell/platform/android/surface_texture_external_texture.cc
@@ -57,17 +57,11 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
   if (dl_image_) {
     DlAutoCanvasRestore autoRestore(context.canvas, true);
 
-    // The incoming texture is vertically flipped, so we flip it back.
-    //
-    // OpenGL's coordinate system has Positive Y equivalent to up, while Skia's
-    // coordinate system (as well as Impeller's) has Negative Y equvalent to up.
-    {
-      // Move (translate) the origin to the bottom-left corner of the image.
-      context.canvas->Translate(bounds.x(), bounds.y() + bounds.height());
-
-      // No change in the X axis, but we need to flip the Y axis.
-      context.canvas->Scale(1, -1);
-    }
+    // The incoming texture is vertically flipped, so we flip it
+    // back. OpenGL's coordinate system has Positive Y equivalent to up, while
+    // Skia's coordinate system has Negative Y equvalent to up.
+    context.canvas->Translate(bounds.x(), bounds.y() + bounds.height());
+    context.canvas->Scale(bounds.width(), -bounds.height());
 
     if (!transform_.isIdentity()) {
       DlImageColorSource source(dl_image_, DlTileMode::kClamp,
@@ -78,8 +72,7 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
         paintWithShader = *context.paint;
       }
       paintWithShader.setColorSource(&source);
-      context.canvas->DrawRect(SkRect::MakeWH(bounds.width(), bounds.height()),
-                               paintWithShader);
+      context.canvas->DrawRect(SkRect::MakeWH(1, 1), paintWithShader);
     } else {
       context.canvas->DrawImage(dl_image_, {0, 0}, sampling, context.paint);
     }

--- a/testing/scenario_app/bin/android_integration_tests.dart
+++ b/testing/scenario_app/bin/android_integration_tests.dart
@@ -33,6 +33,11 @@ void main(List<String> args) async {
       'smoke-test',
       help: 'runs a single test to verify the setup',
       valueHelp: 'empty to run dev.flutter.scenarios.EngineLaunchE2ETest, or specify a class',
+    )
+    ..addFlag(
+      'use-skia-gold',
+      help: 'use Skia Gold to compare screenshots. Disable for local testing.',
+      defaultsTo: true,
     );
 
   runZonedGuarded(
@@ -40,11 +45,17 @@ void main(List<String> args) async {
       final ArgResults results = parser.parse(args);
       final Directory outDir = Directory(results['out-dir'] as String);
       final File adb = File(results['adb'] as String);
+      final bool useSkiaGold = results['use-skia-gold'] as bool;
       String? smokeTest = results['smoke-test'] as String?;
       if (results.wasParsed('smoke-test') && smokeTest!.isEmpty) {
         smokeTest = 'dev.flutter.scenarios.EngineLaunchE2ETest';
       }
-      await _run(outDir: outDir, adb: adb, smokeTestFullPath: smokeTest);
+      await _run(
+        outDir: outDir,
+        adb: adb,
+        smokeTestFullPath: smokeTest,
+        useSkiaGold: useSkiaGold,
+      );
       exit(0);
     },
     (Object error, StackTrace stackTrace) {
@@ -61,6 +72,7 @@ Future<void> _run({
   required Directory outDir,
   required File adb,
   required String? smokeTestFullPath,
+  required bool useSkiaGold,
 }) async {
   const ProcessManager pm = LocalProcessManager();
 
@@ -181,7 +193,11 @@ Future<void> _run({
         await skiaGoldClient!.auth();
         log('skia gold client is available');
       } else {
-        log('skia gold client is unavailable');
+        if (useSkiaGold) {
+          panic(<String>['skia gold client is unavailable']);
+        } else {
+          log('skia gold client is unavaialble');
+        }
       }
     });
 

--- a/testing/scenario_app/bin/android_integration_tests.dart
+++ b/testing/scenario_app/bin/android_integration_tests.dart
@@ -44,7 +44,7 @@ void main(List<String> args) async {
       if (results.wasParsed('smoke-test') && smokeTest!.isEmpty) {
         smokeTest = 'dev.flutter.scenarios.EngineLaunchE2ETest';
       }
-      await _run(outDir: outDir, adb: adb, smokeTest: smokeTest);
+      await _run(outDir: outDir, adb: adb, smokeTestFullPath: smokeTest);
       exit(0);
     },
     (Object error, StackTrace stackTrace) {
@@ -214,7 +214,7 @@ Future<void> _run({
         'instrument',
         '-w',
         if (smokeTestFullPath != null)
-          '-e class ${smokeTestFullPath}',
+          '-e class $smokeTestFullPath',
         'dev.flutter.scenarios.test/dev.flutter.TestRunner',
       ]);
       if (exitCode != 0) {

--- a/testing/scenario_app/bin/android_integration_tests.dart
+++ b/testing/scenario_app/bin/android_integration_tests.dart
@@ -21,23 +21,23 @@ void main(List<String> args) async {
   final ArgParser parser = ArgParser()
     ..addOption(
       'adb',
-      help: 'absolute path to the adb tool',
+      help: 'Absolute path to the adb tool',
       mandatory: true,
     )
     ..addOption(
       'out-dir',
-      help: 'out directory',
+      help: 'Out directory',
       mandatory: true,
     )
     ..addOption(
       'smoke-test',
       help: 'runs a single test to verify the setup',
-      valueHelp: 'empty to run dev.flutter.scenarios.EngineLaunchE2ETest, or specify a class',
+      valueHelp: 'The class to execute, defaults to dev.flutter.scenarios.EngineLaunchE2ETest',
     )
     ..addFlag(
       'use-skia-gold',
-      help: 'use Skia Gold to compare screenshots. Disable for local testing.',
-      defaultsTo: true,
+      help: 'Use Skia Gold to compare screenshots.',
+      defaultsTo: isLuciEnv,
     );
 
   runZonedGuarded(


### PR DESCRIPTION
https://github.com/flutter/engine/pull/50414/commits/20337eaea438e505d4bd215b4e84362fa9935d2d (now reverted) intentionally re-introduced a bug (https://github.com/flutter/engine/pull/49938) on a now working test runner, and verified that (with some fixes in this PR), we can now catch regressions on CI with SkiaGold:

---

<details>

<summary>ExternalTextureTests_testCanvasSurface.png</summary>

This test shows that what previously was a picture has been reduced down to a single stretched pixel.

**BEFORE**:

![ExternalTextureTests_testCanvasSurface](https://github.com/flutter/engine/assets/168174/1509ea21-2887-4a3b-b200-b857bbfb8304)

**AFTER**:

![ExternalTextureTests_testCanvasSurface](https://github.com/flutter/engine/assets/168174/d9ae19c8-dd39-4e7f-859c-5d82bd1ba0a3)

</details>

<details>

<summary>ExternalTextureTests_testRotatedMediaSurface_180.png</summary>

Similar to above, but shows _another_ bug (kClamp versus kRepeat)

**BEFORE**:

![ExternalTextureTests_testRotatedMediaSurface_180](https://github.com/flutter/engine/assets/168174/fee5bc8d-749f-4a59-976a-a573515fecea)

**AFTER**:

![ExternalTextureTests_testRotatedMediaSurface_180](https://github.com/flutter/engine/assets/168174/a5249f70-22b4-4d36-8b63-e88c8a6846fe)/cc 

</details>

---

This PR now makes the `scenario_test` useful and blocking for Android engine rolls:

- Add support for connecting to SkiaGold by depending on `goldctl` in the appropriate configs.
- Add some useful local debugging flags for skipping SkiaGold or running specific tests (not used by default).
- Failing to connect to Skia gold is now a test failure.