### PR TITLE
Temporarily disable goldens for Safari.

### DIFF
--- a/lib/web_ui/dev/steps/run_suite_step.dart
+++ b/lib/web_ui/dev/steps/run_suite_step.dart
@@ -179,6 +179,11 @@ class RunSuiteStep implements PipelineStep {
       // do not collect goldens.
       return null;
     }
+    if (suite.runConfig.browser == BrowserName.safari) {
+      // Goldens from Safari produce too many diffs, disabled for now.
+      // See https://github.com/flutter/flutter/issues/143591
+      return null;
+    }
     final Renderer renderer = suite.testBundle.compileConfigs.first.renderer;
     final CanvasKitVariant? variant = suite.runConfig.variant;
     final io.Directory workDirectory = getSkiaGoldDirectoryForSuite(suite);


### PR DESCRIPTION
Safari is producing too many golden diffs. See https://github.com/flutter/flutter/issues/143591. This disables them for now to stop the noise, but we should look into a longer term solution.