### PR TITLE
[Impeller] fix cmd buffer recycling bug in test.

### DIFF
--- a/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc
@@ -128,13 +128,15 @@ TEST(CommandPoolRecyclerVKTest, CommandBuffersAreRecycled) {
   }
 
   // Wait for the pool to be reclaimed.
-  auto waiter = fml::AutoResetWaitableEvent();
-  auto rattle = DeathRattle([&waiter]() { waiter.Signal(); });
-  {
-    UniqueResourceVKT<DeathRattle> resource(context->GetResourceManager(),
-                                            std::move(rattle));
+  for (auto i = 0u; i < 2u; i++) {
+    auto waiter = fml::AutoResetWaitableEvent();
+    auto rattle = DeathRattle([&waiter]() { waiter.Signal(); });
+    {
+      UniqueResourceVKT<DeathRattle> resource(context->GetResourceManager(),
+                                              std::move(rattle));
+    }
+    waiter.Wait();
   }
-  waiter.Wait();
 
   {
     // Create a second pool and command buffer, which should reused the existing


### PR DESCRIPTION
Speculative fix for a flake seen by @matanlurey . In the past we've seen race conditions when a single DeathRattle is used, because it actually gets destructed before the cmd pool state. By adding two and waiting we guaranteee that everything has completed in the resource manager.
