### PR TITLE
[Android] Remove the unnecessary parent interface.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -302,19 +302,15 @@ public class FlutterRenderer implements TextureRegistry {
             scheduleEngineFrame();
           };
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        // The callback relies on being executed on the UI thread (unsynchronised read
-        // of
-        // mNativeView
-        // and also the engine code check for platform thread in
-        // Shell::OnPlatformViewMarkTextureFrameAvailable),
-        // so we explicitly pass a Handler for the current thread.
+        // The callback relies on being executed on the UI thread (unsynchronised read of
+        // mNativeView and also the engine code check for platform thread in
+        // Shell::OnPlatformViewMarkTextureFrameAvailable), so we explicitly pass a Handler for the
+        // current thread.
         this.surfaceTexture().setOnFrameAvailableListener(onFrameListener, new Handler());
       } else {
-        // Android documentation states that the listener can be called on an arbitrary
-        // thread.
-        // But in practice, versions of Android that predate the newer API will call the
-        // listener
-        // on the thread where the SurfaceTexture was constructed.
+        // Android documentation states that the listener can be called on an arbitrary thread. But
+        // in practice, versions of Android that predate the newer API will call the listener on the
+        // thread where the SurfaceTexture was constructed.
         this.surfaceTexture().setOnFrameAvailableListener(onFrameListener);
       }
     }
@@ -762,15 +758,11 @@ public class FlutterRenderer implements TextureRegistry {
       // Allow for double buffering.
       builder.setMaxImages(MAX_IMAGES);
       // Use PRIVATE image format so that we can support video decoding.
-      // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our
-      // ability to read back texture data. If we don't always want to use it, how do
-      // we
-      // decide when to use it or not? Perhaps PlatformViews can indicate if they may
-      // contain
-      // DRM'd content.
-      // I need to investigate how PRIVATE impacts our ability to take screenshots or
-      // capture
-      // the output of Flutter application.
+      // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our ability to read
+      // back texture data. If we don't always want to use it, how do we decide when to use it or
+      // not? Perhaps PlatformViews can indicate if they may contain DRM'd content. I need to
+      // investigate how PRIVATE impacts our ability to take screenshots or capture the output of
+      // Flutter application.
       builder.setImageFormat(ImageFormat.PRIVATE);
       // Hint that consumed images will only be read by GPU.
       builder.setUsage(HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);
@@ -960,11 +952,10 @@ public class FlutterRenderer implements TextureRegistry {
    */
   public void startRenderingToSurface(@NonNull Surface surface, boolean onlySwap) {
     if (!onlySwap) {
-      // Stop rendering to the surface releases the associated native resources, which
-      // causes a glitch when toggling between rendering to an image view (hybrid
-      // composition) and
-      // rendering directly to a Surface or Texture view. For more,
-      // https://github.com/flutter/flutter/issues/95343
+      // Stop rendering to the surface releases the associated native resources, which causes a
+      // glitch when toggling between rendering to an image view (hybrid composition) and rendering
+      // directly to a Surface or Texture view.
+      // For more, https://github.com/flutter/flutter/issues/95343
       stopRenderingToSurface();
     }
 
@@ -1015,13 +1006,10 @@ public class FlutterRenderer implements TextureRegistry {
     if (surface != null) {
       flutterJNI.onSurfaceDestroyed();
 
-      // TODO(mattcarroll): the source of truth for this call should be FlutterJNI,
-      // which is where
-      // the call to onFlutterUiDisplayed() comes from. However, no such native
-      // callback exists yet,
-      // so until the engine and FlutterJNI are configured to call us back when
-      // rendering stops,
-      // we will manually monitor that change here.
+      // TODO(mattcarroll): the source of truth for this call should be FlutterJNI, which is where
+      // the call to onFlutterUiDisplayed() comes from. However, no such native callback exists yet,
+      // so until the engine and FlutterJNI are configured to call us back when rendering stops, we
+      // will manually monitor that change here.
       if (isDisplayingFlutterUi) {
         flutterUiDisplayListener.onFlutterUiNoLongerDisplayed();
       }

--- a/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java
@@ -54,15 +54,11 @@ public class ImageReaderPlatformViewRenderTarget implements PlatformViewRenderTa
     // Allow for double buffering.
     builder.setMaxImages(MAX_IMAGES);
     // Use PRIVATE image format so that we can support video decoding.
-    // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our
-    // ability to read back texture data. If we don't always want to use it, how do
-    // we
-    // decide when to use it or not? Perhaps PlatformViews can indicate if they may
-    // contain
-    // DRM'd content.
-    // I need to investigate how PRIVATE impacts our ability to take screenshots or
-    // capture
-    // the output of Flutter application.
+    // TODO(johnmccutchan): Should we always use PRIVATE here? It may impact our ability to read
+    // back texture data. If we don't always want to use it, how do we decide when to use it or not?
+    // Perhaps PlatformViews can indicate if they may contain DRM'd content. I need to investigate
+    // how PRIVATE impacts our ability to take screenshots or capture the output of Flutter
+    // application.
     builder.setImageFormat(ImageFormat.PRIVATE);
     // Hint that consumed images will only be read by GPU.
     builder.setUsage(HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE);

--- a/shell/platform/android/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTarget.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTarget.java
@@ -26,11 +26,9 @@ public class SurfaceTexturePlatformViewRenderTarget implements PlatformViewRende
         @Override
         public void onTrimMemory(int level) {
           // When a memory pressure warning is received and the level equal {@code
-          // ComponentCallbacks2.TRIM_MEMORY_COMPLETE}, the Android system releases the
-          // underlying
-          // surface. If we continue to use the surface (e.g., call lockHardwareCanvas), a
-          // crash
-          // occurs, and we found that this crash appeared on Android10 and above.
+          // ComponentCallbacks2.TRIM_MEMORY_COMPLETE}, the Android system releases the underlying
+          // surface. If we continue to use the surface (e.g., call lockHardwareCanvas), a crash
+          // occurs, and we found that this crash appeared on Android 10 and above.
           // See https://github.com/flutter/flutter/issues/103870 for more details.
           //
           // Here our workaround is to recreate the surface before using it.

--- a/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -135,7 +135,7 @@ public interface TextureRegistry {
   }
 
   @Keep
-  interface ImageConsumer extends TextureEntry {
+  interface ImageConsumer {
     /**
      * Retrieve the last Image produced. Drops all previously produced images.
      *
@@ -148,7 +148,7 @@ public interface TextureRegistry {
   }
 
   @Keep
-  interface GLTextureConsumer extends TextureEntry {
+  interface GLTextureConsumer {
     /**
      * Retrieve the last GL texture produced.
      *


### PR DESCRIPTION
`ImageConsumer` and `GLTextureConsumer` should not inherit from `TextureEntry`.



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
