### PR TITLE
Make all Android `scenario_app` activities full-screen, even on older Android versions.

### DIFF
--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestableFlutterActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestableFlutterActivity.java
@@ -6,10 +6,8 @@ package dev.flutter.scenarios;
 
 import android.os.Bundle;
 import android.view.WindowManager;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestableFlutterActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestableFlutterActivity.java
@@ -4,7 +4,12 @@
 
 package dev.flutter.scenarios;
 
+import android.os.Bundle;
+import android.view.WindowManager;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -20,6 +25,20 @@ public abstract class TestableFlutterActivity extends FlutterActivity {
     flutterEngine
         .getDartExecutor()
         .setMessageHandler("take_screenshot", (byteBuffer, binaryReply) -> notifyFlutterRendered());
+  }
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // On newer versions of Android, this is the default. Because these tests are being used to take
+    // screenshots on Skia Gold, we don't want any of the System UI to show up, even for older API
+    // versions (i.e. 28).
+    //
+    // See also:
+    // https://github.com/flutter/engine/blob/a9081cce1f0dd730577a36ee1ca6d7af5cdc5a9b/shell/platform/android/io/flutter/embedding/android/FlutterView.java#L696
+    // https://github.com/flutter/flutter/issues/143471
+    getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
   }
 
   protected void notifyFlutterRendered() {


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/143471.