### PR TITLE
Add et run command

### DIFF
--- a/bin/et
+++ b/bin/et
@@ -58,11 +58,9 @@ PLATFORM="${OS}-${CPU}"
 DART_SDK_DIR="${ENGINE_DIR}/prebuilts/${PLATFORM}/dart-sdk"
 DART="${DART_SDK_DIR}/bin/dart"
 
-cd "${ENGINE_DIR}/tools/engine_tool"
-
-if [ ! -d ".dart_tool" ]; then
+if [ ! -d "${ENGINE_DIR}/tools/engine_tool/.dart_tool" ]; then
   echo "You must run 'gclient sync -D' before using this tool."
   exit 1
 fi
 
-"${DART}" --disable-dart-dev bin/et.dart "$@"
+"${DART}" --disable-dart-dev "${ENGINE_DIR}/tools/engine_tool/bin/et.dart" "$@"

--- a/ci/builders/local_engine.json
+++ b/ci/builders/local_engine.json
@@ -1,0 +1,118 @@
+{
+  "builds": [
+    {
+      "drone_dimensions": [
+        "os=Mac-13",
+        "os=Linux"
+      ],
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--enable-impeller-vulkan",
+        "--no-lto"
+      ],
+      "name": "android_debug_arm64",
+      "ninja": {
+        "config": "android_debug_arm64",
+        "targets": []
+      }
+    },
+    {
+      "drone_dimensions": [
+        "os=Mac-13",
+        "os=Linux"
+      ],
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--enable-impeller-vulkan",
+        "--no-lto"
+      ],
+      "name": "android_profile_arm64",
+      "ninja": {
+        "config": "android_profile_arm64",
+        "targets": []
+      }
+    },
+    {
+      "drone_dimensions": [
+        "os=Mac-13",
+        "os=Linux"
+      ],
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--enable-impeller-vulkan",
+        "--no-lto"
+      ],
+      "name": "android_release_arm64",
+      "ninja": {
+        "config": "android_release_arm64",
+        "targets": []
+      }
+    },
+    {
+      "drone_dimensions": [
+        "os=Mac-13",
+        "os=Linux"
+      ],
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--no-stripped",
+        "--enable-impeller-vulkan",
+        "--no-lto"
+      ],
+      "name": "host_debug",
+      "ninja": {
+        "config": "host_debug",
+        "targets": []
+      }
+    },
+    {
+      "drone_dimensions": [
+        "os=Mac-13",
+        "os=Linux"
+      ],
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--no-stripped",
+        "--enable-impeller-vulkan",
+        "--no-lto"
+      ],
+      "name": "host_profile",
+      "ninja": {
+        "config": "host_profile",
+        "targets": []
+      }
+    },
+    {
+      "drone_dimensions": [
+        "os=Mac-13",
+        "os=Linux"
+      ],
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--no-stripped",
+        "--enable-impeller-vulkan",
+        "--no-lto"
+      ],
+      "name": "host_release",
+      "ninja": {
+        "config": "host_release",
+        "targets": []
+      }
+    }
+  ]
+}

--- a/testing/litetest/lib/src/matchers.dart
+++ b/testing/litetest/lib/src/matchers.dart
@@ -62,8 +62,8 @@ void isNotEmpty(dynamic d) {
 /// Gives a [Matcher] that asserts that the value being matched is within
 /// `tolerance` of `value`.
 Matcher closeTo(num value, num tolerance) => (dynamic actual) {
-  Expect.approxEquals(value, actual as num, tolerance);
-};
+      Expect.approxEquals(value, actual as num, tolerance);
+    };
 
 /// A [Matcher] that matches NaN.
 void isNaN(dynamic v) {
@@ -74,8 +74,8 @@ void isNaN(dynamic v) {
 /// Gives a [Matcher] that asserts that the value being matched is not equal to
 /// `unexpected`.
 Matcher notEquals(dynamic unexpected) => (dynamic actual) {
-  Expect.notEquals(unexpected, actual);
-};
+      Expect.notEquals(unexpected, actual);
+    };
 
 /// A [Matcher] that matches non-zero values.
 void isNonZero(dynamic d) {
@@ -90,44 +90,64 @@ void throwsRangeError(dynamic d) {
 /// Gives a [Matcher] that asserts that the value being matched is a [String]
 /// that contains `s` as a substring.
 Matcher contains(String s) => (dynamic d) {
-  expect(d, isInstanceOf<String>());
-  Expect.contains(s, d as String);
-};
+      expect(d, isInstanceOf<String>());
+      Expect.contains(s, d as String);
+    };
 
 /// Gives a [Matcher] that asserts that the value being matched is an [Iterable]
 /// of length `d`.
 Matcher hasLength(int l) => (dynamic d) {
-  expect(d, isInstanceOf<Iterable<dynamic>>());
-  expect((d as Iterable<dynamic>).length, equals(l));
-};
+      expect(d, isInstanceOf<Iterable<dynamic>>());
+      expect((d as Iterable<dynamic>).length, equals(l));
+    };
 
 /// Gives a matcher that asserts that the value being matched is a [String] that
 /// starts with `s`.
 Matcher startsWith(String s) => (dynamic d) {
-  expect(d, isInstanceOf<String>());
-  final String h = d as String;
-  if (!h.startsWith(s)) {
-    Expect.fail('Expected "$h" to start with "$s"');
-  }
-};
+      expect(d, isInstanceOf<String>());
+      final String h = d as String;
+      if (!h.startsWith(s)) {
+        Expect.fail('Expected "$h" to start with "$s"');
+      }
+    };
 
 /// Gives a matcher that asserts that the value being matched is a [String] that
 /// ends with `s`.
 Matcher endsWith(String s) => (dynamic d) {
-  expect(d, isInstanceOf<String>());
-  final String h = d as String;
-  if (!h.endsWith(s)) {
-    Expect.fail('Expected "$h" to end with "$s"');
-  }
-};
+      expect(d, isInstanceOf<String>());
+      final String h = d as String;
+      if (!h.endsWith(s)) {
+        Expect.fail('Expected "$h" to end with "$s"');
+      }
+    };
 
 /// Gives a matcher that asserts that the value being matched is a [String] that
 /// regexp matches with `pattern`.
 Matcher hasMatch(String pattern) => (dynamic d) {
-  expect(d, isInstanceOf<String>());
-  final String h = d as String;
-  final RegExp regExp = RegExp(pattern);
-  if (!regExp.hasMatch(h)) {
-    Expect.fail('Expected "$h" to match with "$pattern"');
-  }
-};
+      expect(d, isInstanceOf<String>());
+      final String h = d as String;
+      final RegExp regExp = RegExp(pattern);
+      if (!regExp.hasMatch(h)) {
+        Expect.fail('Expected "$h" to match with "$pattern"');
+      }
+    };
+
+/// Gives a matcher that asserts that the value being matched is a List<String>
+/// that contains the entries in `pattern` in order. There may be values
+/// that are not in the pattern interleaved.
+Matcher containsStringsInOrder(List<String> pattern) => (dynamic d) {
+      expect(d, isInstanceOf<List<String>>());
+      final List<String> input = d as List<String>;
+      int cursor = 0;
+      for (final String el in input) {
+        if (cursor == pattern.length) {
+          break;
+        }
+        if (el == pattern[cursor]) {
+          cursor++;
+        }
+      }
+      if (cursor < pattern.length) {
+        Expect.fail('Did not find ${pattern[cursor]} in $d}');
+      }
+    };

--- a/tools/engine_tool/lib/main.dart
+++ b/tools/engine_tool/lib/main.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ffi' as ffi show Abi;
-import 'dart:io' as io show Directory, exitCode, stderr;
+import 'dart:io' as io show Directory, Platform, exitCode, stderr;
 
 import 'package:engine_build_configs/engine_build_configs.dart';
 import 'package:engine_repo_tools/engine_repo_tools.dart';
@@ -19,7 +19,7 @@ void main(List<String> args) async {
   // Find the engine repo.
   final Engine engine;
   try {
-    engine = Engine.findWithin();
+    engine = Engine.findWithin(p.dirname(io.Platform.script.toFilePath()));
   } catch (e) {
     io.stderr.writeln(e);
     io.exitCode = 1;
@@ -51,15 +51,17 @@ void main(List<String> args) async {
     io.exitCode = 1;
   }
 
+  final Environment environment = Environment(
+    abi: ffi.Abi.current(),
+    engine: engine,
+    platform: const LocalPlatform(),
+    processRunner: ProcessRunner(),
+    logger: Logger(),
+  );
+
   // Use the Engine and BuildConfig collection to build the CommandRunner.
   final ToolCommandRunner runner = ToolCommandRunner(
-    environment: Environment(
-      abi: ffi.Abi.current(),
-      engine: engine,
-      platform: const LocalPlatform(),
-      processRunner: ProcessRunner(),
-      logger: Logger(),
-    ),
+    environment: environment,
     configs: configs,
   );
 

--- a/tools/engine_tool/lib/src/commands/command_runner.dart
+++ b/tools/engine_tool/lib/src/commands/command_runner.dart
@@ -9,6 +9,9 @@ import '../environment.dart';
 import 'build_command.dart';
 import 'format_command.dart';
 import 'query_command.dart';
+import 'run_command.dart';
+
+const int _usageLineLength = 80;
 
 /// The root command runner.
 final class ToolCommandRunner extends CommandRunner<int> {
@@ -17,13 +20,14 @@ final class ToolCommandRunner extends CommandRunner<int> {
   ToolCommandRunner({
     required this.environment,
     required this.configs,
-  }) : super(toolName, toolDescription) {
+  }) : super(toolName, toolDescription, usageLineLength: _usageLineLength) {
     final List<Command<int>> commands = <Command<int>>[
       FormatCommand(
         environment: environment,
       ),
       QueryCommand(environment: environment, configs: configs),
       BuildCommand(environment: environment, configs: configs),
+      RunCommand(environment: environment, configs: configs),
     ];
     commands.forEach(addCommand);
   }

--- a/tools/engine_tool/lib/src/commands/run_command.dart
+++ b/tools/engine_tool/lib/src/commands/run_command.dart
@@ -1,0 +1,153 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' show ProcessStartMode;
+
+import 'package:engine_build_configs/engine_build_configs.dart';
+import 'package:process_runner/process_runner.dart';
+
+import '../build_utils.dart';
+import 'command.dart';
+import 'flags.dart';
+
+/// The root 'run' command.
+final class RunCommand extends CommandBase {
+  /// Constructs the 'run' command.
+  RunCommand({
+    required super.environment,
+    required Map<String, BuilderConfig> configs,
+  }) {
+    builds = runnableBuilds(environment, configs);
+    debugCheckBuilds(builds);
+
+    argParser.addOption(
+      configFlag,
+      abbr: 'c',
+      defaultsTo: '',
+      help:
+          'Specify the build config to use for the target build (usually auto detected)',
+      allowed: <String>[
+        for (final Build build in runnableBuilds(environment, configs))
+          build.name,
+      ],
+      allowedHelp: <String, String>{
+        for (final Build build in runnableBuilds(environment, configs))
+          build.name: build.gn.join(' '),
+      },
+    );
+  }
+
+  /// List of compatible builds.
+  late final List<Build> builds;
+
+  @override
+  String get name => 'run';
+
+  @override
+  String get description => 'Run a flutter app with a local engine build'
+      'All arguments after -- are forwarded to flutter run, e.g.: '
+      'et run -- --profile'
+      'et run -- -d chrome'
+      'See `flutter run --help` for a listing';
+
+  Build? _lookup(String configName) {
+    return builds.where((Build build) => build.name == configName).firstOrNull;
+  }
+
+  Build? _findHostBuild(Build? targetBuild) {
+    if (targetBuild == null) {
+      return null;
+    }
+
+    final String name = targetBuild.name;
+    if (name.startsWith('host_')) {
+      return targetBuild;
+    }
+    // TODO(johnmccutchan): This is brittle, it would be better if we encoded
+    // the host config name in the target config.
+    if (name.contains('_debug')) {
+      return _lookup('host_debug');
+    } else if (name.contains('_profile')) {
+      return _lookup('host_profile');
+    } else if (name.contains('_release')) {
+      return _lookup('host_release');
+    }
+    return null;
+  }
+
+  String _selectTargetConfig() {
+    final String configName = argResults![configFlag] as String;
+    if (configName.isNotEmpty) {
+      return configName;
+    }
+    // TODO(johnmccutchan): We need a way to invoke flutter tool and be told
+    // which OS and CPU architecture the selected device requires, for now
+    // use some hard coded values:
+    const String targetOS = 'android';
+    const String cpuArch = 'arm64';
+
+    // Sniff the build mode from the args that will be passed to flutter run.
+    String mode = 'debug';
+    if (argResults!.rest.contains('--profile')) {
+      mode = 'profile';
+    } else if (argResults!.rest.contains('--release')) {
+      mode = 'release';
+    }
+
+    return '${targetOS}_${mode}_$cpuArch';
+  }
+
+  @override
+  Future<int> run() async {
+    if (!environment.processRunner.processManager.canRun('flutter')) {
+      environment.logger.error('Cannot find flutter command in your path');
+      return 1;
+    }
+    final String configName = _selectTargetConfig();
+    final Build? build = _lookup(configName);
+    final Build? hostBuild = _findHostBuild(build);
+    if (build == null) {
+      environment.logger.error('Could not find build $configName');
+      return 1;
+    }
+    if (hostBuild == null) {
+      environment.logger.error('Could not find host build for $configName');
+      return 1;
+    }
+
+    // First build the host.
+    int r = await runBuild(environment, hostBuild);
+    if (r != 0) {
+      return r;
+    }
+
+    // Now build the target if it isn't the same.
+    if (hostBuild.name != build.name) {
+      r = await runBuild(environment, build);
+      if (r != 0) {
+        return r;
+      }
+    }
+
+    // TODO(johnmccutchan): Be smart and if the user requested a profile
+    // config, add the '--profile' flag when invoking flutter run.
+    final ProcessRunnerResult result =
+        await environment.processRunner.runProcess(
+      <String>[
+        'flutter',
+        'run',
+        '--local-engine-src-path',
+        environment.engine.srcDir.path,
+        '--local-engine',
+        build.name,
+        '--local-engine-host',
+        hostBuild.name,
+        ...argResults!.rest,
+      ],
+      runInShell: true,
+      startMode: ProcessStartMode.inheritStdio,
+    );
+    return result.exitCode;
+  }
+}

--- a/tools/engine_tool/test/fixtures.dart
+++ b/tools/engine_tool/test/fixtures.dart
@@ -46,6 +46,30 @@ String testConfig(String os) => '''
           }
         ]
       }
+    },
+    {},
+    {},
+    {
+      "drone_dimensions": [
+        "os=$os"
+      ],
+      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "name": "host_debug",
+      "ninja": {
+        "config": "host_debug",
+        "targets": ["ninja_target"]
+      }
+    },
+    {
+      "drone_dimensions": [
+        "os=$os"
+      ],
+      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "name": "android_debug_arm64",
+      "ninja": {
+        "config": "android_debug_arm64",
+        "targets": ["ninja_target"]
+      }
     }
   ],
   "generators": {

--- a/tools/engine_tool/test/query_command_test.dart
+++ b/tools/engine_tool/test/query_command_test.dart
@@ -89,8 +89,12 @@ void main() {
         '\n',
         '"linux_test_config" builder:\n',
         '   "build_name" config\n',
+        '   "host_debug" config\n',
+        '   "android_debug_arm64" config\n',
         '"linux_test_config2" builder:\n',
         '   "build_name" config\n',
+        '   "host_debug" config\n',
+        '   "android_debug_arm64" config\n',
       ]),
     );
   });
@@ -117,6 +121,8 @@ void main() {
           '\n',
           '"linux_test_config" builder:\n',
           '   "build_name" config\n',
+          '   "host_debug" config\n',
+          '   "android_debug_arm64" config\n',
         ]));
   });
 
@@ -135,7 +141,7 @@ void main() {
     expect(result, equals(0));
     expect(
       logger.testLogs.length,
-      equals(10),
+      equals(26),
     );
   });
 }

--- a/tools/engine_tool/test/run_command_test.dart
+++ b/tools/engine_tool/test/run_command_test.dart
@@ -8,7 +8,6 @@ import 'dart:io' as io;
 
 import 'package:engine_build_configs/engine_build_configs.dart';
 import 'package:engine_repo_tools/engine_repo_tools.dart';
-import 'package:engine_tool/src/build_utils.dart';
 import 'package:engine_tool/src/commands/command_runner.dart';
 import 'package:engine_tool/src/environment.dart';
 import 'package:engine_tool/src/logger.dart';
@@ -76,82 +75,18 @@ void main() {
     );
   }
 
-  test('can find host runnable build', () async {
-    final Logger logger = Logger.test();
-    final (Environment env, _) = linuxEnv(logger);
-    final List<Build> result = runnableBuilds(env, configs);
-    expect(result.length, equals(6));
-    expect(result[0].name, equals('build_name'));
-  });
-
-  test('build command invokes gn', () async {
+  test('run command invokes flutter run', () async {
     final Logger logger = Logger.test();
     final (Environment env, List<List<String>> runHistory) = linuxEnv(logger);
     final ToolCommandRunner runner = ToolCommandRunner(
       environment: env,
       configs: configs,
     );
-    final int result = await runner.run(<String>[
-      'build',
-      '--config',
-      'build_name',
-    ]);
+    final int result =
+        await runner.run(<String>['run', '--', '--weird_argument']);
     expect(result, equals(0));
-    expect(runHistory.length, greaterThanOrEqualTo(1));
-    expect(runHistory[0].length, greaterThanOrEqualTo(1));
-    expect(runHistory[0][0], contains('gn'));
-  });
-
-  test('build command invokes ninja', () async {
-    final Logger logger = Logger.test();
-    final (Environment env, List<List<String>> runHistory) = linuxEnv(logger);
-    final ToolCommandRunner runner = ToolCommandRunner(
-      environment: env,
-      configs: configs,
-    );
-    final int result = await runner.run(<String>[
-      'build',
-      '--config',
-      'build_name',
-    ]);
-    expect(result, equals(0));
-    expect(runHistory.length, greaterThanOrEqualTo(2));
-    expect(runHistory[1].length, greaterThanOrEqualTo(1));
-    expect(runHistory[1][0], contains('ninja'));
-  });
-
-  test('build command invokes generator', () async {
-    final Logger logger = Logger.test();
-    final (Environment env, List<List<String>> runHistory) = linuxEnv(logger);
-    final ToolCommandRunner runner = ToolCommandRunner(
-      environment: env,
-      configs: configs,
-    );
-    final int result = await runner.run(<String>[
-      'build',
-      '--config',
-      'build_name',
-    ]);
-    expect(result, equals(0));
-    expect(runHistory.length, greaterThanOrEqualTo(3));
-    expect(runHistory[2].length, greaterThanOrEqualTo(2));
-    expect(runHistory[2][0], contains('python3'));
-    expect(runHistory[2][1], contains('gen/script.py'));
-  });
-
-  test('build command does not invoke tests', () async {
-    final Logger logger = Logger.test();
-    final (Environment env, List<List<String>> runHistory) = linuxEnv(logger);
-    final ToolCommandRunner runner = ToolCommandRunner(
-      environment: env,
-      configs: configs,
-    );
-    final int result = await runner.run(<String>[
-      'build',
-      '--config',
-      'build_name',
-    ]);
-    expect(result, equals(0));
-    expect(runHistory.length, lessThanOrEqualTo(3));
+    expect(runHistory.length, greaterThanOrEqualTo(5));
+    expect(runHistory[4],
+        containsStringsInOrder(<String>['flutter', 'run', '--weird_argument']));
   });
 }

--- a/tools/pkg/engine_build_configs/bin/check.dart
+++ b/tools/pkg/engine_build_configs/bin/check.dart
@@ -7,7 +7,6 @@ import 'dart:io' as io;
 import 'package:engine_build_configs/engine_build_configs.dart';
 import 'package:engine_repo_tools/engine_repo_tools.dart';
 import 'package:path/path.dart' as p;
-import 'package:platform/platform.dart';
 
 // Usage:
 // $ dart bin/check.dart [/path/to/engine/src]
@@ -65,39 +64,20 @@ void main(List<String> args) {
     }
     for (final String error in buildConfigErrors) {
       io.stderr.writeln('    $error');
+      io.exitCode = 1;
     }
   }
 
-  // Check that global builds for the same platform are uniquely named.
-  final List<String> hostPlatforms = <String>[
-    Platform.linux,
-    Platform.macOS,
-    Platform.windows,
-  ];
-
-  // For each host platform, a mapping from GlobalBuild.name to GlobalBuild.
-  final Map<String, Map<String, (BuilderConfig, Build)>> builds =
-      <String, Map<String, (BuilderConfig, Build)>>{};
-  for (final String platform in hostPlatforms) {
-    builds[platform] = <String, (BuilderConfig, Build)>{};
-  }
-  for (final String name in configs.keys) {
-    final BuilderConfig buildConfig = configs[name]!;
-    for (final Build build in buildConfig.builds) {
-      for (final String platform in hostPlatforms) {
-        if (!build.canRunOn(FakePlatform(operatingSystem: platform))) {
-          continue;
-        }
-        if (builds[platform]!.containsKey(build.name)) {
-          final (BuilderConfig oldConfig, _) = builds[platform]![build.name]!;
-          io.stderr.writeln(
-            '${build.name} is duplicated.\n'
-            '\tFound definition in ${buildConfig.path}.\n'
-            '\tPrevious definition was in ${oldConfig.path}.',
-          );
-          io.exitCode = 1;
-        }
-        builds[platform]![build.name] = (buildConfig, build);
+  // We require all builds within a builder config to be uniquely named.
+  final Map<String, Set<String>> builderBuildSet = <String, Set<String>>{};
+  for (final String builderName in configs.keys) {
+    final BuilderConfig builderConfig = configs[builderName]!;
+    final Set<String> builds =
+        builderBuildSet.putIfAbsent(builderName, () => <String>{});
+    for (final Build build in builderConfig.builds) {
+      if (builds.contains(build.name)) {
+        io.stderr.writeln('${build.name} is duplicated in $builderName\n');
+        io.exitCode = 1;
       }
     }
   }


### PR DESCRIPTION
The `run` command builds both the host and target engines and then invokes `flutter run` so that it runs the app using the custom engine builds.

It is expected that 'et run' be used inside the directory of a flutter application.

Command line flags passed after `--` will be forwarded to `flutter run`.

Some examples:

- `et run` Build the debug variant and runs the app in that mode.
- `et run -- --profile` Build the profile variant and runs the app in that mode.
- `et run -- --release` Build the release variant and runs the app in that mode.

Also:

- Start a local_engine.json builder definition (it is missing a lot)
- Tweak the test fixture.
- Add a new Matcher to litetest.
- Tweaked the build config linter to only care about duplicate build names within the same builder.