### PR TITLE
[cherry pick to roll branch][g3 roll] Revert "Remove unused drone_dimension field" (#51214)

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -205,6 +205,10 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_fuchsia
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
+    drone_dimensions:
+      - os=Linux
     dimensions:
       kvm: "1"
     # TODO(https://github.com/flutter/flutter/issues/138559): Re-enable/delete.
@@ -242,6 +246,8 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_arm_host_engine
+    drone_dimensions:
+      - os=Linux
 
   - name: Linux linux_host_engine
     recipe: engine_v2/engine_v2
@@ -254,6 +260,8 @@ targets:
         [
           {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
         ]
+    drone_dimensions:
+      - os=Linux
 
   - name: Linux linux_host_desktop_engine
     recipe: engine_v2/engine_v2
@@ -262,6 +270,8 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_host_desktop_engine
+    drone_dimensions:
+      - os=Linux
 
   - name: Linux linux_android_aot_engine
     recipe: engine_v2/engine_v2
@@ -270,6 +280,8 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_android_aot_engine
+    drone_dimensions:
+      - os=Linux
 
   - name: Linux linux_android_debug_engine
     recipe: engine_v2/engine_v2
@@ -278,6 +290,8 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_android_debug_engine
+    drone_dimensions:
+      - os=Linux
 
   - name: Linux linux_license
     recipe: engine_v2/builder
@@ -293,6 +307,8 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_web_engine
+    drone_dimensions:
+      - os=Linux
     runIf:
       - DEPS
       - .ci.yaml
@@ -345,6 +361,8 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: mac_android_aot_engine
+    drone_dimensions:
+      - os=Linux
 
   - name: Mac mac_clang_tidy
     recipe: engine_v2/engine_v2
@@ -382,6 +400,8 @@ targets:
         {
           "sdk_version": "15a240d"
         }
+    drone_dimensions:
+      - os=Mac-13
 
   - name: Mac mac_unopt
     recipe: engine_v2/engine_v2
@@ -401,6 +421,9 @@ targets:
         {
           "sdk_version": "15a240d"
         }
+    drone_dimensions:
+      - os=Mac-13
+      - cpu=x86
 
   - name: Mac impeller-cmake-example
     bringup: true
@@ -417,6 +440,8 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: windows_android_aot_engine
+    drone_dimensions:
+      - os=Windows
 
   - name: Windows windows_host_engine
     recipe: engine_v2/engine_v2
@@ -425,6 +450,8 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: windows_host_engine
+    drone_dimensions:
+      - os=Windows
 
   - name: Windows windows_arm_host_engine
     recipe: engine_v2/engine_v2
@@ -435,6 +462,8 @@ targets:
     properties:
       add_recipes_cq: "true"
       config_name: windows_arm_host_engine
+    drone_dimensions:
+      - os=Windows
 
   - name: Windows windows_unopt
     recipe: engine_v2/builder


### PR DESCRIPTION
Reverts flutter/engine#50893

issue: https://github.com/flutter/flutter/issues/144644

cherry picks from main branch to release branch

