### PR TITLE
Add pub.dev to the hosted package URIs checked by the pub_get_offline script

### DIFF
--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -72,7 +72,8 @@ def check_package(package):
     for package_data in packages_data:
       package_uri = package_data['rootUri']
       package_name = package_data['name']
-      if '.pub-cache' in package_uri and 'pub.dartlang.org' in package_uri:
+      if '.pub-cache' in package_uri and ('pub.dartlang.org' in package_uri or
+                                          'pub.dev' in package_uri):
         print('Error: package "%s" was fetched from pub' % package_name)
         pub_count = pub_count + 1
   if pub_count > 0:


### PR DESCRIPTION
pub get --offline may fetch packages that are in the local package cache but were previously downloaded from a hosted source.  The script needs to check for packages that came from either the old or new locations of the Dart hosted package repository.