### PR TITLE
add new builder benchmark with a global saveLayer

### DIFF
--- a/display_list/benchmarking/dl_builder_benchmarks.cc
+++ b/display_list/benchmarking/dl_builder_benchmarks.cc
@@ -108,6 +108,25 @@ static void BM_DisplayListBuilderWithClipRect(
   }
 }
 
+static void BM_DisplayListBuilderWithGlobalSaveLayer(
+    benchmark::State& state,
+    DisplayListBuilderBenchmarkType type) {
+  bool prepare_rtree = NeedPrepareRTree(type);
+  while (state.KeepRunning()) {
+    DisplayListBuilder builder(prepare_rtree);
+    builder.SaveLayer(nullptr, nullptr);
+    DlOpReceiver& receiver = DisplayListBuilderBenchmarkAccessor(builder);
+    for (auto& group : allRenderingOps) {
+      for (size_t i = 0; i < group.variants.size(); i++) {
+        auto& invocation = group.variants[i];
+        invocation.Invoke(receiver);
+      }
+    }
+    builder.Restore();
+    Complete(builder, type);
+  }
+}
+
 static void BM_DisplayListBuilderWithSaveLayer(
     benchmark::State& state,
     DisplayListBuilderBenchmarkType type) {
@@ -213,6 +232,23 @@ BENCHMARK_CAPTURE(BM_DisplayListBuilderWithClipRect,
                   DisplayListBuilderBenchmarkType::kRtree)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_CAPTURE(BM_DisplayListBuilderWithClipRect,
+                  kBoundsAndRtree,
+                  DisplayListBuilderBenchmarkType::kBoundsAndRtree)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_CAPTURE(BM_DisplayListBuilderWithGlobalSaveLayer,
+                  kDefault,
+                  DisplayListBuilderBenchmarkType::kDefault)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DisplayListBuilderWithGlobalSaveLayer,
+                  kBounds,
+                  DisplayListBuilderBenchmarkType::kBounds)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DisplayListBuilderWithGlobalSaveLayer,
+                  kRtree,
+                  DisplayListBuilderBenchmarkType::kRtree)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_CAPTURE(BM_DisplayListBuilderWithGlobalSaveLayer,
                   kBoundsAndRtree,
                   DisplayListBuilderBenchmarkType::kBoundsAndRtree)
     ->Unit(benchmark::kMicrosecond);


### PR DESCRIPTION
The existing DisplayListBuilder benchmarks that have a SaveLayer call do so around each rendering call which stresses measuring the cost of the SaveLayer/Restore calls. This new benchmark does a single SaveLayer/Restore around the entire array of rendering ops to measure the performance of adding new calls inside an existing layer.

No tests because this is just a new benchmark.