### PR TITLE
Support gtest-parallel when running Impeller unit tests

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -64,6 +64,7 @@ source_set("fml") {
     "paths.cc",
     "paths.h",
     "posix_wrappers.h",
+    "process.h",
     "raster_thread_merger.cc",
     "raster_thread_merger.h",
     "shared_thread_merger.cc",
@@ -251,6 +252,7 @@ source_set("fml") {
       "platform/win/native_library_win.cc",
       "platform/win/paths_win.cc",
       "platform/win/posix_wrappers_win.cc",
+      "platform/win/process_win.cc",
     ]
   } else {
     sources += [
@@ -260,6 +262,7 @@ source_set("fml") {
       "platform/posix/native_library_posix.cc",
       "platform/posix/paths_posix.cc",
       "platform/posix/posix_wrappers_posix.cc",
+      "platform/posix/process_posix.cc",
     ]
   }
 }

--- a/fml/platform/posix/process_posix.cc
+++ b/fml/platform/posix/process_posix.cc
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <unistd.h>
+
+namespace fml {
+
+int GetCurrentProcId() {
+  return static_cast<int>(getpid());
+}
+
+}  // namespace fml

--- a/fml/platform/win/process_win.cc
+++ b/fml/platform/win/process_win.cc
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <windows.h>
+
+namespace fml {
+
+int GetCurrentProcId() {
+  return static_cast<int>(::GetCurrentProcessId());
+}
+
+}  // namespace fml

--- a/fml/process.h
+++ b/fml/process.h
@@ -1,0 +1,14 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_PROCESS_H_
+#define FLUTTER_FML_PROCESS_H_
+
+namespace fml {
+
+int GetCurrentProcId();
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_PROCESS_H_

--- a/impeller/compiler/compiler_test.h
+++ b/impeller/compiler/compiler_test.h
@@ -36,6 +36,7 @@ class CompilerTest : public ::testing::TestWithParam<TargetPlatform> {
       const char* entry_point_name = "main") const;
 
  private:
+  std::string intermediates_path_;
   fml::UniqueFD intermediates_directory_;
 
   CompilerTest(const CompilerTest&) = delete;


### PR DESCRIPTION
ImpellerC tests that use a temporary directory will append the current process ID to the directory name to avoid collisions.

The temporary directory will also be deleted after each test case completes.

See https://github.com/flutter/flutter/issues/143379