### PR TITLE
Run apple SDK finders as gclient hooks

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -103,6 +103,10 @@ vars = {
   # Checkout Linux dependencies only when building on Linux.
   'download_linux_deps': 'host_os == "linux"',
 
+  # The minimum macOS SDK version. This must match the setting in
+  # //flutter/tools/gn.
+  'mac_sdk_min': '10.14',
+
   # Downloads the fuchsia SDK as listed in fuchsia_sdk_path var. This variable
   # is currently only used for the Fuchsia LSC process and is not intended for
   # local development.
@@ -279,7 +283,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '7b537de78ac2239982ace130d1845374e5dcf113',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'ebc2748229c8377d97ee1cafd11dff07c285f440',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',
@@ -1205,6 +1209,32 @@ hooks = [
       'src/flutter/tools/fuchsia/with_envs.py',
       'src/flutter/tools/fuchsia/test_scripts/update_product_bundles.py',
       'terminal.x64,terminal.qemu-arm64',
+    ]
+  },
+  # The following two scripts check if they are running in the LUCI
+  # environment, and do nothing if so. This is because Xcode is not yet
+  # installed in CI when these hooks are run.
+  {
+    'name': 'Find the iOS device SDKs',
+    'pattern': '.',
+    'condition': 'host_os == "mac"',
+    'action': [
+      'python3',
+      'src/build/config/ios/ios_sdk.py',
+      # This cleans up entries under flutter/prebuilts for this script and the
+      # following script.
+      '--as-gclient-hook'
+    ]
+  },
+  {
+    'name': 'Find the macOS SDK',
+    'pattern': '.',
+    'condition': 'host_os == "mac"',
+    'action': [
+      'python3',
+      'src/build/mac/find_sdk.py',
+      '--as-gclient-hook',
+      Var('mac_sdk_min')
     ]
   }
 ]

--- a/tools/gn
+++ b/tools/gn
@@ -314,6 +314,36 @@ def setup_goma(args):
   return goma_gn_args
 
 
+# Find the locations of the macOS and iOS SDKs under flutter/prebuilts.
+def setup_apple_sdks():
+  sdks_gn_args = {}
+
+  # These are needed on a macOS host regardless of target.
+  # This value should agree with the 'mac_sdk_min' value in the DEPS file.
+  sdks_gn_args['mac_sdk_min'] = '10.14'
+
+  # The MACOSX_DEPLOYMENT_TARGET variable used when compiling.
+  # Must be of the form x.x.x for Info.plist files.
+  sdks_gn_args['mac_deployment_target'] = '10.14.0'
+
+  running_on_luci = os.environ.get('LUCI_CONTEXT') is not None
+  if running_on_luci:
+    return sdks_gn_args
+
+  prefixes = [
+      ('MacOSX', 'mac_sdk_path'),
+      ('iPhoneOS', 'ios_device_sdk_path'),
+      ('iPhoneSimulator', 'ios_simulator_sdk_path'),
+  ]
+  sdks_path = os.path.join(SRC_ROOT, 'flutter', 'prebuilts', 'SDKs')
+  sdk_entries = os.listdir(sdks_path)
+  for (prefix, arg) in prefixes:
+    for entry in sdk_entries:
+      if entry.startswith(prefix):
+        sdks_gn_args[arg] = os.path.join(sdks_path, entry)
+  return sdks_gn_args
+
+
 def to_gn_args(args):
   if args.simulator:
     if args.target_os != 'ios':
@@ -429,16 +459,12 @@ def to_gn_args(args):
   if get_host_os() == 'mac' and not args.force_mac_arm64:
     gn_args['host_cpu'] = 'x64'
 
-  if is_host_build(args) and gn_args['host_os'] == 'mac':
-    # macOS unit tests include Vulkan headers which reference Metal types
-    # introduced in macOS 10.14.
-    gn_args['mac_sdk_min'] = '10.14'
-    gn_args['mac_deployment_target'] = '10.14.0'
-
   if gn_args['target_os'] == 'ios':
     gn_args['use_ios_simulator'] = args.simulator
+    gn_args.update(setup_apple_sdks())
   elif get_host_os() == 'mac':
     gn_args['use_ios_simulator'] = False
+    gn_args.update(setup_apple_sdks())
 
   if args.dart_debug:
     gn_args['dart_debug'] = True


### PR DESCRIPTION
Currently, these scripts run on each invocation of `gn`, and can take many seconds to run.

This PR shifts them to run as `gclient` hooks instead, so that `gn` will be faster.

Needs https://github.com/flutter/buildroot/pull/825.