### PR TITLE
[Impeller] Fix a race that can abort the process if the Vulkan context is destroyed while pipeline creation tasks are pending

### DIFF
--- a/impeller/base/base_unittests.cc
+++ b/impeller/base/base_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/testing/testing.h"
+#include "impeller/base/promise.h"
 #include "impeller/base/strings.h"
 #include "impeller/base/thread.h"
 
@@ -231,6 +232,22 @@ TEST(ConditionVariableTest, TestsCriticalSectionAfterWait) {
     threads[i].join();
   }
   ASSERT_EQ(sum, kThreadCount);
+}
+
+TEST(BaseTest, PromiseDestructWrapperValue) {
+  PromiseDestructWrapper<int> wrapper;
+  std::future future = wrapper.get_future();
+  wrapper.set_value(123);
+  ASSERT_EQ(future.get(), 123);
+}
+
+TEST(BaseTest, PromiseDestructWrapperEmpty) {
+  auto wrapper = std::make_shared<PromiseDestructWrapper<int>>();
+  std::future future = wrapper->get_future();
+
+  // Destroy the empty promise with the future still pending. Verify that the
+  // process does not abort while destructing the promise.
+  wrapper.reset();
 }
 
 }  // namespace testing

--- a/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_library_vk.cc
@@ -170,7 +170,7 @@ PipelineFuture<PipelineDescriptor> PipelineLibraryVK::GetPipeline(
   }
 
   auto promise = std::make_shared<
-      std::promise<std::shared_ptr<Pipeline<PipelineDescriptor>>>>();
+      PromiseDestructWrapper<std::shared_ptr<Pipeline<PipelineDescriptor>>>>();
   auto pipeline_future =
       PipelineFuture<PipelineDescriptor>{descriptor, promise->get_future()};
   pipelines_[descriptor] = pipeline_future;


### PR DESCRIPTION
The Vulkan pipeline library queues pipeline creation tasks to a ConcurrentTaskRunner.  If the ContextVK is destroyed before these tasks execute, then the ConcurrentMessageLoop destructor will delete the pending tasks.

Each task lambda holds a reference to a promise that will be completed with the pipeline.  If the task was never run and its promise was never completed, then the promise destructor will complete it with an exception.  This will cause a std::abort because Flutter is built without exception support.

This PR wraps the promise in an object that completes it with a default value during destruction if the promise was never given a value.