### PR TITLE
[Impeller] force bootstrap render pass.

### DIFF
--- a/impeller/aiks/testing/context_mock.h
+++ b/impeller/aiks/testing/context_mock.h
@@ -117,6 +117,11 @@ class ContextMock : public Context {
               (const override));
 
   MOCK_METHOD(void, Shutdown, (), (override));
+
+  MOCK_METHOD(void,
+              InitializeCommonlyUsedShadersIfNeeded,
+              (),
+              (const, override));
 };
 
 }  // namespace testing

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -612,12 +612,14 @@ void ContentContext::FlushCommandBuffers() const {
 }
 
 void ContentContext::InitializeCommonlyUsedShadersIfNeeded() const {
+  TRACE_EVENT0("flutter", "InitializeCommonlyUsedShadersIfNeeded");
+  GetContext()->InitializeCommonlyUsedShadersIfNeeded();
+
   if (GetContext()->GetBackendType() == Context::BackendType::kOpenGLES) {
     // TODO(jonahwilliams): The OpenGL Embedder Unittests hang if this code
     // runs.
     return;
   }
-  TRACE_EVENT0("flutter", "InitializeCommonlyUsedShadersIfNeeded");
 
   // Initialize commonly used shaders that aren't defaults. These settings were
   // chosen based on the knowledge that we mix and match triangle and

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -6,6 +6,8 @@
 
 #include "fml/concurrent_message_loop.h"
 #include "impeller/renderer/backend/vulkan/command_queue_vk.h"
+#include "impeller/renderer/backend/vulkan/render_pass_builder_vk.h"
+#include "impeller/renderer/render_target.h"
 
 #ifdef FML_OS_ANDROID
 #include <pthread.h>
@@ -570,6 +572,48 @@ std::shared_ptr<DescriptorPoolRecyclerVK> ContextVK::GetDescriptorPoolRecycler()
 
 std::shared_ptr<CommandQueue> ContextVK::GetCommandQueue() const {
   return command_queue_vk_;
+}
+
+// Creating a render pass is observed to take an additional 6ms on a Pixel 7
+// device as the driver will lazily bootstrap and compile shaders to do so.
+// The render pass does not need to be begun or executed.
+void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
+  FML_LOG(ERROR) << "a";
+  RenderTargetAllocator rt_allocator(GetResourceAllocator());
+  RenderTarget render_target =
+      RenderTarget::CreateOffscreenMSAA(*this, rt_allocator, {1, 1}, 1);
+
+  RenderPassBuilderVK builder;
+  for (const auto& [bind_point, color] : render_target.GetColorAttachments()) {
+    builder.SetColorAttachment(
+        bind_point,                                          //
+        color.texture->GetTextureDescriptor().format,        //
+        color.texture->GetTextureDescriptor().sample_count,  //
+        color.load_action,                                   //
+        color.store_action                                   //
+    );
+  }
+
+  if (auto depth = render_target.GetDepthAttachment(); depth.has_value()) {
+    builder.SetDepthStencilAttachment(
+        depth->texture->GetTextureDescriptor().format,        //
+        depth->texture->GetTextureDescriptor().sample_count,  //
+        depth->load_action,                                   //
+        depth->store_action                                   //
+    );
+  }
+
+  if (auto stencil = render_target.GetStencilAttachment();
+      stencil.has_value()) {
+    builder.SetStencilAttachment(
+        stencil->texture->GetTextureDescriptor().format,        //
+        stencil->texture->GetTextureDescriptor().sample_count,  //
+        stencil->load_action,                                   //
+        stencil->store_action                                   //
+    );
+  }
+
+  auto pass = builder.Build(GetDevice());
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -158,6 +158,8 @@ class ContextVK final : public Context,
 
   void RecordFrameEndTime() const;
 
+  void InitializeCommonlyUsedShadersIfNeeded() const override;
+
  private:
   struct DeviceHolderImpl : public DeviceHolder {
     // |DeviceHolder|

--- a/impeller/renderer/backend/vulkan/surface_context_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.cc
@@ -122,4 +122,8 @@ const vk::Device& SurfaceContextVK::GetDevice() const {
   return parent_->GetDevice();
 }
 
+void SurfaceContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
+  parent_->InitializeCommonlyUsedShadersIfNeeded();
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/surface_context_vk.h
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.h
@@ -78,6 +78,8 @@ class SurfaceContextVK : public Context,
   ///        recreated on the next frame.
   void UpdateSurfaceSize(const ISize& size) const;
 
+  void InitializeCommonlyUsedShadersIfNeeded() const override;
+
 #ifdef FML_OS_ANDROID
   vk::UniqueSurfaceKHR CreateAndroidSurface(ANativeWindow* window) const;
 #endif  // FML_OS_ANDROID

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -186,6 +186,14 @@ class Context {
     FML_CHECK(false && "not supported in this context");
   }
 
+  /// Run backend specific additional setup and create common shader variants.
+  ///
+  /// This bootstrap is intended to improve the performance of several
+  /// first frame benchmarks that are tracked in the flutter device lab.
+  /// The workload includes initializing commonly used but not default
+  /// shader variants, as well as forcing driver initialization.
+  virtual void InitializeCommonlyUsedShadersIfNeeded() const {}
+
  protected:
   Context();
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/138236

Creating the first VkRenderPass takes 6ms on a Pixel 7.

In the previous PR I attempted to use the Impeller HAL API, but this caused more problems than it solved - breaking mocks and also leading to odd behavior I think may be due to threading issues when submitting the bootstrap cmd buffer.

It seems like all we need to do to trigger the shader compilation is create the render pass, so add a ContextVK override that creates and throws it away, without beginning the render pass, creating a cmd buffer, or doing any extra work.