### PR TITLE
Count back the vsync_transitions_missed of warm up frames

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -68,8 +68,10 @@ void Animator::BeginFrame(
 
   frame_request_number_++;
 
-  frame_timings_recorder_ = std::move(frame_timings_recorder);
-  frame_timings_recorder_->RecordBuildStart(fml::TimePoint::Now());
+  if (frame_timings_recorder_ == nullptr) {
+    frame_timings_recorder_ = std::move(frame_timings_recorder);
+    frame_timings_recorder_->RecordBuildStart(fml::TimePoint::Now());
+  }
 
   size_t flow_id_count = trace_flow_ids_.size();
   std::unique_ptr<uint64_t[]> flow_ids =
@@ -153,7 +155,7 @@ void Animator::EndFrame() {
       delegate_.OnAnimatorDraw(layer_tree_pipeline_);
     }
   }
-  frame_timings_recorder_ = nullptr;
+  // frame_timings_recorder_ = nullptr;
 
   if (!frame_scheduled_ && has_rendered_) {
     // Wait a tad more than 3 60hz frames before reporting a big idle period.
@@ -181,8 +183,8 @@ void Animator::EndFrame() {
         },
         kNotifyIdleTaskWaitTime);
   }
-  FML_DCHECK(layer_trees_tasks_.empty());
-  FML_DCHECK(frame_timings_recorder_ == nullptr);
+  // FML_DCHECK(layer_trees_tasks_.empty());
+  // FML_DCHECK(frame_timings_recorder_ == nullptr);
 }
 
 void Animator::Render(int64_t view_id,


### PR DESCRIPTION
With this PR, the frame timing recorder will be reverted to picking up the really long "frame budget missing" of the warm up frame. My local test shows that `99th_percentile_vsync_transitions_missed` for `windows_home_scroll_perf__timeline_summary` rises from 4.5 to 131.0 with this PR.

**What this PR does:** `Animator` no longer clears `frame_timings_recorder_` at the end of a frame if the frame has not rendered any views, and uses the existing `frame_timings_recorder_` at the start of a frame if there is one. 

**Why this works:** In a regular single-view app, the only occasion that a frame will be rendered without any views is during the start-up frame: the frame scheduled immediately after the engine has been created and before the Dart isolate runs. (Yes, this frame scheduling is pretty much unnecessary since the Dart isolate almost always schedules one during `main()`, but that's not the topic of this PR.)
* Before the multi-view change, since a frame must be ended by `Animator::Render`, a frame without any view is never ended, and `frame_timings_recorder_` just stays there with the ancient vsync target time of the engine creation. Later, the warm-up frame is rendered by calling `Animator::Render` without a preceding `Animator::BeginFrame`, and the existing `frame_timings_recorder_` is just used (instead of fabricating a new one), and records a really, really long frame budget miss.
* After the multi-view change without this PR, frames will always call `Animator::BeginFrame` and `EndFrame` even without any views, and since `EndFrame` always clears `frame_timings_recorder_`, the ancient vsync target time is not kept. Additionally, `Animator::BeginFrame` always creates a new `frame_timings_recorder_`.
* With this PR, `Animator::EndFrame` no longer clears `frame_timings_recorder_` if there aren't any rendered views, which happens to be the exact scenario for the frame at the engine creation, allowing the warm up frame to pick up the time again.


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests

[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
