### PR TITLE
Add tracing "Frame" in the engine

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -115,6 +115,7 @@ void Animator::BeginFrame(
       frame_timings_recorder_->GetVsyncTargetTime();
   dart_frame_deadline_ = frame_target_time.ToEpochDelta();
   uint64_t frame_number = frame_timings_recorder_->GetFrameNumber();
+  TRACE_EVENT_ASYNC_BEGIN0("flutter", "Frame", frame_number);
   delegate_.OnAnimatorBeginFrame(frame_target_time, frame_number);
 }
 
@@ -125,6 +126,7 @@ void Animator::EndFrame() {
     // `EndFrame` again.
     return;
   }
+  uint64_t frame_number = frame_timings_recorder_->GetFrameNumber();
   if (!layer_trees_tasks_.empty()) {
     // The build is completed in OnAnimatorBeginFrame.
     frame_timings_recorder_->RecordBuildEnd(fml::TimePoint::Now());
@@ -154,6 +156,7 @@ void Animator::EndFrame() {
     }
   }
   frame_timings_recorder_ = nullptr;
+  TRACE_EVENT_ASYNC_END0("flutter", "Frame", frame_number);
 
   if (!frame_scheduled_ && has_rendered_) {
     // Wait a tad more than 3 60hz frames before reporting a big idle period.


### PR DESCRIPTION
This is to be used with https://github.com/flutter/flutter/pull/144789. Please see that issue for discussion.

The two new places are chosen to keep the new range as close to the old range as possible:
* The trace will start right before `PlatformDispatcher.handleBeginFrame`.
* The trace will end after `PlatformDispatcher.handleDrawFrame` and the part that used to be within `Animator::Render`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
