### PR TITLE
[Impeller] remove expensive trace events.

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -702,7 +702,6 @@ void Canvas::AddEntityToCurrentPass(Entity entity) {
 void Canvas::SaveLayer(const Paint& paint,
                        std::optional<Rect> bounds,
                        const std::shared_ptr<ImageFilter>& backdrop_filter) {
-  TRACE_EVENT0("flutter", "Canvas::saveLayer");
   Save(true, paint.blend_mode, backdrop_filter);
 
   // The DisplayList bounds/rtree doesn't account for filters applied to parent

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -883,8 +883,6 @@ bool EntityPass::OnRender(
     std::shared_ptr<Contents> backdrop_filter_contents,
     const std::optional<InlinePassContext::RenderPassResult>&
         collapsed_parent_pass) const {
-  TRACE_EVENT0("impeller", "EntityPass::OnRender");
-
   if (!active_clips_.empty()) {
     VALIDATION_LOG << SPrintF(
         "EntityPass (Depth=%d) contains one or more clips with an unresolved "


### PR DESCRIPTION
In applications with lots of compositing like https://github.com/flutter/flutter/issues/140257 , these trace events constitute a large % of CPU time without providing any performance insight.
