### PR TITLE
[Impeller] Fix path winding when bridging from contours with an odd number of points.

### DIFF
--- a/impeller/aiks/aiks_path_unittests.cc
+++ b/impeller/aiks/aiks_path_unittests.cc
@@ -412,20 +412,40 @@ TEST_P(AiksTest, CanRenderOverlappingMultiContourPath) {
 
   const Scalar kTriangleHeight = 100;
   canvas.Translate(Vector2(200, 200));
-  // Form a path similar to the Material drop slider value indicator.
-  auto path =
-      PathBuilder{}
-          .MoveTo({0, kTriangleHeight})
-          .LineTo({-kTriangleHeight / 2.0f, 0})
-          .LineTo({kTriangleHeight / 2.0f, 0})
-          .Close()
-          .AddRoundedRect(
-              Rect::MakeXYWH(-kTriangleHeight / 2.0f, -kTriangleHeight / 2.0f,
-                             kTriangleHeight, kTriangleHeight),
-              radii)
-          .TakePath();
+  // Form a path similar to the Material drop slider value indicator. Both
+  // shapes should render identically side-by-side.
+  {
+    auto path =
+        PathBuilder{}
+            .MoveTo({0, kTriangleHeight})
+            .LineTo({-kTriangleHeight / 2.0f, 0})
+            .LineTo({kTriangleHeight / 2.0f, 0})
+            .Close()
+            .AddRoundedRect(
+                Rect::MakeXYWH(-kTriangleHeight / 2.0f, -kTriangleHeight / 2.0f,
+                               kTriangleHeight, kTriangleHeight),
+                radii)
+            .TakePath();
 
-  canvas.DrawPath(path, paint);
+    canvas.DrawPath(path, paint);
+  }
+  canvas.Translate(Vector2(100, 0));
+  {
+    auto path =
+        PathBuilder{}
+            .MoveTo({0, kTriangleHeight})
+            .LineTo({-kTriangleHeight / 2.0f, 0})
+            .LineTo({0, -10})
+            .LineTo({kTriangleHeight / 2.0f, 0})
+            .Close()
+            .AddRoundedRect(
+                Rect::MakeXYWH(-kTriangleHeight / 2.0f, -kTriangleHeight / 2.0f,
+                               kTriangleHeight, kTriangleHeight),
+                radii)
+            .TakePath();
+
+    canvas.DrawPath(path, paint);
+  }
 
   ASSERT_TRUE(OpenPlaygroundHere(canvas.EndRecordingAsPicture()));
 }

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -212,14 +212,14 @@ std::vector<Point> Tessellator::TessellateConvex(const Path& path,
 
     size_t a = start + 1;
     size_t b = end - 1;
-    while (a < b) {
+    while (a <= b) {
+      // If the contour has an odd number of points, two identical points will
+      // be appended when a == b. This ensures the triangle winding order will
+      // remain the same after bridging to the next contour.
       output.emplace_back(polyline.GetPoint(a));
       output.emplace_back(polyline.GetPoint(b));
       a++;
       b--;
-    }
-    if (a == b) {
-      output.emplace_back(polyline.GetPoint(a));
     }
   }
   return output;

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -112,7 +112,7 @@ TEST(TessellatorTest, TessellateConvex) {
         PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 10, 10)).TakePath(), 1.0);
 
     std::vector<Point> expected = {
-        {0, 0}, {10, 0}, {0, 10}, {10, 10},  //
+        {0, 0}, {10, 0}, {0, 10}, {10, 10}, {10, 10},  //
     };
     EXPECT_EQ(pts, expected);
   }
@@ -125,9 +125,9 @@ TEST(TessellatorTest, TessellateConvex) {
                                       .TakePath(),
                                   1.0);
 
-    std::vector<Point> expected = {{0, 0},   {10, 0},  {0, 10},  {10, 10},
-                                   {10, 10}, {20, 20}, {20, 20}, {20, 20},
-                                   {30, 20}, {20, 30}, {30, 30}};
+    std::vector<Point> expected = {
+        {0, 0},   {10, 0},  {0, 10},  {10, 10}, {10, 10}, {10, 10}, {20, 20},
+        {20, 20}, {20, 20}, {30, 20}, {20, 30}, {30, 30}, {30, 30}};
     EXPECT_EQ(pts, expected);
   }
 }


### PR DESCRIPTION
If the previous contour has an odd number of points, insert a duplicate point to keep the winding order consistent across contours.

Before:

![Screenshot 2024-03-05 at 4 16 46 PM](https://github.com/flutter/engine/assets/919017/05306c92-78e9-4d16-88c1-6191d8ee1160)

After:

![Screenshot 2024-03-05 at 4 14 54 PM](https://github.com/flutter/engine/assets/919017/3743527f-d686-4c98-87f3-cb4db3c1a1ef)
