### PR TITLE
Add a Dart FFI method to synchronously render a frame

### DIFF
--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -98,7 +98,7 @@ typedef CanvasPath Path;
   V(NativeStringAttribute::initSpellOutStringAttribute)            \
   V(PlatformConfigurationNativeApi::DefaultRouteName)              \
   V(PlatformConfigurationNativeApi::ScheduleFrame)                 \
-  V(PlatformConfigurationNativeApi::ImposeSyncFrame)               \
+  V(PlatformConfigurationNativeApi::ForceSyncFrame)                \
   V(PlatformConfigurationNativeApi::Render)                        \
   V(PlatformConfigurationNativeApi::UpdateSemantics)               \
   V(PlatformConfigurationNativeApi::SetNeedsReportTimings)         \

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -98,6 +98,7 @@ typedef CanvasPath Path;
   V(NativeStringAttribute::initSpellOutStringAttribute)            \
   V(PlatformConfigurationNativeApi::DefaultRouteName)              \
   V(PlatformConfigurationNativeApi::ScheduleFrame)                 \
+  V(PlatformConfigurationNativeApi::ImposeSyncFrame)               \
   V(PlatformConfigurationNativeApi::Render)                        \
   V(PlatformConfigurationNativeApi::UpdateSemantics)               \
   V(PlatformConfigurationNativeApi::SetNeedsReportTimings)         \

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -801,10 +801,40 @@ class PlatformDispatcher {
   ///
   ///  * [SchedulerBinding], the Flutter framework class which manages the
   ///    scheduling of frames.
+  ///  * [imposeSyncFrame], a similar method that is used in rare cases that
+  ///    a frame must be rendered immediately.
   void scheduleFrame() => _scheduleFrame();
 
   @Native<Void Function()>(symbol: 'PlatformConfigurationNativeApi::ScheduleFrame')
   external static void _scheduleFrame();
+
+  /// Immediately render a frame by invoking the [onBeginFrame] and
+  /// [onDrawFrame] callbacks synchronously.
+  ///
+  /// This method performs the same computation for a frame as [scheduleFrame]
+  /// does, but instead of doing so at an appropriate opportunity, the render is
+  /// completed synchronously within this call.
+  ///
+  /// This method should not be used in usual cases. It is designed for
+  /// situations that require a frame is rendered as soon as possible, even at
+  /// the cost of rendering quality.
+  ///
+  /// See also:
+  ///
+  ///  * [SchedulerBinding], the Flutter framework class which manages the
+  ///    scheduling of frames.
+  ///  * [scheduleFrame].
+  ///
+  // TODO(dkwingsmt): This method is not used for now, and is not implemented by
+  // the engine yet. This is because we have to land the Dart FFI method first
+  // before being able to run the performance test for the full changes due to
+  // the restriction of the performance test. Eventually, we should either land
+  // the full changes, or remove this method.
+  // https://github.com/flutter/flutter/issues/142851
+  void imposeSyncFrame() => _imposeSyncFrame();
+
+  @Native<Void Function()>(symbol: 'PlatformConfigurationNativeApi::ImposeSyncFrame')
+  external static void _imposeSyncFrame();
 
   /// Additional accessibility features that may be enabled by the platform.
   AccessibilityFeatures get accessibilityFeatures => _configuration.accessibilityFeatures;

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -815,14 +815,16 @@ class PlatformDispatcher {
   /// does, but instead of doing so at an appropriate opportunity, the render is
   /// completed synchronously within this call.
   ///
-  /// This method should not be used in usual cases. It is designed for
-  /// situations that require a frame is rendered as soon as possible, even at
-  /// the cost of rendering quality.
+  /// Prefer [scheduleFrame] to update the display in normal operation. The
+  /// [forceSyncFrame] method is designed for situations that require a frame is
+  /// rendered as soon as possible, even at the cost of rendering quality. An
+  /// example of using this method is [SchedulerBinding.scheduleWarmUpFrame],
+  /// which is called during application startup so that the first frame can be
+  /// presented to the screen a few extra milliseconds earlier.
   ///
   /// See also:
   ///
-  ///  * [SchedulerBinding], the Flutter framework class which manages the
-  ///    scheduling of frames.
+  ///  * [SchedulerBinding.scheduleWarmUpFrame], which uses this method.
   ///  * [scheduleFrame].
   ///
   // TODO(dkwingsmt): This method is not used for now, and is not implemented by

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -801,7 +801,7 @@ class PlatformDispatcher {
   ///
   ///  * [SchedulerBinding], the Flutter framework class which manages the
   ///    scheduling of frames.
-  ///  * [imposeSyncFrame], a similar method that is used in rare cases that
+  ///  * [forceSyncFrame], a similar method that is used in rare cases that
   ///    a frame must be rendered immediately.
   void scheduleFrame() => _scheduleFrame();
 
@@ -831,10 +831,10 @@ class PlatformDispatcher {
   // the restriction of the performance test. Eventually, we should either land
   // the full changes, or remove this method.
   // https://github.com/flutter/flutter/issues/142851
-  void imposeSyncFrame() => _imposeSyncFrame();
+  void forceSyncFrame() => _forceSyncFrame();
 
-  @Native<Void Function()>(symbol: 'PlatformConfigurationNativeApi::ImposeSyncFrame')
-  external static void _imposeSyncFrame();
+  @Native<Void Function()>(symbol: 'PlatformConfigurationNativeApi::ForceSyncFrame')
+  external static void _forceSyncFrame();
 
   /// Additional accessibility features that may be enabled by the platform.
   AccessibilityFeatures get accessibilityFeatures => _configuration.accessibilityFeatures;

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -589,7 +589,7 @@ void PlatformConfigurationNativeApi::ScheduleFrame() {
   UIDartState::Current()->platform_configuration()->client()->ScheduleFrame();
 }
 
-void PlatformConfigurationNativeApi::ImposeSyncFrame() {
+void PlatformConfigurationNativeApi::ForceSyncFrame() {
   // TODO(dkwingsmt): This method is not implemented and is not used for now.
   // This is because we have to land the Dart FFI method first before being able
   // to run the performance test for the full changes due to the restriction of

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -589,6 +589,16 @@ void PlatformConfigurationNativeApi::ScheduleFrame() {
   UIDartState::Current()->platform_configuration()->client()->ScheduleFrame();
 }
 
+void PlatformConfigurationNativeApi::ImposeSyncFrame() {
+  // TODO(dkwingsmt): This method is not implemented and is not used for now.
+  // This is because we have to land the Dart FFI method first before being able
+  // to run the performance test for the full changes due to the restriction of
+  // the performance test. Eventually, we should either land the full changes,
+  // or remove this method.
+  // https://github.com/flutter/flutter/issues/142851
+  FML_UNREACHABLE();
+}
+
 void PlatformConfigurationNativeApi::UpdateSemantics(SemanticsUpdate* update) {
   UIDartState::ThrowIfUIOperationsProhibited();
   UIDartState::Current()->platform_configuration()->client()->UpdateSemantics(

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -557,6 +557,8 @@ class PlatformConfigurationNativeApi {
 
   static void ScheduleFrame();
 
+  static void ImposeSyncFrame();
+
   static void Render(int64_t view_id,
                      Scene* scene,
                      double width,

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -557,7 +557,7 @@ class PlatformConfigurationNativeApi {
 
   static void ScheduleFrame();
 
-  static void ImposeSyncFrame();
+  static void ForceSyncFrame();
 
   static void Render(int64_t view_id,
                      Scene* scene,


### PR DESCRIPTION
This PR adds `PlatformDispatcher.imposeSyncFrame`.

This function is not used by anyone, nor is implemented by the engine. The usage and implementation should be added by a later PR. The full PR must be verified by a performance test, but the performance test currently has a problem of not being able to recognize local dart:ui changes. 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
