### PR TITLE
[Impeller] more nullchecks in image decoder.

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -556,6 +556,9 @@ std::shared_ptr<impeller::DeviceBuffer> ImpellerAllocator::GetDeviceBuffer()
 }
 
 bool ImpellerAllocator::allocPixelRef(SkBitmap* bitmap) {
+  if (!bitmap) {
+    return false;
+  }
   const SkImageInfo& info = bitmap->info();
   if (kUnknown_SkColorType == info.colorType() || info.width() < 0 ||
       info.height() < 0 || !info.validRowBytes(bitmap->rowBytes())) {
@@ -571,6 +574,9 @@ bool ImpellerAllocator::allocPixelRef(SkBitmap* bitmap) {
       kShouldUseMallocDeviceBuffer
           ? std::make_shared<MallocDeviceBuffer>(descriptor)
           : allocator_->CreateBuffer(descriptor);
+  if (!device_buffer) {
+    return false;
+  }
 
   struct ImpellerPixelRef final : public SkPixelRef {
     ImpellerPixelRef(int w, int h, void* s, size_t r)

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -1050,6 +1050,13 @@ TEST_F(ImageDecoderFixtureTest,
   PostTaskSync(runners.GetIOTaskRunner(), [&]() { io_manager.reset(); });
 }
 
+TEST_F(ImageDecoderFixtureTest, NullCheckBuffer) {
+  auto context = std::make_shared<impeller::TestImpellerContext>();
+  auto allocator = ImpellerAllocator(context.GetResourceAllocator());
+
+  EXPECT_FALSE(allocator.allocPixelRef(nullptr));
+}
+
 }  // namespace testing
 }  // namespace flutter
 

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -1052,7 +1052,7 @@ TEST_F(ImageDecoderFixtureTest,
 
 TEST_F(ImageDecoderFixtureTest, NullCheckBuffer) {
   auto context = std::make_shared<impeller::TestImpellerContext>();
-  auto allocator = ImpellerAllocator(context.GetResourceAllocator());
+  auto allocator = ImpellerAllocator(context->GetResourceAllocator());
 
   EXPECT_FALSE(allocator.allocPixelRef(nullptr));
 }


### PR DESCRIPTION
Speculative fix for https://github.com/flutter/flutter/issues/138897 which cannot be reprouced.