### PR TITLE
[web] Fix HtmlViewEmbedder.dispose

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -658,7 +658,7 @@ class HtmlViewEmbedder {
 
   /// Disposes the state of this view embedder.
   void dispose() {
-    disposeViews(_viewClipChains.keys);
+    disposeViews(_viewClipChains.keys.toList());
     _context = EmbedderFrameContext();
     _currentCompositionParams.clear();
     debugCleanupSvgClipPaths();

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -974,6 +974,43 @@ void testMain() {
       }
     });
   });
+
+  test('can dispose without crashing', () async {
+    ui_web.platformViewRegistry.registerViewFactory(
+        'test-view',
+        (int viewId) =>
+            createDomHTMLDivElement()..className = 'platform-view',
+        isVisible: false);
+
+    await createPlatformView(0, 'test-view');
+    await createPlatformView(1, 'test-view');
+    await createPlatformView(2, 'test-view');
+
+    LayerSceneBuilder sb = LayerSceneBuilder()
+      ..pushOffset(0, 0)
+      ..addPlatformView(0, width: 10, height: 10)
+      ..addPlatformView(1, width: 10, height: 10)
+      ..addPlatformView(2, width: 10, height: 10)
+      ..pop();
+
+    await renderScene(sb.build());
+
+    _expectSceneMatches(<_EmbeddedViewMarker>[
+      _overlay,
+      _platformView,
+      _platformView,
+      _platformView,
+    ]);
+
+    expect(() {
+      final HtmlViewEmbedder embedder =
+        (renderer as CanvasKitRenderer)
+          .debugGetRasterizerForView(implicitView)!
+          .viewEmbedder;
+      // The following line used to cause a "Concurrent modification during iteration"
+      embedder.dispose();
+    }, returnsNormally);
+  });
 }
 
 // Used to test that the platform views and overlays are in the correct order in


### PR DESCRIPTION
Fix a `Concurrent modification during iteration` in the `dispose` method of the HtmlViewEmbedder.

### Issues

Fixes https://github.com/flutter/flutter/issues/143193

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
