### PR TITLE
[dart:ui] Add view ID to `PointerData.toString`

### DIFF
--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -381,7 +381,7 @@ class PointerData {
   final double rotation;
 
   @override
-  String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
+  String toString() => 'PointerData(viewId: $viewId, x: $physicalX, y: $physicalY)';
 
   /// Returns a complete textual description of the information in this object.
   String toStringFull() {

--- a/lib/web_ui/lib/pointer.dart
+++ b/lib/web_ui/lib/pointer.dart
@@ -111,7 +111,7 @@ class PointerData {
   final double rotation;
 
   @override
-  String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
+  String toString() => 'PointerData(viewId: $viewId, x: $physicalX, y: $physicalY)';
   String toStringFull() {
     return '$runtimeType('
            'embedderId: $embedderId, '

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2700,7 +2700,7 @@ TEST_F(EmbedderTest, CanSendPointer) {
       CREATE_NATIVE_ENTRY([&message_latch](Dart_NativeArguments args) {
         auto message = tonic::DartConverter<std::string>::FromDart(
             Dart_GetNativeArgument(args, 0));
-        ASSERT_EQ("PointerData(x: 123.0, y: 456.0)", message);
+        ASSERT_EQ("PointerData(viewId: 0, x: 123.0, y: 456.0)", message);
         message_latch.Signal();
       }));
 
@@ -2715,6 +2715,7 @@ TEST_F(EmbedderTest, CanSendPointer) {
   pointer_event.x = 123;
   pointer_event.y = 456;
   pointer_event.timestamp = static_cast<size_t>(1234567890);
+  pointer_event.view_id = 0;
 
   FlutterEngineResult result =
       FlutterEngineSendPointerEvent(engine.get(), &pointer_event, 1);


### PR DESCRIPTION
The pointer's `x` and `y` coordinates are relative to the view's origin.

Part of https://github.com/flutter/flutter/issues/112205
Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
