### PR TITLE
[Embedder API] Add multi-view present callback

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1290,12 +1290,21 @@ InferExternalViewEmbedderFromArgs(const FlutterCompositor* compositor,
       SAFE_ACCESS(compositor, collect_backing_store_callback, nullptr);
   auto c_present_callback =
       SAFE_ACCESS(compositor, present_layers_callback, nullptr);
+  auto c_present_view_callback =
+      SAFE_ACCESS(compositor, present_view_callback, nullptr);
   bool avoid_backing_store_cache =
       SAFE_ACCESS(compositor, avoid_backing_store_cache, false);
 
   // Make sure the required callbacks are present
-  if (!c_create_callback || !c_collect_callback || !c_present_callback) {
+  if (!c_create_callback || !c_collect_callback) {
     FML_LOG(ERROR) << "Required compositor callbacks absent.";
+    return {nullptr, true};
+  }
+  // Either the present view or the present layers callback must be provided.
+  if ((!c_present_view_callback && !c_present_callback) ||
+      (c_present_view_callback && c_present_callback)) {
+    FML_LOG(ERROR) << "Either present_layers_callback or present_view_callback "
+                      "must be provided but not both.";
     return {nullptr, true};
   }
 
@@ -1312,14 +1321,32 @@ InferExternalViewEmbedderFromArgs(const FlutterCompositor* compositor,
                                               enable_impeller);
           };
 
-  flutter::EmbedderExternalViewEmbedder::PresentCallback present_callback =
-      [c_present_callback,
-       user_data = compositor->user_data](const auto& layers) {
-        TRACE_EVENT0("flutter", "FlutterCompositorPresentLayers");
-        return c_present_callback(
-            const_cast<const FlutterLayer**>(layers.data()), layers.size(),
-            user_data);
+  flutter::EmbedderExternalViewEmbedder::PresentCallback present_callback;
+  if (c_present_callback) {
+    present_callback = [c_present_callback, user_data = compositor->user_data](
+                           FlutterViewId view_id, const auto& layers) {
+      TRACE_EVENT0("flutter", "FlutterCompositorPresentLayers");
+      return c_present_callback(const_cast<const FlutterLayer**>(layers.data()),
+                                layers.size(), user_data);
+    };
+  } else {
+    FML_DCHECK(c_present_view_callback != nullptr);
+    present_callback = [c_present_view_callback,
+                        user_data = compositor->user_data](
+                           FlutterViewId view_id, const auto& layers) {
+      TRACE_EVENT0("flutter", "FlutterCompositorPresentLayers");
+
+      FlutterPresentViewInfo info = {
+          .struct_size = sizeof(FlutterPresentViewInfo),
+          .view_id = view_id,
+          .layers = const_cast<const FlutterLayer**>(layers.data()),
+          .layers_count = layers.size(),
+          .user_data = user_data,
       };
+
+      return c_present_view_callback(&info);
+    };
+  }
 
   return {std::make_unique<flutter::EmbedderExternalViewEmbedder>(
               avoid_backing_store_cache, create_render_target_callback,

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1769,11 +1769,9 @@ typedef bool (*FlutterLayersPresentCallback)(const FlutterLayer** layers,
                                              size_t layers_count,
                                              void* user_data);
 
-/// The callback invoked when the embedder should present
-/// to a view.
+/// The callback invoked when the embedder should present to a view.
 ///
-/// The |FlutterPresentViewInfo| will be deallocated
-/// once the callback returns.
+/// The |FlutterPresentViewInfo| will be deallocated once the callback returns.
 typedef bool (*FlutterPresentViewCallback)(
     const FlutterPresentViewInfo* /* present info */);
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1738,6 +1738,24 @@ typedef struct {
   FlutterBackingStorePresentInfo* backing_store_present_info;
 } FlutterLayer;
 
+typedef struct {
+  /// The size of this struct.
+  /// Must be sizeof(FlutterPresentViewInfo).
+  size_t struct_size;
+
+  /// The identifier of the target view.
+  FlutterViewId view_id;
+
+  /// The layers that should be composited onto the view.
+  const FlutterLayer** layers;
+
+  /// The count of layers.
+  size_t layers_count;
+
+  /// The |FlutterCompositor.user_data|.
+  void* user_data;
+} FlutterPresentViewInfo;
+
 typedef bool (*FlutterBackingStoreCreateCallback)(
     const FlutterBackingStoreConfig* config,
     FlutterBackingStore* backing_store_out,
@@ -1751,13 +1769,22 @@ typedef bool (*FlutterLayersPresentCallback)(const FlutterLayer** layers,
                                              size_t layers_count,
                                              void* user_data);
 
+/// The callback invoked when the embedder should present
+/// to a view.
+///
+/// The |FlutterPresentViewInfo| will be deallocated
+/// once the callback returns.
+typedef bool (*FlutterPresentViewCallback)(
+    const FlutterPresentViewInfo* /* present info */);
+
 typedef struct {
   /// This size of this struct. Must be sizeof(FlutterCompositor).
   size_t struct_size;
   /// A baton that in not interpreted by the engine in any way. If it passed
   /// back to the embedder in `FlutterCompositor.create_backing_store_callback`,
-  /// `FlutterCompositor.collect_backing_store_callback` and
-  /// `FlutterCompositor.present_layers_callback`
+  /// `FlutterCompositor.collect_backing_store_callback`,
+  /// `FlutterCompositor.present_layers_callback`, and
+  /// `FlutterCompositor.present_view_callback`.
   void* user_data;
   /// A callback invoked by the engine to obtain a backing store for a specific
   /// `FlutterLayer`.
@@ -1771,10 +1798,23 @@ typedef struct {
   /// embedder may collect any resources associated with the backing store.
   FlutterBackingStoreCollectCallback collect_backing_store_callback;
   /// Callback invoked by the engine to composite the contents of each layer
-  /// onto the screen.
+  /// onto the implicit view.
+  ///
+  /// DEPRECATED: Use |present_view_callback| to support multiple views.
+  ///
+  /// Only one of `present_layers_callback` and `present_view_callback` may be
+  /// provided. Providing both is an error and engine initialization will
+  /// terminate.
   FlutterLayersPresentCallback present_layers_callback;
   /// Avoid caching backing stores provided by this compositor.
   bool avoid_backing_store_cache;
+  /// Callback invoked by the engine to composite the contents of each layer
+  /// onto the specified view.
+  ///
+  /// Only one of `present_layers_callback` and `present_view_callback` may be
+  /// provided. Providing both is an error and engine initialization will
+  /// terminate.
+  FlutterPresentViewCallback present_view_callback;
 } FlutterCompositor;
 
 typedef struct {

--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -488,7 +488,10 @@ void EmbedderExternalViewEmbedder::SubmitFlutterView(
 
     builder.PushLayers(presented_layers);
 
-    presented_layers.InvokePresentCallback(present_callback_);
+    // TODO(loic-sharma): Currently only supports a single view.
+    // See https://github.com/flutter/flutter/issues/135530.
+    presented_layers.InvokePresentCallback(kFlutterImplicitViewId,
+                                           present_callback_);
   }
 
   // See why this is necessary in the comment where this collection in

--- a/shell/platform/embedder/embedder_external_view_embedder.h
+++ b/shell/platform/embedder/embedder_external_view_embedder.h
@@ -35,7 +35,8 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
           const std::shared_ptr<impeller::AiksContext>& aiks_context,
           const FlutterBackingStoreConfig& config)>;
   using PresentCallback =
-      std::function<bool(const std::vector<const FlutterLayer*>& layers)>;
+      std::function<bool(FlutterViewId view_id,
+                         const std::vector<const FlutterLayer*>& layers)>;
   using SurfaceTransformationCallback = std::function<SkMatrix(void)>;
 
   //----------------------------------------------------------------------------

--- a/shell/platform/embedder/embedder_layers.cc
+++ b/shell/platform/embedder/embedder_layers.cc
@@ -229,13 +229,14 @@ void EmbedderLayers::PushPlatformViewLayer(
 }
 
 void EmbedderLayers::InvokePresentCallback(
+    FlutterViewId view_id,
     const PresentCallback& callback) const {
   std::vector<const FlutterLayer*> presented_layers_pointers;
   presented_layers_pointers.reserve(presented_layers_.size());
   for (const auto& layer : presented_layers_) {
     presented_layers_pointers.push_back(&layer);
   }
-  callback(presented_layers_pointers);
+  callback(view_id, presented_layers_pointers);
 }
 
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_layers.h
+++ b/shell/platform/embedder/embedder_layers.h
@@ -31,8 +31,10 @@ class EmbedderLayers {
                              const EmbeddedViewParams& params);
 
   using PresentCallback =
-      std::function<bool(const std::vector<const FlutterLayer*>& layers)>;
-  void InvokePresentCallback(const PresentCallback& callback) const;
+      std::function<bool(FlutterViewId view_id,
+                         const std::vector<const FlutterLayer*>& layers)>;
+  void InvokePresentCallback(FlutterViewId view_id,
+                             const PresentCallback& callback) const;
 
  private:
   const SkISize frame_size_;

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -815,6 +815,26 @@ Future<void> key_data_late_echo() async {
 }
 
 @pragma('vm:entry-point')
+void render_implicit_view() {
+  PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
+    final Size size = Size(800.0, 600.0);
+    final Color red = Color.fromARGB(127, 255, 0, 0);
+
+    final SceneBuilder builder = SceneBuilder();
+
+    builder.pushOffset(0.0, 0.0);
+
+    builder.addPicture(
+        Offset(0.0, 0.0), CreateColoredBox(red, size));
+
+    builder.pop();
+
+    PlatformDispatcher.instance.implicitView?.render(builder.build());
+  };
+  PlatformDispatcher.instance.scheduleFrame();
+}
+
+@pragma('vm:entry-point')
 void render_gradient() {
   PlatformDispatcher.instance.onBeginFrame = (Duration duration) {
     final Size size = Size(800.0, 600.0);

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -105,7 +105,8 @@ class EmbedderConfigBuilder {
   void SetPlatformMessageCallback(
       const std::function<void(const FlutterPlatformMessage*)>& callback);
 
-  void SetCompositor(bool avoid_backing_store_cache = false);
+  void SetCompositor(bool avoid_backing_store_cache = false,
+                     bool use_present_layers_callback = false);
 
   FlutterCompositor& GetCompositor();
 

--- a/shell/platform/embedder/tests/embedder_metal_unittests.mm
+++ b/shell/platform/embedder/tests/embedder_metal_unittests.mm
@@ -138,7 +138,7 @@ TEST_F(EmbedderTest, MetalCompositorMustBeAbleToRenderPlatformViews) {
 
   fml::CountDownLatch latch(3);
   context.GetCompositor().SetNextPresentCallback(
-      [&](const FlutterLayer** layers, size_t layers_count) {
+      [&](FlutterViewId view_id, const FlutterLayer** layers, size_t layers_count) {
         ASSERT_EQ(layers_count, 3u);
 
         {
@@ -326,7 +326,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownSceneMetal) {
   auto scene_image = context.GetNextSceneImage();
 
   context.GetCompositor().SetNextPresentCallback(
-      [&](const FlutterLayer** layers, size_t layers_count) {
+      [&](FlutterViewId view_id, const FlutterLayer** layers, size_t layers_count) {
         ASSERT_EQ(layers_count, 5u);
 
         // Layer Root

--- a/shell/platform/embedder/tests/embedder_test_compositor.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor.cc
@@ -60,7 +60,8 @@ sk_sp<SkImage> EmbedderTestCompositor::GetLastComposition() {
   return last_composition_;
 }
 
-bool EmbedderTestCompositor::Present(const FlutterLayer** layers,
+bool EmbedderTestCompositor::Present(FlutterViewId view_id,
+                                     const FlutterLayer** layers,
                                      size_t layers_count) {
   if (!UpdateOffscrenComposition(layers, layers_count)) {
     FML_LOG(ERROR)
@@ -75,7 +76,7 @@ bool EmbedderTestCompositor::Present(const FlutterLayer** layers,
     if (present_callback_is_one_shot_) {
       present_callback_ = nullptr;
     }
-    callback(layers, layers_count);
+    callback(view_id, layers, layers_count);
   }
 
   InvokeAllCallbacks(on_present_callbacks_);

--- a/shell/platform/embedder/tests/embedder_test_compositor.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor.h
@@ -21,8 +21,9 @@ class EmbedderTestCompositor {
   using PlatformViewRendererCallback =
       std::function<sk_sp<SkImage>(const FlutterLayer& layer,
                                    GrDirectContext* context)>;
-  using PresentCallback =
-      std::function<void(const FlutterLayer** layers, size_t layers_count)>;
+  using PresentCallback = std::function<void(FlutterViewId view_id,
+                                             const FlutterLayer** layers,
+                                             size_t layers_count)>;
 
   EmbedderTestCompositor(SkISize surface_size, sk_sp<GrDirectContext> context);
 
@@ -36,7 +37,9 @@ class EmbedderTestCompositor {
 
   bool CollectBackingStore(const FlutterBackingStore* backing_store);
 
-  bool Present(const FlutterLayer** layers, size_t layers_count);
+  bool Present(FlutterViewId view_id,
+               const FlutterLayer** layers,
+               size_t layers_count);
 
   void SetPlatformViewRendererCallback(
       const PlatformViewRendererCallback& callback);


### PR DESCRIPTION
Adds `FlutterCompositor.present_view_callback` to the embedder API. This new present callback adds a `view_id` member to allow embedders know which view is being presented.

The embedder API does not allow embedders to create multiple views yet. This will be added in a future  pull request.

Design doc: https://flutter.dev/go/multi-view-embedder-apis

Pull request that migrates the Windows embedder to this new embedder API: https://github.com/flutter/engine/pull/51293

Part of https://github.com/flutter/flutter/issues/144806
Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
