### PR TITLE
Hook ImageReaderSurfaceProducer to the onTrimMemory listener interface

### DIFF
--- a/shell/platform/android/image_external_texture.cc
+++ b/shell/platform/android/image_external_texture.cc
@@ -26,7 +26,6 @@ void ImageExternalTexture::Paint(PaintContext& context,
   if (state_ == AttachmentState::kDetached) {
     return;
   }
-  latest_bounds_ = bounds;
   Attach(context);
   const bool should_process_frame = !freeze;
   if (should_process_frame) {

--- a/shell/platform/android/image_external_texture.h
+++ b/shell/platform/android/image_external_texture.h
@@ -59,8 +59,6 @@ class ImageExternalTexture : public flutter::Texture {
 
   fml::jni::ScopedJavaGlobalRef<jobject> image_texture_entry_;
   std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
-  SkRect latest_bounds_ = SkRect::MakeEmpty();
-  fml::jni::ScopedJavaGlobalRef<jobject> latest_android_image_;
 
   enum class AttachmentState { kUninitialized, kAttached, kDetached };
   AttachmentState state_ = AttachmentState::kUninitialized;

--- a/shell/platform/android/image_external_texture_gl.h
+++ b/shell/platform/android/image_external_texture_gl.h
@@ -33,7 +33,9 @@ class ImageExternalTextureGL : public ImageExternalTexture {
   void Attach(PaintContext& context) override;
   void Detach() override;
   void ProcessFrame(PaintContext& context, const SkRect& bounds) override;
-  void UpdateImage(JavaLocalRef& hardware_buffer, PaintContext& context);
+  void UpdateImage(JavaLocalRef& hardware_buffer,
+                   const SkRect& bounds,
+                   PaintContext& context);
 
   virtual sk_sp<flutter::DlImage> CreateDlImage(
       PaintContext& context,

--- a/shell/platform/android/image_external_texture_vk.cc
+++ b/shell/platform/android/image_external_texture_vk.cc
@@ -38,9 +38,7 @@ void ImageExternalTextureVK::ProcessFrame(PaintContext& context,
   if (image.is_null()) {
     return;
   }
-  JavaLocalRef old_android_image(latest_android_image_);
-  latest_android_image_.Reset(image);
-  JavaLocalRef hardware_buffer = HardwareBufferFor(latest_android_image_);
+  JavaLocalRef hardware_buffer = HardwareBufferFor(image);
   AHardwareBuffer* latest_hardware_buffer = AHardwareBufferFor(hardware_buffer);
 
   AHardwareBuffer_Desc hb_desc = {};
@@ -53,9 +51,6 @@ void ImageExternalTextureVK::ProcessFrame(PaintContext& context,
     dl_image_ = existing_image;
 
     CloseHardwareBuffer(hardware_buffer);
-    // IMPORTANT: We have just received a new frame to display so close the
-    // previous Java Image so that it is recycled and used for a future frame.
-    CloseImage(old_android_image);
     return;
   }
 
@@ -105,9 +100,6 @@ void ImageExternalTextureVK::ProcessFrame(PaintContext& context,
     image_lru_.AddImage(dl_image_, key.value());
   }
   CloseHardwareBuffer(hardware_buffer);
-  // IMPORTANT: We have just received a new frame to display so close the
-  // previous Java Image so that it is recycled and used for a future frame.
-  CloseImage(old_android_image);
 }
 
 }  // namespace flutter


### PR DESCRIPTION
- Close all ImageReaders and Images when we get an onTrimMemory callback.
- Remove the first frame fix based around caching the last image displayed because it isn't safe to do on some platforms. Leave a TODO to revisit this.

We have seen some reports of platform views not working after an application is backgrounded and then resumed. According to Android GPU folks ImageReader/Image/HardwareBuffers should be valid after an application has been resumed. However on Samsung we know that isn't the case and there are (unconfirmed) reports of it also impacting Pixel devices. 

Should fix https://github.com/flutter/flutter/issues/142978 and https://github.com/flutter/flutter/issues/139039

Also fixes https://github.com/flutter/flutter/issues/143720