### PR TITLE
Migrate Android `scenario_app` to the `SurfaceProducer` API

### DIFF
--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
@@ -36,6 +36,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.util.Supplier;
+
+import io.flutter.view.TextureRegistry;
 import io.flutter.view.TextureRegistry.SurfaceTextureEntry;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,7 +56,7 @@ public class ExternalTextureFlutterActivity extends TestActivity {
   private final CountDownLatch firstFrameLatch = new CountDownLatch(2);
 
   private long textureId = 0;
-  private SurfaceTextureEntry surfaceTextureEntry;
+  private TextureRegistry.SurfaceProducer surfaceProducer;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -143,19 +145,18 @@ public class ExternalTextureFlutterActivity extends TestActivity {
   public void onPause() {
     surfaceViewRenderer.destroy();
     flutterRenderer.destroy();
-    surfaceTextureEntry.release();
+    surfaceProducer.release();
     super.onPause();
   }
 
   @Override
   public void onFlutterUiDisplayed() {
-    surfaceTextureEntry =
-        Objects.requireNonNull(getFlutterEngine()).getRenderer().createSurfaceTexture();
-    SurfaceTexture surfaceTexture = surfaceTextureEntry.surfaceTexture();
-    surfaceTexture.setDefaultBufferSize(SURFACE_WIDTH, SURFACE_HEIGHT);
-    flutterRenderer.attach(new Surface(surfaceTexture), firstFrameLatch);
+    surfaceProducer =
+        Objects.requireNonNull(getFlutterEngine()).getRenderer().createSurfaceProducer();
+    surfaceProducer.setSize(SURFACE_WIDTH, SURFACE_HEIGHT);
+    flutterRenderer.attach(surfaceProducer.getSurface(), firstFrameLatch);
     flutterRenderer.repaint();
-    textureId = surfaceTextureEntry.id();
+    textureId = surfaceProducer.id();
 
     super.onFlutterUiDisplayed();
   }

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
@@ -11,7 +11,6 @@ import android.graphics.LinearGradient;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.Shader.TileMode;
-import android.graphics.SurfaceTexture;
 import android.hardware.HardwareBuffer;
 import android.media.Image;
 import android.media.ImageReader;
@@ -36,9 +35,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.util.Supplier;
-
 import io.flutter.view.TextureRegistry;
-import io.flutter.view.TextureRegistry.SurfaceTextureEntry;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;


### PR DESCRIPTION
Part of testing https://github.com/flutter/flutter/issues/139702.

Without this PR, the Impeller + Vulkan Scenario App will draw nothing/potentially crash, because there is no way to draw the (current) `SurfaceTexture`-based textures in Vulkan (and never will be).

This change does the following:
- Skia -> Nothing
- Impeller + OpenGLES -> On newer Android devices, uses `ImageReader` instead
- Impeller + Vulkan -> Always uses `ImageReader`

See also: https://api.flutter.dev/javadoc/io/flutter/view/TextureRegistry.SurfaceProducer.html.