### PR TITLE
Adjust Android emulator test timeouts

### DIFF
--- a/ci/builders/linux_android_emulator.json
+++ b/ci/builders/linux_android_emulator.json
@@ -61,6 +61,8 @@
                 {
                     "language": "dart",
                     "name": "Android Scenario App Integration Tests (Impeller/Vulkan)",
+                    "test_timeout_secs": 900,
+                    "max_attempts": 2,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",

--- a/ci/builders/linux_android_emulator_api_33.json
+++ b/ci/builders/linux_android_emulator_api_33.json
@@ -61,6 +61,8 @@
                 {
                     "language": "dart",
                     "name": "Scenario App Integration Tests",
+                    "test_timeout_secs": 900,
+                    "max_attempts": 2,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",

--- a/ci/builders/linux_android_emulator_opengles.json
+++ b/ci/builders/linux_android_emulator_opengles.json
@@ -36,6 +36,8 @@
                 {
                     "language": "dart",
                     "name": "Android Scenario App Integration Tests (Impeller/OpenGLES)",
+                    "test_timeout_secs": 900,
+                    "max_attempts": 2,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",

--- a/ci/builders/linux_android_emulator_skia.json
+++ b/ci/builders/linux_android_emulator_skia.json
@@ -37,6 +37,8 @@
                 {
                     "language": "dart",
                     "name": "Android Scenario App Integration Tests (Skia)",
+                    "test_timeout_secs": 900,
+                    "max_attempts": 2,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",


### PR DESCRIPTION
This reduces the scenario app test timeout from 30 minutes to 15 minutes (passing runs seem to take about 5 minutes), and limits the scenario app tests from 2 retries to only 1 retry.

These changes will hopefully allow logs collection to be successful when the tests timeout.