### PR TITLE
Update codec defines for Skia

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -17,7 +17,10 @@ if (is_fuchsia) {
 config("skia_public") {
   include_dirs = [ "$_skia_root" ]
 
-  defines = []
+  defines = [
+    "SK_CODEC_DECODES_BMP",
+    "SK_CODEC_DECODES_WBMP",
+  ]
   cflags_objcc = []
   if (is_fuchsia || is_linux) {
     defines += [ "SK_R32_SHIFT=16" ]
@@ -534,7 +537,10 @@ optional("xps") {
 
 optional("png_decode") {
   enabled = skia_use_libpng_decode
-  public_defines = [ "SK_CODEC_DECODES_PNG" ]
+  public_defines = [
+    "SK_CODEC_DECODES_PNG",
+    "SK_CODEC_DECODES_ICO",
+  ]
 
   deps = [ "//third_party/libpng" ]
   sources = [
@@ -581,7 +587,11 @@ optional("webp_encode") {
 
 optional("wuffs") {
   enabled = skia_use_wuffs
-  public_defines = [ "SK_HAS_WUFFS_LIBRARY" ]
+  public_defines = [
+    "SK_HAS_WUFFS_LIBRARY",  # TODO remove after rolling
+                             # http://review.skia.org/811816
+    "SK_CODEC_DECODES_GIF",
+  ]
 
   deps = [ "//flutter/third_party/wuffs" ]
   sources = [ "$_skia_root/src/codec/SkWuffsCodec.cpp" ]


### PR DESCRIPTION
Skia is coalescing some defines related to codecs in https://skia-review.googlesource.com/c/skia/+/811816

This will let that change land (hopefully).

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
