### PR TITLE
[Web] Update modifier state when Meta key is seen as Process key

### DIFF
--- a/lib/web_ui/lib/src/engine/raw_keyboard.dart
+++ b/lib/web_ui/lib/src/engine/raw_keyboard.dart
@@ -123,6 +123,10 @@ class RawKeyboard {
       } else if (event.key == 'Meta' && operatingSystem == OperatingSystem.linux) {
         // On Chrome Linux, metaState can be wrong when a Meta key is pressed.
         _lastMetaState |= _modifierMeta;
+      } else if (event.code == 'MetaLeft' && event.key == 'Process') {
+        // When Meta key is pressed, browsers can emit an event whose key is 'Process'.
+        // See https://github.com/flutter/flutter/issues/141186.
+        _lastMetaState |= _modifierMeta;
       }
     }
     final Map<String, dynamic> eventData = <String, dynamic>{


### PR DESCRIPTION
## Description

On Web, browsers can emit key events with a logical key sets to `Process` when the physical key is MetaLeft. Because the modifier state is 0 despite Meta key being pressed this will trigger an assert.
This PR adds some logic for this specific case. Maybe a more slightly broader solution will be needed (using the same logic for all modifiers ?). I focused on MetaLeft because it was directly reported on  https://github.com/flutter/flutter/issues/141186.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/141186.

## Tests

Adds 1 test.