### PR TITLE
Make Skia object ostream operators work with unit tests

### DIFF
--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -128,6 +128,7 @@ if (enable_unittests) {
       ":display_list_fixtures",
       "//flutter/display_list/testing:display_list_testing",
       "//flutter/testing",
+      "//flutter/testing:skia",
     ]
 
     if (!defined(defines)) {

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -18,6 +18,7 @@
 #include "flutter/display_list/utils/dl_receiver_utils.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/math.h"
+#include "flutter/testing/assertions_skia.h"
 #include "flutter/testing/display_list_testing.h"
 #include "flutter/testing/testing.h"
 

--- a/testing/assertions_skia.cc
+++ b/testing/assertions_skia.cc
@@ -4,9 +4,6 @@
 
 #include "flutter/testing/assertions_skia.h"
 
-namespace flutter {
-namespace testing {
-
 std::ostream& operator<<(std::ostream& os, const SkClipOp& o) {
   switch (o) {
     case SkClipOp::kDifference:
@@ -99,6 +96,3 @@ std::ostream& operator<<(std::ostream& os, const SkSamplingOptions& s) {
               << ", Mipmap: " << static_cast<int>(s.mipmap);
   }
 }
-
-}  // namespace testing
-}  // namespace flutter

--- a/testing/assertions_skia.cc
+++ b/testing/assertions_skia.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/testing/assertions_skia.h"
 
+namespace std {
+
 std::ostream& operator<<(std::ostream& os, const SkClipOp& o) {
   switch (o) {
     case SkClipOp::kDifference:
@@ -96,3 +98,5 @@ std::ostream& operator<<(std::ostream& os, const SkSamplingOptions& s) {
               << ", Mipmap: " << static_cast<int>(s.mipmap);
   }
 }
+
+}  // namespace std

--- a/testing/assertions_skia.h
+++ b/testing/assertions_skia.h
@@ -16,6 +16,8 @@
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkSamplingOptions.h"
 
+namespace std {
+
 extern std::ostream& operator<<(std::ostream& os, const SkClipOp& o);
 extern std::ostream& operator<<(std::ostream& os, const SkMatrix& m);
 extern std::ostream& operator<<(std::ostream& os, const SkM44& m);
@@ -29,5 +31,7 @@ extern std::ostream& operator<<(std::ostream& os, const SkISize& size);
 extern std::ostream& operator<<(std::ostream& os, const SkColor4f& r);
 extern std::ostream& operator<<(std::ostream& os, const SkPaint& r);
 extern std::ostream& operator<<(std::ostream& os, const SkSamplingOptions& s);
+
+}  // namespace std
 
 #endif  // FLUTTER_TESTING_ASSERTIONS_SKIA_H_

--- a/testing/assertions_skia.h
+++ b/testing/assertions_skia.h
@@ -16,9 +16,6 @@
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkSamplingOptions.h"
 
-namespace flutter {
-namespace testing {
-
 extern std::ostream& operator<<(std::ostream& os, const SkClipOp& o);
 extern std::ostream& operator<<(std::ostream& os, const SkMatrix& m);
 extern std::ostream& operator<<(std::ostream& os, const SkM44& m);
@@ -32,8 +29,5 @@ extern std::ostream& operator<<(std::ostream& os, const SkISize& size);
 extern std::ostream& operator<<(std::ostream& os, const SkColor4f& r);
 extern std::ostream& operator<<(std::ostream& os, const SkPaint& r);
 extern std::ostream& operator<<(std::ostream& os, const SkSamplingOptions& s);
-
-}  // namespace testing
-}  // namespace flutter
 
 #endif  // FLUTTER_TESTING_ASSERTIONS_SKIA_H_


### PR DESCRIPTION
Unit tests currently output basic hex dumps of skia objects even though we have ostream operators for many of the common ones. It looks like the operators were created in the wrong namespace (flutter/testing rather than the std namespace). Changing the namespace for the associated `assertions_skia` source files makes them compatible with unit tests that deal with these objects provided that the test files include that header and gn dependency, as verified with the `display_list_unittests` here.