### PR TITLE
[Impeller] add missing std::move in setup depth stencil.

### DIFF
--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -394,7 +394,7 @@ void RenderTarget::SetupDepthStencilAttachments(
   stencil0.load_action = stencil_attachment_config.load_action;
   stencil0.store_action = stencil_attachment_config.store_action;
   stencil0.clear_stencil = 0u;
-  stencil0.texture = depth_stencil_texture;
+  stencil0.texture = std::move(depth_stencil_texture);
 
   stencil0.texture->SetLabel(
       SPrintF("%s Depth+Stencil Texture", label.c_str()));


### PR DESCRIPTION
We copy the std::shared_ptr since both the stencil and depth attachments need to reference this shared ptr. The second usage can still be moved to avoid a shared_ptr release.