### PR TITLE
[Impeller] Remove the Vulkan queue submit thread and always present Vulkan images on the raster thread

### DIFF
--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -106,15 +106,6 @@ PlaygroundImplVK::PlaygroundImplVK(PlaygroundSwitches switches)
     return;
   }
 
-  // Without this, the playground will timeout waiting for the presentation.
-  // It's better to have some Vulkan validation tests running on CI to catch
-  // regressions, but for now this is a workaround.
-  //
-  // TODO(matanlurey): https://github.com/flutter/flutter/issues/134852.
-  //
-  // (Note, if you're using MoltenVK, or Linux, you can comment out this line).
-  context_vk->SetSyncPresentation(true);
-
   VkSurfaceKHR vk_surface;
   auto res = vk::Result{::glfwCreateWindowSurface(
       context_vk->GetInstance(),  // instance

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -91,11 +91,6 @@ class ContextVK final : public Context,
   // |Context|
   void Shutdown() override;
 
-  // |Context|
-  void SetSyncPresentation(bool value) override { sync_presentation_ = value; }
-
-  bool GetSyncPresentation() const { return sync_presentation_; }
-
   void SetOffscreenFormat(PixelFormat pixel_format);
 
   template <typename T>
@@ -202,7 +197,6 @@ class ContextVK final : public Context,
   std::shared_ptr<DescriptorPoolRecyclerVK> descriptor_pool_recycler_;
   std::shared_ptr<CommandQueue> command_queue_vk_;
 
-  bool sync_presentation_ = false;
   const uint64_t hash_;
 
   bool is_valid_ = false;

--- a/impeller/renderer/backend/vulkan/surface_context_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.cc
@@ -91,10 +91,6 @@ std::unique_ptr<Surface> SurfaceContextVK::AcquireNextSurface() {
   return surface;
 }
 
-void SurfaceContextVK::SetSyncPresentation(bool value) {
-  parent_->SetSyncPresentation(value);
-}
-
 void SurfaceContextVK::UpdateSurfaceSize(const ISize& size) const {
   swapchain_->UpdateSurfaceSize(size);
 }

--- a/impeller/renderer/backend/vulkan/surface_context_vk.h
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.h
@@ -69,9 +69,6 @@ class SurfaceContextVK : public Context,
   // |Context|
   void Shutdown() override;
 
-  // |Context|
-  void SetSyncPresentation(bool value) override;
-
   [[nodiscard]] bool SetWindowSurface(vk::UniqueSurfaceKHR surface,
                                       const ISize& size);
 

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -171,17 +171,6 @@ class Context {
   ///
   virtual void Shutdown() = 0;
 
-  //----------------------------------------------------------------------------
-  /// @brief      Force the Vulkan presentation (submitKHR) to be performed on
-  ///             the raster task runner.
-  ///
-  ///             This is required for correct rendering on Android when using
-  ///             the hybrid composition mode. This has no effect on other
-  ///             backends. This is analogous to the check for isMainThread in
-  ///             surface_mtl.mm to block presentation on scheduling of all
-  ///             pending work.
-  virtual void SetSyncPresentation(bool value) {}
-
   CaptureContext capture;
 
   /// Stores a task on the `ContextMTL` that is awaiting access for the GPU.

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -353,8 +353,4 @@ void AndroidShellHolder::UpdateDisplayMetrics() {
   shell_->OnDisplayUpdates(std::move(displays));
 }
 
-void AndroidShellHolder::SetIsRenderingToImageView(bool value) {
-  platform_view_->SetIsRenderingToImageView(value);
-}
-
 }  // namespace flutter

--- a/shell/platform/android/android_shell_holder.h
+++ b/shell/platform/android/android_shell_holder.h
@@ -105,8 +105,6 @@ class AndroidShellHolder {
 
   void UpdateDisplayMetrics();
 
-  void SetIsRenderingToImageView(bool value);
-
  private:
   const flutter::Settings settings_;
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -143,7 +143,6 @@ public class FlutterImageView extends View implements RenderSurface {
     switch (kind) {
       case background:
         flutterRenderer.swapSurface(imageReader.getSurface());
-        flutterRenderer.SetRenderingToImageView(true);
         break;
       case overlay:
         // Do nothing since the attachment is done by the handler of
@@ -174,12 +173,6 @@ public class FlutterImageView extends View implements RenderSurface {
     closeCurrentImage();
     invalidate();
     isAttachedToFlutterRenderer = false;
-    if (kind == SurfaceKind.background) {
-      // The overlay FlutterImageViews seem to be constructed per frame and not
-      // always used; An overlay FlutterImageView always seems to imply
-      // a background FlutterImageView.
-      flutterRenderer.SetRenderingToImageView(false);
-    }
   }
 
   public void pause() {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -755,13 +755,6 @@ public class FlutterJNI {
       int[] displayFeaturesType,
       int[] displayFeaturesState);
 
-  @UiThread
-  public void SetIsRenderingToImageView(boolean value) {
-    nativeSetIsRenderingToImageView(nativeShellHolderId, value);
-  }
-
-  private native void nativeSetIsRenderingToImageView(long nativeShellHolderId, boolean value);
-
   // ----- End Render Surface Support -----
 
   // ------ Start Touch Interaction Support ---

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -65,7 +65,6 @@ public class FlutterRenderer implements TextureRegistry {
   @NonNull private final AtomicLong nextTextureId = new AtomicLong(0L);
   @Nullable private Surface surface;
   private boolean isDisplayingFlutterUi = false;
-  private int isRenderingToImageViewCount = 0;
   private final Handler handler = new Handler();
 
   @NonNull
@@ -97,19 +96,6 @@ public class FlutterRenderer implements TextureRegistry {
    */
   public boolean isDisplayingFlutterUi() {
     return isDisplayingFlutterUi;
-  }
-
-  /**
-   * Informs the renderer whether the surface it is rendering to is backend by a {@code
-   * FlutterImageView}, which requires additional synchonization in the Vulkan backend.
-   */
-  public void SetRenderingToImageView(boolean value) {
-    if (value) {
-      isRenderingToImageViewCount++;
-    } else {
-      isRenderingToImageViewCount--;
-    }
-    flutterJNI.SetIsRenderingToImageView(isRenderingToImageViewCount > 0);
   }
 
   /**

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -120,12 +120,6 @@ class PlatformViewAndroid final : public PlatformView {
     return platform_message_handler_;
   }
 
-  void SetIsRenderingToImageView(bool value) {
-    if (GetImpellerContext()) {
-      GetImpellerContext()->SetSyncPresentation(value);
-    }
-  }
-
  private:
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
   std::shared_ptr<AndroidContext> android_context_;

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -556,13 +556,6 @@ static void NotifyLowMemoryWarning(JNIEnv* env,
   ANDROID_SHELL_HOLDER->NotifyLowMemoryWarning();
 }
 
-static void SetIsRenderingToImageView(JNIEnv* env,
-                                      jobject jcaller,
-                                      jlong shell_holder,
-                                      bool value) {
-  ANDROID_SHELL_HOLDER->SetIsRenderingToImageView(value);
-}
-
 static jboolean FlutterTextUtilsIsEmoji(JNIEnv* env,
                                         jobject obj,
                                         jint codePoint) {
@@ -721,11 +714,6 @@ bool RegisterApi(JNIEnv* env) {
           .name = "nativeNotifyLowMemoryWarning",
           .signature = "(J)V",
           .fnPtr = reinterpret_cast<void*>(&NotifyLowMemoryWarning),
-      },
-      {
-          .name = "nativeSetIsRenderingToImageView",
-          .signature = "(JZ)V",
-          .fnPtr = reinterpret_cast<void*>(&SetIsRenderingToImageView),
       },
 
       // Start of methods from FlutterView


### PR DESCRIPTION
The queue submit thread could sometimes call vkQueuePresentKHR while the raster thread is calling vkAcquireNextImageKHR.  The simultaneous use of the swapchain on multiple threads violates Vulkan threading rules.