### PR TITLE
Remove unused drone_dimension field

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -189,8 +189,6 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_fuchsia
-    drone_dimensions:
-      - os=Linux
     dimensions:
       kvm: "1"
     # TODO(https://github.com/flutter/flutter/issues/138559): Re-enable/delete.
@@ -228,8 +226,6 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_arm_host_engine
-    drone_dimensions:
-      - os=Linux
 
   - name: Linux linux_host_engine
     recipe: engine_v2/engine_v2
@@ -242,8 +238,6 @@ targets:
         [
           {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
         ]
-    drone_dimensions:
-      - os=Linux
 
   - name: Linux linux_host_desktop_engine
     recipe: engine_v2/engine_v2
@@ -252,8 +246,6 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_host_desktop_engine
-    drone_dimensions:
-      - os=Linux
 
   - name: Linux linux_android_aot_engine
     recipe: engine_v2/engine_v2
@@ -262,8 +254,6 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_android_aot_engine
-    drone_dimensions:
-      - os=Linux
 
   - name: Linux linux_android_debug_engine
     recipe: engine_v2/engine_v2
@@ -272,8 +262,6 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_android_debug_engine
-    drone_dimensions:
-      - os=Linux
 
   - name: Linux linux_license
     recipe: engine_v2/builder
@@ -289,8 +277,6 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_web_engine
-    drone_dimensions:
-      - os=Linux
     runIf:
       - DEPS
       - .ci.yaml
@@ -344,8 +330,6 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: mac_android_aot_engine
-    drone_dimensions:
-      - os=Linux
 
   - name: Mac mac_clang_tidy
     recipe: engine_v2/engine_v2
@@ -383,8 +367,6 @@ targets:
         {
           "sdk_version": "15a240d"
         }
-    drone_dimensions:
-      - os=Mac-13
 
   - name: Mac mac_unopt
     recipe: engine_v2/engine_v2
@@ -404,9 +386,6 @@ targets:
         {
           "sdk_version": "15a240d"
         }
-    drone_dimensions:
-      - os=Mac-13
-      - cpu=x86
 
   - name: Mac impeller-cmake-example
     bringup: true
@@ -423,8 +402,6 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: windows_android_aot_engine
-    drone_dimensions:
-      - os=Windows
 
   - name: Windows windows_host_engine
     recipe: engine_v2/engine_v2
@@ -433,8 +410,6 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: windows_host_engine
-    drone_dimensions:
-      - os=Windows
 
   - name: Windows windows_arm_host_engine
     recipe: engine_v2/engine_v2
@@ -445,8 +420,6 @@ targets:
     properties:
       add_recipes_cq: "true"
       config_name: windows_arm_host_engine
-    drone_dimensions:
-      - os=Windows
 
   - name: Windows windows_unopt
     recipe: engine_v2/builder


### PR DESCRIPTION
The `drone_dimensions` is expected to be defined under property only. The field level definition has never been used.

part of https://github.com/flutter/flutter/issues/143671