### PR TITLE
Fix github md "Note" and "Tip" blocks in Android shell README

### DIFF
--- a/shell/platform/android/README.md
+++ b/shell/platform/android/README.md
@@ -84,7 +84,7 @@ flutter run \
   --local-engine=$ENGINE/out/android_debug_unopt_arm64
 ```
 
-> ![NOTE]
+> [!NOTE]
 > External texture rendering on Android is based on the device API level. For
 > example to test the OpenGLES branch (which uses `SurfaceTexture`), you'll
 > typically need an older device or emulator with an API version 29 or lower.
@@ -105,7 +105,7 @@ See [our wiki](https://github.com/flutter/flutter/wiki/Testing-the-engine#java--
 
 How to edit and contribute to the Android embedder.
 
-> ![TIP]
+> [!TIP]
 > This guide assumes you already have a working Engine development environment:
 >
 > - [Setting up the Engine development environment](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment)
@@ -149,7 +149,7 @@ completion:
 
 ![Example](https://github.com/flutter/flutter/assets/168174/8a75dd27-66e1-4c4f-88af-667a73b909b6)
 
-> ![NOTE] > `--compile-commands-dir` must point to an Android build output:
+> [!NOTE] > `--compile-commands-dir` must point to an Android build output:
 >
 > ```jsonc
 > {

--- a/shell/platform/android/README.md
+++ b/shell/platform/android/README.md
@@ -149,7 +149,8 @@ completion:
 
 ![Example](https://github.com/flutter/flutter/assets/168174/8a75dd27-66e1-4c4f-88af-667a73b909b6)
 
-> [!NOTE] > `--compile-commands-dir` must point to an Android build output:
+> [!NOTE]
+> `--compile-commands-dir` must point to an Android build output:
 >
 > ```jsonc
 > {


### PR DESCRIPTION
Fixes a couple of misformatted "NOTE" and "TIP" blocks.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
