### PR TITLE
[Impeller] Remove support of toggling Vulkan playgrounds in addition to enabling that backend.

### DIFF
--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -34,10 +34,6 @@ config("impeller_public_config") {
     defines += [ "IMPELLER_ENABLE_VULKAN=1" ]
   }
 
-  if (impeller_enable_vulkan_playgrounds) {
-    defines += [ "IMPELLER_ENABLE_VULKAN_PLAYGROUNDS=1" ]
-  }
-
   if (impeller_trace_all_gl_calls) {
     defines += [ "IMPELLER_TRACE_ALL_GL_CALLS" ]
   }

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -107,7 +107,7 @@ bool Playground::SupportsBackend(PlaygroundBackend backend) {
       return false;
 #endif  // IMPELLER_ENABLE_OPENGLES
     case PlaygroundBackend::kVulkan:
-#if IMPELLER_ENABLE_VULKAN && IMPELLER_ENABLE_VULKAN_PLAYGROUNDS
+#if IMPELLER_ENABLE_VULKAN
       return true;
 #else   // IMPELLER_ENABLE_VULKAN
       return false;

--- a/impeller/tools/impeller.gni
+++ b/impeller/tools/impeller.gni
@@ -25,13 +25,6 @@ declare_args() {
   impeller_enable_vulkan = (is_linux || is_win || is_android ||
                             enable_unittests) && target_os != "fuchsia"
 
-  # Whether playgrounds should run with Vulkan.
-  #
-  # impeller_enable_vulkan may be true in build environments that run tests but
-  # do not have a Vulkan ICD present.
-  impeller_enable_vulkan_playgrounds =
-      (is_linux || is_win || is_android) && target_os != "fuchsia"
-
   # Whether to use a prebuilt impellerc.
   # If this is the empty string, impellerc will be built.
   # If it is non-empty, it should be the absolute path to impellerc.

--- a/tools/gn
+++ b/tools/gn
@@ -639,9 +639,6 @@ def to_gn_args(args):
   if args.enable_impeller_vulkan:
     gn_args['impeller_enable_vulkan'] = True
 
-  if args.enable_impeller_vulkan_playgrounds:
-    gn_args['impeller_enable_vulkan_playgrounds'] = True
-
   if args.enable_impeller_opengles:
     gn_args['impeller_enable_opengles'] = True
 
@@ -1095,14 +1092,6 @@ def parse_args(args):
       default=False,
       action='store_true',
       help='Enable the Impeller Vulkan backend.'
-  )
-
-  parser.add_argument(
-      '--enable-impeller-vulkan-playgrounds',
-      default=False,
-      action='store_true',
-      help='Enable the Impeller Vulkan Playgrounds. ' +
-      'The Impeller Vulkan backend needs to be enabled.'
   )
 
   parser.add_argument(


### PR DESCRIPTION
Now, you get playgrounds no all backends if you enable that backend.

Second attempt at https://github.com/flutter/engine/pull/49949
