### PR TITLE
Sever the //flutter/vulkan dependency in Flutter in the Android embedder.

### DIFF
--- a/shell/platform/android/android_context_vulkan_impeller.h
+++ b/shell/platform/android/android_context_vulkan_impeller.h
@@ -7,8 +7,8 @@
 
 #include "flutter/fml/concurrent_message_loop.h"
 #include "flutter/fml/macros.h"
+#include "flutter/fml/native_library.h"
 #include "flutter/shell/platform/android/context/android_context.h"
-#include "flutter/vulkan/procs/vulkan_proc_table.h"
 
 namespace flutter {
 
@@ -22,7 +22,7 @@ class AndroidContextVulkanImpeller : public AndroidContext {
   bool IsValid() const override;
 
  private:
-  fml::RefPtr<vulkan::VulkanProcTable> proc_table_;
+  fml::RefPtr<fml::NativeLibrary> vulkan_dylib_;
   bool is_valid_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidContextVulkanImpeller);


### PR DESCRIPTION
The previous code was setting up a proc table, then getting the address of the proc that was used to the setup that table, then setting up another proc table. Directly setup the final proc table and don't depend on //impeller/vulkan.

Part of https://github.com/flutter/flutter/issues/143127
Similar to https://github.com/flutter/engine/pull/50454