### PR TITLE
Move the `scenario_app` running Impeller+OpenGLES to `bringup: triue`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -67,6 +67,27 @@ targets:
       - shell/platform/android/**
       - testing/scenario_app/**
 
+  # TODO(matanlurey): OpenGLES is very flaky, https://github.com/flutter/flutter/issues/143626.
+  - name: Linux linux_android_emulator_opengles_tests
+    bringup: true
+    enabled_branches:
+      - main
+    recipe: engine_v2/engine_v2
+    properties:
+      config_name: linux_android_emulator_opengles
+      dependencies: >-
+        [
+          {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
+        ]
+    timeout: 60
+    runIf:
+      - .ci.yaml
+      - ci/builders/linux_android_emulator.json
+      - DEPS
+      - lib/ui/**
+      - shell/platform/android/**
+      - testing/scenario_app/**
+
 # Task to run Linux linux_android_emulator_tests on AVDs running Android 33
 # instead of 34 for investigating https://github.com/flutter/flutter/issues/137947.
   - name: Linux linux_android_emulator_tests_api_33

--- a/ci/builders/linux_android_emulator.json
+++ b/ci/builders/linux_android_emulator.json
@@ -100,29 +100,6 @@
                         "--enable-impeller",
                         "--impeller-backend=vulkan"
                     ]
-                },
-                {
-                    "language": "bash",
-                    "name": "Android Scenario App Integration Tests (Impeller/OpenGLES)",
-                    "test_dependencies": [
-                        {
-                            "dependency": "android_virtual_device",
-                            "version": "android_34_google_apis_x64.textpb"
-                        },
-                        {
-                            "dependency": "avd_cipd_version",
-                            "version": "build_id:8759428741582061553"
-                        }
-                    ],
-                    "contexts": [
-                        "android_virtual_device"
-                    ],
-                    "script": "flutter/testing/scenario_app/run_android_tests.sh",
-                    "parameters": [
-                        "android_debug_x64",
-                        "--enable-impeller",
-                        "--impeller-backend=opengles"
-                    ]
                 }
             ]
         },

--- a/ci/builders/linux_android_emulator_opengles.json
+++ b/ci/builders/linux_android_emulator_opengles.json
@@ -1,0 +1,60 @@
+{
+    "builds": [
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux",
+                "kvm=1",
+                "cores=8"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--android",
+                "--android-cpu=x64",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "dependencies": [
+                {
+                    "dependency": "goldctl",
+                    "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
+                }
+            ],
+            "name": "android_debug_x64",
+            "ninja": {
+                "config": "android_debug_x64",
+                "targets": [
+                    "flutter/testing/scenario_app"
+                ]
+            },
+            "tests": [
+                {
+                    "language": "bash",
+                    "name": "Android Scenario App Integration Tests (Impeller/OpenGLES)",
+                    "test_dependencies": [
+                        {
+                            "dependency": "android_virtual_device",
+                            "version": "android_34_google_apis_x64.textpb"
+                        },
+                        {
+                            "dependency": "avd_cipd_version",
+                            "version": "build_id:8759428741582061553"
+                        }
+                    ],
+                    "contexts": [
+                        "android_virtual_device"
+                    ],
+                    "script": "flutter/testing/scenario_app/run_android_tests.sh",
+                    "parameters": [
+                        "android_debug_x64",
+                        "--enable-impeller",
+                        "--impeller-backend=opengles"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
1. OpenGLES is much flakier than Skia or Vulkan.
2. OpenGLES is not currently being released so it's lower priority to fix.

See https://github.com/flutter/flutter/issues/143626.