### PR TITLE
[Impeller] use DefaultUniformAlignment for compute buffers.

### DIFF
--- a/impeller/entity/geometry/point_field_geometry.cc
+++ b/impeller/entity/geometry/point_field_geometry.cc
@@ -156,8 +156,8 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
       host_buffer.Emplace(points_.data(), points_.size() * sizeof(Point),
                           DefaultUniformAlignment());
 
-  BufferView geometry_buffer =
-      host_buffer.Emplace(nullptr, total * sizeof(Point), alignof(Point));
+  BufferView geometry_buffer = host_buffer.Emplace(
+      nullptr, total * sizeof(Point), DefaultUniformAlignment());
 
   BufferView output;
   {
@@ -185,8 +185,8 @@ GeometryResult PointFieldGeometry::GetPositionBufferGPU(
   }
 
   if (texture_coverage.has_value() && effect_transform.has_value()) {
-    BufferView geometry_uv_buffer =
-        host_buffer.Emplace(nullptr, total * sizeof(Vector4), alignof(Vector4));
+    BufferView geometry_uv_buffer = host_buffer.Emplace(
+        nullptr, total * sizeof(Vector4), DefaultUniformAlignment());
 
     using UV = UvComputeShader;
 

--- a/impeller/playground/playground_impl.cc
+++ b/impeller/playground/playground_impl.cc
@@ -35,6 +35,7 @@ std::unique_ptr<PlaygroundImpl> PlaygroundImpl::Create(
 #endif  // IMPELLER_ENABLE_OPENGLES
 #if IMPELLER_ENABLE_VULKAN
     case PlaygroundBackend::kVulkan:
+      switches.enable_vulkan_validation = true;
       return std::make_unique<PlaygroundImplVK>(switches);
 #endif  // IMPELLER_ENABLE_VULKAN
     default:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/144959

locally this only shows failures before on the impeller_goldens test shard.
