### PR TITLE
[scenario] trigger firstFrameLatch on exception.

### DIFF
--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
@@ -417,13 +417,7 @@ public class ExternalTextureFlutterActivity extends TestActivity {
         // IllegalStateException.
         // Simply log and return.
         Log.i(TAG, "Surface disconnected from ImageWriter", e);
-
-        if (onFirstFrame != null) {
-          onFirstFrame.countDown();
-          onFirstFrame = null;
-        }
         image.close();
-        return;
       }
 
       Log.v(TAG, "Output image");

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
@@ -417,6 +417,11 @@ public class ExternalTextureFlutterActivity extends TestActivity {
         // IllegalStateException.
         // Simply log and return.
         Log.i(TAG, "Surface disconnected from ImageWriter", e);
+
+        if (onFirstFrame != null) {
+          onFirstFrame.countDown();
+          onFirstFrame = null;
+        }
         image.close();
         return;
       }


### PR DESCRIPTION
If we hit this exception (which we seem to do a lot), then we weren't triggering the first frame latch.