### PR TITLE
Improve, test, and fix a bug related to `adb logcat` filtering.

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -909,6 +909,7 @@ def build_dart_host_test_list(build_dir):
       ),
       (os.path.join('flutter', 'testing', 'litetest'), []),
       (os.path.join('flutter', 'testing', 'skia_gold_client'), []),
+      (os.path.join('flutter', 'testing', 'scenario_app'), []),
       (
           os.path.join('flutter', 'tools', 'api_check'),
           [os.path.join(BUILDROOT_DIR, 'flutter')],

--- a/testing/scenario_app/README.md
+++ b/testing/scenario_app/README.md
@@ -18,7 +18,7 @@ See also:
 - [`ios/`](ios/), the iOS-side native code and tests.
 - [`android/`](android/), the Android-side native code and tests.
 
-[file_issue]: https://github.com/flutter/flutter/issues/new?labels=e:%20scenario-app,engine,platform-android,fyi-android,team-engine
+[file_issue]: https://github.com/flutter/flutter/issues/new?labels=e:%20scenario-app,engine,team-engine
 
 ## Running a smoke test on Firebase TestLab
 

--- a/testing/scenario_app/bin/README.md
+++ b/testing/scenario_app/bin/README.md
@@ -5,6 +5,13 @@ This directory contains code specific to running Android integration tests.
 The tests are uploaded and run on the device using `adb`, and screenshots are
 captured and compared using Skia Gold (if available, for example on CI).
 
+See also:
+
+- [File an issue][file_issue] with the `e: scenario-app, platform-android`
+  labels.
+
+[file_issue]: https://github.com/flutter/flutter/issues/new?labels=e:%20scenario-app,engine,platform-android,fyi-android,team-engine
+
 ## Usage
 
 ```sh

--- a/testing/scenario_app/bin/utils/adb_logcat_filtering.dart
+++ b/testing/scenario_app/bin/utils/adb_logcat_filtering.dart
@@ -85,10 +85,15 @@ extension type const AdbLogLine._(Match _match) {
   };
 
   @visibleForTesting
-  static const Set<String> kKnownUsefulTags = <String>{
+  static const Set<String> kKnownUsefulGeneralTags = <String>{
     'utter.scenario',
     'utter.scenarios',
     'TestRunner',
+  };
+
+  @visibleForTesting
+  static const Set<String> kKnownUsefulErrorTags = <String>{
+    'androidemu',
   };
 
   /// Returns `true` if the log line is verbose.
@@ -108,7 +113,11 @@ extension type const AdbLogLine._(Match _match) {
       return false;
     }
 
-    if (kKnownUsefulTags.contains(name)) {
+    if (kKnownUsefulGeneralTags.contains(name)) {
+      return true;
+    }
+
+    if (severity == 'E' && kKnownUsefulErrorTags.contains(name)) {
       return true;
     }
 

--- a/testing/scenario_app/bin/utils/adb_logcat_filtering.dart
+++ b/testing/scenario_app/bin/utils/adb_logcat_filtering.dart
@@ -78,16 +78,24 @@ extension type const AdbLogLine._(Match _match) {
 
   @visibleForTesting
   static const Set<String> knownNoiseTags = <String>{
+    'CCodec',
+    'CCodecBufferChannel',
+    'CCodecConfig',
+    'Codec2Client',
+    'ColorUtils',
+    'DMABUFHEAPS',
+    'Gralloc4',
+    'MediaCodec',
     'MonitoringInstr',
     'ResourceExtractor',
+    'UsageTrackerFacilitator',
+    'hw-BpHwBinder',
     'ziparchive',
   };
 
   @visibleForTesting
   static const Set<String> knownUsefulTags = <String>{
-    'utter.scenario',
-    'utter.scenarios',
-    'TestRunner',
+    'ActivityManager',
   };
 
   @visibleForTesting
@@ -104,8 +112,8 @@ extension type const AdbLogLine._(Match _match) {
       return true;
     }
 
-    // Debug logs are rarely useful.
-    if (severity == 'D') {
+    // Verbose and debug logs are rarely useful.
+    if (severity == 'V' || severity == 'D') {
       return false;
     }
 
@@ -126,9 +134,9 @@ extension type const AdbLogLine._(Match _match) {
       // YOLO, let's keep it anyway.
       return name.toLowerCase().contains('flutter') ||
           message.toLowerCase().contains('flutter');
-    } else {
-      return process == filterProcessId;
     }
+
+    return process == filterProcessId;
   }
 
   /// Logs the line to the console.

--- a/testing/scenario_app/bin/utils/adb_logcat_filtering.dart
+++ b/testing/scenario_app/bin/utils/adb_logcat_filtering.dart
@@ -77,23 +77,23 @@ extension type const AdbLogLine._(Match _match) {
   }
 
   @visibleForTesting
-  static const Set<String> kKnownNoiseTags = <String>{
+  static const Set<String> knownNoiseTags = <String>{
     'MonitoringInstr',
     'ResourceExtractor',
-    'THREAD_STATE',
     'ziparchive',
   };
 
   @visibleForTesting
-  static const Set<String> kKnownUsefulGeneralTags = <String>{
+  static const Set<String> knownUsefulTags = <String>{
     'utter.scenario',
     'utter.scenarios',
     'TestRunner',
   };
 
   @visibleForTesting
-  static const Set<String> kKnownUsefulErrorTags = <String>{
+  static const Set<String> knownUsefulErrorTags = <String>{
     'androidemu',
+    'THREAD_STATE',
   };
 
   /// Returns `true` if the log line is verbose.
@@ -109,15 +109,15 @@ extension type const AdbLogLine._(Match _match) {
       return false;
     }
 
-    if (kKnownNoiseTags.contains(name)) {
+    if (knownNoiseTags.contains(name)) {
       return false;
     }
 
-    if (kKnownUsefulGeneralTags.contains(name)) {
+    if (knownUsefulTags.contains(name)) {
       return true;
     }
 
-    if (severity == 'E' && kKnownUsefulErrorTags.contains(name)) {
+    if (severity == 'E' && knownUsefulErrorTags.contains(name)) {
       return true;
     }
 

--- a/testing/scenario_app/pubspec.yaml
+++ b/testing/scenario_app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   skia_gold_client: any
 
 dev_dependencies:
-  litetest:
+  litetest: any
 
 dependency_overrides:
   args:

--- a/testing/scenario_app/pubspec.yaml
+++ b/testing/scenario_app/pubspec.yaml
@@ -25,9 +25,14 @@ dependencies:
   vector_math: any
   skia_gold_client: any
 
+dev_dependencies:
+  litetest:
+
 dependency_overrides:
   args:
     path: ../../../third_party/dart/third_party/pkg/args
+  async_helper:
+    path: ../../../third_party/dart/pkg/async_helper
   collection:
     path: ../../../third_party/dart/third_party/pkg/collection
   crypto:
@@ -36,8 +41,12 @@ dependency_overrides:
     path: ../../tools/dir_contents_diff
   engine_repo_tools:
     path: ../../tools/pkg/engine_repo_tools
+  expect:
+    path: ../../../third_party/dart/pkg/expect
   file:
     path: ../../../third_party/dart/third_party/pkg/file/packages/file
+  litetest:
+    path: ../litetest
   meta:
     path: ../../../third_party/dart/pkg/meta
   path:
@@ -48,6 +57,8 @@ dependency_overrides:
     path: ../../third_party/pkg/process
   skia_gold_client:
     path: ../../testing/skia_gold_client
+  smith:
+    path: ../../../third_party/dart/pkg/smith
   sky_engine:
     path: ../../sky/packages/sky_engine
   typed_data:

--- a/testing/scenario_app/test/adb_log_filter_test.dart
+++ b/testing/scenario_app/test/adb_log_filter_test.dart
@@ -1,0 +1,82 @@
+import 'package:litetest/litetest.dart';
+
+import '../bin/utils/adb_logcat_filtering.dart';
+import 'src/fake_adb_logcat.dart';
+
+void main() {
+  /// Simulates the filtering of logcat output [lines].
+  Iterable<String> filter(Iterable<String> lines, {int? filterProcessId}) {
+    if (lines.isEmpty) {
+      throw StateError('No log lines to filter. This is unexpected.');
+    }
+    return lines.where((String line) {
+      final AdbLogLine? logLine = AdbLogLine.tryParse(line);
+      if (logLine == null) {
+        throw StateError('Invalid log line: $line');
+      }
+      final bool isVerbose = logLine.isVerbose(filterProcessId: filterProcessId?.toString());
+      return !isVerbose;
+    });
+  }
+
+  test('should always retain fatal logs', () {
+    final FakeAdbLogcat logcat = FakeAdbLogcat();
+    final FakeAdbProcess process = logcat.withProcess();
+    process.fatal('Something', 'A bad thing happened');
+
+    final Iterable<String> filtered = filter(logcat.drain());
+    expect(filtered, hasLength(1));
+    expect(filtered.first, contains('Something: A bad thing happened'));
+  });
+
+  test('should never retain debug logs', () {
+    final FakeAdbLogcat logcat = FakeAdbLogcat();
+    final FakeAdbProcess process = logcat.withProcess();
+    final String tag = AdbLogLine.kKnownNoiseTags.first;
+    process.debug(tag, 'A debug message');
+
+    final Iterable<String> filtered = filter(logcat.drain());
+    expect(filtered, isEmpty);
+  });
+
+  test('should never retain logs from known "noise" tags', () {
+    final FakeAdbLogcat logcat = FakeAdbLogcat();
+    final FakeAdbProcess process = logcat.withProcess();
+    final String tag = AdbLogLine.kKnownNoiseTags.first;
+    process.info(tag, 'Flutter flutter flutter');
+
+    final Iterable<String> filtered = filter(logcat.drain());
+    expect(filtered, isEmpty);
+  });
+
+  test('should always retain logs from known "useful" tags', () {
+    final FakeAdbLogcat logcat = FakeAdbLogcat();
+    final FakeAdbProcess process = logcat.withProcess();
+    final String tag = AdbLogLine.kKnownUsefulTags.first;
+    process.info(tag, 'A useful message');
+
+    final Iterable<String> filtered = filter(logcat.drain());
+    expect(filtered, hasLength(1));
+    expect(filtered.first, contains('$tag: A useful message'));
+  });
+
+  test('if a process ID is passed, retain the log', () {
+    final FakeAdbLogcat logcat = FakeAdbLogcat();
+    final FakeAdbProcess process = logcat.withProcess();
+    process.info('SomeTag', 'A message');
+
+    final Iterable<String> filtered = filter(logcat.drain(), filterProcessId: process.processId);
+    expect(filtered, hasLength(1));
+    expect(filtered.first, contains('SomeTag: A message'));
+  });
+
+  test('even if a process ID passed, retain logs containing "flutter"', () {
+    final FakeAdbLogcat logcat = FakeAdbLogcat();
+    final FakeAdbProcess process = logcat.withProcess();
+    process.info('SomeTag', 'A message with flutter');
+
+    final Iterable<String> filtered = filter(logcat.drain(), filterProcessId: process.processId);
+    expect(filtered, hasLength(1));
+    expect(filtered.first, contains('SomeTag: A message with flutter'));
+  });
+}

--- a/testing/scenario_app/test/adb_log_filter_test.dart
+++ b/testing/scenario_app/test/adb_log_filter_test.dart
@@ -91,4 +91,16 @@ void main() {
     expect(filtered, hasLength(1));
     expect(filtered.first, contains('$tag: An error message'));
   });
+
+  test('should filter out error logs from unimportant processes', () {
+    final FakeAdbLogcat logcat = FakeAdbLogcat();
+    final FakeAdbProcess process = logcat.withProcess();
+
+    // I hate this one.
+    const String tag = 'gs.intelligence';
+    process.error(tag, 'No package ID ff found for resource ID 0xffffffff.');
+
+    final Iterable<String> filtered = filter(logcat.drain());
+    expect(filtered, isEmpty);
+  });
 }

--- a/testing/scenario_app/test/adb_log_filter_test.dart
+++ b/testing/scenario_app/test/adb_log_filter_test.dart
@@ -32,7 +32,7 @@ void main() {
   test('should never retain debug logs', () {
     final FakeAdbLogcat logcat = FakeAdbLogcat();
     final FakeAdbProcess process = logcat.withProcess();
-    final String tag = AdbLogLine.kKnownNoiseTags.first;
+    final String tag = AdbLogLine.knownNoiseTags.first;
     process.debug(tag, 'A debug message');
 
     final Iterable<String> filtered = filter(logcat.drain());
@@ -42,7 +42,7 @@ void main() {
   test('should never retain logs from known "noise" tags', () {
     final FakeAdbLogcat logcat = FakeAdbLogcat();
     final FakeAdbProcess process = logcat.withProcess();
-    final String tag = AdbLogLine.kKnownNoiseTags.first;
+    final String tag = AdbLogLine.knownNoiseTags.first;
     process.info(tag, 'Flutter flutter flutter');
 
     final Iterable<String> filtered = filter(logcat.drain());
@@ -52,7 +52,7 @@ void main() {
   test('should always retain logs from known "useful" tags', () {
     final FakeAdbLogcat logcat = FakeAdbLogcat();
     final FakeAdbProcess process = logcat.withProcess();
-    final String tag = AdbLogLine.kKnownUsefulGeneralTags.first;
+    final String tag = AdbLogLine.knownUsefulTags.first;
     process.info(tag, 'A useful message');
 
     final Iterable<String> filtered = filter(logcat.drain());
@@ -83,7 +83,7 @@ void main() {
   test('should retain E-level flags from known "useful" error tags', () {
     final FakeAdbLogcat logcat = FakeAdbLogcat();
     final FakeAdbProcess process = logcat.withProcess();
-    final String tag = AdbLogLine.kKnownUsefulErrorTags.first;
+    final String tag = AdbLogLine.knownUsefulErrorTags.first;
     process.error(tag, 'An error message');
     process.info(tag, 'An info message');
 

--- a/testing/scenario_app/test/adb_log_filter_test.dart
+++ b/testing/scenario_app/test/adb_log_filter_test.dart
@@ -52,7 +52,7 @@ void main() {
   test('should always retain logs from known "useful" tags', () {
     final FakeAdbLogcat logcat = FakeAdbLogcat();
     final FakeAdbProcess process = logcat.withProcess();
-    final String tag = AdbLogLine.kKnownUsefulTags.first;
+    final String tag = AdbLogLine.kKnownUsefulGeneralTags.first;
     process.info(tag, 'A useful message');
 
     final Iterable<String> filtered = filter(logcat.drain());
@@ -78,5 +78,17 @@ void main() {
     final Iterable<String> filtered = filter(logcat.drain(), filterProcessId: process.processId);
     expect(filtered, hasLength(1));
     expect(filtered.first, contains('SomeTag: A message with flutter'));
+  });
+
+  test('should retain E-level flags from known "useful" error tags', () {
+    final FakeAdbLogcat logcat = FakeAdbLogcat();
+    final FakeAdbProcess process = logcat.withProcess();
+    final String tag = AdbLogLine.kKnownUsefulErrorTags.first;
+    process.error(tag, 'An error message');
+    process.info(tag, 'An info message');
+
+    final Iterable<String> filtered = filter(logcat.drain());
+    expect(filtered, hasLength(1));
+    expect(filtered.first, contains('$tag: An error message'));
   });
 }

--- a/testing/scenario_app/test/src/fake_adb_logcat.dart
+++ b/testing/scenario_app/test/src/fake_adb_logcat.dart
@@ -1,0 +1,145 @@
+import '../../bin/utils/adb_logcat_filtering.dart';
+
+/// Simulates the output of `adb logcat`, i.e. for testing.
+///
+/// ## Example
+///
+/// ```dart
+/// final FakeAdbLogcat logcat = FakeAdbLogcat();
+/// final FakeAdbProcess process = logcat.withProcess();
+/// process.info('ActivityManager', 'Force stopping dev.flutter.scenarios appid=10226 user=0: start instr');
+/// // ...
+/// final List<String> logLines = logcat.drain();
+/// // ...
+/// ```
+final class FakeAdbLogcat {
+  final List<String> _lines = <String>[];
+  final Map<int, FakeAdbProcess> _processById = <int, FakeAdbProcess>{};
+
+  /// The current date and time.
+  DateTime _now = DateTime.now();
+
+  /// Returns the date and time for the next log line.
+  ///
+  /// Time is progressed by 1 second each time this method is called.
+  DateTime _progressTime({Duration by = const Duration(seconds: 1)}) {
+    _now = _now.add(by);
+    return _now;
+  }
+
+  /// `02-22 13:54:39.839`
+  static String _formatTime(DateTime time) {
+    return '${time.month.toString().padLeft(2, '0')}-'
+        '${time.day.toString().padLeft(2, '0')} '
+        '${time.hour.toString().padLeft(2, '0')}:'
+        '${time.minute.toString().padLeft(2, '0')}:'
+        '${time.second.toString().padLeft(2, '0')}.'
+        '${time.millisecond.toString().padLeft(3, '0')}';
+  }
+
+  void _write({
+    required int processId,
+    required int threadId,
+    required String severity,
+    required String tag,
+    required String message,
+  }) {
+    final DateTime time = _progressTime();
+    final String line = '${_formatTime(time)}   $processId  $threadId $severity $tag: $message';
+    assert(AdbLogLine.tryParse(line) != null, 'Invalid log line: $line');
+    _lines.add(line);
+  }
+
+  /// Drains the stored log lines and returns them.
+  List<String> drain() {
+    final List<String> result = List<String>.from(_lines);
+    _lines.clear();
+    return result;
+  }
+
+  /// Creates a new process writing to this logcat.
+  ///
+  /// Optionally specify a [processId] to use for the process, otherwise a
+  /// simple default is used (sequential numbers starting from 1000).
+  FakeAdbProcess withProcess({int? processId}) {
+    processId ??= 1000 + _processById.length;
+    return _processById.putIfAbsent(
+      processId,
+      () => _createProcess(processId: processId!),
+    );
+  }
+
+  FakeAdbProcess _createProcess({required int processId}) {
+    return FakeAdbProcess._(this, processId: processId);
+  }
+}
+
+/// A stateful fixture that represents a fake process writing to `adb logcat`.
+///
+/// See [FakeAdbLogcat.withProcess] for how to create this fixture.
+final class FakeAdbProcess {
+  const FakeAdbProcess._(
+    this._logcat, {
+    required this.processId,
+  });
+
+  final FakeAdbLogcat _logcat;
+
+  /// The process ID of this process.
+  final int processId;
+
+  /// Writes a debug log message.
+  void debug(String tag, String message, {int threadId = 1}) {
+    _logcat._write(
+      processId: processId,
+      threadId: threadId,
+      severity: 'D',
+      tag: tag,
+      message: message,
+    );
+  }
+
+  /// Writes an info log message.
+  void info(String tag, String message, {int threadId = 1}) {
+    _logcat._write(
+      processId: processId,
+      threadId: threadId,
+      severity: 'I',
+      tag: tag,
+      message: message,
+    );
+  }
+
+  /// Writes a warning log message.
+  void warning(String tag, String message, {int threadId = 1}) {
+    _logcat._write(
+      processId: processId,
+      threadId: threadId,
+      severity: 'W',
+      tag: tag,
+      message: message,
+    );
+  }
+
+  /// Writes an error log message.
+  void error(String tag, String message, {int threadId = 1}) {
+    _logcat._write(
+      processId: processId,
+      threadId: threadId,
+      severity: 'E',
+      tag: tag,
+      message: message,
+    );
+  }
+
+  /// Writes a fatal log message.
+  void fatal(String tag, String message, {int threadId = 1}) {
+    _logcat._write(
+      processId: processId,
+      threadId: threadId,
+      severity: 'F',
+      tag: tag,
+      message: message,
+    );
+  }
+}


### PR DESCRIPTION
1. Write tests for the `AdbLogLine` extension/parsing, and run it on CI.
  Fixes https://github.com/flutter/flutter/issues/144164.

2. Improve the logging to include `androidemu`-related errors logs 
  Work towards https://github.com/flutter/flutter/issues/144164.

3. Clarified logic/fixed a bug related to handling `filterProcessId: ...`