### PR TITLE
[Impeller] Don't use constants from an extension.

### DIFF
--- a/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
@@ -171,8 +171,8 @@ void InsertBarrierForInputAttachmentRead(const vk::CommandBuffer& buffer,
   image_levels.aspectMask = vk::ImageAspectFlagBits::eColor;
   image_levels.baseArrayLayer = 0u;
   image_levels.baseMipLevel = 0u;
-  image_levels.layerCount = VK_REMAINING_ARRAY_LAYERS;
-  image_levels.levelCount = VK_REMAINING_MIP_LEVELS;
+  image_levels.layerCount = 1u;
+  image_levels.levelCount = 1u;
   barrier.subresourceRange = image_levels;
 
   buffer.pipelineBarrier(kSelfDependencySrcStageMask,  //


### PR DESCRIPTION
While reading the Vulkan spec for unrelated reasons, I noticed that VK_REMAINING_ARRAY_LAYERS is part of VK_KHR_maintenance5. Using this without enabling the feature is invalid usage as documented in [VUID-VkImageSubresourceLayers-layerCount-09243](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageSubresourceLayers.html#VUID-VkImageSubresourceLayers-layerCount-09243).

It doesn't seem to trip validation (or perhaps our layers are too old). I had used the constant because it originally seemed convenient. But 1u is correct as the barrier is inserted on color attachment which can only have one layer and lever.