### PR TITLE
[Impeller] Make StC work for Position+UV buffers.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -3537,7 +3537,8 @@ TEST_P(AiksTest, CorrectClipDepthAssignedToEntities) {
                      //            once we switch to the clip depth approach.
 
   auto picture = canvas.EndRecordingAsPicture();
-  std::array<uint32_t, 5> expected = {
+
+  std::vector<uint32_t> expected = {
       2,  // DrawRRect
       4,  // ClipRRect -- Has a depth value equal to the max depth of all the
           //              content it affect. In this case, the SaveLayer and all
@@ -3546,8 +3547,14 @@ TEST_P(AiksTest, CorrectClipDepthAssignedToEntities) {
           //              contents are rendered, so it should have a depth value
           //              greater than all its contents.
       3,  // DrawRRect
-      5,  // Restore (will be removed once we switch to the clip depth approach)
   };
+
+  if constexpr (!ContentContext::kEnableStencilThenCover) {
+    expected.push_back(  //
+        5  // Restore (no longer necessary when clipping on the depth buffer)
+    );
+  }
+
   std::vector<uint32_t> actual;
 
   picture.pass->IterateAllElements([&](EntityPass::Element& element) -> bool {

--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -169,36 +169,6 @@ bool GenerateMipmap(const std::shared_ptr<Context>& context,
   return context->GetCommandQueue()->Submit({buffer}).ok();
 }
 
-TEST_P(AiksTest, CanRenderMultiContourPaths) {
-  auto texture = CreateTextureForFixture("table_mountain_nx.png",
-                                         /*enable_mipmapping=*/true);
-  GenerateMipmap(GetContext(), texture, "table_mountain_nx");
-  Canvas canvas;
-  canvas.Scale(GetContentScale());
-  canvas.Translate({100.0f, 100.0f, 0});
-  Paint paint;
-  paint.color = Color::White();
-  paint.style = Paint::Style::kFill;
-
-  auto draw_path = [&]() {
-    PathBuilder path_builder;
-    path_builder.AddCircle({150, 150}, 150);
-    path_builder.AddRoundedRect(Rect::MakeLTRB(300, 300, 600, 600), 10);
-    canvas.DrawPath(path_builder.TakePath(), paint);
-  };
-
-  // Solid color source.
-  paint.color_source = ColorSource::MakeColor();
-  draw_path();
-
-  // Image color source.
-  paint.color_source = ColorSource::MakeImage(texture, Entity::TileMode::kClamp,
-                                              Entity::TileMode::kClamp, {}, {});
-  draw_path();
-
-  ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
-}
-
 void CanRenderTiledTexture(AiksTest* aiks_test,
                            Entity::TileMode tile_mode,
                            Matrix local_matrix = {}) {

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -219,10 +219,8 @@ bool Canvas::Restore() {
   }
 
   transform_stack_.pop_back();
-  if constexpr (!ContentContext::kEnableStencilThenCover) {
-    if (num_clips > 0) {
-      RestoreClip();
-    }
+  if (num_clips > 0) {
+    RestoreClip();
   }
 
   return true;

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -10,6 +10,7 @@
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/contents.h"
 #include "impeller/entity/geometry/geometry.h"
+#include "impeller/entity/geometry/rect_geometry.h"
 #include "impeller/geometry/matrix.h"
 
 namespace impeller {
@@ -112,80 +113,82 @@ class ColorSourceContents : public Contents {
           ContentContextOptions)>;
 
   template <typename VertexShaderT>
-  bool DrawGeometry(GeometryResult geometry_result,
-                    const ContentContext& renderer,
+  bool DrawGeometry(const ContentContext& renderer,
                     const Entity& entity,
                     RenderPass& pass,
                     const PipelineBuilderCallback& pipeline_callback,
                     typename VertexShaderT::FrameInfo frame_info,
-                    const BindFragmentCallback& bind_fragment_callback) const {
+                    const BindFragmentCallback& bind_fragment_callback,
+                    bool enable_uvs = false,
+                    Rect texture_coverage = {},
+                    const Matrix& effect_transform = {}) const {
     auto options = OptionsFromPassAndEntity(pass, entity);
+
+    GeometryResult::Mode geometry_mode = GetGeometry()->GetResultMode();
+    Geometry& geometry = *GetGeometry();
+
+    const bool is_stencil_then_cover =
+        geometry_mode == GeometryResult::Mode::kNonZero ||
+        geometry_mode == GeometryResult::Mode::kEvenOdd;
+    if (is_stencil_then_cover) {
+      pass.SetStencilReference(0);
+
+      /// Stencil preparation draw.
+
+      GeometryResult stencil_geometry_result =
+          GetGeometry()->GetPositionBuffer(renderer, entity, pass);
+      pass.SetVertexBuffer(std::move(stencil_geometry_result.vertex_buffer));
+      options.primitive_type = stencil_geometry_result.type;
+
+      options.blend_mode = BlendMode::kDestination;
+      switch (stencil_geometry_result.mode) {
+        case GeometryResult::Mode::kNonZero:
+          pass.SetCommandLabel("Stencil preparation (NonZero)");
+          options.stencil_mode =
+              ContentContextOptions::StencilMode::kStencilNonZeroFill;
+          break;
+        case GeometryResult::Mode::kEvenOdd:
+          pass.SetCommandLabel("Stencil preparation (EvenOdd)");
+          options.stencil_mode =
+              ContentContextOptions::StencilMode::kStencilEvenOddFill;
+          break;
+        default:
+          FML_UNREACHABLE();
+      }
+      pass.SetPipeline(renderer.GetClipPipeline(options));
+      ClipPipeline::VertexShader::FrameInfo clip_frame_info;
+      clip_frame_info.depth = entity.GetShaderClipDepth();
+      clip_frame_info.mvp = stencil_geometry_result.transform;
+      ClipPipeline::VertexShader::BindFrameInfo(
+          pass, renderer.GetTransientsBuffer().EmplaceUniform(clip_frame_info));
+
+      if (!pass.Draw().ok()) {
+        return false;
+      }
+
+      /// Cover draw.
+
+      options.blend_mode = entity.GetBlendMode();
+      options.stencil_mode = ContentContextOptions::StencilMode::kCoverCompare;
+      std::optional<Rect> maybe_cover_area = GetGeometry()->GetCoverage({});
+      if (!maybe_cover_area.has_value()) {
+        return true;
+      }
+      geometry = RectGeometry(maybe_cover_area.value());
+    }
+
+    GeometryResult geometry_result =
+        enable_uvs
+            ? geometry.GetPositionUVBuffer(texture_coverage, effect_transform,
+                                           renderer, entity, pass)
+            : geometry.GetPositionBuffer(renderer, entity, pass);
+    pass.SetVertexBuffer(std::move(geometry_result.vertex_buffer));
     options.primitive_type = geometry_result.type;
 
     // Take the pre-populated vertex shader uniform struct and set managed
     // values.
     frame_info.depth = entity.GetShaderClipDepth();
     frame_info.mvp = geometry_result.transform;
-
-    pass.SetVertexBuffer(std::move(geometry_result.vertex_buffer));
-
-    if constexpr (ContentContext::kEnableStencilThenCover) {
-      const bool is_stencil_then_cover =
-          geometry_result.mode == GeometryResult::Mode::kNonZero ||
-          geometry_result.mode == GeometryResult::Mode::kEvenOdd;
-      if (is_stencil_then_cover) {
-        pass.SetStencilReference(0);
-
-        /// Stencil preparation draw.
-
-        options.blend_mode = BlendMode::kDestination;
-        switch (geometry_result.mode) {
-          case GeometryResult::Mode::kNonZero:
-            pass.SetCommandLabel("Stencil preparation (NonZero)");
-            options.stencil_mode =
-                ContentContextOptions::StencilMode::kStencilNonZeroFill;
-            break;
-          case GeometryResult::Mode::kEvenOdd:
-            pass.SetCommandLabel("Stencil preparation (EvenOdd)");
-            options.stencil_mode =
-                ContentContextOptions::StencilMode::kStencilEvenOddFill;
-            break;
-          default:
-            FML_UNREACHABLE();
-        }
-        pass.SetPipeline(renderer.GetClipPipeline(options));
-        ClipPipeline::VertexShader::FrameInfo clip_frame_info;
-        clip_frame_info.depth = entity.GetShaderClipDepth();
-        clip_frame_info.mvp = geometry_result.transform;
-        ClipPipeline::VertexShader::BindFrameInfo(
-            pass,
-            renderer.GetTransientsBuffer().EmplaceUniform(clip_frame_info));
-
-        if (!pass.Draw().ok()) {
-          return false;
-        }
-
-        /// Cover draw.
-
-        options.blend_mode = entity.GetBlendMode();
-        options.stencil_mode =
-            ContentContextOptions::StencilMode::kCoverCompare;
-        std::optional<Rect> maybe_cover_area =
-            GetGeometry()->GetCoverage(entity.GetTransform());
-        if (!maybe_cover_area.has_value()) {
-          return true;
-        }
-        auto points = maybe_cover_area.value().GetPoints();
-        auto vertices =
-            VertexBufferBuilder<typename VertexShaderT::PerVertexData>{}
-                .AddVertices(
-                    {{points[0]}, {points[1]}, {points[2]}, {points[3]}})
-                .CreateVertexBuffer(renderer.GetTransientsBuffer());
-        pass.SetVertexBuffer(std::move(vertices));
-
-        frame_info.mvp = pass.GetOrthographicTransform();
-      }
-    }
 
     // If overdraw prevention is enabled (like when drawing stroke paths), we
     // increment the stencil buffer as we draw, preventing overlapping fragments
@@ -233,39 +236,6 @@ class ColorSourceContents : public Contents {
       }
     }
     return true;
-  }
-
-  template <typename VertexShaderT>
-  bool DrawPositions(const ContentContext& renderer,
-                     const Entity& entity,
-                     RenderPass& pass,
-                     const PipelineBuilderCallback& pipeline_callback,
-                     typename VertexShaderT::FrameInfo frame_info,
-                     const BindFragmentCallback& bind_pipeline_callback) const {
-    GeometryResult geometry_result =
-        GetGeometry()->GetPositionBuffer(renderer, entity, pass);
-
-    return DrawGeometry<VertexShaderT>(std::move(geometry_result), renderer,
-                                       entity, pass, pipeline_callback,
-                                       frame_info, bind_pipeline_callback);
-  }
-
-  template <typename VertexShaderT>
-  bool DrawPositionsAndUVs(
-      Rect texture_coverage,
-      const Matrix& effect_transform,
-      const ContentContext& renderer,
-      const Entity& entity,
-      RenderPass& pass,
-      const PipelineBuilderCallback& pipeline_callback,
-      typename VertexShaderT::FrameInfo frame_info,
-      const BindFragmentCallback& bind_pipeline_callback) const {
-    auto geometry_result = GetGeometry()->GetPositionUVBuffer(
-        texture_coverage, effect_transform, renderer, entity, pass);
-
-    return DrawGeometry<VertexShaderT>(std::move(geometry_result), renderer,
-                                       entity, pass, pipeline_callback,
-                                       frame_info, bind_pipeline_callback);
   }
 
  private:

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -167,6 +167,7 @@ class ColorSourceContents : public Contents {
 
         /// Cover draw.
 
+        options.blend_mode = entity.GetBlendMode();
         options.stencil_mode =
             ContentContextOptions::StencilMode::kCoverCompare;
         std::optional<Rect> maybe_cover_area =

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -71,7 +71,7 @@ bool ConicalGradientContents::RenderSSBO(const ContentContext& renderer,
       [&renderer](ContentContextOptions options) {
         return renderer.GetConicalGradientSSBOFillPipeline(options);
       };
-  return ColorSourceContents::DrawPositions<VS>(
+  return ColorSourceContents::DrawGeometry<VS>(
       renderer, entity, pass, pipeline_callback, frame_info,
       [this, &renderer](RenderPass& pass) {
         FS::FragInfo frag_info;
@@ -128,7 +128,7 @@ bool ConicalGradientContents::RenderTexture(const ContentContext& renderer,
       [&renderer](ContentContextOptions options) {
         return renderer.GetConicalGradientFillPipeline(options);
       };
-  return ColorSourceContents::DrawPositions<VS>(
+  return ColorSourceContents::DrawGeometry<VS>(
       renderer, entity, pass, pipeline_callback, frame_info,
       [this, &renderer, &gradient_texture](RenderPass& pass) {
         FS::FragInfo frag_info;

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -480,23 +480,25 @@ fml::StatusOr<RenderTarget> ContentContext::MakeSubpass(
     ISize texture_size,
     const SubpassCallback& subpass_callback,
     bool msaa_enabled,
+    bool depth_stencil_enabled,
     int32_t mip_count) const {
   const std::shared_ptr<Context>& context = GetContext();
   RenderTarget subpass_target;
+
+  std::optional<RenderTarget::AttachmentConfig> depth_stencil_config =
+      depth_stencil_enabled ? RenderTarget::kDefaultStencilAttachmentConfig
+                            : std::optional<RenderTarget::AttachmentConfig>();
+
   if (context->GetCapabilities()->SupportsOffscreenMSAA() && msaa_enabled) {
     subpass_target = RenderTarget::CreateOffscreenMSAA(
         *context, *GetRenderTargetCache(), texture_size,
         /*mip_count=*/mip_count, SPrintF("%s Offscreen", label.c_str()),
-        RenderTarget::kDefaultColorAttachmentConfigMSAA,
-        std::nullopt  // stencil_attachment_config
-    );
+        RenderTarget::kDefaultColorAttachmentConfigMSAA, depth_stencil_config);
   } else {
     subpass_target = RenderTarget::CreateOffscreen(
         *context, *GetRenderTargetCache(), texture_size,
         /*mip_count=*/mip_count, SPrintF("%s Offscreen", label.c_str()),
-        RenderTarget::kDefaultColorAttachmentConfig,  //
-        std::nullopt  // stencil_attachment_config
-    );
+        RenderTarget::kDefaultColorAttachmentConfig, depth_stencil_config);
   }
   return MakeSubpass(label, subpass_target, subpass_callback);
 }

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -408,7 +408,7 @@ class ContentContext {
   ///
   // TODO(bdero): Remove this setting once StC is fully de-risked
   //              https://github.com/flutter/flutter/issues/123671
-  static constexpr bool kEnableStencilThenCover = true;
+  static constexpr bool kEnableStencilThenCover = false;
 
 #if IMPELLER_ENABLE_3D
   std::shared_ptr<scene::SceneContext> GetSceneContext() const;

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -408,7 +408,7 @@ class ContentContext {
   ///
   // TODO(bdero): Remove this setting once StC is fully de-risked
   //              https://github.com/flutter/flutter/issues/123671
-  static constexpr bool kEnableStencilThenCover = false;
+  static constexpr bool kEnableStencilThenCover = true;
 
 #if IMPELLER_ENABLE_3D
   std::shared_ptr<scene::SceneContext> GetSceneContext() const;
@@ -793,6 +793,7 @@ class ContentContext {
       ISize texture_size,
       const SubpassCallback& subpass_callback,
       bool msaa_enabled = true,
+      bool depth_stencil_enabled = false,
       int32_t mip_count = 1) const;
 
   /// Makes a subpass that will render to `subpass_target`.

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -101,7 +101,7 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
             entity.GetTransform());
         return contents.Render(renderer, sub_entity, pass);
       },
-      msaa_enabled,
+      msaa_enabled, /*depth_stencil_enabled=*/true,
       std::min(mip_count, static_cast<int32_t>(subpass_size.MipCount())));
 
   if (!render_target.ok()) {

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -75,7 +75,7 @@ bool LinearGradientContents::RenderTexture(const ContentContext& renderer,
       [&renderer](ContentContextOptions options) {
         return renderer.GetLinearGradientFillPipeline(options);
       };
-  return ColorSourceContents::DrawPositions<VS>(
+  return ColorSourceContents::DrawGeometry<VS>(
       renderer, entity, pass, pipeline_callback, frame_info,
       [this, &renderer](RenderPass& pass) {
         auto gradient_data = CreateGradientBuffer(colors_, stops_);
@@ -126,7 +126,7 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
       [&renderer](ContentContextOptions options) {
         return renderer.GetLinearGradientSSBOFillPipeline(options);
       };
-  return ColorSourceContents::DrawPositions<VS>(
+  return ColorSourceContents::DrawGeometry<VS>(
       renderer, entity, pass, pipeline_callback, frame_info,
       [this, &renderer](RenderPass& pass) {
         FS::FragInfo frag_info;

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -77,7 +77,7 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
       [&renderer](ContentContextOptions options) {
         return renderer.GetRadialGradientSSBOFillPipeline(options);
       };
-  return ColorSourceContents::DrawPositions<VS>(
+  return ColorSourceContents::DrawGeometry<VS>(
       renderer, entity, pass, pipeline_callback, frame_info,
       [this, &renderer](RenderPass& pass) {
         FS::FragInfo frag_info;
@@ -127,7 +127,7 @@ bool RadialGradientContents::RenderTexture(const ContentContext& renderer,
       [&renderer](ContentContextOptions options) {
         return renderer.GetRadialGradientFillPipeline(options);
       };
-  return ColorSourceContents::DrawPositions<VS>(
+  return ColorSourceContents::DrawGeometry<VS>(
       renderer, entity, pass, pipeline_callback, frame_info,
       [this, &renderer, &gradient_texture](RenderPass& pass) {
         FS::FragInfo frag_info;

--- a/impeller/entity/contents/runtime_effect_contents.cc
+++ b/impeller/entity/contents/runtime_effect_contents.cc
@@ -144,6 +144,8 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
   BindFragmentCallback bind_callback = [this, &renderer, &context,
                                         &descriptor_set_layouts](
                                            RenderPass& pass) {
+    descriptor_set_layouts.clear();
+
     size_t minimum_sampler_index = 100000000;
     size_t buffer_index = 0;
     size_t buffer_offset = 0;
@@ -313,9 +315,9 @@ bool RuntimeEffectContents::Render(const ContentContext& renderer,
         runtime_stage_->GetEntrypoint(), options, create_callback);
   };
 
-  return ColorSourceContents::DrawPositions<VS>(renderer, entity, pass,
-                                                pipeline_callback,
-                                                VS::FrameInfo{}, bind_callback);
+  return ColorSourceContents::DrawGeometry<VS>(renderer, entity, pass,
+                                               pipeline_callback,
+                                               VS::FrameInfo{}, bind_callback);
 }
 
 }  // namespace impeller

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -58,7 +58,7 @@ bool SolidColorContents::Render(const ContentContext& renderer,
       [&renderer](ContentContextOptions options) {
         return renderer.GetSolidFillPipeline(options);
       };
-  return ColorSourceContents::DrawPositions<VS>(
+  return ColorSourceContents::DrawGeometry<VS>(
       renderer, entity, pass, pipeline_callback, frame_info,
       [](RenderPass& pass) {
         pass.SetCommandLabel("Solid Fill");

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -85,7 +85,7 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
       [&renderer](ContentContextOptions options) {
         return renderer.GetSweepGradientSSBOFillPipeline(options);
       };
-  return ColorSourceContents::DrawPositions<VS>(
+  return ColorSourceContents::DrawGeometry<VS>(
       renderer, entity, pass, pipeline_callback, frame_info,
       [this, &renderer](RenderPass& pass) {
         FS::FragInfo frag_info;
@@ -134,7 +134,7 @@ bool SweepGradientContents::RenderTexture(const ContentContext& renderer,
       [&renderer](ContentContextOptions options) {
         return renderer.GetSweepGradientFillPipeline(options);
       };
-  return ColorSourceContents::DrawPositions<VS>(
+  return ColorSourceContents::DrawGeometry<VS>(
       renderer, entity, pass, pipeline_callback, frame_info,
       [this, &renderer, &gradient_texture](RenderPass& pass) {
         FS::FragInfo frag_info;

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -154,9 +154,8 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
       [&renderer, &pipeline_method](ContentContextOptions options) {
         return (renderer.*pipeline_method)(options);
       };
-  return ColorSourceContents::DrawPositionsAndUVs<VS>(
-      Rect::MakeSize(texture_size), GetInverseEffectTransform(), renderer,
-      entity, pass, pipeline_callback, frame_info,
+  return ColorSourceContents::DrawGeometry<VS>(
+      renderer, entity, pass, pipeline_callback, frame_info,
       [this, &renderer, &is_external_texture,
        &uses_emulated_tile_mode](RenderPass& pass) {
         auto& host_buffer = renderer.GetTransientsBuffer();
@@ -215,7 +214,10 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
         }
 
         return true;
-      });
+      },
+      /*enable_uvs=*/true,
+      /*texture_coverage=*/Rect::MakeSize(texture_size),
+      /*effect_transform=*/GetInverseEffectTransform());
 }
 
 std::optional<Snapshot> TiledTextureContents::RenderToSnapshot(

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -131,7 +131,7 @@ class Entity {
   std::shared_ptr<Contents> contents_;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   uint32_t clip_depth_ = 0u;
-  uint32_t new_clip_depth_ = 0u;
+  uint32_t new_clip_depth_ = 1u;
   mutable Capture capture_;
 };
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -839,6 +839,11 @@ bool EntityPass::RenderElement(Entity& element_entity,
       }
       clip_coverage_stack.resize(restoration_index + 1);
 
+      if constexpr (ContentContext::kEnableStencilThenCover) {
+        // Skip all clip restores when stencil-then-cover is enabled.
+        return true;
+      }
+
       if (!clip_coverage_stack.back().coverage.has_value()) {
         // Running this restore op won't make anything renderable, so skip it.
         return true;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2788,7 +2788,11 @@ TEST_P(EntityTest, FillPathGeometryGetPositionBufferReturnsExpectedMode) {
                     .Close()
                     .TakePath();
     GeometryResult result = get_result(path);
-    EXPECT_EQ(result.mode, GeometryResult::Mode::kNormal);
+    if constexpr (ContentContext::kEnableStencilThenCover) {
+      EXPECT_EQ(result.mode, GeometryResult::Mode::kNonZero);
+    } else {
+      EXPECT_EQ(result.mode, GeometryResult::Mode::kNormal);
+    }
   }
 }
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <algorithm>
 #include <cstring>
 #include <memory>
 #include <optional>
@@ -2606,7 +2607,9 @@ class TestRenderTargetAllocator : public RenderTargetAllocator {
 
   void End() override { RenderTargetAllocator::End(); }
 
-  std::vector<TextureDescriptor> GetDescriptors() const { return allocated_; }
+  std::vector<TextureDescriptor> GetAllocatedTextureDescriptors() const {
+    return allocated_;
+  }
 
   void ResetDescriptors() { allocated_.clear(); }
 
@@ -2651,39 +2654,19 @@ TEST_P(EntityTest, AdvancedBlendCoverageHintIsNotResetByEntityPass) {
 
   EXPECT_TRUE(pass->Render(content_context, rt));
 
-  if (test_allocator->GetDescriptors().size() == 6u) {
-    EXPECT_EQ(test_allocator->GetDescriptors()[0].size, ISize(1000, 1000));
-    EXPECT_EQ(test_allocator->GetDescriptors()[1].size, ISize(1000, 1000));
-    EXPECT_EQ(test_allocator->GetDescriptors()[2].size, ISize(1000, 1000));
-    EXPECT_EQ(test_allocator->GetDescriptors()[3].size, ISize(1000, 1000));
+  std::vector<TextureDescriptor> descriptors =
+      test_allocator->GetAllocatedTextureDescriptors();
 
-    EXPECT_EQ(test_allocator->GetDescriptors()[4].size, ISize(200, 200));
-    EXPECT_EQ(test_allocator->GetDescriptors()[5].size, ISize(200, 200));
-  } else if (test_allocator->GetDescriptors().size() == 7u) {
-    // Onscreen render target.
-    EXPECT_EQ(test_allocator->GetDescriptors()[0].size, ISize(1000, 1000));
-    EXPECT_EQ(test_allocator->GetDescriptors()[1].size, ISize(1000, 1000));
-    EXPECT_EQ(test_allocator->GetDescriptors()[2].size, ISize(1000, 1000));
+  auto contains_size = [&descriptors](ISize size) -> bool {
+    return std::find_if(descriptors.begin(), descriptors.end(),
+                        [&size](auto desc) { return desc.size == size; }) !=
+           descriptors.end();
+  };
 
-    EXPECT_EQ(test_allocator->GetDescriptors()[3].size, ISize(200, 200));
-    EXPECT_EQ(test_allocator->GetDescriptors()[4].size, ISize(200, 200));
-    EXPECT_EQ(test_allocator->GetDescriptors()[5].size, ISize(200, 200));
-    EXPECT_EQ(test_allocator->GetDescriptors()[6].size, ISize(200, 200));
-  } else if (test_allocator->GetDescriptors().size() == 4u) {
-    EXPECT_EQ(test_allocator->GetDescriptors()[0].size, ISize(1000, 1000));
-    EXPECT_EQ(test_allocator->GetDescriptors()[1].size, ISize(1000, 1000));
-
-    EXPECT_EQ(test_allocator->GetDescriptors()[2].size, ISize(200, 200));
-    EXPECT_EQ(test_allocator->GetDescriptors()[3].size, ISize(200, 200));
-  } else {
-    std::stringstream sizes;
-    for (const auto& desc : test_allocator->GetDescriptors()) {
-      sizes << "\nISize" << desc.size;
-    }
-    EXPECT_TRUE(false) << "Unexpected number of render targets. Total: "
-                       << test_allocator->GetDescriptors().size()
-                       << "\nExpected sizes: " << sizes.str();
-  }
+  EXPECT_TRUE(contains_size(ISize(1000, 1000)))
+      << "The root texture wasn't allocated";
+  EXPECT_TRUE(contains_size(ISize(200, 200)))
+      << "The ColorBurned texture wasn't allocated (100x100 scales up 2x)";
 }
 
 TEST_P(EntityTest, SpecializationConstantsAreAppliedToVariants) {

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2676,7 +2676,13 @@ TEST_P(EntityTest, AdvancedBlendCoverageHintIsNotResetByEntityPass) {
     EXPECT_EQ(test_allocator->GetDescriptors()[2].size, ISize(200, 200));
     EXPECT_EQ(test_allocator->GetDescriptors()[3].size, ISize(200, 200));
   } else {
-    EXPECT_TRUE(false);
+    std::stringstream sizes;
+    for (const auto& desc : test_allocator->GetDescriptors()) {
+      sizes << "\nISize" << desc.size;
+    }
+    EXPECT_TRUE(false) << "Unexpected number of render targets. Total: "
+                       << test_allocator->GetDescriptors().size()
+                       << "\nExpected sizes: " << sizes.str();
   }
 }
 

--- a/impeller/entity/geometry/fill_path_geometry.h
+++ b/impeller/entity/geometry/fill_path_geometry.h
@@ -42,6 +42,9 @@ class FillPathGeometry final : public Geometry {
                                      const Entity& entity,
                                      RenderPass& pass) const override;
 
+  // |Geometry|
+  GeometryResult::Mode GetResultMode() const override;
+
   Path path_;
   std::optional<Rect> inner_rect_;
 

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -168,6 +168,10 @@ GeometryResult Geometry::GetPositionUVBuffer(Rect texture_coverage,
   return {};
 }
 
+GeometryResult::Mode Geometry::GetResultMode() const {
+  return GeometryResult::Mode::kNormal;
+}
+
 std::shared_ptr<Geometry> Geometry::MakeFillPath(
     const Path& path,
     std::optional<Rect> inner_rect) {

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -128,6 +128,8 @@ class Geometry {
                                              const Entity& entity,
                                              RenderPass& pass) const = 0;
 
+  virtual GeometryResult::Mode GetResultMode() const;
+
   virtual GeometryVertexType GetVertexType() const = 0;
 
   virtual std::optional<Rect> GetCoverage(const Matrix& transform) const = 0;

--- a/impeller/entity/geometry/rect_geometry.h
+++ b/impeller/entity/geometry/rect_geometry.h
@@ -21,7 +21,6 @@ class RectGeometry final : public Geometry {
   // |Geometry|
   bool IsAxisAlignedRect() const override;
 
- private:
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,
                                    const Entity& entity,
@@ -40,6 +39,7 @@ class RectGeometry final : public Geometry {
                                      const Entity& entity,
                                      RenderPass& pass) const override;
 
+ private:
   Rect rect_;
 
   RectGeometry(const RectGeometry&) = delete;

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -6,6 +6,7 @@
 
 #include "impeller/core/buffer_view.h"
 #include "impeller/core/formats.h"
+#include "impeller/entity/geometry/geometry.h"
 #include "impeller/entity/texture_fill.vert.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/geometry/path_component.h"
@@ -644,6 +645,10 @@ GeometryResult StrokePathGeometry::GetPositionUVBuffer(
       .transform = pass.GetOrthographicTransform() * entity.GetTransform(),
       .mode = GeometryResult::Mode::kPreventOverdraw,
   };
+}
+
+GeometryResult::Mode StrokePathGeometry::GetResultMode() const {
+  return GeometryResult::Mode::kPreventOverdraw;
 }
 
 GeometryVertexType StrokePathGeometry::GetVertexType() const {

--- a/impeller/entity/geometry/stroke_path_geometry.h
+++ b/impeller/entity/geometry/stroke_path_geometry.h
@@ -42,6 +42,9 @@ class StrokePathGeometry final : public Geometry {
                                      RenderPass& pass) const override;
 
   // |Geometry|
+  GeometryResult::Mode GetResultMode() const override;
+
+  // |Geometry|
   GeometryVertexType GetVertexType() const override;
 
   // |Geometry|


### PR DESCRIPTION
The accumulated fixes pulled out of the flag flip PR: https://github.com/flutter/engine/pull/50856

* Also fixes tests to make them resilient to StC being on/off.
* Fix blending for the cover draw.
* Default to depth=1 which is much more reasonable as depth=0 will never draw anything for cover draws. This allows enclosed subpass rendering cases like `Contents::RenderToSnapshot` for filter inputs to work by default and makes mistakes harder.
* Use depth+stencil attachments for `Contents::RenderToSnapshot` subpasses to allow for StC draws.