### PR TITLE
[Impeller] Implement YUV texture import and sampling for video player frames.

### DIFF
--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -115,6 +115,10 @@ impeller_component("vulkan") {
     "vk.h",
     "vma.cc",
     "vma.h",
+    "yuv_conversion_library_vk.cc",
+    "yuv_conversion_library_vk.h",
+    "yuv_conversion_vk.cc",
+    "yuv_conversion_vk.h",
   ]
 
   public_deps = [

--- a/impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.h
+++ b/impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.h
@@ -15,17 +15,31 @@
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_source_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
+#include "impeller/renderer/backend/vulkan/yuv_conversion_vk.h"
 
 #include <android/hardware_buffer.h>
 #include <android/hardware_buffer_jni.h>
 
 namespace impeller {
 
+class ContextVK;
+
+//------------------------------------------------------------------------------
+/// @brief      A texture source that wraps an instance of AHardwareBuffer.
+///
+///             The formats and conversions supported by Android Hardware
+///             Buffers are a superset of those supported by Impeller (and
+///             Vulkan for that matter). Impeller and Vulkan descriptors
+///             obtained from the these texture sources are advisory and it
+///             usually isn't possible to create copies of images and image
+///             views held in these texture sources using the inferred
+///             descriptors. The objects are meant to be used directly (either
+///             as render targets or sources for sampling), not copied.
+///
 class AndroidHardwareBufferTextureSourceVK final : public TextureSourceVK {
  public:
   AndroidHardwareBufferTextureSourceVK(
-      TextureDescriptor desc,
-      const vk::Device& device,
+      const std::shared_ptr<ContextVK>& context,
       struct AHardwareBuffer* hardware_buffer,
       const AHardwareBuffer_Desc& hardware_buffer_desc);
 
@@ -43,14 +57,18 @@ class AndroidHardwareBufferTextureSourceVK final : public TextureSourceVK {
 
   bool IsValid() const;
 
-  bool IsSwapchainImage() const override { return false; }
+  // |TextureSourceVK|
+  bool IsSwapchainImage() const override;
+
+  // |TextureSourceVK|
+  std::shared_ptr<YUVConversionVK> GetYUVConversion() const override;
 
  private:
-  const vk::Device& device_;
-  vk::Image image_ = VK_NULL_HANDLE;
-  vk::UniqueImageView image_view_ = {};
-  vk::DeviceMemory device_memory_ = VK_NULL_HANDLE;
-
+  vk::UniqueDeviceMemory device_memory_;
+  vk::UniqueImage image_;
+  vk::UniqueImageView image_view_;
+  std::shared_ptr<YUVConversionVK> yuv_conversion_;
+  bool needs_yuv_conversion_ = false;
   bool is_valid_ = false;
 
   AndroidHardwareBufferTextureSourceVK(

--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -9,7 +9,6 @@
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
-#include "vulkan/vulkan_core.h"
 
 namespace impeller {
 
@@ -153,25 +152,58 @@ CapabilitiesVK::GetEnabledInstanceExtensions() const {
   return required;
 }
 
-static const char* GetDeviceExtensionName(OptionalDeviceExtensionVK ext) {
+static const char* GetExtensionName(RequiredCommonDeviceExtensionVK ext) {
+  switch (ext) {
+    case RequiredCommonDeviceExtensionVK::kKHRSwapchain:
+      return VK_KHR_SWAPCHAIN_EXTENSION_NAME;
+    case RequiredCommonDeviceExtensionVK::kLast:
+      return "Unknown";
+  }
+  FML_UNREACHABLE();
+}
+
+static const char* GetExtensionName(RequiredAndroidDeviceExtensionVK ext) {
+  switch (ext) {
+    case RequiredAndroidDeviceExtensionVK::
+        kANDROIDExternalMemoryAndroidHardwareBuffer:
+      return "VK_ANDROID_external_memory_android_hardware_buffer";
+    case RequiredAndroidDeviceExtensionVK::kKHRSamplerYcbcrConversion:
+      return VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME;
+    case RequiredAndroidDeviceExtensionVK::kKHRExternalMemory:
+      return VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME;
+    case RequiredAndroidDeviceExtensionVK::kEXTQueueFamilyForeign:
+      return VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME;
+    case RequiredAndroidDeviceExtensionVK::kKHRDedicatedAllocation:
+      return VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME;
+    case RequiredAndroidDeviceExtensionVK::kLast:
+      return "Unknown";
+  }
+  FML_UNREACHABLE();
+}
+
+static const char* GetExtensionName(OptionalDeviceExtensionVK ext) {
   switch (ext) {
     case OptionalDeviceExtensionVK::kEXTPipelineCreationFeedback:
       return VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME;
+    case OptionalDeviceExtensionVK::kVKKHRPortabilitySubset:
+      return "VK_KHR_portability_subset";
     case OptionalDeviceExtensionVK::kLast:
       return "Unknown";
   }
-  return "Unknown";
+  FML_UNREACHABLE();
 }
 
-static void IterateOptionalDeviceExtensions(
-    const std::function<void(OptionalDeviceExtensionVK)>& it) {
+template <class T>
+static bool IterateExtensions(const std::function<bool(T)>& it) {
   if (!it) {
-    return;
+    return false;
   }
-  for (size_t i = 0;
-       i < static_cast<uint32_t>(OptionalDeviceExtensionVK::kLast); i++) {
-    it(static_cast<OptionalDeviceExtensionVK>(i));
+  for (size_t i = 0; i < static_cast<uint32_t>(T::kLast); i++) {
+    if (!it(static_cast<T>(i))) {
+      return false;
+    }
   }
+  return true;
 }
 
 static std::optional<std::set<std::string>> GetSupportedDeviceExtensions(
@@ -200,36 +232,49 @@ CapabilitiesVK::GetEnabledDeviceExtensions(
 
   std::vector<std::string> enabled;
 
-  if (exts->find("VK_KHR_swapchain") == exts->end()) {
-    VALIDATION_LOG << "Device does not support the swapchain extension.";
-    return std::nullopt;
-  }
-  enabled.push_back("VK_KHR_swapchain");
-
-  // Required for non-conformant implementations like MoltenVK.
-  if (exts->find("VK_KHR_portability_subset") != exts->end()) {
-    enabled.push_back("VK_KHR_portability_subset");
-  }
-
-#ifdef FML_OS_ANDROID
-  if (exts->find("VK_ANDROID_external_memory_android_hardware_buffer") ==
-      exts->end()) {
-    VALIDATION_LOG
-        << "Device does not support "
-           "VK_ANDROID_external_memory_android_hardware_buffer extension.";
-    return std::nullopt;
-  }
-  enabled.push_back("VK_ANDROID_external_memory_android_hardware_buffer");
-  enabled.push_back("VK_EXT_queue_family_foreign");
-#endif
-
-  // Enable all optional extensions if the device supports it.
-  IterateOptionalDeviceExtensions([&](auto ext) {
-    auto ext_name = GetDeviceExtensionName(ext);
-    if (exts->find(ext_name) != exts->end()) {
-      enabled.push_back(ext_name);
+  auto for_each_common_extension = [&](RequiredCommonDeviceExtensionVK ext) {
+    auto name = GetExtensionName(ext);
+    if (exts->find(name) == exts->end()) {
+      VALIDATION_LOG << "Device does not support required extension: " << name;
+      return false;
     }
-  });
+    enabled.push_back(name);
+    return true;
+  };
+
+  auto for_each_android_extension = [&](RequiredAndroidDeviceExtensionVK ext) {
+#ifdef FML_OS_ANDROID
+    auto name = GetExtensionName(ext);
+    if (exts->find(name) == exts->end()) {
+      VALIDATION_LOG << "Device does not support required Android extension: "
+                     << name;
+      return false;
+    }
+    enabled.push_back(name);
+#endif  //  FML_OS_ANDROID
+    return true;
+  };
+
+  auto for_each_optional_extension = [&](OptionalDeviceExtensionVK ext) {
+    auto name = GetExtensionName(ext);
+    if (exts->find(name) != exts->end()) {
+      enabled.push_back(name);
+    }
+    return true;
+  };
+
+  const auto iterate_extensions =
+      IterateExtensions<RequiredCommonDeviceExtensionVK>(
+          for_each_common_extension) &&
+      IterateExtensions<RequiredAndroidDeviceExtensionVK>(
+          for_each_android_extension) &&
+      IterateExtensions<OptionalDeviceExtensionVK>(for_each_optional_extension);
+
+  if (!iterate_extensions) {
+    VALIDATION_LOG << "Device not suitable since required extensions are not "
+                      "supported.";
+    return std::nullopt;
+  }
 
   return enabled;
 }
@@ -282,7 +327,14 @@ static bool HasRequiredQueues(const vk::PhysicalDevice& physical_device) {
                                     vk::QueueFlagBits::eTransfer));
 }
 
-std::optional<vk::PhysicalDeviceFeatures>
+template <class ExtensionEnum>
+static bool IsExtensionInList(const std::vector<std::string>& list,
+                              ExtensionEnum ext) {
+  const std::string name = GetExtensionName(ext);
+  return std::find(list.begin(), list.end(), name) != list.end();
+}
+
+std::optional<CapabilitiesVK::PhysicalDeviceFeatures>
 CapabilitiesVK::GetEnabledDeviceFeatures(
     const vk::PhysicalDevice& device) const {
   if (!PhysicalDeviceSupportsRequiredFormats(device)) {
@@ -300,20 +352,41 @@ CapabilitiesVK::GetEnabledDeviceFeatures(
     return std::nullopt;
   }
 
-  if (!GetEnabledDeviceExtensions(device).has_value()) {
+  const auto enabled_extensions = GetEnabledDeviceExtensions(device);
+  if (!enabled_extensions.has_value()) {
     VALIDATION_LOG << "Device doesn't support the required queues.";
     return std::nullopt;
   }
 
-  const auto device_features = device.getFeatures();
+  PhysicalDeviceFeatures supported_chain;
+  device.getFeatures2(&supported_chain.get());
 
-  vk::PhysicalDeviceFeatures required;
+  PhysicalDeviceFeatures required_chain;
 
-  // We require this for enabling wireframes in the playground. But its not
-  // necessarily a big deal if we don't have this feature.
-  required.fillModeNonSolid = device_features.fillModeNonSolid;
+  // Base features.
+  {
+    auto& required = required_chain.get().features;
+    const auto& supported = supported_chain.get().features;
 
-  return required;
+    // We require this for enabling wireframes in the playground. But its not
+    // necessarily a big deal if we don't have this feature.
+    required.fillModeNonSolid = supported.fillModeNonSolid;
+  }
+  // VK_KHR_sampler_ycbcr_conversion features.
+  if (IsExtensionInList(
+          enabled_extensions.value(),
+          RequiredAndroidDeviceExtensionVK::kKHRSamplerYcbcrConversion)) {
+    auto& required =
+        required_chain
+            .get<vk::PhysicalDeviceSamplerYcbcrConversionFeaturesKHR>();
+    const auto& supported =
+        supported_chain
+            .get<vk::PhysicalDeviceSamplerYcbcrConversionFeaturesKHR>();
+
+    required.samplerYcbcrConversion = supported.samplerYcbcrConversion;
+  }
+
+  return required_chain;
 }
 
 bool CapabilitiesVK::HasLayer(const std::string& layer) const {
@@ -386,16 +459,33 @@ bool CapabilitiesVK::SetPhysicalDevice(const vk::PhysicalDevice& device) {
 
   // Determine the optional device extensions this physical device supports.
   {
+    required_common_device_extensions_.clear();
+    required_android_device_extensions_.clear();
     optional_device_extensions_.clear();
     auto exts = GetSupportedDeviceExtensions(device);
     if (!exts.has_value()) {
       return false;
     }
-    IterateOptionalDeviceExtensions([&](auto ext) {
-      auto ext_name = GetDeviceExtensionName(ext);
+    IterateExtensions<RequiredCommonDeviceExtensionVK>([&](auto ext) -> bool {
+      auto ext_name = GetExtensionName(ext);
+      if (exts->find(ext_name) != exts->end()) {
+        required_common_device_extensions_.insert(ext);
+      }
+      return true;
+    });
+    IterateExtensions<RequiredAndroidDeviceExtensionVK>([&](auto ext) -> bool {
+      auto ext_name = GetExtensionName(ext);
+      if (exts->find(ext_name) != exts->end()) {
+        required_android_device_extensions_.insert(ext);
+      }
+      return true;
+    });
+    IterateExtensions<OptionalDeviceExtensionVK>([&](auto ext) -> bool {
+      auto ext_name = GetExtensionName(ext);
       if (exts->find(ext_name) != exts->end()) {
         optional_device_extensions_.insert(ext);
       }
+      return true;
     });
   }
 
@@ -478,14 +568,23 @@ CapabilitiesVK::GetPhysicalDeviceProperties() const {
   return device_properties_;
 }
 
-bool CapabilitiesVK::HasOptionalDeviceExtension(
-    OptionalDeviceExtensionVK extension) const {
-  return optional_device_extensions_.find(extension) !=
-         optional_device_extensions_.end();
-}
-
 PixelFormat CapabilitiesVK::GetDefaultGlyphAtlasFormat() const {
   return PixelFormat::kR8UNormInt;
+}
+
+bool CapabilitiesVK::HasExtension(RequiredCommonDeviceExtensionVK ext) const {
+  return required_common_device_extensions_.find(ext) !=
+         required_common_device_extensions_.end();
+}
+
+bool CapabilitiesVK::HasExtension(RequiredAndroidDeviceExtensionVK ext) const {
+  return required_android_device_extensions_.find(ext) !=
+         required_android_device_extensions_.end();
+}
+
+bool CapabilitiesVK::HasExtension(OptionalDeviceExtensionVK ext) const {
+  return optional_device_extensions_.find(ext) !=
+         optional_device_extensions_.end();
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -19,9 +19,91 @@ namespace impeller {
 
 class ContextVK;
 
+//------------------------------------------------------------------------------
+/// @brief      A device extension available on all platforms. Without the
+///             presence of these extensions, context creation will fail.
+///
+enum class RequiredCommonDeviceExtensionVK : uint32_t {
+  //----------------------------------------------------------------------------
+  /// For displaying content in the window system.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_swapchain.html
+  ///
+  kKHRSwapchain,
+
+  kLast,
+};
+
+//------------------------------------------------------------------------------
+/// @brief      A device extension available on all Android platforms. Without
+///             the presence of these extensions on Android, context creation
+///             will fail.
+///
+///             Platform agnostic code can still check if these Android
+///             extensions are present.
+///
+enum class RequiredAndroidDeviceExtensionVK : uint32_t {
+  //----------------------------------------------------------------------------
+  /// For importing hardware buffers used in external texture composition.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_ANDROID_external_memory_android_hardware_buffer.html
+  ///
+  kANDROIDExternalMemoryAndroidHardwareBuffer,
+
+  //----------------------------------------------------------------------------
+  /// Dependency of kANDROIDExternalMemoryAndroidHardwareBuffer.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_sampler_ycbcr_conversion.html
+  ///
+  kKHRSamplerYcbcrConversion,
+
+  //----------------------------------------------------------------------------
+  /// Dependency of kANDROIDExternalMemoryAndroidHardwareBuffer.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_memory.html
+  ///
+  kKHRExternalMemory,
+
+  //----------------------------------------------------------------------------
+  /// Dependency of kANDROIDExternalMemoryAndroidHardwareBuffer.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_queue_family_foreign.html
+  ///
+  kEXTQueueFamilyForeign,
+
+  //----------------------------------------------------------------------------
+  /// Dependency of kANDROIDExternalMemoryAndroidHardwareBuffer.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_dedicated_allocation.html
+  ///
+  kKHRDedicatedAllocation,
+
+  kLast,
+};
+
+//------------------------------------------------------------------------------
+/// @brief      A device extension enabled if available. Subsystems cannot
+///             assume availability and must check if these extensions are
+///             available.
+///
+/// @see        `CapabilitiesVK::HasExtension`.
+///
 enum class OptionalDeviceExtensionVK : uint32_t {
-  // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_creation_feedback.html
+  //----------------------------------------------------------------------------
+  /// To instrument and profile PSO creation.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_pipeline_creation_feedback.html
+  ///
   kEXTPipelineCreationFeedback,
+
+  //----------------------------------------------------------------------------
+  /// To enable context creation on MoltenVK. A non-conformant Vulkan
+  /// implementation.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_portability_subset.html
+  ///
+  kVKKHRPortabilitySubset,
+
   kLast,
 };
 
@@ -39,7 +121,11 @@ class CapabilitiesVK final : public Capabilities,
 
   bool AreValidationsEnabled() const;
 
-  bool HasOptionalDeviceExtension(OptionalDeviceExtensionVK extension) const;
+  bool HasExtension(RequiredCommonDeviceExtensionVK ext) const;
+
+  bool HasExtension(RequiredAndroidDeviceExtensionVK ext) const;
+
+  bool HasExtension(OptionalDeviceExtensionVK ext) const;
 
   std::optional<std::vector<std::string>> GetEnabledLayers() const;
 
@@ -48,7 +134,11 @@ class CapabilitiesVK final : public Capabilities,
   std::optional<std::vector<std::string>> GetEnabledDeviceExtensions(
       const vk::PhysicalDevice& physical_device) const;
 
-  std::optional<vk::PhysicalDeviceFeatures> GetEnabledDeviceFeatures(
+  using PhysicalDeviceFeatures =
+      vk::StructureChain<vk::PhysicalDeviceFeatures2,
+                         vk::PhysicalDeviceSamplerYcbcrConversionFeaturesKHR>;
+
+  std::optional<PhysicalDeviceFeatures> GetEnabledDeviceFeatures(
       const vk::PhysicalDevice& physical_device) const;
 
   [[nodiscard]] bool SetPhysicalDevice(
@@ -106,6 +196,9 @@ class CapabilitiesVK final : public Capabilities,
  private:
   bool validations_enabled_ = false;
   std::map<std::string, std::set<std::string>> exts_;
+  std::set<RequiredCommonDeviceExtensionVK> required_common_device_extensions_;
+  std::set<RequiredAndroidDeviceExtensionVK>
+      required_android_device_extensions_;
   std::set<OptionalDeviceExtensionVK> optional_device_extensions_;
   mutable PixelFormat default_color_format_ = PixelFormat::kUnknown;
   PixelFormat default_stencil_format_ = PixelFormat::kUnknown;

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -35,6 +35,7 @@
 #include "impeller/renderer/backend/vulkan/gpu_tracer_vk.h"
 #include "impeller/renderer/backend/vulkan/resource_manager_vk.h"
 #include "impeller/renderer/backend/vulkan/surface_context_vk.h"
+#include "impeller/renderer/backend/vulkan/yuv_conversion_library_vk.h"
 #include "impeller/renderer/capabilities.h"
 
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
@@ -323,9 +324,9 @@ void ContextVK::Setup(Settings settings) {
 
   vk::DeviceCreateInfo device_info;
 
+  device_info.setPNext(&enabled_features.value().get());
   device_info.setQueueCreateInfos(queue_create_infos);
   device_info.setPEnabledExtensionNames(enabled_device_extensions_c);
-  device_info.setPEnabledFeatures(&enabled_features.value());
   // Device layers are deprecated and ignored.
 
   {
@@ -443,6 +444,8 @@ void ContextVK::Setup(Settings settings) {
   shader_library_ = std::move(shader_library);
   sampler_library_ = std::move(sampler_library);
   pipeline_library_ = std::move(pipeline_library);
+  yuv_conversion_library_ = std::shared_ptr<YUVConversionLibraryVK>(
+      new YUVConversionLibraryVK(device_holder_));
   queues_ = std::move(queues);
   device_capabilities_ = std::move(caps);
   fence_waiter_ = std::move(fence_waiter);
@@ -611,6 +614,11 @@ void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
   }
 
   auto pass = builder.Build(GetDevice());
+}
+
+const std::shared_ptr<YUVConversionLibraryVK>&
+ContextVK::GetYUVConversionLibrary() const {
+  return yuv_conversion_library_;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -93,6 +93,9 @@ class ContextVK final : public Context,
   // |Context|
   const std::shared_ptr<const Capabilities>& GetCapabilities() const override;
 
+  const std::shared_ptr<YUVConversionLibraryVK>& GetYUVConversionLibrary()
+      const;
+
   // |Context|
   void Shutdown() override;
 
@@ -180,6 +183,7 @@ class ContextVK final : public Context,
   std::shared_ptr<ShaderLibraryVK> shader_library_;
   std::shared_ptr<SamplerLibraryVK> sampler_library_;
   std::shared_ptr<PipelineLibraryVK> pipeline_library_;
+  std::shared_ptr<YUVConversionLibraryVK> yuv_conversion_library_;
   QueuesVK queues_;
   std::shared_ptr<const Capabilities> device_capabilities_;
   std::shared_ptr<FenceWaiterVK> fence_waiter_;

--- a/impeller/renderer/backend/vulkan/pipeline_vk.h
+++ b/impeller/renderer/backend/vulkan/pipeline_vk.h
@@ -10,10 +10,13 @@
 
 #include "impeller/base/backend_cast.h"
 #include "impeller/base/thread.h"
+#include "impeller/core/texture.h"
 #include "impeller/renderer/backend/vulkan/device_holder.h"
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
 #include "impeller/renderer/backend/vulkan/pipeline_cache_vk.h"
+#include "impeller/renderer/backend/vulkan/sampler_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
+#include "impeller/renderer/backend/vulkan/yuv_conversion_vk.h"
 #include "impeller/renderer/pipeline.h"
 
 namespace impeller {
@@ -29,7 +32,8 @@ class PipelineVK final
   static std::unique_ptr<PipelineVK> Create(
       const PipelineDescriptor& desc,
       const std::shared_ptr<DeviceHolder>& device_holder,
-      const std::weak_ptr<PipelineLibrary>& weak_library);
+      const std::weak_ptr<PipelineLibrary>& weak_library,
+      std::shared_ptr<SamplerVK> immutable_sampler = {});
 
   // |Pipeline|
   ~PipelineVK() override;
@@ -40,15 +44,27 @@ class PipelineVK final
 
   const vk::DescriptorSetLayout& GetDescriptorSetLayout() const;
 
+  std::shared_ptr<PipelineVK> CreateVariantForImmutableSamplers(
+      const std::shared_ptr<SamplerVK>& immutable_sampler) const;
+
  private:
   friend class PipelineLibraryVK;
+
+  using ImmutableSamplerVariants =
+      std::unordered_map<ImmutableSamplerKeyVK,
+                         std::shared_ptr<PipelineVK>,
+                         ComparableHash<ImmutableSamplerKeyVK>,
+                         ComparableEqual<ImmutableSamplerKeyVK>>;
 
   std::weak_ptr<DeviceHolder> device_holder_;
   vk::UniquePipeline pipeline_;
   vk::UniqueRenderPass render_pass_;
   vk::UniquePipelineLayout layout_;
   vk::UniqueDescriptorSetLayout descriptor_set_layout_;
-
+  std::shared_ptr<SamplerVK> immutable_sampler_;
+  mutable Mutex immutable_sampler_variants_mutex_;
+  mutable ImmutableSamplerVariants immutable_sampler_variants_ IPLR_GUARDED_BY(
+      immutable_sampler_variants_mutex_);
   bool is_valid_ = false;
 
   PipelineVK(std::weak_ptr<DeviceHolder> device_holder,
@@ -57,7 +73,8 @@ class PipelineVK final
              vk::UniquePipeline pipeline,
              vk::UniqueRenderPass render_pass,
              vk::UniquePipelineLayout layout,
-             vk::UniqueDescriptorSetLayout descriptor_set_layout);
+             vk::UniqueDescriptorSetLayout descriptor_set_layout,
+             std::shared_ptr<SamplerVK> immutable_sampler);
 
   // |Pipeline|
   bool IsValid() const override;

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -16,6 +16,7 @@
 namespace impeller {
 
 class CommandBufferVK;
+class SamplerVK;
 
 class RenderPassVK final : public RenderPass {
  public:
@@ -47,10 +48,9 @@ class RenderPassVK final : public RenderPass {
   size_t vertex_count_ = 0u;
   bool has_index_buffer_ = false;
   bool has_label_ = false;
-  bool pipeline_valid_ = false;
+  std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline_;
   bool pipeline_uses_input_attachments_ = false;
-  vk::DescriptorSet descriptor_set_ = {};
-  vk::PipelineLayout pipeline_layout_ = {};
+  std::shared_ptr<SamplerVK> immutable_sampler_;
 
   RenderPassVK(const std::shared_ptr<const Context>& context,
                const RenderTarget& target,

--- a/impeller/renderer/backend/vulkan/sampler_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/sampler_library_vk.cc
@@ -28,41 +28,8 @@ const std::unique_ptr<const Sampler>& SamplerLibraryVK::GetSampler(
   if (!device_holder || !device_holder->GetDevice()) {
     return kNullSampler;
   }
-
-  const auto mip_map = ToVKSamplerMipmapMode(desc.mip_filter);
-
-  const auto min_filter = ToVKSamplerMinMagFilter(desc.min_filter);
-  const auto mag_filter = ToVKSamplerMinMagFilter(desc.mag_filter);
-
-  const auto address_mode_u = ToVKSamplerAddressMode(desc.width_address_mode);
-  const auto address_mode_v = ToVKSamplerAddressMode(desc.height_address_mode);
-  const auto address_mode_w = ToVKSamplerAddressMode(desc.depth_address_mode);
-
-  const auto sampler_create_info =
-      vk::SamplerCreateInfo()
-          .setMagFilter(mag_filter)
-          .setMinFilter(min_filter)
-          .setAddressModeU(address_mode_u)
-          .setAddressModeV(address_mode_v)
-          .setAddressModeW(address_mode_w)
-          .setBorderColor(vk::BorderColor::eFloatTransparentBlack)
-          .setMipmapMode(mip_map);
-
-  auto res =
-      device_holder->GetDevice().createSamplerUnique(sampler_create_info);
-  if (res.result != vk::Result::eSuccess) {
-    FML_LOG(ERROR) << "Failed to create sampler: " << vk::to_string(res.result);
-    return kNullSampler;
-  }
-
-  auto sampler = std::make_unique<SamplerVK>(desc, std::move(res.value));
-
-  if (!desc.label.empty()) {
-    ContextVK::SetDebugName(device_holder->GetDevice(), sampler->GetSampler(),
-                            desc.label.c_str());
-  }
-
-  return (samplers_[desc] = std::move(sampler));
+  return (samplers_[desc] =
+              std::make_unique<SamplerVK>(device_holder->GetDevice(), desc));
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/sampler_vk.cc
+++ b/impeller/renderer/backend/vulkan/sampler_vk.cc
@@ -4,16 +4,123 @@
 
 #include "impeller/renderer/backend/vulkan/sampler_vk.h"
 
+#include "impeller/renderer/backend/vulkan/context_vk.h"
+#include "impeller/renderer/backend/vulkan/formats_vk.h"
+#include "impeller/renderer/backend/vulkan/yuv_conversion_vk.h"
+
 namespace impeller {
 
-SamplerVK::SamplerVK(SamplerDescriptor desc, vk::UniqueSampler sampler)
+static vk::UniqueSampler CreateSampler(
+    const vk::Device& device,
+    const SamplerDescriptor& desc,
+    const std::shared_ptr<YUVConversionVK>& yuv_conversion) {
+  const auto mip_map = ToVKSamplerMipmapMode(desc.mip_filter);
+
+  const auto min_filter = ToVKSamplerMinMagFilter(desc.min_filter);
+  const auto mag_filter = ToVKSamplerMinMagFilter(desc.mag_filter);
+
+  const auto address_mode_u = ToVKSamplerAddressMode(desc.width_address_mode);
+  const auto address_mode_v = ToVKSamplerAddressMode(desc.height_address_mode);
+  const auto address_mode_w = ToVKSamplerAddressMode(desc.depth_address_mode);
+
+  vk::StructureChain<vk::SamplerCreateInfo,
+                     // For VK_KHR_sampler_ycbcr_conversion
+                     vk::SamplerYcbcrConversionInfo>
+      sampler_chain;
+
+  auto& sampler_info = sampler_chain.get();
+
+  sampler_info.magFilter = mag_filter;
+  sampler_info.minFilter = min_filter;
+  sampler_info.addressModeU = address_mode_u;
+  sampler_info.addressModeV = address_mode_v;
+  sampler_info.addressModeW = address_mode_w;
+  sampler_info.borderColor = vk::BorderColor::eFloatTransparentBlack;
+  sampler_info.mipmapMode = mip_map;
+
+  if (yuv_conversion && yuv_conversion->IsValid()) {
+    sampler_chain.get<vk::SamplerYcbcrConversionInfo>().conversion =
+        yuv_conversion->GetConversion();
+
+    //
+    // TL;DR: When using YUV conversion, our samplers are somewhat hobbled and
+    // not all options configurable in Impeller (especially the linear
+    // filtering which is by far the most used form of filtering) can be
+    // supported. Switch to safe defaults.
+    //
+    // Spec: If sampler Y'CBCR conversion is enabled and the potential format
+    // features of the sampler Y'CBCR conversion do not support or enable
+    // separate reconstruction filters, minFilter and magFilter must be equal to
+    // the sampler Y'CBCR conversion's chromaFilter.
+    //
+    // Thing is, we don't enable separate reconstruction filters. By the time we
+    // are here, we also don't have access to the descriptor used to create this
+    // conversion. So we don't yet know what the chromaFilter is. But eNearest
+    // is a safe bet since the `AndroidHardwareBufferTextureSourceVK` defaults
+    // to that safe value. So just use that.
+    //
+    // See the validation VUID-VkSamplerCreateInfo-minFilter-01645 for more.
+    //
+    sampler_info.magFilter = vk::Filter::eNearest;
+    sampler_info.minFilter = vk::Filter::eNearest;
+
+    // Spec: If sampler Y′CBCR conversion is enabled, addressModeU,
+    // addressModeV, and addressModeW must be
+    // VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, anisotropyEnable must be VK_FALSE,
+    // and unnormalizedCoordinates must be VK_FALSE.
+    //
+    // See the validation VUID-VkSamplerCreateInfo-addressModeU-01646 for more.
+    //
+    sampler_info.addressModeU = vk::SamplerAddressMode::eClampToEdge;
+    sampler_info.addressModeV = vk::SamplerAddressMode::eClampToEdge;
+    sampler_info.addressModeW = vk::SamplerAddressMode::eClampToEdge;
+    sampler_info.anisotropyEnable = false;
+    sampler_info.unnormalizedCoordinates = false;
+  } else {
+    sampler_chain.unlink<vk::SamplerYcbcrConversionInfo>();
+  }
+
+  auto sampler = device.createSamplerUnique(sampler_chain.get());
+  if (sampler.result != vk::Result::eSuccess) {
+    VALIDATION_LOG << "Could not create sampler: "
+                   << vk::to_string(sampler.result);
+    return {};
+  }
+
+  if (!desc.label.empty()) {
+    ContextVK::SetDebugName(device, sampler.value.get(), desc.label.c_str());
+  }
+
+  return std::move(sampler.value);
+}
+
+SamplerVK::SamplerVK(const vk::Device& device,
+                     SamplerDescriptor desc,
+                     std::shared_ptr<YUVConversionVK> yuv_conversion)
     : Sampler(std::move(desc)),
-      sampler_(MakeSharedVK<vk::Sampler>(std::move(sampler))) {}
+      device_(device),
+      sampler_(MakeSharedVK<vk::Sampler>(
+          CreateSampler(device, desc_, yuv_conversion))),
+      yuv_conversion_(std::move(yuv_conversion)) {
+  is_valid_ = sampler_ && !!sampler_->Get();
+}
 
 SamplerVK::~SamplerVK() = default;
 
 vk::Sampler SamplerVK::GetSampler() const {
   return *sampler_;
+}
+
+std::shared_ptr<SamplerVK> SamplerVK::CreateVariantForConversion(
+    std::shared_ptr<YUVConversionVK> conversion) const {
+  if (!conversion || !is_valid_) {
+    return nullptr;
+  }
+  return std::make_shared<SamplerVK>(device_, desc_, std::move(conversion));
+}
+
+const std::shared_ptr<YUVConversionVK>& SamplerVK::GetYUVConversion() const {
+  return yuv_conversion_;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/sampler_vk.h
+++ b/impeller/renderer/backend/vulkan/sampler_vk.h
@@ -14,20 +14,30 @@
 namespace impeller {
 
 class SamplerLibraryVK;
+class YUVConversionVK;
 
 class SamplerVK final : public Sampler, public BackendCast<SamplerVK, Sampler> {
  public:
-  SamplerVK(SamplerDescriptor desc, vk::UniqueSampler sampler);
+  SamplerVK(const vk::Device& device,
+            SamplerDescriptor desc,
+            std::shared_ptr<YUVConversionVK> yuv_conversion = {});
 
   // |Sampler|
   ~SamplerVK() override;
 
   vk::Sampler GetSampler() const;
 
+  std::shared_ptr<SamplerVK> CreateVariantForConversion(
+      std::shared_ptr<YUVConversionVK> conversion) const;
+
+  const std::shared_ptr<YUVConversionVK>& GetYUVConversion() const;
+
  private:
   friend SamplerLibraryVK;
 
-  std::shared_ptr<SharedObjectVKT<vk::Sampler>> sampler_;
+  const vk::Device device_;
+  SharedHandleVK<vk::Sampler> sampler_;
+  std::shared_ptr<YUVConversionVK> yuv_conversion_;
   bool is_valid_ = false;
 
   SamplerVK(const SamplerVK&) = delete;

--- a/impeller/renderer/backend/vulkan/texture_source_vk.cc
+++ b/impeller/renderer/backend/vulkan/texture_source_vk.cc
@@ -14,6 +14,10 @@ const TextureDescriptor& TextureSourceVK::GetTextureDescriptor() const {
   return desc_;
 }
 
+std::shared_ptr<YUVConversionVK> TextureSourceVK::GetYUVConversion() const {
+  return nullptr;
+}
+
 vk::ImageLayout TextureSourceVK::GetLayout() const {
   ReaderLock lock(layout_mutex_);
   return layout_;

--- a/impeller/renderer/backend/vulkan/texture_source_vk.h
+++ b/impeller/renderer/backend/vulkan/texture_source_vk.h
@@ -12,57 +12,117 @@
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
 #include "impeller/renderer/backend/vulkan/shared_object_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
+#include "impeller/renderer/backend/vulkan/yuv_conversion_vk.h"
 #include "vulkan/vulkan_handles.hpp"
 
 namespace impeller {
 
-/// Abstract base class that represents a vkImage and an vkImageView.
+//------------------------------------------------------------------------------
+/// @brief      Abstract base class that represents a vkImage and an
+///             vkImageView.
 ///
-/// This is intended to be used with an impeller::TextureVK. Example
-/// implementations represent swapchain images or uploaded textures.
+///             This is intended to be used with an impeller::TextureVK. Example
+///             implementations represent swapchain images, uploaded textures,
+///             Android Hardware Buffer backend textures, etc...
+///
 class TextureSourceVK {
  public:
   virtual ~TextureSourceVK();
 
+  //----------------------------------------------------------------------------
+  /// @brief      Gets the texture descriptor for this image source.
+  ///
+  /// @warning    Texture descriptors from texture sources whose capabilities
+  ///             are a superset of those that can be expressed with Vulkan
+  ///             (like Android Hardware Buffer) are inferred. Stuff like size,
+  ///             mip-counts, types is reliable. So use these descriptors as
+  ///             advisory. Creating copies of texture sources from these
+  ///             descriptors is usually not possible and  depends on the
+  ///             allocator used.
+  ///
+  /// @return     The texture descriptor.
+  ///
   const TextureDescriptor& GetTextureDescriptor() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Get the image handle for this texture source.
+  ///
+  /// @return     The image.
+  ///
   virtual vk::Image GetImage() const = 0;
 
-  /// @brief Retrieve the image view used for sampling/blitting/compute with
-  ///        this texture source.
+  //----------------------------------------------------------------------------
+  /// @brief      Retrieve the image view used for sampling/blitting/compute
+  ///             with this texture source.
+  ///
+  /// @return     The image view.
+  ///
   virtual vk::ImageView GetImageView() const = 0;
 
-  /// @brief Retrieve the image view used for render target attachments
-  ///        with this texture source.
+  //----------------------------------------------------------------------------
+  /// @brief      Retrieve the image view used for render target attachments
+  ///             with this texture source.
   ///
-  /// ImageViews used as render target attachments cannot have any mip levels.
-  /// In cases where we want to generate mipmaps with the result of this
-  /// texture, we need to create multiple image views.
+  ///             ImageViews used as render target attachments cannot have any
+  ///             mip levels. In cases where we want to generate mipmaps with
+  ///             the result of this texture, we need to create multiple image
+  ///             views.
+  ///
+  /// @return     The render target view.
+  ///
   virtual vk::ImageView GetRenderTargetView() const = 0;
 
-  /// Encodes the layout transition `barrier` to `barrier.cmd_buffer` for the
-  /// image.
+  //----------------------------------------------------------------------------
+  /// @brief      Encodes the layout transition `barrier` to
+  ///             `barrier.cmd_buffer` for the image.
   ///
-  /// The transition is from the layout stored via `SetLayoutWithoutEncoding` to
-  /// `barrier.new_layout`.
+  ///             The transition is from the layout stored via
+  ///             `SetLayoutWithoutEncoding` to `barrier.new_layout`.
+  ///
+  /// @param[in]  barrier  The barrier.
+  ///
+  /// @return     If the layout transition was successfully made.
+  ///
   fml::Status SetLayout(const BarrierVK& barrier) const;
 
-  /// Store the layout of the image.
+  //----------------------------------------------------------------------------
+  /// @brief      Store the layout of the image.
   ///
-  /// This just is bookkeeping on the CPU, to actually set the layout use
-  /// `SetLayout`.
+  ///             This just is bookkeeping on the CPU, to actually set the
+  ///             layout use `SetLayout`.
   ///
-  /// @param layout The new layout.
-  /// @return The old layout.
+  /// @param[in]  layout  The new layout.
+  ///
+  /// @return     The old layout.
+  ///
   vk::ImageLayout SetLayoutWithoutEncoding(vk::ImageLayout layout) const;
 
-  /// Get the last layout assigned to the TextureSourceVK.
+  //----------------------------------------------------------------------------
+  /// @brief      Get the last layout assigned to the TextureSourceVK.
   ///
-  /// This value is synchronized with the GPU via SetLayout so it may not
-  /// reflect the actual layout.
+  ///             This value is synchronized with the GPU via SetLayout so it
+  ///             may not reflect the actual layout.
+  ///
+  /// @return     The last known layout of the texture source.
+  ///
   vk::ImageLayout GetLayout() const;
 
-  /// Whether or not this is a swapchain image.
+  //----------------------------------------------------------------------------
+  /// @brief      When sampling from textures whose formats are not known to
+  ///             Vulkan, a custom conversion is necessary to setup custom
+  ///             samplers. This accessor provides this conversion if one is
+  ///             present. Most texture source have none.
+  ///
+  /// @return     The sampler conversion.
+  ///
+  virtual std::shared_ptr<YUVConversionVK> GetYUVConversion() const;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Determines if swapchain image. That is, an image used as the
+  ///             root render target.
+  ///
+  /// @return     Whether or not this is a swapchain image.
+  ///
   virtual bool IsSwapchainImage() const = 0;
 
  protected:

--- a/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -7,6 +7,7 @@
 #include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/command_encoder_vk.h"
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
+#include "impeller/renderer/backend/vulkan/sampler_vk.h"
 
 namespace impeller {
 
@@ -189,6 +190,28 @@ SharedHandleVK<vk::Framebuffer> TextureVK::GetFramebuffer() const {
 
 SharedHandleVK<vk::RenderPass> TextureVK::GetRenderPass() const {
   return render_pass_;
+}
+
+void TextureVK::SetMipMapGenerated() {
+  mipmap_generated_ = true;
+}
+
+bool TextureVK::IsSwapchainImage() const {
+  return source_->IsSwapchainImage();
+}
+
+std::shared_ptr<SamplerVK> TextureVK::GetImmutableSamplerVariant(
+    const SamplerVK& sampler) const {
+  if (!source_) {
+    return nullptr;
+  }
+  auto conversion = source_->GetYUVConversion();
+  if (!conversion) {
+    // Most textures don't need a sampler conversion and will go down this path.
+    // Only needed for YUV sampling from external textures.
+    return nullptr;
+  }
+  return sampler.CreateVariantForConversion(std::move(conversion));
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/impeller/renderer/backend/vulkan/texture_vk.h
@@ -10,6 +10,7 @@
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/device_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
+#include "impeller/renderer/backend/vulkan/sampler_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_source_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
 
@@ -40,9 +41,12 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
   // |Texture|
   ISize GetSize() const override;
 
-  void SetMipMapGenerated() { mipmap_generated_ = true; }
+  void SetMipMapGenerated();
 
-  bool IsSwapchainImage() const { return source_->IsSwapchainImage(); }
+  bool IsSwapchainImage() const;
+
+  std::shared_ptr<SamplerVK> GetImmutableSamplerVariant(
+      const SamplerVK& sampler) const;
 
   // These methods should only be used by render_pass_vk.h
 

--- a/impeller/renderer/backend/vulkan/yuv_conversion_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/yuv_conversion_library_vk.cc
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/yuv_conversion_library_vk.h"
+
+#include "impeller/base/validation.h"
+#include "impeller/renderer/backend/vulkan/device_holder.h"
+
+namespace impeller {
+
+YUVConversionLibraryVK::YUVConversionLibraryVK(
+    std::weak_ptr<DeviceHolder> device_holder)
+    : device_holder_(std::move(device_holder)) {}
+
+YUVConversionLibraryVK::~YUVConversionLibraryVK() = default;
+
+std::shared_ptr<YUVConversionVK> YUVConversionLibraryVK::GetConversion(
+    const YUVConversionDescriptorVK& desc) {
+  Lock lock(conversions_mutex_);
+  auto found = conversions_.find(desc);
+  if (found != conversions_.end()) {
+    return found->second;
+  }
+  auto device_holder = device_holder_.lock();
+  if (!device_holder) {
+    VALIDATION_LOG << "Context loss during creation of YUV conversion.";
+    return nullptr;
+  }
+  return (conversions_[desc] = std::shared_ptr<YUVConversionVK>(
+              new YUVConversionVK(device_holder->GetDevice(), desc)));
+}
+
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/yuv_conversion_library_vk.h
+++ b/impeller/renderer/backend/vulkan/yuv_conversion_library_vk.h
@@ -1,0 +1,65 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_YUV_CONVERSION_LIBRARY_VK_H_
+#define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_YUV_CONVERSION_LIBRARY_VK_H_
+
+#include "impeller/renderer/backend/vulkan/yuv_conversion_vk.h"
+
+namespace impeller {
+
+class DeviceHolder;
+
+//------------------------------------------------------------------------------
+/// @brief      Due the way the Vulkan spec. treats "identically defined"
+///             conversions, creating two conversion with identical descriptors,
+///             using one with the image and the other with the sampler, is
+///             invalid use.
+///
+///             A conversion library hashes and caches identical descriptors to
+///             de-duplicate conversions.
+///
+///             There can only be one conversion library (the constructor is
+///             private to force this) and it found in the context.
+///
+class YUVConversionLibraryVK {
+ public:
+  ~YUVConversionLibraryVK();
+
+  YUVConversionLibraryVK(const YUVConversionLibraryVK&) = delete;
+
+  YUVConversionLibraryVK& operator=(const YUVConversionLibraryVK&) = delete;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Get a conversion for the given descriptor. If there is already
+  ///             a conversion created for an equivalent descriptor, a reference
+  ///             to that descriptor is returned instead.
+  ///
+  /// @param[in]  desc  The descriptor.
+  ///
+  /// @return     The conversion. A previously created conversion if one was
+  ///             present and a new one if not. A newly created conversion is
+  ///             cached for subsequent accesses.
+  ///
+  std::shared_ptr<YUVConversionVK> GetConversion(
+      const YUVConversionDescriptorVK& chain);
+
+ private:
+  friend class ContextVK;
+
+  using ConversionsMap = std::unordered_map<YUVConversionDescriptorVK,
+                                            std::shared_ptr<YUVConversionVK>,
+                                            YUVConversionDescriptorVKHash,
+                                            YUVConversionDescriptorVKEqual>;
+
+  std::weak_ptr<DeviceHolder> device_holder_;
+  Mutex conversions_mutex_;
+  ConversionsMap conversions_ IPLR_GUARDED_BY(conversions_mutex_);
+
+  explicit YUVConversionLibraryVK(std::weak_ptr<DeviceHolder> device_holder);
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_YUV_CONVERSION_LIBRARY_VK_H_

--- a/impeller/renderer/backend/vulkan/yuv_conversion_vk.cc
+++ b/impeller/renderer/backend/vulkan/yuv_conversion_vk.cc
@@ -1,0 +1,118 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/renderer/backend/vulkan/yuv_conversion_vk.h"
+
+#include "flutter/fml/hash_combine.h"
+#include "impeller/base/validation.h"
+#include "impeller/renderer/backend/vulkan/device_holder.h"
+#include "impeller/renderer/backend/vulkan/sampler_vk.h"
+
+namespace impeller {
+
+YUVConversionVK::YUVConversionVK(const vk::Device& device,
+                                 const YUVConversionDescriptorVK& chain)
+    : chain_(chain) {
+  auto conversion = device.createSamplerYcbcrConversionUnique(chain_.get());
+  if (conversion.result != vk::Result::eSuccess) {
+    VALIDATION_LOG << "Could not create YUV conversion: "
+                   << vk::to_string(conversion.result);
+    return;
+  }
+  conversion_ = std::move(conversion.value);
+}
+
+YUVConversionVK::~YUVConversionVK() = default;
+
+bool YUVConversionVK::IsValid() const {
+  return conversion_ && !!conversion_.get();
+}
+
+vk::SamplerYcbcrConversion YUVConversionVK::GetConversion() const {
+  return conversion_ ? conversion_.get() : VK_NULL_HANDLE;
+}
+
+const YUVConversionDescriptorVK& YUVConversionVK::GetDescriptor() const {
+  return chain_;
+}
+
+std::size_t YUVConversionDescriptorVKHash::operator()(
+    const YUVConversionDescriptorVK& desc) const {
+  // Hashers in Vulkan HPP hash the pNext member which isn't what we want for
+  // these to be stable.
+  const auto& conv = desc.get();
+
+  std::size_t hash = fml::HashCombine(conv.format,                      //
+                                      conv.ycbcrModel,                  //
+                                      conv.ycbcrRange,                  //
+                                      conv.components.r,                //
+                                      conv.components.g,                //
+                                      conv.components.b,                //
+                                      conv.components.a,                //
+                                      conv.xChromaOffset,               //
+                                      conv.yChromaOffset,               //
+                                      conv.chromaFilter,                //
+                                      conv.forceExplicitReconstruction  //
+  );
+#if FML_OS_ANDROID
+  const auto external_format = desc.get<vk::ExternalFormatANDROID>();
+  fml::HashCombineSeed(hash, external_format.externalFormat);
+#endif  // FML_OS_ANDROID
+
+  return hash;
+};
+
+bool YUVConversionDescriptorVKEqual::operator()(
+    const YUVConversionDescriptorVK& lhs_desc,
+    const YUVConversionDescriptorVK& rhs_desc) const {
+  // Default equality checks in Vulkan HPP checks pNext member members by
+  // pointer which isn't what we want.
+  {
+    const auto& lhs = lhs_desc.get();
+    const auto& rhs = rhs_desc.get();
+
+    if (lhs.format != rhs.format ||                                         //
+        lhs.ycbcrModel != rhs.ycbcrModel ||                                 //
+        lhs.ycbcrRange != rhs.ycbcrRange ||                                 //
+        lhs.components.r != rhs.components.r ||                             //
+        lhs.components.g != rhs.components.g ||                             //
+        lhs.components.b != rhs.components.b ||                             //
+        lhs.components.a != rhs.components.a ||                             //
+        lhs.xChromaOffset != rhs.xChromaOffset ||                           //
+        lhs.yChromaOffset != rhs.yChromaOffset ||                           //
+        lhs.chromaFilter != rhs.chromaFilter ||                             //
+        lhs.forceExplicitReconstruction != rhs.forceExplicitReconstruction  //
+    ) {
+      return false;
+    }
+  }
+#if FML_OS_ANDROID
+  {
+    const auto lhs = lhs_desc.get<vk::ExternalFormatANDROID>();
+    const auto rhs = rhs_desc.get<vk::ExternalFormatANDROID>();
+    return lhs.externalFormat == rhs.externalFormat;
+  }
+#else   // FML_OS_ANDROID
+  return true;
+#endif  // FML_OS_ANDROID
+}
+
+ImmutableSamplerKeyVK::ImmutableSamplerKeyVK(const SamplerVK& sampler)
+    : sampler(sampler.GetDescriptor()) {
+  if (const auto& conversion = sampler.GetYUVConversion()) {
+    yuv_conversion = conversion->GetDescriptor();
+  }
+}
+
+bool ImmutableSamplerKeyVK::IsEqual(const ImmutableSamplerKeyVK& other) const {
+  return sampler.IsEqual(other.sampler) &&
+         YUVConversionDescriptorVKEqual{}(yuv_conversion, other.yuv_conversion);
+}
+
+std::size_t ImmutableSamplerKeyVK::GetHash() const {
+  return fml::HashCombine(sampler.GetHash(),
+                          YUVConversionDescriptorVKHash{}(yuv_conversion));
+}
+
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/yuv_conversion_vk.h
+++ b/impeller/renderer/backend/vulkan/yuv_conversion_vk.h
@@ -1,0 +1,109 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_YUV_CONVERSION_VK_H_
+#define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_YUV_CONVERSION_VK_H_
+
+#include <unordered_map>
+
+#include "flutter/fml/build_config.h"
+#include "impeller/base/comparable.h"
+#include "impeller/base/thread.h"
+#include "impeller/core/sampler.h"
+#include "impeller/renderer/backend/vulkan/sampler_vk.h"
+#include "impeller/renderer/backend/vulkan/shared_object_vk.h"
+#include "impeller/renderer/backend/vulkan/vk.h"
+
+namespace impeller {
+
+//------------------------------------------------------------------------------
+/// A descriptor used to create a new YUV conversion in a conversion library.
+///
+using YUVConversionDescriptorVK =
+    vk::StructureChain<vk::SamplerYcbcrConversionCreateInfo
+#if FML_OS_ANDROID
+                       // For VK_ANDROID_external_memory_android_hardware_buffer
+                       ,
+                       vk::ExternalFormatANDROID
+#endif  // FML_OS_ANDROID
+                       >;
+
+class YUVConversionLibraryVK;
+
+//------------------------------------------------------------------------------
+/// @brief      It is sometimes necessary to deal with formats not native to
+///             Vulkan. In such cases, extra information is necessary to access
+///             images. A YUV conversion object is needed in such instances.
+///
+///             There are usually only a handful of viable conversions in a
+///             given context. However, due to the way the Vulkan spec. treats
+///             "identically defined" conversions, only a single conversion
+///             object is valid for an equivalent `YUVConversionDescriptorVK`.
+///             Because of this restriction, it is not possible to just create a
+///             conversion from a descriptor (as the underlying handles will be
+///             equivalent but different). Instead, a conversion may only be
+///             obtained from a conversion library. Libraries handle hashing and
+///             caching conversions by descriptor. Caller can find a library on
+///             the top-level context. They may not create their own (the
+///             constructor is private).
+///
+class YUVConversionVK final {
+ public:
+  ~YUVConversionVK();
+
+  YUVConversionVK(const YUVConversionVK&) = delete;
+
+  YUVConversionVK& operator=(const YUVConversionVK&) = delete;
+
+  //----------------------------------------------------------------------------
+  /// @return     `true` if this conversion is valid for use with images and
+  ///             samplers.
+  ///
+  bool IsValid() const;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Get the descriptor used to create this conversion.
+  ///
+  const YUVConversionDescriptorVK& GetDescriptor() const;
+
+  //----------------------------------------------------------------------------
+  /// @return     The Vulkan handle of the YUV conversion.
+  ///
+  vk::SamplerYcbcrConversion GetConversion() const;
+
+ private:
+  friend class YUVConversionLibraryVK;
+
+  YUVConversionDescriptorVK chain_;
+  vk::UniqueSamplerYcbcrConversion conversion_;
+
+  YUVConversionVK(const vk::Device& device,
+                  const YUVConversionDescriptorVK& chain);
+};
+
+struct YUVConversionDescriptorVKHash {
+  std::size_t operator()(const YUVConversionDescriptorVK& object) const;
+};
+
+struct YUVConversionDescriptorVKEqual {
+  bool operator()(const YUVConversionDescriptorVK& lhs,
+                  const YUVConversionDescriptorVK& rhs) const;
+};
+
+struct ImmutableSamplerKeyVK : public Comparable<ImmutableSamplerKeyVK> {
+  SamplerDescriptor sampler;
+  YUVConversionDescriptorVK yuv_conversion;
+
+  explicit ImmutableSamplerKeyVK(const SamplerVK& sampler);
+
+  // |Comparable<ImmutableSamplerKey>|
+  std::size_t GetHash() const override;
+
+  // |Comparable<ImmutableSamplerKey>|
+  bool IsEqual(const ImmutableSamplerKeyVK& other) const override;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_YUV_CONVERSION_VK_H_

--- a/shell/platform/android/image_external_texture_vk.cc
+++ b/shell/platform/android/image_external_texture_vk.cc
@@ -54,18 +54,9 @@ void ImageExternalTextureVK::ProcessFrame(PaintContext& context,
     return;
   }
 
-  impeller::TextureDescriptor desc;
-  desc.storage_mode = impeller::StorageMode::kDevicePrivate;
-  desc.size = {static_cast<int>(bounds.width()),
-               static_cast<int>(bounds.height())};
-  // TODO(johnmccutchan): Use hb_desc to compute the correct format at runtime.
-  desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
-  desc.mip_count = 1;
-
   auto texture_source =
       std::make_shared<impeller::AndroidHardwareBufferTextureSourceVK>(
-          desc, impeller_context_->GetDevice(), latest_hardware_buffer,
-          hb_desc);
+          impeller_context_, latest_hardware_buffer, hb_desc);
 
   auto texture =
       std::make_shared<impeller::TextureVK>(impeller_context_, texture_source);


### PR DESCRIPTION
This patch rounds out support for importing Android Hardware Buffers as Vulkan
images and sampling from them.

Not all Android Hardware Buffers are in formats that Vulkan (let alone Impeller)
understands. Some YUV textures have formats with no equivalent `vk::Format` enum
and need extra information on how to sample from them.

This patch adds support for correctly importing and sampling from such formats.

There are severe restrictions on how sampling from such external formats works.
For one, it isn’t possible to assign a combined image sampler in the render
pass. The pipeline itself needs to be rebuilt to reference a specially created
immutable sampler. This immutable sampler is a combination of the usual
information present in an Impeller SamplerDescriptor as well as a custom
“conversion” object obtained while importing the Android Hardware Buffer.

There is no way to predict what conversion object will be necessary ahead of
time as this will depend on the source of the Android Hardware Buffers and is
likely different for different video feeds, camera sources, and other Android
Hardware Buffer texture sources.

To handle this uncertainty, a new pipeline variant with a JIT determined
immutable sampler will be hashed and cached before being used in a render pass.
The number of pipeline variants created just-in-time will depend on the number
of sampler variants used in the render pass to sample from wrapped Image. For
instance, specifying a sampler with a different address mode will likely result
in a new pipeline variant being created.

In most cases however, there will just be one or two additional pipeline
variants per application. Impellers sampler diversity is very low with most
samplers being the usual NN samplers. It may be possible to preload even this
pipeline by trying known conversions. As said previously, there can only be a
handful of these conversions.

More restrictions on sampling from such images includes being limited to
`VK_FILTER_LINEAR` without additional format and extension wrangling and
performance penalties.

Fixes https://github.com/flutter/flutter/issues/142082.