### PR TITLE
[Windows] Allow plugins to get views

### DIFF
--- a/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h
+++ b/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h
@@ -54,7 +54,7 @@ class PluginRegistrar {
   void AddPlugin(std::unique_ptr<Plugin> plugin);
 
  protected:
-  FlutterDesktopPluginRegistrarRef registrar() { return registrar_; }
+  FlutterDesktopPluginRegistrarRef registrar() const { return registrar_; }
 
   // Destroys all owned plugins. Subclasses should call this at the beginning of
   // their destructors to prevent the possibility of an owned plugin trying to

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
@@ -17,6 +17,7 @@ class FlutterView {
  public:
   explicit FlutterView(FlutterDesktopViewRef view) : view_(view) {}
 
+  // Destroys this reference to the view. The underlying view is not destroyed.
   virtual ~FlutterView() = default;
 
   // Prevent copying.

--- a/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
@@ -32,7 +32,7 @@ class PluginRegistrarWindows : public PluginRegistrar {
   explicit PluginRegistrarWindows(
       FlutterDesktopPluginRegistrarRef core_registrar)
       : PluginRegistrar(core_registrar) {
-    view_ = std::make_unique<FlutterView>(
+    implicit_view_ = std::make_unique<FlutterView>(
         FlutterDesktopPluginRegistrarGetView(core_registrar));
   }
 
@@ -40,14 +40,29 @@ class PluginRegistrarWindows : public PluginRegistrar {
     // Must be the first call.
     ClearPlugins();
     // Explicitly cleared to facilitate destruction order testing.
-    view_.reset();
+    implicit_view_.reset();
   }
 
   // Prevent copying.
   PluginRegistrarWindows(PluginRegistrarWindows const&) = delete;
   PluginRegistrarWindows& operator=(PluginRegistrarWindows const&) = delete;
 
-  FlutterView* GetView() { return view_.get(); }
+  // Returns the implicit view, or nullptr if there is no implicit view.
+  //
+  // See:
+  // https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/implicitView.html
+  //
+  // DEPRECATED: Use |GetViewById| instead.
+  FlutterView* GetView() { return implicit_view_.get(); }
+
+  // Returns the view with the given ID, or nullptr if the view does not exist.
+  //
+  // Destroying the shared pointer destroys the reference to the view; it does
+  // not destroy the underlying view.
+  std::shared_ptr<FlutterView> GetViewById(FlutterViewId view_id) const {
+    return std::make_shared<FlutterView>(
+        FlutterDesktopPluginRegistrarGetViewById(registrar(), view_id));
+  }
 
   // Registers |delegate| to receive WindowProc callbacks for the top-level
   // window containing this Flutter instance. Returns an ID that can be used to
@@ -115,7 +130,7 @@ class PluginRegistrarWindows : public PluginRegistrar {
   }
 
   // The associated FlutterView, if any.
-  std::unique_ptr<FlutterView> view_;
+  std::unique_ptr<FlutterView> implicit_view_;
 
   // The next ID to return from RegisterWindowProcDelegate.
   int next_window_proc_delegate_id_ = 1;

--- a/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
@@ -32,8 +32,11 @@ class PluginRegistrarWindows : public PluginRegistrar {
   explicit PluginRegistrarWindows(
       FlutterDesktopPluginRegistrarRef core_registrar)
       : PluginRegistrar(core_registrar) {
-    implicit_view_ = std::make_unique<FlutterView>(
-        FlutterDesktopPluginRegistrarGetView(core_registrar));
+    FlutterDesktopViewRef implicit_view =
+        FlutterDesktopPluginRegistrarGetView(core_registrar);
+    if (implicit_view) {
+      implicit_view_ = std::make_unique<FlutterView>(implicit_view);
+    }
   }
 
   virtual ~PluginRegistrarWindows() {
@@ -60,8 +63,13 @@ class PluginRegistrarWindows : public PluginRegistrar {
   // Destroying the shared pointer destroys the reference to the view; it does
   // not destroy the underlying view.
   std::shared_ptr<FlutterView> GetViewById(FlutterViewId view_id) const {
-    return std::make_shared<FlutterView>(
-        FlutterDesktopPluginRegistrarGetViewById(registrar(), view_id));
+    FlutterDesktopViewRef view =
+        FlutterDesktopPluginRegistrarGetViewById(registrar(), view_id);
+    if (!view) {
+      return nullptr;
+    }
+
+    return std::make_shared<FlutterView>(view);
   }
 
   // Registers |delegate| to receive WindowProc callbacks for the top-level

--- a/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
+++ b/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
@@ -7,11 +7,14 @@
 
 #include "flutter/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h"
 #include "flutter/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
 
 namespace {
+
+using ::testing::Return;
 
 // Stub implementation to validate calls to the API.
 class TestWindowsApi : public testing::StubFlutterWindowsApi {
@@ -23,6 +26,12 @@ class TestWindowsApi : public testing::StubFlutterWindowsApi {
     last_registered_delegate_ = delegate;
     last_registered_user_data_ = user_data;
   }
+
+  MOCK_METHOD(FlutterDesktopViewRef, PluginRegistrarGetView, (), (override));
+  MOCK_METHOD(FlutterDesktopViewRef,
+              PluginRegistrarGetViewById,
+              (FlutterDesktopViewId),
+              (override));
 
   void PluginRegistrarUnregisterTopLevelWindowProcDelegate(
       FlutterDesktopWindowProcCallback delegate) override {
@@ -65,25 +74,47 @@ class TestPlugin : public Plugin {
 }  // namespace
 
 TEST(PluginRegistrarWindowsTest, GetView) {
-  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
-      std::make_unique<TestWindowsApi>());
+  auto windows_api = std::make_unique<TestWindowsApi>();
+  EXPECT_CALL(*windows_api, PluginRegistrarGetView)
+      .WillOnce(Return(reinterpret_cast<FlutterDesktopViewRef>(1)));
+
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(std::move(windows_api));
   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
   PluginRegistrarWindows registrar(
       reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
+
   EXPECT_NE(registrar.GetView(), nullptr);
 }
 
 TEST(PluginRegistrarWindowsTest, GetViewById) {
-  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
-      std::make_unique<TestWindowsApi>());
+  auto windows_api = std::make_unique<TestWindowsApi>();
+  EXPECT_CALL(*windows_api, PluginRegistrarGetView)
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(*windows_api, PluginRegistrarGetViewById(123))
+      .WillOnce(Return(reinterpret_cast<FlutterDesktopViewRef>(1)));
+  EXPECT_CALL(*windows_api, PluginRegistrarGetViewById(456))
+      .WillOnce(Return(nullptr));
+
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(std::move(windows_api));
   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
   PluginRegistrarWindows registrar(
       reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
-  EXPECT_NE(registrar.GetViewById(123), nullptr);
+
+  EXPECT_EQ(registrar.GetView(), nullptr);
+  EXPECT_NE(registrar.GetViewById(123).get(), nullptr);
+  EXPECT_EQ(registrar.GetViewById(456).get(), nullptr);
 }
 
 // Tests that the registrar runs plugin destructors before its own teardown.
 TEST(PluginRegistrarWindowsTest, PluginDestroyedBeforeRegistrar) {
+  auto windows_api = std::make_unique<TestWindowsApi>();
+  EXPECT_CALL(*windows_api, PluginRegistrarGetView)
+      .WillRepeatedly(Return(reinterpret_cast<FlutterDesktopViewRef>(1)));
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(std::move(windows_api));
+  auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
+  PluginRegistrarWindows registrar(
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
+
   auto dummy_registrar_handle =
       reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1);
   bool registrar_valid_at_destruction = false;
@@ -98,8 +129,9 @@ TEST(PluginRegistrarWindowsTest, PluginDestroyedBeforeRegistrar) {
 }
 
 TEST(PluginRegistrarWindowsTest, RegisterUnregister) {
-  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
-      std::make_unique<TestWindowsApi>());
+  auto windows_api = std::make_unique<TestWindowsApi>();
+  EXPECT_CALL(*windows_api, PluginRegistrarGetView).WillOnce(Return(nullptr));
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(std::move(windows_api));
   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
   PluginRegistrarWindows registrar(
       reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
@@ -127,8 +159,9 @@ TEST(PluginRegistrarWindowsTest, RegisterUnregister) {
 }
 
 TEST(PluginRegistrarWindowsTest, CallsRegisteredDelegates) {
-  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
-      std::make_unique<TestWindowsApi>());
+  auto windows_api = std::make_unique<TestWindowsApi>();
+  EXPECT_CALL(*windows_api, PluginRegistrarGetView).WillOnce(Return(nullptr));
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(std::move(windows_api));
   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
   PluginRegistrarWindows registrar(
       reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
@@ -163,8 +196,9 @@ TEST(PluginRegistrarWindowsTest, CallsRegisteredDelegates) {
 }
 
 TEST(PluginRegistrarWindowsTest, StopsOnceHandled) {
-  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
-      std::make_unique<TestWindowsApi>());
+  auto windows_api = std::make_unique<TestWindowsApi>();
+  EXPECT_CALL(*windows_api, PluginRegistrarGetView).WillOnce(Return(nullptr));
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(std::move(windows_api));
   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
   PluginRegistrarWindows registrar(
       reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));

--- a/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
+++ b/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
@@ -73,6 +73,15 @@ TEST(PluginRegistrarWindowsTest, GetView) {
   EXPECT_NE(registrar.GetView(), nullptr);
 }
 
+TEST(PluginRegistrarWindowsTest, GetViewById) {
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
+      std::make_unique<TestWindowsApi>());
+  auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
+  PluginRegistrarWindows registrar(
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
+  EXPECT_NE(registrar.GetViewById(123), nullptr);
+}
+
 // Tests that the registrar runs plugin destructors before its own teardown.
 TEST(PluginRegistrarWindowsTest, PluginDestroyedBeforeRegistrar) {
   auto dummy_registrar_handle =

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -194,15 +194,19 @@ void FlutterDesktopEngineRegisterPlatformViewType(
 
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(
     FlutterDesktopPluginRegistrarRef controller) {
-  // The stub ignores this, so just return an arbitrary non-zero value.
-  return reinterpret_cast<FlutterDesktopViewRef>(1);
+  if (s_stub_implementation) {
+    return s_stub_implementation->PluginRegistrarGetView();
+  }
+  return nullptr;
 }
 
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetViewById(
     FlutterDesktopPluginRegistrarRef controller,
     FlutterDesktopViewId view_id) {
-  // The stub ignores this, so just return an arbitrary non-zero value.
-  return reinterpret_cast<FlutterDesktopViewRef>(1);
+  if (s_stub_implementation) {
+    return s_stub_implementation->PluginRegistrarGetViewById(view_id);
+  }
+  return nullptr;
 }
 
 void FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate(

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -198,6 +198,13 @@ FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(
   return reinterpret_cast<FlutterDesktopViewRef>(1);
 }
 
+FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetViewById(
+    FlutterDesktopPluginRegistrarRef controller,
+    FlutterDesktopViewId view_id) {
+  // The stub ignores this, so just return an arbitrary non-zero value.
+  return reinterpret_cast<FlutterDesktopViewRef>(1);
+}
+
 void FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopWindowProcCallback delegate,

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
@@ -86,6 +86,15 @@ class StubFlutterWindowsApi {
     return reinterpret_cast<IDXGIAdapter*>(2);
   }
 
+  // Called for FlutterDesktopPluginRegistrarGetView.
+  virtual FlutterDesktopViewRef PluginRegistrarGetView() { return nullptr; }
+
+  // Called for FlutterDesktopPluginRegistrarGetViewById.
+  virtual FlutterDesktopViewRef PluginRegistrarGetViewById(
+      FlutterDesktopViewId view_id) {
+    return nullptr;
+  }
+
   // Called for FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate.
   virtual void PluginRegistrarRegisterTopLevelWindowProcDelegate(
       FlutterDesktopWindowProcCallback delegate,

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -261,10 +261,13 @@ void FlutterDesktopEngineRegisterPlatformViewType(
 
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(
     FlutterDesktopPluginRegistrarRef registrar) {
-  // TODO(loicsharma): Add |FlutterDesktopPluginRegistrarGetViewById| and
-  // deprecate this API as it makes single view assumptions.
-  // https://github.com/flutter/flutter/issues/143767
   return HandleForView(registrar->engine->view(flutter::kImplicitViewId));
+}
+
+FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetViewById(
+    FlutterDesktopPluginRegistrarRef registrar,
+    FlutterDesktopViewId view_id) {
+  return HandleForView(registrar->engine->view(view_id));
 }
 
 void FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate(

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -333,6 +333,64 @@ TEST_F(WindowsTest, GetGraphicsAdapter) {
   ASSERT_TRUE(SUCCEEDED(dxgi_adapter->GetDesc(&desc)));
 }
 
+// Implicit view has the implicit view ID.
+TEST_F(WindowsTest, PluginRegistrarGetImplicitView) {
+  auto& context = GetContext();
+  WindowsConfigBuilder builder(context);
+  ViewControllerPtr controller{builder.Run()};
+  ASSERT_NE(controller, nullptr);
+
+  FlutterDesktopEngineRef engine =
+      FlutterDesktopViewControllerGetEngine(controller.get());
+  FlutterDesktopPluginRegistrarRef registrar =
+      FlutterDesktopEngineGetPluginRegistrar(engine, "foo_bar");
+  FlutterDesktopViewRef implicit_view =
+      FlutterDesktopPluginRegistrarGetView(registrar);
+
+  ASSERT_NE(implicit_view, nullptr);
+}
+
+TEST_F(WindowsTest, PluginRegistrarGetView) {
+  auto& context = GetContext();
+  WindowsConfigBuilder builder(context);
+  ViewControllerPtr controller{builder.Run()};
+  ASSERT_NE(controller, nullptr);
+
+  FlutterDesktopEngineRef engine =
+      FlutterDesktopViewControllerGetEngine(controller.get());
+  FlutterDesktopPluginRegistrarRef registrar =
+      FlutterDesktopEngineGetPluginRegistrar(engine, "foo_bar");
+
+  FlutterDesktopViewId view_id =
+      FlutterDesktopViewControllerGetViewId(controller.get());
+  FlutterDesktopViewRef view =
+      FlutterDesktopPluginRegistrarGetViewById(registrar, view_id);
+
+  FlutterDesktopViewRef view_123 = FlutterDesktopPluginRegistrarGetViewById(
+      registrar, static_cast<FlutterDesktopViewId>(123));
+
+  ASSERT_NE(view, nullptr);
+  ASSERT_EQ(view_123, nullptr);
+}
+
+TEST_F(WindowsTest, PluginRegistrarGetViewHeadless) {
+  auto& context = GetContext();
+  WindowsConfigBuilder builder(context);
+  EnginePtr engine{builder.RunHeadless()};
+  ASSERT_NE(engine, nullptr);
+
+  FlutterDesktopPluginRegistrarRef registrar =
+      FlutterDesktopEngineGetPluginRegistrar(engine.get(), "foo_bar");
+
+  FlutterDesktopViewRef implicit_view =
+      FlutterDesktopPluginRegistrarGetView(registrar);
+  FlutterDesktopViewRef view_123 = FlutterDesktopPluginRegistrarGetViewById(
+      registrar, static_cast<FlutterDesktopViewId>(123));
+
+  ASSERT_EQ(implicit_view, nullptr);
+  ASSERT_EQ(view_123, nullptr);
+}
+
 // Verify the app does not crash if EGL initializes successfully but
 // the rendering surface cannot be created.
 TEST_F(WindowsTest, SurfaceOptional) {

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -249,9 +249,21 @@ typedef bool (*FlutterDesktopWindowProcCallback)(HWND /* hwnd */,
                                                  void* /* user data */,
                                                  LRESULT* result);
 
-// Returns the view associated with this registrar's engine instance.
+// Returns the implicit view associated with this registrar's engine instance,
+// or null if there is no implicit view.
+//
+// See:
+// https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/implicitView.html
+//
+// DEPRECATED: Use |FlutterDesktopPluginRegistrarGetViewById| instead.
 FLUTTER_EXPORT FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(
     FlutterDesktopPluginRegistrarRef registrar);
+
+// Returns the view associated with the registrar's engine instance, or null if
+// the view does not exist.
+FLUTTER_EXPORT FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetViewById(
+    FlutterDesktopPluginRegistrarRef registrar,
+    FlutterDesktopViewId view_id);
 
 FLUTTER_EXPORT void
 FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate(


### PR DESCRIPTION
Allow Flutter Windows plugins to get views by their ID.

Design doc: https://flutter.dev/go/desktop-multi-view-runner-apis

Part of https://github.com/flutter/flutter/issues/143767
Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
