### PR TITLE
Avoid unnecessary transform resets for pixel snapping

### DIFF
--- a/flow/diff_context.cc
+++ b/flow/diff_context.cc
@@ -61,11 +61,17 @@ void DiffContext::MakeCurrentTransformIntegral() {
   // TODO(knopp): This is duplicated from LayerStack. Maybe should be part of
   // clip tracker?
   if (clip_tracker_.using_4x4_matrix()) {
-    clip_tracker_.setTransform(
-        RasterCacheUtil::GetIntegralTransCTM(clip_tracker_.matrix_4x4()));
+    SkM44 integral;
+    if (RasterCacheUtil::ComputeIntegralTransCTM(clip_tracker_.matrix_4x4(),
+                                                 &integral)) {
+      clip_tracker_.setTransform(integral);
+    }
   } else {
-    clip_tracker_.setTransform(
-        RasterCacheUtil::GetIntegralTransCTM(clip_tracker_.matrix_3x3()));
+    SkMatrix integral;
+    if (RasterCacheUtil::ComputeIntegralTransCTM(clip_tracker_.matrix_3x3(),
+                                                 &integral)) {
+      clip_tracker_.setTransform(integral);
+    }
   }
 }
 

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -249,7 +249,7 @@ TEST_F(DisplayListLayerTest, CachedIncompatibleDisplayListOpacityInheritance) {
                               &paint_context(), false);
 
   int opacity_alpha = 0x7F;
-  SkPoint opacity_offset = SkPoint::Make(10, 10);
+  SkPoint opacity_offset = SkPoint::Make(10.2, 10.2);
   auto opacity_layer =
       std::make_shared<OpacityLayer>(opacity_alpha, opacity_offset);
   opacity_layer->Add(display_list_layer);

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -454,9 +454,8 @@ TEST_F(ImageFilterLayerTest, CacheChildren) {
     expected_builder.Save();
     {
       expected_builder.Translate(offset.fX, offset.fY);
-      // snap translation components to pixels due to using raster cache
-      expected_builder.TransformReset();
-      expected_builder.Transform(snapped_matrix);
+      // translation components already snapped to pixels, intent to
+      // use raster cache won't change them
       DlPaint dl_paint;
       dl_paint.setImageFilter(transformed_filter.get());
       raster_cache()->Draw(cacheable_image_filter_item->GetId().value(),

--- a/flow/layers/layer_state_stack.cc
+++ b/flow/layers/layer_state_stack.cc
@@ -114,8 +114,10 @@ class DlCanvasDelegate : public LayerStateStack::Delegate {
     canvas_->Transform(matrix);
   }
   void integralTransform() override {
-    SkM44 matrix = RasterCacheUtil::GetIntegralTransCTM(matrix_4x4());
-    canvas_->SetTransform(matrix);
+    SkM44 integral;
+    if (RasterCacheUtil::ComputeIntegralTransCTM(matrix_4x4(), &integral)) {
+      canvas_->SetTransform(integral);
+    }
   }
 
   void clipRect(const SkRect& rect, ClipOp op, bool is_aa) override {
@@ -168,11 +170,17 @@ class PrerollDelegate : public LayerStateStack::Delegate {
   }
   void integralTransform() override {
     if (tracker_.using_4x4_matrix()) {
-      tracker_.setTransform(
-          RasterCacheUtil::GetIntegralTransCTM(tracker_.matrix_4x4()));
+      SkM44 integral;
+      if (RasterCacheUtil::ComputeIntegralTransCTM(tracker_.matrix_4x4(),
+                                                   &integral)) {
+        tracker_.setTransform(integral);
+      }
     } else {
-      tracker_.setTransform(
-          RasterCacheUtil::GetIntegralTransCTM(tracker_.matrix_3x3()));
+      SkMatrix integral;
+      if (RasterCacheUtil::ComputeIntegralTransCTM(tracker_.matrix_3x3(),
+                                                   &integral)) {
+        tracker_.setTransform(integral);
+      }
     }
   }
 

--- a/flow/layers/shader_mask_layer_unittests.cc
+++ b/flow/layers/shader_mask_layer_unittests.cc
@@ -443,10 +443,10 @@ TEST_F(ShaderMaskLayerTest, SimpleFilterWithRasterCacheLayerNotCached) {
   /* (ShaderMask)layer::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.TransformReset();
-      // The layer will perform this Identity transform operation by default,
-      // but it should be ignored both here and in the layer paint
-      expected_builder.Transform(SkMatrix());
+      // The layer will notice that the CTM is already an integer matrix
+      // and will not perform an Integral CTM operation.
+      // expected_builder.TransformReset();
+      // expected_builder.Transform(SkMatrix());
       expected_builder.SaveLayer(&child_bounds);
       {
         /* mock_layer::Paint */ {

--- a/flow/raster_cache_util.cc
+++ b/flow/raster_cache_util.cc
@@ -4,4 +4,67 @@
 
 #include "flutter/flow/raster_cache_util.h"
 
-namespace flutter {}
+namespace flutter {
+
+bool RasterCacheUtil::ComputeIntegralTransCTM(const SkMatrix& in,
+                                              SkMatrix* out) {
+  // Avoid integral snapping if the matrix has complex transformation to avoid
+  // the artifact observed in https://github.com/flutter/flutter/issues/41654.
+  if (!in.isScaleTranslate()) {
+    return false;
+  }
+
+  SkScalar in_tx = in.getTranslateX();
+  SkScalar in_ty = in.getTranslateY();
+  SkScalar out_tx = SkScalarRoundToScalar(in_tx);
+  SkScalar out_ty = SkScalarRoundToScalar(in_ty);
+  if (out_tx != in_tx || out_ty != in_ty) {
+    // As a side effect of those tests we also know that neither translation
+    // component was a NaN
+    *out = in;
+    (*out)[SkMatrix::kMTransX] = out_tx;
+    (*out)[SkMatrix::kMTransY] = out_ty;
+    return true;
+  }
+
+  return false;
+}
+
+bool RasterCacheUtil::ComputeIntegralTransCTM(const SkM44& in, SkM44* out) {
+  // Avoid integral snapping if the matrix has complex transformation to avoid
+  // the artifact observed in https://github.com/flutter/flutter/issues/41654.
+  if (in.rc(0, 1) != 0 || in.rc(0, 2) != 0) {
+    // X multiplied by either Y or Z
+    return false;
+  }
+  if (in.rc(1, 0) != 0 || in.rc(1, 2) != 0) {
+    // Y multiplied by either X or Z
+    return false;
+  }
+  // We do not need to worry about the Z row unless the W row
+  // has perspective entries...
+  if (in.rc(3, 0) != 0 || in.rc(3, 1) != 0 || in.rc(3, 2) != 0 ||
+      in.rc(3, 3) != 1) {
+    // W not identity row, therefore perspective is applied
+    return false;
+  }
+
+  SkScalar in_tx = in.rc(0, 3);
+  SkScalar in_ty = in.rc(1, 3);
+  SkScalar out_tx = SkScalarRoundToScalar(in_tx);
+  SkScalar out_ty = SkScalarRoundToScalar(in_ty);
+  if (out_tx != in_tx || out_ty != in_ty) {
+    // As a side effect of those tests we also know that neither translation
+    // component was a NaN
+    *out = in;
+    out->setRC(0, 3, out_tx);
+    out->setRC(1, 3, out_ty);
+    // No need to worry about Z translation because it has no effect
+    // without perspective entries...
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace flutter

--- a/flow/raster_cache_util.cc
+++ b/flow/raster_cache_util.cc
@@ -41,13 +41,13 @@ bool RasterCacheUtil::ComputeIntegralTransCTM(const SkM44& in, SkM44* out) {
     // Y multiplied by either X or Z
     return false;
   }
-  // We do not need to worry about the Z row unless the W row
-  // has perspective entries...
   if (in.rc(3, 0) != 0 || in.rc(3, 1) != 0 || in.rc(3, 2) != 0 ||
       in.rc(3, 3) != 1) {
     // W not identity row, therefore perspective is applied
     return false;
   }
+  // We do not need to worry about the Z row unless the W row
+  // has perspective entries, which we've just eliminated...
 
   SkScalar in_tx = in.rc(0, 3);
   SkScalar in_ty = in.rc(1, 3);


### PR DESCRIPTION
During some new development work that might make transform resets more expensive we realized that the resets were mostly coming from the calls to snap the transform to a pixel translate value and many of those were NOPs since the transform was already on a pixel translate value. This PR will avoid those trivially unnecessary reset operations.