### PR TITLE
Use Instrumentation.waitForIdleSync() after rotation requests.

### DIFF
--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformTextureUiTests.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformTextureUiTests.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import androidx.annotation.NonNull;
 import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import dev.flutter.scenarios.PlatformViewsActivity;
@@ -34,6 +35,7 @@ public class PlatformTextureUiTests {
 
   @Before
   public void setUp() {
+    instrumentation = InstrumentationRegistry.getInstrumentation();
     intent = new Intent(Intent.ACTION_MAIN);
     // Render a texture.
     intent.putExtra("use_android_view", false);

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformTextureUiTests.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformTextureUiTests.java
@@ -4,6 +4,7 @@
 
 package dev.flutter.scenariosui;
 
+import android.app.Instrumentation;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import androidx.annotation.NonNull;
@@ -19,7 +20,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class PlatformTextureUiTests {
-  Intent intent;
+  private Instrumentation instrumentation;
+  private Intent intent;
 
   @Rule @NonNull
   public ActivityTestRule<PlatformViewsActivity> activityRule =
@@ -99,6 +101,7 @@ public class PlatformTextureUiTests {
     intent.putExtra("scenario_name", "platform_view_rotate");
     PlatformViewsActivity activity = activityRule.launchActivity(intent);
     activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+    instrumentation.waitForIdleSync();
     ScreenshotUtil.capture(activity, goldName("testPlatformViewRotate"));
   }
 

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewUiTests.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewUiTests.java
@@ -4,10 +4,12 @@
 
 package dev.flutter.scenariosui;
 
+import android.app.Instrumentation;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import androidx.annotation.NonNull;
 import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import dev.flutter.scenarios.PlatformViewsActivity;
@@ -19,7 +21,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class PlatformViewUiTests {
-  Intent intent;
+  private Instrumentation instrumentation;
+  private Intent intent;
 
   @Rule @NonNull
   public ActivityTestRule<PlatformViewsActivity> activityRule =
@@ -32,6 +35,7 @@ public class PlatformViewUiTests {
 
   @Before
   public void setUp() {
+    instrumentation = InstrumentationRegistry.getInstrumentation();
     intent = new Intent(Intent.ACTION_MAIN);
     // Render a native android view.
     intent.putExtra("use_android_view", true);
@@ -99,6 +103,7 @@ public class PlatformViewUiTests {
     intent.putExtra("scenario_name", "platform_view_rotate");
     PlatformViewsActivity activity = activityRule.launchActivity(intent);
     activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+    instrumentation.waitForIdleSync();
     ScreenshotUtil.capture(activity, goldName("testPlatformViewRotate"));
   }
 

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithSurfaceViewUiTest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithSurfaceViewUiTest.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import androidx.annotation.NonNull;
 import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import dev.flutter.scenarios.PlatformViewsActivity;
@@ -35,6 +36,7 @@ public class PlatformViewWithSurfaceViewUiTest {
 
   @Before
   public void setUp() {
+    instrumentation = InstrumentationRegistry.getInstrumentation();
     intent = new Intent(Intent.ACTION_MAIN);
     // Render a texture.
     intent.putExtra("use_android_view", false);

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithSurfaceViewUiTest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithSurfaceViewUiTest.java
@@ -4,6 +4,7 @@
 
 package dev.flutter.scenariosui;
 
+import android.app.Instrumentation;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import androidx.annotation.NonNull;
@@ -20,7 +21,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class PlatformViewWithSurfaceViewUiTest {
-  Intent intent;
+  private Instrumentation instrumentation;
+  private Intent intent;
 
   @Rule @NonNull
   public ActivityTestRule<PlatformViewsActivity> activityRule =
@@ -100,6 +102,7 @@ public class PlatformViewWithSurfaceViewUiTest {
     intent.putExtra("scenario_name", "platform_view_rotate");
     PlatformViewsActivity activity = activityRule.launchActivity(intent);
     activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+    instrumentation.waitForIdleSync();
     ScreenshotUtil.capture(activity, goldName("testPlatformViewRotate"));
   }
 

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithTextureViewUiTest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/PlatformViewWithTextureViewUiTest.java
@@ -4,10 +4,12 @@
 
 package dev.flutter.scenariosui;
 
+import android.app.Instrumentation;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import androidx.annotation.NonNull;
 import androidx.test.filters.LargeTest;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import dev.flutter.scenarios.PlatformViewsActivity;
@@ -19,7 +21,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class PlatformViewWithTextureViewUiTest {
-  Intent intent;
+  private Instrumentation instrumentation;
+  private Intent intent;
 
   @Rule @NonNull
   public ActivityTestRule<PlatformViewsActivity> activityRule =
@@ -32,6 +35,7 @@ public class PlatformViewWithTextureViewUiTest {
 
   @Before
   public void setUp() {
+    instrumentation = InstrumentationRegistry.getInstrumentation();
     intent = new Intent(Intent.ACTION_MAIN);
     intent.putExtra("view_type", PlatformViewsActivity.TEXTURE_VIEW_PV);
   }
@@ -97,6 +101,7 @@ public class PlatformViewWithTextureViewUiTest {
     intent.putExtra("scenario_name", "platform_view_rotate");
     PlatformViewsActivity activity = activityRule.launchActivity(intent);
     activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+    instrumentation.waitForIdleSync();
     ScreenshotUtil.capture(activity, goldName("testPlatformViewRotate"));
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/144553.

Looking roughly at:

- <https://stackoverflow.com/questions/42482522/test-recreating-android-activity-using-instrumentation-and-junit4>
- <https://stackoverflow.com/questions/10982370/instrumentation-test-for-android-how-to-receive-new-activity-after-orientation>

... and given the fact it's only the rotation tests that seem especially flaky, let's give it a shot?

/cc @reidbaker @johnmccutchan if you have other advice.
