### PR TITLE
Disambiguate conditional expressions

### DIFF
--- a/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -357,7 +357,8 @@ std::unique_ptr<PipelineVK> PipelineVK::Create(
   std::vector<vk::DescriptorSetLayoutBinding> set_bindings;
 
   vk::Sampler vk_immutable_sampler =
-      immutable_sampler ? immutable_sampler->GetSampler() : VK_NULL_HANDLE;
+      immutable_sampler ? immutable_sampler->GetSampler()
+                        : static_cast<vk::Sampler>(VK_NULL_HANDLE);
 
   for (auto layout : desc.GetVertexDescriptor()->GetDescriptorSetLayouts()) {
     vk::DescriptorSetLayoutBinding set_binding;

--- a/impeller/renderer/backend/vulkan/yuv_conversion_vk.cc
+++ b/impeller/renderer/backend/vulkan/yuv_conversion_vk.cc
@@ -30,7 +30,8 @@ bool YUVConversionVK::IsValid() const {
 }
 
 vk::SamplerYcbcrConversion YUVConversionVK::GetConversion() const {
-  return conversion_ ? conversion_.get() : VK_NULL_HANDLE;
+  return conversion_ ? conversion_.get()
+                     : static_cast<vk::SamplerYcbcrConversion>(VK_NULL_HANDLE);
 }
 
 const YUVConversionDescriptorVK& YUVConversionVK::GetDescriptor() const {


### PR DESCRIPTION
Internally, when targeting x86 Android, these files fail to compile:

```
impeller/renderer/backend/vulkan/yuv_conversion_vk.cc:33:22: error: conditional expression is ambiguous; 'const impeller::vk::SamplerYcbcrConversion' can be converted to 'unsigned long long' and vice versa
  return conversion_ ? conversion_.get() : VK_NULL_HANDLE;
                     ^ ~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~
impeller/renderer/backend/vulkan/pipeline_vk.cc:360:25: error: conditional expression is ambiguous; 'vk::Sampler' can be converted to 'unsigned long long' and vice versa
      immutable_sampler ? immutable_sampler->GetSampler() : VK_NULL_HANDLE;
                        ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~
```

The cause is that internally, `VULKAN_HPP_TYPESAFE_CONVERSION` is set but not for the GN build here. Copying from the [vulkan docs](https://github.com/KhronosGroup/Vulkan-Hpp/blob/main/README.md#cc-interop-for-handles):

> On 64-bit platforms Vulkan-Hpp supports implicit conversions between C++ Vulkan handles and C Vulkan handles. On 32-bit platforms all non-dispatchable handles are defined as `uint64_t`, thus preventing type-conversion checks at compile time which would catch assignments between incompatible handle types. Due to that Vulkan-Hpp does not enable implicit conversion for 32-bit platforms by default and it is recommended to use a `static_cast` for the conversion like this: `VkImage = static_cast<VkImage>(cppImage)` to prevent converting some arbitrary int to a handle or vice versa by accident. If you're developing your code on a 64-bit platform, but want compile your code for a 32-bit platform without adding the explicit casts you can define `VULKAN_HPP_TYPESAFE_CONVERSION` to 1 in your build system or before including `vulkan.hpp`. On 64-bit platforms this define is set to 1 by default and can be set to 0 to disable implicit conversions.

I'm not sure if doing the `static_cast` on the `VK_NULL_HANDLE` in this PR is right though. When targeting x86, this macro ends up being [defined as](https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers/+/5a5c9a643484d888873e32c5d7d484fae8e71d3d/include/vulkan/vulkan_core.h#46) `0LL`. But at the same time, putting the cast on the other ternary branch (e.g. `static_cast<vk::Sampler>(immutable_sampler->GetSampler())`) doesn't resolve the error.

*List which issues are fixed by this PR. You must list at least one issue.*
b/328355475


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
