### PR TITLE
[web] Increase tolerance for golden diffs on Safari

### DIFF
--- a/web_sdk/web_test_utils/lib/image_compare.dart
+++ b/web_sdk/web_test_utils/lib/image_compare.dart
@@ -40,19 +40,26 @@ Future<String> compareImage(
     // comparison.
     final int screenshotSize = screenshot.width * screenshot.height;
 
-    late int pixelColorDelta;
+    final int pixelColorDeltaPerChannel;
+    final double differentPixelsRate;
+
     if (isCanvaskitTest) {
-      pixelColorDelta = 21;
+      differentPixelsRate = 0.1;
+      pixelColorDeltaPerChannel = 7;
     } else if (skiaClient.dimensions != null && skiaClient.dimensions!['Browser'] == 'ios-safari') {
-      pixelColorDelta = 15;
+      differentPixelsRate = 0.15;
+      pixelColorDeltaPerChannel = 16;
     } else {
-      pixelColorDelta = 3;
+      differentPixelsRate = 0.1;
+      pixelColorDeltaPerChannel = 1;
     }
+
     skiaClient.addImg(
       filename,
       screenshotFile,
       screenshotSize: screenshotSize,
-      pixelColorDelta: pixelColorDelta,
+      differentPixelsRate: differentPixelsRate,
+      pixelColorDelta: pixelColorDeltaPerChannel * 3,
     );
     return 'OK';
   }


### PR DESCRIPTION
1. Re-institute the 10% pixel count tolerance number that was accidentally lost in [this commit](https://github.com/flutter/engine/commit/a0f389e6a0eb5d0316024f577ab61dfd2ac4f5d2#diff-356abf8d8d08b3ba08c35d6399e2a21d3107aa16c55f4303bb3b8f96195bbcc0) (this applies to all web environments).
2. Allow each individual pixel on Safari to differ by a value of 16 per RGB channel.