### PR TITLE
[Impeller] Fix the clip replay mechanism.

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -721,12 +721,7 @@ bool EntityPass::RenderElement(Entity& element_entity,
     return false;
   }
 
-  // If the pass context returns a backdrop texture, we need to draw it to the
-  // current pass. We do this because it's faster and takes significantly less
-  // memory than storing/loading large MSAA textures. Also, it's not possible to
-  // blit the non-MSAA resolve texture of the previous pass to MSAA textures
-  // (let alone a transient one).
-  if (result.backdrop_texture) {
+  if (result.just_created) {
     // Restore any clips that were recorded before the backdrop filter was
     // applied.
     auto& replay_entities = clip_replay_->GetReplayEntities();
@@ -735,7 +730,14 @@ bool EntityPass::RenderElement(Entity& element_entity,
         VALIDATION_LOG << "Failed to render entity for clip restore.";
       }
     }
+  }
 
+  // If the pass context returns a backdrop texture, we need to draw it to the
+  // current pass. We do this because it's faster and takes significantly less
+  // memory than storing/loading large MSAA textures. Also, it's not possible to
+  // blit the non-MSAA resolve texture of the previous pass to MSAA textures
+  // (let alone a transient one).
+  if (result.backdrop_texture) {
     auto size_rect = Rect::MakeSize(result.pass->GetRenderTargetSize());
     auto msaa_backdrop_contents = TextureContents::MakeRect(size_rect);
     msaa_backdrop_contents->SetStencilEnabled(false);

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -187,6 +187,7 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
       " Count=" + std::to_string(pass_count_));
 
   result.pass = pass_;
+  result.just_created = true;
 
   if (!renderer_.GetContext()->GetCapabilities()->SupportsReadFromResolve() &&
       result.backdrop_texture ==

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -17,6 +17,7 @@ namespace impeller {
 class InlinePassContext {
  public:
   struct RenderPassResult {
+    bool just_created = false;
     std::shared_ptr<RenderPass> pass;
     std::shared_ptr<Texture> backdrop_texture;
   };


### PR DESCRIPTION
Clips were being ignored whenever MSAA backdrop restores were being done by attachment load.

Unblocks the StC flag flip: https://github.com/flutter/engine/pull/50856

Note that the new Gaussian blur does not currently work on GLES, and it's expected that this will cause backdrop blurs to cut a transparent hole wherever the backdrop blur should render.

This happens because the gaussian blur renders as fully transparent black (among other things, it uses arrays of structs for the uniforms, which is unsupported in GLES). Then, the backdrop blur renders the blur's result with the `Source` blend mode, cutting out a hole in this case.