### PR TITLE
[Windows] Make the view own its EGL surface

### DIFF
--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -230,6 +230,7 @@ executable("flutter_windows_unittests") {
     "testing/test_keyboard.cc",
     "testing/test_keyboard.h",
     "testing/test_keyboard_unittests.cc",
+    "testing/view_modifier.h",
     "testing/windows_test.cc",
     "testing/windows_test.h",
     "testing/windows_test_config_builder.cc",

--- a/shell/platform/windows/compositor_opengl.h
+++ b/shell/platform/windows/compositor_opengl.h
@@ -53,7 +53,7 @@ class CompositorOpenGL : public Compositor {
   bool Initialize();
 
   // Clear the view's surface and removes any previously presented layers.
-  bool ClearSurface();
+  bool Clear(FlutterWindowsView* view);
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/egl/manager.h
+++ b/shell/platform/windows/egl/manager.h
@@ -37,22 +37,19 @@ class Manager {
   // Whether the manager is currently valid.
   bool IsValid() const;
 
-  // Creates an EGLSurface wrapper and backing DirectX 11 SwapChain
-  // associated with window, in the appropriate format for display.
-  // HWND is the window backing the surface. Width and height represent
-  // dimensions surface is created at.
+  // Creates an EGL surface that can be used to render a Flutter view into a
+  // win32 HWND.
   //
-  // After the surface is created, |SetVSyncEnabled| should be called on a
-  // thread that can bind the |render_context_|.
-  virtual bool CreateWindowSurface(HWND hwnd, size_t width, size_t height);
-
-  // Resizes backing surface from current size to newly requested size
-  // based on width and height for the specific case when width and height do
-  // not match current surface dimensions. HWND is the window backing the
-  // surface.
+  // After the surface is created, |WindowSurface::SetVSyncEnabled| should be
+  // called on a thread that can make the surface current.
   //
-  // This binds |render_context_| to the current thread.
-  virtual void ResizeWindowSurface(HWND hwnd, size_t width, size_t height);
+  // HWND is the window backing the surface. Width and height are the surface's
+  // physical pixel dimensions.
+  //
+  // Returns nullptr on failure.
+  virtual std::unique_ptr<WindowSurface> CreateWindowSurface(HWND hwnd,
+                                                             size_t width,
+                                                             size_t height);
 
   // Check if the current thread has a context bound.
   bool HasContextCurrent();
@@ -73,9 +70,6 @@ class Manager {
 
   // Get the EGL context used for async texture uploads.
   virtual Context* resource_context() const;
-
-  // Get the EGL surface that backs the Flutter view.
-  virtual WindowSurface* surface() const;
 
  protected:
   // Creates a new surface manager retaining reference to the passed-in target
@@ -114,9 +108,6 @@ class Manager {
 
   // The EGL context used for async texture uploads.
   std::unique_ptr<Context> resource_context_;
-
-  // Th EGL surface used to render into the Flutter view.
-  std::unique_ptr<WindowSurface> surface_;
 
   // The current D3D device.
   Microsoft::WRL::ComPtr<ID3D11Device> resolved_device_ = nullptr;

--- a/shell/platform/windows/egl/surface.h
+++ b/shell/platform/windows/egl/surface.h
@@ -19,7 +19,7 @@ class Surface {
  public:
   Surface(EGLDisplay display, EGLContext context, EGLSurface surface);
 
-  ~Surface();
+  virtual ~Surface();
 
   // Destroy the EGL surface and invalidate this object.
   //

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -30,8 +30,9 @@ class HalfBrokenEGLManager : public egl::Manager {
  public:
   HalfBrokenEGLManager() : egl::Manager(/*enable_impeller = */ false) {}
 
-  bool CreateWindowSurface(HWND hwnd, size_t width, size_t height) override {
-    return false;
+  std::unique_ptr<egl::WindowSurface>
+  CreateWindowSurface(HWND hwnd, size_t width, size_t height) override {
+    return nullptr;
   }
 };
 

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -52,11 +52,16 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // Destroys current rendering surface if one has been allocated.
   void DestroyRenderSurface();
 
+  // Get the EGL surface that backs the Flutter view.
+  //
+  // This might be nullptr or an invalid surface.
+  egl::WindowSurface* surface() const;
+
   // Return the currently configured HWND.
   virtual HWND GetWindowHandle() const;
 
   // Returns the engine backing this view.
-  FlutterWindowsEngine* GetEngine();
+  FlutterWindowsEngine* GetEngine() const;
 
   // Tells the engine to generate a new frame
   void ForceRedraw();
@@ -79,16 +84,17 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   void OnHighContrastChanged() override;
 
   // Called on the raster thread when |CompositorOpenGL| receives an empty
-  // frame.
+  // frame. Returns true if the frame can be presented.
   //
-  // This resizes the surface if a resize is pending.
-  void OnEmptyFrameGenerated();
+  // This destroys and then re-creates the view's surface if a resize is
+  // pending.
+  bool OnEmptyFrameGenerated();
 
   // Called on the raster thread when |CompositorOpenGL| receives a frame.
   // Returns true if the frame can be presented.
   //
-  // This resizes the surface if a resize is pending and |width| and
-  // |height| match the target size.
+  // This destroys and then re-creates the view's surface if a resize is pending
+  // and |width| and |height| match the target size.
   bool OnFrameGenerated(size_t width, size_t height);
 
   // Called on the raster thread after |CompositorOpenGL| presents a frame.
@@ -226,6 +232,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   CreateAccessibilityBridge();
 
  private:
+  // Allows setting the surface in tests.
+  friend class ViewModifier;
+
   // Struct holding the state of an individual pointer. The engine doesn't keep
   // track of which buttons have been pressed, so it's the embedding's
   // responsibility.
@@ -266,6 +275,17 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
     // and the buffers have been swapped.
     kDone,
   };
+
+  // Resize the surface to the desired size.
+  //
+  // If the dimensions have changed, this destroys the original surface and
+  // creates a new one.
+  //
+  // This must be run on the raster thread. This binds the surface to the
+  // current thread.
+  //
+  // Width and height are the surface's desired physical pixel dimensions.
+  bool ResizeRenderSurface(size_t width, size_t height);
 
   // Sends a window metrics update to the Flutter engine using current window
   // dimensions in physical
@@ -370,6 +390,12 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
 
   // Mocks win32 APIs.
   std::shared_ptr<WindowsProcTable> windows_proc_table_;
+
+  // The EGL surface backing the view.
+  //
+  // Null if using software rasterization, the surface hasn't been created yet,
+  // or if surface creation failed.
+  std::unique_ptr<egl::WindowSurface> surface_ = nullptr;
 
   // Keeps track of pointer states in relation to the window.
   std::unordered_map<int32_t, std::unique_ptr<PointerState>> pointer_states_;

--- a/shell/platform/windows/testing/egl/mock_manager.h
+++ b/shell/platform/windows/testing/egl/mock_manager.h
@@ -18,12 +18,13 @@ class MockManager : public flutter::egl::Manager {
  public:
   MockManager() : Manager(false) {}
 
-  MOCK_METHOD(bool, CreateWindowSurface, (HWND, size_t, size_t), (override));
-  MOCK_METHOD(void, ResizeWindowSurface, (HWND, size_t, size_t), (override));
+  MOCK_METHOD(std::unique_ptr<flutter::egl::WindowSurface>,
+              CreateWindowSurface,
+              (HWND, size_t, size_t),
+              (override));
 
   MOCK_METHOD(flutter::egl::Context*, render_context, (), (const, override));
   MOCK_METHOD(flutter::egl::Context*, resource_context, (), (const, override));
-  MOCK_METHOD(flutter::egl::WindowSurface*, surface, (), (const, override));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockManager);

--- a/shell/platform/windows/testing/view_modifier.h
+++ b/shell/platform/windows/testing/view_modifier.h
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_VIEW_MODIFIER_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_VIEW_MODIFIER_H_
+
+#include "flutter/fml/macros.h"
+#include "flutter/shell/platform/windows/egl/window_surface.h"
+#include "flutter/shell/platform/windows/flutter_windows_view.h"
+
+namespace flutter {
+
+// A test utility class providing the ability to access and alter various
+// private fields in a |FlutterWindowsView| instance.
+class ViewModifier {
+ public:
+  explicit ViewModifier(FlutterWindowsView* view) : view_(view) {}
+
+  // Override the EGL surface used by the view.
+  //
+  // Modifications are to the view, and will last for the lifetime of the
+  // view unless overwritten again.
+  void SetSurface(std::unique_ptr<egl::WindowSurface> surface) {
+    view_->surface_ = std::move(surface);
+  }
+
+ private:
+  FlutterWindowsView* view_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ViewModifier);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_VIEW_MODIFIER_H_


### PR DESCRIPTION
This makes the view own its EGL surface. This will allow us to support multiple EGL surfaces once the engine supports having multiple views.

Some notable changes:

1. EGL surface resizing logic is now entirely in `FlutterWindowsView`. Previously some resizing logic was in the `egl::Manager`, however, the view has to handle resizing failures so this unifies the logic in one place.
2. The `OnEmptyFrameGenerated` and `OnFrameGenerated` now return `false` (aka "don't present") if the surface is invalid. This simplifies the compositor as it no longer needs to check for invalid surfaces
3. This introduces a `ViewModifier` testing helper to allow overriding a view's surface. This isn't strictly necessary, tests can setup a surface by mocking several EGL methods and calling `FlutterWindowsView::CreateRenderSurface()`. However, this is verbose & heavily tied to implementation details. The `ViewModifier` avoids this boilerplate.
4. `CompositorOpenGL`'s initialization now makes the render context current without any render surfaces. Previously it also made the view's surface current, which was unnecessary.

Part of https://github.com/flutter/flutter/issues/137267

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
