### PR TITLE
Do not use AChoreographer on 32 bit devices

### DIFF
--- a/fml/platform/android/ndk_helpers.cc
+++ b/fml/platform/android/ndk_helpers.cc
@@ -100,9 +100,15 @@ void InitOnceCallback() {
   LOOKUP(android, AChoreographer_getInstance);
   if (_AChoreographer_getInstance) {
     LOOKUP(android, AChoreographer_postFrameCallback64);
+// See discussion at
+// https://github.com/flutter/engine/pull/31859#discussion_r822072987
+// This method is not suitable for Flutter's use cases on 32 bit architectures,
+// and we should fall back to the Java based Choreographer.
+#if FML_ARCH_CPU_64_BITS
     if (!_AChoreographer_postFrameCallback64) {
       LOOKUP(android, AChoreographer_postFrameCallback);
     }
+#endif
   }
 
   LOOKUP(android, ASurfaceControl_createFromWindow);

--- a/fml/platform/android/ndk_helpers_unittests.cc
+++ b/fml/platform/android/ndk_helpers_unittests.cc
@@ -45,7 +45,7 @@ TEST_F(NdkHelpersTest, AChoreographer32) {
       NDKHelpers::AChoreographer_getInstance(), &OnVsync32, nullptr);
 }
 #else
-TEST_F(NdkHelpersTest, AChoreographer32_NotSupported) {
+TEST_F(NdkHelpersTest, AChoreographer32NotSupported) {
   if (android_get_device_api_level() >= 29) {
     GTEST_SKIP() << "This test is for less than API 29.";
   }

--- a/fml/platform/android/ndk_helpers_unittests.cc
+++ b/fml/platform/android/ndk_helpers_unittests.cc
@@ -26,6 +26,7 @@ TEST_F(NdkHelpersTest, ATrace) {
   EXPECT_FALSE(NDKHelpers::ATrace_isEnabled());
 }
 
+#if FML_ARCH_CPU_64_BITS
 TEST_F(NdkHelpersTest, AChoreographer32) {
   if (android_get_device_api_level() >= 29) {
     GTEST_SKIP() << "This test is for less than API 29.";
@@ -43,6 +44,19 @@ TEST_F(NdkHelpersTest, AChoreographer32) {
   NDKHelpers::AChoreographer_postFrameCallback(
       NDKHelpers::AChoreographer_getInstance(), &OnVsync32, nullptr);
 }
+#else
+TEST_F(NdkHelpersTest, AChoreographer32_NotSupported) {
+  if (android_get_device_api_level() >= 29) {
+    GTEST_SKIP() << "This test is for less than API 29.";
+  }
+
+  // The 32 bit framecallback on 32 bit architectures does not deliver
+  // sufficient resolution. See
+  // https://github.com/flutter/engine/pull/31859#discussion_r822072987
+  EXPECT_EQ(NDKHelpers::ChoreographerSupported(),
+            ChoreographerSupportStatus::kUnsupported);
+}
+#endif  // FML_ARCH_CPU_64_BITS
 
 TEST_F(NdkHelpersTest, AChoreographer64) {
   if (android_get_device_api_level() < 29) {


### PR DESCRIPTION
This is a fix forward alternative to the revert here: https://github.com/flutter/engine/pull/50581

If the revert lands first I'll rebase into this. I'm working on verifying this locally against the devicelab tests.