### PR TITLE
[Impeller] Log non-default graphics backend usages, use IMPORTANT rather than ERROR

### DIFF
--- a/fml/log_level.h
+++ b/fml/log_level.h
@@ -13,8 +13,11 @@ typedef int LogSeverity;
 constexpr LogSeverity kLogInfo = 0;
 constexpr LogSeverity kLogWarning = 1;
 constexpr LogSeverity kLogError = 2;
-constexpr LogSeverity kLogFatal = 3;
-constexpr LogSeverity kLogNumSeverities = 4;
+// A log that is not an error, is important enough to display even if ordinary
+// info is hidden.
+constexpr LogSeverity kLogImportant = 3;
+constexpr LogSeverity kLogFatal = 4;
+constexpr LogSeverity kLogNumSeverities = 5;
 
 // DEPRECATED: Use |kLogInfo|.
 // Ignoring Clang Tidy because this is used in a very common substitution macro.
@@ -30,6 +33,11 @@ constexpr LogSeverity LOG_WARNING = kLogWarning;
 // Ignoring Clang Tidy because this is used in a very common substitution macro.
 // NOLINTNEXTLINE(readability-identifier-naming)
 constexpr LogSeverity LOG_ERROR = kLogError;
+
+// DEPRECATED: Use |kLogImportant|.
+// Ignoring Clang Tidy because this is used in a very common substitution macro.
+// NOLINTNEXTLINE(readability-identifier-naming)
+constexpr LogSeverity LOG_IMPORTANT = kLogImportant;
 
 // DEPRECATED: Use |kLogFatal|.
 // Ignoring Clang Tidy because this is used in a very common substitution macro.

--- a/fml/logging.cc
+++ b/fml/logging.cc
@@ -28,7 +28,7 @@ namespace {
 
 #if !defined(OS_FUCHSIA)
 const char* const kLogSeverityNames[kLogNumSeverities] = {
-    "INFO", "WARNING", "ERROR", "FATAL", "IMPORTANT"};
+    "INFO", "WARNING", "ERROR", "IMPORTANT", "FATAL"};
 
 const char* GetNameForLogSeverity(LogSeverity severity) {
   if (severity >= kLogInfo && severity < kLogNumSeverities) {
@@ -41,14 +41,6 @@ const char* GetNameForLogSeverity(LogSeverity severity) {
 const char* StripDots(const char* path) {
   while (strncmp(path, "../", 3) == 0) {
     path += 3;
-  }
-  return path;
-}
-
-const char* StripPath(const char* path) {
-  auto* p = strrchr(path, '/');
-  if (p) {
-    return p + 1;
   }
   return path;
 }
@@ -98,9 +90,7 @@ LogMessage::LogMessage(LogSeverity severity,
                        const char* file,
                        int line,
                        const char* condition)
-    : severity_(severity),
-      file_(severity > kLogInfo ? StripDots(file) : StripPath(file)),
-      line_(line) {
+    : severity_(severity), file_(StripDots(file)), line_(line) {
 #if !defined(OS_FUCHSIA)
   stream_ << "[";
   if (severity >= kLogInfo) {
@@ -144,7 +134,6 @@ LogMessage::~LogMessage() {
 #if !defined(OS_FUCHSIA)
   stream_ << std::endl;
 #endif
-
   if (capture_next_log_stream_) {
     *capture_next_log_stream_ << stream_.str();
     capture_next_log_stream_ = nullptr;

--- a/fml/logging.cc
+++ b/fml/logging.cc
@@ -27,8 +27,8 @@ namespace fml {
 namespace {
 
 #if !defined(OS_FUCHSIA)
-const char* const kLogSeverityNames[kLogNumSeverities] = {"INFO", "WARNING",
-                                                          "ERROR", "FATAL"};
+const char* const kLogSeverityNames[kLogNumSeverities] = {
+    "INFO", "WARNING", "ERROR", "FATAL", "IMPORTANT"};
 
 const char* GetNameForLogSeverity(LogSeverity severity) {
   if (severity >= kLogInfo && severity < kLogNumSeverities) {
@@ -153,6 +153,7 @@ LogMessage::~LogMessage() {
     android_LogPriority priority =
         (severity_ < 0) ? ANDROID_LOG_VERBOSE : ANDROID_LOG_UNKNOWN;
     switch (severity_) {
+      case kLogImportant:
       case kLogInfo:
         priority = ANDROID_LOG_INFO;
         break;
@@ -172,6 +173,7 @@ LogMessage::~LogMessage() {
 #elif defined(OS_FUCHSIA)
     FuchsiaLogSeverity severity;
     switch (severity_) {
+      case kLogImportant:
       case kLogInfo:
         severity = FUCHSIA_LOG_INFO;
         break;

--- a/fml/logging_unittests.cc
+++ b/fml/logging_unittests.cc
@@ -7,10 +7,15 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/log_settings.h"
 #include "flutter/fml/logging.h"
+#include "fml/log_level.h"
 #include "gtest/gtest.h"
 
 namespace fml {
 namespace testing {
+
+static_assert(fml::kLogFatal == fml::kLogNumSeverities - 1);
+static_assert(fml::kLogImportant < fml::kLogFatal);
+static_assert(fml::kLogImportant > fml::kLogError);
 
 #ifndef OS_FUCHSIA
 class MakeSureFmlLogDoesNotSegfaultWhenStaticallyCalled {

--- a/fml/logging_unittests.cc
+++ b/fml/logging_unittests.cc
@@ -72,10 +72,8 @@ TEST(LoggingTest, UnreachableKillProcessWithMacro) {
   ASSERT_DEATH({ FML_UNREACHABLE(); }, "");
 }
 
+#if !OS_FUCHSIA
 TEST(LoggingTest, SanityTests) {
-#if OS_FUCHSIA
-  GTEST_SKIP() << "Fuchsia does this differently.";
-#endif  // OS_FUCHSIA
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   std::vector<std::string> severities = {"INFO", "WARNING", "ERROR",
                                          "IMPORTANT"};
@@ -97,6 +95,7 @@ TEST(LoggingTest, SanityTests) {
       },
       R"(\[FATAL:path/to/file.cc\(5\)\] Goodbye)");
 }
+#endif  // !OS_FUCHSIA
 
 }  // namespace testing
 }  // namespace fml

--- a/fml/logging_unittests.cc
+++ b/fml/logging_unittests.cc
@@ -72,7 +72,7 @@ TEST(LoggingTest, UnreachableKillProcessWithMacro) {
   ASSERT_DEATH({ FML_UNREACHABLE(); }, "");
 }
 
-#if !OS_FUCHSIA
+#ifndef OS_FUCHSIA
 TEST(LoggingTest, SanityTests) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   std::vector<std::string> severities = {"INFO", "WARNING", "ERROR",

--- a/shell/platform/android/android_context_gl_impeller.cc
+++ b/shell/platform/android/android_context_gl_impeller.cc
@@ -84,7 +84,7 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
     FML_LOG(ERROR) << "Could not add reactor worker.";
     return nullptr;
   }
-  FML_LOG(ERROR) << "Using the Impeller rendering backend (OpenGLES).";
+  FML_LOG(IMPORTANT) << "Using the Impeller rendering backend (OpenGLES).";
   return context;
 }
 

--- a/shell/platform/android/android_context_vulkan_impeller.cc
+++ b/shell/platform/android/android_context_vulkan_impeller.cc
@@ -48,10 +48,10 @@ static std::shared_ptr<impeller::Context> CreateImpellerContext(
 
   if (context && impeller::CapabilitiesVK::Cast(*context->GetCapabilities())
                      .AreValidationsEnabled()) {
-    FML_LOG(ERROR) << "Using the Impeller rendering backend (Vulkan with "
-                      "Validation Layers).";
+    FML_LOG(IMPORTANT) << "Using the Impeller rendering backend (Vulkan with "
+                          "Validation Layers).";
   } else {
-    FML_LOG(ERROR) << "Using the Impeller rendering backend (Vulkan).";
+    FML_LOG(IMPORTANT) << "Using the Impeller rendering backend (Vulkan).";
   }
 
   return context;

--- a/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm
@@ -39,7 +39,6 @@ static std::shared_ptr<impeller::ContextMTL> CreateImpellerContext(
     FML_LOG(ERROR) << "Could not create Metal Impeller Context.";
     return nullptr;
   }
-  FML_LOG(ERROR) << "Using the Impeller rendering backend.";
 
   return context;
 }

--- a/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.mm
@@ -60,6 +60,8 @@ FLUTTER_ASSERT_ARC
       return nil;
     }
 
+    FML_LOG(IMPORTANT) << "Using the Skia rendering backend (Metal).";
+
     _resourceContext->setResourceCacheLimit(0u);
   }
   return self;

--- a/shell/platform/embedder/embedder_surface_gl_impeller.cc
+++ b/shell/platform/embedder/embedder_surface_gl_impeller.cc
@@ -94,7 +94,7 @@ EmbedderSurfaceGLImpeller::EmbedderSurfaceGLImpeller(
   }
 
   gl_dispatch_table_.gl_clear_current_callback();
-  FML_LOG(ERROR) << "Using the Impeller rendering backend (OpenGL).";
+  FML_LOG(IMPORTANT) << "Using the Impeller rendering backend (OpenGL).";
   valid_ = true;
 }
 

--- a/shell/platform/embedder/embedder_surface_metal_impeller.mm
+++ b/shell/platform/embedder/embedder_surface_metal_impeller.mm
@@ -34,16 +34,16 @@ EmbedderSurfaceMetalImpeller::EmbedderSurfaceMetalImpeller(
       metal_dispatch_table_(std::move(metal_dispatch_table)),
       external_view_embedder_(std::move(external_view_embedder)) {
   std::vector<std::shared_ptr<fml::Mapping>> shader_mappings = {
-    std::make_shared<fml::NonOwnedMapping>(impeller_entity_shaders_data,
-                                           impeller_entity_shaders_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_entity_shaders_data,
+                                             impeller_entity_shaders_length),
 #if IMPELLER_ENABLE_3D
-    std::make_shared<fml::NonOwnedMapping>(impeller_scene_shaders_data,
-                                           impeller_scene_shaders_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_scene_shaders_data,
+                                             impeller_scene_shaders_length),
 #endif  // IMPELLER_ENABLE_3D
-    std::make_shared<fml::NonOwnedMapping>(impeller_modern_shaders_data,
-                                           impeller_modern_shaders_length),
-    std::make_shared<fml::NonOwnedMapping>(impeller_framebuffer_blend_shaders_data,
-                                           impeller_framebuffer_blend_shaders_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_modern_shaders_data,
+                                             impeller_modern_shaders_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_framebuffer_blend_shaders_data,
+                                             impeller_framebuffer_blend_shaders_length),
   };
   context_ = impeller::ContextMTL::Create(
       (id<MTLDevice>)device,                     // device
@@ -52,7 +52,7 @@ EmbedderSurfaceMetalImpeller::EmbedderSurfaceMetalImpeller(
       std::make_shared<fml::SyncSwitch>(false),  // is_gpu_disabled_sync_switch
       "Impeller Library"                         // library_label
   );
-  FML_LOG(ERROR) << "Using the Impeller rendering backend (Metal).";
+  FML_LOG(IMPORTANT) << "Using the Impeller rendering backend (Metal).";
 
   valid_ = !!context_;
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/142488

- Only logs on iOS if Skia is used instead of Impeller.
- Logs on other platforms if Impeller is used instead of Skia.
- Uses "IMPORTANT" rather than "ERROR" for these logs. This will show up by default since flutter_tools sets ERROR and above as logs to show.
- Adds some tests.
- Makes INFO log print file paths the same as other verbosities.