### PR TITLE
[Windows] Reduce log level of unsupported accessibility event message

### DIFF
--- a/shell/platform/windows/accessibility_plugin.cc
+++ b/shell/platform/windows/accessibility_plugin.cc
@@ -63,8 +63,8 @@ void HandleMessage(AccessibilityPlugin* plugin, const EncodableValue& message) {
 
     plugin->Announce(*message);
   } else {
-    FML_LOG(ERROR) << "Accessibility message type '" << *type
-                   << "' is not supported.";
+    FML_LOG(WARNING) << "Accessibility message type '" << *type
+                     << "' is not supported.";
   }
 }
 

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 
+#include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
@@ -716,6 +717,8 @@ TEST_F(FlutterWindowsEngineTest, AccessibilityAnnouncementHeadless) {
 // Verify the engine does not crash if it receives an accessibility event
 // it does not support yet.
 TEST_F(FlutterWindowsEngineTest, AccessibilityTooltip) {
+  fml::testing::LogCapture log_capture;
+
   auto& context = GetContext();
   WindowsConfigBuilder builder{context};
   builder.SetDartEntrypoint("sendAccessibilityTooltipEvent");
@@ -736,6 +739,11 @@ TEST_F(FlutterWindowsEngineTest, AccessibilityTooltip) {
   while (!done) {
     windows_engine->task_runner()->ProcessTasks();
   }
+
+  // Verify no error was logged.
+  // Regression test for:
+  // https://github.com/flutter/flutter/issues/144274
+  EXPECT_EQ(log_capture.str().find("tooltip"), std::string::npos);
 }
 
 class MockWindowsLifecycleManager : public WindowsLifecycleManager {


### PR DESCRIPTION
https://github.com/flutter/engine/pull/50975 made the Windows embedder a bit more defensive on accessibility event messages and introduced an error if it received an event it does not support. This change reduces that error to a warning as it can be triggered by hovering over the counter app's `+` button.

Fixes https://github.com/flutter/flutter/issues/144274

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
