### PR TITLE
Revert text cursor position calculation windows

### DIFF
--- a/shell/platform/common/text_input_model.cc
+++ b/shell/platform/common/text_input_model.cc
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "flutter/fml/string_conversion.h"
+#include "flutter/fml/build_config.h"
 
 namespace flutter {
 
@@ -79,8 +80,12 @@ void TextInputModel::UpdateComposingText(const std::u16string& text,
       composing_range_.collapsed() ? selection_ : composing_range_;
   text_.replace(rangeToDelete.start(), rangeToDelete.length(), text);
   composing_range_.set_end(composing_range_.start() + text.length());
+#if FML_OS_WIN
+  selection_ = TextRange(composing_range_.end());
+#else   // FML_OS_WIN
   selection_ = TextRange(selection.start() + composing_range_.start(),
                          selection.extent() + composing_range_.start());
+#endif  // FML_OS_WIN
 }
 
 void TextInputModel::UpdateComposingText(const std::u16string& text) {

--- a/shell/platform/common/text_input_model.cc
+++ b/shell/platform/common/text_input_model.cc
@@ -7,8 +7,8 @@
 #include <algorithm>
 #include <string>
 
-#include "flutter/fml/string_conversion.h"
 #include "flutter/fml/build_config.h"
+#include "flutter/fml/string_conversion.h"
 
 namespace flutter {
 

--- a/shell/platform/common/text_input_model.cc
+++ b/shell/platform/common/text_input_model.cc
@@ -84,14 +84,14 @@ void TextInputModel::UpdateComposingText(const std::u16string& text,
   selection_ = TextRange(selection.start() + composing_range_.start(),
                          selection.extent() + composing_range_.start());
 
-  bool koreanIncluded = false;
+  bool korean_included = false;
   std::u16string composing_texts = text_.substr(composing_range_.start(), text.length());
   if (composing_texts.length() > 0) {
-    const std::regex _korRegexp("^[ㄱ-ㆎ|가-힣]+$");
+    const std::regex kor_regex("^[ㄱ-ㆎ|가-힣]+$");
     std::string u8string = fml::Utf16ToUtf8(composing_texts);
-    koreanIncluded = std::regex_match(u8string, _korRegexp);
+    korean_included = std::regex_match(u8string, kor_regex);
   }
-  if (koreanIncluded) {
+  if (korean_included) {
     selection_ = TextRange(selection.extent() + composing_range_.end());
   }
 }

--- a/shell/platform/common/text_input_model.cc
+++ b/shell/platform/common/text_input_model.cc
@@ -85,9 +85,7 @@ void TextInputModel::UpdateComposingText(const std::u16string& text,
                          selection.extent() + composing_range_.start());
 
   bool korean_included = false;
-  std::u16string composing_texts =
-      text_.substr(composing_range_.start(), text.length());
-  if (composing_texts.length() > 0) {
+  if (text.length() > 0) {
     std::wregex kor_regex(L"[ㄱ-ㅎㅏ-ㅣ가-힣]");
     korean_included = std::regex_match(text.cbegin(), text.cend(), kor_regex);
   }

--- a/shell/platform/common/text_input_model.cc
+++ b/shell/platform/common/text_input_model.cc
@@ -85,7 +85,8 @@ void TextInputModel::UpdateComposingText(const std::u16string& text,
                          selection.extent() + composing_range_.start());
 
   bool korean_included = false;
-  std::u16string composing_texts = text_.substr(composing_range_.start(), text.length());
+  std::u16string composing_texts =
+      text_.substr(composing_range_.start(), text.length());
   if (composing_texts.length() > 0) {
     const std::regex kor_regex("^[ㄱ-ㆎ|가-힣]+$");
     std::string u8string = fml::Utf16ToUtf8(composing_texts);

--- a/shell/platform/common/text_input_model.cc
+++ b/shell/platform/common/text_input_model.cc
@@ -88,9 +88,8 @@ void TextInputModel::UpdateComposingText(const std::u16string& text,
   std::u16string composing_texts =
       text_.substr(composing_range_.start(), text.length());
   if (composing_texts.length() > 0) {
-    const std::regex kor_regex("^[ㄱ-ㆎ|가-힣]+$");
-    std::string u8string = fml::Utf16ToUtf8(composing_texts);
-    korean_included = std::regex_match(u8string, kor_regex);
+    std::wregex kor_regex(L"[ㄱ-ㅎㅏ-ㅣ가-힣]");
+    korean_included = std::regex_match(text.cbegin(), text.cend(), kor_regex);
   }
   if (korean_included) {
     selection_ = TextRange(selection.extent() + composing_range_.end());

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -197,6 +197,7 @@ void TextInputPlugin::ComposeChangeHook(const std::u16string& text,
   std::string text_before_change = active_model_->GetText();
   TextRange composing_before_change = active_model_->composing_range();
   active_model_->AddText(text);
+  cursor_pos += active_model_->composing_range().extent();
   active_model_->UpdateComposingText(text, TextRange(cursor_pos, cursor_pos));
   std::string text_after_change = active_model_->GetText();
   if (enable_delta_model) {

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -197,9 +197,7 @@ void TextInputPlugin::ComposeChangeHook(const std::u16string& text,
   std::string text_before_change = active_model_->GetText();
   TextRange composing_before_change = active_model_->composing_range();
   active_model_->AddText(text);
-  cursor_pos += active_model_->composing_range().extent();
   active_model_->UpdateComposingText(text, TextRange(cursor_pos, cursor_pos));
-  std::string text_after_change = active_model_->GetText();
   if (enable_delta_model) {
     TextEditingDelta delta = TextEditingDelta(
         fml::Utf8ToUtf16(text_before_change), composing_before_change, text);


### PR DESCRIPTION
Reverts the logic for calculating the TextField input text cursor position when inputting Korean characters (3.13.9)
- Issue occurred since 3.16.x
- https://github.com/flutter/flutter/issues/140739

List which issues are fixed by this PR. You must list at least one issue.
- When entering Korean text, the input cursor must be located on the right side of the input text.
However, when entering Korean text, the input cursor is located to the left of the entered character.

Recorded Video about the issue:

- Before (origin/main):
https://github.com/flutter/engine/assets/121159478/25d86b34-677c-4bc4-bc5e-b0179f36484c

- Modified (origin/revert_text_cursor_position_calculation_windows)
https://github.com/flutter/engine/assets/121159478/7a53799f-7c1d-404b-be33-d4568b9a001c


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.