### PR TITLE
[et] Automatically fetch dependencies on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ app.*.symbols
 
 # The gn-sdk from Chromium and managed by DEPS and gclient.
 /tools/fuchsia/gn-sdk
+
+# DEPS hash created by gclient runhooks
+build/DEPS.sha256

--- a/DEPS
+++ b/DEPS
@@ -1239,5 +1239,20 @@ hooks = [
       '--as-gclient-hook',
       Var('mac_sdk_min')
     ]
-  }
+  },
+  # Track the hash of this DEPS file.
+  # Used by the engine tool to determine whether to sync again.
+  # Keep this step last.
+  {
+    'name': 'Update DEPS hash file',
+    'pattern': '.',
+    'action': [
+      'python3',
+      'src/flutter/build/sha256.py',
+      '--source',
+      'src/flutter/DEPS',
+      '--output',
+      'src/flutter/build/DEPS.sha256'
+    ]
+  },
 ]

--- a/build/sha256.py
+++ b/build/sha256.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import hashlib
+import sys
+
+
+def main(args):
+  with open(args.source, 'rb') as source_file:
+    digest = hashlib.file_digest(source_file, "sha256")
+
+  with open(args.output, 'w') as output_file:
+    output_file.write(digest.hexdigest())
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Write the SHA-256 hex digest of a file.')
+  parser.add_argument('--source', help='Path to file to hash', type=str, required=True)
+  parser.add_argument(
+      '--output', help='Path to file to output the SHA-256 hex digest', type=str, required=True
+  )
+  sys.exit(main(parser.parse_args()))

--- a/tools/engine_tool/lib/main.dart
+++ b/tools/engine_tool/lib/main.dart
@@ -7,6 +7,7 @@ import 'dart:io' as io show Directory, Platform, exitCode, stderr;
 
 import 'package:engine_build_configs/engine_build_configs.dart';
 import 'package:engine_repo_tools/engine_repo_tools.dart';
+import 'package:file/local.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:process_runner/process_runner.dart';
@@ -54,6 +55,7 @@ void main(List<String> args) async {
   final Environment environment = Environment(
     abi: ffi.Abi.current(),
     engine: engine,
+    fileSystem: const LocalFileSystem(),
     platform: const LocalPlatform(),
     processRunner: ProcessRunner(),
     logger: Logger(),

--- a/tools/engine_tool/lib/src/commands/build_command.dart
+++ b/tools/engine_tool/lib/src/commands/build_command.dart
@@ -5,6 +5,7 @@
 import 'package:engine_build_configs/engine_build_configs.dart';
 
 import '../build_utils.dart';
+import '../dependencies.dart';
 import 'command.dart';
 import 'flags.dart';
 
@@ -52,7 +53,10 @@ final class BuildCommand extends CommandBase {
       return 1;
     }
 
-    // TODO(loic-sharma): Fetch dependencies if needed.
+    if (!dependenciesUpdated(environment)) {
+      await fetchDependencies(environment);
+    }
+
     return runBuild(environment, build);
   }
 }

--- a/tools/engine_tool/lib/src/dependencies.dart
+++ b/tools/engine_tool/lib/src/dependencies.dart
@@ -13,6 +13,8 @@ import 'environment.dart';
 import 'logger.dart';
 
 /// Check whether the DEPS file has been changed since the last gclient sync.
+///
+/// Returns `false` is dependencies are out-of-date.
 bool dependenciesUpdated(Environment environment) {
   try {
     // The DEPS.sha256 file contains a SHA-256 hash of the DEPS file.
@@ -20,14 +22,15 @@ bool dependenciesUpdated(Environment environment) {
     final String hashPath = p.join(
       environment.engine.flutterDir.path, 'build', 'DEPS.sha256',
     );
-    final io.File hashFile = io.File(hashPath);
+    final io.File hashFile = environment.fileSystem.file(hashPath);
     final String previousHash = hashFile.readAsStringSync().toLowerCase();
 
     // Find the DEPS file's latest hash.
     final String depsPath = p.join(
       environment.engine.flutterDir.path, 'DEPS',
     );
-    final Uint8List depsBytes = io.File(depsPath).readAsBytesSync();
+    final io.File depsFile = environment.fileSystem.file(depsPath);
+    final Uint8List depsBytes = depsFile.readAsBytesSync();
     final crypto.Digest latestDigest = crypto.sha256.convert(depsBytes);
     final String latestHash = latestDigest.toString().toLowerCase();
 
@@ -56,6 +59,7 @@ Future<int> fetchDependencies(
       spinner = environment.logger.startSpinner();
     }
 
+    // TODO(loicsharma): Add a -j flag.
     result = await environment.processRunner.runProcess(
       <String>[
         'gclient',

--- a/tools/engine_tool/lib/src/dependencies.dart
+++ b/tools/engine_tool/lib/src/dependencies.dart
@@ -3,11 +3,39 @@
 // found in the LICENSE file.
 
 import 'dart:io' as io;
+import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:path/path.dart' as p;
 import 'package:process_runner/process_runner.dart';
 
 import 'environment.dart';
 import 'logger.dart';
+
+/// Check whether the DEPS file has been changed since the last gclient sync.
+bool dependenciesUpdated(Environment environment) {
+  try {
+    // The DEPS.sha256 file contains a SHA-256 hash of the DEPS file.
+    // It is created by gclient runhooks.
+    final String hashPath = p.join(
+      environment.engine.flutterDir.path, 'build', 'DEPS.sha256',
+    );
+    final io.File hashFile = io.File(hashPath);
+    final String previousHash = hashFile.readAsStringSync().toLowerCase();
+
+    // Find the DEPS file's latest hash.
+    final String depsPath = p.join(
+      environment.engine.flutterDir.path, 'DEPS',
+    );
+    final Uint8List depsBytes = io.File(depsPath).readAsBytesSync();
+    final crypto.Digest latestDigest = crypto.sha256.convert(depsBytes);
+    final String latestHash = latestDigest.toString().toLowerCase();
+
+    return latestHash == previousHash;
+  } catch (_) {
+    return false;
+  }
+}
 
 /// Update Flutter engine dependencies. Returns an exit code.
 Future<int> fetchDependencies(

--- a/tools/engine_tool/lib/src/environment.dart
+++ b/tools/engine_tool/lib/src/environment.dart
@@ -5,6 +5,7 @@
 import 'dart:ffi' as ffi show Abi;
 
 import 'package:engine_repo_tools/engine_repo_tools.dart';
+import 'package:file/file.dart';
 import 'package:platform/platform.dart';
 import 'package:process_runner/process_runner.dart';
 
@@ -21,6 +22,7 @@ final class Environment {
   Environment({
     required this.abi,
     required this.engine,
+    required this.fileSystem,
     required this.logger,
     required this.platform,
     required this.processRunner,
@@ -31,6 +33,9 @@ final class Environment {
 
   /// Information about paths in the engine repo.
   final Engine engine;
+
+  /// Facility for commands to access files.
+  final FileSystem fileSystem;
 
   /// Where log messages are written.
   final Logger logger;

--- a/tools/engine_tool/pubspec.yaml
+++ b/tools/engine_tool/pubspec.yaml
@@ -18,6 +18,7 @@ environment:
 
 dependencies:
   args: any
+  crypto: any
   engine_build_configs:
     path: ../pkg/engine_build_configs
   engine_repo_tools:

--- a/tools/engine_tool/pubspec.yaml
+++ b/tools/engine_tool/pubspec.yaml
@@ -18,7 +18,6 @@ environment:
 
 dependencies:
   args: any
-  crypto: any
   engine_build_configs:
     path: ../pkg/engine_build_configs
   engine_repo_tools:
@@ -47,6 +46,8 @@ dependency_overrides:
     path: ../../../third_party/dart/pkg/async_helper
   collection:
     path: ../../../third_party/dart/third_party/pkg/collection
+  crypto:
+    path: ../../../third_party/dart/third_party/pkg/crypto
   expect:
     path: ../../../third_party/dart/pkg/expect
   file:

--- a/tools/engine_tool/pubspec.yaml
+++ b/tools/engine_tool/pubspec.yaml
@@ -75,5 +75,7 @@ dependency_overrides:
     path: ../../../third_party/dart/third_party/pkg/string_scanner
   term_glyph:
     path: ../../../third_party/dart/third_party/pkg/term_glyph
+  typed_data:
+    path: ../../../third_party/dart/third_party/pkg/typed_data
   yaml:
     path: ../../../third_party/dart/third_party/pkg/yaml

--- a/tools/engine_tool/test/build_command_test.dart
+++ b/tools/engine_tool/test/build_command_test.dart
@@ -155,4 +155,16 @@ void main() {
     expect(result, equals(0));
     expect(runHistory.length, lessThanOrEqualTo(3));
   });
+
+  test('build command fetches dependencies', () async {
+    // TODO: DEPS SHA-256 hex digest does not match DEPS.sha256 contents.
+  });
+
+  test('build command fetches dependencies if sync never ran', () async {
+    // TODO: No DEPS.sha256 file
+  });
+
+  test('build command does not fetch dependencies if updated', () async {
+    // TODO: DEPS SHA-256 hex digest matches DEPS.sha256 contents.
+  });
 }

--- a/tools/engine_tool/test/fetch_command_test.dart
+++ b/tools/engine_tool/test/fetch_command_test.dart
@@ -10,6 +10,7 @@ import 'package:engine_repo_tools/engine_repo_tools.dart';
 import 'package:engine_tool/src/commands/command_runner.dart';
 import 'package:engine_tool/src/environment.dart';
 import 'package:engine_tool/src/logger.dart';
+import 'package:file/memory.dart';
 import 'package:litetest/litetest.dart';
 import 'package:platform/platform.dart';
 import 'package:process_fakes/process_fakes.dart';
@@ -31,6 +32,7 @@ void main() {
       Environment(
         abi: ffi.Abi.linuxX64,
         engine: engine,
+        fileSystem: MemoryFileSystem(),
         platform: FakePlatform(operatingSystem: Platform.linux),
         processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {

--- a/tools/engine_tool/test/format_command_test.dart
+++ b/tools/engine_tool/test/format_command_test.dart
@@ -11,6 +11,7 @@ import 'package:engine_tool/src/commands/command_runner.dart';
 import 'package:engine_tool/src/commands/flags.dart';
 import 'package:engine_tool/src/environment.dart';
 import 'package:engine_tool/src/logger.dart';
+import 'package:file/memory.dart';
 import 'package:litetest/litetest.dart';
 import 'package:logging/logging.dart' as log;
 import 'package:platform/platform.dart';
@@ -31,6 +32,7 @@ void main() {
     return Environment(
       abi: ffi.Abi.linuxX64,
       engine: engine,
+      fileSystem: MemoryFileSystem(),
       platform: FakePlatform(
         resolvedExecutable: '/dart',
         operatingSystem: Platform.linux,

--- a/tools/engine_tool/test/query_command_test.dart
+++ b/tools/engine_tool/test/query_command_test.dart
@@ -11,6 +11,7 @@ import 'package:engine_repo_tools/engine_repo_tools.dart';
 import 'package:engine_tool/src/commands/command_runner.dart';
 import 'package:engine_tool/src/environment.dart';
 import 'package:engine_tool/src/logger.dart';
+import 'package:file/memory.dart';
 import 'package:litetest/litetest.dart';
 import 'package:logging/logging.dart' as log;
 import 'package:platform/platform.dart';
@@ -58,6 +59,7 @@ void main() {
     return Environment(
       abi: ffi.Abi.linuxX64,
       engine: engine,
+      fileSystem: MemoryFileSystem(),
       platform: FakePlatform(operatingSystem: Platform.linux),
       processRunner: ProcessRunner(
         processManager: FakeProcessManager(),

--- a/tools/engine_tool/test/run_command_test.dart
+++ b/tools/engine_tool/test/run_command_test.dart
@@ -12,6 +12,7 @@ import 'package:engine_tool/src/commands/command_runner.dart';
 import 'package:engine_tool/src/environment.dart';
 import 'package:engine_tool/src/logger.dart';
 import 'package:engine_tool/src/run_utils.dart';
+import 'package:file/memory.dart';
 import 'package:litetest/litetest.dart';
 import 'package:platform/platform.dart';
 import 'package:process_fakes/process_fakes.dart';
@@ -60,6 +61,7 @@ void main() {
       Environment(
         abi: ffi.Abi.linuxX64,
         engine: engine,
+        fileSystem: MemoryFileSystem(),
         platform: FakePlatform(operatingSystem: Platform.linux),
         processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {


### PR DESCRIPTION
Running `gclient` now creates a `//flutter/build/DEPS.sha256` file that contains the SHA-256 hash of the `//flutter/DEPS` file.

The engine tool uses this `DEPS.sha256` file to determine whether `gclient` needs to be run again.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
