### PR TITLE
[Impeller] use fewer threads for shader bootstrap workers on low core machines.

### DIFF
--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -103,6 +103,12 @@ std::shared_ptr<ContextVK> ContextVK::Create(Settings settings) {
   return context;
 }
 
+size_t ChooseThreadCountForWorkers(size_t hardware_concurrency) {
+  // Never create more than 4 worker threads. Attempt to use up to
+  // half of the available concurrency.
+  return std::min(4ull, std::max(hardware_concurrency / 2ull, 1ull));
+}
+
 namespace {
 thread_local uint64_t tls_context_count = 0;
 uint64_t CalculateHash(void* ptr) {
@@ -133,7 +139,7 @@ void ContextVK::Setup(Settings settings) {
   }
 
   raster_message_loop_ = fml::ConcurrentMessageLoop::Create(
-      std::min(4u, std::thread::hardware_concurrency()));
+      ChooseThreadCountForWorkers(std::thread::hardware_concurrency()));
   raster_message_loop_->PostTaskToAllWorkers([]() {
     // Currently we only use the worker task pool for small parts of a frame
     // workload, if this changes this setting may need to be adjusted.

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -107,7 +107,7 @@ std::shared_ptr<ContextVK> ContextVK::Create(Settings settings) {
 size_t ContextVK::ChooseThreadCountForWorkers(size_t hardware_concurrency) {
   // Never create more than 4 worker threads. Attempt to use up to
   // half of the available concurrency.
-  return std::clamp(hardware_concurrency / 2ull, /*min=*/1ull, /*max=*/4ull);
+  return std::clamp(hardware_concurrency / 2ull, /*lo=*/1ull, /*hi=*/4ull);
 }
 
 namespace {

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -103,10 +103,11 @@ std::shared_ptr<ContextVK> ContextVK::Create(Settings settings) {
   return context;
 }
 
-size_t ChooseThreadCountForWorkers(size_t hardware_concurrency) {
+// static
+size_t ContextVK::ChooseThreadCountForWorkers(size_t hardware_concurrency) {
   // Never create more than 4 worker threads. Attempt to use up to
   // half of the available concurrency.
-  return std::min(4ull, std::max(hardware_concurrency / 2ull, 1ull));
+  return std::clamp(hardware_concurrency / 2ull, /*min=*/1ull, /*max=*/4ull);
 }
 
 namespace {

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -38,11 +38,6 @@ class GPUTracerVK;
 class DescriptorPoolRecyclerVK;
 class CommandQueueVK;
 
-/// Choose the number of worker threads the context_vk will create.
-///
-/// Visible for testing.
-size_t ChooseThreadCountForWorkers(size_t hardware_concurrency);
-
 class ContextVK final : public Context,
                         public BackendCast<ContextVK, Context>,
                         public std::enable_shared_from_this<ContextVK> {
@@ -58,6 +53,11 @@ class ContextVK final : public Context,
 
     Settings(Settings&&) = default;
   };
+
+  /// Choose the number of worker threads the context_vk will create.
+  ///
+  /// Visible for testing.
+  static size_t ChooseThreadCountForWorkers(size_t hardware_concurrency);
 
   static std::shared_ptr<ContextVK> Create(Settings settings);
 

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -38,6 +38,11 @@ class GPUTracerVK;
 class DescriptorPoolRecyclerVK;
 class CommandQueueVK;
 
+/// Choose the number of worker threads the context_vk will create.
+///
+/// Visible for testing.
+size_t ChooseThreadCountForWorkers(size_t hardware_concurrency);
+
 class ContextVK final : public Context,
                         public BackendCast<ContextVK, Context>,
                         public std::enable_shared_from_this<ContextVK> {

--- a/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -13,16 +13,16 @@ namespace impeller {
 namespace testing {
 
 TEST(ContextVKTest, CommonHardwareConcurrencyConfigurations) {
-  EXPECT_EQ(ChooseThreadCountForWorkers(100u), 4u);
-  EXPECT_EQ(ChooseThreadCountForWorkers(9u), 4u);
-  EXPECT_EQ(ChooseThreadCountForWorkers(8u), 4u);
-  EXPECT_EQ(ChooseThreadCountForWorkers(7u), 3u);
-  EXPECT_EQ(ChooseThreadCountForWorkers(6u), 3u);
-  EXPECT_EQ(ChooseThreadCountForWorkers(5u), 2u);
-  EXPECT_EQ(ChooseThreadCountForWorkers(4u), 2u);
-  EXPECT_EQ(ChooseThreadCountForWorkers(3u), 1u);
-  EXPECT_EQ(ChooseThreadCountForWorkers(2u), 1u);
-  EXPECT_EQ(ChooseThreadCountForWorkers(1u), 1u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(100u), 4u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(9u), 4u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(8u), 4u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(7u), 3u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(6u), 3u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(5u), 2u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(4u), 2u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(3u), 1u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(2u), 1u);
+  EXPECT_EQ(ContextVK::ChooseThreadCountForWorkers(1u), 1u);
 }
 
 TEST(ContextVKTest, DeletesCommandPools) {

--- a/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -12,6 +12,19 @@
 namespace impeller {
 namespace testing {
 
+TEST(ContextVKTest, CommonHardwareConcurrencyConfigurations) {
+  EXPECT_EQ(ChooseThreadCountForWorkers(100u), 4u);
+  EXPECT_EQ(ChooseThreadCountForWorkers(9u), 4u);
+  EXPECT_EQ(ChooseThreadCountForWorkers(8u), 4u);
+  EXPECT_EQ(ChooseThreadCountForWorkers(7u), 3u);
+  EXPECT_EQ(ChooseThreadCountForWorkers(6u), 3u);
+  EXPECT_EQ(ChooseThreadCountForWorkers(5u), 2u);
+  EXPECT_EQ(ChooseThreadCountForWorkers(4u), 2u);
+  EXPECT_EQ(ChooseThreadCountForWorkers(3u), 1u);
+  EXPECT_EQ(ChooseThreadCountForWorkers(2u), 1u);
+  EXPECT_EQ(ChooseThreadCountForWorkers(1u), 1u);
+}
+
 TEST(ContextVKTest, DeletesCommandPools) {
   std::weak_ptr<ContextVK> weak_context;
   std::weak_ptr<CommandPoolVK> weak_pool;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/143540

We were using 4 threads for shader bootstrap on a device with only 4 cores. Using fewer threads seems to improve performance on fewer core machines.
