### PR TITLE
Replace usage of an integer for GdkModifierType

### DIFF
--- a/shell/platform/linux/fl_key_channel_responder_test.cc
+++ b/shell/platform/linux/fl_key_channel_responder_test.cc
@@ -45,7 +45,7 @@ static FlKeyEvent* fl_key_event_new_by_mock(guint32 time_in_milliseconds,
                                             bool is_press,
                                             guint keyval,
                                             guint16 keycode,
-                                            int state,
+                                            GdkModifierType state,
                                             gboolean is_modifier) {
   _g_key_event.is_press = is_press;
   _g_key_event.time = time_in_milliseconds;
@@ -72,7 +72,8 @@ TEST(FlKeyChannelResponderTest, SendKeyEvent) {
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04, 0x0, false),
+      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04,
+                               static_cast<GdkModifierType>(0), false),
       responder_callback, loop);
   expected_value =
       "{type: keydown, keymap: linux, scanCode: 4, toolkit: gtk, keyCode: 65, "
@@ -84,7 +85,8 @@ TEST(FlKeyChannelResponderTest, SendKeyEvent) {
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(23456, false, GDK_KEY_A, 0x04, 0x0, false),
+      fl_key_event_new_by_mock(23456, false, GDK_KEY_A, 0x04,
+                               static_cast<GdkModifierType>(0), false),
       responder_callback, loop);
   expected_value =
       "{type: keyup, keymap: linux, scanCode: 4, toolkit: gtk, keyCode: 65, "
@@ -111,7 +113,8 @@ void test_lock_event(guint key_code,
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12345, true, key_code, 0x04, 0x0, false),
+      fl_key_event_new_by_mock(12345, true, key_code, 0x04,
+                               static_cast<GdkModifierType>(0), false),
       responder_callback, loop);
   expected_value = down_expected;
   expected_handled = FALSE;
@@ -123,7 +126,8 @@ void test_lock_event(guint key_code,
   expected_handled = FALSE;
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12346, false, key_code, 0x04, 0x0, false),
+      fl_key_event_new_by_mock(12346, false, key_code, 0x04,
+                               static_cast<GdkModifierType>(0), false),
       responder_callback, loop);
 
   // Blocks here until echo_response_cb is called.
@@ -171,7 +175,8 @@ TEST(FlKeyChannelResponderTest, TestKeyEventHandledByFramework) {
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04, 0x0, false),
+      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04,
+                               static_cast<GdkModifierType>(0), false),
       responder_callback, loop);
   expected_handled = TRUE;
   expected_value =
@@ -196,7 +201,8 @@ TEST(FlKeyChannelResponderTest, UseSpecifiedLogicalKey) {
 
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04, 0x0, false),
+      fl_key_event_new_by_mock(12345, true, GDK_KEY_A, 0x04,
+                               static_cast<GdkModifierType>(0), false),
       responder_callback, loop, 888);
   expected_handled = TRUE;
   expected_value =

--- a/shell/platform/linux/fl_key_embedder_responder_test.cc
+++ b/shell/platform/linux/fl_key_embedder_responder_test.cc
@@ -116,7 +116,7 @@ static FlKeyEvent* fl_key_event_new_by_mock(guint32 time_in_milliseconds,
                                             bool is_press,
                                             guint keyval,
                                             guint16 keycode,
-                                            int state,
+                                            GdkModifierType state,
                                             gboolean is_modifier) {
   _g_key_event.is_press = is_press;
   _g_key_event.time = time_in_milliseconds;
@@ -179,8 +179,8 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   // Key down
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12345, kPress, GDK_KEY_a, kKeyCodeKeyA, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(12345, kPress, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -199,8 +199,8 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   // Key up
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12346, kRelease, GDK_KEY_a, kKeyCodeKeyA, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(12346, kRelease, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -220,8 +220,8 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   // Key down
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12347, kPress, GDK_KEY_q, kKeyCodeKeyA, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(12347, kPress, GDK_KEY_q, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -240,8 +240,8 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   // Key up
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(12348, kRelease, GDK_KEY_q, kKeyCodeKeyA, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(12348, kRelease, GDK_KEY_q, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -276,7 +276,7 @@ TEST(FlKeyEmbedderResponderTest, UsesSpecifiedLogicalKey) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(12345, kPress, GDK_KEY_ampersand, kKeyCodeDigit1,
-                               0, kIsNotModifier),
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data, kLogicalDigit1);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -310,7 +310,7 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(101, kPress, GDK_KEY_Shift_R, kKeyCodeShiftRight,
-                               0, kIsModifier),
+                               static_cast<GdkModifierType>(0), kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -327,8 +327,8 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   // Press key A
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(102, kPress, GDK_KEY_A, kKeyCodeKeyA, 0x1,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(102, kPress, GDK_KEY_A, kKeyCodeKeyA,
+                               GDK_SHIFT_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -346,7 +346,7 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(103, kRelease, GDK_KEY_Shift_R,
-                               kKeyCodeShiftRight, 0x1, kIsModifier),
+                               kKeyCodeShiftRight, GDK_SHIFT_MASK, kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -363,8 +363,8 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   // Release key A
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(104, kRelease, GDK_KEY_A, kKeyCodeKeyA, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(104, kRelease, GDK_KEY_A, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -402,8 +402,8 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   // Press Numpad 1 (stage 0)
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(101, kPress, GDK_KEY_KP_End, kKeyCodeNumpad1, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(101, kPress, GDK_KEY_KP_End, kKeyCodeNumpad1,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -421,7 +421,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(102, kPress, GDK_KEY_Num_Lock, kKeyCodeNumLock,
-                               0, kIsNotModifier),
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -439,7 +439,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(104, kRelease, GDK_KEY_KP_1, kKeyCodeNumpad1,
-                               0x10, kIsNotModifier),
+                               GDK_MOD2_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -457,7 +457,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(103, kRelease, GDK_KEY_Num_Lock, kKeyCodeNumLock,
-                               0x10, kIsModifier),
+                               GDK_MOD2_MASK, kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -475,7 +475,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(101, kPress, GDK_KEY_KP_End, kKeyCodeNumpad1,
-                               0x10, kIsNotModifier),
+                               GDK_MOD2_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -493,7 +493,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(102, kPress, GDK_KEY_Num_Lock, kKeyCodeNumLock,
-                               0x10, kIsNotModifier),
+                               GDK_MOD2_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -511,7 +511,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(104, kRelease, GDK_KEY_KP_1, kKeyCodeNumpad1,
-                               0x10, kIsNotModifier),
+                               GDK_MOD2_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -529,7 +529,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(103, kRelease, GDK_KEY_Num_Lock, kKeyCodeNumLock,
-                               0x10, kIsModifier),
+                               GDK_MOD2_MASK, kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -560,7 +560,7 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
 
   FlKeyEmbedderCallRecord* record;
 
-  guint state = 0;
+  GdkModifierType state = static_cast<GdkModifierType>(0);
 
   // Press shift left
   fl_key_responder_handle_event(
@@ -618,7 +618,7 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
   invoke_record_callback_and_verify(record, TRUE, &user_data);
   g_ptr_array_clear(g_call_records);
 
-  state = 0;
+  state = static_cast<GdkModifierType>(0);
 
   // Release digit 1, which is "1" because shift has been released.
   fl_key_responder_handle_event(
@@ -659,7 +659,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(101, kPress, GDK_KEY_Caps_Lock, kKeyCodeCapsLock,
-                               0x0, kIsModifier),
+                               static_cast<GdkModifierType>(0), kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -676,8 +676,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   // Press key A (stage 1)
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(102, kPress, GDK_KEY_A, kKeyCodeKeyA, 0x2,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(102, kPress, GDK_KEY_A, kKeyCodeKeyA,
+                               GDK_LOCK_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -695,7 +695,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(103, kRelease, GDK_KEY_Caps_Lock,
-                               kKeyCodeCapsLock, 0x2, kIsModifier),
+                               kKeyCodeCapsLock, GDK_LOCK_MASK, kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -712,8 +712,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   // Release key A (stage 2)
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(104, kRelease, GDK_KEY_A, kKeyCodeKeyA, 0x2,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(104, kRelease, GDK_KEY_A, kKeyCodeKeyA,
+                               GDK_LOCK_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -731,7 +731,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(105, kPress, GDK_KEY_Caps_Lock, kKeyCodeCapsLock,
-                               0x2, kIsModifier),
+                               GDK_LOCK_MASK, kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -748,8 +748,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   // Press key A (stage 3)
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(106, kPress, GDK_KEY_A, kKeyCodeKeyA, 0x2,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(106, kPress, GDK_KEY_A, kKeyCodeKeyA,
+                               GDK_LOCK_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -767,7 +767,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(107, kRelease, GDK_KEY_Caps_Lock,
-                               kKeyCodeCapsLock, 0x2, kIsModifier),
+                               kKeyCodeCapsLock, GDK_LOCK_MASK, kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -784,8 +784,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   // Release key A (stage 0)
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(108, kRelease, GDK_KEY_a, kKeyCodeKeyA, 0x0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(108, kRelease, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -819,8 +819,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   // Press key A (stage 0)
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(101, kPress, GDK_KEY_a, kKeyCodeKeyA, 0x0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(101, kPress, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -838,7 +838,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(102, kPress, GDK_KEY_Caps_Lock, kKeyCodeCapsLock,
-                               0x2, kIsModifier),
+                               GDK_LOCK_MASK, kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -856,7 +856,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(103, kRelease, GDK_KEY_Caps_Lock,
-                               kKeyCodeCapsLock, 0x2, kIsModifier),
+                               kKeyCodeCapsLock, GDK_LOCK_MASK, kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -873,8 +873,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   // Release key A (stage 2)
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(104, kRelease, GDK_KEY_A, kKeyCodeKeyA, 0x2,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(104, kRelease, GDK_KEY_A, kKeyCodeKeyA,
+                               GDK_LOCK_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -891,8 +891,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   // Press key A (stage 2)
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(105, kPress, GDK_KEY_A, kKeyCodeKeyA, 0x2,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(105, kPress, GDK_KEY_A, kKeyCodeKeyA,
+                               GDK_LOCK_MASK, kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -910,7 +910,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(106, kPress, GDK_KEY_Caps_Lock, kKeyCodeCapsLock,
-                               0x0, kIsModifier),
+                               static_cast<GdkModifierType>(0), kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -928,7 +928,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(107, kRelease, GDK_KEY_Caps_Lock,
-                               kKeyCodeCapsLock, 0x2, kIsModifier),
+                               kKeyCodeCapsLock, GDK_LOCK_MASK, kIsModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -945,8 +945,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   // Release key A (stage 0)
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(108, kRelease, GDK_KEY_a, kKeyCodeKeyA, 0x0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(108, kRelease, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -976,8 +976,8 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
   // Press KeyA
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(101, kPress, GDK_KEY_a, kKeyCodeKeyA, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(101, kPress, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -990,8 +990,8 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
   g_expected_handled = false;
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(102, kPress, GDK_KEY_a, kKeyCodeKeyA, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(102, kPress, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -1010,8 +1010,8 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
   // Release KeyA
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(103, kRelease, GDK_KEY_q, kKeyCodeKeyA, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(103, kRelease, GDK_KEY_q, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -1036,8 +1036,8 @@ TEST(FlKeyEmbedderResponderTest, IgnoreAbruptUpEvent) {
   g_expected_handled = true;  // The empty event is always handled.
   fl_key_responder_handle_event(
       responder,
-      fl_key_event_new_by_mock(103, kRelease, GDK_KEY_q, kKeyCodeKeyA, 0,
-                               kIsNotModifier),
+      fl_key_event_new_by_mock(103, kRelease, GDK_KEY_q, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), kIsNotModifier),
       verify_response_handled, &user_data);
 
   EXPECT_EQ(g_call_records->len, 1u);
@@ -1067,7 +1067,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   // Test 1: synthesize key down.
 
   // A key down of control left is missed.
-  guint state = GDK_CONTROL_MASK;
+  GdkModifierType state = GDK_CONTROL_MASK;
 
   // Send a ControlLeft up
   fl_key_responder_handle_event(
@@ -1099,7 +1099,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   // Test 2: synthesize key up.
 
   // Send a ControlLeft down.
-  state = 0;
+  state = static_cast<GdkModifierType>(0);
   fl_key_responder_handle_event(
       responder,
       fl_key_event_new_by_mock(102, kPress, GDK_KEY_Control_L,
@@ -1111,7 +1111,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   g_ptr_array_clear(g_call_records);
 
   // A key up of control left is missed.
-  state = 0;
+  state = static_cast<GdkModifierType>(0);
 
   // Send another ControlLeft down
   fl_key_responder_handle_event(
@@ -1196,7 +1196,7 @@ TEST(FlKeyEmbedderResponderTest,
   FlKeyEmbedderCallRecord* record;
 
   // A key down of control left is missed.
-  guint state = GDK_CONTROL_MASK;
+  GdkModifierType state = GDK_CONTROL_MASK;
 
   // Send a normal event (KeyA down)
   fl_key_responder_handle_event(
@@ -1226,7 +1226,7 @@ TEST(FlKeyEmbedderResponderTest,
   g_ptr_array_clear(g_call_records);
 
   // A key up of control left is missed.
-  state = 0;
+  state = static_cast<GdkModifierType>(0);
 
   // Send a normal event (KeyA up)
   fl_key_responder_handle_event(
@@ -1258,7 +1258,7 @@ TEST(FlKeyEmbedderResponderTest,
   // Test non-default key mapping.
 
   // Press a key with physical CapsLock and logical ControlLeft.
-  state = 0;
+  state = static_cast<GdkModifierType>(0);
 
   fl_key_responder_handle_event(
       responder,
@@ -1279,7 +1279,7 @@ TEST(FlKeyEmbedderResponderTest,
   g_ptr_array_clear(g_call_records);
 
   // The key up of the control left press is missed.
-  state = 0;
+  state = static_cast<GdkModifierType>(0);
 
   // Send a normal event (KeyA down).
   fl_key_responder_handle_event(
@@ -1327,7 +1327,7 @@ TEST(FlKeyEmbedderResponderTest,
   FlKeyEmbedderCallRecord* record;
 
   // Press a key with physical CapsLock and logical ControlLeft.
-  guint state = 0;
+  GdkModifierType state = static_cast<GdkModifierType>(0);
 
   fl_key_responder_handle_event(
       responder,
@@ -1348,7 +1348,7 @@ TEST(FlKeyEmbedderResponderTest,
   g_ptr_array_clear(g_call_records);
 
   // The key up of the control left press is missed.
-  state = 0;
+  state = static_cast<GdkModifierType>(0);
 
   // Send a normal event (KeyA down).
   fl_key_responder_handle_event(
@@ -1395,7 +1395,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
   FlKeyEmbedderCallRecord* record;
 
   // The NumLock is desynchronized by being enabled.
-  guint state = GDK_MOD2_MASK;
+  GdkModifierType state = GDK_MOD2_MASK;
 
   // Send a normal event
   fl_key_responder_handle_event(
@@ -1425,7 +1425,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
   g_ptr_array_clear(g_call_records);
 
   // The NumLock is desynchronized by being disabled.
-  state = 0;
+  state = static_cast<GdkModifierType>(0);
 
   // Release key A
   fl_key_responder_handle_event(
@@ -1503,7 +1503,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnSelfEvents) {
   FlKeyEmbedderCallRecord* record;
 
   // The NumLock is desynchronized by being enabled.
-  guint state = GDK_MOD2_MASK;
+  GdkModifierType state = GDK_MOD2_MASK;
 
   // NumLock down
   fl_key_responder_handle_event(
@@ -1602,7 +1602,8 @@ TEST(FlKeyEmbedderResponderTest, SynthesizationOccursOnIgnoredEvents) {
   FlKeyEmbedderCallRecord* record;
 
   // The NumLock is desynchronized by being enabled, and Control is pressed.
-  guint state = GDK_MOD2_MASK | GDK_CONTROL_MASK;
+  GdkModifierType state =
+      static_cast<GdkModifierType>(GDK_MOD2_MASK | GDK_CONTROL_MASK);
 
   // Send a KeyA up event, which will be ignored.
   g_expected_handled = true;  // The ignored event is always handled.
@@ -1655,7 +1656,8 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   guint32 now_time = 1;
   // A convenient shorthand to simulate events.
   auto send_key_event = [responder, &now_time](bool is_press, guint keyval,
-                                               guint16 keycode, int state) {
+                                               guint16 keycode,
+                                               GdkModifierType state) {
     now_time += 1;
     int user_data = 123;  // Arbitrary user data
     fl_key_responder_handle_event(
@@ -1667,7 +1669,8 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
 
   FlKeyEmbedderCallRecord* record;
 
-  send_key_event(kPress, GDK_KEY_Shift_L, kKeyCodeShiftLeft, 0x2000000);
+  send_key_event(kPress, GDK_KEY_Shift_L, kKeyCodeShiftLeft,
+                 GDK_MODIFIER_RESERVED_25_MASK);
   EXPECT_EQ(g_call_records->len, 1u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
@@ -1675,7 +1678,9 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   EXPECT_EQ(record->event->logical, kLogicalShiftLeft);
   EXPECT_EQ(record->event->synthesized, false);
 
-  send_key_event(kPress, GDK_KEY_Meta_R, kKeyCodeAltRight, 0x2000001);
+  send_key_event(kPress, GDK_KEY_Meta_R, kKeyCodeAltRight,
+                 static_cast<GdkModifierType>(GDK_SHIFT_MASK |
+                                              GDK_MODIFIER_RESERVED_25_MASK));
   EXPECT_EQ(g_call_records->len, 2u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 1));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
@@ -1684,7 +1689,8 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   EXPECT_EQ(record->event->synthesized, false);
 
   send_key_event(kRelease, GDK_KEY_ISO_Next_Group, kKeyCodeShiftLeft,
-                 0x2000009);
+                 static_cast<GdkModifierType>(GDK_SHIFT_MASK | GDK_MOD1_MASK |
+                                              GDK_MODIFIER_RESERVED_25_MASK));
   EXPECT_EQ(g_call_records->len, 5u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 2));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
@@ -1704,7 +1710,9 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   EXPECT_EQ(record->event->logical, kLogicalShiftLeft);
   EXPECT_EQ(record->event->synthesized, false);
 
-  send_key_event(kPress, GDK_KEY_ISO_Next_Group, kKeyCodeShiftLeft, 0x2000008);
+  send_key_event(kPress, GDK_KEY_ISO_Next_Group, kKeyCodeShiftLeft,
+                 static_cast<GdkModifierType>(GDK_MOD1_MASK |
+                                              GDK_MODIFIER_RESERVED_25_MASK));
   EXPECT_EQ(g_call_records->len, 6u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 5));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
@@ -1713,13 +1721,17 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   EXPECT_EQ(record->event->synthesized, false);
 
   send_key_event(kRelease, GDK_KEY_ISO_Level3_Shift, kKeyCodeAltRight,
-                 0x2002008);
+                 static_cast<GdkModifierType>(GDK_MOD1_MASK |
+                                              GDK_MODIFIER_RESERVED_13_MASK |
+                                              GDK_MODIFIER_RESERVED_25_MASK));
   EXPECT_EQ(g_call_records->len, 7u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 6));
   EXPECT_EQ(record->event->physical, 0u);
   EXPECT_EQ(record->event->logical, 0u);
 
-  send_key_event(kRelease, GDK_KEY_Shift_L, kKeyCodeShiftLeft, 0x2002000);
+  send_key_event(kRelease, GDK_KEY_Shift_L, kKeyCodeShiftLeft,
+                 static_cast<GdkModifierType>(GDK_MODIFIER_RESERVED_13_MASK |
+                                              GDK_MODIFIER_RESERVED_25_MASK));
   EXPECT_EQ(g_call_records->len, 9u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 7));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeUp);
@@ -1753,7 +1765,8 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
   guint32 now_time = 1;
   // A convenient shorthand to simulate events.
   auto send_key_event = [responder, &now_time](bool is_press, guint keyval,
-                                               guint16 keycode, int state) {
+                                               guint16 keycode,
+                                               GdkModifierType state) {
     now_time += 1;
     int user_data = 123;  // Arbitrary user data
     fl_key_responder_handle_event(
@@ -1766,7 +1779,8 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
   FlKeyEmbedderCallRecord* record;
 
   // ShiftLeft + AltLeft
-  send_key_event(kPress, GDK_KEY_Shift_L, kKeyCodeShiftLeft, 0x2000000);
+  send_key_event(kPress, GDK_KEY_Shift_L, kKeyCodeShiftLeft,
+                 GDK_MODIFIER_RESERVED_25_MASK);
   EXPECT_EQ(g_call_records->len, 1u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
@@ -1774,7 +1788,9 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
   EXPECT_EQ(record->event->logical, kLogicalShiftLeft);
   EXPECT_EQ(record->event->synthesized, false);
 
-  send_key_event(kPress, GDK_KEY_Meta_L, kKeyCodeAltLeft, 0x2000001);
+  send_key_event(kPress, GDK_KEY_Meta_L, kKeyCodeAltLeft,
+                 static_cast<GdkModifierType>(GDK_SHIFT_MASK |
+                                              GDK_MODIFIER_RESERVED_25_MASK));
   EXPECT_EQ(g_call_records->len, 2u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 1));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
@@ -1782,12 +1798,16 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
   EXPECT_EQ(record->event->logical, kLogicalMetaLeft);
   EXPECT_EQ(record->event->synthesized, false);
 
-  send_key_event(kRelease, GDK_KEY_Meta_L, kKeyCodeAltLeft, 0x2002000);
-  send_key_event(kRelease, GDK_KEY_Shift_L, kKeyCodeShiftLeft, 0x2000000);
+  send_key_event(kRelease, GDK_KEY_Meta_L, kKeyCodeAltLeft,
+                 static_cast<GdkModifierType>(GDK_MODIFIER_RESERVED_13_MASK |
+                                              GDK_MODIFIER_RESERVED_25_MASK));
+  send_key_event(kRelease, GDK_KEY_Shift_L, kKeyCodeShiftLeft,
+                 GDK_MODIFIER_RESERVED_25_MASK);
   g_ptr_array_clear(g_call_records);
 
   // ShiftRight + AltLeft
-  send_key_event(kPress, GDK_KEY_Shift_R, kKeyCodeShiftRight, 0x2000000);
+  send_key_event(kPress, GDK_KEY_Shift_R, kKeyCodeShiftRight,
+                 GDK_MODIFIER_RESERVED_25_MASK);
   EXPECT_EQ(g_call_records->len, 1u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
@@ -1795,7 +1815,9 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
   EXPECT_EQ(record->event->logical, kLogicalShiftRight);
   EXPECT_EQ(record->event->synthesized, false);
 
-  send_key_event(kPress, GDK_KEY_Meta_L, kKeyCodeAltLeft, 0x2000001);
+  send_key_event(kPress, GDK_KEY_Meta_L, kKeyCodeAltLeft,
+                 static_cast<GdkModifierType>(GDK_SHIFT_MASK |
+                                              GDK_MODIFIER_RESERVED_25_MASK));
   EXPECT_EQ(g_call_records->len, 2u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 1));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);

--- a/shell/platform/linux/fl_key_event.h
+++ b/shell/platform/linux/fl_key_event.h
@@ -38,7 +38,7 @@ typedef struct _FlKeyEvent {
   // Keyval.
   guint keyval;
   // Modifier state.
-  int state;
+  GdkModifierType state;
   // Keyboard group.
   guint8 group;
   // An opaque pointer to the original event.

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -485,7 +485,7 @@ static FlKeyEvent* fl_key_event_clone_information_only(FlKeyEvent* event) {
 static FlKeyEvent* fl_key_event_new_by_mock(bool is_press,
                                             guint keyval,
                                             guint16 keycode,
-                                            int state,
+                                            GdkModifierType state,
                                             gboolean is_modifier,
                                             guint8 group = 0) {
   FlKeyEvent* event = g_new(FlKeyEvent, 1);
@@ -661,12 +661,14 @@ TEST(FlKeyboardManagerTest, DisposeWithUnresolvedPends) {
   tester.recordEmbedderCallsTo(call_records);
   fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
 
   tester.respondToEmbedderCallsWith(true);
   fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
 
   tester.flushChannelMessages();
 
@@ -687,7 +689,8 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   // Dispatch a key event
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
   tester.flushChannelMessages();
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
@@ -704,7 +707,8 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   /// Test 2: Two events that are unhandled by the framework
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
   tester.flushChannelMessages();
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
@@ -715,7 +719,8 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   // Dispatch another key event
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_b, kKeyCodeKeyB, 0x0, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_b, kKeyCodeKeyB,
+                               static_cast<GdkModifierType>(0), false));
   tester.flushChannelMessages();
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
@@ -745,7 +750,8 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
   /// redispatching only works once.
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
   tester.flushChannelMessages();
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
@@ -768,7 +774,8 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithSyncResponds) {
   // Dispatch a key event
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
   tester.flushChannelMessages();
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(call_records.size(), 1u);
@@ -784,7 +791,8 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithSyncResponds) {
   tester.respondToEmbedderCallsWithAndRecordsTo(false, call_records);
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
   tester.flushChannelMessages();
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(call_records.size(), 1u);
@@ -816,7 +824,8 @@ TEST(FlKeyboardManagerTest, WithTwoAsyncDelegates) {
 
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
 
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
@@ -836,7 +845,8 @@ TEST(FlKeyboardManagerTest, WithTwoAsyncDelegates) {
   /// Test 2: All delegates respond false
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA, 0x0, false));
+      fl_key_event_new_by_mock(false, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
 
   EXPECT_EQ(manager_handled, true);
   EXPECT_EQ(redispatched.size(), 0u);
@@ -869,7 +879,8 @@ TEST(FlKeyboardManagerTest, TextInputPluginReturnsFalse) {
   // Dispatch a key event.
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
   tester.flushChannelMessages();
   EXPECT_EQ(manager_handled, true);
   // The event was redispatched because no one handles it.
@@ -891,7 +902,8 @@ TEST(FlKeyboardManagerTest, TextInputPluginReturnsTrue) {
   // Dispatch a key event.
   manager_handled = fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
   tester.flushChannelMessages();
   EXPECT_EQ(manager_handled, true);
   // The event was not redispatched because text input plugin handles it.
@@ -908,11 +920,13 @@ TEST(FlKeyboardManagerTest, CorrectLogicalKeyForLayouts) {
 
   auto sendTap = [&](guint8 keycode, guint keyval, guint8 group) {
     fl_keyboard_manager_handle_event(
-        tester.manager(),
-        fl_key_event_new_by_mock(true, keyval, keycode, 0, false, group));
+        tester.manager(), fl_key_event_new_by_mock(
+                              true, keyval, keycode,
+                              static_cast<GdkModifierType>(0), false, group));
     fl_keyboard_manager_handle_event(
-        tester.manager(),
-        fl_key_event_new_by_mock(false, keyval, keycode, 0, false, group));
+        tester.manager(), fl_key_event_new_by_mock(
+                              false, keyval, keycode,
+                              static_cast<GdkModifierType>(0), false, group));
   };
 
   /* US keyboard layout */
@@ -1038,7 +1052,8 @@ TEST(FlKeyboardManagerTest, GetPressedState) {
   // Dispatch a key event.
   fl_keyboard_manager_handle_event(
       tester.manager(),
-      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA, 0, false));
+      fl_key_event_new_by_mock(true, GDK_KEY_a, kKeyCodeKeyA,
+                               static_cast<GdkModifierType>(0), false));
 
   GHashTable* pressedState =
       fl_keyboard_manager_get_pressed_state(tester.manager());


### PR DESCRIPTION
The integer is replaced with the enumerated type in GTK4. The documentation in GTK3 indicates the value is the enumerated type.
