### PR TITLE
[WIP] Investigate keyboard state sync on Windows

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -383,6 +383,9 @@ class FlutterWindowsEngine {
   // Handlers for keyboard events from Windows.
   std::unique_ptr<KeyboardHandlerBase> keyboard_key_handler_;
 
+  // Wether the framework is ready to receive keyboard events.
+  bool canSendKeyboardEvents_ = false;
+
   // Handlers for text events from Windows.
   std::unique_ptr<TextInputPlugin> text_input_plugin_;
 

--- a/shell/platform/windows/keyboard_key_channel_handler.h
+++ b/shell/platform/windows/keyboard_key_channel_handler.h
@@ -24,9 +24,12 @@ namespace flutter {
 class KeyboardKeyChannelHandler
     : public KeyboardKeyHandler::KeyboardKeyHandlerDelegate {
  public:
+  using CanSendHandler = std::function<bool()>;
+
   // Create a |KeyboardKeyChannelHandler| by specifying the messenger
   // through which the events are sent.
-  explicit KeyboardKeyChannelHandler(flutter::BinaryMessenger* messenger);
+  explicit KeyboardKeyChannelHandler(flutter::BinaryMessenger* messenger,
+                                     CanSendHandler can_send);
 
   ~KeyboardKeyChannelHandler();
 
@@ -46,6 +49,9 @@ class KeyboardKeyChannelHandler
  private:
   // The Flutter system channel for key event messages.
   std::unique_ptr<flutter::BasicMessageChannel<rapidjson::Document>> channel_;
+
+  // A callback which returns a bool indicating if key events can be sent.
+  CanSendHandler can_send_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(KeyboardKeyChannelHandler);
 };

--- a/shell/platform/windows/keyboard_key_channel_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler_unittests.cc
@@ -51,7 +51,7 @@ TEST(KeyboardKeyChannelHandlerTest, KeyboardHookHandling) {
         }
       });
 
-  KeyboardKeyChannelHandler handler(&messenger);
+  KeyboardKeyChannelHandler handler(&messenger, []() { return true; });
   bool last_handled = false;
 
   handler.KeyboardHook(
@@ -106,7 +106,7 @@ TEST(KeyboardKeyChannelHandlerTest, ExtendedKeysAreSentToRedispatch) {
         }
       });
 
-  KeyboardKeyChannelHandler handler(&messenger);
+  KeyboardKeyChannelHandler handler(&messenger, []() { return true; });
   bool last_handled = true;
 
   // Extended key flag is passed to redispatched events if set.
@@ -140,7 +140,8 @@ TEST(KeyboardKeyChannelHandlerTest, DeadKeysDoNotCrash) {
         return true;
       });
 
-  KeyboardKeyChannelHandler handler(&messenger);
+  KeyboardKeyChannelHandler handler(&messenger, []() { return true; });
+
   // Extended key flag is passed to redispatched events if set.
   handler.KeyboardHook(0xDD, 0x1a, WM_KEYDOWN, 0x8000005E, false, false,
                        [](bool handled) {});
@@ -164,7 +165,8 @@ TEST(KeyboardKeyChannelHandlerTest, EmptyResponsesDoNotCrash) {
         return true;
       });
 
-  KeyboardKeyChannelHandler handler(&messenger);
+  KeyboardKeyChannelHandler handler(&messenger, []() { return true; });
+
   handler.KeyboardHook(64, kUnhandledScanCode, WM_KEYDOWN, L'b', false, false,
                        [](bool handled) {});
 


### PR DESCRIPTION
## Description

This is a WIP PR to evaluate how https://github.com/flutter/engine/pull/44827 can help to find a solution for https://github.com/flutter/flutter/issues/125975.

This PR makes it a little more difficult to reproduce https://github.com/flutter/flutter/issues/125975 but unfortunately, it does not fix the issue fully.

From my local experimentation, it seems that, with this PR, the engine key pressed state can be updated just after the framework queried the state and before the framework registered key channel handlers (this leads to framework and engine key pressed state being different).

My guess is that this happens because of the async call on the framework side:

```dart
    _keyboard.syncKeyboardState().then((_) {
      platformDispatcher.onKeyData = _keyEventManager.handleKeyData;
      SystemChannels.keyEvent.setMessageHandler(_keyEventManager.handleRawKeyMessage);
    });
```

See https://github.com/flutter/flutter/blob/74e054f04ae59cd9e721710f183f53897b3c9ded/packages/flutter/lib/src/services/binding.dart#L83-L86


## Related Issue

Related https://github.com/flutter/flutter/issues/125975

## Tests

WIP only
