### PR TITLE
iPad keyboard cut/copy/paste buttons

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1145,11 +1145,6 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
-  // When scribble is available, the FlutterTextInputView will display the native toolbar unless
-  // these text editing actions are disabled.
-  if ([self isScribbleAvailable] && sender == NULL) {
-    return NO;
-  }
   if (action == @selector(paste:)) {
     // Forbid pasting images, memojis, or other non-string content.
     return [UIPasteboard generalPasteboard].string != nil;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1146,12 +1146,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
   if (action == @selector(paste:)) {
-    UIPasteboard* pasteboard = [UIPasteboard generalPasteboard];
-    if (@available(iOS 10, *)) {
-      return pasteboard.hasStrings;
-    }
     // Forbid pasting images, memojis, or other non-string content.
-    return pasteboard.string != nil;
+    return [UIPasteboard generalPasteboard].hasStrings;
   }
 
   return [super canPerformAction:action withSender:sender];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1146,8 +1146,12 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
   if (action == @selector(paste:)) {
+    UIPasteboard* pasteboard = [UIPasteboard generalPasteboard];
+    if (@available(iOS 10, *)) {
+      return pasteboard.hasStrings;
+    }
     // Forbid pasting images, memojis, or other non-string content.
-    return [UIPasteboard generalPasteboard].string != nil;
+    return pasteboard.string != nil;
   }
 
   return [super canPerformAction:action withSender:sender];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -1299,15 +1299,15 @@ FLUTTER_ASSERT_ARC
     [mockInputView insertText:@"aaaa"];
     [mockInputView selectAll:nil];
 
-    XCTAssertFalse([mockInputView canPerformAction:@selector(copy:) withSender:NULL]);
+    XCTAssertTrue([mockInputView canPerformAction:@selector(copy:) withSender:NULL]);
     XCTAssertTrue([mockInputView canPerformAction:@selector(copy:) withSender:@"sender"]);
     XCTAssertFalse([mockInputView canPerformAction:@selector(paste:) withSender:NULL]);
     XCTAssertFalse([mockInputView canPerformAction:@selector(paste:) withSender:@"sender"]);
 
     [mockInputView copy:NULL];
-    XCTAssertFalse([mockInputView canPerformAction:@selector(copy:) withSender:NULL]);
+    XCTAssertTrue([mockInputView canPerformAction:@selector(copy:) withSender:NULL]);
     XCTAssertTrue([mockInputView canPerformAction:@selector(copy:) withSender:@"sender"]);
-    XCTAssertFalse([mockInputView canPerformAction:@selector(paste:) withSender:NULL]);
+    XCTAssertTrue([mockInputView canPerformAction:@selector(paste:) withSender:NULL]);
     XCTAssertTrue([mockInputView canPerformAction:@selector(paste:) withSender:@"sender"]);
   }
 }


### PR DESCRIPTION
The cut/copy/paste buttons above the keyboard on iPad were always greyed out, and this PR enables them to work with the current text input as normal.

| Native Reminders app on iPad allows cut/copy/paste | Flutter app on iPad greys out cut/copy/paste | Flutter after this PR |
| --- | --- | --- |
| ![Screenshot 2024-02-23 at 10 57 08 AM](https://github.com/flutter/flutter/assets/389558/565500b0-4271-4d3a-9a3f-8a6751494afb) | ![Screenshot 2024-02-23 at 10 56 24 AM](https://github.com/flutter/flutter/assets/389558/bdbaf2b4-c2ec-44e1-87f6-b7cfd81b5903) | ![Screenshot 2024-02-23 at 12 25 07 PM](https://github.com/flutter/engine/assets/389558/cd6dc561-7f9e-4be5-81c4-695cea3e70a9) |

Fixes https://github.com/flutter/flutter/issues/102940
