### PR TITLE
Revert "[skwasm] Clip pictures if they go beyond the bounds of the window. (#50887)"

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -482,14 +482,4 @@ class SkwasmPictureRenderer implements PictureRenderer {
   @override
   FutureOr<RenderResult> renderPictures(List<ScenePicture> pictures) =>
     surface.renderPictures(pictures.cast<SkwasmPicture>());
-
-  @override
-  ScenePicture clipPicture(ScenePicture picture, ui.Rect clip) {
-    final ui.PictureRecorder recorder = ui.PictureRecorder();
-    final ui.Canvas canvas = ui.Canvas(recorder, clip);
-    canvas.clipRect(clip);
-    canvas.drawPicture(picture);
-
-    return recorder.endRecording() as ScenePicture;
-  }
 }

--- a/lib/web_ui/test/engine/scene_view_test.dart
+++ b/lib/web_ui/test/engine/scene_view_test.dart
@@ -43,14 +43,7 @@ class StubPictureRenderer implements PictureRenderer {
     );
   }
 
-  @override
-  ScenePicture clipPicture(ScenePicture picture, ui.Rect clip) {
-    clipRequests[picture] = clip;
-    return picture;
-  }
-
   List<ScenePicture> renderedPictures = <ScenePicture>[];
-  Map<ScenePicture, ui.Rect> clipRequests = <ScenePicture, ui.Rect>{};
 }
 
 void testMain() {
@@ -155,22 +148,5 @@ void testMain() {
     expect(stubPictureRenderer.renderedPictures.length, 2);
     expect(stubPictureRenderer.renderedPictures.first, pictures.first);
     expect(stubPictureRenderer.renderedPictures.last, pictures.last);
-  });
-
-  test('SceneView clips pictures that are outside the window screen', () async {
-      final StubPicture picture = StubPicture(const ui.Rect.fromLTWH(
-        -50,
-        -50,
-        100,
-        120,
-      ));
-
-      final EngineRootLayer rootLayer = EngineRootLayer();
-      rootLayer.slices.add(PictureSlice(picture));
-      final EngineScene scene = EngineScene(rootLayer);
-      await sceneView.renderScene(scene, null);
-
-      expect(stubPictureRenderer.renderedPictures.length, 1);
-      expect(stubPictureRenderer.clipRequests.containsKey(picture), true);
   });
 }


### PR DESCRIPTION
This reverts commit 63b6117514f6cac6eb701277e156dbacbdb4e1bf.

The change is causing skwasm benchmarks to flake. See https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.prod/Linux%20web_benchmarks_skwasm
