### PR TITLE
Fix null filter NOP case in DlLocalMatrixImageFilter

### DIFF
--- a/display_list/effects/dl_image_filter.h
+++ b/display_list/effects/dl_image_filter.h
@@ -700,7 +700,8 @@ class DlLocalMatrixImageFilter final : public DlImageFilter {
   SkRect* map_local_bounds(const SkRect& input_bounds,
                            SkRect& output_bounds) const override {
     if (!image_filter_) {
-      return nullptr;
+      output_bounds = input_bounds;
+      return &output_bounds;
     }
     return image_filter_->map_local_bounds(input_bounds, output_bounds);
   }
@@ -709,7 +710,8 @@ class DlLocalMatrixImageFilter final : public DlImageFilter {
                              const SkMatrix& ctm,
                              SkIRect& output_bounds) const override {
     if (!image_filter_) {
-      return nullptr;
+      output_bounds = input_bounds;
+      return &output_bounds;
     }
     return image_filter_->map_device_bounds(
         input_bounds, SkMatrix::Concat(ctm, matrix_), output_bounds);
@@ -719,7 +721,8 @@ class DlLocalMatrixImageFilter final : public DlImageFilter {
                                    const SkMatrix& ctm,
                                    SkIRect& input_bounds) const override {
     if (!image_filter_) {
-      return nullptr;
+      input_bounds = output_bounds;
+      return &input_bounds;
     }
     return image_filter_->get_input_device_bounds(
         output_bounds, SkMatrix::Concat(ctm, matrix_), input_bounds);

--- a/display_list/effects/dl_image_filter_unittests.cc
+++ b/display_list/effects/dl_image_filter_unittests.cc
@@ -741,6 +741,7 @@ TEST(DisplayListImageFilter, LocalImageFilterBounds) {
       SkRect output_bounds;
       EXPECT_EQ(filter.map_local_bounds(input_bounds, output_bounds),
                 &output_bounds);
+      EXPECT_EQ(input_bounds, output_bounds);
     }
     for (unsigned k = 0; k < bounds_matrices.size(); k++) {
       auto& bounds_matrix = bounds_matrices[k];
@@ -750,6 +751,7 @@ TEST(DisplayListImageFilter, LocalImageFilterBounds) {
         EXPECT_EQ(filter.map_device_bounds(input_bounds, bounds_matrix,
                                            output_bounds),
                   &output_bounds);
+        EXPECT_EQ(input_bounds, output_bounds);
       }
       {
         const auto output_bounds = SkIRect::MakeLTRB(20, 20, 80, 80);
@@ -757,6 +759,7 @@ TEST(DisplayListImageFilter, LocalImageFilterBounds) {
         EXPECT_EQ(filter.get_input_device_bounds(output_bounds, bounds_matrix,
                                                  input_bounds),
                   &input_bounds);
+        EXPECT_EQ(input_bounds, output_bounds);
       }
     }
   }

--- a/display_list/effects/dl_image_filter_unittests.cc
+++ b/display_list/effects/dl_image_filter_unittests.cc
@@ -734,6 +734,33 @@ TEST(DisplayListImageFilter, LocalImageFilterBounds) {
   std::vector<SkMatrix> bounds_matrices{SkMatrix::Translate(5.0, 10.0),
                                         SkMatrix::Scale(2.0, 2.0)};
 
+  for (unsigned j = 0; j < matrices.size(); j++) {
+    DlLocalMatrixImageFilter filter(matrices[j], nullptr);
+    {
+      const auto input_bounds = SkRect::MakeLTRB(20, 20, 80, 80);
+      SkRect output_bounds;
+      EXPECT_EQ(filter.map_local_bounds(input_bounds, output_bounds),
+                &output_bounds);
+    }
+    for (unsigned k = 0; k < bounds_matrices.size(); k++) {
+      auto& bounds_matrix = bounds_matrices[k];
+      {
+        const auto input_bounds = SkIRect::MakeLTRB(20, 20, 80, 80);
+        SkIRect output_bounds;
+        EXPECT_EQ(filter.map_device_bounds(input_bounds, bounds_matrix,
+                                           output_bounds),
+                  &output_bounds);
+      }
+      {
+        const auto output_bounds = SkIRect::MakeLTRB(20, 20, 80, 80);
+        SkIRect input_bounds;
+        EXPECT_EQ(filter.get_input_device_bounds(output_bounds, bounds_matrix,
+                                                 input_bounds),
+                  &input_bounds);
+      }
+    }
+  }
+
   for (unsigned i = 0; i < sk_filters.size(); i++) {
     for (unsigned j = 0; j < matrices.size(); j++) {
       for (unsigned k = 0; k < bounds_matrices.size(); k++) {


### PR DESCRIPTION
The `DlLocalMatrixImageFilter` was returning null from the bounds methods when it had no filter to apply which violates the method contracts. It should have been setting the result rect to the argument rect and returning a valid pointer to meet the method contract.