### PR TITLE
[fuchsia] Update Inspect library usage

### DIFF
--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -58,9 +58,10 @@ template("runner_sources") {
       "$fuchsia_sdk_root/pkg:async-loop-cpp",
       "$fuchsia_sdk_root/pkg:async-loop-default",
       "$fuchsia_sdk_root/pkg:fidl_cpp",
+      "$fuchsia_sdk_root/pkg:inspect",
+      "$fuchsia_sdk_root/pkg:inspect_component_cpp",
       "$fuchsia_sdk_root/pkg:sys_cpp",
       "$fuchsia_sdk_root/pkg:sys_cpp_testing",
-      "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
       "$fuchsia_sdk_root/pkg:trace",
       "$fuchsia_sdk_root/pkg:vfs_cpp",
       "$fuchsia_sdk_root/pkg:zx",
@@ -99,7 +100,7 @@ template("runner") {
 
     deps = [
              ":" + target_name + "_runner_sources",
-             "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
+             "$fuchsia_sdk_root/pkg:inspect_component_cpp",
              "$fuchsia_sdk_root/pkg:trace-provider-so",
            ] + extra_deps
   }

--- a/shell/platform/fuchsia/dart_runner/main.cc
+++ b/shell/platform/fuchsia/dart_runner/main.cc
@@ -4,7 +4,7 @@
 
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/async-loop/default.h>
-#include <lib/sys/inspect/cpp/component.h>
+#include <lib/inspect/component/cpp/component.h>
 #include <lib/trace-provider/provider.h>
 #include <lib/trace/event.h>
 

--- a/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
+++ b/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
@@ -2,16 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 {
-    capabilities: [
-        // Required for inspect.
-        // Copied from inspect/client.shard.cml because out-of-tree doesn't
-        // have support for CML includes from the SDK.
-        {
-            directory: "diagnostics",
-            rights: [ "connect" ],
-            path: "/diagnostics",
-        },
-    ],
     use: [
         // This is used by the Dart VM to communicate from Dart code to C++ code.
         {
@@ -36,6 +26,7 @@
             protocol: [
                 "fuchsia.device.NameProvider",  // For fdio uname()
                 "fuchsia.feedback.CrashReporter",
+                "fuchsia.inspect.InspectSink",  // For inspect
                 "fuchsia.intl.PropertyProvider",  // For dartVM timezone support
                 "fuchsia.logger.LogSink",  // For syslog
                 "fuchsia.net.name.Lookup",  // For fdio sockets
@@ -50,15 +41,5 @@
             from: "parent",
             availability: "optional",
         },
-    ],
-    expose: [
-        // Required for inspect.
-        // Copied from inspect/client.shard.cml because out-of-tree doesn't
-        // have support for CML includes from the SDK.
-        {
-            directory: "diagnostics",
-            from: "self",
-            to: "framework",
-        },
-    ],
+    ]
 }

--- a/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/dart-aot-runner-integration-test.cc
+++ b/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/dart-aot-runner-integration-test.cc
@@ -83,6 +83,7 @@ TEST_F(RealmBuilderTest, DartRunnerStartsUp) {
                              Protocol{"fuchsia.posix.socket.Provider"},
                              Protocol{"fuchsia.intl.PropertyProvider"},
                              Protocol{"fuchsia.vulkan.loader.Loader"},
+                             Protocol{"fuchsia.inspect.InspectSink"},
                              Directory{"config-data"}},
             .source = ParentRef(),
             .targets = {kDartAotRunnerRef, kDartAotEchoServerRef}});

--- a/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
+++ b/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_aot_runner/meta/dart-aot-runner-integration-test.cml
@@ -19,6 +19,7 @@
             // Offer capabilities needed by components in this test realm.
             // Keep it minimal, describe only what's actually needed.
             protocol: [
+                "fuchsia.inspect.InspectSink",
                 "fuchsia.logger.LogSink",
                 "fuchsia.sysmem.Allocator",
                 "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/dart-jit-runner-integration-test.cc
+++ b/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/dart-jit-runner-integration-test.cc
@@ -81,6 +81,7 @@ TEST_F(RealmBuilderTest, DartRunnerStartsUp) {
                              Protocol{"fuchsia.tracing.provider.Registry"},
                              Protocol{"fuchsia.posix.socket.Provider"},
                              Protocol{"fuchsia.intl.PropertyProvider"},
+                             Protocol{"fuchsia.inspect.InspectSink"},
                              Directory{"config-data"}},
             .source = ParentRef(),
             .targets = {kDartJitRunnerRef, kDartJitEchoServerRef}});

--- a/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
+++ b/shell/platform/fuchsia/dart_runner/tests/startup_integration_test/dart_jit_runner/meta/dart-jit-runner-integration-test.cml
@@ -19,6 +19,7 @@
             // Offer capabilities needed by components in this test realm.
             // Keep it minimal, describe only what's actually needed.
             protocol: [
+                "fuchsia.inspect.InspectSink",
                 "fuchsia.logger.LogSink",
                 "fuchsia.sysmem.Allocator",
                 "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -140,8 +140,8 @@ template("runner_sources") {
 
     public_deps = [
                     "$fuchsia_sdk_root/pkg:inspect",
+                    "$fuchsia_sdk_root/pkg:inspect_component_cpp",
                     "$fuchsia_sdk_root/pkg:sys_cpp",
-                    "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
                     "//flutter/shell/platform/fuchsia/runtime/dart/utils",
                   ] + flutter_public_deps
 

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.h
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.h
@@ -12,7 +12,7 @@
 #include <fuchsia/accessibility/semantics/cpp/fidl.h>
 #include <fuchsia/ui/gfx/cpp/fidl.h>
 #include <lib/fidl/cpp/binding_set.h>
-#include <lib/sys/inspect/cpp/component.h>
+#include <lib/inspect/component/cpp/component.h>
 #include <zircon/types.h>
 
 #include <memory>

--- a/shell/platform/fuchsia/flutter/main.cc
+++ b/shell/platform/fuchsia/flutter/main.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 #include <lib/async-loop/cpp/loop.h>
-#include <lib/sys/inspect/cpp/component.h>
+#include <lib/inspect/component/cpp/component.h>
 #include <lib/trace-provider/provider.h>
 #include <lib/trace/event.h>
 

--- a/shell/platform/fuchsia/flutter/meta/common.shard.cml
+++ b/shell/platform/fuchsia/flutter/meta/common.shard.cml
@@ -2,16 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file
 {
-    capabilities: [
-        // Required for inspect.
-        // Copied from inspect/client.shard.cml because out-of-tree doesn't
-        // have support for CML includes from the SDK.
-        {
-            directory: "diagnostics",
-            rights: [ "connect" ],
-            path: "/diagnostics",
-        },
-    ],
     use: [
         // This is used by the Dart VM to communicate from Dart code to C++ code.
         {
@@ -43,6 +33,7 @@
                 "fuchsia.device.NameProvider",
                 "fuchsia.feedback.CrashReporter",
                 "fuchsia.fonts.Provider",
+                "fuchsia.inspect.InspectSink", // Copied from inspect/client.shard.cml.
                 "fuchsia.intl.PropertyProvider",
                 "fuchsia.logger.LogSink", // Copied from syslog/client.shard.cml.
                 "fuchsia.media.ProfileProvider",
@@ -64,15 +55,5 @@
             ],
             availability: "optional",
         },
-    ],
-    expose: [
-        // Required for inspect.
-        // Copied from inspect/client.shard.cml because out-of-tree doesn't
-        // have support for CML includes from the SDK.
-        {
-            directory: "diagnostics",
-            from: "self",
-            to: "framework",
-        },
-    ],
+    ]
 }

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/BUILD.gn
@@ -23,6 +23,7 @@ executable("flutter-embedder-test-bin") {
   libs = [ "$fuchsia_sdk_path/arch/$target_cpu/sysroot/lib/libzircon.so" ]
 
   deps = [
+    "$fuchsia_sdk_root/fidl:fuchsia.inspect",
     "$fuchsia_sdk_root/fidl:fuchsia.logger",
     "$fuchsia_sdk_root/fidl:fuchsia.tracing.provider",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.app",

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <fuchsia/inspect/cpp/fidl.h>
 #include <fuchsia/logger/cpp/fidl.h>
 #include <fuchsia/tracing/provider/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>
@@ -232,6 +233,7 @@ void FlutterEmbedderTest::SetUpRealmBase() {
       Route{.capabilities =
                 {
                     Protocol{fuchsia::logger::LogSink::Name_},
+                    Protocol{fuchsia::inspect::InspectSink::Name_},
                     Protocol{fuchsia::sysmem::Allocator::Name_},
                     Protocol{fuchsia::tracing::provider::Registry::Name_},
                     Protocol{kVulkanLoaderServiceName},
@@ -243,6 +245,7 @@ void FlutterEmbedderTest::SetUpRealmBase() {
   // Route base system services to the test UI stack.
   realm_builder_.AddRoute(Route{
       .capabilities = {Protocol{fuchsia::logger::LogSink::Name_},
+                       Protocol{fuchsia::inspect::InspectSink::Name_},
                        Protocol{fuchsia::sysmem::Allocator::Name_},
                        Protocol{fuchsia::tracing::provider::Registry::Name_},
                        Protocol{kVulkanLoaderServiceName}},

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
@@ -18,6 +18,7 @@
             // Offer capabilities needed by components in this test realm.
             // Keep it minimal, describe only what's actually needed.
             protocol: [
+                "fuchsia.inspect.InspectSink",
                 "fuchsia.logger.LogSink",
                 "fuchsia.sysmem.Allocator",
                 "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/mouse-input/meta/mouse-input-test.cml
@@ -25,6 +25,7 @@
             // Offer capabilities needed by components in this test realm.
             // Keep it minimal, describe only what's actually needed.
             protocol: [
+                "fuchsia.inspect.InspectSink",
                 "fuchsia.kernel.RootJobForInspect",
                 "fuchsia.kernel.Stats",
                 "fuchsia.logger.LogSink",

--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
@@ -24,6 +24,7 @@
     offer: [
         {
             protocol: [
+                "fuchsia.inspect.InspectSink",
                 "fuchsia.kernel.RootJobForInspect",
                 "fuchsia.kernel.Stats",
                 "fuchsia.logger.LogSink",

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
@@ -25,6 +25,7 @@
             // Offer capabilities needed by components in this test realm.
             // Keep it minimal, describe only what's actually needed.
             protocol: [
+                "fuchsia.inspect.InspectSink",
                 "fuchsia.kernel.RootJobForInspect",
                 "fuchsia.kernel.Stats",
                 "fuchsia.logger.LogSink",

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/BUILD.gn
@@ -41,6 +41,7 @@ source_set("portable_ui_test") {
 
   deps = [
     ":check_view",
+    "$fuchsia_sdk_root/fidl:fuchsia.inspect",
     "$fuchsia_sdk_root/fidl:fuchsia.logger",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
     "$fuchsia_sdk_root/fidl:fuchsia.ui.composition",

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -4,6 +4,7 @@
 
 #include "portable_ui_test.h"
 
+#include <fuchsia/inspect/cpp/fidl.h>
 #include <fuchsia/logger/cpp/fidl.h>
 #include <fuchsia/tracing/provider/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>
@@ -77,6 +78,7 @@ void PortableUITest::SetUpRealmBase() {
   // // Route base system services to flutter and the test UI stack.
   realm_builder_.AddRoute(Route{
       .capabilities = {Protocol{fuchsia::logger::LogSink::Name_},
+                       Protocol{fuchsia::inspect::InspectSink::Name_},
                        Protocol{fuchsia::sysmem::Allocator::Name_},
                        Protocol{fuchsia::tracing::provider::Registry::Name_},
                        Protocol{fuchsia::ui::input::ImeService::Name_},

--- a/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -44,7 +44,7 @@ template("make_utils") {
              "$fuchsia_sdk_root/pkg:async-loop-default",
              "$fuchsia_sdk_root/pkg:fdio",
              "$fuchsia_sdk_root/pkg:sys_cpp",
-             "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
+             "$fuchsia_sdk_root/pkg:inspect_component_cpp",
              "$fuchsia_sdk_root/pkg:trace",
              "$fuchsia_sdk_root/pkg:vfs_cpp",
              "$fuchsia_sdk_root/pkg:zx",
@@ -99,7 +99,8 @@ executable("dart_utils_unittests") {
   deps = [
     ":utils",
     ":utils_fixtures",
-    "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
+    "$fuchsia_sdk_root/pkg:inspect_component_cpp",
+    "$fuchsia_sdk_root/pkg:sys_cpp",
     "//flutter/testing",
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/dart/runtime/bin:dart_io_api",

--- a/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.cc
@@ -3,26 +3,28 @@
 // found in the LICENSE file.
 
 #include "root_inspect_node.h"
+#include <lib/async/default.h>
 
 namespace dart_utils {
 
-std::unique_ptr<sys::ComponentInspector> RootInspectNode::inspector_;
+std::unique_ptr<inspect::ComponentInspector> RootInspectNode::inspector_;
 std::mutex RootInspectNode::mutex_;
 
 void RootInspectNode::Initialize(sys::ComponentContext* context) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (!inspector_) {
-    inspector_ = std::make_unique<sys::ComponentInspector>(context);
+    inspector_ = std::make_unique<inspect::ComponentInspector>(
+        async_get_default_dispatcher(), inspect::PublishOptions{});
   }
 }
 
 inspect::Node RootInspectNode::CreateRootChild(const std::string& name) {
   std::lock_guard<std::mutex> lock(mutex_);
-  return inspector_->inspector()->GetRoot().CreateChild(name);
+  return inspector_->inspector().GetRoot().CreateChild(name);
 }
 
 inspect::Inspector* RootInspectNode::GetInspector() {
-  return inspector_->inspector();
+  return &inspector_->inspector();
 }
 
 }  // namespace dart_utils

--- a/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h
@@ -5,7 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_ROOT_INSPECT_NODE_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_ROOT_INSPECT_NODE_H_
 
-#include <lib/sys/inspect/cpp/component.h>
+#include <lib/inspect/component/cpp/component.h>
+#include <lib/sys/cpp/component_context.h>
 
 #include <memory>
 #include <mutex>
@@ -36,7 +37,7 @@ class RootInspectNode {
   static inspect::Inspector* GetInspector();
 
  private:
-  static std::unique_ptr<sys::ComponentInspector> inspector_;
+  static std::unique_ptr<inspect::ComponentInspector> inspector_;
   static std::mutex mutex_;
 };
 


### PR DESCRIPTION
The new Inspect library uses InspectSink as described in [RFC-168](https://fuchsia.dev/fuchsia-src/contribute/governance/rfcs/0168_exposing_inspect_through_inspectsink?hl=en).

Additionally it's using the new CPP bindings instead of the deprecated HLCPP bindings.

Bug: https://g-issues.fuchsia.dev/issues/320785253

I've verified on a relevant Fuchsia build that the Flutter runner continues to correctly publish Inspect after this change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
