### PR TITLE
Move protobuf to //flutter/third_party

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,8 +129,10 @@ app.*.symbols
 # Prebuilt binaries.
 /prebuilts/
 
+# TODO(67373): This entry is temporarily disabled, but can be restored once the
+# buildmoot is completed.
 # GN build support for protobufs vended by Fuchsia.
-/build/secondary/third_party/protobuf
+# /build/secondary/third_party/protobuf
 
 # RBE support configurations and scripts vended from CIPD
 /build/rbe

--- a/DEPS
+++ b/DEPS
@@ -328,11 +328,13 @@ deps = {
   'src/third_party/perfetto':
    Var('flutter_git') + "/third_party/perfetto" + '@' + Var('dart_perfetto_rev'),
 
-  'src/third_party/protobuf':
+  'src/flutter/third_party/protobuf':
    Var('flutter_git') + '/third_party/protobuf' + '@' + Var('dart_libprotobuf_rev'),
 
-  'src/flutter/build/secondary/third_party/protobuf':
-   Var('flutter_git') + '/third_party/protobuf-gn' + '@' + Var('dart_protobuf_gn_rev'),
+  # TODO(67373): These are temporarily checked in, but this dep can be restored
+  # once the buildmoot is completed.
+  # 'src/flutter/build/secondary/third_party/protobuf':
+  #  Var('flutter_git') + '/third_party/protobuf-gn' + '@' + Var('dart_protobuf_gn_rev'),
 
   'src/third_party/dart':
    Var('dart_git') + '/sdk.git' + '@' + Var('dart_revision'),

--- a/build/secondary/third_party/protobuf/AUTHORS
+++ b/build/secondary/third_party/protobuf/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Fuchsia Authors.
+
+# Names should be added to this file as one of
+#     Organization's name
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+
+Google LLC.

--- a/build/secondary/third_party/protobuf/BUILD.gn
+++ b/build/secondary/third_party/protobuf/BUILD.gn
@@ -1,0 +1,536 @@
+# THIS FILE IS GENERATED FROM BUILD.input.gn BY gen.py
+# EDIT BUILD.input.gn FIRST AND THEN RUN gen.py
+#
+#
+# Copyright 2017 The Fuchsia Authors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#    * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import("//build/test.gni")
+import("//third_party/protobuf/proto_library.gni")
+
+config("protobuf_config") {
+  include_dirs = [ "//flutter/third_party/protobuf/src" ]
+  defines = [
+    "GOOGLE_PROTOBUF_NO_RTTI",
+    "HAVE_PTHREAD",
+  ]
+  cflags = []
+  if (is_clang) {
+    cflags += [
+      # Needed to support PROTOBUF_INTERNAL_CHECK_CLASS_SIZE in descriptor.h
+      "-Wno-c++98-compat-extra-semi",
+
+      # There are implicit conversions in parse_context.h
+      "-Wno-shorten-64-to-32",
+    ]
+  }
+}
+
+config("protobuf_warnings") {
+  cflags = []
+
+  if (is_clang) {
+    # These are all needed as of https://github.com/protocolbuffers/protobuf/releases/tag/v3.21.12
+    cflags += [
+      "-Wno-deprecated-pragma",
+      "-Wno-enum-enum-conversion",
+      "-Wno-extra-semi",
+      "-Wno-float-conversion",
+      "-Wno-implicit-float-conversion",
+      "-Wno-implicit-int-conversion",
+      "-Wno-implicit-int-float-conversion",
+      "-Wno-invalid-noreturn",
+      "-Wno-missing-field-initializers",
+      "-Wno-sign-compare",
+      "-Wno-unused-function",
+      "-Wno-unused-private-field",
+      "-Wno-deprecated-declarations", # Mac deprecated sprintf
+    ]
+  }
+}
+
+# This config should be applied to targets using generated code from the proto
+# compiler. It sets up the include directories properly.
+config("using_proto") {
+  include_dirs = [
+    "//flutter/third_party/protobuf/src",
+    "$root_gen_dir",
+  ]
+}
+
+static_library("protobuf_lite") {
+  sources = [
+    "//flutter/third_party/protobuf/src/google/protobuf/any_lite.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/arena.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/arenastring.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/arenaz_sampler.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/extension_set.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_enum_util.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_tctable_lite.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_util.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/implicit_weak_message.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/inlined_string_field.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/coded_stream.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/io_win32.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/strtod.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/zero_copy_stream.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/zero_copy_stream_impl.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/zero_copy_stream_impl_lite.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/map.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/message_lite.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/parse_context.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/repeated_field.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/repeated_ptr_field.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/bytestream.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/common.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/int128.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/status.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/statusor.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/stringpiece.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/stringprintf.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/structurally_valid.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/strutil.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/time.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/wire_format_lite.cc",
+  ]
+
+  # git ls-files -- ':!*/compiler/*' ':!*/testing/*' ':!*/util/*' 'src/google/protobuf/*.h' | sed 's/^/"/' | sed 's/$/",/'
+  public = [
+    "//flutter/third_party/protobuf/src/google/protobuf/any.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/any.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/api.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arena.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arena_impl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arena_test_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arenastring.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arenaz_sampler.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/descriptor.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/descriptor.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/descriptor_database.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/duration.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/dynamic_message.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/empty.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/endian.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/explicitly_constructed.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/extension_set.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/extension_set_inl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/field_access_listener.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/field_mask.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_enum_reflection.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_enum_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_bases.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_reflection.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_tctable_decl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_tctable_impl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/has_bits.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/implicit_weak_message.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/inlined_string_field.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/coded_stream.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/gzip_stream.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/io_win32.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/package_info.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/printer.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/strtod.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/tokenizer.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/zero_copy_stream.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/zero_copy_stream_impl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/zero_copy_stream_impl_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_entry.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_entry_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_field.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_field_inl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_field_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_lite_test_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_test_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_test_util_impl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_type_handler.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/message.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/message_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/metadata.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/metadata_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/package_info.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/parse_context.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/port.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/reflection.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/reflection_internal.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/reflection_ops.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/reflection_tester.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/repeated_field.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/repeated_ptr_field.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/service.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/source_context.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/string_member_robber.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/struct.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/bytestream.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/callback.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/casts.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/common.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/hash.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/int128.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/logging.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/macros.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/map_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/mathutil.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/mutex.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/once.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/platform_macros.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/port.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/status.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/status_macros.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/statusor.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/stl_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/stringpiece.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/stringprintf.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/strutil.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/substitute.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/template_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/time.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/test_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/test_util2.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/test_util_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/text_format.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/timestamp.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/type.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/unknown_field_set.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/wire_format.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/wire_format_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/wrappers.pb.h",
+  ]
+  configs += [ ":protobuf_warnings" ]
+  public_configs = [ ":protobuf_config" ]
+}
+
+# This is the full, heavy protobuf lib that's needed for c++ .protos that don't
+# specify the LITE_RUNTIME option. The protocol compiler itself (protoc) falls
+# into that category.
+static_library("protobuf_full") {
+  sources = [
+    "//flutter/third_party/protobuf/src/google/protobuf/any.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/any.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/api.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/compiler/importer.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/compiler/parser.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/descriptor.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/descriptor.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/descriptor_database.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/duration.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/dynamic_message.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/empty.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/extension_set_heavy.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/field_mask.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_bases.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_reflection.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_tctable_full.cc",
+
+    # gzip_stream.cc pulls in zlib, but it's not actually used by protoc, just
+    # by test code, so instead of compiling zlib for the host, let's just
+    # exclude this.
+    # "//flutter/third_party/protobuf/src/google/protobuf/io/gzip_stream.cc",
+
+    "//flutter/third_party/protobuf/src/google/protobuf/io/printer.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/tokenizer.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_field.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/message.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/reflection_ops.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/service.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/source_context.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/struct.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/substitute.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/text_format.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/timestamp.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/type.pb.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/unknown_field_set.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/delimited_message_util.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/field_comparator.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/field_mask_util.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/datapiece.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/default_value_objectwriter.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/error_listener.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/field_mask_utility.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/json_escaping.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/json_objectwriter.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/json_stream_parser.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/object_writer.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/proto_writer.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/protostream_objectwriter.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/type_info.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/utility.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/json_util.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/message_differencer.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/time_util.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/type_resolver_util.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/wire_format.cc",
+    "//flutter/third_party/protobuf/src/google/protobuf/wrappers.pb.cc",
+  ]
+
+  # git ls-files -- ':!*/compiler/*' ':!*/testing/*' 'src/google/protobuf/*.h' | sed 's/^/"/' | sed 's/$/",/'
+  public = [
+    "//flutter/third_party/protobuf/src/google/protobuf/any.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/any.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/api.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arena.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arena_impl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arena_test_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arenastring.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/arenaz_sampler.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/descriptor.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/descriptor.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/descriptor_database.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/duration.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/dynamic_message.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/empty.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/endian.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/explicitly_constructed.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/extension_set.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/extension_set_inl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/field_access_listener.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/field_mask.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_enum_reflection.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_enum_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_bases.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_reflection.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_tctable_decl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_tctable_impl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/generated_message_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/has_bits.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/implicit_weak_message.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/inlined_string_field.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/coded_stream.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/gzip_stream.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/io_win32.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/package_info.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/printer.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/strtod.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/tokenizer.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/zero_copy_stream.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/zero_copy_stream_impl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/io/zero_copy_stream_impl_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_entry.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_entry_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_field.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_field_inl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_field_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_lite_test_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_test_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_test_util_impl.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/map_type_handler.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/message.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/message_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/metadata.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/metadata_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/package_info.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/parse_context.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/port.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/reflection.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/reflection_internal.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/reflection_ops.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/reflection_tester.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/repeated_field.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/repeated_ptr_field.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/service.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/source_context.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/string_member_robber.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/struct.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/bytestream.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/callback.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/casts.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/common.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/hash.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/int128.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/logging.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/macros.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/map_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/mathutil.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/mutex.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/once.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/platform_macros.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/port.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/status.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/status_macros.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/statusor.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/stl_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/stringpiece.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/stringprintf.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/strutil.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/substitute.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/template_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/stubs/time.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/test_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/test_util2.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/test_util_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/text_format.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/timestamp.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/type.pb.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/unknown_field_set.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/delimited_message_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/field_comparator.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/field_mask_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/constants.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/datapiece.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/default_value_objectwriter.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/error_listener.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/expecting_objectwriter.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/field_mask_utility.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/json_escaping.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/json_objectwriter.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/json_stream_parser.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/location_tracker.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/mock_error_listener.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/object_location_tracker.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/object_source.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/object_writer.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/proto_writer.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/protostream_objectsource.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/protostream_objectwriter.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/structured_objectwriter.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/type_info.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/type_info_test_helper.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/internal/utility.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/json_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/message_differencer.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/package_info.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/time_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/type_resolver.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/util/type_resolver_util.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/wire_format.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/wire_format_lite.h",
+    "//flutter/third_party/protobuf/src/google/protobuf/wrappers.pb.h",
+  ]
+  configs += [ ":protobuf_warnings" ]
+  public_configs = [ ":protobuf_config" ]
+  deps = [ ":protobuf_lite" ]
+}
+
+# Only compile the compiler for the host architecture.
+if (current_toolchain == host_toolchain) {
+  # protoc compiler is separated into protoc library and executable targets to
+  # support protoc plugins that need to link libprotoc, but not the main()
+  # itself. See src/google/protobuf/compiler/plugin.h
+  #
+  # git ls-files -- ':!*/main.cc' ':!*test*' ':!*mock*' 'src/google/protobuf/compiler/*.cc' | sed 's/^/"/' | sed 's/$/",/'
+  static_library("protoc_lib") {
+    sources = [
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/code_generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/command_line_interface.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/enum.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/enum_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/extension.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/file.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/helpers.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/map_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/message.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/message_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/padding_optimizer.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/parse_function_generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/primitive_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/service.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/cpp/string_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_enum.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_enum_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_field_base.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_helpers.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_map_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_message.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_message_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_reflection_class.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_repeated_enum_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_repeated_message_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_repeated_primitive_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_source_generator_base.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/csharp/csharp_wrapper_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/importer.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/context.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/doc_comment.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/enum.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/enum_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/enum_field_lite.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/enum_lite.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/extension.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/extension_lite.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/file.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/generator_factory.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/helpers.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/kotlin_generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/map_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/map_field_lite.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/message.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/message_builder.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/message_builder_lite.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/message_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/message_field_lite.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/message_lite.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/name_resolver.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/primitive_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/primitive_field_lite.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/service.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/shared_code_generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/string_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/java/string_field_lite.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_enum.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_enum_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_extension.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_file.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_helpers.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_map_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_message.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_message_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_oneof.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/objectivec/objectivec_primitive_field.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/parser.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/php/php_generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/plugin.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/plugin.pb.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/python/generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/python/helpers.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/python/pyi_generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/ruby/ruby_generator.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/subprocess.cc",
+      "//flutter/third_party/protobuf/src/google/protobuf/compiler/zip_writer.cc",
+    ]
+    configs += [ ":protobuf_warnings" ]
+    public_deps = [ ":protobuf_full" ]
+  }
+
+  executable("protoc") {
+    sources = [ "//flutter/third_party/protobuf/src/google/protobuf/compiler/main.cc" ]
+    deps = [ ":protoc_lib" ]
+  }
+}

--- a/build/secondary/third_party/protobuf/BUILD.input.gn
+++ b/build/secondary/third_party/protobuf/BUILD.input.gn
@@ -1,0 +1,211 @@
+# Copyright 2017 The Fuchsia Authors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#    * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import("//build/test.gni")
+import("//third_party/protobuf/proto_library.gni")
+
+config("protobuf_config") {
+  include_dirs = [ "src" ]
+  defines = [
+    "GOOGLE_PROTOBUF_NO_RTTI",
+    "HAVE_PTHREAD",
+  ]
+  cflags = []
+  if (is_clang) {
+    cflags += [
+      # Needed to support PROTOBUF_INTERNAL_CHECK_CLASS_SIZE in descriptor.h
+      "-Wno-c++98-compat-extra-semi",
+
+      # There are implicit conversions in parse_context.h
+      "-Wno-shorten-64-to-32",
+    ]
+  }
+}
+
+config("protobuf_warnings") {
+  cflags = []
+
+  if (is_clang) {
+    # These are all needed as of https://github.com/protocolbuffers/protobuf/releases/tag/v3.21.12
+    cflags += [
+      "-Wno-deprecated-pragma",
+      "-Wno-enum-enum-conversion",
+      "-Wno-extra-semi",
+      "-Wno-float-conversion",
+      "-Wno-implicit-float-conversion",
+      "-Wno-implicit-int-conversion",
+      "-Wno-implicit-int-float-conversion",
+      "-Wno-invalid-noreturn",
+      "-Wno-missing-field-initializers",
+      "-Wno-sign-compare",
+      "-Wno-unused-function",
+      "-Wno-unused-private-field",
+    ]
+  }
+}
+
+# This config should be applied to targets using generated code from the proto
+# compiler. It sets up the include directories properly.
+config("using_proto") {
+  include_dirs = [
+    "src",
+    "$root_gen_dir",
+  ]
+}
+
+static_library("protobuf_lite") {
+  sources = [
+    "src/google/protobuf/any_lite.cc",
+    "src/google/protobuf/arena.cc",
+    "src/google/protobuf/arenastring.cc",
+    "src/google/protobuf/arenaz_sampler.cc",
+    "src/google/protobuf/extension_set.cc",
+    "src/google/protobuf/generated_enum_util.cc",
+    "src/google/protobuf/generated_message_tctable_lite.cc",
+    "src/google/protobuf/generated_message_util.cc",
+    "src/google/protobuf/implicit_weak_message.cc",
+    "src/google/protobuf/inlined_string_field.cc",
+    "src/google/protobuf/io/coded_stream.cc",
+    "src/google/protobuf/io/io_win32.cc",
+    "src/google/protobuf/io/strtod.cc",
+    "src/google/protobuf/io/zero_copy_stream.cc",
+    "src/google/protobuf/io/zero_copy_stream_impl.cc",
+    "src/google/protobuf/io/zero_copy_stream_impl_lite.cc",
+    "src/google/protobuf/map.cc",
+    "src/google/protobuf/message_lite.cc",
+    "src/google/protobuf/parse_context.cc",
+    "src/google/protobuf/repeated_field.cc",
+    "src/google/protobuf/repeated_ptr_field.cc",
+    "src/google/protobuf/stubs/bytestream.cc",
+    "src/google/protobuf/stubs/common.cc",
+    "src/google/protobuf/stubs/int128.cc",
+    "src/google/protobuf/stubs/status.cc",
+    "src/google/protobuf/stubs/statusor.cc",
+    "src/google/protobuf/stubs/stringpiece.cc",
+    "src/google/protobuf/stubs/stringprintf.cc",
+    "src/google/protobuf/stubs/structurally_valid.cc",
+    "src/google/protobuf/stubs/strutil.cc",
+    "src/google/protobuf/stubs/time.cc",
+    "src/google/protobuf/wire_format_lite.cc",
+  ]
+
+  # git ls-files -- ':!*/compiler/*' ':!*/testing/*' ':!*/util/*' 'src/google/protobuf/*.h' | sed 's/^/"/' | sed 's/$/",/'
+  public = [ PROTOBUF_LITE_PUBLIC ]
+  configs += [ ":protobuf_warnings" ]
+  public_configs = [ ":protobuf_config" ]
+}
+
+# This is the full, heavy protobuf lib that's needed for c++ .protos that don't
+# specify the LITE_RUNTIME option. The protocol compiler itself (protoc) falls
+# into that category.
+static_library("protobuf_full") {
+  sources = [
+    "src/google/protobuf/any.cc",
+    "src/google/protobuf/any.pb.cc",
+    "src/google/protobuf/api.pb.cc",
+    "src/google/protobuf/compiler/importer.cc",
+    "src/google/protobuf/compiler/parser.cc",
+    "src/google/protobuf/descriptor.cc",
+    "src/google/protobuf/descriptor.pb.cc",
+    "src/google/protobuf/descriptor_database.cc",
+    "src/google/protobuf/duration.pb.cc",
+    "src/google/protobuf/dynamic_message.cc",
+    "src/google/protobuf/empty.pb.cc",
+    "src/google/protobuf/extension_set_heavy.cc",
+    "src/google/protobuf/field_mask.pb.cc",
+    "src/google/protobuf/generated_message_bases.cc",
+    "src/google/protobuf/generated_message_reflection.cc",
+    "src/google/protobuf/generated_message_tctable_full.cc",
+
+    # gzip_stream.cc pulls in zlib, but it's not actually used by protoc, just
+    # by test code, so instead of compiling zlib for the host, let's just
+    # exclude this.
+    # "src/google/protobuf/io/gzip_stream.cc",
+
+    "src/google/protobuf/io/printer.cc",
+    "src/google/protobuf/io/tokenizer.cc",
+    "src/google/protobuf/map_field.cc",
+    "src/google/protobuf/message.cc",
+    "src/google/protobuf/reflection_ops.cc",
+    "src/google/protobuf/service.cc",
+    "src/google/protobuf/source_context.pb.cc",
+    "src/google/protobuf/struct.pb.cc",
+    "src/google/protobuf/stubs/substitute.cc",
+    "src/google/protobuf/text_format.cc",
+    "src/google/protobuf/timestamp.pb.cc",
+    "src/google/protobuf/type.pb.cc",
+    "src/google/protobuf/unknown_field_set.cc",
+    "src/google/protobuf/util/delimited_message_util.cc",
+    "src/google/protobuf/util/field_comparator.cc",
+    "src/google/protobuf/util/field_mask_util.cc",
+    "src/google/protobuf/util/internal/datapiece.cc",
+    "src/google/protobuf/util/internal/default_value_objectwriter.cc",
+    "src/google/protobuf/util/internal/error_listener.cc",
+    "src/google/protobuf/util/internal/field_mask_utility.cc",
+    "src/google/protobuf/util/internal/json_escaping.cc",
+    "src/google/protobuf/util/internal/json_objectwriter.cc",
+    "src/google/protobuf/util/internal/json_stream_parser.cc",
+    "src/google/protobuf/util/internal/object_writer.cc",
+    "src/google/protobuf/util/internal/proto_writer.cc",
+    "src/google/protobuf/util/internal/protostream_objectsource.cc",
+    "src/google/protobuf/util/internal/protostream_objectwriter.cc",
+    "src/google/protobuf/util/internal/type_info.cc",
+    "src/google/protobuf/util/internal/utility.cc",
+    "src/google/protobuf/util/json_util.cc",
+    "src/google/protobuf/util/message_differencer.cc",
+    "src/google/protobuf/util/time_util.cc",
+    "src/google/protobuf/util/type_resolver_util.cc",
+    "src/google/protobuf/wire_format.cc",
+    "src/google/protobuf/wrappers.pb.cc",
+  ]
+
+  # git ls-files -- ':!*/compiler/*' ':!*/testing/*' 'src/google/protobuf/*.h' | sed 's/^/"/' | sed 's/$/",/'
+  public = [ PROTOBUF_FULL_PUBLIC ]
+  configs += [ ":protobuf_warnings" ]
+  public_configs = [ ":protobuf_config" ]
+  deps = [ ":protobuf_lite" ]
+}
+
+# Only compile the compiler for the host architecture.
+if (current_toolchain == host_toolchain) {
+  # protoc compiler is separated into protoc library and executable targets to
+  # support protoc plugins that need to link libprotoc, but not the main()
+  # itself. See src/google/protobuf/compiler/plugin.h
+  #
+  # git ls-files -- ':!*/main.cc' ':!*test*' ':!*mock*' 'src/google/protobuf/compiler/*.cc' | sed 's/^/"/' | sed 's/$/",/'
+  static_library("protoc_lib") {
+    sources = [ PROTOC_LIB_SOURCES ]
+    configs += [ ":protobuf_warnings" ]
+    public_deps = [ ":protobuf_full" ]
+  }
+
+  executable("protoc") {
+    sources = [ "src/google/protobuf/compiler/main.cc" ]
+    deps = [ ":protoc_lib" ]
+  }
+}

--- a/build/secondary/third_party/protobuf/CONTRIBUTING.md
+++ b/build/secondary/third_party/protobuf/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to Fuchsia
+
+Fuchsia lets anyone contribute to the project, regardless of their employer.
+The Fuchsia project reviews and encourages well-tested, high-quality
+contributions from anyone who wants to contribute to Fuchsia.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement (CLA).
+
+To see any Contributor License Agreements on file or to sign a CLA, go to <https://cla.developers.google.com/>.
+
+For more information about the Google CLA, see [Contributor License Agreements](https://cla.developers.google.com/about).
+
+## Contributing changes and submitting code reviews
+
+All changes require review, including changes by project members.
+
+For detailed instructions on how to contribute changes,
+see [Contribute changes](/docs/development/source_code/contribute_changes.md).
+
+## Community guidelines
+
+This project observes the following community guidelines:
+
+  * [Google's Open Source Community Guidelines](https://opensource.google/conduct/)
+
+  * [Fuchsia Code of Conduct](/docs/CODE_OF_CONDUCT.md)
+
+## Governance
+
+Review Fuchsia's [Governance](/docs/contribute/governance/governance.md)
+statement.

--- a/build/secondary/third_party/protobuf/LICENSE
+++ b/build/secondary/third_party/protobuf/LICENSE
@@ -1,0 +1,24 @@
+// Copyright 2021 The Fuchsia Authors.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/build/secondary/third_party/protobuf/OWNERS
+++ b/build/secondary/third_party/protobuf/OWNERS
@@ -1,0 +1,5 @@
+azani@google.com
+camrdale@google.com
+frousseau@google.com
+stevefung@google.com
+zmbush@google.com

--- a/build/secondary/third_party/protobuf/PATENTS
+++ b/build/secondary/third_party/protobuf/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Fuchsia project.
+
+Google hereby grants to you a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell,
+import, transfer, and otherwise run, modify and propagate the contents
+of this implementation of Fuchsia, where such license applies only to
+those patent claims, both currently owned by Google and acquired in
+the future, licensable by Google that are necessarily infringed by
+this implementation. This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation. If you or your agent or exclusive licensee institute
+or order or agree to the institution of patent litigation or any other
+patent enforcement activity against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that this
+implementation of Fuchsia constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of
+Fuchsia shall terminate as of the date such litigation is filed.

--- a/build/secondary/third_party/protobuf/README.md
+++ b/build/secondary/third_party/protobuf/README.md
@@ -1,0 +1,17 @@
+# Protocol Buffers GN Build Support
+
+This repository contains
+[GN build system](https://gn.googlesource.com/gn/+/HEAD/) support for
+[Protocol Buffers](https://github.com/protocolbuffers/protobuf). It's in its own
+repository because it needs to be shared by
+[Fuchsia](https://fuchsia.googlesource.com/fuchsia/) and
+[Cobalt](https://fuchsia.googlesource.com/cobalt/).
+
+This repo should be checked out such that:
+
+* It is in `//build/secondary/third_party/protobuf`.
+* Protobuf is in `//third_party/protobuf`.
+* `//.gn` contains `secondary_source = "//build/secondary/"`
+
+See the
+[GN documentation on secondary_source](https://gn.googlesource.com/gn/+/master/docs/reference.md#other-help-topics-gn-file-variables).

--- a/build/secondary/third_party/protobuf/gen.py
+++ b/build/secondary/third_party/protobuf/gen.py
@@ -1,0 +1,44 @@
+import subprocess
+import os
+
+gn_in = open("BUILD.input.gn", "rb")
+gn_file = gn_in.read()
+gn_in.close()
+
+
+def get_files(path, exclude=[]):
+    cmd = ["git", "ls-files", "--"]
+    for ex in exclude:
+        cmd.append(":!%s" % ex)
+    cmd.append(path)
+    git_ls = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        cwd=os.path.join(os.environ["FUCHSIA_DIR"], "third_party", "protobuf"))
+    sed1 = subprocess.Popen(
+        ["sed", "s/^/\"/"], stdin=git_ls.stdout, stdout=subprocess.PIPE)
+    return subprocess.check_output(["sed", "s/$/\",/"], stdin=sed1.stdout)
+
+
+gn_file = gn_file.replace(
+    b"PROTOBUF_LITE_PUBLIC",
+    get_files(
+        "src/google/protobuf/*.h",
+        exclude=["*/compiler/*", "*/testing/*", "*/util/*"]))
+gn_file = gn_file.replace(
+    b"PROTOBUF_FULL_PUBLIC",
+    get_files(
+        "src/google/protobuf/*.h", exclude=["*/compiler/*", "*/testing/*"]))
+gn_file = gn_file.replace(
+    b"PROTOC_LIB_SOURCES",
+    get_files(
+        "src/google/protobuf/compiler/*.cc",
+        exclude=["*/main.cc", "*test*", "*mock*"]))
+
+gn_file = subprocess.check_output(["gn", "format", "--stdin"], input=gn_file)
+
+gn_out = open("BUILD.gn", "wb")
+gn_out.write(
+    b"# THIS FILE IS GENERATED FROM BUILD.input.gn BY gen.py\n# EDIT BUILD.input.gn FIRST AND THEN RUN gen.py\n#\n#\n"
+)
+gn_out.write(gn_file)

--- a/build/secondary/third_party/protobuf/proto_library.gni
+++ b/build/secondary/third_party/protobuf/proto_library.gni
@@ -1,0 +1,483 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Compile a protocol buffer.
+#
+# Protobuf parameters:
+#
+#   proto_in_dir (optional)
+#       Specifies the path relative to the current BUILD.gn file where
+#       proto files are located and the directory structure of
+#       this proto library starts.
+#
+#       This option can be calculated automatically but it will raise an
+#       assertion error if any nested directories are found.
+#
+#   proto_out_dir (optional)
+#       Specifies the path suffix that output files are generated under.
+#       This path will be appended to |root_gen_dir|, but for python stubs
+#       it will be appended to |root_build_dir|/pyproto.
+#
+#   generate_python (optional, default true)
+#       Generate Python protobuf stubs.
+#
+#   generate_cc (optional, default true)
+#       Generate C++ protobuf stubs.
+#
+#   generate_descriptor_set (optional, default false)
+#       Generate a descriptor set file at a default location
+#       "${target_out_dir}/${target_name}.desc.pb".
+#
+#   generate_descriptor (optional, default "")
+#       Generate a descriptor set file at a specific location rooted underneath
+#       the generated files directory.
+#       Cannot be used in combination with |generate_descriptor|.
+#
+#   generate_go (optional, default false)
+#       Generate Go protobuf stubs.
+#       Mutually exclusive with generate_go_grpc.
+#
+#   generate_go_grpc (optional, default false)
+#       Generate a Go gRPC protobuf stub, instead of a regular one.
+#       Mutually exclusive with generate_go.
+#
+#   cc_generator_options (optional)
+#       List of extra flags passed to the protocol compiler.  If you need to
+#       add an EXPORT macro to a protobuf's C++ header, set the
+#       'cc_generator_options' variable with the value:
+#       'dllexport_decl=FOO_EXPORT:' (note trailing colon).
+#
+#       It is likely you also need to #include a file for the above EXPORT
+#       macro to work (see cc_include) and set
+#       component_build_force_source_set = true.
+#
+#   cc_include (optional)
+#       String listing an extra include that should be passed.
+#       Example: cc_include = "foo/bar.h"
+#
+#   generator_plugin_label (optional)
+#       GN label for plugin executable which generates custom cc stubs.
+#       Don't specify a toolchain, host toolchain is assumed.
+#
+#   generator_plugin_script (optional)
+#       Path to plugin script. Mutually exclusive with |generator_plugin_label|.
+#
+#   generator_plugin_script_deps (optional)
+#       List of additional files required for generator plugin script.
+#
+#   generator_plugin_suffix[es] (required if using a plugin)
+#       Suffix (before extension) for generated .cc and .h files
+#       or list of suffixes for all files (with extensions).
+#
+#   generator_plugin_options (optional)
+#       Extra flags passed to the plugin. See cc_generator_options.
+#
+#   deps (optional)
+#       Additional dependencies.
+#
+#   use_protobuf_full (optional)
+#       If adding protobuf library would be required, adds protobuf_full to deps
+#       instead of protobuf_lite.
+#
+#   import_protobuf_full (optional)
+#       Allows .proto files to import .proto files from protobuf_full, without
+#       adding a dependency on all the C++ code in that library.
+#
+#   import_dirs (optional)
+#       A list of extra import directories to be passed to protoc compiler. The
+#       default case is just proto_in_dir.
+#       WARNING: This options should not be used in Chrome code until
+#       http://crbug.com/691451 is resolved.
+#
+# Parameters for compiling the generated code:
+#
+#   defines (optional)
+#       Defines to supply to the source set that compiles the generated source
+#       code.
+#
+#   extra_configs (optional)
+#       A list of config labels that will be appended to the configs applying
+#       to the source set.
+#
+# Example:
+#  proto_library("mylib") {
+#    sources = [
+#      "foo.proto",
+#    ]
+#  }
+
+if (host_os == "win") {
+  _host_executable_suffix = ".exe"
+} else {
+  _host_executable_suffix = ""
+}
+
+template("proto_library") {
+  assert(defined(invoker.sources), "Need sources for proto_library")
+  proto_sources = invoker.sources
+
+  forward_variables_from(invoker, [ "visibility" ])
+
+  if (defined(invoker.generate_cc)) {
+    generate_cc = invoker.generate_cc
+  } else {
+    generate_cc = true
+  }
+
+  if (defined(invoker.generate_python)) {
+    generate_python = invoker.generate_python
+  } else {
+    generate_python = true
+  }
+
+  generate_go = defined(invoker.generate_go) && invoker.generate_go
+  generate_go_grpc =
+      defined(invoker.generate_go_grpc) && invoker.generate_go_grpc
+
+  assert(!generate_go || !generate_go_grpc,
+         "Only one of generate_go or generate_go_grpc can be enabled!")
+
+  not_needed(invoker, ["propagate_imports_configs"])
+
+  if (defined(invoker.generator_plugin_label)) {
+    # Straightforward way to get the name of executable doesn't work because
+    # |root_out_dir| and |root_build_dir| may differ in cross-compilation and
+    # also Windows executables have .exe at the end.
+
+    plugin_host_label = invoker.generator_plugin_label + "($host_toolchain)"
+    plugin_path =
+        get_label_info(plugin_host_label, "root_out_dir") + "/" +
+        get_label_info(plugin_host_label, "name") + _host_executable_suffix
+    generate_with_plugin = true
+  } else if (defined(invoker.generator_plugin_script)) {
+    plugin_path = invoker.generator_plugin_script
+    generate_with_plugin = true
+  } else {
+    generate_with_plugin = false
+  }
+
+  if (generate_with_plugin) {
+    if (defined(invoker.generator_plugin_suffix)) {
+      generator_plugin_suffixes = [
+        "${invoker.generator_plugin_suffix}.h",
+        "${invoker.generator_plugin_suffix}.cc",
+      ]
+    } else {
+      generator_plugin_suffixes = invoker.generator_plugin_suffixes
+    }
+  }
+
+  if (defined(invoker.proto_in_dir)) {
+    proto_in_dir = invoker.proto_in_dir
+  } else {
+    proto_in_dir = get_path_info(proto_sources[0], "dir")
+
+    # Sanity check, |proto_in_dir| should be defined to allow sub-directories.
+    foreach(proto_source, proto_sources) {
+      assert(get_path_info(proto_source, "dir") == proto_in_dir,
+             "Please define |proto_in_dir| to allow nested directories.")
+    }
+  }
+
+  # Avoid absolute path because of the assumption that |proto_in_dir| is
+  # relative to the directory of current BUILD.gn file.
+  proto_in_dir = rebase_path(proto_in_dir, ".")
+
+  if (defined(invoker.proto_out_dir)) {
+    proto_out_dir = invoker.proto_out_dir
+  } else {
+    # Absolute path to the directory of current BUILD.gn file excluding "//".
+    proto_out_dir = rebase_path(".", "//")
+    if (proto_in_dir != ".") {
+      proto_out_dir += "/$proto_in_dir"
+    }
+  }
+
+  # We need both absolute path to use in GN statements and a relative one
+  # to pass to external script.
+  if (generate_cc || generate_with_plugin) {
+    cc_out_dir = "$root_gen_dir/" + proto_out_dir
+    rel_cc_out_dir = rebase_path(cc_out_dir, root_build_dir)
+  }
+  if (generate_python) {
+    py_out_dir = "$root_out_dir/pyproto/" + proto_out_dir
+    rel_py_out_dir = rebase_path(py_out_dir, root_build_dir)
+  }
+  if (generate_go || generate_go_grpc) {
+    go_out_dir = "$root_gen_dir/go-proto-gen/src/" + proto_out_dir
+    rel_go_out_dir = rebase_path(go_out_dir, root_build_dir)
+  }
+
+  protos = rebase_path(invoker.sources, proto_in_dir)
+  protogens = []
+
+  descriptor_set_path_ = ""
+  if (defined(invoker.generate_descriptor_set) &&
+      invoker.generate_descriptor_set) {
+    assert(!defined(invoker.generate_descriptor))
+    descriptor_set_path_ = "${target_out_dir}/${target_name}.desc.pb"
+  } else if (defined(invoker.generate_descriptor)) {
+    descriptor_set_path_ =
+        "$root_gen_dir/" + 
+        rebase_path(proto_out_dir, "//") +
+        invoker.generate_descriptor
+  }
+  if (descriptor_set_path_ != "") {
+    protogens += [ descriptor_set_path_ ]
+  }
+
+  # List output files.
+  foreach(proto, protos) {
+    proto_dir = get_path_info(proto, "dir")
+    proto_name = get_path_info(proto, "name")
+    proto_path = proto_dir + "/" + proto_name
+
+    if (generate_cc) {
+      protogens += [
+        "$cc_out_dir/$proto_path.pb.h",
+        "$cc_out_dir/$proto_path.pb.cc",
+      ]
+    }
+    if (generate_python) {
+      protogens += [ "$py_out_dir/${proto_path}_pb2.py" ]
+    }
+    if (generate_go) {
+      protogens += [ "$go_out_dir/${proto_path}.pb.go" ]
+    }
+    if (generate_go_grpc) {
+      protogens += [ "$go_out_dir/${proto_path}_grpc.pb.go" ]
+    }
+    if (generate_with_plugin) {
+      foreach(suffix, generator_plugin_suffixes) {
+        protogens += [ "$cc_out_dir/${proto_path}${suffix}" ]
+      }
+    }
+    if (descriptor_set_path_ != "") {
+      # Descriptor-only protobuf targets do not use |proto_path|
+      not_needed(["proto_path"])
+    }
+  }
+
+  generated_file("${target_name}_protoc_outputs") {
+    contents = rebase_path(protogens, root_build_dir)
+    outputs = [ "${target_gen_dir}/${target_name}.protoc_output_info" ]
+  }
+  protoc_output_info_target = ":${target_name}_protoc_outputs"
+
+  action_name = "${target_name}_gen"
+
+  # Generate protobuf stubs.
+  action(action_name) {
+    visibility = []
+    visibility = [ ":*" ]
+    script = "//build/secondary/third_party/protobuf/protoc_wrapper.py"
+    sources = proto_sources
+    outputs = protogens
+    args = protos
+
+    protoc_label = "//third_party/protobuf:protoc($host_toolchain)"
+    protoc_path = get_label_info(protoc_label, "root_out_dir") + "/protoc" +
+                  _host_executable_suffix
+
+    if (generate_go || generate_go_grpc) {
+      if (generate_go_grpc) {
+        protoc_gen_go_label = "//third_party/golibs/google.golang.org/grpc/cmd/protoc-gen-go-grpc($host_toolchain)"
+      } else {
+        protoc_gen_go_label = "//third_party/golibs/google.golang.org/protobuf/cmd/protoc-gen-go($host_toolchain)"
+      }
+      protoc_gen_go_path = get_label_info(protoc_gen_go_label, "root_out_dir") +
+                           "/" + get_label_info(protoc_gen_go_label, "name")
+    }
+
+    # Depfile information.
+    depfile = "${target_gen_dir}/${target_name}.d"
+    protoc_output_info_files = get_target_outputs(protoc_output_info_target)
+    protoc_output_info_file = protoc_output_info_files[0]
+    args += [
+      "--depfile",
+      rebase_path(depfile, root_build_dir),
+      "--depfile-outputs",
+      rebase_path(protoc_output_info_file, root_build_dir),
+    ]
+
+    args += [
+      # Wrapper should never pick a system protoc.
+      # Path should be rebased because |root_build_dir| for current toolchain
+      # may be different from |root_out_dir| of protoc built on host toolchain.
+      "--protoc",
+      "./" + rebase_path(protoc_path, root_build_dir),
+      "--proto-in-dir",
+      rebase_path(proto_in_dir, root_build_dir),
+    ]
+
+    if (generate_cc) {
+      args += [
+        "--cc-out-dir",
+        rel_cc_out_dir,
+      ]
+      if (defined(invoker.cc_generator_options)) {
+        args += [
+          "--cc-options",
+          invoker.cc_generator_options,
+        ]
+      }
+      if (defined(invoker.cc_include)) {
+        args += [
+          "--include",
+          invoker.cc_include,
+        ]
+      }
+    }
+
+    if (generate_python) {
+      args += [
+        "--py-out-dir",
+        rel_py_out_dir,
+      ]
+    }
+
+    if (descriptor_set_path_ != "") {
+      args += [
+        "--descriptor-set-out",
+        rebase_path(descriptor_set_path_, root_build_dir),
+      ]
+    }
+
+    if (generate_go || generate_go_grpc) {
+      args += [
+        "--plugin",
+        rebase_path(protoc_gen_go_path, root_build_dir),
+        "--plugin-out-dir",
+        rel_go_out_dir,
+        "--plugin-options",
+        "paths=source_relative",
+      ]
+    }
+
+    if (generate_with_plugin) {
+      args += [
+        "--plugin",
+        rebase_path(plugin_path, root_build_dir),
+        "--plugin-out-dir",
+        rel_cc_out_dir,
+      ]
+      if (defined(invoker.generator_plugin_options)) {
+        args += [
+          "--plugin-options",
+          invoker.generator_plugin_options,
+        ]
+      }
+    }
+
+    if (defined(invoker.import_dirs)) {
+      foreach(path, invoker.import_dirs) {
+        args += [ "--import-dir=" + rebase_path(path, root_build_dir) ]
+      }
+    }
+
+    if ((defined(invoker.use_protobuf_full) && invoker.use_protobuf_full) ||
+        (defined(invoker.import_protobuf_full) &&
+         invoker.import_protobuf_full)) {
+      args += [ "--import-dir=" +
+                rebase_path("//third_party/protobuf/src", root_build_dir) ]
+    }
+
+    # System protoc is not used so it's necessary to build one.
+    inputs = [
+      protoc_path,
+      protoc_output_info_file,
+    ]
+    deps = [
+      protoc_label,
+      protoc_output_info_target,
+    ]
+
+    if (generate_go || generate_go_grpc) {
+      deps += [ protoc_gen_go_label ]
+      inputs += [ protoc_gen_go_path ]
+    }
+
+    if (generate_with_plugin) {
+      inputs += [ plugin_path ]
+      if (defined(invoker.generator_plugin_script_deps)) {
+        # Additional scripts for plugin.
+        inputs += invoker.generator_plugin_script_deps
+      }
+      if (defined(plugin_host_label)) {
+        # Action depends on native generator plugin but for host toolchain only.
+        deps += [ plugin_host_label ]
+      }
+    }
+
+    if (defined(invoker.deps)) {
+      # The deps may have steps that have to run before running protoc.
+      deps += invoker.deps
+    }
+  }
+
+  # Option to disable building a library in component build.
+  if (defined(invoker.component_build_force_source_set) &&
+      invoker.component_build_force_source_set && is_component_build) {
+    link_target_type = "source_set"
+  }
+
+  # Build generated protobuf stubs as static libary.
+  _static_lib_deps = []
+  if (generate_cc || generate_python || generate_with_plugin) {
+    _static_lib_name = "${target_name}_static_lib"
+    _static_lib_deps = [ ":${_static_lib_name}" ]
+    static_library(_static_lib_name) {
+      forward_variables_from(invoker,
+                             [
+                               "defines",
+                               "deps",
+                               "testonly",
+                             ])
+      visibility = []
+      visibility = [ ":*" ]
+      output_name = target_name
+      sources = []
+      foreach(source, get_target_outputs(":${action_name}")) {
+        extension = get_path_info(source, "extension")
+        if (extension == "h" || extension == "cc") {
+          sources += [ source ]
+        }
+      }
+
+      if (defined(invoker.extra_configs)) {
+        configs += invoker.extra_configs
+      }
+
+      configs += [ "//third_party/protobuf:protobuf_warnings" ]
+      public_configs = [ "//third_party/protobuf:using_proto" ]
+
+      if (!defined(deps)) {
+        deps = []
+      }
+      deps += [ ":${action_name}" ]
+
+      if (generate_cc) {
+        # If using built-in cc generator, the resulting headers reference
+        # headers within protobuf_lite. Hence, dependencies require those
+        # headers too. If using generator plugin, extra deps should be
+        # resolved by the invoker.
+        if (defined(invoker.use_protobuf_full) &&
+            invoker.use_protobuf_full == true) {
+          public_deps = [ "//third_party/protobuf:protobuf_full" ]
+        } else {
+          public_deps = [ "//third_party/protobuf:protobuf_lite" ]
+        }
+
+        # Allows generated protobufs to use #include subpaths rooted from
+        # |proto_out_dir|.
+        include_dirs = [ "${root_gen_dir}/" +
+                         rebase_path(proto_out_dir, "//") ]
+      }
+    }
+  }
+
+  group(target_name) {
+    public_deps = [ ":${action_name}" ] + _static_lib_deps
+  }
+}

--- a/build/secondary/third_party/protobuf/protoc_wrapper.py
+++ b/build/secondary/third_party/protobuf/protoc_wrapper.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3.8
+# Copyright 2012 Google Inc.  All Rights Reserved.
+
+"""
+A simple wrapper for protoc.
+Script for //third_party/protobuf/proto_library.gni .
+Features:
+- Inserts #include for extra header automatically.
+- Prevents bad proto names.
+"""
+
+from __future__ import print_function
+import argparse
+import os
+import os.path
+import re
+import subprocess
+import sys
+import tempfile
+
+PROTOC_INCLUDE_POINT = "// @@protoc_insertion_point(includes)"
+
+
+def FormatGeneratorOptions(options):
+  if not options:
+    return ""
+  if options.endswith(":"):
+    return options
+  return options + ":"
+
+
+def VerifyProtoNames(protos):
+  for filename in protos:
+    if "-" in filename:
+      raise RuntimeError("Proto file names must not contain hyphens "
+                         "(see http://crbug.com/386125 for more information).")
+
+
+def StripProtoExtension(filename):
+  if not filename.endswith(".proto"):
+    raise RuntimeError("Invalid proto filename extension: "
+                       "{0} .".format(filename))
+  return filename.rsplit(".", 1)[0]
+
+
+def WriteIncludes(headers, include):
+  for filename in headers:
+    include_point_found = False
+    contents = []
+    with open(filename) as f:
+      for line in f:
+        stripped_line = line.strip()
+        contents.append(stripped_line)
+        if stripped_line == PROTOC_INCLUDE_POINT:
+          if include_point_found:
+            raise RuntimeError("Multiple include points found.")
+          include_point_found = True
+          extra_statement = "#include \"{0}\"".format(include)
+          contents.append(extra_statement)
+
+      if not include_point_found:
+        raise RuntimeError("Include point not found in header: "
+                           "{0} .".format(filename))
+
+    with open(filename, "w") as f:
+      for line in contents:
+        print(line, file=f)
+
+
+def WriteDepfile(depfile, out_list, dep_list):
+  os.makedirs(os.path.dirname(depfile), exist_ok=True)
+  with open(depfile, 'w') as f:
+    print("{0}: {1}".format(" ".join(out_list), " ".join(dep_list)), file=f)
+
+
+def WritePluginDepfile(depfile, outputs, dependencies):
+  with open(outputs) as f:
+    outs = [line.strip() for line in f]
+  with open(dependencies) as f:
+    deps = [line.strip() for line in f]
+  WriteDepfile(depfile, outs, deps)
+
+
+def WriteProtocDepfile(depfile, outputs, deps_list):
+  with open(outputs) as f:
+    outs = [line.strip() for line in f]
+  WriteDepfile(depfile, outs, deps_list)
+
+
+def ExtractImports(proto, proto_dir, import_dirs):
+  filename = os.path.join(proto_dir, proto)
+  imports = set()
+
+  with open(filename) as f:
+    # Search the file for import.
+    for line in f:
+      match = re.match(r'^\s*import(?:\s+public)?\s+"([^"]+)"\s*;\s*$', line)
+      if match:
+        imported = match[1]
+
+        # Check import directories to find the imported file.
+        for candidate_dir in [proto_dir] + import_dirs:
+          candidate_path = os.path.join(candidate_dir, imported)
+          if os.path.exists(candidate_path):
+            imports.add(candidate_path)
+            # Transitively check imports.
+            imports.update(ExtractImports(imported, candidate_dir, import_dirs))
+            break
+
+  return imports
+
+
+def main(argv):
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--protoc",
+                      help="Relative path to compiler.")
+
+  parser.add_argument("--proto-in-dir",
+                      help="Base directory with source protos.")
+  parser.add_argument("--cc-out-dir",
+                      help="Output directory for standard C++ generator.")
+  parser.add_argument("--py-out-dir",
+                      help="Output directory for standard Python generator.")
+  parser.add_argument("--plugin-out-dir",
+                      help="Output directory for custom generator plugin.")
+
+  parser.add_argument("--depfile",
+                      help="Output location for the protoc depfile.")
+  parser.add_argument("--depfile-outputs",
+                      help="File containing a list of files to be generated.")
+
+  parser.add_argument("--plugin",
+                      help="Relative path to custom generator plugin.")
+  parser.add_argument("--plugin-depfile",
+                      help="Output location for the plugin depfile.")
+  parser.add_argument("--plugin-depfile-deps",
+                      help="File containing plugin deps not set as other input.")
+  parser.add_argument("--plugin-depfile-outputs",
+                      help="File containing a list of files that will be generated.")
+  parser.add_argument("--plugin-options",
+                      help="Custom generator plugin options.")
+  parser.add_argument("--cc-options",
+                      help="Standard C++ generator options.")
+  parser.add_argument("--include",
+                      help="Name of include to insert into generated headers.")
+  parser.add_argument("--import-dir", action="append", default=[],
+                      help="Extra import directory for protos, can be repeated."
+  )
+  parser.add_argument("--descriptor-set-out",
+                      help="Passed through to protoc as --descriptor_set_out")
+
+  parser.add_argument("protos", nargs="+",
+                      help="Input protobuf definition file(s).")
+
+  options = parser.parse_args()
+
+  proto_dir = os.path.relpath(options.proto_in_dir)
+  protoc_cmd = [os.path.realpath(options.protoc)]
+
+  protos = options.protos
+  headers = []
+  VerifyProtoNames(protos)
+
+  if options.descriptor_set_out:
+    protoc_cmd += ["--descriptor_set_out", options.descriptor_set_out]
+
+  if options.py_out_dir:
+    protoc_cmd += ["--python_out", options.py_out_dir]
+
+  if options.cc_out_dir:
+    cc_out_dir = options.cc_out_dir
+    cc_options = FormatGeneratorOptions(options.cc_options)
+    protoc_cmd += ["--cpp_out", cc_options + cc_out_dir]
+    for filename in protos:
+      stripped_name = StripProtoExtension(filename)
+      headers.append(os.path.join(cc_out_dir, stripped_name + ".pb.h"))
+
+  if options.plugin_out_dir:
+    plugin_options = FormatGeneratorOptions(options.plugin_options)
+    protoc_cmd += [
+      "--plugin", "protoc-gen-plugin=" + os.path.relpath(options.plugin),
+      "--plugin_out", plugin_options + options.plugin_out_dir
+    ]
+
+  if options.plugin_depfile:
+    if not options.plugin_depfile_deps or not options.plugin_depfile_outputs:
+      raise RuntimeError("If plugin depfile is supplied, then the plugin "
+                         "depfile deps and outputs must be set.")
+    depfile = options.plugin_depfile
+    dep_info = options.plugin_depfile_deps
+    outputs = options.plugin_depfile_outputs
+    WritePluginDepfile(depfile, outputs, dep_info)
+
+  if options.depfile:
+    if not options.depfile_outputs:
+      raise RuntimeError("If depfile is supplied, depfile outputs must also"
+                         "be supplied.")
+
+    depfile = options.depfile
+    outputs = options.depfile_outputs
+    deps = set()
+
+    for proto in protos:
+      deps.update(ExtractImports(proto, proto_dir, options.import_dir))
+    WriteProtocDepfile(depfile, outputs, deps)
+
+  protoc_cmd += ["--proto_path", proto_dir]
+  for path in options.import_dir:
+    protoc_cmd += ["--proto_path", path]
+
+  protoc_cmd += [os.path.join(proto_dir, name) for name in protos]
+
+  ret = subprocess.call(protoc_cmd)
+  if ret != 0:
+    raise RuntimeError("Protoc has returned non-zero status: "
+                       "{0} .".format(ret))
+
+  if options.include:
+    WriteIncludes(headers, options.include)
+
+
+if __name__ == "__main__":
+  try:
+    main(sys.argv)
+  except RuntimeError as e:
+    print(e, file=sys.stderr)
+    sys.exit(1)

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -1426,6 +1426,7 @@
 ../../../flutter/third_party/pkg/process
 ../../../flutter/third_party/pkg/process_runner
 ../../../flutter/third_party/pkg/vector_math
+../../../flutter/third_party/protobuf
 ../../../flutter/third_party/pyyaml
 ../../../flutter/third_party/rapidjson/.git
 ../../../flutter/third_party/rapidjson/.gitattributes
@@ -3081,7 +3082,6 @@
 ../../../third_party/perfetto/ui/src/plugins/dev.perfetto.AndroidPerf/OWNERS
 ../../../third_party/perfetto/ui/src/plugins/dev.perfetto.LargeScreensPerf/OWNERS
 ../../../third_party/perfetto/ui/src/test
-../../../third_party/protobuf
 ../../../third_party/vulkan-deps/.git
 ../../../third_party/vulkan-deps/.gitattributes
 ../../../third_party/vulkan-deps/.gitignore

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: f49b025536bc4384432f8ab917d316cd
+Signature: 0efc328e1ec5308cf91a9069c33c0463
 

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -359,7 +359,7 @@ Future<int> main(List<String> args) async {
       ),
     );
     final List<io.File> fileList = await fixture.tool.computeFilesOfInterest();
-    expect(fileList.length, lessThan(1000));
+    expect(fileList.length, lessThan(2000));
   });
 
   test('Sharding', () async {

--- a/tools/licenses/lib/paths.dart
+++ b/tools/licenses/lib/paths.dart
@@ -90,6 +90,7 @@ final Set<String> skippedPaths = <String>{
   r'flutter/third_party/pkg/process',
   r'flutter/third_party/pkg/process_runner',
   r'flutter/third_party/pkg/vector_math',
+  r'flutter/third_party/protobuf', // build-time dependency only
   r'flutter/third_party/pyyaml', // build-time dependency only
   r'flutter/third_party/rapidjson/contrib', // contains nothing that ends up in the binary executable
   r'flutter/third_party/rapidjson/doc', // documentation
@@ -187,7 +188,6 @@ final Set<String> skippedPaths = <String>{
   r'third_party/perfetto/src/trace_processor', // contains nothing that ends up in the binary executable
   r'third_party/perfetto/src/traced', // contains nothing that ends up in the binary executable
   r'third_party/perfetto/src/tracing', // contains nothing that ends up in the binary executable
-  r'third_party/protobuf', // build-time dependency only
   r'third_party/vulkan-deps/glslang/LICENSE', // excluded to make sure we don't accidentally apply it as a default license
   r'third_party/vulkan-deps/glslang/src/LICENSE.txt', // redundant with licenses inside files
   r'third_party/vulkan-deps/glslang/src/glslang/OSDependent/Web', // we only use glslang in impellerc, not in web apps


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/67373

Currently the files in the secondary buildroot for protobuf are checked out from their own git repo. Flutter owns a mirror of that repo. To move protobuf to `//flutter/third_party`, we can land a change in that repo, and then revert it after we're done with the buildmoot. Alternately, in this PR, I've just copied the files into the flutter/engine repo under the secondary buildroot and made the changes.