### PR TITLE
Reverts the logic for calculating the TextField input text cursor position when inputting Korean characters (3.13.9)

### DIFF
--- a/shell/platform/common/text_input_model.cc
+++ b/shell/platform/common/text_input_model.cc
@@ -79,8 +79,7 @@ void TextInputModel::UpdateComposingText(const std::u16string& text,
       composing_range_.collapsed() ? selection_ : composing_range_;
   text_.replace(rangeToDelete.start(), rangeToDelete.length(), text);
   composing_range_.set_end(composing_range_.start() + text.length());
-  selection_ = TextRange(selection.start() + composing_range_.start(),
-                         selection.extent() + composing_range_.start());
+  selection_ = TextRange(composing_range_.end());
 }
 
 void TextInputModel::UpdateComposingText(const std::u16string& text) {

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -197,6 +197,7 @@ void TextInputPlugin::ComposeChangeHook(const std::u16string& text,
   std::string text_before_change = active_model_->GetText();
   TextRange composing_before_change = active_model_->composing_range();
   active_model_->AddText(text);
+  cursor_pos += active_model_->composing_range().extent();
   active_model_->UpdateComposingText(text, TextRange(cursor_pos, cursor_pos));
   std::string text_after_change = active_model_->GetText();
   if (enable_delta_model) {


### PR DESCRIPTION
Reverts the logic for calculating the TextField input text cursor position when inputting Korean characters (3.13.9)

- Issue occurred since 3.16.x
- https://github.com/flutter/flutter/issues/140739


List which issues are fixed by this PR. You must list at least one issue.
* When entering Korean text, the input cursor must be located on the right side of the input text.
However, when entering Korean text, the input cursor is located to the left of the entered character.

Recorded Video about the issue:
* Before (origin/main branch)
    https://github.com/flutter/engine/assets/121159478/116c849e-d149-46ce-b3e4-eadcf7239b76

* Modified (origin/text_cursor_position_incorrect_windows)
    https://github.com/flutter/engine/assets/121159478/61852bca-da6e-4864-89e1-7e787d67355b

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
