### PR TITLE
Add support for dart_src GN variable to flutter_frontend_server build

### DIFF
--- a/flutter_frontend_server/BUILD.gn
+++ b/flutter_frontend_server/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/build/dart/dart.gni")
 import("//flutter/common/config.gni")
 
 copy("frontend_server") {


### PR DESCRIPTION
Support for the dart_src GN variable was missing the import of the variable definition in the flutter_frontend_server BUILD.gn file.

Follow up to https://github.com/flutter/engine/pull/50624/

Part of issue https://github.com/flutter/flutter/issues/143335