### PR TITLE
[Windows] Move to new present callback

### DIFF
--- a/shell/platform/windows/compositor.h
+++ b/shell/platform/windows/compositor.h
@@ -31,7 +31,9 @@ class Compositor {
   virtual bool CollectBackingStore(const FlutterBackingStore* store) = 0;
 
   // Present Flutter content and platform views onto the view.
-  virtual bool Present(const FlutterLayer** layers, size_t layers_count) = 0;
+  virtual bool Present(FlutterViewId view_id,
+                       const FlutterLayer** layers,
+                       size_t layers_count) = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/compositor_opengl.cc
+++ b/shell/platform/windows/compositor_opengl.cc
@@ -92,11 +92,10 @@ bool CompositorOpenGL::CollectBackingStore(const FlutterBackingStore* store) {
   return true;
 }
 
-bool CompositorOpenGL::Present(const FlutterLayer** layers,
+bool CompositorOpenGL::Present(FlutterViewId view_id,
+                               const FlutterLayer** layers,
                                size_t layers_count) {
-  // TODO(loicsharma): Remove implicit view assumption.
-  // https://github.com/flutter/flutter/issues/142845
-  FlutterWindowsView* view = engine_->view(kImplicitViewId);
+  FlutterWindowsView* view = engine_->view(view_id);
   if (!view) {
     return false;
   }

--- a/shell/platform/windows/compositor_opengl.h
+++ b/shell/platform/windows/compositor_opengl.h
@@ -28,7 +28,9 @@ class CompositorOpenGL : public Compositor {
   bool CollectBackingStore(const FlutterBackingStore* store) override;
 
   /// |Compositor|
-  bool Present(const FlutterLayer** layers, size_t layers_count) override;
+  bool Present(FlutterViewId view_id,
+               const FlutterLayer** layers,
+               size_t layers_count) override;
 
  private:
   // The Flutter engine that manages the views to render.

--- a/shell/platform/windows/compositor_software.cc
+++ b/shell/platform/windows/compositor_software.cc
@@ -38,11 +38,10 @@ bool CompositorSoftware::CollectBackingStore(const FlutterBackingStore* store) {
   return true;
 }
 
-bool CompositorSoftware::Present(const FlutterLayer** layers,
+bool CompositorSoftware::Present(FlutterViewId view_id,
+                                 const FlutterLayer** layers,
                                  size_t layers_count) {
-  // TODO(loicsharma): Remove implicit view assumption.
-  // https://github.com/flutter/flutter/issues/142845
-  FlutterWindowsView* view = engine_->view(kImplicitViewId);
+  FlutterWindowsView* view = engine_->view(view_id);
   if (!view) {
     return false;
   }

--- a/shell/platform/windows/compositor_software.h
+++ b/shell/platform/windows/compositor_software.h
@@ -24,7 +24,9 @@ class CompositorSoftware : public Compositor {
   bool CollectBackingStore(const FlutterBackingStore* store) override;
 
   /// |Compositor|
-  bool Present(const FlutterLayer** layers, size_t layers_count) override;
+  bool Present(FlutterViewId view_id,
+               const FlutterLayer** layers,
+               size_t layers_count) override;
 
  private:
   FlutterWindowsEngine* engine_;

--- a/shell/platform/windows/compositor_software_unittests.cc
+++ b/shell/platform/windows/compositor_software_unittests.cc
@@ -104,7 +104,7 @@ TEST_F(CompositorSoftwareTest, Present) {
   const FlutterLayer* layer_ptr = &layer;
 
   EXPECT_CALL(*view(), PresentSoftwareBitmap).WillOnce(Return(true));
-  EXPECT_TRUE(compositor.Present(&layer_ptr, 1));
+  EXPECT_TRUE(compositor.Present(view()->view_id(), &layer_ptr, 1));
 
   ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
 }
@@ -115,7 +115,31 @@ TEST_F(CompositorSoftwareTest, PresentEmpty) {
   auto compositor = CompositorSoftware{engine()};
 
   EXPECT_CALL(*view(), ClearSoftwareBitmap).WillOnce(Return(true));
-  EXPECT_TRUE(compositor.Present(nullptr, 0));
+  EXPECT_TRUE(compositor.Present(view()->view_id(), nullptr, 0));
+}
+
+TEST_F(CompositorSoftwareTest, UnknownViewIgnored) {
+  UseEngineWithView();
+
+  auto compositor = CompositorSoftware{engine()};
+
+  FlutterBackingStoreConfig config = {};
+  FlutterBackingStore backing_store = {};
+
+  ASSERT_TRUE(compositor.CreateBackingStore(config, &backing_store));
+
+  FlutterLayer layer = {};
+  layer.type = kFlutterLayerContentTypeBackingStore;
+  layer.backing_store = &backing_store;
+  const FlutterLayer* layer_ptr = &layer;
+
+  FlutterViewId unknown_view_id = 123;
+  ASSERT_NE(view()->view_id(), unknown_view_id);
+  ASSERT_EQ(engine()->view(unknown_view_id), nullptr);
+
+  EXPECT_FALSE(compositor.Present(unknown_view_id, &layer_ptr, 1));
+
+  ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
 }
 
 TEST_F(CompositorSoftwareTest, HeadlessPresentIgnored) {
@@ -133,7 +157,7 @@ TEST_F(CompositorSoftwareTest, HeadlessPresentIgnored) {
   layer.backing_store = &backing_store;
   const FlutterLayer* layer_ptr = &layer;
 
-  EXPECT_FALSE(compositor.Present(&layer_ptr, 1));
+  EXPECT_FALSE(compositor.Present(kImplicitViewId, &layer_ptr, 1));
 
   ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
 }

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -414,12 +414,12 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
     return host->compositor_->CollectBackingStore(backing_store);
   };
 
-  compositor.present_layers_callback = [](const FlutterLayer** layers,
-                                          size_t layers_count,
-                                          void* user_data) -> bool {
-    auto host = static_cast<FlutterWindowsEngine*>(user_data);
+  compositor.present_view_callback =
+      [](const FlutterPresentViewInfo* info) -> bool {
+    auto host = static_cast<FlutterWindowsEngine*>(info->user_data);
 
-    return host->compositor_->Present(layers, layers_count);
+    return host->compositor_->Present(info->view_id, info->layers,
+                                      info->layers_count);
   };
   args.compositor = &compositor;
 


### PR DESCRIPTION
Migrates the Windows embedder to the new present callback which includes a `view_id` value.

Design doc: https://flutter.dev/go/multi-view-embedder-apis

Part of https://github.com/flutter/flutter/issues/144810
Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
