### PR TITLE
[Impeller] move path out of PathBuilder in TakePath.

### DIFF
--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -15,11 +15,7 @@ namespace impeller {
 
 Path::Path() : data_(new Data()) {}
 
-Path::Path(const Data& data) : data_(new Data(data)) {
-  FML_DCHECK(data_->points.size() == data_->points.capacity());
-  FML_DCHECK(data_->components.size() == data_->components.capacity());
-  FML_DCHECK(data_->contours.size() == data_->contours.capacity());
-}
+Path::Path(Data data) : data_(std::make_shared<Data>(std::move(data))) {}
 
 Path::~Path() = default;
 
@@ -351,6 +347,10 @@ std::optional<Rect> Path::GetTransformedBoundingBox(
     return std::nullopt;
   }
   return bounds->TransformBounds(transform);
+}
+
+Path::Data Path::Data::Clone() const {
+  return Path::Data(*this);
 }
 
 }  // namespace impeller

--- a/impeller/geometry/path.cc
+++ b/impeller/geometry/path.cc
@@ -349,8 +349,4 @@ std::optional<Rect> Path::GetTransformedBoundingBox(
   return bounds->TransformBounds(transform);
 }
 
-Path::Data Path::Data::Clone() const {
-  return Path::Data(*this);
-}
-
 }  // namespace impeller

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -200,9 +200,13 @@ class Path {
   // builder from affecting the existing taken paths.
   struct Data {
     Data() = default;
-    Data(const Data& other) = default;
+
+    Data(Data&& other) = default;
 
     ~Data() = default;
+
+    /// Eagerly copies all data into a new data struct.
+    Data Clone() const;
 
     FillType fill = FillType::kNonZero;
     Convexity convexity = Convexity::kUnknown;
@@ -212,10 +216,11 @@ class Path {
 
     std::optional<Rect> bounds;
 
-    bool locked = false;
+   private:
+    Data(const Data& other) = default;
   };
 
-  explicit Path(const Data& data);
+  explicit Path(Data data);
 
   std::shared_ptr<const Data> data_;
 };

--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -203,10 +203,9 @@ class Path {
 
     Data(Data&& other) = default;
 
-    ~Data() = default;
+    Data(const Data& other) = default;
 
-    /// Eagerly copies all data into a new data struct.
-    Data Clone() const;
+    ~Data() = default;
 
     FillType fill = FillType::kNonZero;
     Convexity convexity = Convexity::kUnknown;
@@ -215,9 +214,6 @@ class Path {
     std::vector<ContourComponent> contours;
 
     std::optional<Rect> bounds;
-
-   private:
-    Data(const Data& other) = default;
   };
 
   explicit Path(Data data);

--- a/impeller/geometry/path_builder.cc
+++ b/impeller/geometry/path_builder.cc
@@ -16,7 +16,7 @@ PathBuilder::~PathBuilder() = default;
 
 Path PathBuilder::CopyPath(FillType fill) {
   prototype_.fill = fill;
-  return Path(prototype_.Clone());
+  return Path(prototype_);
 }
 
 Path PathBuilder::TakePath(FillType fill) {

--- a/impeller/geometry/path_builder.cc
+++ b/impeller/geometry/path_builder.cc
@@ -16,13 +16,13 @@ PathBuilder::~PathBuilder() = default;
 
 Path PathBuilder::CopyPath(FillType fill) {
   prototype_.fill = fill;
-  return Path(prototype_);
+  return Path(prototype_.Clone());
 }
 
 Path PathBuilder::TakePath(FillType fill) {
   prototype_.fill = fill;
   UpdateBounds();
-  return Path(prototype_);
+  return Path(std::move(prototype_));
 }
 
 void PathBuilder::Reserve(size_t point_size, size_t verb_size) {

--- a/impeller/geometry/path_unittests.cc
+++ b/impeller/geometry/path_unittests.cc
@@ -486,7 +486,7 @@ TEST(PathTest, CanBeCloned) {
   }
 }
 
-TEST(PathTest, PathBuilderDoesNotMutateTakenPaths) {
+TEST(PathTest, PathBuilderDoesNotMutateCopiedPaths) {
   auto test_isolation =
       [](const std::function<void(PathBuilder & builder)>& mutator,
          bool will_close, Point mutation_offset, const std::string& label) {

--- a/impeller/geometry/path_unittests.cc
+++ b/impeller/geometry/path_unittests.cc
@@ -525,23 +525,23 @@ TEST(PathTest, PathBuilderDoesNotMutateTakenPaths) {
           }
         };
 
-        auto path1 = builder.TakePath();
+        auto path1 = builder.CopyPath();
         verify_path(path1, false, false, {},
                     "Initial Path1 state before " + label);
 
         for (int i = 0; i < 10; i++) {
-          auto path = builder.TakePath();
+          auto path = builder.CopyPath();
           verify_path(
               path, false, false, {},
-              "Extra TakePath #" + std::to_string(i + 1) + " for " + label);
+              "Extra CopyPath #" + std::to_string(i + 1) + " for " + label);
         }
         mutator(builder);
         verify_path(path1, false, false, {},
                     "Path1 state after subsequent " + label);
 
-        auto path2 = builder.TakePath();
+        auto path2 = builder.CopyPath();
         verify_path(path1, false, false, {},
-                    "Path1 state after subsequent " + label + " and TakePath");
+                    "Path1 state after subsequent " + label + " and CopyPath");
         verify_path(path2, true, will_close, mutation_offset,
                     "Initial Path2 state with subsequent " + label);
       };


### PR DESCRIPTION
We should move this path so we don't end up allocating/deallocating twice. 

Fixes https://github.com/flutter/flutter/issues/142873
