### PR TITLE
Allow deprecated members from the Dart SDK to roll in.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,8 +10,10 @@ analyzer:
     strict-inference: true
     strict-raw-types: true
   errors:
-    # allow self-reference to deprecated members (we do this because otherwise we have
-    # to annotate every member in every test, assert, etc, when we deprecate something)
+    # allow deprecated members (we do this because otherwise we have to annotate
+    # every member in every test, assert, etc, when we or the Dart SDK deprecates
+    # something (https://github.com/flutter/flutter/issues/143312)
+    deprecated_member_use: ignore
     deprecated_member_use_from_same_package: ignore
   exclude: # DIFFERENT FROM FLUTTER/FLUTTER
     # Fixture depends on dart:ui and raises false positives.


### PR DESCRIPTION
Namely, without breaking the tree. This is a deliberate policy decision change.

See https://github.com/flutter/flutter/issues/143312.