### PR TITLE
[Impeller] switch fallback default from ImpellerVulkan to SkiaOpenGLES

### DIFF
--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -236,6 +236,9 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
            "software rendering or disable impeller.";
     return AndroidRenderingAPI::kSoftware;
   }
+  constexpr AndroidRenderingAPI kVulkanUnsupportedFallback =
+      AndroidRenderingAPI::kSkiaOpenGLES;
+
   // Debug/Profile only functionality for testing a specific
   // backend configuration.
 #ifndef FLUTTER_RELEASE
@@ -258,7 +261,7 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
     // feature.
     int api_level = android_get_device_api_level();
     if (api_level < kMinimumAndroidApiLevelForVulkan) {
-      return AndroidRenderingAPI::kImpellerOpenGLES;
+      return kVulkanUnsupportedFallback;
     }
     // Determine if Vulkan is supported by creating a Vulkan context and
     // checking if it is valid.
@@ -268,7 +271,7 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
         /*enable_vulkan_gpu_tracing=*/false,
         /*quiet=*/true);
     if (!vulkan_backend->IsValid()) {
-      return AndroidRenderingAPI::kImpellerOpenGLES;
+      return kVulkanUnsupportedFallback;
     }
     return AndroidRenderingAPI::kImpellerVulkan;
   }

--- a/shell/platform/android/platform_view_android_unittests.cc
+++ b/shell/platform/android/platform_view_android_unittests.cc
@@ -22,7 +22,7 @@ TEST(AndroidPlatformView, SelectsVulkanBasedOnApiLevel) {
               AndroidRenderingAPI::kImpellerVulkan);
   } else {
     EXPECT_EQ(FlutterMain::SelectedRenderingAPI(settings),
-              AndroidRenderingAPI::kImpellerOpenGLES);
+              AndroidRenderingAPI::kSkiaOpenGLES);
   }
 }
 


### PR DESCRIPTION
Unblocks shipping Impeller on Android before GLES is ready.
