### PR TITLE
Run engine_tool tests

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -923,6 +923,7 @@ def build_dart_host_test_list(build_dir):
               os.path.join(build_dir, 'dart-sdk', 'lib', 'libraries.json'),
           ],
       ),
+      (os.path.join('flutter', 'tools', 'engine_tool'), []),
       (os.path.join('flutter', 'tools', 'githooks'), []),
       (os.path.join('flutter', 'tools', 'header_guard_check'), []),
       (os.path.join('flutter', 'tools', 'pkg', 'engine_build_configs'), []),


### PR DESCRIPTION
Follow-up on https://github.com/flutter/engine/pull/50642, which added tests, but didn't run them. This PR runs them.