### PR TITLE
[Impeller] Assign subpass depth on restore rather than creation.

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -176,7 +176,6 @@ void Canvas::Save(bool create_subpass,
   if (create_subpass) {
     entry.rendering_mode = Entity::RenderingMode::kSubpass;
     auto subpass = std::make_unique<EntityPass>();
-    subpass->SetNewClipDepth(++current_depth_);
     subpass->SetEnableOffscreenCheckerboard(
         debug_options.offscreen_texture_checkerboard);
     if (backdrop_filter) {
@@ -214,6 +213,7 @@ bool Canvas::Restore() {
 
   if (transform_stack_.back().rendering_mode ==
       Entity::RenderingMode::kSubpass) {
+    current_pass_->SetNewClipDepth(++current_depth_);
     current_pass_ = GetCurrentPass().GetSuperpass();
     FML_DCHECK(current_pass_);
   }

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -200,6 +200,7 @@ bool ClipRestoreContents::Render(const ContentContext& renderer,
       vtx_builder.CreateVertexBuffer(renderer.GetTransientsBuffer()));
 
   VS::FrameInfo info;
+  info.depth = entity.GetShaderClipDepth();
   info.mvp = pass.GetOrthographicTransform();
   VS::BindFrameInfo(pass, renderer.GetTransientsBuffer().EmplaceUniform(info));
 

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -21,7 +21,12 @@ ContentContextOptions OptionsFromPass(const RenderPass& pass) {
   ContentContextOptions opts;
   opts.sample_count = pass.GetSampleCount();
   opts.color_attachment_pixel_format = pass.GetRenderTargetPixelFormat();
-  opts.has_depth_stencil_attachments = pass.HasStencilAttachment();
+
+  bool has_depth_stencil_attachments =
+      pass.HasDepthAttachment() && pass.HasStencilAttachment();
+  FML_DCHECK(pass.HasDepthAttachment() == pass.HasStencilAttachment());
+
+  opts.has_depth_stencil_attachments = has_depth_stencil_attachments;
   return opts;
 }
 

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -470,6 +470,7 @@ std::optional<Entity> BlendFilterContents::CreateForegroundPorterDuffBlend(
 
     FS::FragInfo frag_info;
     VS::FrameInfo frame_info;
+    frame_info.depth = entity.GetShaderClipDepth();
 
     auto dst_sampler_descriptor = dst_snapshot->sampler_descriptor;
     if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -89,6 +89,7 @@ fml::StatusOr<RenderTarget> MakeDownsampleSubpass(
         pass.SetPipeline(renderer.GetTexturePipeline(pipeline_options));
 
         TextureFillVertexShader::FrameInfo frame_info;
+        frame_info.depth = 0.0;
         frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
         frame_info.texture_sampler_y_coord_scale = 1.0;
         frame_info.alpha = 1.0;

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -110,6 +110,9 @@ uint32_t Entity::GetNewClipDepth() const {
 static const Scalar kDepthEpsilon = 1.0f / std::pow(2, 18);
 
 float Entity::GetShaderClipDepth() const {
+  FML_LOG(ERROR) << "shader depth: " << new_clip_depth_ * kDepthEpsilon
+                 << "new_clip_depth_: " << new_clip_depth_
+                 << "epsilon: " << kDepthEpsilon;
   return new_clip_depth_ * kDepthEpsilon;
 }
 

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -111,8 +111,8 @@ static const Scalar kDepthEpsilon = 1.0f / std::pow(2, 18);
 
 float Entity::GetShaderClipDepth() const {
   FML_LOG(ERROR) << "shader depth: " << new_clip_depth_ * kDepthEpsilon
-                 << "new_clip_depth_: " << new_clip_depth_
-                 << "epsilon: " << kDepthEpsilon;
+                 << " new_clip_depth_: " << new_clip_depth_
+                 << " epsilon: " << kDepthEpsilon;
   return new_clip_depth_ * kDepthEpsilon;
 }
 

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -110,9 +110,6 @@ uint32_t Entity::GetNewClipDepth() const {
 static const Scalar kDepthEpsilon = 1.0f / std::pow(2, 18);
 
 float Entity::GetShaderClipDepth() const {
-  FML_LOG(ERROR) << "shader depth: " << new_clip_depth_ * kDepthEpsilon
-                 << " new_clip_depth_: " << new_clip_depth_
-                 << " epsilon: " << kDepthEpsilon;
   return new_clip_depth_ * kDepthEpsilon;
 }
 

--- a/impeller/entity/shaders/blending/framebuffer_blend.vert
+++ b/impeller/entity/shaders/blending/framebuffer_blend.vert
@@ -21,7 +21,8 @@ in vec2 src_texture_coords;
 out vec2 v_src_texture_coords;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(vertices, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
   v_src_texture_coords =
       IPRemapCoords(src_texture_coords, frame_info.src_y_coord_scale);
 }

--- a/impeller/entity/shaders/blending/porter_duff_blend.vert
+++ b/impeller/entity/shaders/blending/porter_duff_blend.vert
@@ -20,7 +20,8 @@ out vec2 v_texture_coords;
 out f16vec4 v_color;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(vertices, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(vertices, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
   v_color = f16vec4(color);
   v_texture_coords =
       IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);

--- a/impeller/entity/shaders/clip.vert
+++ b/impeller/entity/shaders/clip.vert
@@ -13,5 +13,6 @@ frame_info;
 in vec2 position;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
 }

--- a/impeller/entity/shaders/glyph_atlas.vert
+++ b/impeller/entity/shaders/glyph_atlas.vert
@@ -80,7 +80,8 @@ void main() {
                     0.0, 1.0);
   }
 
-  gl_Position = frame_info.mvp * vec4(position.xy, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(position.xy, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
   v_uv = uv_origin + unit_position * uv_size;
   v_text_color = frame_info.text_color;
 }

--- a/impeller/entity/shaders/gradient_fill.vert
+++ b/impeller/entity/shaders/gradient_fill.vert
@@ -17,6 +17,7 @@ in vec2 position;
 out vec2 v_position;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
   v_position = IPVec2TransformPosition(frame_info.matrix, position);
 }

--- a/impeller/entity/shaders/position_color.vert
+++ b/impeller/entity/shaders/position_color.vert
@@ -17,6 +17,7 @@ in vec4 color;
 out f16vec4 v_color;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
   v_color = f16vec4(color);
 }

--- a/impeller/entity/shaders/rrect_blur.vert
+++ b/impeller/entity/shaders/rrect_blur.vert
@@ -15,7 +15,8 @@ in vec2 position;
 out vec2 v_position;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
   // The fragment stage uses local coordinates to compute the blur.
   v_position = position;
 }

--- a/impeller/entity/shaders/runtime_effect.vert
+++ b/impeller/entity/shaders/runtime_effect.vert
@@ -17,6 +17,7 @@ in vec2 position;
 out vec2 _fragCoord;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
   _fragCoord = position;
 }

--- a/impeller/entity/shaders/solid_fill.vert
+++ b/impeller/entity/shaders/solid_fill.vert
@@ -17,5 +17,6 @@ IMPELLER_MAYBE_FLAT out f16vec4 v_color;
 
 void main() {
   v_color = frame_info.color;
-  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
 }

--- a/impeller/entity/shaders/texture_fill.vert
+++ b/impeller/entity/shaders/texture_fill.vert
@@ -20,7 +20,8 @@ out vec2 v_texture_coords;
 IMPELLER_MAYBE_FLAT out float16_t v_alpha;
 
 void main() {
-  gl_Position = frame_info.mvp * vec4(position, frame_info.depth, 1.0);
+  gl_Position = frame_info.mvp * vec4(position, 0.0, 1.0);
+  gl_Position.z = frame_info.depth;
   v_alpha = frame_info.alpha;
   v_texture_coords =
       IPRemapCoords(texture_coords, frame_info.texture_sampler_y_coord_scale);

--- a/impeller/renderer/compute_subgroup_unittests.cc
+++ b/impeller/renderer/compute_subgroup_unittests.cc
@@ -159,6 +159,7 @@ TEST_P(ComputeSubgroupTest, PathPlayground) {
                      .index_type = IndexType::kNone});
 
     VS::FrameInfo frame_info;
+    frame_info.depth = 0.0;
     auto world_matrix = Matrix::MakeScale(GetContentScale());
     frame_info.mvp = pass.GetOrthographicTransform() * world_matrix;
     frame_info.color = Color::Red().Premultiply();
@@ -357,6 +358,7 @@ TEST_P(ComputeSubgroupTest, LargePath) {
                      .index_type = IndexType::kNone});
 
     VS::FrameInfo frame_info;
+    frame_info.depth = 0.0;
     auto world_matrix = Matrix::MakeScale(GetContentScale());
     frame_info.mvp = pass.GetOrthographicTransform() * world_matrix;
     frame_info.color = Color::Red().Premultiply();
@@ -436,6 +438,7 @@ TEST_P(ComputeSubgroupTest, QuadAndCubicInOnePath) {
                      .index_type = IndexType::kNone});
 
     VS::FrameInfo frame_info;
+    frame_info.depth = 0.0;
     auto world_matrix = Matrix::MakeScale(GetContentScale());
     frame_info.mvp = pass.GetOrthographicTransform() * world_matrix;
     frame_info.color = Color::Red().Premultiply();

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -12,6 +12,7 @@ RenderPass::RenderPass(std::shared_ptr<const Context> context,
     : context_(std::move(context)),
       sample_count_(target.GetSampleCount()),
       pixel_format_(target.GetRenderTargetPixelFormat()),
+      has_depth_attachment_(target.GetDepthAttachment().has_value()),
       has_stencil_attachment_(target.GetStencilAttachment().has_value()),
       render_target_size_(target.GetRenderTargetSize()),
       render_target_(target),
@@ -25,6 +26,10 @@ SampleCount RenderPass::GetSampleCount() const {
 
 PixelFormat RenderPass::GetRenderTargetPixelFormat() const {
   return pixel_format_;
+}
+
+bool RenderPass::HasDepthAttachment() const {
+  return has_depth_attachment_;
 }
 
 bool RenderPass::HasStencilAttachment() const {

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -157,6 +157,10 @@ class RenderPass : public ResourceBinder {
   PixelFormat GetRenderTargetPixelFormat() const;
 
   //----------------------------------------------------------------------------
+  /// @brief      Whether the render target has a depth attachment.
+  bool HasDepthAttachment() const;
+
+  //----------------------------------------------------------------------------
   /// @brief      Whether the render target has an stencil attachment.
   bool HasStencilAttachment() const;
 
@@ -169,6 +173,7 @@ class RenderPass : public ResourceBinder {
   // a const reference.
   const SampleCount sample_count_;
   const PixelFormat pixel_format_;
+  const bool has_depth_attachment_;
   const bool has_stencil_attachment_;
   const ISize render_target_size_;
   const RenderTarget render_target_;

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -773,9 +773,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -792,9 +792,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -803,9 +803,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -813,7 +813,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 28,
+          "uniform_registers_used": 24,
           "work_registers_used": 32
         }
       }
@@ -2594,8 +2594,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -2613,8 +2613,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -2624,8 +2624,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -2634,7 +2634,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 28,
+          "uniform_registers_used": 18,
           "work_registers_used": 32
         }
       }
@@ -2652,7 +2652,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               3.0,
               0.0
             ],
@@ -2665,22 +2665,21 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               3.0,
               0.0
             ],
             "total_bound_pipelines": [
-              "arithmetic",
               "load_store"
             ],
             "total_cycles": [
-              3.0,
+              2.6666667461395264,
               3.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 7,
+          "uniform_registers_used": 6,
           "work_registers_used": 2
         }
       }
@@ -3612,8 +3611,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.390625,
-              0.390625,
+              0.359375,
+              0.359375,
               0.09375,
               0.0,
               4.0,
@@ -3631,8 +3630,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.328125,
-              0.328125,
+              0.296875,
+              0.296875,
               0.03125,
               0.0,
               4.0,
@@ -3642,8 +3641,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.546875,
-              0.546875,
+              0.515625,
+              0.515625,
               0.109375,
               0.0,
               4.0,
@@ -3652,7 +3651,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 46,
+          "uniform_registers_used": 36,
           "work_registers_used": 32
         },
         "Varying": {
@@ -3703,7 +3702,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 22,
+          "uniform_registers_used": 18,
           "work_registers_used": 16
         }
       }
@@ -3721,7 +3720,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              6.929999828338623,
+              6.599999904632568,
               8.0,
               0.0
             ],
@@ -3734,7 +3733,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              5.940000057220459,
+              5.610000133514404,
               8.0,
               0.0
             ],
@@ -3742,13 +3741,13 @@
               "arithmetic"
             ],
             "total_cycles": [
-              9.0,
+              8.666666984558105,
               8.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
+          "uniform_registers_used": 11,
           "work_registers_used": 3
         }
       }
@@ -3888,8 +3887,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -3907,8 +3906,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -3918,8 +3917,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -3928,7 +3927,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 38,
+          "uniform_registers_used": 28,
           "work_registers_used": 32
         },
         "Varying": {
@@ -3979,7 +3978,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 22,
+          "uniform_registers_used": 18,
           "work_registers_used": 11
         }
       }
@@ -3997,7 +3996,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              3.630000114440918,
+              3.299999952316284,
               4.0,
               0.0
             ],
@@ -4010,7 +4009,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              3.630000114440918,
+              3.299999952316284,
               4.0,
               0.0
             ],
@@ -4018,13 +4017,13 @@
               "load_store"
             ],
             "total_cycles": [
-              3.6666667461395264,
+              3.3333332538604736,
               4.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 10,
+          "uniform_registers_used": 9,
           "work_registers_used": 3
         }
       }
@@ -5063,8 +5062,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5082,8 +5081,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5093,8 +5092,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5103,7 +5102,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 30,
+          "uniform_registers_used": 20,
           "work_registers_used": 32
         },
         "Varying": {
@@ -5154,7 +5153,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 14,
+          "uniform_registers_used": 10,
           "work_registers_used": 12
         }
       }
@@ -5172,7 +5171,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              3.299999952316284,
+              2.9700000286102295,
               7.0,
               0.0
             ],
@@ -5185,7 +5184,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              3.299999952316284,
+              2.9700000286102295,
               7.0,
               0.0
             ],
@@ -5193,14 +5192,14 @@
               "load_store"
             ],
             "total_cycles": [
-              3.3333332538604736,
+              3.0,
               7.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 7,
-          "work_registers_used": 2
+          "uniform_registers_used": 6,
+          "work_registers_used": 3
         }
       }
     }
@@ -5220,8 +5219,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5239,8 +5238,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5250,8 +5249,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5260,7 +5259,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 28,
+          "uniform_registers_used": 18,
           "work_registers_used": 32
         },
         "Varying": {
@@ -5311,7 +5310,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
+          "uniform_registers_used": 10,
           "work_registers_used": 9
         }
       }
@@ -5329,7 +5328,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               5.0,
               0.0
             ],
@@ -5342,7 +5341,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               5.0,
               0.0
             ],
@@ -5350,13 +5349,13 @@
               "load_store"
             ],
             "total_cycles": [
-              3.0,
+              2.6666667461395264,
               5.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 7,
+          "uniform_registers_used": 6,
           "work_registers_used": 2
         }
       }
@@ -5612,8 +5611,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5631,8 +5630,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5642,8 +5641,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5652,7 +5651,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 28,
+          "uniform_registers_used": 18,
           "work_registers_used": 32
         },
         "Varying": {
@@ -5703,7 +5702,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
+          "uniform_registers_used": 10,
           "work_registers_used": 7
         }
       }
@@ -5721,7 +5720,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               4.0,
               0.0
             ],
@@ -5734,7 +5733,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               4.0,
               0.0
             ],
@@ -5742,13 +5741,13 @@
               "load_store"
             ],
             "total_cycles": [
-              3.0,
+              2.6666667461395264,
               4.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 7,
+          "uniform_registers_used": 6,
           "work_registers_used": 2
         }
       }
@@ -5769,8 +5768,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5788,8 +5787,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5799,8 +5798,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -5809,7 +5808,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 28,
+          "uniform_registers_used": 18,
           "work_registers_used": 32
         },
         "Varying": {
@@ -5860,7 +5859,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 12,
+          "uniform_registers_used": 10,
           "work_registers_used": 7
         }
       }
@@ -5878,7 +5877,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               4.0,
               0.0
             ],
@@ -5891,7 +5890,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               4.0,
               0.0
             ],
@@ -5899,13 +5898,13 @@
               "load_store"
             ],
             "total_cycles": [
-              3.0,
+              2.6666667461395264,
               4.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 7,
+          "uniform_registers_used": 6,
           "work_registers_used": 2
         }
       }
@@ -6043,8 +6042,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -6062,8 +6061,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -6073,8 +6072,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -6083,7 +6082,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 32,
+          "uniform_registers_used": 22,
           "work_registers_used": 32
         },
         "Varying": {
@@ -6134,7 +6133,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 16,
+          "uniform_registers_used": 14,
           "work_registers_used": 7
         }
       }
@@ -6152,7 +6151,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               4.0,
               0.0
             ],
@@ -6165,7 +6164,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              2.9700000286102295,
+              2.640000104904175,
               4.0,
               0.0
             ],
@@ -6173,13 +6172,13 @@
               "load_store"
             ],
             "total_cycles": [
-              3.0,
+              2.6666667461395264,
               4.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 8,
+          "uniform_registers_used": 7,
           "work_registers_used": 2
         }
       }
@@ -6714,8 +6713,8 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -6733,8 +6732,8 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -6744,8 +6743,8 @@
               "load_store"
             ],
             "total_cycles": [
-              0.140625,
-              0.140625,
+              0.109375,
+              0.109375,
               0.0,
               0.0,
               2.0,
@@ -6754,7 +6753,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 30,
+          "uniform_registers_used": 20,
           "work_registers_used": 32
         },
         "Varying": {
@@ -6805,7 +6804,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 14,
+          "uniform_registers_used": 12,
           "work_registers_used": 8
         }
       }
@@ -6823,7 +6822,7 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              3.299999952316284,
+              2.9700000286102295,
               6.0,
               0.0
             ],
@@ -6836,7 +6835,7 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              3.299999952316284,
+              2.9700000286102295,
               6.0,
               0.0
             ],
@@ -6844,14 +6843,14 @@
               "load_store"
             ],
             "total_cycles": [
-              3.3333332538604736,
+              3.0,
               6.0,
               0.0
             ]
           },
           "thread_occupancy": 100,
-          "uniform_registers_used": 7,
-          "work_registers_used": 2
+          "uniform_registers_used": 6,
+          "work_registers_used": 3
         }
       }
     }
@@ -7798,9 +7797,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.375,
-              0.375,
-              0.109375,
+              0.34375,
+              0.34375,
+              0.125,
               0.0,
               4.0,
               0.0
@@ -7817,9 +7816,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.28125,
-              0.28125,
-              0.03125,
+              0.25,
+              0.25,
+              0.046875,
               0.0,
               4.0,
               0.0
@@ -7828,9 +7827,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.53125,
-              0.53125,
-              0.125,
+              0.5,
+              0.5,
+              0.140625,
               0.0,
               4.0,
               0.0
@@ -7838,7 +7837,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 50,
+          "uniform_registers_used": 44,
           "work_registers_used": 32
         },
         "Varying": {
@@ -7889,7 +7888,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 38,
+          "uniform_registers_used": 36,
           "work_registers_used": 13
         }
       }
@@ -7980,9 +7979,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -7999,9 +7998,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -8010,9 +8009,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -8020,7 +8019,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 44,
+          "uniform_registers_used": 40,
           "work_registers_used": 32
         },
         "Varying": {
@@ -8071,7 +8070,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 36,
+          "uniform_registers_used": 34,
           "work_registers_used": 11
         }
       }
@@ -8881,9 +8880,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -8900,9 +8899,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -8911,9 +8910,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -8921,7 +8920,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 30,
+          "uniform_registers_used": 24,
           "work_registers_used": 32
         },
         "Varying": {
@@ -8972,7 +8971,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 22,
+          "uniform_registers_used": 20,
           "work_registers_used": 10
         }
       }
@@ -8993,9 +8992,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9012,9 +9011,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9023,9 +9022,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9033,7 +9032,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 28,
+          "uniform_registers_used": 24,
           "work_registers_used": 32
         },
         "Varying": {
@@ -9084,7 +9083,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 18,
           "work_registers_used": 9
         }
       }
@@ -9321,9 +9320,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9340,9 +9339,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9351,9 +9350,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9361,7 +9360,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 28,
+          "uniform_registers_used": 24,
           "work_registers_used": 32
         },
         "Varying": {
@@ -9412,7 +9411,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 18,
           "work_registers_used": 7
         }
       }
@@ -9433,9 +9432,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9452,9 +9451,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9463,9 +9462,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9473,7 +9472,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 28,
+          "uniform_registers_used": 24,
           "work_registers_used": 32
         },
         "Varying": {
@@ -9524,7 +9523,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 20,
+          "uniform_registers_used": 18,
           "work_registers_used": 7
         }
       }
@@ -9615,9 +9614,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9634,9 +9633,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9645,9 +9644,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -9655,7 +9654,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 32,
+          "uniform_registers_used": 28,
           "work_registers_used": 32
         },
         "Varying": {
@@ -9706,7 +9705,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 24,
+          "uniform_registers_used": 22,
           "work_registers_used": 7
         }
       }
@@ -10126,9 +10125,9 @@
               "load_store"
             ],
             "longest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -10145,9 +10144,9 @@
               "load_store"
             ],
             "shortest_path_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -10156,9 +10155,9 @@
               "load_store"
             ],
             "total_cycles": [
-              0.125,
-              0.125,
-              0.0,
+              0.09375,
+              0.09375,
+              0.015625,
               0.0,
               2.0,
               0.0
@@ -10166,7 +10165,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 30,
+          "uniform_registers_used": 24,
           "work_registers_used": 32
         },
         "Varying": {
@@ -10217,7 +10216,7 @@
           },
           "stack_spill_bytes": 0,
           "thread_occupancy": 100,
-          "uniform_registers_used": 22,
+          "uniform_registers_used": 20,
           "work_registers_used": 10
         }
       }


### PR DESCRIPTION
The subpass depth is used for drawing the texture to the parent pass. So it needs a depth > all of the clips contained within the subpass.

Also correct the way we're assigning the depth value in shaders.