### PR TITLE
[Impeller] disble render pass caches.

### DIFF
--- a/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
@@ -11,41 +11,7 @@
 namespace impeller {
 namespace testing {
 
-using DISABLED_RendererTest = PlaygroundTest;
-
-TEST_P(DISABLED_RendererTest, CachesRenderPassAndFramebuffer) {
-  if (GetBackend() != PlaygroundBackend::kVulkan) {
-    GTEST_SKIP() << "Test only applies to Vulkan";
-  }
-
-  auto allocator = std::make_shared<RenderTargetAllocator>(
-      GetContext()->GetResourceAllocator());
-
-  auto render_target = RenderTarget::CreateOffscreenMSAA(
-      *GetContext(), *allocator, {100, 100}, 1);
-  auto resolve_texture =
-      render_target.GetColorAttachments().find(0u)->second.resolve_texture;
-  auto& texture_vk = TextureVK::Cast(*resolve_texture);
-
-  EXPECT_EQ(texture_vk.GetFramebuffer(), nullptr);
-  EXPECT_EQ(texture_vk.GetRenderPass(), nullptr);
-
-  auto buffer = GetContext()->CreateCommandBuffer();
-  auto render_pass = buffer->CreateRenderPass(render_target);
-
-  EXPECT_NE(texture_vk.GetFramebuffer(), nullptr);
-  EXPECT_NE(texture_vk.GetRenderPass(), nullptr);
-
-  render_pass->EncodeCommands();
-  GetContext()->GetCommandQueue()->Submit({buffer});
-
-  // Can be reused without error.
-  auto buffer_2 = GetContext()->CreateCommandBuffer();
-  auto render_pass_2 = buffer_2->CreateRenderPass(render_target);
-
-  EXPECT_TRUE(render_pass_2->EncodeCommands());
-  EXPECT_TRUE(GetContext()->GetCommandQueue()->Submit({buffer_2}).ok());
-}
+//
 
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
@@ -11,9 +11,9 @@
 namespace impeller {
 namespace testing {
 
-using RendererTest = PlaygroundTest;
+using DISABLED_RendererTest = PlaygroundTest;
 
-TEST_P(RendererTest, CachesRenderPassAndFramebuffer) {
+TEST_P(DISABLED_RendererTest, CachesRenderPassAndFramebuffer) {
   if (GetBackend() != PlaygroundBackend::kVulkan) {
     GTEST_SKIP() << "Test only applies to Vulkan";
   }


### PR DESCRIPTION
This is related to the crashes in https://github.com/flutter/flutter/issues/144116

> I'm going to disable this caching for now until I understand why its not working for tester. Potentially the cache itself was unsafe and validation is just missing, but I need to do some research. If I don't find anything then i'll consider conditionally disabling for flutter tester builds
