### PR TITLE
Restore //third_party/web_dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -789,6 +789,16 @@ deps = {
      'dep_type': 'cipd',
    },
 
+  'src/third_party/web_dependencies': {
+     'packages': [
+       {
+         'package': 'flutter/web/canvaskit_bundle',
+         'version': Var('canvaskit_cipd_instance')
+       }
+     ],
+     'dep_type': 'cipd',
+   },
+
   'src/third_party/java/openjdk': {
      'packages': [
        {


### PR DESCRIPTION
The removal in https://github.com/flutter/engine/pull/51299 appears to be confusing the engine -> framework autoroller.
