### PR TITLE
[web] Remove unused `allowInterop` usage in flutter web code

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -3041,8 +3041,7 @@ extension DomScreenOrientationExtension on DomScreenOrientation {
 
 // A helper class for managing a subscription. On construction it will add an
 // event listener of the requested type to the target. Calling [cancel] will
-// remove the listener. Caller is still responsible for calling [allowInterop]
-// on the listener before creating the subscription.
+// remove the listener.
 class DomSubscription {
   DomSubscription(
       this.target, String typeString, DartDomEventListener dartListener)
@@ -3268,9 +3267,6 @@ abstract class DomTrustedTypePolicyOptions {
   ///
   /// `createScriptURL` is a callback function that contains code to run when
   /// creating a TrustedScriptURL object.
-  ///
-  /// The following properties need to be manually wrapped in [allowInterop]
-  /// before being passed to this constructor: [createScriptURL].
   external factory DomTrustedTypePolicyOptions({
     JSFunction? createScriptURL,
   });

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -24,9 +24,6 @@ import 'display.dart';
 import 'dom.dart';
 import 'vector_math.dart';
 
-export 'package:js/js_util.dart' show allowInterop;
-
-
 /// Returns true if [object] has property [name], false otherwise.
 ///
 /// This is equivalent to writing `name in object` in plain JavaScript.


### PR DESCRIPTION
The CLs that migrated to static interop forgot to update the corresponding comments regarding the need to use `allowInterop`.

The re-exported `allowInterop` function happened in an internal library (not exposed via `dart:ui*`) and was unused.

Issue https://github.com/dart-lang/sdk/issues/54908