### PR TITLE
[Impeller] Create a new render target with the specified attachment configs when reusing cached render target textures

### DIFF
--- a/impeller/entity/render_target_cache.cc
+++ b/impeller/entity/render_target_cache.cc
@@ -52,9 +52,10 @@ RenderTarget RenderTargetCache::CreateOffscreen(
                         .find(0u)
                         ->second;
       auto depth = render_target_data.render_target.GetDepthAttachment();
+      std::shared_ptr<Texture> depth_tex = depth ? depth->texture : nullptr;
       return RenderTargetAllocator::CreateOffscreen(
           context, size, mip_count, label, color_attachment_config,
-          stencil_attachment_config, color0.texture, depth->texture);
+          stencil_attachment_config, color0.texture, depth_tex);
     }
   }
   RenderTarget created_target = RenderTargetAllocator::CreateOffscreen(
@@ -97,10 +98,11 @@ RenderTarget RenderTargetCache::CreateOffscreenMSAA(
                         .find(0u)
                         ->second;
       auto depth = render_target_data.render_target.GetDepthAttachment();
+      std::shared_ptr<Texture> depth_tex = depth ? depth->texture : nullptr;
       return RenderTargetAllocator::CreateOffscreenMSAA(
           context, size, mip_count, label, color_attachment_config,
           stencil_attachment_config, color0.texture, color0.resolve_texture,
-          depth->texture);
+          depth_tex);
     }
   }
   RenderTarget created_target = RenderTargetAllocator::CreateOffscreenMSAA(

--- a/impeller/entity/render_target_cache.cc
+++ b/impeller/entity/render_target_cache.cc
@@ -33,7 +33,11 @@ RenderTarget RenderTargetCache::CreateOffscreen(
     int mip_count,
     const std::string& label,
     RenderTarget::AttachmentConfig color_attachment_config,
-    std::optional<RenderTarget::AttachmentConfig> stencil_attachment_config) {
+    std::optional<RenderTarget::AttachmentConfig> stencil_attachment_config,
+    const std::shared_ptr<Texture>& existing_color_texture,
+    const std::shared_ptr<Texture>& existing_depth_stencil_texture) {
+  FML_DCHECK(existing_color_texture == nullptr &&
+             existing_depth_stencil_texture == nullptr);
   auto config = RenderTargetConfig{
       .size = size,
       .mip_count = static_cast<size_t>(mip_count),
@@ -44,7 +48,13 @@ RenderTarget RenderTargetCache::CreateOffscreen(
     const auto other_config = render_target_data.config;
     if (!render_target_data.used_this_frame && other_config == config) {
       render_target_data.used_this_frame = true;
-      return render_target_data.render_target;
+      auto color0 = render_target_data.render_target.GetColorAttachments()
+                        .find(0u)
+                        ->second;
+      auto depth = render_target_data.render_target.GetDepthAttachment();
+      return RenderTargetAllocator::CreateOffscreen(
+          context, size, mip_count, label, color_attachment_config,
+          stencil_attachment_config, color0.texture, depth->texture);
     }
   }
   RenderTarget created_target = RenderTargetAllocator::CreateOffscreen(
@@ -66,7 +76,13 @@ RenderTarget RenderTargetCache::CreateOffscreenMSAA(
     int mip_count,
     const std::string& label,
     RenderTarget::AttachmentConfigMSAA color_attachment_config,
-    std::optional<RenderTarget::AttachmentConfig> stencil_attachment_config) {
+    std::optional<RenderTarget::AttachmentConfig> stencil_attachment_config,
+    const std::shared_ptr<Texture>& existing_color_msaa_texture,
+    const std::shared_ptr<Texture>& existing_color_resolve_texture,
+    const std::shared_ptr<Texture>& existing_depth_stencil_texture) {
+  FML_DCHECK(existing_color_msaa_texture == nullptr &&
+             existing_color_resolve_texture == nullptr &&
+             existing_depth_stencil_texture == nullptr);
   auto config = RenderTargetConfig{
       .size = size,
       .mip_count = static_cast<size_t>(mip_count),
@@ -77,7 +93,14 @@ RenderTarget RenderTargetCache::CreateOffscreenMSAA(
     const auto other_config = render_target_data.config;
     if (!render_target_data.used_this_frame && other_config == config) {
       render_target_data.used_this_frame = true;
-      return render_target_data.render_target;
+      auto color0 = render_target_data.render_target.GetColorAttachments()
+                        .find(0u)
+                        ->second;
+      auto depth = render_target_data.render_target.GetDepthAttachment();
+      return RenderTargetAllocator::CreateOffscreenMSAA(
+          context, size, mip_count, label, color_attachment_config,
+          stencil_attachment_config, color0.texture, color0.resolve_texture,
+          depth->texture);
     }
   }
   RenderTarget created_target = RenderTargetAllocator::CreateOffscreenMSAA(

--- a/impeller/entity/render_target_cache.h
+++ b/impeller/entity/render_target_cache.h
@@ -33,7 +33,10 @@ class RenderTargetCache : public RenderTargetAllocator {
       RenderTarget::AttachmentConfig color_attachment_config =
           RenderTarget::kDefaultColorAttachmentConfig,
       std::optional<RenderTarget::AttachmentConfig> stencil_attachment_config =
-          RenderTarget::kDefaultStencilAttachmentConfig) override;
+          RenderTarget::kDefaultStencilAttachmentConfig,
+      const std::shared_ptr<Texture>& existing_color_texture = nullptr,
+      const std::shared_ptr<Texture>& existing_depth_stencil_texture =
+          nullptr) override;
 
   RenderTarget CreateOffscreenMSAA(
       const Context& context,
@@ -43,7 +46,11 @@ class RenderTargetCache : public RenderTargetAllocator {
       RenderTarget::AttachmentConfigMSAA color_attachment_config =
           RenderTarget::kDefaultColorAttachmentConfigMSAA,
       std::optional<RenderTarget::AttachmentConfig> stencil_attachment_config =
-          RenderTarget::kDefaultStencilAttachmentConfig) override;
+          RenderTarget::kDefaultStencilAttachmentConfig,
+      const std::shared_ptr<Texture>& existing_color_msaa_texture = nullptr,
+      const std::shared_ptr<Texture>& existing_color_resolve_texture = nullptr,
+      const std::shared_ptr<Texture>& existing_depth_stencil_texture =
+          nullptr) override;
 
   // visible for testing.
   size_t CachedTextureCount() const;

--- a/impeller/renderer/render_target.h
+++ b/impeller/renderer/render_target.h
@@ -84,7 +84,8 @@ class RenderTarget final {
       bool msaa,
       const std::string& label = "Offscreen",
       RenderTarget::AttachmentConfig stencil_attachment_config =
-          RenderTarget::kDefaultStencilAttachmentConfig);
+          RenderTarget::kDefaultStencilAttachmentConfig,
+      const std::shared_ptr<Texture>& depth_stencil_texture = nullptr);
 
   SampleCount GetSampleCount() const;
 
@@ -152,7 +153,9 @@ class RenderTargetAllocator {
       RenderTarget::AttachmentConfig color_attachment_config =
           RenderTarget::kDefaultColorAttachmentConfig,
       std::optional<RenderTarget::AttachmentConfig> stencil_attachment_config =
-          RenderTarget::kDefaultStencilAttachmentConfig);
+          RenderTarget::kDefaultStencilAttachmentConfig,
+      const std::shared_ptr<Texture>& existing_color_texture = nullptr,
+      const std::shared_ptr<Texture>& existing_depth_stencil_texture = nullptr);
 
   virtual RenderTarget CreateOffscreenMSAA(
       const Context& context,
@@ -162,7 +165,10 @@ class RenderTargetAllocator {
       RenderTarget::AttachmentConfigMSAA color_attachment_config =
           RenderTarget::kDefaultColorAttachmentConfigMSAA,
       std::optional<RenderTarget::AttachmentConfig> stencil_attachment_config =
-          RenderTarget::kDefaultStencilAttachmentConfig);
+          RenderTarget::kDefaultStencilAttachmentConfig,
+      const std::shared_ptr<Texture>& existing_color_msaa_texture = nullptr,
+      const std::shared_ptr<Texture>& existing_color_resolve_texture = nullptr,
+      const std::shared_ptr<Texture>& existing_depth_stencil_texture = nullptr);
 
   /// @brief Mark the beginning of a frame workload.
   ///
@@ -176,15 +182,6 @@ class RenderTargetAllocator {
   virtual void End();
 
  private:
-  void SetupDepthStencilAttachments(
-      Allocator& allocator,
-      const Context& context,
-      ISize size,
-      bool msaa,
-      const std::string& label = "Offscreen",
-      RenderTarget::AttachmentConfig stencil_attachment_config =
-          RenderTarget::kDefaultStencilAttachmentConfig);
-
   std::shared_ptr<Allocator> allocator_;
 };
 


### PR DESCRIPTION
If the RenderTargetCache::Create methods reuse a cached RenderTarget as is, then the returned RenderTarget may contain AttachmentConfig parameters that do not match the ones passed to the create method.

This PR instead creates a new RenderTarget based on the existing textures from the cached RenderTarget.