### PR TITLE
[Impeller] Enable depth buffer clipping & Stencil-then-Cover path rendering.

### DIFF
--- a/impeller/aiks/picture.cc
+++ b/impeller/aiks/picture.cc
@@ -66,17 +66,15 @@ std::shared_ptr<Texture> Picture::RenderToTexture(
         /*mip_count=*/1,
         "Picture Snapshot MSAA",  // label
         RenderTarget::
-            kDefaultColorAttachmentConfigMSAA,  // color_attachment_config
-        std::nullopt                            // stencil_attachment_config
+            kDefaultColorAttachmentConfigMSAA  // color_attachment_config
     );
   } else {
     target = render_target_allocator.CreateOffscreen(
         *impeller_context,  // context
         size,               // size
         /*mip_count=*/1,
-        "Picture Snapshot",                           // label
-        RenderTarget::kDefaultColorAttachmentConfig,  // color_attachment_config
-        std::nullopt  // stencil_attachment_config
+        "Picture Snapshot",                          // label
+        RenderTarget::kDefaultColorAttachmentConfig  // color_attachment_config
     );
   }
   if (!target.IsValid()) {

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -408,7 +408,7 @@ class ContentContext {
   ///
   // TODO(bdero): Remove this setting once StC is fully de-risked
   //              https://github.com/flutter/flutter/issues/123671
-  static constexpr bool kEnableStencilThenCover = false;
+  static constexpr bool kEnableStencilThenCover = true;
 
 #if IMPELLER_ENABLE_3D
   std::shared_ptr<scene::SceneContext> GetSceneContext() const;


### PR DESCRIPTION
Turn the page, wash your hands.

Addresses the following issues:
* https://github.com/flutter/flutter/issues/143077
* https://github.com/flutter/flutter/issues/137714
* https://github.com/flutter/flutter/issues/138460
* https://github.com/flutter/flutter/issues/123671
* https://github.com/flutter/flutter/issues/141961
* https://github.com/flutter/flutter/issues/134432