### PR TITLE
Correctly offset the cull rect of the opacity layer.

### DIFF
--- a/lib/web_ui/lib/src/engine/layers.dart
+++ b/lib/web_ui/lib/src/engine/layers.dart
@@ -283,6 +283,7 @@ class OpacityOperation implements LayerOperation {
     if (offset != ui.Offset.zero) {
       canvas.save();
       canvas.translate(offset.dx, offset.dy);
+      cullRect = cullRect.shift(-offset);
     }
     canvas.saveLayer(
       cullRect,

--- a/lib/web_ui/test/ui/scene_builder_test.dart
+++ b/lib/web_ui/test/ui/scene_builder_test.dart
@@ -124,16 +124,16 @@ Future<void> testMain() async {
         );
       }));
 
-      sceneBuilder.pushOpacity(0x7F);
+      sceneBuilder.pushOpacity(0x7F, offset: const ui.Offset(150, 150));
       sceneBuilder.addPicture(ui.Offset.zero, drawPicture((ui.Canvas canvas) {
         final ui.Paint paint = ui.Paint()..color = const ui.Color(0xFFFF0000);
         canvas.drawCircle(
-          const ui.Offset(125, 150),
+          const ui.Offset(-25, 0),
           50,
           paint
         );
         canvas.drawCircle(
-          const ui.Offset(175, 150),
+          const ui.Offset(25, 0),
           50,
           paint
         );


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/140999. Previously, the cull rect would be misplaced causing many elements to not render at all.