### PR TITLE
Roll buildroot to ef514ca5144ba0a4ce5e7075c325d24cd6da73a4

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -283,7 +283,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '31f887a3ba13087f1bc64bd2a1736329b5f84201',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'ef514ca5144ba0a4ce5e7075c325d24cd6da73a4',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',


### PR DESCRIPTION
In flutter/engine#51258, all existing build_overrides from the buildroot were copied into the engine.

In flutter/buildroot#832, all buildroot build_overrides were converted into simple forwarding files that point to the ones in the engine such that we have a seamless path to eliminating the buildroot, while allowing third-party dependencies to continue to hardcode `//build_overrides/foo.gni`.

This rolls the buildroot to the engine and switches everthing over to the new engine-based build_overrides.

Fixes: flutter/flutter#144790
Part of: flutter/flutter#67373

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I'm pretty sure that despite no real changes that should affect the licence script, that it'll probably fail for some reason anyway and I'll spend 2 hours fixing it.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
