### PR TITLE
[codesign] fix typo in binary path

### DIFF
--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -221,7 +221,6 @@ def zip_xcframework_archive(dst):
   filepath_with_entitlements = ''
   filepath_without_entitlements = (
       'FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS'
-      'FlutterMacOS.framework/Versions/A/FlutterMacOS'
   )
   embed_codesign_configuration(os.path.join(dst, 'entitlements.txt'), filepath_with_entitlements)
 

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -220,7 +220,8 @@ def zip_framework(dst, args):
 def zip_xcframework_archive(dst):
   filepath_with_entitlements = ''
   filepath_without_entitlements = (
-      'FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS'
+      'FlutterMacOS.xcframework/macos-arm64_x86_64/'
+      'FlutterMacOS.framework/Versions/A/FlutterMacOS'
   )
   embed_codesign_configuration(os.path.join(dst, 'entitlements.txt'), filepath_with_entitlements)
 

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -220,7 +220,7 @@ def zip_framework(dst, args):
 def zip_xcframework_archive(dst):
   filepath_with_entitlements = ''
   filepath_without_entitlements = (
-      'FlutterMacOS.xcframework/macos-arm64_x84_64/'
+      'FlutterMacOS.xcframework/macos-arm64_x84_64/FlutterMacOS.framework/Versions/A/FlutterMacOS'
       'FlutterMacOS.framework/Versions/A/FlutterMacOS'
   )
   embed_codesign_configuration(os.path.join(dst, 'entitlements.txt'), filepath_with_entitlements)

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -220,7 +220,7 @@ def zip_framework(dst, args):
 def zip_xcframework_archive(dst):
   filepath_with_entitlements = ''
   filepath_without_entitlements = (
-      'FlutterMacOS.xcframework/macos-arm64_x84_64/FlutterMacOS.framework/Versions/A/FlutterMacOS'
+      'FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/Versions/A/FlutterMacOS'
       'FlutterMacOS.framework/Versions/A/FlutterMacOS'
   )
   embed_codesign_configuration(os.path.join(dst, 'entitlements.txt'), filepath_with_entitlements)


### PR DESCRIPTION
failure in release: [link](https://logs.chromium.org/logs/dart-internal/buildbucket/cr-buildbucket/8753728916366397505/+/u/Global_generators/Codesign__Volumes_Work_s_w_ir_cache_builder_src_out_release_framework_unsigned_framework.zip/codesign_Apple_engine_binaries/stdout)

Updates x84 to x86