### PR TITLE
Fix git hooks on Windows

### DIFF
--- a/tools/githooks/lib/src/messages.dart
+++ b/tools/githooks/lib/src/messages.dart
@@ -14,6 +14,6 @@ void printGclientSyncReminder(String command) {
   final String postfix = io.stdout.supportsAnsiEscapes ? _reset : '';
   io.stderr.writeln('$command: The engine source tree has been updated.');
   io.stderr.writeln(
-    '\n${prefix}You man need to run "gclient sync -D"$postfix\n',
+    '\n${prefix}You may need to run "gclient sync -D"$postfix\n',
   );
 }

--- a/tools/githooks/post-checkout
+++ b/tools/githooks/post-checkout
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env vpython3
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/githooks/post-merge
+++ b/tools/githooks/post-merge
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env vpython3
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/githooks/pre-push
+++ b/tools/githooks/pre-push
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env vpython3
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/githooks/pre-rebase
+++ b/tools/githooks/pre-rebase
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env vpython3
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.


### PR DESCRIPTION
Windows does not pre-install python3. Previously Windows users would just use Python from depot tools, but this was broken by https://github.com/flutter/engine/pull/51156.