### PR TITLE
Remove timeouts from CountdownLatch.await in tests

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -27,7 +27,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.view.TextureRegistry;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
@@ -263,8 +262,8 @@ public class FlutterRendererTest {
             });
     fakeFinalizer.start();
     try {
-      latch.await(5L, TimeUnit.SECONDS);
-    } catch (Throwable e) {
+      latch.await();
+    } catch (InterruptedException e) {
       // do nothing
     }
   }

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
@@ -94,9 +94,7 @@ public class ExternalTextureFlutterActivity extends TestActivity {
     super.waitUntilFlutterRendered();
 
     try {
-      if (!firstFrameLatch.await(10, java.util.concurrent.TimeUnit.SECONDS)) {
-        throw new RuntimeException("Timeout waiting for firstFrameLatch to signal");
-      }
+      firstFrameLatch.await();
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
See https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#never-check-if-a-port-is-available-before-using-it-never-add-timeouts-and-other-race-conditions

This may be contributing to flakiness in the Java/Scenario_app tests. We should just timeout when CI says it's taken too long - on a slow machine 5 or 10 seconds may not be enough time.