### PR TITLE
Remove obsolete `cache_root` property

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -118,7 +118,6 @@ targets:
     presubmit: false
     properties:
       cache_name: "builder"
-      cache_root: "cache"
       cache_paths: >-
         [
           "builder",
@@ -138,7 +137,6 @@ targets:
     presubmit: false
     properties:
       cache_name: "builder"
-      cache_root: "cache"
       cache_paths: >-
         [
           "builder",
@@ -157,7 +155,6 @@ targets:
     presubmit: false
     properties:
       cache_name: "builder"
-      cache_root: "cache"
       cache_paths: >-
         [
           "builder",


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/143671

Lands following: https://flutter-review.googlesource.com/c/recipes/+/55401