### PR TITLE
Make sure to call `setHeightOverride` as well on TextStyle and StrutStyle

### DIFF
--- a/lib/web_ui/skwasm/text/strut_style.cpp
+++ b/lib/web_ui/skwasm/text/strut_style.cpp
@@ -33,6 +33,7 @@ SKWASM_EXPORT void strutStyle_setFontSize(StrutStyle* style,
 
 SKWASM_EXPORT void strutStyle_setHeight(StrutStyle* style, SkScalar height) {
   style->setHeight(height);
+  style->setHeightOverride(true);
 }
 
 SKWASM_EXPORT void strutStyle_setHalfLeading(StrutStyle* style,

--- a/lib/web_ui/skwasm/text/text_style.cpp
+++ b/lib/web_ui/skwasm/text/text_style.cpp
@@ -96,6 +96,7 @@ SKWASM_EXPORT void textStyle_setWordSpacing(TextStyle* style,
 
 SKWASM_EXPORT void textStyle_setHeight(TextStyle* style, SkScalar height) {
   style->setHeight(height);
+  style->setHeightOverride(true);
 }
 
 SKWASM_EXPORT void textStyle_setHalfLeading(TextStyle* style,

--- a/lib/web_ui/test/ui/text_golden_test.dart
+++ b/lib/web_ui/test/ui/text_golden_test.dart
@@ -68,6 +68,11 @@ Future<void> testMain() async {
         layoutWidth: 50, paragraphHeight: 1.5);
   });
 
+  test('text styles - text style height overriding paragraph height', () async {
+    await testTextStyle('text style height and paragraph style height',
+      layoutWidth: 50, paragraphHeight: 1.5, height: 2.0);
+  });
+
   test('text styles - paragraph text height behavior', () async {
     await testTextStyle('paragraph text height behavior',
         layoutWidth: 50,


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/143877

We apparently need to call `setHeightOverride(true)` on `TextStyle` and `StrutStyle` objects in order to properly apply the height.