### PR TITLE
[Impeller] Add GeometryResult enum with StC modes.

### DIFF
--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -123,7 +123,7 @@ class ColorSourceContents : public Contents {
     // increment the stencil buffer as we draw, preventing overlapping fragments
     // from drawing. Afterwards, we need to append another draw call to clean up
     // the stencil buffer (happens below in this method).
-    if (geometry_result.prevent_overdraw) {
+    if (geometry_result.mode == GeometryResult::Mode::kPreventOverdraw) {
       options.stencil_mode =
           ContentContextOptions::StencilMode::kLegacyClipIncrement;
     }
@@ -156,7 +156,7 @@ class ColorSourceContents : public Contents {
     // If we performed overdraw prevention, a subsection of the clip heightmap
     // was incremented by 1 in order to self-clip. So simply append a clip
     // restore to clean it up.
-    if (geometry_result.prevent_overdraw) {
+    if (geometry_result.mode == GeometryResult::Mode::kPreventOverdraw) {
       auto restore = ClipRestoreContents();
       restore.SetRestoreCoverage(GetCoverage(entity));
       return restore.Render(renderer, entity, pass);

--- a/impeller/entity/geometry/cover_geometry.cc
+++ b/impeller/entity/geometry/cover_geometry.cc
@@ -30,7 +30,6 @@ GeometryResult CoverGeometry::GetPositionBuffer(const ContentContext& renderer,
               .index_type = IndexType::k16bit,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -32,7 +32,6 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
         .type = PrimitiveType::kTriangleStrip,
         .vertex_buffer = vertex_buffer,
         .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-        .prevent_overdraw = false,
     };
   }
 
@@ -62,7 +61,6 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
       .type = PrimitiveType::kTriangle,
       .vertex_buffer = vertex_buffer,
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 
@@ -97,7 +95,6 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
         .vertex_buffer =
             vertex_builder.CreateVertexBuffer(renderer.GetTransientsBuffer()),
         .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-        .prevent_overdraw = false,
     };
   }
 
@@ -130,7 +127,6 @@ GeometryResult FillPathGeometry::GetPositionUVBuffer(
       .vertex_buffer =
           vertex_builder.CreateVertexBuffer(renderer.GetTransientsBuffer()),
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -51,7 +51,6 @@ GeometryResult Geometry::ComputePositionGeometry(
               .index_type = IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 
@@ -87,7 +86,6 @@ GeometryResult Geometry::ComputePositionUVGeometry(
               .index_type = IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 
@@ -159,7 +157,6 @@ GeometryResult ComputeUVGeometryForRect(Rect source_rect,
               .index_type = IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -33,7 +33,7 @@ struct GeometryResult {
     kPreventOverdraw,
   };
 
-  PrimitiveType type;
+  PrimitiveType type = PrimitiveType::kTriangleStrip;
   VertexBuffer vertex_buffer;
   Matrix transform;
   Mode mode = Mode::kNormal;

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -18,10 +18,25 @@ namespace impeller {
 class Tessellator;
 
 struct GeometryResult {
+  enum class Mode {
+    /// The geometry has no overlapping triangles.
+    kNormal,
+    /// The geometry may have overlapping triangles. The geometry should be
+    /// stenciled with the NonZero fill rule.
+    kNonZero,
+    /// The geometry may have overlapping triangles. The geometry should be
+    /// stenciled with the EvenOdd fill rule.
+    kEvenOdd,
+    /// The geometry may have overlapping triangles, but they should not
+    /// overdraw or cancel each other out. This is a special case for stroke
+    /// geometry.
+    kPreventOverdraw,
+  };
+
   PrimitiveType type;
   VertexBuffer vertex_buffer;
   Matrix transform;
-  bool prevent_overdraw;
+  Mode mode = Mode::kNormal;
 };
 
 static const GeometryResult kEmptyResult = {

--- a/impeller/entity/geometry/geometry_unittests.cc
+++ b/impeller/entity/geometry/geometry_unittests.cc
@@ -208,5 +208,12 @@ TEST(EntityGeometryTest, StrokePathGeometryTransformOfLine) {
   }
 }
 
+TEST(EntityGeometryTest, GeometryResultHasReasonableDefaults) {
+  GeometryResult result;
+  EXPECT_EQ(result.type, PrimitiveType::kTriangleStrip);
+  EXPECT_EQ(result.transform, Matrix());
+  EXPECT_EQ(result.mode, GeometryResult::Mode::kNormal);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -105,7 +105,6 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
               .index_type = IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 
@@ -158,7 +157,6 @@ GeometryResult LineGeometry::GetPositionUVBuffer(Rect texture_coverage,
               .index_type = IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 

--- a/impeller/entity/geometry/point_field_geometry.cc
+++ b/impeller/entity/geometry/point_field_geometry.cc
@@ -30,7 +30,6 @@ GeometryResult PointFieldGeometry::GetPositionBuffer(
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer = vtx_builder->CreateVertexBuffer(host_buffer),
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 
@@ -58,7 +57,6 @@ GeometryResult PointFieldGeometry::GetPositionUVBuffer(
       .type = PrimitiveType::kTriangleStrip,
       .vertex_buffer = uv_vtx_builder.CreateVertexBuffer(host_buffer),
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 
@@ -223,7 +221,6 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
                         .vertex_count = total,
                         .index_type = IndexType::kNone},
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 

--- a/impeller/entity/geometry/rect_geometry.cc
+++ b/impeller/entity/geometry/rect_geometry.cc
@@ -22,7 +22,6 @@ GeometryResult RectGeometry::GetPositionBuffer(const ContentContext& renderer,
               .index_type = IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -596,7 +596,7 @@ GeometryResult StrokePathGeometry::GetPositionBuffer(
               .index_type = IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = true,
+      .mode = GeometryResult::Mode::kPreventOverdraw,
   };
 }
 
@@ -642,7 +642,7 @@ GeometryResult StrokePathGeometry::GetPositionUVBuffer(
               .index_type = IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = true,
+      .mode = GeometryResult::Mode::kPreventOverdraw,
   };
 }
 

--- a/impeller/entity/geometry/vertices_geometry.cc
+++ b/impeller/entity/geometry/vertices_geometry.cc
@@ -139,7 +139,6 @@ GeometryResult VerticesGeometry::GetPositionBuffer(
                   index_count > 0 ? IndexType::k16bit : IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 
@@ -184,7 +183,6 @@ GeometryResult VerticesGeometry::GetPositionColorBuffer(
                   index_count > 0 ? IndexType::k16bit : IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 
@@ -242,7 +240,6 @@ GeometryResult VerticesGeometry::GetPositionUVBuffer(
                   index_count > 0 ? IndexType::k16bit : IndexType::kNone,
           },
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
-      .prevent_overdraw = false,
   };
 }
 


### PR DESCRIPTION
Replace `prevent_overdraw` with an enum that also containing the two StC cases.