### PR TITLE
Add a comparative benchmark for SkM44 vs SkMatrix vs impeller::Matrix

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -141,6 +141,7 @@ group("flutter") {
       "//flutter/display_list:display_list_benchmarks",
       "//flutter/display_list:display_list_builder_benchmarks",
       "//flutter/display_list:display_list_region_benchmarks",
+      "//flutter/display_list:display_list_transform_benchmarks",
       "//flutter/fml:fml_benchmarks",
       "//flutter/impeller/aiks:canvas_benchmarks",
       "//flutter/impeller/geometry:geometry_benchmarks",

--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -204,6 +204,18 @@ if (enable_unittests) {
       "//flutter/testing:testing_lib",
     ]
   }
+
+  executable("display_list_transform_benchmarks") {
+    testonly = true
+
+    sources = [ "benchmarking/dl_transform_benchmarks.cc" ]
+
+    deps = [
+      ":display_list_fixtures",
+      "//flutter/benchmarking",
+      "//flutter/testing:testing_lib",
+    ]
+  }
 }
 
 source_set("display_list_benchmarks_source") {

--- a/display_list/benchmarking/dl_transform_benchmarks.cc
+++ b/display_list/benchmarking/dl_transform_benchmarks.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <functional>
+
 #include "flutter/benchmarking/benchmarking.h"
 
 #include "flutter/impeller/geometry/matrix.h"
@@ -21,28 +23,26 @@ enum class AdapterType {
   kImpellerMatrix,
 };
 
-// This struct should be a "castable" replacement for the various rect
-// objects being used (SkRect or impeller::Rect), so that no adapter
-// gets an advantage in the rect bounds transform benchmarks. Each
-// sub-class of Adapter (Skia vs Impeller) will assert this similarity
-// in its constructor (which is only executed once per benchmark in the
-// setup code outside of the timed body).
-struct TestRect {
-  static constexpr TestRect MakeLTRB(float left,
-                                     float top,
-                                     float right,
-                                     float bottom) {
-    return TestRect(left, top, right, bottom);
-  }
+union TestPoint {
+  TestPoint() {}
 
-  float left;
-  float top;
-  float right;
-  float bottom;
+  SkPoint sk_point;
+  impeller::Point impeller_point;
+};
 
- private:
-  constexpr TestRect(float l, float t, float r, float b)
-      : left(l), top(t), right(r), bottom(b) {}
+union TestRect {
+  TestRect() {}
+
+  SkRect sk_rect;
+  impeller::Rect impeller_rect;
+};
+
+union TestTransform {
+  TestTransform() {}
+
+  SkMatrix sk_matrix;
+  SkM44 sk_m44;
+  impeller::Matrix impeller_matrix;
 };
 
 // We use a virtual adapter class rather than templating the BM_* methods
@@ -59,47 +59,57 @@ class TransformAdapter {
   // for a method that does a conversion to and from the TestRect object
   // (which should be the same as the method call overhead since it does
   // no work).
-  virtual void DoNothing() const = 0;
-  virtual TestRect DoNothing(const TestRect& rect) const = 0;
+  virtual void DoNothing(TestTransform& ignored) const = 0;
+
+  virtual void InitRectLTRB(TestRect& rect,
+                            float left,
+                            float top,
+                            float right,
+                            float bottom) const = 0;
+  virtual void InitPoint(TestPoint& point, float x, float y) const = 0;
 
   // The actual methods that do work and are the meat of the benchmarks.
-  virtual void SetIdentity() = 0;
-  virtual void SetTranslate(float tx, float ty) = 0;
-  virtual void SetScale(float sx, float sy) = 0;
-  virtual void SetRotate(float radians) = 0;
+  virtual void SetIdentity(TestTransform& result) const = 0;
 
-  virtual void Translate(float tx, float ty) = 0;
-  virtual void Scale(float sx, float sy) = 0;
-  virtual void Rotate(float radians) = 0;
+  virtual void Translate(TestTransform& result, float tx, float ty) const = 0;
+  virtual void Scale(TestTransform& result, float sx, float sy) const = 0;
+  virtual void RotateRadians(TestTransform& result, float radians) const = 0;
 
-  virtual TestRect TransformRect(const TestRect& rect) const = 0;
+  virtual void Concat(const TestTransform& a,
+                      const TestTransform& b,
+                      TestTransform& result) const = 0;
+
+  virtual void TransformPoint(const TestTransform& transform,
+                              const TestPoint& in,
+                              TestPoint& out) const = 0;
+  virtual void TransformPoints(const TestTransform& transform,
+                               const TestPoint in[],
+                               TestPoint out[],
+                               int n) const = 0;
+  virtual void TransformRect(const TestTransform& transform,
+                             const TestRect& in,
+                             TestRect& out) const = 0;
+  virtual void InvertUnchecked(const TestTransform& transform,
+                               TestTransform& result) const = 0;
+  virtual bool InvertAndCheck(const TestTransform& transform,
+                              TestTransform& result) const = 0;
 };
 
 class SkiaAdapterBase : public TransformAdapter {
  public:
-  SkiaAdapterBase() {
-    static_assert(sizeof(TestRect) == sizeof(SkRect));
-    const TestRect tr = TestRect::MakeLTRB(1, 2, 3, 4);
-    auto& sr = ToSkRect(tr);
-    FML_CHECK(sr.fLeft == 1.0f);
-    FML_CHECK(sr.fTop == 2.0f);
-    FML_CHECK(sr.fRight == 3.0f);
-    FML_CHECK(sr.fBottom == 4.0f);
-  }
-
   // DoNothing methods used to measure overhead for various operations
-  void DoNothing() const override {}
-  TestRect DoNothing(const TestRect& rect) const override {
-    return ToTestRect(ToSkRect(rect));
+  void DoNothing(TestTransform& ignored) const override {}
+
+  void InitPoint(TestPoint& point, float x, float y) const override {
+    point.sk_point.set(x, y);
   }
 
- protected:
-  static constexpr const SkRect& ToSkRect(const TestRect& rect) {
-    return *((const SkRect*)(&rect));
-  }
-
-  static constexpr const TestRect& ToTestRect(const SkRect& rect) {
-    return *((const TestRect*)(&rect));
+  void InitRectLTRB(TestRect& rect,
+                    float left,
+                    float top,
+                    float right,
+                    float bottom) const override {
+    rect.sk_rect.setLTRB(left, top, right, bottom);
   }
 };
 
@@ -108,36 +118,59 @@ class SkMatrixAdapter : public SkiaAdapterBase {
   SkMatrixAdapter() = default;
   ~SkMatrixAdapter() = default;
 
-  void SetIdentity() override { transform_ = SkMatrix::I(); }
-
-  void SetTranslate(float tx, float ty) override {
-    transform_ = SkMatrix::Translate(tx, ty);
+  void SetIdentity(TestTransform& result) const override {
+    result.sk_matrix.setIdentity();
   }
 
-  void SetScale(float sx, float sy) override {
-    transform_ = SkMatrix::Scale(sx, sy);
+  void Translate(TestTransform& result, float tx, float ty) const override {
+    result.sk_matrix.preTranslate(tx, ty);
   }
 
-  void SetRotate(float radians) override {
-    transform_ = SkMatrix::RotateRad(radians);
+  void Scale(TestTransform& result, float sx, float sy) const override {
+    result.sk_matrix.preScale(sx, sy);
   }
 
-  void Translate(float tx, float ty) override {
-    transform_.preTranslate(tx, ty);
+  void RotateRadians(TestTransform& result, float radians) const override {
+    result.sk_matrix.preRotate(SkRadiansToDegrees(radians));
   }
 
-  void Scale(float sx, float sy) override { transform_.preScale(sx, sy); }
-
-  void Rotate(float radians) override {
-    transform_.preRotate(SkRadiansToDegrees(radians));
+  void Concat(const TestTransform& a,
+              const TestTransform& b,
+              TestTransform& result) const override {
+    result.sk_matrix = SkMatrix::Concat(a.sk_matrix, b.sk_matrix);
   }
 
-  TestRect TransformRect(const TestRect& rect) const override {
-    return ToTestRect(transform_.mapRect(ToSkRect(rect)));
+  void TransformPoint(const TestTransform& transform,
+                      const TestPoint& in,
+                      TestPoint& out) const override {
+    out.sk_point = transform.sk_matrix.mapPoint(in.sk_point);
   }
 
- private:
-  SkMatrix transform_;
+  void TransformPoints(const TestTransform& transform,
+                       const TestPoint in[],
+                       TestPoint out[],
+                       int n) const override {
+    static_assert(sizeof(TestPoint) == sizeof(SkPoint));
+    transform.sk_matrix.mapPoints(reinterpret_cast<SkPoint*>(out),
+                                  reinterpret_cast<const SkPoint*>(in), n);
+  }
+
+  void TransformRect(const TestTransform& transform,
+                     const TestRect& in,
+                     TestRect& out) const override {
+    out.sk_rect = transform.sk_matrix.mapRect(in.sk_rect);
+  }
+
+  void InvertUnchecked(const TestTransform& transform,
+                       TestTransform& result) const override {
+    [[maybe_unused]]
+    bool ret = transform.sk_matrix.invert(&result.sk_matrix);
+  }
+
+  bool InvertAndCheck(const TestTransform& transform,
+                      TestTransform& result) const override {
+    return transform.sk_matrix.invert(&result.sk_matrix);
+  }
 };
 
 class SkM44Adapter : public SkiaAdapterBase {
@@ -145,99 +178,169 @@ class SkM44Adapter : public SkiaAdapterBase {
   SkM44Adapter() = default;
   ~SkM44Adapter() = default;
 
-  void SetIdentity() override { transform_ = SkM44(); }
-
-  void SetTranslate(float tx, float ty) override {
-    transform_ = SkM44::Translate(tx, ty);
+  void SetIdentity(TestTransform& storage) const override {
+    storage.sk_m44.setIdentity();
   }
 
-  void SetScale(float sx, float sy) override {
-    transform_ = SkM44::Scale(sx, sy);
+  void Translate(TestTransform& storage, float tx, float ty) const override {
+    storage.sk_m44.preTranslate(tx, ty);
   }
 
-  void SetRotate(float radians) override {
-    transform_ = SkM44::Rotate({0, 0, 1}, radians);
+  void Scale(TestTransform& storage, float sx, float sy) const override {
+    storage.sk_m44.preScale(sx, sy);
   }
 
-  void Translate(float tx, float ty) override {
-    transform_.preTranslate(tx, ty);
+  void RotateRadians(TestTransform& storage, float radians) const override {
+    storage.sk_m44.preConcat(SkM44::Rotate({0, 0, 1}, radians));
   }
 
-  void Scale(float sx, float sy) override { transform_.preScale(sx, sy); }
-
-  void Rotate(float radians) override {
-    transform_.preConcat(SkM44::Rotate({0, 0, 1}, radians));
+  void Concat(const TestTransform& a,
+              const TestTransform& b,
+              TestTransform& result) const override {
+    result.sk_m44.setConcat(a.sk_m44, b.sk_m44);
   }
 
-  TestRect TransformRect(const TestRect& rect) const override {
-    return ToTestRect(transform_.asM33().mapRect(ToSkRect(rect)));
+  void TransformPoint(const TestTransform& transform,
+                      const TestPoint& in,
+                      TestPoint& out) const override {
+    out.sk_point = transform.sk_m44.asM33().mapPoint(in.sk_point);
   }
 
- private:
-  SkM44 transform_;
+  void TransformPoints(const TestTransform& transform,
+                       const TestPoint in[],
+                       TestPoint out[],
+                       int n) const override {
+    static_assert(sizeof(TestPoint) == sizeof(SkPoint));
+    transform.sk_m44.asM33().mapPoints(reinterpret_cast<SkPoint*>(out),
+                                       reinterpret_cast<const SkPoint*>(in), n);
+  }
+
+  void TransformRect(const TestTransform& transform,
+                     const TestRect& in,
+                     TestRect& out) const override {
+    out.sk_rect = transform.sk_m44.asM33().mapRect(in.sk_rect);
+  }
+
+  void InvertUnchecked(const TestTransform& transform,
+                       TestTransform& result) const override {
+    [[maybe_unused]]
+    bool ret = transform.sk_m44.invert(&result.sk_m44);
+  }
+
+  bool InvertAndCheck(const TestTransform& transform,
+                      TestTransform& result) const override {
+    return transform.sk_m44.invert(&result.sk_m44);
+  }
 };
 
 class ImpellerMatrixAdapter : public TransformAdapter {
  public:
-  ImpellerMatrixAdapter() {
-    static_assert(sizeof(TestRect) == sizeof(impeller::Rect));
-    const TestRect tr = TestRect::MakeLTRB(1, 2, 3, 4);
-    auto& sr = ToImpellerRect(tr);
-    FML_CHECK(sr.GetLeft() == 1.0f);
-    FML_CHECK(sr.GetTop() == 2.0f);
-    FML_CHECK(sr.GetRight() == 3.0f);
-    FML_CHECK(sr.GetBottom() == 4.0f);
-  }
-
+  ImpellerMatrixAdapter() = default;
   ~ImpellerMatrixAdapter() = default;
 
-  void DoNothing() const override {}
-  TestRect DoNothing(const TestRect& rect) const override {
-    return ToTestRect(ToImpellerRect(rect));
+  void DoNothing(TestTransform& ignored) const override {}
+
+  void InitPoint(TestPoint& point, float x, float y) const override {
+    point.impeller_point = impeller::Point(x, y);
   }
 
-  void SetIdentity() override { transform_ = impeller::Matrix(); }
-
-  void SetTranslate(float tx, float ty) override {
-    transform_ = impeller::Matrix::MakeTranslation({tx, ty});
+  void InitRectLTRB(TestRect& rect,
+                    float left,
+                    float top,
+                    float right,
+                    float bottom) const override {
+    rect.impeller_rect = impeller::Rect::MakeLTRB(left, top, right, bottom);
   }
 
-  void SetScale(float sx, float sy) override {
-    transform_ = impeller::Matrix::MakeScale({sx, sy, 1.0f});
+  void SetIdentity(TestTransform& storage) const override {
+    storage.impeller_matrix = impeller::Matrix();
   }
 
-  void SetRotate(float radians) override {
-    transform_ = impeller::Matrix::MakeRotationZ(impeller::Radians(radians));
+  void Translate(TestTransform& storage, float tx, float ty) const override {
+    storage.impeller_matrix = storage.impeller_matrix.Translate({tx, ty});
   }
 
-  void Translate(float tx, float ty) override {
-    transform_ = transform_.Translate({tx, ty});
+  void Scale(TestTransform& storage, float sx, float sy) const override {
+    storage.impeller_matrix = storage.impeller_matrix.Scale({sx, sy, 1.0f});
   }
 
-  void Scale(float sx, float sy) override {
-    transform_ = transform_.Scale({sx, sy, 1.0f});
+  void RotateRadians(TestTransform& storage, float radians) const override {
+    storage.impeller_matrix =
+        storage.impeller_matrix *
+        impeller::Matrix::MakeRotationZ(impeller::Radians(radians));
   }
 
-  void Rotate(float radians) override {
-    transform_ = transform_ *
-                 impeller::Matrix::MakeRotationZ(impeller::Radians(radians));
+  void Concat(const TestTransform& a,
+              const TestTransform& b,
+              TestTransform& result) const override {
+    result.impeller_matrix = a.impeller_matrix * b.impeller_matrix;
   }
 
-  TestRect TransformRect(const TestRect& rect) const override {
-    return ToTestRect(ToImpellerRect(rect).TransformBounds(transform_));
+  void TransformPoint(const TestTransform& transform,
+                      const TestPoint& in,
+                      TestPoint& out) const override {
+    out.impeller_point = transform.impeller_matrix * in.impeller_point;
   }
 
- private:
-  impeller::Matrix transform_;
-
-  static constexpr const impeller::Rect& ToImpellerRect(const TestRect& rect) {
-    return *((const impeller::Rect*)(&rect));
+  void TransformPoints(const TestTransform& transform,
+                       const TestPoint in[],
+                       TestPoint out[],
+                       int n) const override {
+    for (int i = 0; i < n; i++) {
+      out[i].impeller_point = transform.impeller_matrix * in[i].impeller_point;
+    }
   }
 
-  static constexpr const TestRect& ToTestRect(const impeller::Rect& rect) {
-    return *((const TestRect*)(&rect));
+  void TransformRect(const TestTransform& transform,
+                     const TestRect& in,
+                     TestRect& out) const override {
+    out.impeller_rect =
+        in.impeller_rect.TransformBounds(transform.impeller_matrix);
+  }
+
+  void InvertUnchecked(const TestTransform& transform,
+                       TestTransform& result) const override {
+    result.impeller_matrix = transform.impeller_matrix.Invert();
+  }
+
+  bool InvertAndCheck(const TestTransform& transform,
+                      TestTransform& result) const override {
+    result.impeller_matrix = transform.impeller_matrix.Invert();
+    return transform.impeller_matrix.GetDeterminant() != 0.0f;
   }
 };
+
+using SetupFunction = std::function<void(TransformAdapter*, TestTransform&)>;
+
+static void SetupIdentity(const TransformAdapter* adapter,
+                          TestTransform& transform) {
+  adapter->SetIdentity(transform);
+}
+
+static void SetupTranslate(const TransformAdapter* adapter,
+                           TestTransform& transform) {
+  adapter->SetIdentity(transform);
+  adapter->Translate(transform, 10.2, 12.3);
+}
+
+static void SetupScale(const TransformAdapter* adapter,
+                       TestTransform& transform) {
+  adapter->SetIdentity(transform);
+  adapter->Scale(transform, 2.0, 2.0);
+}
+
+static void SetupScaleTranslate(const TransformAdapter* adapter,
+                                TestTransform& transform) {
+  adapter->SetIdentity(transform);
+  adapter->Scale(transform, 2.0, 2.0);
+  adapter->Translate(transform, 10.2, 12.3);
+}
+
+static void SetupRotate(const TransformAdapter* adapter,
+                        TestTransform& transform) {
+  adapter->SetIdentity(transform);
+  adapter->RotateRadians(transform, kPiOver4);
+}
 
 // We use a function to return the appropriate adapter so that all methods
 // used in benchmarking are "pure virtual" and cannot be optimized out
@@ -259,108 +362,152 @@ static std::unique_ptr<TransformAdapter> GetAdapter(AdapterType type) {
 
 static void BM_AdapterDispatchOverhead(benchmark::State& state,
                                        AdapterType type) {
-  auto tx = GetAdapter(type);
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
   while (state.KeepRunning()) {
-    tx->DoNothing();
-  }
-}
-
-static void BM_AdapterRectOverhead(benchmark::State& state, AdapterType type) {
-  auto tx = GetAdapter(type);
-  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
-  while (state.KeepRunning()) {
-    tx->DoNothing(rect);
+    adapter->DoNothing(transform);
   }
 }
 
 static void BM_SetIdentity(benchmark::State& state, AdapterType type) {
-  auto tx = GetAdapter(type);
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
   while (state.KeepRunning()) {
-    tx->SetIdentity();
+    adapter->SetIdentity(transform);
   }
 }
 
-static void BM_SetTranslate(benchmark::State& state,
-                            AdapterType type,
-                            float x,
-                            float y) {
-  auto tx = GetAdapter(type);
-  while (state.KeepRunning()) {
-    tx->SetTranslate(x, y);
-  }
-}
-
-static void BM_SetScale(benchmark::State& state,
-                        AdapterType type,
-                        float scale) {
-  auto tx = GetAdapter(type);
-  while (state.KeepRunning()) {
-    tx->SetScale(scale, scale);
-  }
-}
-
-static void BM_SetRotate(benchmark::State& state,
+static void BM_Translate(benchmark::State& state,
                          AdapterType type,
-                         float radians) {
-  auto tx = GetAdapter(type);
+                         float tx,
+                         float ty) {
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
+  adapter->SetIdentity(transform);
+  bool flip = true;
   while (state.KeepRunning()) {
-    tx->SetRotate(radians);
+    if (flip) {
+      adapter->Translate(transform, tx, ty);
+    } else {
+      adapter->Translate(transform, -tx, -ty);
+    }
+    flip = !flip;
   }
 }
 
-static void BM_IdentityBounds(benchmark::State& state, AdapterType type) {
-  auto tx = GetAdapter(type);
-  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
+static void BM_Scale(benchmark::State& state, AdapterType type, float scale) {
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
+  adapter->SetIdentity(transform);
+  float inv_scale = 1.0f / scale;
+  bool flip = true;
   while (state.KeepRunning()) {
-    tx->TransformRect(rect);
+    if (flip) {
+      adapter->Scale(transform, scale, scale);
+    } else {
+      adapter->Scale(transform, inv_scale, inv_scale);
+    }
+    flip = !flip;
   }
 }
 
-static void BM_TranslateBounds(benchmark::State& state,
+static void BM_Rotate(benchmark::State& state,
+                      AdapterType type,
+                      float radians) {
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
+  adapter->SetIdentity(transform);
+  while (state.KeepRunning()) {
+    adapter->RotateRadians(transform, radians);
+  }
+}
+
+static void BM_Concat(benchmark::State& state,
+                      AdapterType type,
+                      const SetupFunction& a_setup,
+                      const SetupFunction& b_setup) {
+  auto adapter = GetAdapter(type);
+  TestTransform a, b, result;
+  a_setup(adapter.get(), a);
+  b_setup(adapter.get(), b);
+  while (state.KeepRunning()) {
+    adapter->Concat(a, b, result);
+  }
+}
+
+static void BM_TransformPoint(benchmark::State& state,
+                              AdapterType type,
+                              const SetupFunction& setup) {
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
+  setup(adapter.get(), transform);
+  TestPoint point, result;
+  adapter->InitPoint(point, 25.7, 32.4);
+  while (state.KeepRunning()) {
+    adapter->TransformPoint(transform, point, result);
+  }
+}
+
+static void BM_TransformPoints(benchmark::State& state,
                                AdapterType type,
-                               float x,
-                               float y) {
-  auto tx = GetAdapter(type);
-  tx->Translate(x, y);
-  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
+                               const SetupFunction& setup) {
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
+  setup(adapter.get(), transform);
+  const int Xs = 10;
+  const int Ys = 10;
+  const int N = Xs * Ys;
+  TestPoint points[N];
+  for (int i = 0; i < Xs; i++) {
+    for (int j = 0; j < Ys; j++) {
+      int index = i * Xs + j;
+      FML_CHECK(index < N);
+      adapter->InitPoint(points[index], i * 23.3 + 17, j * 32.7 + 12);
+    }
+  }
+  TestPoint results[N];
+  int64_t item_count = 0;
   while (state.KeepRunning()) {
-    tx->TransformRect(rect);
+    adapter->TransformPoints(transform, points, results, N);
+    item_count += N;
+  }
+  state.SetItemsProcessed(item_count);
+}
+
+static void BM_TransformRect(benchmark::State& state,
+                             AdapterType type,
+                             const SetupFunction& setup) {
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
+  setup(adapter.get(), transform);
+  TestRect rect, result;
+  adapter->InitRectLTRB(rect, 100, 100, 200, 200);
+  while (state.KeepRunning()) {
+    adapter->TransformRect(transform, rect, result);
   }
 }
 
-static void BM_ScaleBounds(benchmark::State& state,
-                           AdapterType type,
-                           float scale) {
-  auto tx = GetAdapter(type);
-  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
-  tx->SetScale(scale, scale);
+static void BM_InvertUnchecked(benchmark::State& state,
+                               AdapterType type,
+                               const SetupFunction& setup) {
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
+  setup(adapter.get(), transform);
+  TestTransform result;
   while (state.KeepRunning()) {
-    tx->TransformRect(rect);
+    adapter->InvertUnchecked(transform, result);
   }
 }
 
-static void BM_ScaleTranslateBounds(benchmark::State& state,
-                                    AdapterType type,
-                                    float scale,
-                                    float x,
-                                    float y) {
-  auto tx = GetAdapter(type);
-  tx->SetScale(scale, scale);
-  tx->Translate(x, y);
-  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
+static void BM_InvertAndCheck(benchmark::State& state,
+                              AdapterType type,
+                              const SetupFunction& setup) {
+  auto adapter = GetAdapter(type);
+  TestTransform transform;
+  setup(adapter.get(), transform);
+  TestTransform result;
   while (state.KeepRunning()) {
-    tx->TransformRect(rect);
-  }
-}
-
-static void BM_RotateBounds(benchmark::State& state,
-                            AdapterType type,
-                            float radians) {
-  auto tx = GetAdapter(type);
-  tx->SetRotate(radians);
-  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
-  while (state.KeepRunning()) {
-    tx->TransformRect(rect);
+    adapter->InvertAndCheck(transform, result);
   }
 }
 
@@ -381,17 +528,65 @@ static void BM_RotateBounds(benchmark::State& state,
   BENCHMARK_CAPTURE_TYPE_ARGS(name, ImpellerMatrix, __VA_ARGS__)
 
 BENCHMARK_CAPTURE_ALL(BM_AdapterDispatchOverhead);
-BENCHMARK_CAPTURE_ALL(BM_AdapterRectOverhead);
 
 BENCHMARK_CAPTURE_ALL(BM_SetIdentity);
-BENCHMARK_CAPTURE_ALL_ARGS(BM_SetTranslate, 10.0f, 15.0f);
-BENCHMARK_CAPTURE_ALL_ARGS(BM_SetScale, 2.0f);
-BENCHMARK_CAPTURE_ALL_ARGS(BM_SetRotate, kPiOver4);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_Translate, 10.0f, 15.0f);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_Scale, 2.0f);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_Rotate, kPiOver4);
 
-BENCHMARK_CAPTURE_ALL(BM_IdentityBounds);
-BENCHMARK_CAPTURE_ALL_ARGS(BM_TranslateBounds, 10.0f, 15.0f);
-BENCHMARK_CAPTURE_ALL_ARGS(BM_ScaleBounds, 2.0f);
-BENCHMARK_CAPTURE_ALL_ARGS(BM_ScaleTranslateBounds, 2.0f, 10.0f, 15.0f);
-BENCHMARK_CAPTURE_ALL_ARGS(BM_RotateBounds, kPiOver4);
+// clang-format off
+#define BENCHMARK_CAPTURE_TYPE_SETUP(name, type, setup) \
+  BENCHMARK_CAPTURE(name, setup/type, AdapterType::k##type, Setup##setup)
+// clang-format on
+
+#define BENCHMARK_CAPTURE_ALL_SETUP(name, setup)       \
+  BENCHMARK_CAPTURE_TYPE_SETUP(name, SkMatrix, setup); \
+  BENCHMARK_CAPTURE_TYPE_SETUP(name, SkM44, setup);    \
+  BENCHMARK_CAPTURE_TYPE_SETUP(name, ImpellerMatrix, setup)
+
+// clang-format off
+#define BENCHMARK_CAPTURE_TYPE_SETUP2(name, type, setup1, setup2)   \
+  BENCHMARK_CAPTURE(name, setup1*setup2/type, AdapterType::k##type, \
+                    Setup##setup1, Setup##setup2)
+// clang-format on
+
+#define BENCHMARK_CAPTURE_ALL_SETUP2(name, setup1, setup2)       \
+  BENCHMARK_CAPTURE_TYPE_SETUP2(name, SkMatrix, setup1, setup2); \
+  BENCHMARK_CAPTURE_TYPE_SETUP2(name, SkM44, setup1, setup2);    \
+  BENCHMARK_CAPTURE_TYPE_SETUP2(name, ImpellerMatrix, setup1, setup2)
+
+BENCHMARK_CAPTURE_ALL_SETUP2(BM_Concat, Scale, Translate);
+BENCHMARK_CAPTURE_ALL_SETUP2(BM_Concat, ScaleTranslate, ScaleTranslate);
+BENCHMARK_CAPTURE_ALL_SETUP2(BM_Concat, ScaleTranslate, Rotate);
+
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertUnchecked, Identity);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertUnchecked, Translate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertUnchecked, Scale);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertUnchecked, ScaleTranslate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertUnchecked, Rotate);
+
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertAndCheck, Identity);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertAndCheck, Translate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertAndCheck, Scale);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertAndCheck, ScaleTranslate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_InvertAndCheck, Rotate);
+
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoint, Identity);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoint, Translate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoint, Scale);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoint, ScaleTranslate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoint, Rotate);
+
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoints, Identity);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoints, Translate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoints, Scale);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoints, ScaleTranslate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformPoints, Rotate);
+
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformRect, Identity);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformRect, Translate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformRect, Scale);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformRect, ScaleTranslate);
+BENCHMARK_CAPTURE_ALL_SETUP(BM_TransformRect, Rotate);
 
 }  // namespace flutter

--- a/display_list/benchmarking/dl_transform_benchmarks.cc
+++ b/display_list/benchmarking/dl_transform_benchmarks.cc
@@ -1,0 +1,397 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/benchmarking/benchmarking.h"
+
+#include "flutter/impeller/geometry/matrix.h"
+#include "flutter/impeller/geometry/rect.h"
+#include "third_party/skia/include/core/SkM44.h"
+#include "third_party/skia/include/core/SkMatrix.h"
+
+namespace flutter {
+
+namespace {
+
+static constexpr float kPiOver4 = impeller::kPiOver4;
+
+enum class AdapterType {
+  kSkMatrix,
+  kSkM44,
+  kImpellerMatrix,
+};
+
+// This struct should be a "castable" replacement for the various rect
+// objects being used (SkRect or impeller::Rect), so that no adapter
+// gets an advantage in the rect bounds transform benchmarks. Each
+// sub-class of Adapter (Skia vs Impeller) will assert this similarity
+// in its constructor (which is only executed once per benchmark in the
+// setup code outside of the timed body).
+struct TestRect {
+  static constexpr TestRect MakeLTRB(float left,
+                                     float top,
+                                     float right,
+                                     float bottom) {
+    return TestRect(left, top, right, bottom);
+  }
+
+  float left;
+  float top;
+  float right;
+  float bottom;
+
+ private:
+  constexpr TestRect(float l, float t, float r, float b)
+      : left(l), top(t), right(r), bottom(b) {}
+};
+
+// We use a virtual adapter class rather than templating the BM_* methods
+// to prevent the compiler from optimizing the benchmark bodies into a
+// null set of instructions because the calculation can be proven to have
+// no side effects and the result is never used.
+class TransformAdapter {
+ public:
+  TransformAdapter() = default;
+  virtual ~TransformAdapter() = default;
+
+  // Two methods to test the overhead of just calling a virtual method on
+  // the adapter (should be the same for all inheriting subclasses) and
+  // for a method that does a conversion to and from the TestRect object
+  // (which should be the same as the method call overhead since it does
+  // no work).
+  virtual void DoNothing() const = 0;
+  virtual TestRect DoNothing(const TestRect& rect) const = 0;
+
+  // The actual methods that do work and are the meat of the benchmarks.
+  virtual void SetIdentity() = 0;
+  virtual void SetTranslate(float tx, float ty) = 0;
+  virtual void SetScale(float sx, float sy) = 0;
+  virtual void SetRotate(float radians) = 0;
+
+  virtual void Translate(float tx, float ty) = 0;
+  virtual void Scale(float sx, float sy) = 0;
+  virtual void Rotate(float radians) = 0;
+
+  virtual TestRect TransformRect(const TestRect& rect) const = 0;
+};
+
+class SkiaAdapterBase : public TransformAdapter {
+ public:
+  SkiaAdapterBase() {
+    static_assert(sizeof(TestRect) == sizeof(SkRect));
+    const TestRect tr = TestRect::MakeLTRB(1, 2, 3, 4);
+    auto& sr = ToSkRect(tr);
+    FML_CHECK(sr.fLeft == 1.0f);
+    FML_CHECK(sr.fTop == 2.0f);
+    FML_CHECK(sr.fRight == 3.0f);
+    FML_CHECK(sr.fBottom == 4.0f);
+  }
+
+  // DoNothing methods used to measure overhead for various operations
+  void DoNothing() const override {}
+  TestRect DoNothing(const TestRect& rect) const override {
+    return ToTestRect(ToSkRect(rect));
+  }
+
+ protected:
+  static constexpr const SkRect& ToSkRect(const TestRect& rect) {
+    return *((const SkRect*)(&rect));
+  }
+
+  static constexpr const TestRect& ToTestRect(const SkRect& rect) {
+    return *((const TestRect*)(&rect));
+  }
+};
+
+class SkMatrixAdapter : public SkiaAdapterBase {
+ public:
+  SkMatrixAdapter() = default;
+  ~SkMatrixAdapter() = default;
+
+  void SetIdentity() override { transform_ = SkMatrix::I(); }
+
+  void SetTranslate(float tx, float ty) override {
+    transform_ = SkMatrix::Translate(tx, ty);
+  }
+
+  void SetScale(float sx, float sy) override {
+    transform_ = SkMatrix::Scale(sx, sy);
+  }
+
+  void SetRotate(float radians) override {
+    transform_ = SkMatrix::RotateRad(radians);
+  }
+
+  void Translate(float tx, float ty) override {
+    transform_.preTranslate(tx, ty);
+  }
+
+  void Scale(float sx, float sy) override { transform_.preScale(sx, sy); }
+
+  void Rotate(float radians) override {
+    transform_.preRotate(SkRadiansToDegrees(radians));
+  }
+
+  TestRect TransformRect(const TestRect& rect) const override {
+    return ToTestRect(transform_.mapRect(ToSkRect(rect)));
+  }
+
+ private:
+  SkMatrix transform_;
+};
+
+class SkM44Adapter : public SkiaAdapterBase {
+ public:
+  SkM44Adapter() = default;
+  ~SkM44Adapter() = default;
+
+  void SetIdentity() override { transform_ = SkM44(); }
+
+  void SetTranslate(float tx, float ty) override {
+    transform_ = SkM44::Translate(tx, ty);
+  }
+
+  void SetScale(float sx, float sy) override {
+    transform_ = SkM44::Scale(sx, sy);
+  }
+
+  void SetRotate(float radians) override {
+    transform_ = SkM44::Rotate({0, 0, 1}, radians);
+  }
+
+  void Translate(float tx, float ty) override {
+    transform_.preTranslate(tx, ty);
+  }
+
+  void Scale(float sx, float sy) override { transform_.preScale(sx, sy); }
+
+  void Rotate(float radians) override {
+    transform_.preConcat(SkM44::Rotate({0, 0, 1}, radians));
+  }
+
+  TestRect TransformRect(const TestRect& rect) const override {
+    return ToTestRect(transform_.asM33().mapRect(ToSkRect(rect)));
+  }
+
+ private:
+  SkM44 transform_;
+};
+
+class ImpellerMatrixAdapter : public TransformAdapter {
+ public:
+  ImpellerMatrixAdapter() {
+    static_assert(sizeof(TestRect) == sizeof(impeller::Rect));
+    const TestRect tr = TestRect::MakeLTRB(1, 2, 3, 4);
+    auto& sr = ToImpellerRect(tr);
+    FML_CHECK(sr.GetLeft() == 1.0f);
+    FML_CHECK(sr.GetTop() == 2.0f);
+    FML_CHECK(sr.GetRight() == 3.0f);
+    FML_CHECK(sr.GetBottom() == 4.0f);
+  }
+
+  ~ImpellerMatrixAdapter() = default;
+
+  void DoNothing() const override {}
+  TestRect DoNothing(const TestRect& rect) const override {
+    return ToTestRect(ToImpellerRect(rect));
+  }
+
+  void SetIdentity() override { transform_ = impeller::Matrix(); }
+
+  void SetTranslate(float tx, float ty) override {
+    transform_ = impeller::Matrix::MakeTranslation({tx, ty});
+  }
+
+  void SetScale(float sx, float sy) override {
+    transform_ = impeller::Matrix::MakeScale({sx, sy, 1.0f});
+  }
+
+  void SetRotate(float radians) override {
+    transform_ = impeller::Matrix::MakeRotationZ(impeller::Radians(radians));
+  }
+
+  void Translate(float tx, float ty) override {
+    transform_ = transform_.Translate({tx, ty});
+  }
+
+  void Scale(float sx, float sy) override {
+    transform_ = transform_.Scale({sx, sy, 1.0f});
+  }
+
+  void Rotate(float radians) override {
+    transform_ = transform_ *
+                 impeller::Matrix::MakeRotationZ(impeller::Radians(radians));
+  }
+
+  TestRect TransformRect(const TestRect& rect) const override {
+    return ToTestRect(ToImpellerRect(rect).TransformBounds(transform_));
+  }
+
+ private:
+  impeller::Matrix transform_;
+
+  static constexpr const impeller::Rect& ToImpellerRect(const TestRect& rect) {
+    return *((const impeller::Rect*)(&rect));
+  }
+
+  static constexpr const TestRect& ToTestRect(const impeller::Rect& rect) {
+    return *((const TestRect*)(&rect));
+  }
+};
+
+// We use a function to return the appropriate adapter so that all methods
+// used in benchmarking are "pure virtual" and cannot be optimized out
+// due to issues such as the arguments being constexpr and the result
+// simplified to a constant value.
+static std::unique_ptr<TransformAdapter> GetAdapter(AdapterType type) {
+  switch (type) {
+    case AdapterType::kSkMatrix:
+      return std::make_unique<SkMatrixAdapter>();
+    case AdapterType::kSkM44:
+      return std::make_unique<SkM44Adapter>();
+    case AdapterType::kImpellerMatrix:
+      return std::make_unique<ImpellerMatrixAdapter>();
+  }
+  FML_UNREACHABLE();
+}
+
+}  // namespace
+
+static void BM_AdapterDispatchOverhead(benchmark::State& state,
+                                       AdapterType type) {
+  auto tx = GetAdapter(type);
+  while (state.KeepRunning()) {
+    tx->DoNothing();
+  }
+}
+
+static void BM_AdapterRectOverhead(benchmark::State& state, AdapterType type) {
+  auto tx = GetAdapter(type);
+  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
+  while (state.KeepRunning()) {
+    tx->DoNothing(rect);
+  }
+}
+
+static void BM_SetIdentity(benchmark::State& state, AdapterType type) {
+  auto tx = GetAdapter(type);
+  while (state.KeepRunning()) {
+    tx->SetIdentity();
+  }
+}
+
+static void BM_SetTranslate(benchmark::State& state,
+                            AdapterType type,
+                            float x,
+                            float y) {
+  auto tx = GetAdapter(type);
+  while (state.KeepRunning()) {
+    tx->SetTranslate(x, y);
+  }
+}
+
+static void BM_SetScale(benchmark::State& state,
+                        AdapterType type,
+                        float scale) {
+  auto tx = GetAdapter(type);
+  while (state.KeepRunning()) {
+    tx->SetScale(scale, scale);
+  }
+}
+
+static void BM_SetRotate(benchmark::State& state,
+                         AdapterType type,
+                         float radians) {
+  auto tx = GetAdapter(type);
+  while (state.KeepRunning()) {
+    tx->SetRotate(radians);
+  }
+}
+
+static void BM_IdentityBounds(benchmark::State& state, AdapterType type) {
+  auto tx = GetAdapter(type);
+  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
+  while (state.KeepRunning()) {
+    tx->TransformRect(rect);
+  }
+}
+
+static void BM_TranslateBounds(benchmark::State& state,
+                               AdapterType type,
+                               float x,
+                               float y) {
+  auto tx = GetAdapter(type);
+  tx->Translate(x, y);
+  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
+  while (state.KeepRunning()) {
+    tx->TransformRect(rect);
+  }
+}
+
+static void BM_ScaleBounds(benchmark::State& state,
+                           AdapterType type,
+                           float scale) {
+  auto tx = GetAdapter(type);
+  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
+  tx->SetScale(scale, scale);
+  while (state.KeepRunning()) {
+    tx->TransformRect(rect);
+  }
+}
+
+static void BM_ScaleTranslateBounds(benchmark::State& state,
+                                    AdapterType type,
+                                    float scale,
+                                    float x,
+                                    float y) {
+  auto tx = GetAdapter(type);
+  tx->SetScale(scale, scale);
+  tx->Translate(x, y);
+  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
+  while (state.KeepRunning()) {
+    tx->TransformRect(rect);
+  }
+}
+
+static void BM_RotateBounds(benchmark::State& state,
+                            AdapterType type,
+                            float radians) {
+  auto tx = GetAdapter(type);
+  tx->SetRotate(radians);
+  TestRect rect = TestRect::MakeLTRB(100, 100, 200, 200);
+  while (state.KeepRunning()) {
+    tx->TransformRect(rect);
+  }
+}
+
+#define BENCHMARK_CAPTURE_TYPE(name, type) \
+  BENCHMARK_CAPTURE(name, type, AdapterType::k##type)
+
+#define BENCHMARK_CAPTURE_TYPE_ARGS(name, type, ...) \
+  BENCHMARK_CAPTURE(name, type, AdapterType::k##type, __VA_ARGS__)
+
+#define BENCHMARK_CAPTURE_ALL(name)       \
+  BENCHMARK_CAPTURE_TYPE(name, SkMatrix); \
+  BENCHMARK_CAPTURE_TYPE(name, SkM44);    \
+  BENCHMARK_CAPTURE_TYPE(name, ImpellerMatrix)
+
+#define BENCHMARK_CAPTURE_ALL_ARGS(name, ...)               \
+  BENCHMARK_CAPTURE_TYPE_ARGS(name, SkMatrix, __VA_ARGS__); \
+  BENCHMARK_CAPTURE_TYPE_ARGS(name, SkM44, __VA_ARGS__);    \
+  BENCHMARK_CAPTURE_TYPE_ARGS(name, ImpellerMatrix, __VA_ARGS__)
+
+BENCHMARK_CAPTURE_ALL(BM_AdapterDispatchOverhead);
+BENCHMARK_CAPTURE_ALL(BM_AdapterRectOverhead);
+
+BENCHMARK_CAPTURE_ALL(BM_SetIdentity);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_SetTranslate, 10.0f, 15.0f);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_SetScale, 2.0f);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_SetRotate, kPiOver4);
+
+BENCHMARK_CAPTURE_ALL(BM_IdentityBounds);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_TranslateBounds, 10.0f, 15.0f);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_ScaleBounds, 2.0f);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_ScaleTranslateBounds, 2.0f, 10.0f, 15.0f);
+BENCHMARK_CAPTURE_ALL_ARGS(BM_RotateBounds, kPiOver4);
+
+}  // namespace flutter


### PR DESCRIPTION
In preparation for converting the DisplayList and engine Layer code to using Impeller data structures the performance differential for the various transform objects is important information. According to this benchmark, the performance of Impeller's data structure is sometimes faster and never significantly worse than the Skia objects.