### PR TITLE
Disable Android API v28 tests on CI.

### DIFF
--- a/ci/builders/linux_android_emulator.json
+++ b/ci/builders/linux_android_emulator.json
@@ -181,52 +181,6 @@
                             "--type",
                             "android"
                     ]
-                },
-
-                {
-                    "language": "bash",
-                    "name": "Android Scenario App Integration Tests (Skia, API v28)",
-                    "test_dependencies": [
-                        {
-                            "dependency": "android_virtual_device",
-                            "version": "android_28_google_apis_x86.textpb"
-                        },
-                        {
-                            "dependency": "avd_cipd_version",
-                            "version": "build_id:8759428741582061553"
-                        }
-                    ],
-                    "contexts": [
-                        "android_virtual_device"
-                    ],
-                    "script": "flutter/testing/scenario_app/run_android_tests.sh",
-                    "parameters": [
-                        "android_debug_x86",
-                        "--no-enable-impeller"
-                    ]
-                },
-                {
-                    "language": "bash",
-                    "name": "Android Scenario App Integration Tests (Impeller/OpenGLES, API v28)",
-                    "test_dependencies": [
-                        {
-                            "dependency": "android_virtual_device",
-                            "version": "android_28_google_apis_x86.textpb"
-                        },
-                        {
-                            "dependency": "avd_cipd_version",
-                            "version": "build_id:8759428741582061553"
-                        }
-                    ],
-                    "contexts": [
-                        "android_virtual_device"
-                    ],
-                    "script": "flutter/testing/scenario_app/run_android_tests.sh",
-                    "parameters": [
-                        "android_debug_x86",
-                        "--enable-impeller",
-                        "--impeller-backend=opengles"
-                    ]
                 }
             ]
         }


### PR DESCRIPTION
They are too unstable. See https://github.com/flutter/flutter/issues/143471.

![image](https://github.com/flutter/engine/assets/168174/311aa4ab-2c1d-40ec-bd43-b87e38d4b3d6)
