### PR TITLE
Skip configuration dependency if unit tests are disabled

### DIFF
--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -51,7 +51,7 @@ source_set("testing") {
 
   sources = [ "run_all_unittests.cc" ]
 
-  if (is_linux) {
+  if (enable_unittests && is_linux) {
     # So that we can call gtk_init in main().
     configs += [ "//flutter/shell/platform/linux/config:gtk" ]
   }


### PR DESCRIPTION
## Description

This makes the GTK dependency only active if unit tests are enabled, so that it won't create an undesired dependency on embedded platforms.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/144421
