### PR TITLE
[macOS] Wrap FlutterEngineTest in autoreleasepool

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -222,8 +222,7 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
   EXPECT_TRUE(stdout_capture.GetOutput().find("Hello logging") != std::string::npos);
 }
 
-// TODO(cbracken): Needs deflaking. https://github.com/flutter/flutter/issues/124677
-TEST_F(FlutterEngineTest, DISABLED_BackgroundIsBlack) {
+TEST_F(FlutterEngineTest, BackgroundIsBlack) {
   FlutterEngine* engine = GetFlutterEngine();
 
   // Latch to ensure the entire layer tree has been generated and presented.
@@ -252,8 +251,7 @@ TEST_F(FlutterEngineTest, DISABLED_BackgroundIsBlack) {
   latch.Wait();
 }
 
-// TODO(cbracken): Needs deflaking. https://github.com/flutter/flutter/issues/124677
-TEST_F(FlutterEngineTest, DISABLED_CanOverrideBackgroundColor) {
+TEST_F(FlutterEngineTest, CanOverrideBackgroundColor) {
   FlutterEngine* engine = GetFlutterEngine();
 
   // Latch to ensure the entire layer tree has been generated and presented.

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h
@@ -15,7 +15,7 @@
 
 namespace flutter::testing {
 
-class FlutterEngineTest : public ::testing::Test {
+class FlutterEngineTest : public AutoreleasePoolTest {
  public:
   FlutterEngineTest();
 


### PR DESCRIPTION
Previously, these were not freeing allocations. This resulted in a lot of running engines/threads which triggered issues with running out of resources (Metal resources in particular).

This also re-enables two disabled unit tests for view background colour.

Issue: https://github.com/flutter/flutter/issues/124677

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added at least one completely unnecessary checkbox.
- [X] J'ai ajouté une case à cocher dans une langue autre que l'anglais.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
