### PR TITLE
Explicitly list Android embedding dependency jars in GN

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -350,14 +350,38 @@ android_java_sources = [
   "io/flutter/view/VsyncWaiter.java",
 ]
 
-list_script = rebase_path("//build/ls.py", ".", "//")
-embedding_dependencies_jars =
-    exec_script(list_script,
-                [
-                  "--target-directory",
-                  rebase_path("//third_party/android_embedding_dependencies"),
-                ],
-                "list lines")
+embedding_dependencies_jars = [
+  "//third_party/android_embedding_dependencies/lib/activity-1.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/annotation-1.2.0.jar",
+  "//third_party/android_embedding_dependencies/lib/annotation-experimental-1.1.0.jar",
+  "//third_party/android_embedding_dependencies/lib/annotations-13.0.jar",
+  "//third_party/android_embedding_dependencies/lib/collection-1.1.0.jar",
+  "//third_party/android_embedding_dependencies/lib/core-1.6.0.jar",
+  "//third_party/android_embedding_dependencies/lib/core-1.8.0.jar",
+  "//third_party/android_embedding_dependencies/lib/core-common-2.1.0.jar",
+  "//third_party/android_embedding_dependencies/lib/core-runtime-2.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/customview-1.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/fragment-1.1.0.jar",
+  "//third_party/android_embedding_dependencies/lib/kotlin-stdlib-1.5.31.jar",
+  "//third_party/android_embedding_dependencies/lib/kotlin-stdlib-common-1.5.31.jar",
+  "//third_party/android_embedding_dependencies/lib/kotlin-stdlib-jdk7-1.5.30.jar",
+  "//third_party/android_embedding_dependencies/lib/kotlin-stdlib-jdk8-1.5.30.jar",
+  "//third_party/android_embedding_dependencies/lib/kotlinx-coroutines-android-1.5.2.jar",
+  "//third_party/android_embedding_dependencies/lib/kotlinx-coroutines-core-jvm-1.5.2.jar",
+  "//third_party/android_embedding_dependencies/lib/lifecycle-common-2.2.0.jar",
+  "//third_party/android_embedding_dependencies/lib/lifecycle-common-java8-2.2.0.jar",
+  "//third_party/android_embedding_dependencies/lib/lifecycle-livedata-2.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/lifecycle-livedata-core-2.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/lifecycle-runtime-2.2.0.jar",
+  "//third_party/android_embedding_dependencies/lib/lifecycle-viewmodel-2.1.0.jar",
+  "//third_party/android_embedding_dependencies/lib/loader-1.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/savedstate-1.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/tracing-1.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/versionedparcelable-1.1.1.jar",
+  "//third_party/android_embedding_dependencies/lib/viewpager-1.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/window-1.0.0-beta04.jar",
+  "//third_party/android_embedding_dependencies/lib/window-java-1.0.0-beta04.jar",
+]
 
 action("check_imports") {
   script = "//flutter/tools/android_illegal_imports.py"

--- a/tools/cipd/android_embedding_bundle/README.md
+++ b/tools/cipd/android_embedding_bundle/README.md
@@ -32,3 +32,5 @@ below explain how to fetch the license information for the dependencies.
    `$version_tag` is the output of `date +%Y-%m-%dT%T%z`.
 1. Update the `DEPS` file entry for `android_embedding_dependencies` with the
    new tag: `last_updated:"$version_tag"`.
+1. Update the GN list `embedding_dependencies_jars` in
+   `src/flutter/shell/platform/android/BUILD.gn`.


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/144430.

From `gn help inputs`: "It may be tempting to write a script that enumerates all files in a directory
  as inputs. Don't do this!"