### PR TITLE
[Impeller] Remove references to moved impeller/image from README.

### DIFF
--- a/impeller/README.md
+++ b/impeller/README.md
@@ -106,13 +106,6 @@ states of completion:
 * **`//impeller/base`**: Contains C++ utilities that are used throughout the
   Impeller family of frameworks. Ideally, these should go in `//flutter/fml` but
   their use is probably not widespread enough to at this time.
-* **`//impeller/image`**: The Impeller renderer works with textures whose memory
-  is resident in device memory. However, pending the migration of
-  `//flutter/display_list` to graphics package agnosticism and the subsequent
-  migration of the image decoders to work with the package agnostic types, there
-  needs to be a way for tests and such to decode compressed image data. This
-  sub-framework provides that functionality. This sub-framework is slated for
-  removal and must not be used outside of tests.
 * **`//fixtures`**: Contains test fixtures used by the various test harnesses.
   This depends on `//flutter/testing`.
 * **`//impeller/tools`**: Contains all GN rules and python scripts for working


### PR DESCRIPTION
Moved by @dnfield in https://github.com/flutter/engine/pull/50480