### PR TITLE
[Impeller] Call vkQueuePresentKHR through the ContextVK's synchronized graphics queue wrapper

### DIFF
--- a/impeller/renderer/backend/vulkan/queue_vk.cc
+++ b/impeller/renderer/backend/vulkan/queue_vk.cc
@@ -23,6 +23,11 @@ vk::Result QueueVK::Submit(const vk::SubmitInfo& submit_info,
   return queue_.submit(submit_info, fence);
 }
 
+vk::Result QueueVK::Present(const vk::PresentInfoKHR& present_info) {
+  Lock lock(queue_mutex_);
+  return queue_.presentKHR(present_info);
+}
+
 void QueueVK::InsertDebugMarker(std::string_view label) const {
   if (!HasValidationLayers()) {
     return;

--- a/impeller/renderer/backend/vulkan/queue_vk.h
+++ b/impeller/renderer/backend/vulkan/queue_vk.h
@@ -39,6 +39,8 @@ class QueueVK {
   vk::Result Submit(const vk::SubmitInfo& submit_info,
                     const vk::Fence& fence) const;
 
+  vk::Result Present(const vk::PresentInfoKHR& present_info);
+
   void InsertDebugMarker(std::string_view label) const;
 
  private:

--- a/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain_impl_vk.h
@@ -66,7 +66,6 @@ class SwapchainImplVK final
  private:
   std::weak_ptr<Context> context_;
   vk::UniqueSurfaceKHR surface_;
-  vk::Queue present_queue_ = {};
   vk::Format surface_format_ = vk::Format::eUndefined;
   vk::UniqueSwapchainKHR swapchain_;
   std::vector<std::shared_ptr<SwapchainImageVK>> images_;


### PR DESCRIPTION
SwapchainImplVK had been querying the physical device for a queue that supports presentation on the specified surface.  However, the selected queue is typically the same VkQueue instance as the graphics queue provided by ContextVK.

This could cause a thread policy violation where the raster thread is calling vkQueuePresentKHR while the IO thread is calling vkQueueSubmit on the same queue during image decoding.

This PR moves the vkQueuePresentKHR call to the ContextVK's graphics queue wrapper, which serializes access to the VkQueue.