### PR TITLE
Remove rewrapper prefix from compiler commands for clang-tidy

### DIFF
--- a/ci/builders/linux_clang_tidy.json
+++ b/ci/builders/linux_clang_tidy.json
@@ -6,13 +6,18 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--android",
                 "--android-cpu",
                 "arm64",
                 "--no-lto",
                 "--target-dir",
-                "android_debug_arm64_clang_tidy"
+                "android_debug_arm64_clang_tidy",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "android_debug_arm64_clang_tidy",
             "ninja": {
@@ -25,13 +30,18 @@
                 "device_type=none",
                 "os=Linux"
             ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
             "gn": [
                 "--runtime-mode",
                 "debug",
                 "--prebuilt-dart-sdk",
                 "--no-lto",
                 "--target-dir",
-                "host_debug_clang_tidy"
+                "host_debug_clang_tidy",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "host_debug_clang_tidy",
             "ninja": {
@@ -58,6 +68,7 @@
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
+                        "--verbose",
                         "--variant",
                         "host_debug_clang_tidy",
                         "--lint-all",
@@ -87,6 +98,7 @@
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
+                        "--verbose",
                         "--variant",
                         "host_debug_clang_tidy",
                         "--lint-all",
@@ -116,6 +128,7 @@
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
+                        "--verbose",
                         "--variant",
                         "host_debug_clang_tidy",
                         "--lint-all",
@@ -145,6 +158,7 @@
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
+                        "--verbose",
                         "--variant",
                         "host_debug_clang_tidy",
                         "--lint-all",
@@ -172,6 +186,7 @@
                 {
                     "name": "test: lint android_debug_arm64",
                     "parameters": [
+                        "--verbose",
                         "--variant",
                         "android_debug_arm64_clang_tidy",
                         "--lint-all",

--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -7,7 +7,8 @@
                 "cpu=arm64"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--runtime-mode",
@@ -16,7 +17,9 @@
                 "--no-lto",
                 "--force-mac-arm64",
                 "--target-dir",
-                "host_debug_clang_tidy"
+                "host_debug_clang_tidy",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "host_debug_clang_tidy",
             "ninja": {
@@ -30,7 +33,8 @@
                 "cpu=arm64"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--ios",
@@ -40,7 +44,9 @@
                 "--no-lto",
                 "--force-mac-arm64",
                 "--target-dir",
-                "ios_debug_sim_clang_tidy"
+                "ios_debug_sim_clang_tidy",
+                "--rbe",
+                "--no-goma"
             ],
             "name": "ios_debug_sim_clang_tidy",
             "ninja": {

--- a/tools/clang_tidy/lib/src/command.dart
+++ b/tools/clang_tidy/lib/src/command.dart
@@ -55,8 +55,8 @@ class Command {
   /// The file on which the command operates.
   late final String filePath;
 
-  static final RegExp _pathRegex = RegExp(r'\S*clang/bin/clang');
-  static final RegExp _argRegex = RegExp(r'-MF \S*');
+  static final RegExp _pathRegex = RegExp(r'\S*clang/bin/clang(\+\+)?');
+  static final RegExp _argRegex = RegExp(r'-MF\s+\S+\s+');
 
   // Filter out any extra commands that were appended to the compile command.
   static final RegExp _extraCommandRegex = RegExp(r'&&.*$');
@@ -67,6 +67,11 @@ class Command {
   String get tidyArgs {
     return _tidyArgs ??= (() {
       String result = command;
+      result = result.replaceAll(r'\s+', ' ');
+      // Remove everything that comes before the compiler command.
+      result = result.split(' ')
+                     .skipWhile((String s) => !_pathRegex.hasMatch(s))
+                     .join(' ');
       result = result.replaceAll(_pathRegex, '');
       result = result.replaceAll(_argRegex, '');
       result = result.replaceAll(_extraCommandRegex, '');
@@ -81,7 +86,7 @@ class Command {
     return _tidyPath ??= _pathRegex.stringMatch(command)?.replaceAll(
       'clang/bin/clang',
       'clang/bin/clang-tidy',
-    ) ?? '';
+    ).replaceAll('clang-tidy++', 'clang-tidy') ?? '';
   }
 
   /// Whether this command operates on any of the files in `queries`.

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -586,5 +586,29 @@ Future<int> main(List<String> args) async {
     expect(command.tidyArgs.trim(), 'filename');
   });
 
+  test('Command filters out the -MF flag', () {
+    final Command command = Command.fromMap(<String, String>{
+        'directory': '/unused',
+        'command':
+          '../../buildtools/mac-x64/clang/bin/clang -MF stuff filename ',
+        'file': 'unused',
+    });
+    expect(command.tidyArgs.trim(), 'filename');
+  });
+
+  test('Command filters out rewrapper command before a compile command', () {
+    final Command command = Command.fromMap(<String, String>{
+        'directory': '/unused',
+        'command':
+          'flutter/engine/src/buildtools/mac-arm64/reclient/rewrapper '
+          '--cfg=flutter/engine/src/flutter/build/rbe/rewrapper-mac-arm64.cfg '
+          '--exec_root=flutter/engine/src/ '
+          '--labels=type=compile,compiler=clang,lang=cpp '
+          '../../buildtools/mac-x64/clang/bin/clang++ filename ',
+        'file': 'unused',
+    });
+    expect(command.tidyArgs.trim(), 'filename');
+  });
+
   return 0;
 }


### PR DESCRIPTION
This PR also enables RBE for builds for clang-tidy.