### PR TITLE
[Windows] Fix top-level message procedure order

### DIFF
--- a/shell/platform/fuchsia/flutter/software_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/software_surface_producer.cc
@@ -7,7 +7,7 @@
 #include <lib/fdio/directory.h>
 #include <lib/zx/process.h>
 
-#include <algorithm>  // Foor std::remove_if
+#include <algorithm>  // For std::remove_if
 #include <memory>
 #include <string>
 #include <utility>

--- a/shell/platform/windows/window_proc_delegate_manager.cc
+++ b/shell/platform/windows/window_proc_delegate_manager.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/windows/window_proc_delegate_manager.h"
 
+#include <algorithm>
+
 #include "flutter/shell/platform/embedder/embedder.h"
 
 namespace flutter {
@@ -12,26 +14,37 @@ WindowProcDelegateManager::WindowProcDelegateManager() = default;
 WindowProcDelegateManager::~WindowProcDelegateManager() = default;
 
 void WindowProcDelegateManager::RegisterTopLevelWindowProcDelegate(
-    FlutterDesktopWindowProcCallback delegate,
+    FlutterDesktopWindowProcCallback callback,
     void* user_data) {
-  top_level_window_proc_handlers_[delegate] = user_data;
+  UnregisterTopLevelWindowProcDelegate(callback);
+
+  delegates_.push_back(WindowProcDelegate{
+      .callback = callback,
+      .user_data = user_data,
+  });
 }
 
 void WindowProcDelegateManager::UnregisterTopLevelWindowProcDelegate(
-    FlutterDesktopWindowProcCallback delegate) {
-  top_level_window_proc_handlers_.erase(delegate);
+    FlutterDesktopWindowProcCallback callback) {
+  delegates_.erase(
+      std::remove_if(delegates_.begin(), delegates_.end(),
+                     [&callback](const WindowProcDelegate& delegate) {
+                       return delegate.callback == callback;
+                     }),
+      delegates_.end());
 }
 
 std::optional<LRESULT> WindowProcDelegateManager::OnTopLevelWindowProc(
     HWND hwnd,
     UINT message,
     WPARAM wparam,
-    LPARAM lparam) {
+    LPARAM lparam) const {
   std::optional<LRESULT> result;
-  for (const auto& [handler, user_data] : top_level_window_proc_handlers_) {
+  for (const auto& delegate : delegates_) {
     LPARAM handler_result;
     // Stop as soon as any delegate indicates that it has handled the message.
-    if (handler(hwnd, message, wparam, lparam, user_data, &handler_result)) {
+    if (delegate.callback(hwnd, message, wparam, lparam, delegate.user_data,
+                          &handler_result)) {
       result = handler_result;
       break;
     }

--- a/shell/platform/windows/window_proc_delegate_manager.h
+++ b/shell/platform/windows/window_proc_delegate_manager.h
@@ -7,8 +7,8 @@
 
 #include <Windows.h>
 
-#include <map>
 #include <optional>
+#include <vector>
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
@@ -22,30 +22,35 @@ class WindowProcDelegateManager {
   explicit WindowProcDelegateManager();
   ~WindowProcDelegateManager();
 
-  // Adds |delegate| as a delegate to be called for |OnTopLevelWindowProc|.
+  // Adds |callback| as a delegate to be called for |OnTopLevelWindowProc|.
   //
-  // Multiple calls with the same |delegate| will replace the previous
+  // Multiple calls with the same |callback| will replace the previous
   // registration, even if |user_data| is different.
   void RegisterTopLevelWindowProcDelegate(
-      FlutterDesktopWindowProcCallback delegate,
+      FlutterDesktopWindowProcCallback callback,
       void* user_data);
 
-  // Unregisters |delegate| as a delate for |OnTopLevelWindowProc|.
+  // Unregisters |callback| as a delegate for |OnTopLevelWindowProc|.
   void UnregisterTopLevelWindowProcDelegate(
-      FlutterDesktopWindowProcCallback delegate);
+      FlutterDesktopWindowProcCallback callback);
 
-  // Calls any registered WindowProc delegates.
+  // Calls any registered WindowProc delegates in the order they were
+  // registered.
   //
   // If a result is returned, then the message was handled in such a way that
   // further handling should not be done.
   std::optional<LRESULT> OnTopLevelWindowProc(HWND hwnd,
                                               UINT message,
                                               WPARAM wparam,
-                                              LPARAM lparam);
+                                              LPARAM lparam) const;
 
  private:
-  std::map<FlutterDesktopWindowProcCallback, void*>
-      top_level_window_proc_handlers_;
+  struct WindowProcDelegate {
+    FlutterDesktopWindowProcCallback callback = nullptr;
+    void* user_data = nullptr;
+  };
+
+  std::vector<WindowProcDelegate> delegates_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(WindowProcDelegateManager);
 };


### PR DESCRIPTION
The Windows embedder registers "message procedures" to handle to top-level window events. These message procedures should be called in the order that they are registered.

For example, a plugin can override the embedder's app lifecycle behavior by registering a message procedure before the embedder's app lifecycle message procedure.

This did not always work as expected as the message procedures were ordered by their pointers instead of their insertion order.

Fixes https://github.com/flutter/flutter/issues/137963

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
