### PR TITLE
Remove host_debug_unopt build from  linux_host_engine.json

### DIFF
--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -13,30 +13,6 @@
                 "--runtime-mode",
                 "debug",
                 "--unoptimized",
-                "--prebuilt-dart-sdk"
-            ],
-            "name": "host_debug_unopt",
-            "ninja": {
-                "config": "host_debug_unopt",
-                "targets": [
-                    "flutter",
-                    "flutter/sky/packages"
-                ]
-            }
-        },
-        {
-            "archives": [],
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false
-            },
-            "gn": [
-                "--runtime-mode",
-                "debug",
-                "--unoptimized",
                 "--prebuilt-dart-sdk",
                 "--target-dir",
                 "host_debug_impeller_vulkan"


### PR DESCRIPTION
It wasn't being used for anything on this builder, and the same config was being built below under a different name.
