### PR TITLE
Add the web package to the set of Dart third_party packages in DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -80,6 +80,7 @@ vars = {
   'dart_pub_rev': '4ab2e3663f0a98be40427e004e789caebf3ea72e',
   'dart_tools_rev': '2ef7673ca4c8eb346debe6d628f0196788fc3c66',
   'dart_watcher_rev': '21858a41da1482922e03ee65cdf2169d01d59a67',
+  "dart_web_rev": "a54a1f0447979f9a3ea220199eca849ffb214e91",
   'dart_webdev_rev': '629c63214466a77d0994e9b8003120f48af9ef1d',
   'dart_webkit_inspection_protocol_rev': '07295b9a5a1f1851666269128e95a9644d65107a',
   'dart_yaml_edit_rev': '2a9a11bee120d507d61d501c34585440be8c12b6',
@@ -497,7 +498,10 @@ deps = {
   'src/third_party/dart/third_party/pkg/watcher':
    Var('dart_git') + '/watcher.git' + '@' + Var('dart_watcher_rev'),
 
-  'src/third_party/dart/third_party/pkg/web_socket_channel':
+  'src/third_party/dart/third_party/pkg/web':
+   Var('dart_git') + '/web.git' + '@' + Var('dart_web_rev'),
+
+   'src/third_party/dart/third_party/pkg/web_socket_channel':
    Var('dart_git') + '/web_socket_channel.git@5241175e7c66271850d6e75fb9ec90068f9dd3c4',
 
   'src/third_party/dart/third_party/pkg/webdev':

--- a/testing/benchmark/pubspec.yaml
+++ b/testing/benchmark/pubspec.yaml
@@ -73,3 +73,5 @@ dependency_overrides:
     path: ../../../third_party/dart/third_party/pkg/term_glyph
   typed_data:
     path: ../../../third_party/dart/third_party/pkg/typed_data
+  web:
+    path: ../../../third_party/dart/third_party/pkg/web

--- a/tools/gen_web_locale_keymap/pubspec.yaml
+++ b/tools/gen_web_locale_keymap/pubspec.yaml
@@ -33,3 +33,5 @@ dependency_overrides:
     path: ../../../third_party/dart/third_party/pkg/term_glyph
   typed_data:
     path: ../../../third_party/dart/third_party/pkg/typed_data
+  web:
+    path: ../../../third_party/dart/third_party/pkg/web


### PR DESCRIPTION
Dart is rolling the http package to a version that depends on the web package. (see https://dart.googlesource.com/http/+/d8b237d273f49bada2aa7feaa0e7795e2541fe83)