### PR TITLE
Fix implementation imports outside of lib

### DIFF
--- a/lib/web_ui/dev/browser.dart
+++ b/lib/web_ui/dev/browser.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:image/image.dart';
-import 'package:test_api/src/backend/runtime.dart';
+import 'package:test_api/backend.dart';
 
 /// Provides the environment for a specific web browser.
 abstract class BrowserEnvironment {

--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as path;
-import 'package:watcher/src/watch_event.dart';
+import 'package:watcher/watcher.dart';
 
 import 'environment.dart';
 import 'exceptions.dart';

--- a/lib/web_ui/dev/chrome.dart
+++ b/lib/web_ui/dev/chrome.dart
@@ -9,7 +9,7 @@ import 'dart:math' as math;
 
 import 'package:image/image.dart';
 import 'package:path/path.dart' as path;
-import 'package:test_api/src/backend/runtime.dart';
+import 'package:test_api/backend.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     as wip;
 

--- a/lib/web_ui/dev/edge.dart
+++ b/lib/web_ui/dev/edge.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:test_api/src/backend/runtime.dart';
+import 'package:test_api/backend.dart';
 
 import 'browser.dart';
 import 'browser_process.dart';

--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:test_api/src/backend/runtime.dart';
-import 'package:test_core/src/util/io.dart';
+import 'package:test_api/backend.dart';
+import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
 
 import 'browser.dart';
 import 'browser_process.dart';

--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as path;
 import 'package:test_api/backend.dart';
+// TODO(ditman): Fix ignore when https://github.com/flutter/flutter/issues/143599 is resolved.
 import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
 
 import 'browser.dart';

--- a/lib/web_ui/dev/safari_macos.dart
+++ b/lib/web_ui/dev/safari_macos.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:test_api/src/backend/runtime.dart';
+import 'package:test_api/backend.dart';
 
 import 'webdriver_browser.dart';
 

--- a/lib/web_ui/dev/steps/run_suite_step.dart
+++ b/lib/web_ui/dev/steps/run_suite_step.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as pathlib;
 //                https://github.com/dart-lang/test/issues/1521
 import 'package:skia_gold_client/skia_gold_client.dart';
 import 'package:test_api/backend.dart' as hack;
+// TODO(ditman): Fix ignores when https://github.com/flutter/flutter/issues/143599 is resolved.
 import 'package:test_core/src/executable.dart' as test; // ignore: implementation_imports
 import 'package:test_core/src/runner/hack_register_platform.dart' as hack; // ignore: implementation_imports
 

--- a/lib/web_ui/dev/steps/run_suite_step.dart
+++ b/lib/web_ui/dev/steps/run_suite_step.dart
@@ -9,9 +9,9 @@ import 'package:path/path.dart' as pathlib;
 // TODO(yjbanov): remove hacks when this is fixed:
 //                https://github.com/dart-lang/test/issues/1521
 import 'package:skia_gold_client/skia_gold_client.dart';
-import 'package:test_api/src/backend/runtime.dart' as hack;
-import 'package:test_core/src/executable.dart' as test;
-import 'package:test_core/src/runner/hack_register_platform.dart' as hack;
+import 'package:test_api/backend.dart' as hack;
+import 'package:test_core/src/executable.dart' as test; // ignore: implementation_imports
+import 'package:test_core/src/runner/hack_register_platform.dart' as hack; // ignore: implementation_imports
 
 import '../browser.dart';
 import '../common.dart';

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -22,16 +22,13 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:skia_gold_client/skia_gold_client.dart';
 import 'package:stream_channel/stream_channel.dart';
 
-import 'package:test_api/src/backend/runtime.dart';
-import 'package:test_api/src/backend/suite_platform.dart';
-import 'package:test_core/src/runner/configuration.dart';
-import 'package:test_core/src/runner/environment.dart';
-import 'package:test_core/src/runner/platform.dart';
-import 'package:test_core/src/runner/plugin/platform_helpers.dart';
-import 'package:test_core/src/runner/runner_suite.dart';
-import 'package:test_core/src/runner/suite.dart';
-import 'package:test_core/src/util/io.dart';
-import 'package:test_core/src/util/stack_trace_mapper.dart';
+import 'package:test_core/backend.dart' hide Compiler;
+import 'package:test_core/src/runner/environment.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/platform.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/plugin/platform_helpers.dart'; // ignore: implementation_imports
+import 'package:test_core/src/runner/runner_suite.dart'; // ignore: implementation_imports
+import 'package:test_core/src/util/io.dart'; // ignore: implementation_imports
+import 'package:test_core/src/util/stack_trace_mapper.dart'; // ignore: implementation_imports
 
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:web_test_utils/image_compare.dart';

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -23,6 +23,7 @@ import 'package:skia_gold_client/skia_gold_client.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'package:test_core/backend.dart' hide Compiler;
+// TODO(ditman): Fix ignores when https://github.com/flutter/flutter/issues/143599 is resolved.
 import 'package:test_core/src/runner/environment.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/platform.dart'; // ignore: implementation_imports
 import 'package:test_core/src/runner/plugin/platform_helpers.dart'; // ignore: implementation_imports


### PR DESCRIPTION
Work towards https://github.com/dart-lang/linter/issues/4859

There are libraries outside a `lib/` directory, which violate `implementation_imports`.