### PR TITLE
[Impeller] use specific format for bootstrap texture.

### DIFF
--- a/impeller/base/validation.cc
+++ b/impeller/base/validation.cc
@@ -11,7 +11,7 @@
 namespace impeller {
 
 static std::atomic_int32_t sValidationLogsDisabledCount = 0;
-static bool sValidationLogsAreFatal = false;
+static std::atomic_int32_t sValidationLogsAreFatal = 0;
 
 void ImpellerValidationErrorsSetFatal(bool fatal) {
   sValidationLogsAreFatal = fatal;
@@ -23,6 +23,14 @@ ScopedValidationDisable::ScopedValidationDisable() {
 
 ScopedValidationDisable::~ScopedValidationDisable() {
   sValidationLogsDisabledCount--;
+}
+
+ScopedValidationFatal::ScopedValidationFatal() {
+  sValidationLogsAreFatal++;
+}
+
+ScopedValidationFatal::~ScopedValidationFatal() {
+  sValidationLogsAreFatal--;
 }
 
 ValidationLog::ValidationLog() = default;
@@ -43,7 +51,7 @@ void ImpellerValidationBreak(const char* message) {
   std::stringstream stream;
   stream << "Break on '" << __FUNCTION__
          << "' to inspect point of failure: " << message;
-  if (sValidationLogsAreFatal) {
+  if (sValidationLogsAreFatal > 0) {
     FML_LOG(FATAL) << stream.str();
   } else {
     FML_LOG(ERROR) << stream.str();

--- a/impeller/base/validation.h
+++ b/impeller/base/validation.h
@@ -49,6 +49,16 @@ struct ScopedValidationDisable {
   ScopedValidationDisable& operator=(const ScopedValidationDisable&) = delete;
 };
 
+struct ScopedValidationFatal {
+  ScopedValidationFatal();
+
+  ~ScopedValidationFatal();
+
+  ScopedValidationFatal(const ScopedValidationFatal&) = delete;
+
+  ScopedValidationFatal& operator=(const ScopedValidationFatal&) = delete;
+};
+
 }  // namespace impeller
 
 //------------------------------------------------------------------------------

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -671,7 +671,7 @@ void ContentContext::InitializeCommonlyUsedShadersIfNeeded() const {
   TextureDescriptor desc;
   desc.size = {1, 1};
   desc.storage_mode = StorageMode::kHostVisible;
-  desc.format = context_->GetCapabilities()->GetDefaultColorFormat();
+  desc.format = PixelFormat::kR8G8B8A8UNormInt;
   auto texture = GetContext()->GetResourceAllocator()->CreateTexture(desc);
   uint32_t color = 0;
   if (!texture->SetContents(reinterpret_cast<uint8_t*>(&color), 4u)) {


### PR DESCRIPTION
If we select a wide gamut format then 32 bits isn't enough to fill the texture.
