### PR TITLE
[Impeller] Remove non-Flutter fill types from impeller::Path.

### DIFF
--- a/impeller/geometry/path.h
+++ b/impeller/geometry/path.h
@@ -29,9 +29,6 @@ enum class Join {
 enum class FillType {
   kNonZero,  // The default winding order.
   kOdd,
-  kPositive,
-  kNegative,
-  kAbsGeqTwo,
 };
 
 enum class Convexity {

--- a/impeller/geometry/path_unittests.cc
+++ b/impeller/geometry/path_unittests.cc
@@ -461,7 +461,7 @@ TEST(PathTest, CanBeCloned) {
   builder.SetBounds(Rect::MakeLTRB(0, 0, 100, 100));
   builder.SetConvexity(Convexity::kConvex);
 
-  auto path_a = builder.TakePath(FillType::kAbsGeqTwo);
+  auto path_a = builder.TakePath(FillType::kOdd);
   // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   auto path_b = path_a;
 

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -400,7 +400,7 @@ TEST_P(RendererTest, CanRenderInstanced) {
             Tessellator{}.Tessellate(
                 PathBuilder{}
                     .AddRect(Rect::MakeXYWH(10, 10, 100, 100))
-                    .TakePath(FillType::kPositive),
+                    .TakePath(FillType::kOdd),
                 1.0f,
                 [&builder](const float* vertices, size_t vertices_count,
                            const uint16_t* indices, size_t indices_count) {

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -51,12 +51,6 @@ static int ToTessWindingRule(FillType fill_type) {
       return TESS_WINDING_ODD;
     case FillType::kNonZero:
       return TESS_WINDING_NONZERO;
-    case FillType::kPositive:
-      return TESS_WINDING_POSITIVE;
-    case FillType::kNegative:
-      return TESS_WINDING_NEGATIVE;
-    case FillType::kAbsGeqTwo:
-      return TESS_WINDING_ABS_GEQ_TWO;
   }
   return TESS_WINDING_ODD;
 }

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -17,7 +17,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
   // Zero points.
   {
     Tessellator t;
-    auto path = PathBuilder{}.TakePath(FillType::kPositive);
+    auto path = PathBuilder{}.TakePath(FillType::kOdd);
     Tessellator::Result result = t.Tessellate(
         path, 1.0f,
         [](const float* vertices, size_t vertices_count,
@@ -29,7 +29,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
   // One point.
   {
     Tessellator t;
-    auto path = PathBuilder{}.LineTo({0, 0}).TakePath(FillType::kPositive);
+    auto path = PathBuilder{}.LineTo({0, 0}).TakePath(FillType::kOdd);
     Tessellator::Result result = t.Tessellate(
         path, 1.0f,
         [](const float* vertices, size_t vertices_count,
@@ -41,8 +41,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
   // Two points.
   {
     Tessellator t;
-    auto path =
-        PathBuilder{}.AddLine({0, 0}, {0, 1}).TakePath(FillType::kPositive);
+    auto path = PathBuilder{}.AddLine({0, 0}, {0, 1}).TakePath(FillType::kOdd);
     Tessellator::Result result = t.Tessellate(
         path, 1.0f,
         [](const float* vertices, size_t vertices_count,
@@ -59,7 +58,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
       auto coord = i * 1.0f;
       builder.AddLine({coord, coord}, {coord + 1, coord + 1});
     }
-    auto path = builder.TakePath(FillType::kPositive);
+    auto path = builder.TakePath(FillType::kOdd);
     Tessellator::Result result = t.Tessellate(
         path, 1.0f,
         [](const float* vertices, size_t vertices_count,
@@ -71,8 +70,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
   // Closure fails.
   {
     Tessellator t;
-    auto path =
-        PathBuilder{}.AddLine({0, 0}, {0, 1}).TakePath(FillType::kPositive);
+    auto path = PathBuilder{}.AddLine({0, 0}, {0, 1}).TakePath(FillType::kOdd);
     Tessellator::Result result = t.Tessellate(
         path, 1.0f,
         [](const float* vertices, size_t vertices_count,


### PR DESCRIPTION
Flutter only supports evenOdd and nonZero, with nonZero being the default.