### PR TITLE
[web] - fix text editing IME composition interruption on geometry updates

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1338,9 +1338,9 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
   void updateElementPlacement(EditableTextGeometry textGeometry) {
     geometry = textGeometry;
     if (isEnabled) {
-      // On updates, we shouldn't go through the entire placeElement() flow if 
+      // On updates, we shouldn't go through the entire placeElement() flow if
       // we are in the middle of IME composition, otherwise we risk interrupting it.
-      // Geometry updates occur when a multiline input expands or contracts. If 
+      // Geometry updates occur when a multiline input expands or contracts. If
       // we are in the middle of composition, we should just update the geometry.
       // See: https://github.com/flutter/flutter/issues/98817
       if(composingText != null) {

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1338,7 +1338,16 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
   void updateElementPlacement(EditableTextGeometry textGeometry) {
     geometry = textGeometry;
     if (isEnabled) {
-      placeElement();
+      // On updates, we shouldn't go through the entire placeElement() flow if 
+      // we are in the middle of IME composition, otherwise we risk interrupting it.
+      // Geometry updates occur when a multiline input expands or contracts. If 
+      // we are in the middle of composition, we should just update the geometry.
+      // See: https://github.com/flutter/flutter/issues/98817
+      if(composingText != null) {
+        geometry?.applyToDomElement(activeDomElement);
+      } else {
+        placeElement();
+      }
     }
   }
 

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -3471,7 +3471,7 @@ class GlobalTextEditingStrategySpy extends GloballyPositionedTextEditingStrategy
   GlobalTextEditingStrategySpy(super.owner);
 
   int placeElementCount = 0;
-  
+
   @override
   void placeElement() {
     placeElementCount++;

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -513,6 +513,64 @@ Future<void> testMain() async {
       expect(editingStrategy!.domElement!.style.width, '13px');
       expect(editingStrategy!.domElement!.style.height, '12px');
     });
+
+    test('updateElementPlacement() should not call placeElement() when in mid-composition', () {
+      final HybridTextEditing testTextEditing = HybridTextEditing();
+      final GlobalTextEditingStrategySpy editingStrategy = GlobalTextEditingStrategySpy(testTextEditing);
+      testTextEditing.debugTextEditingStrategyOverride = editingStrategy;
+      testTextEditing.configuration = singlelineConfig;
+
+      editingStrategy.enable(
+        singlelineConfig,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+      expect(editingStrategy.isEnabled, isTrue);
+
+      // placeElement() called from enable()
+      expect(editingStrategy.placeElementCount, 1);
+
+      // No geometry should be set until setEditableSizeAndTransform is called.
+      expect(editingStrategy.domElement!.style.transform, '');
+      expect(editingStrategy.domElement!.style.width, '');
+      expect(editingStrategy.domElement!.style.height, '');
+
+      // set some composing text.
+      editingStrategy.composingText = '뮤';
+
+      testTextEditing.acceptCommand(TextInputSetEditableSizeAndTransform(geometry: EditableTextGeometry(
+        width: 13,
+        height: 12,
+        globalTransform: Matrix4.translationValues(14, 15, 0).storage,
+      )), () {});
+
+      // placeElement() should not be called again.
+      expect(editingStrategy.placeElementCount, 1);
+
+      // geometry should be applied.
+      expect(editingStrategy.domElement!.style.transform,
+          'matrix(1, 0, 0, 1, 14, 15)');
+      expect(editingStrategy.domElement!.style.width, '13px');
+      expect(editingStrategy.domElement!.style.height, '12px');
+
+      // set composing text to null.
+      editingStrategy.composingText = null;
+
+      testTextEditing.acceptCommand(TextInputSetEditableSizeAndTransform(geometry: EditableTextGeometry(
+        width: 10,
+        height: 10,
+        globalTransform: Matrix4.translationValues(11, 12, 0).storage,
+      )), () {});
+
+      // placeElement() should be called again.
+      expect(editingStrategy.placeElementCount, 2);
+
+      // geometry should be updated.
+      expect(editingStrategy.domElement!.style.transform,
+          'matrix(1, 0, 0, 1, 11, 12)');
+      expect(editingStrategy.domElement!.style.width, '10px');
+      expect(editingStrategy.domElement!.style.height, '10px');
+    });
   });
 
   group('$HybridTextEditing', () {
@@ -3406,5 +3464,17 @@ void clearForms() {
 Future<void> waitForDesktopSafariFocus() async {
   if (textEditing.strategy is SafariDesktopTextEditingStrategy) {
     await Future<void>.delayed(Duration.zero);
+  }
+}
+
+class GlobalTextEditingStrategySpy extends GloballyPositionedTextEditingStrategy {
+  GlobalTextEditingStrategySpy(super.owner);
+
+  int placeElementCount = 0;
+  
+  @override
+  void placeElement() {
+    placeElementCount++;
+    super.placeElement();
   }
 }


### PR DESCRIPTION
This change fixes an issue where IME composition gets interrupted when the `setEditableSizeAndTransform` platform message is received mid-composition.  This occurs when a multiline input expands and needs to inform the underlying `textarea` to update its size.  

Fixes https://github.com/flutter/flutter/issues/134797
Fixes https://github.com/flutter/flutter/issues/98817

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
