### PR TITLE
Adds githooks that reminds to run `gclient sync -D`

### DIFF
--- a/tools/githooks/lib/githooks.dart
+++ b/tools/githooks/lib/githooks.dart
@@ -7,7 +7,10 @@ import 'dart:io' as io;
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 
+import 'src/post_checkout_command.dart';
+import 'src/post_merge_command.dart';
 import 'src/pre_push_command.dart';
+import 'src/pre_rebase_command.dart';
 
 /// Runs the githooks
 Future<int> run(List<String> args) async {
@@ -15,7 +18,10 @@ Future<int> run(List<String> args) async {
     'githooks',
     'Githooks implementation for the flutter/engine repo.',
   )
-  ..addCommand(PrePushCommand());
+  ..addCommand(PostCheckoutCommand())
+  ..addCommand(PostMergeCommand())
+  ..addCommand(PrePushCommand())
+  ..addCommand(PreRebaseCommand());
 
   // Add top-level arguments.
   runner.argParser

--- a/tools/githooks/lib/src/messages.dart
+++ b/tools/githooks/lib/src/messages.dart
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+const String _redBoldUnderline = '\x1B[31;1;4m';
+const String _reset = '\x1B[0m';
+
+/// Prints a reminder to stdout to run `gclient sync -D`. Uses colors when
+/// stdout supports ANSI escape codes.
+void printGclientSyncReminder(String command) {
+  final String prefix = io.stdout.supportsAnsiEscapes ? _redBoldUnderline : '';
+  final String postfix = io.stdout.supportsAnsiEscapes ? _reset : '';
+  io.stderr.writeln('$command: The engine source tree has been updated.');
+  io.stderr.writeln(
+    '\n${prefix}You man need to run "gclient sync -D"$postfix\n',
+  );
+}

--- a/tools/githooks/lib/src/post_checkout_command.dart
+++ b/tools/githooks/lib/src/post_checkout_command.dart
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+
+import 'messages.dart';
+
+/// The command that implements the post-checkout githook
+class PostCheckoutCommand extends Command<bool> {
+  @override
+  final String name = 'post-checkout';
+
+  @override
+  final String description = 'Checks that run after the worktree is updated';
+
+  @override
+  Future<bool> run() async {
+    printGclientSyncReminder(name);
+    return true;
+  }
+}

--- a/tools/githooks/lib/src/post_merge_command.dart
+++ b/tools/githooks/lib/src/post_merge_command.dart
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+
+import 'messages.dart';
+
+/// The command that implements the post-merge githook
+class PostMergeCommand extends Command<bool> {
+  @override
+  final String name = 'post-merge';
+
+  @override
+  final String description = 'Checks to run after a "git merge"';
+
+  @override
+  Future<bool> run() async {
+    printGclientSyncReminder(name);
+    return true;
+  }
+}

--- a/tools/githooks/lib/src/pre_rebase_command.dart
+++ b/tools/githooks/lib/src/pre_rebase_command.dart
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+
+import 'messages.dart';
+
+/// The command that implements the pre-rebase githook
+class PreRebaseCommand extends Command<bool> {
+  @override
+  final String name = 'pre-rebase';
+
+  @override
+  final String description = 'Checks to run before a "git rebase"';
+
+  @override
+  Future<bool> run() async {
+    printGclientSyncReminder(name);
+    // Returning false here will block the rebase.
+    return true;
+  }
+}

--- a/tools/githooks/post-checkout
+++ b/tools/githooks/post-checkout
@@ -4,18 +4,16 @@
 # found in the LICENSE file.
 
 '''
-Runs the pre-push githooks.
+Runs the post-checkout githooks.
 '''
 
 import os
 import subprocess
 import sys
 
-
 SRC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 FLUTTER_DIR = os.path.join(SRC_ROOT, 'flutter')
 DART_BIN = os.path.join(SRC_ROOT, 'third_party', 'dart', 'tools', 'sdks', 'dart-sdk', 'bin')
-ENABLE_CLANG_TIDY = os.environ.get('PRE_PUSH_CLANG_TIDY')
 
 def Main(argv):
   githook_args = [
@@ -23,17 +21,12 @@ def Main(argv):
     FLUTTER_DIR,
   ]
 
-  if ENABLE_CLANG_TIDY is not None:
-    githook_args += [
-      '--enable-clang-tidy',
-    ]
-
   result = subprocess.run([
     os.path.join(DART_BIN, 'dart'),
     '--disable-dart-dev',
     os.path.join(FLUTTER_DIR, 'tools', 'githooks', 'bin', 'main.dart'),
   ] + githook_args + [
-    'pre-push',
+    'post-checkout',
   ] + argv[1:], cwd=SRC_ROOT)
   return result.returncode
 

--- a/tools/githooks/post-merge
+++ b/tools/githooks/post-merge
@@ -4,18 +4,16 @@
 # found in the LICENSE file.
 
 '''
-Runs the pre-push githooks.
+Runs the post-merge githooks.
 '''
 
 import os
 import subprocess
 import sys
 
-
 SRC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 FLUTTER_DIR = os.path.join(SRC_ROOT, 'flutter')
 DART_BIN = os.path.join(SRC_ROOT, 'third_party', 'dart', 'tools', 'sdks', 'dart-sdk', 'bin')
-ENABLE_CLANG_TIDY = os.environ.get('PRE_PUSH_CLANG_TIDY')
 
 def Main(argv):
   githook_args = [
@@ -23,17 +21,12 @@ def Main(argv):
     FLUTTER_DIR,
   ]
 
-  if ENABLE_CLANG_TIDY is not None:
-    githook_args += [
-      '--enable-clang-tidy',
-    ]
-
   result = subprocess.run([
     os.path.join(DART_BIN, 'dart'),
     '--disable-dart-dev',
     os.path.join(FLUTTER_DIR, 'tools', 'githooks', 'bin', 'main.dart'),
   ] + githook_args + [
-    'pre-push',
+    'post-merge',
   ] + argv[1:], cwd=SRC_ROOT)
   return result.returncode
 

--- a/tools/githooks/pre-rebase
+++ b/tools/githooks/pre-rebase
@@ -4,18 +4,16 @@
 # found in the LICENSE file.
 
 '''
-Runs the pre-push githooks.
+Runs the pre-rebase githooks.
 '''
 
 import os
 import subprocess
 import sys
 
-
 SRC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 FLUTTER_DIR = os.path.join(SRC_ROOT, 'flutter')
 DART_BIN = os.path.join(SRC_ROOT, 'third_party', 'dart', 'tools', 'sdks', 'dart-sdk', 'bin')
-ENABLE_CLANG_TIDY = os.environ.get('PRE_PUSH_CLANG_TIDY')
 
 def Main(argv):
   githook_args = [
@@ -23,17 +21,12 @@ def Main(argv):
     FLUTTER_DIR,
   ]
 
-  if ENABLE_CLANG_TIDY is not None:
-    githook_args += [
-      '--enable-clang-tidy',
-    ]
-
   result = subprocess.run([
     os.path.join(DART_BIN, 'dart'),
     '--disable-dart-dev',
     os.path.join(FLUTTER_DIR, 'tools', 'githooks', 'bin', 'main.dart'),
   ] + githook_args + [
-    'pre-push',
+    'pre-rebase',
   ] + argv[1:], cwd=SRC_ROOT)
   return result.returncode
 

--- a/tools/githooks/test/githooks_test.dart
+++ b/tools/githooks/test/githooks_test.dart
@@ -66,4 +66,52 @@ void main() {
     }
     expect(result, equals(1));
   });
+
+  test('post-merge runs successfully', () async {
+    int? result;
+    try {
+      final io.Directory flutterPath = io.File(io.Platform.script.path)
+        .parent.parent.parent;
+      result = await run(<String>[
+        'post-merge',
+        '--flutter',
+        flutterPath.path,
+      ]);
+    } catch (e, st) {
+      fail('Unexpected exception: $e\n$st');
+    }
+    expect(result, equals(0));
+  });
+
+  test('pre-rebase runs successfully', () async {
+    int? result;
+    try {
+      final io.Directory flutterPath = io.File(io.Platform.script.path)
+        .parent.parent.parent;
+      result = await run(<String>[
+        'pre-rebase',
+        '--flutter',
+        flutterPath.path,
+      ]);
+    } catch (e, st) {
+      fail('Unexpected exception: $e\n$st');
+    }
+    expect(result, equals(0));
+  });
+
+  test('post-checkout runs successfully', () async {
+    int? result;
+    try {
+      final io.Directory flutterPath = io.File(io.Platform.script.path)
+        .parent.parent.parent;
+      result = await run(<String>[
+        'post-checkout',
+        '--flutter',
+        flutterPath.path,
+      ]);
+    } catch (e, st) {
+      fail('Unexpected exception: $e\n$st');
+    }
+    expect(result, equals(0));
+  });
 }


### PR DESCRIPTION
This PR adds githooks for `post-checkout`, `post-merge`, `pre-rebase` that remind to run `gclient sync -D`. This is probably going to print the reminder too much. The `pre-rebase` hook runs before a `git pull --rebase` that is actually going to update something, but the other hooks may be needed to cover other workflows. The printed message will also include the hook that it comes from, so we can remove the message from hooks where it doesn't make sense.

<img width="670" alt="Screenshot 2024-03-04 at 18 36 15" src="https://github.com/flutter/engine/assets/6343103/4d3e4661-035d-4ed6-8ed6-2a05b372bf65">
