### PR TITLE
Disable framework smoke tests.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -202,15 +202,6 @@ targets:
     #   - shell/platform/windows/**
     #   - web_sdk/**
 
-  - name: Linux Framework Smoke Tests
-    recipe: engine/framework_smoke
-    enabled_branches:
-      - main
-    timeout: 60
-    properties:
-      gclient_variables: >-
-        {"use_rbe": true}
-
   - name: Linux linux_clang_tidy
     recipe: engine_v2/engine_v2
     timeout: 120


### PR DESCRIPTION
We do not think these tests have value and/or are running in the correct place. These tests almost never fail. When they do fail, it is often due to an unrelated breakage in the framework