### PR TITLE
[Impeller] Increment depth when applying blur style clip in the Gaussian blur.

### DIFF
--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -231,6 +231,7 @@ Entity ApplyBlurStyle(FilterContents::BlurStyle blur_style,
 
   auto shared_blur_entity = std::make_shared<Entity>(std::move(blur_entity));
   shared_blur_entity->SetNewClipDepth(entity.GetNewClipDepth());
+  shared_blur_entity->SetClipDepth(entity.GetClipDepth() + 1);
   auto clipper = std::make_unique<ClipContents>();
   clipper->SetClipOperation(clip_operation);
   clipper->SetGeometry(geometry);


### PR DESCRIPTION
In the old clip stack, clip depth needs to increments/decrement when appending a clip to the current clip stack. Without this change, the applied clips happen to appear inverted.

This happens to also be fixed by enabling StC because the new clip system's depth works differently and doesn't need the increment: https://github.com/flutter/engine/pull/50856