### PR TITLE
[cp-beta] fix typo in binary path (#51339)

### DIFF
--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -220,7 +220,7 @@ def zip_framework(dst, args):
 def zip_xcframework_archive(dst):
   filepath_with_entitlements = ''
   filepath_without_entitlements = (
-      'FlutterMacOS.xcframework/macos-arm64_x84_64/'
+      'FlutterMacOS.xcframework/macos-arm64_x86_64/'
       'FlutterMacOS.framework/Versions/A/FlutterMacOS'
   )
   embed_codesign_configuration(os.path.join(dst, 'entitlements.txt'), filepath_with_entitlements)


### PR DESCRIPTION
### Issue Link:
What is the link to the issue this cherry-pick is addressing?

release failure at [link](https://ci.chromium.org/ui/p/dart-internal/builders/flutter/Mac%20engine_release_builder/536/overview)

### Changelog Description:
Explain this cherry pick in one line that is accessible to most Flutter developers. See [best practices](https://github.com/flutter/flutter/wiki/Hotfix-Documentation-Best-Practices) for examples

Fix typo in the binary path of xcframework artifact.

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)? Does it impact development (ex. flutter doctor crashes when Android Studio is installed), or the shipping production app (the app crashes on launch)

would block the release on codesign error.

### Workaround:
Is there a workaround for this issue?

revert the [xcframework pr](https://github.com/flutter/engine/commit/73a6e0718ec41e910073e7d4b2f21d283921fedb#diff-16e49048cfbb998545e3493d5e3148c515b02de6fb894945df457756a6d9099a) and cherry pick would also work. but we can do a fix forward.

### Risk:
What is the risk level of this cherry-pick?

  - [ x ] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [ x ] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

codesign test should pass in release workflow