### PR TITLE
Initializes RBE in the build config runner

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -219,36 +219,6 @@ def setup_rbe(args):
   # care of starting and stopping the compiler proxy.
   running_on_luci = os.environ.get('LUCI_CONTEXT') is not None
 
-  # Bootstrap reproxy if not running in CI.
-  if not running_on_luci:
-    cipd_reclient_dir = os.path.join(
-        SRC_ROOT,
-        'buildtools',
-        buildtools_dir(),
-        'reclient',
-    )
-    bootstrap_path = os.path.join(cipd_reclient_dir, 'bootstrap')
-    bootstrap_path = bootstrap_path + '.exe' if get_host_os() == 'win' else bootstrap_path
-    reproxy_path = os.path.join(cipd_reclient_dir, 'reproxy')
-    rbe_cfg_path = os.path.join(
-        SRC_ROOT,
-        'flutter',
-        'build',
-        'rbe',
-        'reclient-' + get_host_os() + '.cfg',
-    )
-    bootstrap_cmd = [
-        bootstrap_path,
-        '--re_proxy=' + reproxy_path,
-        '--automatic_auth=true',
-        '--cfg=' + rbe_cfg_path,
-    ]
-    try:
-      subprocess.call(bootstrap_cmd, cwd=SRC_ROOT)
-    except subprocess.CalledProcessError as exc:
-      print('Failed to boostrap reproxy: ', exc.returncode, exc.output)
-      return {}
-
   if args.rbe_server_address:
     rbe_gn_args['rbe_server_address'] = args.rbe_server_address
   if args.rbe_exec_strategy:
@@ -1188,7 +1158,7 @@ def parse_args(args):
 
   parser.add_argument(
       '--trace-gn',
-      default=False,
+      default=True,
       action='store_true',
       help='Write a GN trace log (gn_trace.json) in the Chromium tracing '
       'format in the build directory.'

--- a/tools/pkg/engine_build_configs/bin/run.dart
+++ b/tools/pkg/engine_build_configs/bin/run.dart
@@ -108,11 +108,20 @@ The build names are the "name" fields of the maps in the list of "builds".
     return;
   }
 
+  // If RBE config files aren't in the tree, then disable RBE.
+  final String rbeConfigPath = p.join(
+    engine.srcDir.path, 'flutter', 'build', 'rbe',
+  );
+  final List<String> extraGnArgs = <String>[
+    if (!io.Directory(rbeConfigPath).existsSync()) '--no-rbe',
+  ];
+
   final GlobalBuildRunner buildRunner = GlobalBuildRunner(
     platform: const LocalPlatform(),
     processRunner: ProcessRunner(),
     engineSrcDir: engine.srcDir,
     build: targetBuild,
+    extraGnArgs: extraGnArgs,
     runGenerators: false,
     runTests: false,
   );

--- a/tools/pkg/process_fakes/lib/process_fakes.dart
+++ b/tools/pkg/process_fakes/lib/process_fakes.dart
@@ -15,7 +15,8 @@ final class FakeProcessManager implements ProcessManager {
   FakeProcessManager({
     io.ProcessResult Function(List<String> command) onRun = unhandledRun,
     io.Process Function(List<String> command) onStart = unhandledStart,
-  }) : _onRun = onRun, _onStart = onStart;
+    bool Function(Object?, {String? workingDirectory}) canRun = unhandledCanRun,
+  }) : _onRun = onRun, _onStart = onStart, _canRun = canRun;
 
   /// A default implementation of [onRun] that throws an [UnsupportedError].
   static io.ProcessResult unhandledRun(List<String> command) {
@@ -27,11 +28,19 @@ final class FakeProcessManager implements ProcessManager {
     throw UnsupportedError('Unhandled start: ${command.join(' ')}');
   }
 
+  /// A default implementation of [canRun] that returns `true`.
+  static bool unhandledCanRun(Object? executable, {String? workingDirectory}) {
+    return true;
+  }
+
   final io.ProcessResult Function(List<String> command) _onRun;
   final io.Process Function(List<String> command) _onStart;
+  final bool Function(Object?, {String? workingDirectory}) _canRun;
 
   @override
-  bool canRun(Object? executable, {String? workingDirectory}) => true;
+  bool canRun(Object? executable, {String? workingDirectory}) {
+    return _canRun(executable, workingDirectory: workingDirectory);
+  }
 
   @override
   bool killPid(int pid, [io.ProcessSignal signal = io.ProcessSignal.sigterm]) => true;


### PR DESCRIPTION
Unlike Goma, the local RBE server must be manually started and stopped between each `ninja` build.

This PR adds the startup and shutdown before and after `ninja` is run in the build config runner. It also removes the RBE startup logic from the `gn` script, which was the wrong place for it since there was no opportunity for it to shutdown the service. Removing this logic from the `gn` script will not affect CI since the recipes already do the right startup and shutdown, and logic in the `gn` script skipped the now deleted section of code.