### PR TITLE
[Impeller] Add --enable-impeller-vulkan-playgrounds to ./flutter/tools/gn

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -1225,7 +1225,8 @@ def parse_args(args):
       '--enable-impeller-vulkan-playgrounds',
       default=False,
       action='store_true',
-      help='Enable the Impeller Vulkan Playgrounds. The Impeller Vulkan backend needs to be enabled.'
+      help='Enable the Impeller Vulkan Playgrounds. ' +
+      'The Impeller Vulkan backend needs to be enabled.'
   )
 
   parser.add_argument(

--- a/tools/gn
+++ b/tools/gn
@@ -691,6 +691,9 @@ def to_gn_args(args):
   if args.enable_impeller_vulkan:
     gn_args['impeller_enable_vulkan'] = True
 
+  if args.enable_impeller_vulkan_playgrounds:
+    gn_args['impeller_enable_vulkan_playgrounds'] = True
+
   if args.enable_impeller_opengles:
     gn_args['impeller_enable_opengles'] = True
 
@@ -1216,6 +1219,13 @@ def parse_args(args):
       default=False,
       action='store_true',
       help='Enable the Impeller Vulkan backend.'
+  )
+
+  parser.add_argument(
+      '--enable-impeller-vulkan-playgrounds',
+      default=False,
+      action='store_true',
+      help='Enable the Impeller Vulkan Playgrounds. The Impeller Vulkan backend needs to be enabled.'
   )
 
   parser.add_argument(


### PR DESCRIPTION
One has to manually `gn args` to add this flag (usually on macOS) now.