### PR TITLE
[Impeller] add a per-frame trace event for heap usage on Vulkan.

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -168,6 +168,7 @@
 ../../../flutter/impeller/playground
 ../../../flutter/impeller/renderer/backend/gles/test
 ../../../flutter/impeller/renderer/backend/metal/texture_mtl_unittests.mm
+../../../flutter/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/blit_command_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/command_encoder_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/command_pool_vk_unittests.cc

--- a/impeller/core/allocator.h
+++ b/impeller/core/allocator.h
@@ -44,6 +44,12 @@ class Allocator {
 
   virtual ISize GetMaxTextureSizeSupported() const = 0;
 
+  /// @brief Write debug memory usage information to the dart timeline in debug
+  ///        and profile modes.
+  ///
+  ///        This is only supported on the Vulkan backend.
+  virtual void DebugTraceMemoryStatistics() const {};
+
  protected:
   Allocator();
 

--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -8,6 +8,7 @@ import("../../../tools/impeller.gni")
 impeller_component("vulkan_unittests") {
   testonly = true
   sources = [
+    "allocator_vk_unittests.cc",
     "blit_command_vk_unittests.cc",
     "command_encoder_vk_unittests.cc",
     "command_pool_vk_unittests.cc",

--- a/impeller/renderer/backend/vulkan/allocator_vk.h
+++ b/impeller/renderer/backend/vulkan/allocator_vk.h
@@ -24,6 +24,9 @@ class AllocatorVK final : public Allocator {
   // |Allocator|
   ~AllocatorVK() override;
 
+  // Visible for testing
+  size_t DebugGetHeapUsage() const;
+
  private:
   friend class ContextVK;
 
@@ -36,6 +39,7 @@ class AllocatorVK final : public Allocator {
   bool supports_memoryless_textures_ = false;
   // TODO(jonahwilliams): figure out why CI can't create these buffer pools.
   bool created_buffer_pool_ = true;
+  vk::PhysicalDeviceMemoryProperties memory_properties_;
 
   AllocatorVK(std::weak_ptr<Context> context,
               uint32_t vulkan_api_version,
@@ -57,6 +61,9 @@ class AllocatorVK final : public Allocator {
 
   // |Allocator|
   ISize GetMaxTextureSizeSupported() const override;
+
+  // |Allocator|
+  void DebugTraceMemoryStatistics() const override;
 
   AllocatorVK(const AllocatorVK&) = delete;
 

--- a/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gtest/gtest.h"
+#include "impeller/core/device_buffer_descriptor.h"
+#include "impeller/core/formats.h"
+#include "impeller/renderer/backend/vulkan/allocator_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
+#include "vulkan/vulkan_enums.hpp"
+
+namespace impeller {
+namespace testing {
+
+#ifdef IMPELLER_DEBUG
+
+TEST(AllocatorVKTest, RecreateSwapchainWhenSizeChanges) {
+  auto const context = MockVulkanContextBuilder().Build();
+  auto allocator = context->GetResourceAllocator();
+
+  EXPECT_EQ(
+      reinterpret_cast<AllocatorVK*>(allocator.get())->DebugGetHeapUsage(), 0u);
+
+  allocator->CreateBuffer(DeviceBufferDescriptor{
+      .storage_mode = StorageMode::kDevicePrivate,
+      .size = 1024,
+  });
+
+  // Usage increases beyond the size of the allocated buffer since VMA will
+  // first allocate large blocks of memory and then suballocate small memory
+  // allocations.
+  EXPECT_EQ(
+      reinterpret_cast<AllocatorVK*>(allocator.get())->DebugGetHeapUsage(),
+      16u);
+}
+
+#endif  // IMPELLER_DEBUG
+
+}  // namespace testing
+}  // namespace impeller

--- a/impeller/renderer/backend/vulkan/surface_context_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.cc
@@ -88,6 +88,7 @@ std::unique_ptr<Surface> SurfaceContextVK::AcquireNextSurface() {
         .DidAcquireSurfaceFrame();
   }
   parent_->GetCommandPoolRecycler()->Dispose();
+  parent_->GetResourceAllocator()->DebugTraceMemoryStatistics();
   return surface;
 }
 

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -221,14 +221,20 @@ VkResult vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
 void vkGetPhysicalDeviceMemoryProperties(
     VkPhysicalDevice physicalDevice,
     VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
-  pMemoryProperties->memoryTypeCount = 1;
+  pMemoryProperties->memoryTypeCount = 2;
+  pMemoryProperties->memoryHeapCount = 2;
   pMemoryProperties->memoryTypes[0].heapIndex = 0;
-  // pMemoryProperties->memoryTypes[0].propertyFlags =
-  //     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
-  //     VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD;
-  pMemoryProperties->memoryHeapCount = 1;
+  pMemoryProperties->memoryTypes[0].propertyFlags =
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+      VK_MEMORY_PROPERTY_HOST_COHERENT_BIT |
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+  pMemoryProperties->memoryTypes[1].heapIndex = 1;
+  pMemoryProperties->memoryTypes[1].propertyFlags =
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
   pMemoryProperties->memoryHeaps[0].size = 1024 * 1024 * 1024;
-  pMemoryProperties->memoryHeaps[0].flags = 0;
+  pMemoryProperties->memoryHeaps[0].flags = VK_MEMORY_HEAP_DEVICE_LOCAL_BIT;
+  pMemoryProperties->memoryHeaps[1].size = 1024 * 1024 * 1024;
+  pMemoryProperties->memoryHeaps[1].flags = VK_MEMORY_HEAP_DEVICE_LOCAL_BIT;
 }
 
 VkResult vkCreatePipelineCache(VkDevice device,


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/144617

Adds MemoryBudgetUsageMB which includes the MB of VMA allocated GPU and host memory, approximately per frame. This will be recorded in the devicelab and used to track how much memory pressure we're creating.

Split out from https://github.com/flutter/engine/pull/51187 since that was reverted (and doing big changes is a bad idea anyway).