### PR TITLE
[Impeller] Append fewer redundant points when bridging triangle strips between contours.

### DIFF
--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -111,9 +111,7 @@ TEST(TessellatorTest, TessellateConvex) {
     auto pts = t.TessellateConvex(
         PathBuilder{}.AddRect(Rect::MakeLTRB(0, 0, 10, 10)).TakePath(), 1.0);
 
-    std::vector<Point> expected = {
-        {0, 0}, {10, 0}, {0, 10}, {10, 10}, {10, 10},  //
-    };
+    std::vector<Point> expected = {{0, 0}, {10, 0}, {0, 10}, {10, 10}};
     EXPECT_EQ(pts, expected);
   }
 
@@ -125,9 +123,9 @@ TEST(TessellatorTest, TessellateConvex) {
                                       .TakePath(),
                                   1.0);
 
-    std::vector<Point> expected = {
-        {0, 0},   {10, 0},  {0, 10},  {10, 10}, {10, 10}, {10, 10}, {20, 20},
-        {20, 20}, {20, 20}, {30, 20}, {20, 30}, {30, 30}, {30, 30}};
+    std::vector<Point> expected = {{0, 0},   {10, 0},  {0, 10},  {10, 10},
+                                   {10, 10}, {20, 20}, {20, 20}, {30, 20},
+                                   {20, 30}, {30, 30}};
     EXPECT_EQ(pts, expected);
   }
 }


### PR DESCRIPTION
Optimizes out 1-2 points per contour. Improvement to the TessellateConvex changes I made to get StC over the line.