### PR TITLE
Reapply "Bump everything to Android 21" (#51056)

### DIFF
--- a/shell/platform/android/AndroidManifest.xml
+++ b/shell/platform/android/AndroidManifest.xml
@@ -5,7 +5,7 @@
  -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.flutter.app" android:versionCode="1" android:versionName="0.0.1">
 
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="34" />
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="34" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="true" />

--- a/shell/platform/android/build.gradle
+++ b/shell/platform/android/build.gradle
@@ -23,7 +23,7 @@ android {
     compileSdkVersion 34
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
     }
 
     sourceSets {

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -17,7 +17,6 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Configuration;
 import android.content.res.Resources.NotFoundException;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.TypedValue;
 import android.view.View;
@@ -137,12 +136,10 @@ public final class FlutterActivityDelegate
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      Window window = activity.getWindow();
-      window.addFlags(LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-      window.setStatusBarColor(0x40000000);
-      window.getDecorView().setSystemUiVisibility(PlatformPlugin.DEFAULT_SYSTEM_UI);
-    }
+    Window window = activity.getWindow();
+    window.addFlags(LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+    window.setStatusBarColor(0x40000000);
+    window.getDecorView().setSystemUiVisibility(PlatformPlugin.DEFAULT_SYSTEM_UI);
 
     String[] args = getArgsFromIntent(activity.getIntent());
     FlutterMain.ensureInitializationComplete(activity.getApplicationContext(), args);

--- a/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -204,9 +204,7 @@ public class AndroidTouchProcessor {
   public boolean onGenericMotionEvent(@NonNull MotionEvent event, @NonNull Context context) {
     // Method isFromSource is only available in API 18+ (Jelly Bean MR2)
     // Mouse hover support is not implemented for API < 18.
-    boolean isPointerEvent =
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2
-            && event.isFromSource(InputDevice.SOURCE_CLASS_POINTER);
+    boolean isPointerEvent = event.isFromSource(InputDevice.SOURCE_CLASS_POINTER);
     boolean isMovementEvent =
         (event.getActionMasked() == MotionEvent.ACTION_HOVER_MOVE
             || event.getActionMasked() == MotionEvent.ACTION_SCROLL);

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -49,7 +49,6 @@ import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
 import io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister;
 import io.flutter.plugin.platform.PlatformPlugin;
-import io.flutter.util.ViewUtils;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -216,7 +215,7 @@ public class FlutterActivity extends Activity
    * <p>This ID can be used to lookup {@code FlutterView} in the Android view hierarchy. For more,
    * see {@link android.view.View#findViewById}.
    */
-  public static final int FLUTTER_VIEW_ID = ViewUtils.generateViewId(0xF1F2);
+  public static final int FLUTTER_VIEW_ID = View.generateViewId();
 
   /**
    * Creates an {@link Intent} that launches a {@code FlutterActivity}, which creates a {@link
@@ -773,12 +772,10 @@ public class FlutterActivity extends Activity
   }
 
   private void configureStatusBarForFullscreenFlutterExperience() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      Window window = getWindow();
-      window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-      window.setStatusBarColor(0x40000000);
-      window.getDecorView().setSystemUiVisibility(PlatformPlugin.DEFAULT_SYSTEM_UI);
-    }
+    Window window = getWindow();
+    window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+    window.setStatusBarColor(0x40000000);
+    window.getDecorView().setSystemUiVisibility(PlatformPlugin.DEFAULT_SYSTEM_UI);
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -8,7 +8,6 @@ import android.app.Activity;
 import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -17,7 +16,6 @@ import android.view.ViewTreeObserver.OnWindowFocusChangeListener;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -27,7 +25,6 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 import io.flutter.plugin.platform.PlatformPlugin;
-import io.flutter.util.ViewUtils;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -107,7 +104,7 @@ public class FlutterFragment extends Fragment
    * <p>This ID can be used to lookup {@code FlutterView} in the Android view hierarchy. For more,
    * see {@link android.view.View#findViewById}.
    */
-  public static final int FLUTTER_VIEW_ID = ViewUtils.generateViewId(0xF1F2);
+  public static final int FLUTTER_VIEW_ID = View.generateViewId();
 
   private static final String TAG = "FlutterFragment";
 
@@ -170,18 +167,15 @@ public class FlutterFragment extends Fragment
   protected static final String ARG_SHOULD_AUTOMATICALLY_HANDLE_ON_BACK_PRESSED =
       "should_automatically_handle_on_back_pressed";
 
-  @RequiresApi(18)
   private final OnWindowFocusChangeListener onWindowFocusChangeListener =
-      Build.VERSION.SDK_INT >= 18
-          ? new OnWindowFocusChangeListener() {
-            @Override
-            public void onWindowFocusChanged(boolean hasFocus) {
-              if (stillAttachedForEvent("onWindowFocusChanged")) {
-                delegate.onWindowFocusChanged(hasFocus);
-              }
-            }
+      new OnWindowFocusChangeListener() {
+        @Override
+        public void onWindowFocusChanged(boolean hasFocus) {
+          if (stillAttachedForEvent("onWindowFocusChanged")) {
+            delegate.onWindowFocusChanged(hasFocus);
           }
-          : null;
+        }
+      };
 
   /**
    * Creates a {@code FlutterFragment} with a default configuration.
@@ -1128,20 +1122,15 @@ public class FlutterFragment extends Fragment
   @Override
   public void onViewCreated(View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
-    if (Build.VERSION.SDK_INT >= 18) {
-      view.getViewTreeObserver().addOnWindowFocusChangeListener(onWindowFocusChangeListener);
-    }
+    view.getViewTreeObserver().addOnWindowFocusChangeListener(onWindowFocusChangeListener);
   }
 
   @Override
   public void onDestroyView() {
     super.onDestroyView();
-    if (Build.VERSION.SDK_INT >= 18) {
-      // onWindowFocusChangeListener is API 18+ only.
-      requireView()
-          .getViewTreeObserver()
-          .removeOnWindowFocusChangeListener(onWindowFocusChangeListener);
-    }
+    requireView()
+        .getViewTreeObserver()
+        .removeOnWindowFocusChangeListener(onWindowFocusChangeListener);
     if (stillAttachedForEvent("onDestroyView")) {
       delegate.onDestroyView();
     }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -27,7 +27,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
@@ -45,7 +44,6 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister;
 import io.flutter.plugin.platform.PlatformPlugin;
-import io.flutter.util.ViewUtils;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,8 +65,7 @@ public class FlutterFragmentActivity extends FragmentActivity
   // FlutterFragment management.
   private static final String TAG_FLUTTER_FRAGMENT = "flutter_fragment";
   // TODO(mattcarroll): replace ID with R.id when build system supports R.java
-  public static final int FRAGMENT_CONTAINER_ID =
-      ViewUtils.generateViewId(609893468); // random number
+  public static final int FRAGMENT_CONTAINER_ID = View.generateViewId();
 
   /**
    * Creates an {@link Intent} that launches a {@code FlutterFragmentActivity}, which executes a
@@ -600,12 +597,10 @@ public class FlutterFragmentActivity extends FragmentActivity
   }
 
   private void configureStatusBarForFullscreenFlutterExperience() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      Window window = getWindow();
-      window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-      window.setStatusBarColor(0x40000000);
-      window.getDecorView().setSystemUiVisibility(PlatformPlugin.DEFAULT_SYSTEM_UI);
-    }
+    Window window = getWindow();
+    window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+    window.setStatusBarColor(0x40000000);
+    window.getDecorView().setSystemUiVisibility(PlatformPlugin.DEFAULT_SYSTEM_UI);
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -39,7 +39,6 @@ import java.util.Locale;
  * an {@link android.media.Image} and renders it to the {@link android.graphics.Canvas} in {@code
  * onDraw}.
  */
-@TargetApi(19)
 public class FlutterImageView extends View implements RenderSurface {
   private static final String TAG = "FlutterImageView";
 
@@ -99,7 +98,6 @@ public class FlutterImageView extends View implements RenderSurface {
     Log.w(TAG, String.format(Locale.US, format, args));
   }
 
-  @TargetApi(19)
   @SuppressLint("WrongConstant") // RGBA_8888 is a valid constant.
   @NonNull
   private static ImageReader createImageReader(int width, int height) {
@@ -187,7 +185,6 @@ public class FlutterImageView extends View implements RenderSurface {
    * Acquires the next image to be drawn to the {@link android.graphics.Canvas}. Returns true if
    * there's an image available in the queue.
    */
-  @TargetApi(19)
   public boolean acquireLatestImage() {
     if (!isAttachedToFlutterRenderer) {
       return false;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -290,7 +290,6 @@ public class FlutterView extends FrameLayout
    * <p>{@code FlutterView} requires an {@code Activity} instead of a generic {@code Context} to be
    * compatible with {@link PlatformViewsController}.
    */
-  @TargetApi(19)
   public FlutterView(@NonNull Context context, @NonNull FlutterImageView flutterImageView) {
     this(context, null, flutterImageView);
   }
@@ -357,7 +356,6 @@ public class FlutterView extends FrameLayout
     init();
   }
 
-  @TargetApi(19)
   private FlutterView(
       @NonNull Context context,
       @Nullable AttributeSet attrs,
@@ -643,8 +641,7 @@ public class FlutterView extends FrameLayout
   //
   // This method is replaced by Android API 30 (R/11) getInsets() method which can take the
   // android.view.WindowInsets.Type.ime() flag to find the keyboard inset.
-  @TargetApi(20)
-  @RequiresApi(20)
+
   private int guessBottomKeyboardInset(WindowInsets insets) {
     int screenHeight = getRootView().getHeight();
     // Magic number due to this being a heuristic. This should be replaced, but we have not
@@ -670,8 +667,7 @@ public class FlutterView extends FrameLayout
    * wider than expected padding when the status and navigation bars are hidden.
    */
   @Override
-  @TargetApi(20)
-  @RequiresApi(20)
+
   // The annotations to suppress "InlinedApi" and "NewApi" lints prevent lint warnings
   // caused by usage of Android Q APIs. These calls are safe because they are
   // guarded.
@@ -802,53 +798,6 @@ public class FlutterView extends FrameLayout
     sendViewportMetricsToFlutter();
     return newInsets;
   }
-
-  /**
-   * Invoked when Android's desired window insets change, i.e., padding.
-   *
-   * <p>{@code fitSystemWindows} is an earlier version of {@link
-   * #onApplyWindowInsets(WindowInsets)}. See that method for more details about how window insets
-   * relate to Flutter.
-   */
-  @Override
-  @SuppressWarnings("deprecation")
-  protected boolean fitSystemWindows(@NonNull Rect insets) {
-    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-      // Status bar, left/right system insets partially obscure content (padding).
-      viewportMetrics.viewPaddingTop = insets.top;
-      viewportMetrics.viewPaddingRight = insets.right;
-      viewportMetrics.viewPaddingBottom = 0;
-      viewportMetrics.viewPaddingLeft = insets.left;
-
-      // Bottom system inset (keyboard) should adjust scrollable bottom edge (inset).
-      viewportMetrics.viewInsetTop = 0;
-      viewportMetrics.viewInsetRight = 0;
-      viewportMetrics.viewInsetBottom = insets.bottom;
-      viewportMetrics.viewInsetLeft = 0;
-
-      Log.v(
-          TAG,
-          "Updating window insets (fitSystemWindows()):\n"
-              + "Status bar insets: Top: "
-              + viewportMetrics.viewPaddingTop
-              + ", Left: "
-              + viewportMetrics.viewPaddingLeft
-              + ", Right: "
-              + viewportMetrics.viewPaddingRight
-              + "\n"
-              + "Keyboard insets: Bottom: "
-              + viewportMetrics.viewInsetBottom
-              + ", Left: "
-              + viewportMetrics.viewInsetLeft
-              + ", Right: "
-              + viewportMetrics.viewInsetRight);
-
-      sendViewportMetricsToFlutter();
-      return true;
-    } else {
-      return super.fitSystemWindows(insets);
-    }
-  }
   // ------- End: Process View configuration that Flutter cares about. --------
 
   // -------- Start: Process UI I/O that Flutter cares about. -------
@@ -930,14 +879,7 @@ public class FlutterView extends FrameLayout
       return super.onTouchEvent(event);
     }
 
-    // TODO(abarth): This version check might not be effective in some
-    // versions of Android that statically compile code and will be upset
-    // at the lack of |requestUnbufferedDispatch|. Instead, we should factor
-    // version-dependent code into separate classes for each supported
-    // version and dispatch dynamically.
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      requestUnbufferedDispatch(event);
-    }
+    requestUnbufferedDispatch(event);
 
     return androidTouchProcessor.onTouchEvent(event);
   }

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -1297,22 +1297,17 @@ public class FlutterJNI {
       String countryCode = strings[i + 1];
       String scriptCode = strings[i + 2];
       // Convert to Locales via LocaleBuilder if available (API 21+) to include scriptCode.
-      if (Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-        Locale.Builder localeBuilder = new Locale.Builder();
-        if (!languageCode.isEmpty()) {
-          localeBuilder.setLanguage(languageCode);
-        }
-        if (!countryCode.isEmpty()) {
-          localeBuilder.setRegion(countryCode);
-        }
-        if (!scriptCode.isEmpty()) {
-          localeBuilder.setScript(scriptCode);
-        }
-        supportedLocales.add(localeBuilder.build());
-      } else {
-        // Pre-API 21, we fall back on scriptCode-less locales.
-        supportedLocales.add(new Locale(languageCode, countryCode));
+      Locale.Builder localeBuilder = new Locale.Builder();
+      if (!languageCode.isEmpty()) {
+        localeBuilder.setLanguage(languageCode);
       }
+      if (!countryCode.isEmpty()) {
+        localeBuilder.setRegion(countryCode);
+      }
+      if (!scriptCode.isEmpty()) {
+        localeBuilder.setScript(scriptCode);
+      }
+      supportedLocales.add(localeBuilder.build());
     }
 
     Locale result = localizationPlugin.resolveNativeLocale(supportedLocales);
@@ -1323,11 +1318,7 @@ public class FlutterJNI {
     String[] output = new String[localeDataLength];
     output[0] = result.getLanguage();
     output[1] = result.getCountry();
-    if (Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-      output[2] = result.getScript();
-    } else {
-      output[2] = "";
-    }
+    output[2] = result.getScript();
     return output;
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -412,12 +412,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
     }
 
     // Possible values: armeabi, armeabi-v7a, arm64-v8a, x86, x86_64, mips, mips64
-    String abi;
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      abi = Build.SUPPORTED_ABIS[0];
-    } else {
-      abi = Build.CPU_ABI;
-    }
+    String abi = Build.SUPPORTED_ABIS[0];
     String pathAbi = abi.replace("-", "_"); // abis are represented with underscores in paths.
 
     // TODO(garyq): Optimize this apk/file discovery process to use less i/o and be more
@@ -431,14 +426,12 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
     Queue<File> searchFiles = new LinkedList<>();
     // Downloaded modules are stored here
     searchFiles.add(context.getFilesDir());
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      // The initial installed apks are provided by `sourceDirs` in ApplicationInfo.
-      // The jniLibs we want are in the splits not the baseDir. These
-      // APKs are only searched as a fallback, as base libs generally do not need
-      // to be fully path referenced.
-      for (String path : context.getApplicationInfo().splitSourceDirs) {
-        searchFiles.add(new File(path));
-      }
+    // The initial installed apks are provided by `sourceDirs` in ApplicationInfo.
+    // The jniLibs we want are in the splits not the baseDir. These
+    // APKs are only searched as a fallback, as base libs generally do not need
+    // to be fully path referenced.
+    for (String path : context.getApplicationInfo().splitSourceDirs) {
+      searchFiles.add(new File(path));
     }
 
     while (!searchFiles.isEmpty()) {

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -16,7 +16,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.util.DisplayMetrics;
-import android.view.WindowManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.BuildConfig;
@@ -168,18 +167,9 @@ public class FlutterLoader {
       initStartTimestampMillis = SystemClock.uptimeMillis();
       flutterApplicationInfo = ApplicationInfoLoader.load(appContext);
 
-      VsyncWaiter waiter;
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 /* 17 */) {
-        final DisplayManager dm =
-            (DisplayManager) appContext.getSystemService(Context.DISPLAY_SERVICE);
-        waiter = VsyncWaiter.getInstance(dm, flutterJNI);
-      } else {
-        float fps =
-            ((WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE))
-                .getDefaultDisplay()
-                .getRefreshRate();
-        waiter = VsyncWaiter.getInstance(fps, flutterJNI);
-      }
+      final DisplayManager dm =
+          (DisplayManager) appContext.getSystemService(Context.DISPLAY_SERVICE);
+      VsyncWaiter waiter = VsyncWaiter.getInstance(dm, flutterJNI);
       waiter.init();
 
       // Use a background thread for initialization tasks that require disk access.

--- a/shell/platform/android/io/flutter/embedding/engine/loader/ResourceExtractor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/ResourceExtractor.java
@@ -4,8 +4,6 @@
 
 package io.flutter.embedding.engine.loader;
 
-import static java.util.Arrays.asList;
-
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
@@ -16,7 +14,6 @@ import androidx.annotation.WorkerThread;
 import io.flutter.BuildConfig;
 import io.flutter.Log;
 import java.io.*;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.concurrent.CancellationException;
@@ -26,7 +23,7 @@ import java.util.concurrent.ExecutionException;
 class ResourceExtractor {
   private static final String TAG = "ResourceExtractor";
   private static final String TIMESTAMP_PREFIX = "res_timestamp-";
-  private static final String[] SUPPORTED_ABIS = getSupportedAbis();
+  private static final String[] SUPPORTED_ABIS = Build.SUPPORTED_ABIS;
 
   @SuppressWarnings("deprecation")
   static long getVersionCode(@NonNull PackageInfo packageInfo) {
@@ -247,17 +244,6 @@ class ResourceExtractor {
     byte[] buf = new byte[16 * 1024];
     for (int i; (i = in.read(buf)) >= 0; ) {
       out.write(buf, 0, i);
-    }
-  }
-
-  @SuppressWarnings("deprecation")
-  private static String[] getSupportedAbis() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      return Build.SUPPORTED_ABIS;
-    } else {
-      ArrayList<String> cpuAbis = new ArrayList<String>(asList(Build.CPU_ABI, Build.CPU_ABI2));
-      cpuAbis.removeAll(asList(null, ""));
-      return cpuAbis.toArray(new String[0]);
     }
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -3,7 +3,6 @@ package io.flutter.embedding.engine.mutatorsstack;
 import static android.view.View.OnFocusChangeListener;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
@@ -23,7 +22,6 @@ import io.flutter.util.ViewUtils;
  * A view that applies the {@link io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack} to
  * its children.
  */
-@TargetApi(19)
 public class FlutterMutatorView extends FrameLayout {
   private FlutterMutatorsStack mutatorsStack;
   private float screenDensity;

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -302,18 +302,11 @@ public class FlutterRenderer implements TextureRegistry {
             textureWrapper.markDirty();
             scheduleEngineFrame();
           };
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        // The callback relies on being executed on the UI thread (unsynchronised read of
-        // mNativeView and also the engine code check for platform thread in
-        // Shell::OnPlatformViewMarkTextureFrameAvailable), so we explicitly pass a Handler for the
-        // current thread.
-        this.surfaceTexture().setOnFrameAvailableListener(onFrameListener, new Handler());
-      } else {
-        // Android documentation states that the listener can be called on an arbitrary thread. But
-        // in practice, versions of Android that predate the newer API will call the listener on the
-        // thread where the SurfaceTexture was constructed.
-        this.surfaceTexture().setOnFrameAvailableListener(onFrameListener);
-      }
+      // The callback relies on being executed on the UI thread (unsynchronised read of
+      // mNativeView and also the engine code check for platform thread in
+      // Shell::OnPlatformViewMarkTextureFrameAvailable), so we explicitly pass a Handler for the
+      // current thread.
+      this.surfaceTexture().setOnFrameAvailableListener(onFrameListener, new Handler());
     }
 
     @Override
@@ -895,7 +888,6 @@ public class FlutterRenderer implements TextureRegistry {
     }
 
     @Override
-    @TargetApi(19)
     public void release() {
       if (released) {
         return;
@@ -909,7 +901,6 @@ public class FlutterRenderer implements TextureRegistry {
     }
 
     @Override
-    @TargetApi(19)
     public void pushImage(Image image) {
       if (released) {
         return;
@@ -970,7 +961,6 @@ public class FlutterRenderer implements TextureRegistry {
     }
 
     @Override
-    @TargetApi(19)
     protected void finalize() throws Throwable {
       try {
         if (released) {

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
@@ -4,7 +4,6 @@
 
 package io.flutter.embedding.engine.systemchannels;
 
-import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -91,8 +90,7 @@ public class LocalizationChannel {
               + ")");
       data.add(locale.getLanguage());
       data.add(locale.getCountry());
-      // locale.getScript() was added in API 21.
-      data.add(Build.VERSION.SDK_INT >= 21 ? locale.getScript() : "");
+      data.add(locale.getScript());
       data.add(locale.getVariant());
     }
     channel.invokeMethod("setLocale", data);

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -118,9 +118,6 @@ public class InputConnectionAdaptor extends BaseInputConnection
   }
 
   private CursorAnchorInfo getCursorAnchorInfo() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      return null;
-    }
     if (mCursorAnchorInfoBuilder == null) {
       mCursorAnchorInfoBuilder = new CursorAnchorInfo.Builder();
     } else {
@@ -226,9 +223,6 @@ public class InputConnectionAdaptor extends BaseInputConnection
 
   @Override
   public boolean requestCursorUpdates(int cursorUpdateMode) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      return false;
-    }
     if ((cursorUpdateMode & CURSOR_UPDATE_IMMEDIATE) != 0) {
       mImm.updateCursorAnchorInfo(mFlutterView, getCursorAnchorInfo());
     }
@@ -569,9 +563,6 @@ public class InputConnectionAdaptor extends BaseInputConnection
         mEditable.getComposingStart(),
         mEditable.getComposingEnd());
 
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      return;
-    }
     if (mExtractRequest != null) {
       mImm.updateExtractedText(
           mFlutterView, mExtractRequest.token, getExtractedText(mExtractRequest));

--- a/shell/platform/android/io/flutter/plugin/localization/LocalizationPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/localization/LocalizationPlugin.java
@@ -7,7 +7,6 @@ package io.flutter.plugin.localization;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.os.Build;
 import android.os.LocaleList;
 import androidx.annotation.NonNull;
@@ -39,19 +38,9 @@ public class LocalizationPlugin {
           if (localeString != null) {
             Locale locale = localeFromString(localeString);
 
-            // setLocale and createConfigurationContext is only available on API >= 17
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-              Configuration config = new Configuration(context.getResources().getConfiguration());
-              config.setLocale(locale);
-              localContext = context.createConfigurationContext(config);
-            } else {
-              // In API < 17, we have to update the locale in Configuration.
-              Resources resources = context.getResources();
-              Configuration config = resources.getConfiguration();
-              savedLocale = config.locale;
-              config.locale = locale;
-              resources.updateConfiguration(config, null);
-            }
+            Configuration config = new Configuration(context.getResources().getConfiguration());
+            config.setLocale(locale);
+            localContext = context.createConfigurationContext(config);
           }
 
           String packageName = context.getPackageName();
@@ -59,14 +48,6 @@ public class LocalizationPlugin {
           if (resId != 0) {
             // 0 means the resource is not found.
             stringToReturn = localContext.getResources().getString(resId);
-          }
-
-          // In API < 17, we had to restore the original locale after using.
-          if (localeString != null && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            Resources resources = context.getResources();
-            Configuration config = resources.getConfiguration();
-            config.locale = savedLocale;
-            resources.updateConfiguration(config, null);
           }
 
           return stringToReturn;
@@ -200,31 +181,26 @@ public class LocalizationPlugin {
    */
   @NonNull
   public static Locale localeFromString(@NonNull String localeString) {
-    // Use Locale.forLanguageTag if available (API 21+).
-    if (false && Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-      return Locale.forLanguageTag(localeString);
-    } else {
-      // Normalize the locale string, replace all underscores with hyphens.
-      localeString = localeString.replace('_', '-');
+    // Normalize the locale string, replace all underscores with hyphens.
+    localeString = localeString.replace('_', '-');
 
-      // Pre-API 21, we fall back to manually parsing the locale tag.
-      String parts[] = localeString.split("-", -1);
+    // Pre-API 21, we fall back to manually parsing the locale tag.
+    String parts[] = localeString.split("-", -1);
 
-      // Assume the first part is always the language code.
-      String languageCode = parts[0];
-      String scriptCode = "";
-      String countryCode = "";
-      int index = 1;
-      if (parts.length > index && parts[index].length() == 4) {
-        scriptCode = parts[index];
-        index++;
-      }
-      if (parts.length > index && parts[index].length() >= 2 && parts[index].length() <= 3) {
-        countryCode = parts[index];
-        index++;
-      }
-      // Ignore the rest of the locale for this purpose.
-      return new Locale(languageCode, countryCode, scriptCode);
+    // Assume the first part is always the language code.
+    String languageCode = parts[0];
+    String scriptCode = "";
+    String countryCode = "";
+    int index = 1;
+    if (parts.length > index && parts[index].length() == 4) {
+      scriptCode = parts[index];
+      index++;
     }
+    if (parts.length > index && parts[index].length() >= 2 && parts[index].length() <= 3) {
+      countryCode = parts[index];
+      index++;
+    }
+    // Ignore the rest of the locale for this purpose.
+    return new Locale(languageCode, countryCode, scriptCode);
   }
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -4,7 +4,6 @@
 
 package io.flutter.plugin.platform;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.ActivityManager.TaskDescription;
 import android.content.ClipData;
@@ -206,9 +205,7 @@ public class PlatformPlugin {
         }
         break;
       case SELECTION_CLICK:
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-          view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK);
-        }
+        view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK);
         break;
     }
   }
@@ -220,20 +217,10 @@ public class PlatformPlugin {
   @SuppressWarnings("deprecation")
   private void setSystemChromeApplicationSwitcherDescription(
       PlatformChannel.AppSwitcherDescription description) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      return;
-    }
-
-    // Linter refuses to believe we're only executing this code in API 28 unless we
-    // use distinct if
-    // blocks and
-    // hardcode the API 28 constant.
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P
-        && Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
       activity.setTaskDescription(
           new TaskDescription(description.label, /* icon= */ null, description.color));
-    }
-    if (Build.VERSION.SDK_INT >= 28) {
+    } else {
       TaskDescription taskDescription =
           new TaskDescription(description.label, 0, description.color);
       activity.setTaskDescription(taskDescription);
@@ -291,8 +278,7 @@ public class PlatformPlugin {
               | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
               | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
               | View.SYSTEM_UI_FLAG_FULLSCREEN;
-    } else if (systemUiMode == PlatformChannel.SystemUiMode.IMMERSIVE
-        && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    } else if (systemUiMode == PlatformChannel.SystemUiMode.IMMERSIVE) {
       // IMMERSIVE
       // Available starting at 19
       // Should not show overlays, swipe from edges to reveal overlays, needs onChange callback
@@ -307,8 +293,7 @@ public class PlatformPlugin {
               | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
               | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
               | View.SYSTEM_UI_FLAG_FULLSCREEN;
-    } else if (systemUiMode == PlatformChannel.SystemUiMode.IMMERSIVE_STICKY
-        && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    } else if (systemUiMode == PlatformChannel.SystemUiMode.IMMERSIVE_STICKY) {
       // STICKY IMMERSIVE
       // Available starting at 19
       // Should not show overlays, swipe from edges to reveal overlays. The app will also receive
@@ -352,10 +337,7 @@ public class PlatformPlugin {
             | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
             | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
 
-    // The SYSTEM_UI_FLAG_IMMERSIVE_STICKY flag was introduced in API 19, so we
-    // apply it
-    // if desired, and if the current Android version is 19 or greater.
-    if (overlaysToShow.size() == 0 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    if (overlaysToShow.size() == 0) {
       enabledOverlays |= View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
     }
 
@@ -397,7 +379,6 @@ public class PlatformPlugin {
   }
 
   @SuppressWarnings("deprecation")
-  @TargetApi(21)
   private void setSystemChromeSystemUIOverlayStyle(
       PlatformChannel.SystemChromeStyle systemChromeStyle) {
     Window window = activity.getWindow();

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -156,7 +156,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   private final PlatformViewsChannel.PlatformViewsHandler channelHandler =
       new PlatformViewsChannel.PlatformViewsHandler() {
 
-        @TargetApi(19)
         @Override
         // TODO(egarciad): Remove the need for this.
         // https://github.com/flutter/flutter/issues/96679
@@ -173,7 +172,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           // not applicable to fallback from TLHC to HC.
         }
 
-        @TargetApi(20)
         @Override
         public long createForTextureLayer(
             @NonNull PlatformViewsChannel.PlatformViewCreationRequest request) {
@@ -419,7 +417,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           view.dispatchTouchEvent(event);
         }
 
-        @TargetApi(17)
         @Override
         public void setDirection(int viewId, int direction) {
           if (!validateDirection(direction)) {
@@ -504,7 +501,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
 
   // Creates a platform view based on `request`, performs configuration that's common to
   // all display modes, and adds it to `platformViews`.
-  @TargetApi(19)
   @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
   public PlatformView createPlatformView(
       @NonNull PlatformViewsChannel.PlatformViewCreationRequest request, boolean wrapContext) {
@@ -1080,7 +1076,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    *     testing.
    */
   @VisibleForTesting
-  @TargetApi(Build.VERSION_CODES.KITKAT)
   void initializePlatformViewIfNeeded(int viewId) {
     final PlatformView platformView = platformViews.get(viewId);
     if (platformView == null) {
@@ -1292,7 +1287,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    *     for public use, and is only visible for testing.
    */
   @VisibleForTesting
-  @TargetApi(19)
   @NonNull
   public FlutterOverlaySurface createOverlaySurface(@NonNull PlatformOverlayView imageView) {
     final int id = nextOverlayLayerId++;
@@ -1307,7 +1301,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    *
    * <p>This member is not intended for public use, and is only visible for testing.
    */
-  @TargetApi(19)
   @NonNull
   public FlutterOverlaySurface createOverlaySurface() {
     // Overlay surfaces have the same size as the background surface.

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -7,7 +7,6 @@ package io.flutter.plugin.platform;
 import static android.content.Context.WINDOW_SERVICE;
 import static android.view.View.OnFocusChangeListener;
 
-import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.app.Presentation;
 import android.content.Context;
@@ -15,7 +14,6 @@ import android.content.ContextWrapper;
 import android.content.MutableContextWrapper;
 import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.Display;
 import android.view.Gravity;
@@ -51,7 +49,6 @@ import java.lang.reflect.Proxy;
  *   EmbeddedView
  */
 @Keep
-@TargetApi(Build.VERSION_CODES.KITKAT)
 class SingleViewPresentation extends Presentation {
   private static final String TAG = "PlatformViewsController";
 
@@ -123,9 +120,7 @@ class SingleViewPresentation extends Presentation {
         .setFlags(
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      getWindow().setType(WindowManager.LayoutParams.TYPE_PRIVATE_PRESENTATION);
-    }
+    getWindow().setType(WindowManager.LayoutParams.TYPE_PRIVATE_PRESENTATION);
   }
 
   /**

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -19,7 +19,6 @@ import android.view.ViewTreeObserver;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
-@TargetApi(21)
 class VirtualDisplayController {
   private static String TAG = "VirtualDisplayController";
 

--- a/shell/platform/android/io/flutter/util/PathUtils.java
+++ b/shell/platform/android/io/flutter/util/PathUtils.java
@@ -32,12 +32,8 @@ public final class PathUtils {
   @NonNull
   public static String getCacheDirectory(@NonNull Context applicationContext) {
     File cacheDir;
-    if (Build.VERSION.SDK_INT >= 21) {
-      cacheDir = applicationContext.getCodeCacheDir();
-      if (cacheDir == null) {
-        cacheDir = applicationContext.getCacheDir();
-      }
-    } else {
+    cacheDir = applicationContext.getCodeCacheDir();
+    if (cacheDir == null) {
       cacheDir = applicationContext.getCacheDir();
     }
     if (cacheDir == null) {

--- a/shell/platform/android/io/flutter/util/TraceSection.java
+++ b/shell/platform/android/io/flutter/util/TraceSection.java
@@ -4,11 +4,9 @@
 
 package io.flutter.util;
 
-import android.annotation.TargetApi;
 import androidx.annotation.NonNull;
 import androidx.tracing.Trace;
 
-@TargetApi(19)
 public final class TraceSection implements AutoCloseable {
   /**
    * Factory used to support the try-with-resource construct.

--- a/shell/platform/android/io/flutter/util/ViewUtils.java
+++ b/shell/platform/android/io/flutter/util/ViewUtils.java
@@ -7,7 +7,6 @@ package io.flutter.util;
 import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
-import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
@@ -57,21 +56,6 @@ public final class ViewUtils {
       return getActivity(((ContextWrapper) context).getBaseContext());
     }
     return null;
-  }
-
-  /**
-   * Generates a view id.
-   *
-   * <p>In API level 17 and above, this ID is unique. Below 17, the fallback id is used instead.
-   *
-   * @param fallbackId the fallback id.
-   * @return the view id.
-   */
-  public static int generateViewId(int fallbackId) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      return View.generateViewId();
-    }
-    return fallbackId;
   }
 
   /**

--- a/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
@@ -230,24 +230,18 @@ class AccessibilityViewEmbedder {
     output.setText(input.getText());
     output.setVisibleToUser(input.isVisibleToUser());
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-      output.setEditable(input.isEditable());
-    }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      output.setCanOpenPopup(input.canOpenPopup());
-      output.setCollectionInfo(input.getCollectionInfo());
-      output.setCollectionItemInfo(input.getCollectionItemInfo());
-      output.setContentInvalid(input.isContentInvalid());
-      output.setDismissable(input.isDismissable());
-      output.setInputType(input.getInputType());
-      output.setLiveRegion(input.getLiveRegion());
-      output.setMultiLine(input.isMultiLine());
-      output.setRangeInfo(input.getRangeInfo());
-    }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      output.setError(input.getError());
-      output.setMaxTextLength(input.getMaxTextLength());
-    }
+    output.setEditable(input.isEditable());
+    output.setCanOpenPopup(input.canOpenPopup());
+    output.setCollectionInfo(input.getCollectionInfo());
+    output.setCollectionItemInfo(input.getCollectionItemInfo());
+    output.setContentInvalid(input.isContentInvalid());
+    output.setDismissable(input.isDismissable());
+    output.setInputType(input.getInputType());
+    output.setLiveRegion(input.getLiveRegion());
+    output.setMultiLine(input.isMultiLine());
+    output.setRangeInfo(input.getRangeInfo());
+    output.setError(input.getError());
+    output.setMaxTextLength(input.getMaxTextLength());
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       output.setContextClickable(input.isContextClickable());
       // TODO(amirh): copy traversal before and after.

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -12,7 +12,6 @@ import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Insets;
 import android.graphics.PixelFormat;
-import android.graphics.Rect;
 import android.graphics.SurfaceTexture;
 import android.os.Build;
 import android.os.Handler;
@@ -447,14 +446,7 @@ public class FlutterView extends SurfaceView
       return super.onTouchEvent(event);
     }
 
-    // TODO(abarth): This version check might not be effective in some
-    // versions of Android that statically compile code and will be upset
-    // at the lack of |requestUnbufferedDispatch|. Instead, we should factor
-    // version-dependent code into separate classes for each supported
-    // version and dispatch dynamically.
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      requestUnbufferedDispatch(event);
-    }
+    requestUnbufferedDispatch(event);
 
     return androidTouchProcessor.onTouchEvent(event);
   }
@@ -544,8 +536,7 @@ public class FlutterView extends SurfaceView
   // be padded. When the on-screen keyboard is detected, we want to include the full inset
   // but when the inset is just the hidden nav bar, we want to provide a zero inset so the space
   // can be used.
-  @TargetApi(20)
-  @RequiresApi(20)
+
   private int guessBottomKeyboardInset(WindowInsets insets) {
     int screenHeight = getRootView().getHeight();
     // Magic number due to this being a heuristic. This should be replaced, but we have not
@@ -566,8 +557,6 @@ public class FlutterView extends SurfaceView
   // caused by usage of Android Q APIs. These calls are safe because they are
   // guarded.
   @Override
-  @TargetApi(20)
-  @RequiresApi(20)
   @SuppressLint({"InlinedApi", "NewApi"})
   public final WindowInsets onApplyWindowInsets(WindowInsets insets) {
     // getSystemGestureInsets() was introduced in API 29 and immediately deprecated in 30.
@@ -666,28 +655,6 @@ public class FlutterView extends SurfaceView
 
     updateViewportMetrics();
     return super.onApplyWindowInsets(insets);
-  }
-
-  @Override
-  @SuppressWarnings("deprecation")
-  protected boolean fitSystemWindows(Rect insets) {
-    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-      // Status bar, left/right system insets partially obscure content (padding).
-      mMetrics.physicalViewPaddingTop = insets.top;
-      mMetrics.physicalViewPaddingRight = insets.right;
-      mMetrics.physicalViewPaddingBottom = 0;
-      mMetrics.physicalViewPaddingLeft = insets.left;
-
-      // Bottom system inset (keyboard) should adjust scrollable bottom edge (inset).
-      mMetrics.physicalViewInsetTop = 0;
-      mMetrics.physicalViewInsetRight = 0;
-      mMetrics.physicalViewInsetBottom = insets.bottom;
-      mMetrics.physicalViewInsetLeft = 0;
-      updateViewportMetrics();
-      return true;
-    } else {
-      return super.fitSystemWindows(insets);
-    }
   }
 
   private boolean isAttached() {
@@ -931,19 +898,12 @@ public class FlutterView extends SurfaceView
       this.id = id;
       this.textureWrapper = new SurfaceTextureWrapper(surfaceTexture);
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        // The callback relies on being executed on the UI thread (unsynchronised read of
-        // mNativeView
-        // and also the engine code check for platform thread in
-        // Shell::OnPlatformViewMarkTextureFrameAvailable),
-        // so we explicitly pass a Handler for the current thread.
-        this.surfaceTexture().setOnFrameAvailableListener(onFrameListener, new Handler());
-      } else {
-        // Android documentation states that the listener can be called on an arbitrary thread.
-        // But in practice, versions of Android that predate the newer API will call the listener
-        // on the thread where the SurfaceTexture was constructed.
-        this.surfaceTexture().setOnFrameAvailableListener(onFrameListener);
-      }
+      // The callback relies on being executed on the UI thread (unsynchronised read of
+      // mNativeView
+      // and also the engine code check for platform thread in
+      // Shell::OnPlatformViewMarkTextureFrameAvailable),
+      // so we explicitly pass a Handler for the current thread.
+      this.surfaceTexture().setOnFrameAvailableListener(onFrameListener, new Handler());
     }
 
     private SurfaceTexture.OnFrameAvailableListener onFrameListener =

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -4,7 +4,6 @@
 
 package io.flutter.view;
 
-import android.annotation.TargetApi;
 import android.hardware.display.DisplayManager;
 import android.view.Choreographer;
 import android.view.Display;
@@ -14,7 +13,6 @@ import io.flutter.embedding.engine.FlutterJNI;
 
 // TODO(mattcarroll): add javadoc.
 public class VsyncWaiter {
-  @TargetApi(17)
   class DisplayListener implements DisplayManager.DisplayListener {
     DisplayListener(DisplayManager displayManager) {
       this.displayManager = displayManager;
@@ -59,7 +57,6 @@ public class VsyncWaiter {
     return instance;
   }
 
-  @TargetApi(17)
   @NonNull
   public static VsyncWaiter getInstance(
       @NonNull DisplayManager displayManager, @NonNull FlutterJNI flutterJNI) {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -485,7 +485,7 @@ public class FlutterActivityTest {
   }
 
   @Test
-  @Config(minSdk = Build.VERSION_CODES.KITKAT, maxSdk = Build.VERSION_CODES.P)
+  @Config(minSdk = 21, maxSdk = Build.VERSION_CODES.P)
   public void fullyDrawn_beforeAndroidQ() {
     Intent intent = FlutterActivityWithReportFullyDrawn.createDefaultIntent(ctx);
     ActivityController<FlutterActivityWithReportFullyDrawn> activityController =

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -33,7 +32,6 @@ import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
-@TargetApi(21)
 public class PlayStoreDeferredComponentManagerTest {
   private class TestFlutterJNI extends FlutterJNI {
     public int loadDartDeferredLibraryCalled = 0;

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -22,7 +22,6 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.InputType;
 import android.text.Selection;
@@ -1074,9 +1073,6 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testExtractedText_monitoring() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      return;
-    }
     ListenableEditingState editable = sampleEditable(5, 5);
     View testView = new View(ctx);
     InputConnectionAdaptor adaptor =
@@ -1128,10 +1124,6 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testCursorAnchorInfo() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      return;
-    }
-
     ListenableEditingState editable = sampleEditable(5, 5);
     View testView = new View(ctx);
     InputConnectionAdaptor adaptor =

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1246,9 +1246,6 @@ public class TextInputPluginTest {
   @SuppressWarnings("deprecation") // InputMethodSubtype
   @Test
   public void inputConnection_finishComposingTextUpdatesIMM() throws JSONException {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      return;
-    }
     ShadowBuild.setManufacturer("samsung");
     InputMethodSubtype inputMethodSubtype =
         new InputMethodSubtype(0, 0, /*locale=*/ "en", "", "", false, false);

--- a/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -238,7 +238,7 @@ public class LocalizationPluginTest {
   // Tests the legacy pre API 24 algorithm.
   @Test
   @Config(
-      minSdk = Build.VERSION_CODES.KITKAT,
+      minSdk = Build.VERSION_CODES.LOLLIPOP,
       maxSdk = Build.VERSION_CODES.M,
       qualifiers = "es-rMX")
   public void computePlatformResolvedLocale_emptySupportedLocales_beforeAndroidN() {
@@ -252,7 +252,7 @@ public class LocalizationPluginTest {
   }
 
   @Test
-  @Config(minSdk = Build.VERSION_CODES.KITKAT, maxSdk = Build.VERSION_CODES.M, qualifiers = "")
+  @Config(minSdk = 21, maxSdk = Build.VERSION_CODES.M, qualifiers = "")
   public void computePlatformResolvedLocale_selectFirstLocaleWhenNoUserSetting_beforeAndroidN() {
     FlutterJNI flutterJNI = new FlutterJNI();
     DartExecutor dartExecutor = mock(DartExecutor.class);
@@ -272,10 +272,7 @@ public class LocalizationPluginTest {
   }
 
   @Test
-  @Config(
-      minSdk = Build.VERSION_CODES.KITKAT,
-      maxSdk = Build.VERSION_CODES.M,
-      qualifiers = "fr-rCH")
+  @Config(minSdk = 21, maxSdk = Build.VERSION_CODES.M, qualifiers = "fr-rCH")
   public void computePlatformResolvedLocale_selectFirstLocaleWhenNoExactMatch_beforeAndroidN() {
     FlutterJNI flutterJNI = new FlutterJNI();
     DartExecutor dartExecutor = mock(DartExecutor.class);
@@ -298,10 +295,7 @@ public class LocalizationPluginTest {
   }
 
   @Test
-  @Config(
-      minSdk = Build.VERSION_CODES.KITKAT,
-      maxSdk = Build.VERSION_CODES.M,
-      qualifiers = "it-rIT")
+  @Config(minSdk = 21, maxSdk = Build.VERSION_CODES.M, qualifiers = "it-rIT")
   public void computePlatformResolvedLocale_selectExactMatchLocale_beforeAndroidN() {
     FlutterJNI flutterJNI = new FlutterJNI();
     DartExecutor dartExecutor = mock(DartExecutor.class);
@@ -324,10 +318,7 @@ public class LocalizationPluginTest {
   }
 
   @Test
-  @Config(
-      minSdk = Build.VERSION_CODES.KITKAT,
-      maxSdk = Build.VERSION_CODES.M,
-      qualifiers = "fr-rCH")
+  @Config(minSdk = 21, maxSdk = Build.VERSION_CODES.M, qualifiers = "fr-rCH")
   public void computePlatformResolvedLocale_selectOnlyLanguageLocale_beforeAndroidN() {
     FlutterJNI flutterJNI = new FlutterJNI();
     DartExecutor dartExecutor = mock(DartExecutor.class);
@@ -350,36 +341,30 @@ public class LocalizationPluginTest {
     assertEquals(result[2], "");
   }
 
-  // Tests the legacy pre API 21 algorithm.
-  @Config(sdk = Build.VERSION_CODES.KITKAT)
   @Test
   public void localeFromString_languageOnly() {
     Locale locale = LocalizationPlugin.localeFromString("en");
     assertEquals(locale, new Locale("en"));
   }
 
-  @Config(sdk = Build.VERSION_CODES.KITKAT)
   @Test
   public void localeFromString_languageAndCountry() {
     Locale locale = LocalizationPlugin.localeFromString("en-US");
     assertEquals(locale, new Locale("en", "US"));
   }
 
-  @Config(sdk = Build.VERSION_CODES.KITKAT)
   @Test
   public void localeFromString_languageCountryAndVariant() {
     Locale locale = LocalizationPlugin.localeFromString("zh-Hans-CN");
     assertEquals(locale, new Locale("zh", "CN", "Hans"));
   }
 
-  @Config(sdk = Build.VERSION_CODES.KITKAT)
   @Test
   public void localeFromString_underscore() {
     Locale locale = LocalizationPlugin.localeFromString("zh_Hans_CN");
     assertEquals(locale, new Locale("zh", "CN", "Hans"));
   }
 
-  @Config(sdk = Build.VERSION_CODES.KITKAT)
   @Test
   public void localeFromString_additionalVariantsAreIgnored() {
     Locale locale = LocalizationPlugin.localeFromString("de-DE-u-co-phonebk");

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -71,23 +71,6 @@ public class PlatformPluginTest {
     clipboardFormat = ClipboardContentFormat.PLAIN_TEXT;
   }
 
-  @Config(sdk = Build.VERSION_CODES.KITKAT)
-  @Test
-  public void itIgnoresNewHapticEventsOnOldAndroidPlatforms() {
-    View fakeDecorView = mock(View.class);
-    Window fakeWindow = mock(Window.class);
-    Activity mockActivity = mock(Activity.class);
-    when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
-    when(mockActivity.getWindow()).thenReturn(fakeWindow);
-    PlatformPlugin platformPlugin = new PlatformPlugin(mockActivity, mockPlatformChannel);
-
-    // HEAVY_IMPACT haptic response is only available on "M" (23) and later.
-    platformPlugin.vibrateHapticFeedback(PlatformChannel.HapticFeedbackType.HEAVY_IMPACT);
-
-    // SELECTION_CLICK haptic response is only available on "LOLLIPOP" (21) and later.
-    platformPlugin.vibrateHapticFeedback(PlatformChannel.HapticFeedbackType.SELECTION_CLICK);
-  }
-
   @Test
   public void platformPlugin_getClipboardDataIsNonNullWhenPlainTextCopied() throws IOException {
     View fakeDecorView = mock(View.class);

--- a/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -4,7 +4,6 @@
 
 package io.flutter.plugin.platform;
 
-import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.R;
 import static org.junit.Assert.assertEquals;
@@ -28,7 +27,7 @@ import org.robolectric.annotation.Config;
 @TargetApi(P)
 public class SingleViewPresentationTest {
   @Test
-  @Config(minSdk = KITKAT, maxSdk = R)
+  @Config(minSdk = 21, maxSdk = R)
   public void returnsOuterContextInputMethodManager() {
     // There's a bug in Android Q caused by the IMM being instanced per display.
     // https://github.com/flutter/flutter/issues/38375. We need the context returned by
@@ -59,7 +58,7 @@ public class SingleViewPresentationTest {
   }
 
   @Test
-  @Config(minSdk = KITKAT, maxSdk = R)
+  @Config(minSdk = 21, maxSdk = R)
   public void returnsOuterContextInputMethodManager_createDisplayContext() {
     // The IMM should also persist across display contexts created from the base context.
 

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -64,7 +64,6 @@ import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(AndroidJUnit4.class)
-@TargetApi(19)
 public class AccessibilityBridgeTest {
 
   @Test
@@ -859,7 +858,6 @@ public class AccessibilityBridgeTest {
   }
 
   @Config(sdk = 21)
-  @TargetApi(21)
   @Test
   public void itCanPerformSetText() {
     AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
@@ -899,7 +897,6 @@ public class AccessibilityBridgeTest {
   }
 
   @Config(sdk = 21)
-  @TargetApi(21)
   @Test
   public void itCanPredictSetText() {
     AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
@@ -939,7 +936,6 @@ public class AccessibilityBridgeTest {
   }
 
   @Config(sdk = 21)
-  @TargetApi(21)
   @Test
   public void itBuildsAttributedString() {
     AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
@@ -1006,7 +1002,6 @@ public class AccessibilityBridgeTest {
   }
 
   @Config(sdk = 21)
-  @TargetApi(21)
   @Test
   public void itSetsTextCorrectly() {
     AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
@@ -1142,7 +1137,6 @@ public class AccessibilityBridgeTest {
   }
 
   @Config(sdk = 21)
-  @TargetApi(21)
   @Test
   public void itCanCreateAccessibilityNodeInfoWithSetText() {
     AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);

--- a/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
+++ b/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
-import android.annotation.TargetApi;
 import android.hardware.display.DisplayManager;
 import android.os.Looper;
 import android.view.Display;
@@ -50,7 +49,6 @@ public class VsyncWaiterTest {
     verify(mockFlutterJNI, times(1)).onVsync(anyLong(), eq(1000000000l / 10l), eq(1l));
   }
 
-  @TargetApi(17)
   @Test
   public void itSetsFpsWhenDisplayManagerUpdates() {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
@@ -86,7 +84,6 @@ public class VsyncWaiterTest {
     verify(mockFlutterJNI, times(1)).onVsync(anyLong(), eq(1000000000l / 60l), eq(1l));
   }
 
-  @TargetApi(17)
   @Test
   public void itSetsFpsWhenDisplayManagerDoesNotUpdate() {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -35,7 +35,7 @@ android {
   compileSdkVersion 34
 
   defaultConfig {
-    minSdkVersion 19
+    minSdkVersion 21
   }
 
   compileOptions {

--- a/testing/android_background_image/android/app/build.gradle
+++ b/testing/android_background_image/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
     }
     defaultConfig {
         applicationId 'dev.flutter.android_background_image'
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 34
         versionCode 1
         versionName '1.0'

--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
     }
     defaultConfig {
         applicationId 'dev.flutter.scenarios'
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 34
         versionCode 1
         versionName '1.0'

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/ExternalTextureTests.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/ExternalTextureTests.java
@@ -47,7 +47,6 @@ public class ExternalTextureTests {
   }
 
   @Test
-  @SdkSuppress(minSdkVersion = VERSION_CODES.LOLLIPOP)
   public void testMediaSurface() throws Exception {
     intent.putExtra("scenario_name", "display_texture");
     intent.putExtra("surface_renderer", "media");
@@ -56,7 +55,6 @@ public class ExternalTextureTests {
   }
 
   @Test
-  @SdkSuppress(minSdkVersion = VERSION_CODES.LOLLIPOP)
   public void testRotatedMediaSurface_90() throws Exception {
     intent.putExtra("scenario_name", "display_texture");
     intent.putExtra("surface_renderer", "media");
@@ -66,7 +64,6 @@ public class ExternalTextureTests {
   }
 
   @Test
-  @SdkSuppress(minSdkVersion = VERSION_CODES.LOLLIPOP)
   public void testRotatedMediaSurface_180() throws Exception {
     intent.putExtra("scenario_name", "display_texture");
     intent.putExtra("surface_renderer", "media");
@@ -76,7 +73,6 @@ public class ExternalTextureTests {
   }
 
   @Test
-  @SdkSuppress(minSdkVersion = VERSION_CODES.LOLLIPOP)
   public void testRotatedMediaSurface_270() throws Exception {
     intent.putExtra("scenario_name", "display_texture");
     intent.putExtra("surface_renderer", "media");

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/ExternalTextureFlutterActivity.java
@@ -112,11 +112,7 @@ public class ExternalTextureFlutterActivity extends TestActivity {
           throw new RuntimeException("ImageSurfaceRenderer not supported");
         }
       case "media":
-        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
-          return new MediaSurfaceRenderer(this::createMediaExtractor, extras.getInt("rotation", 0));
-        } else {
-          throw new RuntimeException("MediaSurfaceRenderer not supported");
-        }
+        return new MediaSurfaceRenderer(this::createMediaExtractor, extras.getInt("rotation", 0));
       case "canvas":
       default:
         return new CanvasSurfaceRenderer();
@@ -226,7 +222,6 @@ public class ExternalTextureFlutterActivity extends TestActivity {
   }
 
   /** Decodes a sample video into the attached Surface. */
-  @RequiresApi(VERSION_CODES.LOLLIPOP)
   private static class MediaSurfaceRenderer implements SurfaceRenderer {
     private final Supplier<MediaExtractor> extractorSupplier;
     private final int rotation;

--- a/tools/android_lint/baseline.xml
+++ b/tools/android_lint/baseline.xml
@@ -2,61 +2,6 @@
 <issues format="6" by="lint 8.1.0 [10406996] " type="baseline" client="" dependencies="true" name="" variant="all" version="8.1.0 [10406996] ">
 
     <issue
-        id="InlinedApi"
-        message="Field requires API level 18 (current min is 16): `android.content.pm.ActivityInfo#SCREEN_ORIENTATION_USER_PORTRAIT`"
-        errorLine1="        return ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT;"
-        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java"
-            line="274"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="InlinedApi"
-        message="Field requires API level 18 (current min is 16): `android.content.pm.ActivityInfo#SCREEN_ORIENTATION_USER_LANDSCAPE`"
-        errorLine1="        return ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE;"
-        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java"
-            line="278"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="InlinedApi"
-        message="Field requires API level 18 (current min is 16): `android.content.pm.ActivityInfo#SCREEN_ORIENTATION_FULL_USER`"
-        errorLine1="        return ActivityInfo.SCREEN_ORIENTATION_FULL_USER;"
-        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java"
-            line="282"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="InlinedApi"
-        message="Field requires API level 17 (current min is 16): `android.view.View#LAYOUT_DIRECTION_LTR`"
-        errorLine1="    return direction == View.LAYOUT_DIRECTION_LTR || direction == View.LAYOUT_DIRECTION_RTL;"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java"
-            line="991"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="InlinedApi"
-        message="Field requires API level 17 (current min is 16): `android.view.View#LAYOUT_DIRECTION_RTL`"
-        errorLine1="    return direction == View.LAYOUT_DIRECTION_LTR || direction == View.LAYOUT_DIRECTION_RTL;"
-        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java"
-            line="991"
-            column="67"/>
-    </issue>
-
-    <issue
         id="HardcodedDebugMode"
         message="Avoid hardcoding the debug mode; leaving it out allows debug and release builds to automatically assign one"
         errorLine1="    &lt;application android:label=&quot;Flutter Shell&quot; android:name=&quot;FlutterApplication&quot; android:debuggable=&quot;true&quot;>"

--- a/tools/android_lint/project.xml
+++ b/tools/android_lint/project.xml
@@ -47,6 +47,7 @@
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/android/KeyData.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java" />
+    <src file="../../../flutter/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureSurfaceProducer.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterUiDisplayListener.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/engine/renderer/RenderSurface.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java" />
@@ -108,6 +109,7 @@
     <src file="../../../flutter/shell/platform/android/io/flutter/plugin/platform/SurfaceTexturePlatformViewRenderTarget.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRenderTarget.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/plugin/platform/ImageReaderPlatformViewRenderTarget.java" />
+    <src file="../../../flutter/shell/platform/android/io/flutter/plugin/platform/SurfaceProducerPlatformViewRenderTarget.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRegistry.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java" />
@@ -159,5 +161,6 @@
     <src file="../../../flutter/shell/platform/android/io/flutter/view/FlutterRunArguments.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java" />
+    <src file="../../../flutter/shell/platform/android/io/flutter/BuildConfig.java" />
   </module>
 </project>


### PR DESCRIPTION
This reverts commit c9381fb8ef4ca7542cb99b5f668aa9d6415fc7f6.

Reverted in https://github.com/flutter/engine/pull/51056 because it caused failures in the framework. No changes, but framework test has been updated to use an actual robolectric implementation to avoid those failures.

This should not land until https://github.com/flutter/flutter/pull/144348 has landed in the framework.

@gaaclarke @johnmccutchan fyi