### PR TITLE
Add fuchsia_gn_sdk GN variable pointing to //flutter/tools/fuchsia/gn-sdk

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -769,6 +769,7 @@ def to_gn_args(args):
 
   if args.target_os == 'fuchsia':
     gn_args['gn_configs_path'] = '//flutter/build/config/fuchsia/gn_configs.gni'
+    gn_args['fuchsia_gn_sdk'] = '//flutter/tools/fuchsia/gn-sdk'
   if args.fuchsia_target_api_level is not None:
     gn_args['fuchsia_target_api_level'] = args.fuchsia_target_api_level
   elif args.target_os == 'fuchsia':


### PR DESCRIPTION
The Dart -> Flutter Engine autoroller seems to be failing atm due to fuchsia build errors.

The Dart SDK CL in [0] is depending on a fuchsia gn sdk import. The import path defaults to `//third_party/fuchsia/gn-sdk` in the Dart build rules.

Though flutter seemingly has it in `//flutter/tools/fuchsia/gn-sdk` (which was added to DEPS in 8b240244ef3f3afb7526eb04f03540ef9d809f5a)

=> This is an attempt to override the default & fix autoroller

[0] https://dart-review.googlesource.com/c/sdk/+/355283/14