### PR TITLE
Remove FlKeyEvent.dispose_origin and use GdkEvent type for origin

### DIFF
--- a/shell/platform/linux/fl_key_channel_responder_test.cc
+++ b/shell/platform/linux/fl_key_channel_responder_test.cc
@@ -53,7 +53,6 @@ static FlKeyEvent* fl_key_event_new_by_mock(guint32 time_in_milliseconds,
   _g_key_event.keyval = keyval;
   _g_key_event.keycode = keycode;
   _g_key_event.origin = nullptr;
-  _g_key_event.dispose_origin = nullptr;
   return &_g_key_event;
 }
 

--- a/shell/platform/linux/fl_key_embedder_responder_test.cc
+++ b/shell/platform/linux/fl_key_embedder_responder_test.cc
@@ -124,7 +124,6 @@ static FlKeyEvent* fl_key_event_new_by_mock(guint32 time_in_milliseconds,
   _g_key_event.keyval = keyval;
   _g_key_event.keycode = keycode;
   _g_key_event.origin = nullptr;
-  _g_key_event.dispose_origin = nullptr;
   return &_g_key_event;
 }
 

--- a/shell/platform/linux/fl_key_event.cc
+++ b/shell/platform/linux/fl_key_event.cc
@@ -4,11 +4,6 @@
 
 #include "flutter/shell/platform/linux/fl_key_event.h"
 
-static void dispose_origin_from_gdk_event(gpointer origin) {
-  g_return_if_fail(origin != nullptr);
-  gdk_event_free(reinterpret_cast<GdkEvent*>(origin));
-}
-
 FlKeyEvent* fl_key_event_new_from_gdk_event(GdkEvent* event) {
   g_return_val_if_fail(event != nullptr, nullptr);
   GdkEventType type = gdk_event_get_event_type(event);
@@ -30,14 +25,13 @@ FlKeyEvent* fl_key_event_new_from_gdk_event(GdkEvent* event) {
   result->state = state;
   result->group = event->key.group;
   result->origin = event;
-  result->dispose_origin = dispose_origin_from_gdk_event;
 
   return result;
 }
 
 void fl_key_event_dispose(FlKeyEvent* event) {
-  if (event->dispose_origin != nullptr) {
-    event->dispose_origin(event->origin);
+  if (event->origin != nullptr) {
+    gdk_event_free(event->origin);
   }
   g_free(event);
 }

--- a/shell/platform/linux/fl_key_event.h
+++ b/shell/platform/linux/fl_key_event.h
@@ -8,15 +8,6 @@
 #include <gdk/gdk.h>
 
 /**
- * FlKeyEventDispose:
- * @origin: the #FlKeyEvent::origin to dispose.
- *
- * The signature for #FlKeyEvent::dispose_origin, which
- * frees #FlKeyEvent::origin.
- **/
-typedef void (*FlKeyEventDisposeOrigin)(gpointer origin);
-
-/**
  * FlKeyEvent:
  * A struct that stores information from GdkEvent.
  *
@@ -41,15 +32,8 @@ typedef struct _FlKeyEvent {
   int state;
   // Keyboard group.
   guint8 group;
-  // An opaque pointer to the original event.
-  //
-  // This is used when dispatching.  For native events, this is #GdkEvent
-  // pointer.  For unit tests, this is a dummy pointer.
-  gpointer origin;
-  // A callback to free #origin, called in #fl_key_event_dispose.
-  //
-  // Can be nullptr.
-  FlKeyEventDisposeOrigin dispose_origin;
+  // The original event.
+  GdkEvent* origin;
 } FlKeyEvent;
 
 /**

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -346,8 +346,6 @@ static void fl_mock_view_delegate_class_init(FlMockViewDelegateClass* klass) {
   G_OBJECT_CLASS(klass)->finalize = fl_mock_view_delegate_finalize;
 }
 
-static FlKeyEvent* fl_key_event_clone_information_only(FlKeyEvent* event);
-
 static void fl_mock_view_keyboard_send_key_event(
     FlKeyboardViewDelegate* view_delegate,
     const FlutterKeyEvent* event,
@@ -469,35 +467,20 @@ static void fl_mock_view_set_layout(FlMockViewDelegate* self,
 
 /***** End FlMockViewDelegate *****/
 
-// Return a newly allocated #FlKeyEvent that is a clone to the given #event
-// but with #origin and #dispose set to 0.
-static FlKeyEvent* fl_key_event_clone_information_only(FlKeyEvent* event) {
-  FlKeyEvent* new_event = fl_key_event_clone(event);
-  new_event->origin = nullptr;
-  new_event->dispose_origin = nullptr;
-  return new_event;
-}
-
 // Create a new #FlKeyEvent with the given information.
-//
-// The #origin will be another #FlKeyEvent with the exact information,
-// so that it can be used to redispatch, and is freed upon disposal.
 static FlKeyEvent* fl_key_event_new_by_mock(bool is_press,
                                             guint keyval,
                                             guint16 keycode,
                                             int state,
                                             gboolean is_modifier,
                                             guint8 group = 0) {
-  FlKeyEvent* event = g_new(FlKeyEvent, 1);
+  FlKeyEvent* event = g_new0(FlKeyEvent, 1);
   event->is_press = is_press;
   event->time = 0;
   event->state = state;
   event->keyval = keyval;
   event->group = group;
   event->keycode = keycode;
-  FlKeyEvent* origin_event = fl_key_event_clone_information_only(event);
-  event->origin = origin_event;
-  event->dispose_origin = [](gpointer origin) { g_free(origin); };
   return event;
 }
 

--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -626,8 +626,8 @@ static gboolean fl_text_input_plugin_filter_keypress_default(
     return FALSE;
   }
 
-  GdkEventKey* key_event = reinterpret_cast<GdkEventKey*>(event->origin);
-  if (gtk_im_context_filter_keypress(priv->im_context, key_event)) {
+  if (gtk_im_context_filter_keypress(
+          priv->im_context, reinterpret_cast<GdkEventKey*>(event->origin))) {
     return TRUE;
   }
 

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -290,11 +290,10 @@ static void fl_view_keyboard_delegate_iface_init(
   iface->redispatch_event = [](FlKeyboardViewDelegate* view_delegate,
                                std::unique_ptr<FlKeyEvent> in_event) {
     FlKeyEvent* event = in_event.release();
-    GdkEvent* gdk_event = reinterpret_cast<GdkEvent*>(event->origin);
-    GdkEventType event_type = gdk_event_get_event_type(gdk_event);
+    GdkEventType event_type = gdk_event_get_event_type(event->origin);
     g_return_if_fail(event_type == GDK_KEY_PRESS ||
                      event_type == GDK_KEY_RELEASE);
-    gdk_event_put(gdk_event);
+    gdk_event_put(event->origin);
     fl_key_event_dispose(event);
   };
 


### PR DESCRIPTION
This removes casting. origin was a pointer for testing purposes to be mocked but the tests make no use of this.
