### PR TITLE
[Impeller] Add a TextureGLES API for wrapping a framebuffer and use it to implement OpenGL FBO targets in the embedder library

### DIFF
--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -170,19 +170,21 @@ struct RenderPassData {
     }
   });
 
-  const auto is_default_fbo =
-      TextureGLES::Cast(*pass_data.color_attachment).IsWrapped();
+  TextureGLES& color_gles = TextureGLES::Cast(*pass_data.color_attachment);
+  const bool is_default_fbo = color_gles.IsWrapped();
 
-  if (!is_default_fbo) {
+  if (is_default_fbo) {
+    if (color_gles.GetFBO().has_value()) {
+      gl.BindFramebuffer(GL_FRAMEBUFFER, *color_gles.GetFBO());
+    }
+  } else {
     // Create and bind an offscreen FBO.
     gl.GenFramebuffers(1u, &fbo);
     gl.BindFramebuffer(GL_FRAMEBUFFER, fbo);
 
-    if (auto color = TextureGLES::Cast(pass_data.color_attachment.get())) {
-      if (!color->SetAsFramebufferAttachment(
-              GL_FRAMEBUFFER, TextureGLES::AttachmentType::kColor0)) {
-        return false;
-      }
+    if (!color_gles.SetAsFramebufferAttachment(
+            GL_FRAMEBUFFER, TextureGLES::AttachmentType::kColor0)) {
+      return false;
     }
 
     if (auto depth = TextureGLES::Cast(pass_data.depth_attachment.get())) {

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -175,6 +175,7 @@ struct RenderPassData {
 
   if (is_default_fbo) {
     if (color_gles.GetFBO().has_value()) {
+      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
       gl.BindFramebuffer(GL_FRAMEBUFFER, *color_gles.GetFBO());
     }
   } else {

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -68,21 +68,30 @@ HandleType ToHandleType(TextureGLES::Type type) {
 }
 
 TextureGLES::TextureGLES(ReactorGLES::Ref reactor, TextureDescriptor desc)
-    : TextureGLES(std::move(reactor), desc, false) {}
+    : TextureGLES(std::move(reactor), desc, false, std::nullopt) {}
 
 TextureGLES::TextureGLES(ReactorGLES::Ref reactor,
                          TextureDescriptor desc,
                          enum IsWrapped wrapped)
-    : TextureGLES(std::move(reactor), desc, true) {}
+    : TextureGLES(std::move(reactor), desc, true, std::nullopt) {}
+
+std::shared_ptr<TextureGLES> TextureGLES::WrapFBO(ReactorGLES::Ref reactor,
+                                                  TextureDescriptor desc,
+                                                  GLuint fbo) {
+  return std::shared_ptr<TextureGLES>(
+      new TextureGLES(reactor, desc, true, fbo));
+}
 
 TextureGLES::TextureGLES(std::shared_ptr<ReactorGLES> reactor,
                          TextureDescriptor desc,
-                         bool is_wrapped)
+                         bool is_wrapped,
+                         std::optional<GLuint> fbo)
     : Texture(desc),
       reactor_(std::move(reactor)),
       type_(GetTextureTypeFromDescriptor(GetTextureDescriptor())),
       handle_(reactor_->CreateHandle(ToHandleType(type_))),
-      is_wrapped_(is_wrapped) {
+      is_wrapped_(is_wrapped),
+      fbo_(fbo) {
   // Ensure the texture descriptor itself is valid.
   if (!GetTextureDescriptor().IsValid()) {
     VALIDATION_LOG << "Invalid texture descriptor.";

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -79,7 +79,7 @@ std::shared_ptr<TextureGLES> TextureGLES::WrapFBO(ReactorGLES::Ref reactor,
                                                   TextureDescriptor desc,
                                                   GLuint fbo) {
   return std::shared_ptr<TextureGLES>(
-      new TextureGLES(reactor, desc, true, fbo));
+      new TextureGLES(std::move(reactor), desc, true, fbo));
 }
 
 TextureGLES::TextureGLES(std::shared_ptr<ReactorGLES> reactor,
@@ -91,7 +91,7 @@ TextureGLES::TextureGLES(std::shared_ptr<ReactorGLES> reactor,
       type_(GetTextureTypeFromDescriptor(GetTextureDescriptor())),
       handle_(reactor_->CreateHandle(ToHandleType(type_))),
       is_wrapped_(is_wrapped),
-      fbo_(fbo) {
+      wrapped_fbo_(fbo) {
   // Ensure the texture descriptor itself is valid.
   if (!GetTextureDescriptor().IsValid()) {
     VALIDATION_LOG << "Invalid texture descriptor.";

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -32,6 +32,10 @@ class TextureGLES final : public Texture,
               TextureDescriptor desc,
               IsWrapped wrapped);
 
+  static std::shared_ptr<TextureGLES> WrapFBO(ReactorGLES::Ref reactor,
+                                              TextureDescriptor desc,
+                                              GLuint fbo);
+
   // |Texture|
   ~TextureGLES() override;
 
@@ -54,6 +58,8 @@ class TextureGLES final : public Texture,
 
   bool IsWrapped() const { return is_wrapped_; }
 
+  std::optional<GLuint> GetFBO() const { return fbo_; }
+
  private:
   friend class AllocatorMTL;
 
@@ -62,11 +68,13 @@ class TextureGLES final : public Texture,
   HandleGLES handle_;
   mutable bool contents_initialized_ = false;
   const bool is_wrapped_;
+  const std::optional<GLuint> fbo_;
   bool is_valid_ = false;
 
   TextureGLES(std::shared_ptr<ReactorGLES> reactor,
               TextureDescriptor desc,
-              bool is_wrapped);
+              bool is_wrapped,
+              std::optional<GLuint> fbo);
 
   // |Texture|
   void SetLabel(std::string_view label) override;

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -58,7 +58,7 @@ class TextureGLES final : public Texture,
 
   bool IsWrapped() const { return is_wrapped_; }
 
-  std::optional<GLuint> GetFBO() const { return fbo_; }
+  std::optional<GLuint> GetFBO() const { return wrapped_fbo_; }
 
  private:
   friend class AllocatorMTL;
@@ -68,7 +68,7 @@ class TextureGLES final : public Texture,
   HandleGLES handle_;
   mutable bool contents_initialized_ = false;
   const bool is_wrapped_;
-  const std::optional<GLuint> fbo_;
+  const std::optional<GLuint> wrapped_fbo_;
   bool is_valid_ = false;
 
   TextureGLES(std::shared_ptr<ReactorGLES> reactor,

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -979,9 +979,8 @@ MakeRenderTargetFromBackingStoreImpeller(
   color0_tex.storage_mode = impeller::StorageMode::kDevicePrivate;
 
   impeller::ColorAttachment color0;
-  color0.texture = std::make_shared<impeller::TextureGLES>(
-      gl_context.GetReactor(), color0_tex,
-      impeller::TextureGLES::IsWrapped::kWrapped);
+  color0.texture = impeller::TextureGLES::WrapFBO(
+      gl_context.GetReactor(), color0_tex, framebuffer->name);
   color0.clear_color = impeller::Color::DarkSlateGray();
   color0.load_action = impeller::LoadAction::kClear;
   color0.store_action = impeller::StoreAction::kStore;

--- a/shell/platform/embedder/tests/embedder_test_context_gl.h
+++ b/shell/platform/embedder/tests/embedder_test_context_gl.h
@@ -62,6 +62,8 @@ class EmbedderTestContextGL : public EmbedderTestContext {
   void GLPopulateExistingDamage(const intptr_t id,
                                 FlutterDamage* existing_damage);
 
+  void* GLGetProcAddress(const char* name);
+
  protected:
   virtual void SetupCompositor() override;
 
@@ -87,8 +89,6 @@ class EmbedderTestContextGL : public EmbedderTestContext {
   uint32_t GLGetFramebuffer(FlutterFrameInfo frame_info);
 
   bool GLMakeResourceCurrent();
-
-  void* GLGetProcAddress(const char* name);
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderTestContextGL);
 };


### PR DESCRIPTION
The Linux embedder is rendering to a FlutterOpenGLFramebuffer that specifies an OpenGL FBO.  This API allows the embedder to create a color attachment that wraps the FBO so that the render pass will bind to that FBO during encoding.