### PR TITLE
Make Android Studio be able to run android embedding unit tests out of the box

### DIFF
--- a/shell/platform/android/build.gradle
+++ b/shell/platform/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.4"
+        classpath "com.android.tools.build:gradle:7.4.2"
     }
 }
 
@@ -20,17 +20,46 @@ repositories {
 apply plugin: "com.android.library"
 
 android {
-    compileSdk 34
+    compileSdkVersion 34
+
+    defaultConfig {
+        minSdkVersion 19
+    }
 
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs './'
             java.include './io.flutter/**'
+            test {
+                java.srcDir './test'
+                java.include './test/io.flutter/**'
+            }
         }
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+
+    }
+
+    dependencies {
+        implementation fileTree(include: ["*.jar"], dir: "../../../../third_party/android_embedding_dependencies/lib/")
+
+        // These dependencies should be kept in line with those in the ./test_runner/build.gradle
+        implementation "androidx.test:core:1.4.0"
+        implementation "com.google.android.play:core:1.8.0"
+        implementation "com.ibm.icu:icu4j:69.1"
+        implementation "org.robolectric:robolectric:4.11"
+        implementation "junit:junit:4.13.2"
+        implementation "androidx.test.ext:junit:1.1.4-alpha07"
+
+        def mockitoVersion = "4.7.0"
+        implementation "org.mockito:mockito-core:$mockitoVersion"
+        implementation "org.mockito:mockito-inline:$mockitoVersion"
+        implementation "org.mockito:mockito-android:$mockitoVersion"
     }
 }
 
-dependencies {
-    implementation fileTree(include: ["*.jar"], dir: "../../../../third_party/android_embedding_dependencies/lib/")
-}


### PR DESCRIPTION
This is pretty rough, it largely copies the configuration from the `test_runner/build.gradle`. 

But it lets me click and run unit tests without having to rebuild anything, which is nice:

example
<img width="1537" alt="Screenshot 2024-02-21 at 2 44 19 PM" src="https://github.com/flutter/engine/assets/34871572/a48a14dd-b43e-4bd5-a375-3b44e058d0f6">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
