### PR TITLE
Add scroll lock when using trackpad on web

### DIFF
--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -642,7 +642,7 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
     final double diff = (event.timeStamp ?? double.infinity) - (_lastWheelEvent?.timeStamp ?? 0.0);
 
     print('Diff: $diff; lastScrollEvent: ${trackpadScrollStartWheelEvent != null}');
-    if (diff < 100 * 1000 && trackpadScrollStartWheelEvent != null) {
+    if (diff < 100 && trackpadScrollStartWheelEvent != null) {
       return trackpadScrollStartWheelEvent.deltaX > trackpadScrollStartWheelEvent.deltaY;
     }
     _trackpadScrollStartWheelEvent = event;

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -631,21 +631,22 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
   }
 
   bool _isLockedHorizontally(DomWheelEvent event) {
-    double diff = event.timeStamp - _lastWheelEvent.timeStamp;
+    DomWheelEvent? trackpadScrollStartWheelEvent = _trackpadScrollStartWheelEvent;
+    double diff = (event.timeStamp ?? double.infinity) - (_lastWheelEvent?.timeStamp ?? 0.0);
 
-    if (diff < 10 * 1000) {
-      return _trackpadScrollStartWheelEvent.deltaX > _trackpadScrollStartWheelEvent.deltaY;
+    if (diff < 10 * 1000 && trackpadScrollStartWheelEvent != null) {
+      return trackpadScrollStartWheelEvent.deltaX > trackpadScrollStartWheelEvent.deltaY;
     }
     _trackpadScrollStartWheelEvent = event;
     return event.deltaX > event.deltaY;
   }
 
   bool _isLockedVertically(DomWheelEvent event) {
-    DomWheelEvent trackpadScrollStartWheelEvent = _trackpadScrollStartWheelEvent;
-    double diff = event.timeStamp - _lastWheelEvent.timeStamp;
+    DomWheelEvent? trackpadScrollStartWheelEvent = _trackpadScrollStartWheelEvent;
+    double diff = (event.timeStamp ?? double.infinity) - (_lastWheelEvent?.timeStamp ?? 0.0);
 
     if (diff < 10 * 1000 && trackpadScrollStartWheelEvent != null) {
-      return _trackpadScrollStartWheelEvent.deltaX < _trackpadScrollStartWheelEvent.deltaY;
+      return trackpadScrollStartWheelEvent.deltaX < trackpadScrollStartWheelEvent.deltaY;
     }
     _trackpadScrollStartWheelEvent = event;
     return event.deltaX < event.deltaY;

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -573,6 +573,7 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
     // For all events without this acceleration curve applied, the wheelDelta
     // values are by convention three times greater than the delta values and with
     // the opposite sign.
+    print('wheelDelta: $wheelDelta; delta: $delta');
     if (wheelDelta == null) {
       return false;
     }
@@ -581,6 +582,7 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
   }
 
   bool _isTrackpadEvent(DomWheelEvent event) {
+    if (browserEngine != BrowserEngine.firefox) return true;
     // This function relies on deprecated and non-standard implementation
     // details. Useful reference material can be found below.
     //
@@ -595,10 +597,15 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
       // wheel events.
       return false;
     }
-    if (_isAcceleratedMouseWheelDelta(event.deltaX, event.wheelDeltaX) ||
-        _isAcceleratedMouseWheelDelta(event.deltaY, event.wheelDeltaY)) {
+    final bool acceleratedX = _isAcceleratedMouseWheelDelta(event.deltaX, event.wheelDeltaX);
+    print('acceleratedX: $acceleratedX');
+    final bool acceleratedY = _isAcceleratedMouseWheelDelta(event.deltaY, event.wheelDeltaY);
+    print('acceleratedY: $acceleratedY');
+    // todo: This incorrectly detects trackpad events as mouse events.
+    if (acceleratedX || acceleratedY) {
       return false;
     }
+    print('deltaX: ${event.deltaX}; deltaY: ${event.deltaY}; wheelDeltaX: ${event.wheelDeltaX}; wheelDeltaY: ${event.wheelDeltaY};');
     if (((event.deltaX % 120 == 0) && (event.deltaY % 120 == 0)) ||
         (((event.wheelDeltaX ?? 1) % 120 == 0) && ((event.wheelDeltaY ?? 1) % 120) == 0)) {
       // While not in any formal web standard, `blink` and `webkit` browsers use
@@ -631,10 +638,11 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
   }
 
   bool _isLockedHorizontally(DomWheelEvent event) {
-    DomWheelEvent? trackpadScrollStartWheelEvent = _trackpadScrollStartWheelEvent;
-    double diff = (event.timeStamp ?? double.infinity) - (_lastWheelEvent?.timeStamp ?? 0.0);
+    final DomWheelEvent? trackpadScrollStartWheelEvent = _trackpadScrollStartWheelEvent;
+    final double diff = (event.timeStamp ?? double.infinity) - (_lastWheelEvent?.timeStamp ?? 0.0);
 
-    if (diff < 10 * 1000 && trackpadScrollStartWheelEvent != null) {
+    print('Diff: $diff; lastScrollEvent: ${trackpadScrollStartWheelEvent != null}');
+    if (diff < 100 * 1000 && trackpadScrollStartWheelEvent != null) {
       return trackpadScrollStartWheelEvent.deltaX > trackpadScrollStartWheelEvent.deltaY;
     }
     _trackpadScrollStartWheelEvent = event;
@@ -642,10 +650,11 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
   }
 
   bool _isLockedVertically(DomWheelEvent event) {
-    DomWheelEvent? trackpadScrollStartWheelEvent = _trackpadScrollStartWheelEvent;
-    double diff = (event.timeStamp ?? double.infinity) - (_lastWheelEvent?.timeStamp ?? 0.0);
+    final DomWheelEvent? trackpadScrollStartWheelEvent = _trackpadScrollStartWheelEvent;
+    final double diff = (event.timeStamp ?? double.infinity) - (_lastWheelEvent?.timeStamp ?? 0.0);
 
-    if (diff < 10 * 1000 && trackpadScrollStartWheelEvent != null) {
+    print('Diff: $diff; lastScrollEvent: ${trackpadScrollStartWheelEvent != null}');
+    if (diff < 100 && trackpadScrollStartWheelEvent != null) {
       return trackpadScrollStartWheelEvent.deltaX < trackpadScrollStartWheelEvent.deltaY;
     }
     _trackpadScrollStartWheelEvent = event;
@@ -669,9 +678,10 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
     double deltaX = event.deltaX;
     double deltaY = event.deltaY;
 
+    print('trackpad: ${_isTrackpadEvent(event)}');
     if (_isTrackpadEvent(event) && _isLockedVertically(event)) {
       deltaX = 0;
-    } else if (_isTrackpadEvent(event) && _isLockedVertically(event)) {
+    } else if (_isTrackpadEvent(event) && _isLockedHorizontally(event)) {
       deltaY = 0;
     }
 


### PR DESCRIPTION
_Related PR: https://github.com/flutter/flutter/pull/143658 (Depending on where it should be fixed this or the other PR is obsolete)_

-- 

This is an attempt to fix weird scrolling behavior with trackpads on Flutter web.
It's done by looking at the last scroll events and locking the axis to the major axis of the first scroll axis within a series.
The lock resets automatically if no scroll event is received within x amount of time (e.g. 10ms).

One thing I'm unsure about is if this breaks any use case where 2D scrolling is expected...
An alternative that I've considered is to add it to this class: https://github.com/flutter/engine/blob/a9a3fa616a72628e64194b66db81fe6aab490a1b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
There the axis would be exposes, however it seems like this code is not used?! (for the example in the issue no `flt-semantics-scroll-overflow` DOM element was created)

Attempts to fix https://github.com/flutter/flutter/issues/143276

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
