### PR TITLE
[Windows] Add ID to views

### DIFF
--- a/shell/platform/windows/accessibility_bridge_windows_unittests.cc
+++ b/shell/platform/windows/accessibility_bridge_windows_unittests.cc
@@ -91,7 +91,7 @@ class FlutterWindowsViewSpy : public FlutterWindowsView {
  public:
   FlutterWindowsViewSpy(FlutterWindowsEngine* engine,
                         std::unique_ptr<WindowBindingHandler> handler)
-      : FlutterWindowsView(engine, std::move(handler)) {}
+      : FlutterWindowsView(kImplicitViewId, engine, std::move(handler)) {}
 
  protected:
   virtual std::shared_ptr<AccessibilityBridgeWindows>

--- a/shell/platform/windows/compositor_opengl.cc
+++ b/shell/platform/windows/compositor_opengl.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/windows/compositor_opengl.h"
 
 #include "GLES3/gl3.h"
+#include "flutter/shell/platform/windows/flutter_windows_engine.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 
 namespace flutter {
@@ -93,7 +94,9 @@ bool CompositorOpenGL::CollectBackingStore(const FlutterBackingStore* store) {
 
 bool CompositorOpenGL::Present(const FlutterLayer** layers,
                                size_t layers_count) {
-  FlutterWindowsView* view = engine_->view();
+  // TODO(loicsharma): Remove implicit view assumption.
+  // https://github.com/flutter/flutter/issues/142845
+  FlutterWindowsView* view = engine_->view(kImplicitViewId);
   if (!view) {
     return false;
   }

--- a/shell/platform/windows/compositor_opengl_unittests.cc
+++ b/shell/platform/windows/compositor_opengl_unittests.cc
@@ -95,8 +95,8 @@ class CompositorOpenGLTest : public WindowsTest {
     EXPECT_CALL(*window.get(), SetView).Times(1);
     EXPECT_CALL(*window.get(), GetWindowHandle).WillRepeatedly(Return(nullptr));
 
-    view_ =
-        std::make_unique<FlutterWindowsView>(engine_.get(), std::move(window));
+    view_ = std::make_unique<FlutterWindowsView>(kImplicitViewId, engine_.get(),
+                                                 std::move(window));
 
     if (add_surface) {
       auto surface = std::make_unique<egl::MockWindowSurface>();

--- a/shell/platform/windows/compositor_software.cc
+++ b/shell/platform/windows/compositor_software.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/windows/compositor_software.h"
 
+#include "flutter/shell/platform/windows/flutter_windows_engine.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 
 namespace flutter {
@@ -39,13 +40,16 @@ bool CompositorSoftware::CollectBackingStore(const FlutterBackingStore* store) {
 
 bool CompositorSoftware::Present(const FlutterLayer** layers,
                                  size_t layers_count) {
-  if (!engine_->view()) {
+  // TODO(loicsharma): Remove implicit view assumption.
+  // https://github.com/flutter/flutter/issues/142845
+  FlutterWindowsView* view = engine_->view(kImplicitViewId);
+  if (!view) {
     return false;
   }
 
   // Clear the view if there are no layers to present.
   if (layers_count == 0) {
-    return engine_->view()->ClearSoftwareBitmap();
+    return view->ClearSoftwareBitmap();
   }
 
   // TODO: Support compositing layers and platform views.
@@ -58,7 +62,7 @@ bool CompositorSoftware::Present(const FlutterLayer** layers,
 
   const auto& backing_store = layers[0]->backing_store->software;
 
-  return engine_->view()->PresentSoftwareBitmap(
+  return view->PresentSoftwareBitmap(
       backing_store.allocation, backing_store.row_bytes, backing_store.height);
 }
 

--- a/shell/platform/windows/compositor_software_unittests.cc
+++ b/shell/platform/windows/compositor_software_unittests.cc
@@ -24,7 +24,7 @@ class MockFlutterWindowsView : public FlutterWindowsView {
  public:
   MockFlutterWindowsView(FlutterWindowsEngine* engine,
                          std::unique_ptr<WindowBindingHandler> window)
-      : FlutterWindowsView(engine, std::move(window)) {}
+      : FlutterWindowsView(kImplicitViewId, engine, std::move(window)) {}
   virtual ~MockFlutterWindowsView() = default;
 
   MOCK_METHOD(bool,

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -74,7 +74,10 @@ void CursorHandler::HandleMethodCall(
       return;
     }
     const auto& kind = std::get<std::string>(kind_iter->second);
-    FlutterWindowsView* view = engine_->view();
+
+    // TODO(loicsharma): Remove implicit view assumption.
+    // https://github.com/flutter/flutter/issues/142845
+    FlutterWindowsView* view = engine_->view(kImplicitViewId);
     if (view == nullptr) {
       result->Error(kCursorError,
                     "Cursor is not available in Windows headless mode");
@@ -164,7 +167,10 @@ void CursorHandler::HandleMethodCall(
       return;
     }
     HCURSOR cursor = custom_cursors_[name];
-    FlutterWindowsView* view = engine_->view();
+
+    // TODO(loicsharma): Remove implicit view assumption.
+    // https://github.com/flutter/flutter/issues/142845
+    FlutterWindowsView* view = engine_->view(kImplicitViewId);
     if (view == nullptr) {
       result->Error(kCursorError,
                     "Cursor is not available in Windows headless mode");

--- a/shell/platform/windows/cursor_handler_unittests.cc
+++ b/shell/platform/windows/cursor_handler_unittests.cc
@@ -79,8 +79,8 @@ class CursorHandlerTest : public WindowsTest {
 
     window_ = window.get();
     engine_ = builder.Build();
-    view_ =
-        std::make_unique<FlutterWindowsView>(engine_.get(), std::move(window));
+    view_ = std::make_unique<FlutterWindowsView>(kImplicitViewId, engine_.get(),
+                                                 std::move(window));
 
     EngineModifier modifier{engine_.get()};
     modifier.SetImplicitView(view_.get());

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -98,7 +98,8 @@ class MockFlutterWindowsView : public FlutterWindowsView {
  public:
   MockFlutterWindowsView(FlutterWindowsEngine* engine,
                          std::unique_ptr<WindowBindingHandler> window_binding)
-      : FlutterWindowsView(engine, std::move(window_binding)) {}
+      : FlutterWindowsView(kImplicitViewId, engine, std::move(window_binding)) {
+  }
   ~MockFlutterWindowsView() {}
 
   MOCK_METHOD(void,

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -247,7 +247,10 @@ bool FlutterDesktopEngineProcessExternalWindowMessage(
 
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(
     FlutterDesktopPluginRegistrarRef registrar) {
-  return HandleForView(registrar->engine->view());
+  // TODO(loicsharma): Add |FlutterDesktopPluginRegistrarGetViewById| and
+  // deprecate this API as it makes single view assumptions.
+  // https://github.com/flutter/flutter/issues/143767
+  return HandleForView(registrar->engine->view(flutter::kImplicitViewId));
 }
 
 void FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate(

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -527,7 +527,7 @@ std::chrono::nanoseconds FlutterWindowsEngine::FrameInterval() {
   return std::chrono::nanoseconds(interval);
 }
 
-FlutterWindowsView* FlutterWindowsEngine::view(int64_t view_id) const {
+FlutterWindowsView* FlutterWindowsEngine::view(FlutterViewId view_id) const {
   FML_DCHECK(view_id == kImplicitViewId);
 
   return view_;

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -340,7 +340,10 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
   args.update_semantics_callback2 = [](const FlutterSemanticsUpdate2* update,
                                        void* user_data) {
     auto host = static_cast<FlutterWindowsEngine*>(user_data);
-    auto view = host->view();
+
+    // TODO(loicsharma): Remove implicit view assumption.
+    // https://github.com/flutter/flutter/issues/142845
+    auto view = host->view(kImplicitViewId);
     if (!view) {
       return;
     }
@@ -485,8 +488,10 @@ bool FlutterWindowsEngine::Stop() {
 
 std::unique_ptr<FlutterWindowsView> FlutterWindowsEngine::CreateView(
     std::unique_ptr<WindowBindingHandler> window) {
-  auto view = std::make_unique<FlutterWindowsView>(this, std::move(window),
-                                                   windows_proc_table_);
+  // TODO(loicsharma): Remove implicit view assumption.
+  // https://github.com/flutter/flutter/issues/142845
+  auto view = std::make_unique<FlutterWindowsView>(
+      kImplicitViewId, this, std::move(window), windows_proc_table_);
 
   view_ = view.get();
   InitializeKeyboard();
@@ -520,6 +525,12 @@ std::chrono::nanoseconds FlutterWindowsEngine::FrameInterval() {
   }
 
   return std::chrono::nanoseconds(interval);
+}
+
+FlutterWindowsView* FlutterWindowsEngine::view(int64_t view_id) const {
+  FML_DCHECK(view_id == kImplicitViewId);
+
+  return view_;
 }
 
 // Returns the currently configured Plugin Registrar.

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -44,6 +44,12 @@
 
 namespace flutter {
 
+// The implicit view's ID.
+//
+// See:
+// https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/implicitView.html
+constexpr int64_t kImplicitViewId = 0;
+
 class FlutterWindowsView;
 
 // Update the thread priority for the Windows engine.
@@ -117,7 +123,7 @@ class FlutterWindowsEngine {
 
   // The view displaying this engine's content, if any. This will be null for
   // headless engines.
-  FlutterWindowsView* view() { return view_; }
+  FlutterWindowsView* view(int64_t view_id) const;
 
   // Returns the currently configured Plugin Registrar.
   FlutterDesktopPluginRegistrarRef GetRegistrar();

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -48,7 +48,7 @@ namespace flutter {
 //
 // See:
 // https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/implicitView.html
-constexpr int64_t kImplicitViewId = 0;
+constexpr FlutterViewId kImplicitViewId = 0;
 
 class FlutterWindowsView;
 
@@ -123,7 +123,7 @@ class FlutterWindowsEngine {
 
   // The view displaying this engine's content, if any. This will be null for
   // headless engines.
-  FlutterWindowsView* view(int64_t view_id) const;
+  FlutterWindowsView* view(FlutterViewId view_id) const;
 
   // Returns the currently configured Plugin Registrar.
   FlutterDesktopPluginRegistrarRef GetRegistrar();

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -623,7 +623,7 @@ class MockFlutterWindowsView : public FlutterWindowsView {
  public:
   MockFlutterWindowsView(FlutterWindowsEngine* engine,
                          std::unique_ptr<WindowBindingHandler> wbh)
-      : FlutterWindowsView(engine, std::move(wbh)) {}
+      : FlutterWindowsView(kImplicitViewId, engine, std::move(wbh)) {}
   ~MockFlutterWindowsView() {}
 
   MOCK_METHOD(void,

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -655,7 +655,7 @@ bool FlutterWindowsView::PresentSoftwareBitmap(const void* allocation,
                                                   height);
 }
 
-int64_t FlutterWindowsView::view_id() const {
+FlutterViewId FlutterWindowsView::view_id() const {
   return view_id_;
 }
 

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -84,10 +84,13 @@ void UpdateVsync(const FlutterWindowsEngine& engine,
 }  // namespace
 
 FlutterWindowsView::FlutterWindowsView(
+    int64_t view_id,
     FlutterWindowsEngine* engine,
     std::unique_ptr<WindowBindingHandler> window_binding,
     std::shared_ptr<WindowsProcTable> windows_proc_table)
-    : engine_(engine), windows_proc_table_(std::move(windows_proc_table)) {
+    : view_id_(view_id),
+      engine_(engine),
+      windows_proc_table_(std::move(windows_proc_table)) {
   if (windows_proc_table_ == nullptr) {
     windows_proc_table_ = std::make_shared<WindowsProcTable>();
   }
@@ -650,6 +653,10 @@ bool FlutterWindowsView::PresentSoftwareBitmap(const void* allocation,
                                                size_t height) {
   return binding_handler_->OnBitmapSurfaceUpdated(allocation, row_bytes,
                                                   height);
+}
+
+int64_t FlutterWindowsView::view_id() const {
+  return view_id_;
 }
 
 void FlutterWindowsView::CreateRenderSurface() {

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -84,7 +84,7 @@ void UpdateVsync(const FlutterWindowsEngine& engine,
 }  // namespace
 
 FlutterWindowsView::FlutterWindowsView(
-    int64_t view_id,
+    FlutterViewId view_id,
     FlutterWindowsEngine* engine,
     std::unique_ptr<WindowBindingHandler> window_binding,
     std::shared_ptr<WindowsProcTable> windows_proc_table)

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -33,11 +33,15 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // Creates a FlutterWindowsView with the given implementor of
   // WindowBindingHandler.
   FlutterWindowsView(
+      int64_t view_id,
       FlutterWindowsEngine* engine,
       std::unique_ptr<WindowBindingHandler> window_binding,
       std::shared_ptr<WindowsProcTable> windows_proc_table = nullptr);
 
   virtual ~FlutterWindowsView();
+
+  // Get the view's unique identifier.
+  int64_t view_id() const;
 
   // Creates rendering surface for Flutter engine to draw into.
   // Should be called before calling FlutterEngineRun using this view.
@@ -378,6 +382,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // If true, rendering to the window should synchronize with the vsync
   // to prevent screen tearing.
   bool NeedsVsync() const;
+
+  // The view's unique identifier.
+  int64_t view_id_;
 
   // The engine associated with this view.
   FlutterWindowsEngine* engine_ = nullptr;

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -26,6 +26,9 @@
 
 namespace flutter {
 
+// A unique identifier for a view.
+using FlutterViewId = int64_t;
+
 // An OS-windowing neutral abstration for a Flutter view that works
 // with win32 HWNDs.
 class FlutterWindowsView : public WindowBindingHandlerDelegate {
@@ -33,7 +36,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // Creates a FlutterWindowsView with the given implementor of
   // WindowBindingHandler.
   FlutterWindowsView(
-      int64_t view_id,
+      FlutterViewId view_id,
       FlutterWindowsEngine* engine,
       std::unique_ptr<WindowBindingHandler> window_binding,
       std::shared_ptr<WindowsProcTable> windows_proc_table = nullptr);
@@ -41,7 +44,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   virtual ~FlutterWindowsView();
 
   // Get the view's unique identifier.
-  int64_t view_id() const;
+  FlutterViewId view_id() const;
 
   // Creates rendering surface for Flutter engine to draw into.
   // Should be called before calling FlutterEngineRun using this view.
@@ -384,7 +387,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   bool NeedsVsync() const;
 
   // The view's unique identifier.
-  int64_t view_id_;
+  FlutterViewId view_id_;
 
   // The engine associated with this view.
   FlutterWindowsEngine* engine_ = nullptr;

--- a/shell/platform/windows/flutter_windows_view_unittests.cc
+++ b/shell/platform/windows/flutter_windows_view_unittests.cc
@@ -1029,7 +1029,7 @@ TEST(FlutterWindowsViewTest, WindowRepaintTests) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
   EngineModifier modifier(engine.get());
 
-  FlutterWindowsView view{engine.get(),
+  FlutterWindowsView view{kImplicitViewId, engine.get(),
                           std::make_unique<flutter::FlutterWindow>(100, 100)};
 
   bool schedule_frame_called = false;

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -340,7 +340,7 @@ class TestFlutterWindowsView : public FlutterWindowsView {
                          std::unique_ptr<WindowBindingHandler> window,
                          std::function<void(KeyCall)> on_key_call)
       : on_key_call_(on_key_call),
-        FlutterWindowsView(engine, std::move(window)) {}
+        FlutterWindowsView(kImplicitViewId, engine, std::move(window)) {}
 
   void OnText(const std::u16string& text) override {
     on_key_call_(KeyCall{

--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -248,7 +248,9 @@ PlatformHandler::~PlatformHandler() = default;
 void PlatformHandler::GetPlainText(
     std::unique_ptr<MethodResult<rapidjson::Document>> result,
     std::string_view key) {
-  const FlutterWindowsView* view = engine_->view();
+  // TODO(loicsharma): Remove implicit view assumption.
+  // https://github.com/flutter/flutter/issues/142845
+  const FlutterWindowsView* view = engine_->view(kImplicitViewId);
   if (view == nullptr) {
     result->Error(kClipboardError,
                   "Clipboard is not available in Windows headless mode");
@@ -291,7 +293,9 @@ void PlatformHandler::GetPlainText(
 
 void PlatformHandler::GetHasStrings(
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-  const FlutterWindowsView* view = engine_->view();
+  // TODO(loicsharma): Remove implicit view assumption.
+  // https://github.com/flutter/flutter/issues/142845
+  const FlutterWindowsView* view = engine_->view(kImplicitViewId);
   if (view == nullptr) {
     result->Error(kClipboardError,
                   "Clipboard is not available in Windows headless mode");
@@ -329,7 +333,9 @@ void PlatformHandler::GetHasStrings(
 void PlatformHandler::SetPlainText(
     const std::string& text,
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-  const FlutterWindowsView* view = engine_->view();
+  // TODO(loicsharma): Remove implicit view assumption.
+  // https://github.com/flutter/flutter/issues/142845
+  const FlutterWindowsView* view = engine_->view(kImplicitViewId);
   if (view == nullptr) {
     result->Error(kClipboardError,
                   "Clipboard is not available in Windows headless mode");

--- a/shell/platform/windows/platform_handler_unittests.cc
+++ b/shell/platform/windows/platform_handler_unittests.cc
@@ -155,8 +155,8 @@ class PlatformHandlerTest : public WindowsTest {
     auto window = std::make_unique<NiceMock<MockWindowBindingHandler>>();
 
     engine_ = builder.Build();
-    view_ =
-        std::make_unique<FlutterWindowsView>(engine_.get(), std::move(window));
+    view_ = std::make_unique<FlutterWindowsView>(kImplicitViewId, engine_.get(),
+                                                 std::move(window));
 
     EngineModifier modifier{engine_.get()};
     modifier.SetImplicitView(view_.get());

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -216,7 +216,9 @@ void TextInputPlugin::HandleMethodCall(
   if (method.compare(kShowMethod) == 0 || method.compare(kHideMethod) == 0) {
     // These methods are no-ops.
   } else if (method.compare(kClearClientMethod) == 0) {
-    FlutterWindowsView* view = engine_->view();
+    // TODO(loicsharma): Remove implicit view assumption.
+    // https://github.com/flutter/flutter/issues/142845
+    FlutterWindowsView* view = engine_->view(kImplicitViewId);
     if (view == nullptr) {
       result->Error(kInternalConsistencyError,
                     "Text input is not available in Windows headless mode");
@@ -326,7 +328,9 @@ void TextInputPlugin::HandleMethodCall(
           TextRange(composing_base, composing_extent), cursor_offset);
     }
   } else if (method.compare(kSetMarkedTextRect) == 0) {
-    FlutterWindowsView* view = engine_->view();
+    // TODO(loicsharma): Remove implicit view assumption.
+    // https://github.com/flutter/flutter/issues/142845
+    FlutterWindowsView* view = engine_->view(kImplicitViewId);
     if (view == nullptr) {
       result->Error(kInternalConsistencyError,
                     "Text input is not available in Windows headless mode");
@@ -355,7 +359,9 @@ void TextInputPlugin::HandleMethodCall(
     Rect transformed_rect = GetCursorRect();
     view->OnCursorRectUpdated(transformed_rect);
   } else if (method.compare(kSetEditableSizeAndTransform) == 0) {
-    FlutterWindowsView* view = engine_->view();
+    // TODO(loicsharma): Remove implicit view assumption.
+    // https://github.com/flutter/flutter/issues/142845
+    FlutterWindowsView* view = engine_->view(kImplicitViewId);
     if (view == nullptr) {
       result->Error(kInternalConsistencyError,
                     "Text input is not available in Windows headless mode");

--- a/shell/platform/windows/text_input_plugin_unittest.cc
+++ b/shell/platform/windows/text_input_plugin_unittest.cc
@@ -107,7 +107,7 @@ class MockFlutterWindowsView : public FlutterWindowsView {
  public:
   MockFlutterWindowsView(FlutterWindowsEngine* engine,
                          std::unique_ptr<WindowBindingHandler> window)
-      : FlutterWindowsView(engine, std::move(window)) {}
+      : FlutterWindowsView(kImplicitViewId, engine, std::move(window)) {}
   virtual ~MockFlutterWindowsView() = default;
 
   MOCK_METHOD(void, OnCursorRectUpdated, (const Rect&), (override));


### PR DESCRIPTION
Adds an ID to a view:

1. `FlutterWindowsView` now has a ID
2. The `FlutterWindowsEngine::view(...)` accessor now requires a view ID parameter

This is a refactoring with no semantic changes.

Part of https://github.com/flutter/flutter/issues/143765

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
