### PR TITLE
Migrate build_overrides from buildroot to engine

### DIFF
--- a/build_overrides/angle.gni
+++ b/build_overrides/angle.gni
@@ -1,0 +1,38 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Ensure use_xcode_clang is visibile to ANGLE.
+import("//build/toolchain/toolchain.gni")
+
+# The ANGLE build requires this file to point to the location of third-party
+# dependencies.
+angle_root = "//third_party/angle"
+
+angle_vma_version = 30000001
+
+# Flutter's buildroot looks enough like Chromium to satisfy Angle, and enough
+# to cause GN variable collisions if we don't set this.
+if (!is_fuchsia) {
+  angle_has_build = true
+}
+
+# Overrides for ANGLE's dependencies.
+angle_abseil_cpp_dir = "//flutter/third_party/abseil-cpp"
+angle_glslang_dir = "//flutter/third_party/vulkan-deps/glslang/src"
+angle_googletest_dir = "//third_party/googletest/googletest/src"
+
+# Note: This path doesn't actually exist; see
+# //build/secondary/third_party/jsoncpp/BUILD.gn
+angle_jsoncpp_dir = "//third_party/jsoncpp"
+angle_libjpeg_turbo_dir = "//third_party/libjpeg_turbo"
+angle_libpng_dir = "//flutter/third_party/libpng"
+angle_spirv_headers_dir = "//flutter/third_party/vulkan-deps/spirv-headers/src"
+angle_spirv_tools_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"
+angle_spirv_cross_dir = "//flutter/third_party/vulkan-deps/spirv-cross/src"
+angle_spirv_headers_dir = "//flutter/third_party/vulkan-deps/spirv-headers/src"
+angle_vulkan_memory_allocator_dir = "//third_party/vulkan_memory_allocator"
+
+# This is a general Chromium flag, but in the Flutter build only ANGLE needs it
+# so it is defined here.
+is_cfi = false

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -1,0 +1,13 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# The engine build uses some Chromium-sourced versions of third-party
+# dependencies (e.g, ANGLE, abseil) to use their GN build files, but we don't
+# want the Chromium-specific parts of the build.
+build_with_chromium = false
+
+# Perfetto targets fail to build without this variable. It is used by Perfetto
+# targets to distinguish embedder builds from Perfetto standalone builds, and
+# builds in the Android tree.
+perfetto_build_with_embedder = true

--- a/build_overrides/glslang.gni
+++ b/build_overrides/glslang.gni
@@ -1,0 +1,6 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+glslang_spirv_tools_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"
+spirv_tools_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"

--- a/build_overrides/spirv_tools.gni
+++ b/build_overrides/spirv_tools.gni
@@ -1,0 +1,11 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# We are building inside Flutter.
+spirv_tools_standalone = false
+
+# Paths to SPIRV-Tools dependencies in Flutter.
+spirv_tools_googletest_dir = "//third_party/googletest/googletest/src"
+spirv_tools_spirv_headers_dir =
+    "//flutter/third_party/vulkan-deps/spirv-headers/src"

--- a/build_overrides/swiftshader.gni
+++ b/build_overrides/swiftshader.gni
@@ -1,0 +1,9 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# We are building SwiftShader in Flutter.
+swiftshader_standalone = false
+
+# Path to SwiftShader.
+swiftshader_dir = "//flutter/third_party/swiftshader"

--- a/build_overrides/vulkan_headers.gni
+++ b/build_overrides/vulkan_headers.gni
@@ -1,0 +1,11 @@
+# Copyright 2020 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This file is needed by the vulkan-headers build, but doesn't need to actually
+# set anything.
+
+if (is_linux) {
+  vulkan_use_x11 = true
+  vulkan_use_wayland = true
+}

--- a/build_overrides/vulkan_loader.gni
+++ b/build_overrides/vulkan_loader.gni
@@ -1,0 +1,8 @@
+# Copyright 2020 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+vulkan_headers_dir = "//flutter/third_party/vulkan-deps/vulkan-headers/src"
+
+# Vulkan loader build options
+vulkan_loader_shared = true

--- a/build_overrides/vulkan_tools.gni
+++ b/build_overrides/vulkan_tools.gni
@@ -1,0 +1,9 @@
+# Copyright 2020 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+vulkan_headers_dir = "//flutter/third_party/vulkan-deps/vulkan-headers/src"
+
+# Subdirectories for generated files
+vulkan_data_subdir = ""
+vulkan_gen_subdir = ""

--- a/build_overrides/vulkan_utility_libraries.gni
+++ b/build_overrides/vulkan_utility_libraries.gni
@@ -1,0 +1,5 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+vulkan_headers_dir = "//flutter/third_party/vulkan-deps/vulkan-headers/src"

--- a/build_overrides/vulkan_validation_layers.gni
+++ b/build_overrides/vulkan_validation_layers.gni
@@ -1,0 +1,15 @@
+# Copyright 2020 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+vulkan_headers_dir = "//flutter/third_party/vulkan-deps/vulkan-headers/src"
+vulkan_utility_libraries_dir =
+    "//flutter/third_party/vulkan-deps/vulkan-utility-libraries/src"
+vvl_spirv_tools_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"
+vvl_glslang_dir = "//flutter/third_party/vulkan-deps/spirv-tools/src"
+
+# robin_hood_headers_dir = "//external/robin-hood-hashing/src/include"
+
+# Subdirectories for generated files
+vulkan_data_subdir = "vulkan-data"
+vulkan_gen_subdir = ""

--- a/build_overrides/wayland.gni
+++ b/build_overrides/wayland.gni
@@ -1,0 +1,8 @@
+# Copyright 2019 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# ANGLE expects this to be here.
+
+# Flutter has no wayland third-party dir
+wayland_gn_dir = ""

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -26,6 +26,7 @@
 ../../../flutter/README.md
 ../../../flutter/analysis_options.yaml
 ../../../flutter/build
+../../../flutter/build_overrides
 ../../../flutter/ci
 ../../../flutter/common/README.md
 ../../../flutter/display_list/benchmarking/dl_complexity_unittests.cc

--- a/ci/licenses_golden/licenses_dart
+++ b/ci/licenses_golden/licenses_dart
@@ -4747,7 +4747,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   This Source Code Form is "Incompatible With Secondary Licenses", as
   defined by the Mozilla Public License, v. 2.0.
 
-You may obtain a copy of this library's Source Code Form from: https://dart.googlesource.com/sdk/+/3538739eeea98ec50f66bd45934b53d2d1a6a787
+You may obtain a copy of this library's Source Code Form from: https://dart.googlesource.com/sdk/+/4bc97350dc47dfc431469f9f30108f720ee42ce4
 /third_party/fallback_root_certificates/
 
 ====================================================================================================

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 5517be1afb4a2e347b9c4f018c1d5e5f
+Signature: 6869bf83ae9a2e71a9302f51626429a0
 

--- a/tools/clang_tidy/test/header_filter_regex_test.dart
+++ b/tools/clang_tidy/test/header_filter_regex_test.dart
@@ -38,6 +38,7 @@ void main() {
     const Set<String> intentionallyOmitted = <String>{
       '.git',
       '.github',
+      'build_overrides',
       'prebuilts',
       'third_party',
     };

--- a/tools/licenses/lib/paths.dart
+++ b/tools/licenses/lib/paths.dart
@@ -21,6 +21,7 @@ final Set<String> skippedPaths = <String>{
   r'build_overrides', // only used by build
   r'buildtools', // only used by build
   r'flutter/build',
+  r'flutter/build_overrides', // only used by build
   r'flutter/ci',
   r'flutter/docs',
   r'flutter/flutter_frontend_server',


### PR DESCRIPTION
Files under the build_overrides directory in the buildroot are typically hardcoded imports in third-party dependencies used for project-specific configuration. For example, ANGLE hardcodes an import of `//build_overrides/angle.gni` so that consumers of ANGLE can configure the build to their needs.

This adds a copy all existing src/build_overrides files at the equivalent `src/flutter/build_overrides` path in the engine. A followup patch will replace each existing file under `src/build_overrides` in the buildroot with a shim that just imports the files landed in this patch. This allows third-party dependencies to continue hardcoding the `//build_overrides/foo.gni` path, but provides a seamless path forward when we drop the buildroot.

Issue: https://github.com/flutter/flutter/issues/144790
Part of: https://github.com/flutter/flutter/issues/67373

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] build_overrides is an important part of a healthy breakfast.
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
