### PR TITLE
[Windows] Add view ID runner APIs

### DIFF
--- a/shell/platform/windows/client_wrapper/flutter_view_controller.cc
+++ b/shell/platform/windows/client_wrapper/flutter_view_controller.cc
@@ -29,6 +29,12 @@ FlutterViewController::~FlutterViewController() {
   }
 }
 
+FlutterViewId FlutterViewController::view_id() const {
+  auto view_id = FlutterDesktopViewControllerGetViewId(controller_);
+
+  return static_cast<FlutterViewId>(view_id);
+}
+
 void FlutterViewController::ForceRedraw() {
   FlutterDesktopViewControllerForceRedraw(controller_);
 }

--- a/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_view_controller_unittests.cc
@@ -70,6 +70,15 @@ TEST(FlutterViewControllerTest, CreateDestroy) {
   EXPECT_FALSE(test_api->engine_destroyed());
 }
 
+TEST(FlutterViewControllerTest, GetViewId) {
+  DartProject project(L"data");
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
+      std::make_unique<TestWindowsApi>());
+  auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
+  FlutterViewController controller(100, 100, project);
+  EXPECT_EQ(controller.view_id(), 1);
+}
+
 TEST(FlutterViewControllerTest, GetEngine) {
   DartProject project(L"data");
   testing::ScopedStubFlutterWindowsApi scoped_api_stub(

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
@@ -9,6 +9,9 @@
 
 namespace flutter {
 
+// The unique identifier for a view.
+typedef int64_t FlutterViewId;
+
 // A view displaying Flutter content.
 class FlutterView {
  public:

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
@@ -38,11 +38,14 @@ class FlutterViewController {
   FlutterViewController(FlutterViewController const&) = delete;
   FlutterViewController& operator=(FlutterViewController const&) = delete;
 
+  // Returns the view controller's view ID.
+  FlutterViewId view_id() const;
+
   // Returns the engine running Flutter content in this view.
-  FlutterEngine* engine() { return engine_.get(); }
+  FlutterEngine* engine() const { return engine_.get(); }
 
   // Returns the view managed by this controller.
-  FlutterView* view() { return view_.get(); }
+  FlutterView* view() const { return view_.get(); }
 
   // Requests new frame from the engine and repaints the view.
   void ForceRedraw();

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -52,6 +52,12 @@ void FlutterDesktopViewControllerDestroy(
   }
 }
 
+FlutterDesktopViewId FlutterDesktopViewControllerGetViewId(
+    FlutterDesktopViewControllerRef controller) {
+  // The stub ignores this, so just return an arbitrary non-zero value.
+  return static_cast<FlutterDesktopViewId>(1);
+}
+
 FlutterDesktopEngineRef FlutterDesktopViewControllerGetEngine(
     FlutterDesktopViewControllerRef controller) {
   // The stub ignores this, so just return an arbitrary non-zero value.

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -110,6 +110,12 @@ void FlutterDesktopViewControllerDestroy(FlutterDesktopViewControllerRef ref) {
   delete controller;
 }
 
+FlutterDesktopViewId FlutterDesktopViewControllerGetViewId(
+    FlutterDesktopViewControllerRef ref) {
+  auto controller = ViewControllerFromHandle(ref);
+  return static_cast<FlutterDesktopViewId>(controller->view()->view_id());
+}
+
 FlutterDesktopEngineRef FlutterDesktopViewControllerGetEngine(
     FlutterDesktopViewControllerRef ref) {
   auto controller = ViewControllerFromHandle(ref);

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -307,6 +307,18 @@ TEST_F(WindowsTest, NextFrameCallback) {
   captures.frame_drawn_latch.Wait();
 }
 
+// Implicit view has the implicit view ID.
+TEST_F(WindowsTest, GetViewId) {
+  auto& context = GetContext();
+  WindowsConfigBuilder builder(context);
+  ViewControllerPtr controller{builder.Run()};
+  ASSERT_NE(controller, nullptr);
+  FlutterDesktopViewId view_id =
+      FlutterDesktopViewControllerGetViewId(controller.get());
+
+  ASSERT_EQ(view_id, static_cast<FlutterDesktopViewId>(kImplicitViewId));
+}
+
 TEST_F(WindowsTest, GetGraphicsAdapter) {
   auto& context = GetContext();
   WindowsConfigBuilder builder(context);

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -32,6 +32,9 @@ typedef struct FlutterDesktopView* FlutterDesktopViewRef;
 struct FlutterDesktopEngine;
 typedef struct FlutterDesktopEngine* FlutterDesktopEngineRef;
 
+// The unique identifier for a view.
+typedef int64_t FlutterDesktopViewId;
+
 // Properties for configuring a Flutter engine instance.
 typedef struct {
   // The path to the flutter_assets folder for the application to be run.
@@ -97,13 +100,17 @@ FlutterDesktopViewControllerCreate(int width,
 FLUTTER_EXPORT void FlutterDesktopViewControllerDestroy(
     FlutterDesktopViewControllerRef controller);
 
+// Returns the view controller's view ID.
+FLUTTER_EXPORT FlutterDesktopViewId FlutterDesktopViewControllerGetViewId(
+    FlutterDesktopViewControllerRef view_controller);
+
 // Returns the handle for the engine running in FlutterDesktopViewControllerRef.
 //
 // Its lifetime is the same as the |controller|'s.
 FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopViewControllerGetEngine(
     FlutterDesktopViewControllerRef controller);
-// Returns the view managed by the given controller.
 
+// Returns the view managed by the given controller.
 FLUTTER_EXPORT FlutterDesktopViewRef FlutterDesktopViewControllerGetView(
     FlutterDesktopViewControllerRef controller);
 
@@ -205,7 +212,7 @@ FLUTTER_EXPORT void FlutterDesktopEngineSetNextFrameCallback(
 
 // ========== View ==========
 
-// Return backing HWND for manipulation in host application.
+// Returns the backing HWND for manipulation in host application.
 FLUTTER_EXPORT HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef view);
 
 // Returns the DXGI adapter used for rendering or nullptr in case of error.


### PR DESCRIPTION
Allow Flutter Windows apps and plugins to get the view's ID.

Design doc: https://flutter.dev/go/desktop-multi-view-runner-apis

Part of https://github.com/flutter/flutter/issues/143767
Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
