### PR TITLE
Prepend the accessibility placeholder

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -80,7 +80,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     registerHotRestartListener(dispose);
     AppLifecycleState.instance.addListener(_setAppLifecycleState);
     ViewFocusBinding.instance.addListener(invokeOnViewFocusChange);
-    domDocument.body?.append(accessibilityPlaceholder);
+    domDocument.body?.prepend(accessibilityPlaceholder);
     _onViewDisposedListener = viewManager.onViewDisposed.listen((_) {
       // Send a metrics changed event to the framework when a view is disposed.
       // View creation/resize is handled by the `_didResize` handler in the

--- a/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
@@ -409,8 +409,9 @@ void testMain() {
       });
     });
 
-    test('appends an accesibility placeholder', () {
+    test('adds the accesibility placeholder', () {
       expect(dispatcher.accessibilityPlaceholder.isConnected, isTrue);
+      expect(domDocument.body!.children.first, dispatcher.accessibilityPlaceholder);
     });
 
     test('removes the accesibility placeholder', () {


### PR DESCRIPTION
Prepends the accesibility placeholder. Previously it was being appended (last child) to the body. 

Relevant Issues are:

* Design doc: https://flutter.dev/go/focus-management 
* Focus in web multiview: https://github.com/flutter/flutter/issues/137443
* Platform dispatcher changes: https://github.com/flutter/engine/pull/49841

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
