### PR TITLE
[Impeller] Use the AHB prefix for utils that work with Android Hardware Buffers.

### DIFF
--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -34,8 +34,6 @@ impeller_component("vulkan") {
   sources = [
     "allocator_vk.cc",
     "allocator_vk.h",
-    "android_hardware_buffer_texture_source_vk.cc",
-    "android_hardware_buffer_texture_source_vk.h",
     "barrier_vk.cc",
     "barrier_vk.h",
     "blit_command_vk.cc",
@@ -121,6 +119,13 @@ impeller_component("vulkan") {
     "yuv_conversion_vk.cc",
     "yuv_conversion_vk.h",
   ]
+
+  if (is_android) {
+    sources += [
+      "android/ahb_texture_source_vk.cc",
+      "android/ahb_texture_source_vk.h",
+    ]
+  }
 
   public_deps = [
     "../../:renderer",

--- a/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -2,15 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.h"
-
-#include <cstdint>
+#include "impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h"
 
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_source_vk.h"
 #include "impeller/renderer/backend/vulkan/yuv_conversion_library_vk.h"
-
-#ifdef FML_OS_ANDROID
 
 namespace impeller {
 
@@ -293,7 +289,7 @@ static TextureDescriptor ToTextureDescriptor(
   return desc;
 }
 
-AndroidHardwareBufferTextureSourceVK::AndroidHardwareBufferTextureSourceVK(
+AHBTextureSourceVK::AHBTextureSourceVK(
     const std::shared_ptr<ContextVK>& context,
     struct AHardwareBuffer* ahb,
     const AHardwareBuffer_Desc& ahb_desc)
@@ -373,40 +369,35 @@ AndroidHardwareBufferTextureSourceVK::AndroidHardwareBufferTextureSourceVK(
 }
 
 // |TextureSourceVK|
-AndroidHardwareBufferTextureSourceVK::~AndroidHardwareBufferTextureSourceVK() =
-    default;
+AHBTextureSourceVK::~AHBTextureSourceVK() = default;
 
-bool AndroidHardwareBufferTextureSourceVK::IsValid() const {
+bool AHBTextureSourceVK::IsValid() const {
   return is_valid_;
 }
 
 // |TextureSourceVK|
-vk::Image AndroidHardwareBufferTextureSourceVK::GetImage() const {
+vk::Image AHBTextureSourceVK::GetImage() const {
   return image_.get();
 }
 
 // |TextureSourceVK|
-vk::ImageView AndroidHardwareBufferTextureSourceVK::GetImageView() const {
+vk::ImageView AHBTextureSourceVK::GetImageView() const {
   return image_view_.get();
 }
 
 // |TextureSourceVK|
-vk::ImageView AndroidHardwareBufferTextureSourceVK::GetRenderTargetView()
-    const {
+vk::ImageView AHBTextureSourceVK::GetRenderTargetView() const {
   return image_view_.get();
 }
 
 // |TextureSourceVK|
-bool AndroidHardwareBufferTextureSourceVK::IsSwapchainImage() const {
+bool AHBTextureSourceVK::IsSwapchainImage() const {
   return false;
 }
 
 // |TextureSourceVK|
-std::shared_ptr<YUVConversionVK>
-AndroidHardwareBufferTextureSourceVK::GetYUVConversion() const {
+std::shared_ptr<YUVConversionVK> AHBTextureSourceVK::GetYUVConversion() const {
   return needs_yuv_conversion_ ? yuv_conversion_ : nullptr;
 }
 
 }  // namespace impeller
-
-#endif

--- a/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
+++ b/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
@@ -2,13 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_HARDWARE_BUFFER_TEXTURE_SOURCE_VK_H_
-#define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_HARDWARE_BUFFER_TEXTURE_SOURCE_VK_H_
-
-#include "flutter/fml/build_config.h"
-#include "vulkan/vulkan_core.h"
-
-#ifdef FML_OS_ANDROID
+#ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_AHB_TEXTURE_SOURCE_VK_H_
+#define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_AHB_TEXTURE_SOURCE_VK_H_
 
 #include "flutter/fml/macros.h"
 #include "impeller/geometry/size.h"
@@ -36,15 +31,14 @@ class ContextVK;
 ///             descriptors. The objects are meant to be used directly (either
 ///             as render targets or sources for sampling), not copied.
 ///
-class AndroidHardwareBufferTextureSourceVK final : public TextureSourceVK {
+class AHBTextureSourceVK final : public TextureSourceVK {
  public:
-  AndroidHardwareBufferTextureSourceVK(
-      const std::shared_ptr<ContextVK>& context,
-      struct AHardwareBuffer* hardware_buffer,
-      const AHardwareBuffer_Desc& hardware_buffer_desc);
+  AHBTextureSourceVK(const std::shared_ptr<ContextVK>& context,
+                     struct AHardwareBuffer* hardware_buffer,
+                     const AHardwareBuffer_Desc& hardware_buffer_desc);
 
   // |TextureSourceVK|
-  ~AndroidHardwareBufferTextureSourceVK() override;
+  ~AHBTextureSourceVK() override;
 
   // |TextureSourceVK|
   vk::Image GetImage() const override;
@@ -71,15 +65,11 @@ class AndroidHardwareBufferTextureSourceVK final : public TextureSourceVK {
   bool needs_yuv_conversion_ = false;
   bool is_valid_ = false;
 
-  AndroidHardwareBufferTextureSourceVK(
-      const AndroidHardwareBufferTextureSourceVK&) = delete;
+  AHBTextureSourceVK(const AHBTextureSourceVK&) = delete;
 
-  AndroidHardwareBufferTextureSourceVK& operator=(
-      const AndroidHardwareBufferTextureSourceVK&) = delete;
+  AHBTextureSourceVK& operator=(const AHBTextureSourceVK&) = delete;
 };
 
 }  // namespace impeller
 
-#endif
-
-#endif  // FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_HARDWARE_BUFFER_TEXTURE_SOURCE_VK_H_
+#endif  // FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_ANDROID_AHB_TEXTURE_SOURCE_VK_H_

--- a/shell/platform/android/image_external_texture_vk.cc
+++ b/shell/platform/android/image_external_texture_vk.cc
@@ -6,7 +6,7 @@
 #include "flutter/impeller/core/formats.h"
 #include "flutter/impeller/core/texture_descriptor.h"
 #include "flutter/impeller/display_list/dl_image_impeller.h"
-#include "flutter/impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.h"
+#include "flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h"
 #include "flutter/impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "flutter/impeller/renderer/backend/vulkan/command_encoder_vk.h"
 #include "flutter/impeller/renderer/backend/vulkan/texture_vk.h"
@@ -54,9 +54,8 @@ void ImageExternalTextureVK::ProcessFrame(PaintContext& context,
     return;
   }
 
-  auto texture_source =
-      std::make_shared<impeller::AndroidHardwareBufferTextureSourceVK>(
-          impeller_context_, latest_hardware_buffer, hb_desc);
+  auto texture_source = std::make_shared<impeller::AHBTextureSourceVK>(
+      impeller_context_, latest_hardware_buffer, hb_desc);
 
   auto texture =
       std::make_shared<impeller::TextureVK>(impeller_context_, texture_source);

--- a/shell/platform/android/image_external_texture_vk.h
+++ b/shell/platform/android/image_external_texture_vk.h
@@ -9,7 +9,7 @@
 #include <utility>
 #include "flutter/shell/platform/android/image_external_texture.h"
 
-#include "flutter/impeller/renderer/backend/vulkan/android_hardware_buffer_texture_source_vk.h"
+#include "flutter/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h"
 #include "flutter/impeller/renderer/backend/vulkan/context_vk.h"
 #include "flutter/impeller/renderer/backend/vulkan/vk.h"
 #include "flutter/shell/platform/android/android_context_vulkan_impeller.h"


### PR DESCRIPTION
Also doesn't compile the TU on non-Android platforms.

Part of https://github.com/flutter/engine/pull/51213 being chopped up.

No change in functionality. Just renames and moves stuff around.