### PR TITLE
Add useful default options to `scenario_app/bin/android_integration_tests.dart`

### DIFF
--- a/testing/scenario_app/bin/README.md
+++ b/testing/scenario_app/bin/README.md
@@ -8,9 +8,7 @@ captured and compared using Skia Gold (if available, for example on CI).
 ## Usage
 
 ```sh
-dart bin/android_integration_tests.dart \
-  --adb ../third_party/android_tools/sdk/platform-tools/adb \
-  --out-dir ../out/android_debug_unopt_arm64
+dart bin/android_integration_tests.dart
 ```
 
 ## Debugging
@@ -28,6 +26,12 @@ dart bin/android_integration_tests.dart \
 ```
 
 ## Additional arguments
+
+- `--adb`: The path to the `adb` tool. Defaults to
+  `third_party/android_tools/sdk/platform-tools/adb`.
+
+- `--out-dir`: The directory containing the build artifacts. Defaults to the
+  last updated build directory in `out/` that starts with `android_`.
 
 - `--use-skia-gold`: Use Skia Gold to compare screenshots. Defaults to true
   when running on CI, and false otherwise (i.e. when running locally). If

--- a/testing/scenario_app/bin/README.md
+++ b/testing/scenario_app/bin/README.md
@@ -19,10 +19,7 @@ by class name, which can be useful to verify the setup.
 For example, to run the `EngineLaunchE2ETest` test:
 
 ```sh
-dart bin/android_integration_tests.dart \
-  --adb ../third_party/android_tools/sdk/platform-tools/adb \
-  --out-dir ../out/android_debug_unopt_arm64 \
-  --smoke-test dev.flutter.scenarios.EngineLaunchE2ETest
+dart bin/android_integration_tests.dart --smoke-test dev.flutter.scenarios.EngineLaunchE2ETest
 ```
 
 ## Additional arguments

--- a/testing/scenario_app/bin/README.md
+++ b/testing/scenario_app/bin/README.md
@@ -35,7 +35,7 @@ dart bin/android_integration_tests.dart \
 
 - `--use-skia-gold`: Use Skia Gold to compare screenshots. Defaults to true
   when running on CI, and false otherwise (i.e. when running locally). If
-  set to true, [isSkiaGoldClientAvailable] must be true.
+  set to true, `isSkiaGoldClientAvailable` must be true.
 
 - `--enable-impeller`: Enable Impeller for the Android app. Defaults to
   false, which means that the app will use Skia as the graphics backend.

--- a/testing/scenario_app/bin/android_integration_tests.dart
+++ b/testing/scenario_app/bin/android_integration_tests.dart
@@ -36,12 +36,12 @@ void main(List<String> args) async {
         'sdk',
         'platform-tools',
         'adb',
-      ) : null,   
+      ) : null,
     )
     ..addOption(
       'out-dir',
       help: 'Out directory',
-      defaultsTo: 
+      defaultsTo:
         engine?.
         outputs().
         where((Output o) => basename(o.path.path).startsWith('android_')).

--- a/testing/scenario_app/bin/android_integration_tests.dart
+++ b/testing/scenario_app/bin/android_integration_tests.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:args/args.dart';
+import 'package:engine_repo_tools/engine_repo_tools.dart';
 import 'package:path/path.dart';
 import 'package:process/process.dart';
 import 'package:skia_gold_client/skia_gold_client.dart';
@@ -18,16 +19,34 @@ import 'utils/screenshot_transformer.dart';
 
 // If you update the arguments, update the documentation in the README.md file.
 void main(List<String> args) async {
+  final Engine? engine = Engine.tryFindWithin();
   final ArgParser parser = ArgParser()
+    ..addFlag(
+      'help',
+      help: 'Prints usage information',
+      negatable: false,
+    )
     ..addOption(
       'adb',
       help: 'Absolute path to the adb tool',
-      mandatory: true,
+      defaultsTo: engine != null ? join(
+        engine.srcDir.path,
+        'third_party',
+        'android_tools',
+        'sdk',
+        'platform-tools',
+        'adb',
+      ) : null,   
     )
     ..addOption(
       'out-dir',
       help: 'Out directory',
-      mandatory: true,
+      defaultsTo: 
+        engine?.
+        outputs().
+        where((Output o) => basename(o.path.path).startsWith('android_')).
+        firstOrNull?.
+        path.path,
     )
     ..addOption(
       'smoke-test',
@@ -52,6 +71,18 @@ void main(List<String> args) async {
   runZonedGuarded(
     () async {
       final ArgResults results = parser.parse(args);
+      if (results['help'] as bool) {
+        stdout.writeln(parser.usage);
+        return;
+      }
+
+      if (results['out-dir'] == null) {
+        panic(<String>['--out-dir is required']);
+      }
+      if (results['adb'] == null) {
+        panic(<String>['--adb is required']);
+      }
+
       final Directory outDir = Directory(results['out-dir'] as String);
       final File adb = File(results['adb'] as String);
       final bool useSkiaGold = results['use-skia-gold'] as bool;

--- a/testing/scenario_app/pubspec.yaml
+++ b/testing/scenario_app/pubspec.yaml
@@ -16,6 +16,7 @@ environment:
 # relative to this directory into //third_party/dart, or //third_party/pkg
 dependencies:
   args: any
+  engine_repo_tools: any
   path: any
   process: any
   sky_engine: any

--- a/testing/scenario_app/run_android_tests.sh
+++ b/testing/scenario_app/run_android_tests.sh
@@ -67,6 +67,5 @@ cd $SCRIPT_DIR
 
 "$SRC_DIR"/third_party/dart/tools/sdks/dart-sdk/bin/dart run \
   "$SCRIPT_DIR"/bin/android_integration_tests.dart \
-  --adb="$SRC_DIR"/third_party/android_tools/sdk/platform-tools/adb \
   --out-dir="$OUT_DIR" \
   "$@"


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/143474.

This makes `--adb` and `--out_dir` have useful defaults for most environments.

To be explicit, the `--out-dir` is still specified in the test runner (I could imagine refactoring this further to take a `--variant` instead, but not a priority).

/cc @gmackall 