### PR TITLE
Remove unused property from `Linux Web Framework tests`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -320,7 +320,6 @@ targets:
           {"dependency": "chrome_and_driver", "version": "version:119.0.6045.9"},
           {"dependency": "curl", "version": "version:7.64.0"}
         ]
-      framework: "true"
       no_goma: "true"
       drone_dimensions: >
         ["device_type=none", "os=Linux"]


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/143671

The `framework` property is not being used at all.