### PR TITLE
Shift some Linux builders from Goma to RBE

### DIFF
--- a/ci/builders/linux_android_aot_engine.json
+++ b/ci/builders/linux_android_aot_engine.json
@@ -19,12 +19,17 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--runtime-mode",
                 "profile",
                 "--android",
                 "--android-cpu",
-                "arm"
+                "arm",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_profile",
             "ninja": {
@@ -56,12 +61,17 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--runtime-mode",
                 "release",
                 "--android",
                 "--android-cpu",
-                "arm"
+                "arm",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_release",
             "ninja": {
@@ -94,12 +104,17 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--runtime-mode",
                 "release",
                 "--android",
                 "--android-cpu",
-                "arm64"
+                "arm64",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_release_arm64",
             "ninja": {
@@ -143,12 +158,17 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--android",
                 "--runtime-mode",
                 "profile",
                 "--android-cpu",
-                "arm64"
+                "arm64",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_profile_arm64",
             "ninja": {
@@ -174,7 +194,7 @@
                         "--variant",
                         "android_profile_arm64"
                     ],
-		    "test_if": "main"
+                    "test_if": "main"
                 }
             ]
         },
@@ -198,12 +218,17 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--runtime-mode",
                 "profile",
                 "--android",
                 "--android-cpu",
-                "x64"
+                "x64",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_profile_x64",
             "ninja": {
@@ -236,12 +261,17 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--runtime-mode",
                 "release",
                 "--android",
                 "--android-cpu",
-                "x64"
+                "x64",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_release_x64",
             "ninja": {

--- a/ci/builders/linux_android_debug_engine.json
+++ b/ci/builders/linux_android_debug_engine.json
@@ -17,10 +17,15 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--android",
                 "--android-cpu=x86",
-                "--runtime-mode=jit_release"
+                "--runtime-mode=jit_release",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_jit_release_x86",
             "ninja": {
@@ -69,10 +74,15 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--android",
                 "--android-cpu=arm",
-                "--no-lto"
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_debug",
             "ninja": {
@@ -120,33 +130,17 @@
                 "device_type=none",
                 "os=Linux"
             ],
-            "gn": [
-                "--android",
-                "--android-cpu=arm64",
-                "--no-lto"
-            ],
-            "name": "android_debug_arm64",
-            "ninja": {
-                "config": "android_debug_arm64",
-                "targets": [
-                    "flutter",
-                    "flutter/shell/platform/android:abi_jars"
-                ]
-            }
-        },
-        {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Linux"
-            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--android",
                 "--android-cpu=arm64",
                 "--no-lto",
-                "--enable-vulkan-validation-layers"
+                "--rbe",
+                "--no-goma"
             ],
-            "name": "android_debug_arm64_validation_layers",
+            "name": "android_debug_arm64",
             "ninja": {
                 "config": "android_debug_arm64",
                 "targets": [
@@ -173,10 +167,15 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--android",
                 "--android-cpu=x86",
-                "--no-lto"
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_debug_x86",
             "ninja": {
@@ -205,10 +204,15 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--android",
                 "--android-cpu=x64",
-                "--no-lto"
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_debug_x64",
             "ninja": {

--- a/ci/builders/linux_arm_host_engine.json
+++ b/ci/builders/linux_arm_host_engine.json
@@ -17,7 +17,8 @@
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
@@ -25,7 +26,9 @@
                 "--no-lto",
                 "--target-os=linux",
                 "--linux-cpu=arm64",
-                "--prebuilt-dart-sdk"
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "linux_profile_arm64",
             "ninja": {
@@ -55,14 +58,17 @@
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
                 "debug",
                 "--target-os=linux",
                 "--linux-cpu=arm64",
-                "--prebuilt-dart-sdk"
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "linux_debug_arm64",
             "ninja": {
@@ -92,14 +98,17 @@
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
                 "release",
                 "--target-os=linux",
                 "--linux-cpu=arm64",
-                "--prebuilt-dart-sdk"
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "linux_release_arm64",
             "ninja": {

--- a/ci/builders/linux_host_desktop_engine.json
+++ b/ci/builders/linux_host_desktop_engine.json
@@ -17,13 +17,16 @@
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
                 "debug",
                 "--enable-fontconfig",
-                "--prebuilt-dart-sdk"
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "host_debug",
             "ninja": {
@@ -50,14 +53,17 @@
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
                 "profile",
                 "--no-lto",
                 "--enable-fontconfig",
-                "--prebuilt-dart-sdk"
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "host_profile",
             "ninja": {
@@ -84,13 +90,16 @@
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
                 "release",
                 "--enable-fontconfig",
-                "--prebuilt-dart-sdk"
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "host_release",
             "ninja": {

--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -21,13 +21,16 @@
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
                 "debug",
                 "--prebuilt-dart-sdk",
-                "--build-embedder-examples"
+                "--build-embedder-examples",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "host_debug",
             "ninja": {
@@ -71,14 +74,17 @@
                 "os=Linux"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
                 "profile",
                 "--no-lto",
                 "--prebuilt-dart-sdk",
-                "--build-embedder-examples"
+                "--build-embedder-examples",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "host_profile",
             "ninja": {
@@ -128,13 +134,16 @@
                 }
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
                 "release",
                 "--prebuilt-dart-sdk",
-                "--build-embedder-examples"
+                "--build-embedder-examples",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "host_release",
             "ninja": {

--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -126,6 +126,7 @@
             ]
         },
         {
+            "cas_archive": false,
             "drone_dimensions": [
                 "device_type=none",
                 "os=Linux"
@@ -148,6 +149,32 @@
                 "config": "android_embedder_debug_unopt",
                 "targets": [
                     "flutter/shell/platform/embedder:flutter_engine"
+                ]
+            }
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--android",
+                "--android-cpu=arm64",
+                "--no-lto",
+                "--enable-vulkan-validation-layers",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "android_debug_arm64_validation_layers",
+            "ninja": {
+                "config": "android_debug_arm64",
+                "targets": [
+                    "flutter",
+                    "flutter/shell/platform/android:abi_jars"
                 ]
             }
         },


### PR DESCRIPTION
This PR shifts all Linux builders except for linux_fuchsia and linux_clang_tidy from GOMA to RBE. It also shifts one build from another builder to linux_unopt.