### PR TITLE
[Impeller] Fix a buffer overrun in ImpellerC reflector resource offsets

### DIFF
--- a/impeller/compiler/reflector.h
+++ b/impeller/compiler/reflector.h
@@ -225,6 +225,9 @@ class Reflector {
   std::vector<size_t> ComputeOffsets(
       const spirv_cross::SmallVector<spirv_cross::Resource>& resources) const;
 
+  std::optional<size_t> GetOffset(spirv_cross::ID id,
+                                  const std::vector<size_t>& offsets) const;
+
   std::optional<nlohmann::json::object_t> ReflectType(
       const spirv_cross::TypeID& type_id) const;
 


### PR DESCRIPTION
This issue can be reproduced by running the CompilerTest.MustFailDueToMultipleLocationPerStructMember test with ASAN

(The Impeller tests are not yet running with ASAN on CI)