### PR TITLE
[Impeller] Make masks type safe.

### DIFF
--- a/impeller/base/base_unittests.cc
+++ b/impeller/base/base_unittests.cc
@@ -9,6 +9,18 @@
 #include "impeller/base/thread.h"
 
 namespace impeller {
+
+enum class MyMaskBits : uint32_t {
+  kFoo = 0,
+  kBar = 1 << 0,
+  kBaz = 1 << 1,
+  kBang = 1 << 2,
+};
+
+using MyMask = Mask<MyMaskBits>;
+
+IMPELLER_ENUM_IS_MASK(MyMaskBits);
+
 namespace testing {
 
 struct Foo {
@@ -250,15 +262,6 @@ TEST(BaseTest, NoExceptionPromiseEmpty) {
   // process does not abort while destructing the promise.
   wrapper.reset();
 }
-
-enum class MyMaskBits : uint32_t {
-  kFoo = 0,
-  kBar = 1 << 0,
-  kBaz = 1 << 1,
-  kBang = 1 << 2,
-};
-
-using MyMask = Mask<MyMaskBits>;
 
 TEST(BaseTest, CanUseTypedMasks) {
   {

--- a/impeller/base/mask.h
+++ b/impeller/base/mask.h
@@ -11,7 +11,7 @@ namespace impeller {
 
 template <typename EnumType_>
 struct MaskTraits {
-  static constexpr bool is_mask = false;
+  static constexpr bool kIsMask = false;
 };
 
 //------------------------------------------------------------------------------
@@ -21,7 +21,7 @@ struct MaskTraits {
 #define IMPELLER_ENUM_IS_MASK(enum_name)  \
   template <>                             \
   struct MaskTraits<enum_name> {          \
-    static constexpr bool is_mask = true; \
+    static constexpr bool kIsMask = true; \
   };
 
 //------------------------------------------------------------------------------
@@ -127,7 +127,7 @@ struct Mask {
 
 template <
     typename EnumType,
-    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
+    typename std::enable_if<MaskTraits<EnumType>::kIsMask, bool>::type = true>
 inline constexpr Mask<EnumType> operator|(const EnumType& lhs,
                                           const EnumType& rhs) {
   return Mask<EnumType>{lhs} | rhs;
@@ -135,7 +135,7 @@ inline constexpr Mask<EnumType> operator|(const EnumType& lhs,
 
 template <
     typename EnumType,
-    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
+    typename std::enable_if<MaskTraits<EnumType>::kIsMask, bool>::type = true>
 inline constexpr Mask<EnumType> operator&(const EnumType& lhs,
                                           const EnumType& rhs) {
   return Mask<EnumType>{lhs} & rhs;
@@ -143,7 +143,7 @@ inline constexpr Mask<EnumType> operator&(const EnumType& lhs,
 
 template <
     typename EnumType,
-    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
+    typename std::enable_if<MaskTraits<EnumType>::kIsMask, bool>::type = true>
 inline constexpr Mask<EnumType> operator^(const EnumType& lhs,
                                           const EnumType& rhs) {
   return Mask<EnumType>{lhs} ^ rhs;
@@ -151,14 +151,14 @@ inline constexpr Mask<EnumType> operator^(const EnumType& lhs,
 
 template <
     typename EnumType,
-    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
+    typename std::enable_if<MaskTraits<EnumType>::kIsMask, bool>::type = true>
 inline constexpr Mask<EnumType> operator~(const EnumType& other) {
   return ~Mask<EnumType>{other};
 }
 
 template <
     typename EnumType,
-    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
+    typename std::enable_if<MaskTraits<EnumType>::kIsMask, bool>::type = true>
 inline constexpr Mask<EnumType> operator|(const EnumType& lhs,
                                           const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} | rhs;
@@ -166,7 +166,7 @@ inline constexpr Mask<EnumType> operator|(const EnumType& lhs,
 
 template <
     typename EnumType,
-    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
+    typename std::enable_if<MaskTraits<EnumType>::kIsMask, bool>::type = true>
 inline constexpr Mask<EnumType> operator&(const EnumType& lhs,
                                           const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} & rhs;
@@ -174,7 +174,7 @@ inline constexpr Mask<EnumType> operator&(const EnumType& lhs,
 
 template <
     typename EnumType,
-    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
+    typename std::enable_if<MaskTraits<EnumType>::kIsMask, bool>::type = true>
 inline constexpr Mask<EnumType> operator^(const EnumType& lhs,
                                           const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} ^ rhs;
@@ -184,42 +184,42 @@ inline constexpr Mask<EnumType> operator^(const EnumType& lhs,
 // defaulted spaceship operator post C++20.
 
 template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
+          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
 inline constexpr bool operator<(const EnumType& lhs,
                                 const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} < rhs;
 }
 
 template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
+          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
 inline constexpr bool operator>(const EnumType& lhs,
                                 const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} > rhs;
 }
 
 template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
+          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
 inline constexpr bool operator<=(const EnumType& lhs,
                                  const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} <= rhs;
 }
 
 template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
+          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
 inline constexpr bool operator>=(const EnumType& lhs,
                                  const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} >= rhs;
 }
 
 template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
+          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
 inline constexpr bool operator==(const EnumType& lhs,
                                  const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} == rhs;
 }
 
 template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
+          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
 inline constexpr bool operator!=(const EnumType& lhs,
                                  const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} != rhs;

--- a/impeller/base/mask.h
+++ b/impeller/base/mask.h
@@ -9,6 +9,21 @@
 
 namespace impeller {
 
+template <typename EnumType_>
+struct MaskTraits {
+  static constexpr bool is_mask = false;
+};
+
+//------------------------------------------------------------------------------
+/// @brief      Declare this in the "impeller" namespace to make the enum
+///             maskable.
+///
+#define IMPELLER_ENUM_IS_MASK(enum_name)  \
+  template <>                             \
+  struct MaskTraits<enum_name> {          \
+    static constexpr bool is_mask = true; \
+  };
+
 //------------------------------------------------------------------------------
 /// @brief      A mask of typed enums.
 ///
@@ -110,42 +125,56 @@ struct Mask {
 
 // Construction from Enum Types
 
-template <typename EnumType>
+template <
+    typename EnumType,
+    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
 inline constexpr Mask<EnumType> operator|(const EnumType& lhs,
                                           const EnumType& rhs) {
   return Mask<EnumType>{lhs} | rhs;
 }
 
-template <typename EnumType>
+template <
+    typename EnumType,
+    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
 inline constexpr Mask<EnumType> operator&(const EnumType& lhs,
                                           const EnumType& rhs) {
   return Mask<EnumType>{lhs} & rhs;
 }
 
-template <typename EnumType>
+template <
+    typename EnumType,
+    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
 inline constexpr Mask<EnumType> operator^(const EnumType& lhs,
                                           const EnumType& rhs) {
   return Mask<EnumType>{lhs} ^ rhs;
 }
 
-template <typename EnumType>
+template <
+    typename EnumType,
+    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
 inline constexpr Mask<EnumType> operator~(const EnumType& other) {
   return ~Mask<EnumType>{other};
 }
 
-template <typename EnumType>
+template <
+    typename EnumType,
+    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
 inline constexpr Mask<EnumType> operator|(const EnumType& lhs,
                                           const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} | rhs;
 }
 
-template <typename EnumType>
+template <
+    typename EnumType,
+    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
 inline constexpr Mask<EnumType> operator&(const EnumType& lhs,
                                           const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} & rhs;
 }
 
-template <typename EnumType>
+template <
+    typename EnumType,
+    typename std::enable_if<MaskTraits<EnumType>::is_mask, bool>::type = true>
 inline constexpr Mask<EnumType> operator^(const EnumType& lhs,
                                           const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} ^ rhs;
@@ -154,37 +183,43 @@ inline constexpr Mask<EnumType> operator^(const EnumType& lhs,
 // Relational operators with EnumType promotion. These can be replaced by a
 // defaulted spaceship operator post C++20.
 
-template <typename EnumType>
+template <typename EnumType,
+          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
 inline constexpr bool operator<(const EnumType& lhs,
                                 const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} < rhs;
 }
 
-template <typename EnumType>
+template <typename EnumType,
+          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
 inline constexpr bool operator>(const EnumType& lhs,
                                 const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} > rhs;
 }
 
-template <typename EnumType>
+template <typename EnumType,
+          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
 inline constexpr bool operator<=(const EnumType& lhs,
                                  const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} <= rhs;
 }
 
-template <typename EnumType>
+template <typename EnumType,
+          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
 inline constexpr bool operator>=(const EnumType& lhs,
                                  const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} >= rhs;
 }
 
-template <typename EnumType>
+template <typename EnumType,
+          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
 inline constexpr bool operator==(const EnumType& lhs,
                                  const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} == rhs;
 }
 
-template <typename EnumType>
+template <typename EnumType,
+          typename std::enable_if_t<MaskTraits<EnumType>::is_mask, bool> = true>
 inline constexpr bool operator!=(const EnumType& lhs,
                                  const Mask<EnumType>& rhs) {
   return Mask<EnumType>{lhs} != rhs;

--- a/impeller/core/formats.cc
+++ b/impeller/core/formats.cc
@@ -80,13 +80,13 @@ bool Attachment::IsValid() const {
 
 std::string TextureUsageMaskToString(TextureUsageMask mask) {
   std::vector<TextureUsage> usages;
-  if (mask & static_cast<TextureUsageMask>(TextureUsage::kShaderRead)) {
+  if (mask & TextureUsage::kShaderRead) {
     usages.push_back(TextureUsage::kShaderRead);
   }
-  if (mask & static_cast<TextureUsageMask>(TextureUsage::kShaderWrite)) {
+  if (mask & TextureUsage::kShaderWrite) {
     usages.push_back(TextureUsage::kShaderWrite);
   }
-  if (mask & static_cast<TextureUsageMask>(TextureUsage::kRenderTarget)) {
+  if (mask & TextureUsage::kRenderTarget) {
     usages.push_back(TextureUsage::kRenderTarget);
   }
   std::stringstream stream;

--- a/impeller/core/texture_descriptor.h
+++ b/impeller/core/texture_descriptor.h
@@ -40,8 +40,7 @@ struct TextureDescriptor {
   PixelFormat format = PixelFormat::kUnknown;
   ISize size;
   size_t mip_count = 1u;  // Size::MipCount is usually appropriate.
-  TextureUsageMask usage =
-      static_cast<TextureUsageMask>(TextureUsage::kShaderRead);
+  TextureUsageMask usage = TextureUsage::kShaderRead;
   SampleCount sample_count = SampleCount::kCount1;
   CompressionType compression_type = CompressionType::kLossless;
 

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -458,8 +458,7 @@ ContentContext::ContentContext(
   auto clip_color_attachments =
       clip_pipeline_descriptor->GetColorAttachmentDescriptors();
   for (auto& color_attachment : clip_color_attachments) {
-    color_attachment.second.write_mask =
-        static_cast<uint64_t>(ColorWriteMask::kNone);
+    color_attachment.second.write_mask = ColorWriteMaskBits::kNone;
   }
   clip_pipeline_descriptor->SetColorAttachmentDescriptors(
       std::move(clip_color_attachments));

--- a/impeller/entity/entity_pass_target_unittests.cc
+++ b/impeller/entity/entity_pass_target_unittests.cc
@@ -71,7 +71,7 @@ TEST_P(EntityPassTargetTest, SwapWithMSAAImplicitResolve) {
     color0_tex_desc.sample_count = SampleCount::kCount4;
     color0_tex_desc.format = pixel_format;
     color0_tex_desc.size = ISize{100, 100};
-    color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
+    color0_tex_desc.usage = TextureUsage::kRenderTarget;
 
     auto color0_msaa_tex = allocator.CreateTexture(color0_tex_desc);
 

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -59,18 +59,16 @@ void ConfigureBlending(const ProcTableGLES& gl,
   }
 
   {
-    const auto is_set = [](std::underlying_type_t<ColorWriteMask> mask,
+    const auto is_set = [](ColorWriteMask mask,
                            ColorWriteMask check) -> GLboolean {
-      using RawType = decltype(mask);
-      return (static_cast<RawType>(mask) & static_cast<RawType>(check))
-                 ? GL_TRUE
-                 : GL_FALSE;
+      return (mask & check) ? GL_TRUE : GL_FALSE;
     };
 
-    gl.ColorMask(is_set(color->write_mask, ColorWriteMask::kRed),    // red
-                 is_set(color->write_mask, ColorWriteMask::kGreen),  // green
-                 is_set(color->write_mask, ColorWriteMask::kBlue),   // blue
-                 is_set(color->write_mask, ColorWriteMask::kAlpha)   // alpha
+    gl.ColorMask(
+        is_set(color->write_mask, ColorWriteMaskBits::kRed),    // red
+        is_set(color->write_mask, ColorWriteMaskBits::kGreen),  // green
+        is_set(color->write_mask, ColorWriteMaskBits::kBlue),   // blue
+        is_set(color->write_mask, ColorWriteMaskBits::kAlpha)   // alpha
     );
   }
 }

--- a/impeller/renderer/backend/gles/surface_gles.cc
+++ b/impeller/renderer/backend/gles/surface_gles.cc
@@ -29,7 +29,7 @@ std::unique_ptr<Surface> SurfaceGLES::WrapFBO(
   color0_tex.type = TextureType::kTexture2D;
   color0_tex.format = color_format;
   color0_tex.size = fbo_size;
-  color0_tex.usage = static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+  color0_tex.usage = TextureUsage::kRenderTarget;
   color0_tex.sample_count = SampleCount::kCount1;
   color0_tex.storage_mode = StorageMode::kDevicePrivate;
 
@@ -44,8 +44,7 @@ std::unique_ptr<Surface> SurfaceGLES::WrapFBO(
   depth_stencil_texture_desc.type = TextureType::kTexture2D;
   depth_stencil_texture_desc.format = color_format;
   depth_stencil_texture_desc.size = fbo_size;
-  depth_stencil_texture_desc.usage =
-      static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+  depth_stencil_texture_desc.usage = TextureUsage::kRenderTarget;
   depth_stencil_texture_desc.sample_count = SampleCount::kCount1;
 
   auto depth_stencil_tex = std::make_shared<TextureGLES>(

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -45,8 +45,7 @@ static bool IsDepthStencilFormat(PixelFormat format) {
 static TextureGLES::Type GetTextureTypeFromDescriptor(
     const TextureDescriptor& desc) {
   const auto usage = static_cast<TextureUsageMask>(desc.usage);
-  const auto render_target =
-      static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+  const auto render_target = TextureUsage::kRenderTarget;
   const auto is_msaa = desc.sample_count == SampleCount::kCount4;
   if (usage == render_target && IsDepthStencilFormat(desc.format)) {
     return is_msaa ? TextureGLES::Type::kRenderBufferMultisampled

--- a/impeller/renderer/backend/metal/formats_mtl.h
+++ b/impeller/renderer/backend/metal/formats_mtl.h
@@ -207,25 +207,22 @@ constexpr MTLBlendOperation ToMTLBlendOperation(BlendOperation type) {
   return MTLBlendOperationAdd;
 };
 
-constexpr MTLColorWriteMask ToMTLColorWriteMask(
-    std::underlying_type_t<ColorWriteMask> type) {
-  using UnderlyingType = decltype(type);
-
+constexpr MTLColorWriteMask ToMTLColorWriteMask(ColorWriteMask type) {
   MTLColorWriteMask mask = MTLColorWriteMaskNone;
 
-  if (type & static_cast<UnderlyingType>(ColorWriteMask::kRed)) {
+  if (type & ColorWriteMaskBits::kRed) {
     mask |= MTLColorWriteMaskRed;
   }
 
-  if (type & static_cast<UnderlyingType>(ColorWriteMask::kGreen)) {
+  if (type & ColorWriteMaskBits::kGreen) {
     mask |= MTLColorWriteMaskGreen;
   }
 
-  if (type & static_cast<UnderlyingType>(ColorWriteMask::kBlue)) {
+  if (type & ColorWriteMaskBits::kBlue) {
     mask |= MTLColorWriteMaskBlue;
   }
 
-  if (type & static_cast<UnderlyingType>(ColorWriteMask::kAlpha)) {
+  if (type & ColorWriteMaskBits::kAlpha) {
     mask |= MTLColorWriteMaskAlpha;
   }
 

--- a/impeller/renderer/backend/metal/formats_mtl.mm
+++ b/impeller/renderer/backend/metal/formats_mtl.mm
@@ -95,16 +95,16 @@ MTLTextureDescriptor* ToMTLTextureDescriptor(const TextureDescriptor& desc) {
   mtl_desc.height = desc.size.height;
   mtl_desc.mipmapLevelCount = desc.mip_count;
   mtl_desc.usage = MTLTextureUsageUnknown;
-  if (desc.usage & static_cast<TextureUsageMask>(TextureUsage::kUnknown)) {
+  if (desc.usage & TextureUsage::kUnknown) {
     mtl_desc.usage |= MTLTextureUsageUnknown;
   }
-  if (desc.usage & static_cast<TextureUsageMask>(TextureUsage::kShaderRead)) {
+  if (desc.usage & TextureUsage::kShaderRead) {
     mtl_desc.usage |= MTLTextureUsageShaderRead;
   }
-  if (desc.usage & static_cast<TextureUsageMask>(TextureUsage::kShaderWrite)) {
+  if (desc.usage & TextureUsage::kShaderWrite) {
     mtl_desc.usage |= MTLTextureUsageShaderWrite;
   }
-  if (desc.usage & static_cast<TextureUsageMask>(TextureUsage::kRenderTarget)) {
+  if (desc.usage & TextureUsage::kRenderTarget) {
     mtl_desc.usage |= MTLTextureUsageRenderTarget;
   }
   return mtl_desc;

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -67,8 +67,8 @@ static std::optional<RenderTarget> WrapTextureWithRenderTarget(
   TextureDescriptor resolve_tex_desc;
   resolve_tex_desc.format = FromMTLPixelFormat(texture.pixelFormat);
   resolve_tex_desc.size = root_size;
-  resolve_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget) |
-                           static_cast<uint64_t>(TextureUsage::kShaderRead);
+  resolve_tex_desc.usage =
+      TextureUsage::kRenderTarget | TextureUsage::kShaderRead;
   resolve_tex_desc.sample_count = SampleCount::kCount1;
   resolve_tex_desc.storage_mode = StorageMode::kDevicePrivate;
 
@@ -98,7 +98,7 @@ static std::optional<RenderTarget> WrapTextureWithRenderTarget(
   msaa_tex_desc.sample_count = SampleCount::kCount4;
   msaa_tex_desc.format = resolve_tex->GetTextureDescriptor().format;
   msaa_tex_desc.size = resolve_tex->GetSize();
-  msaa_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
+  msaa_tex_desc.usage = TextureUsage::kRenderTarget;
 
   auto msaa_tex = allocator.CreateTexture(msaa_tex_desc);
   if (!msaa_tex) {

--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -188,7 +188,7 @@ static constexpr vk::ImageUsageFlags ToVKImageUsageFlags(
       break;
   }
 
-  if (usage & static_cast<TextureUsageMask>(TextureUsage::kRenderTarget)) {
+  if (usage & TextureUsage::kRenderTarget) {
     if (PixelFormatIsDepthStencil(format)) {
       vk_usage |= vk::ImageUsageFlagBits::eDepthStencilAttachment;
     } else {
@@ -197,7 +197,7 @@ static constexpr vk::ImageUsageFlags ToVKImageUsageFlags(
     vk_usage |= vk::ImageUsageFlagBits::eInputAttachment;
   }
 
-  if (usage & static_cast<TextureUsageMask>(TextureUsage::kShaderRead)) {
+  if (usage & TextureUsage::kShaderRead) {
     vk_usage |= vk::ImageUsageFlagBits::eSampled;
     // Device transient images can only be used as attachments. The caller
     // specified incorrect usage flags and is attempting to read a device
@@ -208,7 +208,7 @@ static constexpr vk::ImageUsageFlags ToVKImageUsageFlags(
     }
   }
 
-  if (usage & static_cast<TextureUsageMask>(TextureUsage::kShaderWrite)) {
+  if (usage & TextureUsage::kShaderWrite) {
     vk_usage |= vk::ImageUsageFlagBits::eStorage;
     // Device transient images can only be used as attachments. The caller
     // specified incorrect usage flags and is attempting to read a device

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -76,25 +76,22 @@ constexpr vk::BlendOp ToVKBlendOp(BlendOperation op) {
   FML_UNREACHABLE();
 }
 
-constexpr vk::ColorComponentFlags ToVKColorComponentFlags(
-    std::underlying_type_t<ColorWriteMask> type) {
-  using UnderlyingType = decltype(type);
-
+constexpr vk::ColorComponentFlags ToVKColorComponentFlags(ColorWriteMask type) {
   vk::ColorComponentFlags mask;
 
-  if (type & static_cast<UnderlyingType>(ColorWriteMask::kRed)) {
+  if (type & ColorWriteMaskBits::kRed) {
     mask |= vk::ColorComponentFlagBits::eR;
   }
 
-  if (type & static_cast<UnderlyingType>(ColorWriteMask::kGreen)) {
+  if (type & ColorWriteMaskBits::kGreen) {
     mask |= vk::ColorComponentFlagBits::eG;
   }
 
-  if (type & static_cast<UnderlyingType>(ColorWriteMask::kBlue)) {
+  if (type & ColorWriteMaskBits::kBlue) {
     mask |= vk::ColorComponentFlagBits::eB;
   }
 
-  if (type & static_cast<UnderlyingType>(ColorWriteMask::kAlpha)) {
+  if (type & ColorWriteMaskBits::kAlpha) {
     mask |= vk::ColorComponentFlagBits::eA;
   }
 

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -633,7 +633,7 @@ bool RenderPassVK::OnEncodeCommands(const Context& context) const {
   const std::shared_ptr<Texture>& result_texture =
       resolve_image_vk_ ? resolve_image_vk_ : color_image_vk_;
   if (result_texture->GetTextureDescriptor().usage &
-      static_cast<TextureUsageMask>(TextureUsage::kShaderRead)) {
+      TextureUsage::kShaderRead) {
     BarrierVK barrier;
     barrier.cmd_buffer = command_buffer_vk_;
     barrier.src_access = vk::AccessFlagBits::eColorAttachmentWrite |

--- a/impeller/renderer/backend/vulkan/swapchain/khr/khr_surface_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/khr/khr_surface_vk.cc
@@ -28,7 +28,7 @@ std::unique_ptr<KHRSurfaceVK> KHRSurfaceVK::WrapSwapchainImage(
     msaa_tex_desc.sample_count = SampleCount::kCount4;
     msaa_tex_desc.format = swapchain_image->GetPixelFormat();
     msaa_tex_desc.size = swapchain_image->GetSize();
-    msaa_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
+    msaa_tex_desc.usage = TextureUsage::kRenderTarget;
 
     if (!swapchain_image->GetMSAATexture()) {
       msaa_tex = context->GetResourceAllocator()->CreateTexture(msaa_tex_desc);
@@ -46,8 +46,7 @@ std::unique_ptr<KHRSurfaceVK> KHRSurfaceVK::WrapSwapchainImage(
   resolve_tex_desc.type = TextureType::kTexture2D;
   resolve_tex_desc.format = swapchain_image->GetPixelFormat();
   resolve_tex_desc.size = swapchain_image->GetSize();
-  resolve_tex_desc.usage =
-      static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+  resolve_tex_desc.usage = TextureUsage::kRenderTarget;
   resolve_tex_desc.sample_count = SampleCount::kCount1;
   resolve_tex_desc.storage_mode = StorageMode::kDevicePrivate;
 

--- a/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
@@ -222,8 +222,7 @@ KHRSwapchainImplVK::KHRSwapchainImplVK(const std::shared_ptr<Context>& context,
   }
 
   TextureDescriptor texture_desc;
-  texture_desc.usage =
-      static_cast<decltype(texture_desc.usage)>(TextureUsage::kRenderTarget);
+  texture_desc.usage = TextureUsage::kRenderTarget;
   texture_desc.storage_mode = StorageMode::kDevicePrivate;
   texture_desc.format = ToPixelFormat(swapchain_info.imageFormat);
   texture_desc.size = ISize::MakeWH(swapchain_info.imageExtent.width,
@@ -237,7 +236,7 @@ KHRSwapchainImplVK::KHRSwapchainImplVK(const std::shared_ptr<Context>& context,
   msaa_desc.sample_count = SampleCount::kCount4;
   msaa_desc.format = texture_desc.format;
   msaa_desc.size = texture_desc.size;
-  msaa_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
+  msaa_desc.usage = TextureUsage::kRenderTarget;
 
   // The depth+stencil configuration matches the configuration used by
   // RenderTarget::SetupDepthStencilAttachments and matching the swapchain
@@ -254,7 +253,7 @@ KHRSwapchainImplVK::KHRSwapchainImplVK(const std::shared_ptr<Context>& context,
   depth_stencil_desc.format =
       context->GetCapabilities()->GetDefaultDepthStencilFormat();
   depth_stencil_desc.size = texture_desc.size;
-  depth_stencil_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
+  depth_stencil_desc.usage = TextureUsage::kRenderTarget;
 
   std::shared_ptr<Texture> msaa_texture;
   if (enable_msaa) {

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -282,8 +282,8 @@ RenderTarget RenderTargetAllocator::CreateOffscreen(
     color0_tex_desc.format = pixel_format;
     color0_tex_desc.size = size;
     color0_tex_desc.mip_count = mip_count;
-    color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget) |
-                            static_cast<uint64_t>(TextureUsage::kShaderRead);
+    color0_tex_desc.usage =
+        TextureUsage::kRenderTarget | TextureUsage::kShaderRead;
     color0_tex = allocator_->CreateTexture(color0_tex_desc);
     if (!color0_tex) {
       return {};
@@ -338,7 +338,7 @@ RenderTarget RenderTargetAllocator::CreateOffscreenMSAA(
     color0_tex_desc.sample_count = SampleCount::kCount4;
     color0_tex_desc.format = pixel_format;
     color0_tex_desc.size = size;
-    color0_tex_desc.usage = static_cast<uint64_t>(TextureUsage::kRenderTarget);
+    color0_tex_desc.usage = TextureUsage::kRenderTarget;
     if (context.GetCapabilities()->SupportsImplicitResolvingMSAA()) {
       // See below ("SupportsImplicitResolvingMSAA") for more details.
       color0_tex_desc.storage_mode = StorageMode::kDevicePrivate;
@@ -364,8 +364,7 @@ RenderTarget RenderTargetAllocator::CreateOffscreenMSAA(
     color0_resolve_tex_desc.size = size;
     color0_resolve_tex_desc.compression_type = CompressionType::kLossy;
     color0_resolve_tex_desc.usage =
-        static_cast<uint64_t>(TextureUsage::kRenderTarget) |
-        static_cast<uint64_t>(TextureUsage::kShaderRead);
+        TextureUsage::kRenderTarget | TextureUsage::kShaderRead;
     color0_resolve_tex_desc.mip_count = mip_count;
     color0_resolve_tex = allocator_->CreateTexture(color0_resolve_tex_desc);
     if (!color0_resolve_tex) {
@@ -433,8 +432,7 @@ void RenderTarget::SetupDepthStencilAttachments(
     depth_stencil_texture_desc.format =
         context.GetCapabilities()->GetDefaultDepthStencilFormat();
     depth_stencil_texture_desc.size = size;
-    depth_stencil_texture_desc.usage =
-        static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+    depth_stencil_texture_desc.usage = TextureUsage::kRenderTarget;
     depth_stencil_texture = allocator.CreateTexture(depth_stencil_texture_desc);
     if (!depth_stencil_texture) {
       return;  // Error messages are handled by `Allocator::CreateTexture`.

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -336,8 +336,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
     texture_descriptor.storage_mode = StorageMode::kHostVisible;
     texture_descriptor.size = {400, 400};
     texture_descriptor.mip_count = 1u;
-    texture_descriptor.usage =
-        static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+    texture_descriptor.usage = TextureUsage::kRenderTarget;
 
     color0.texture =
         context->GetResourceAllocator()->CreateTexture(texture_descriptor);
@@ -353,8 +352,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
     stencil_texture_desc.storage_mode = StorageMode::kDeviceTransient;
     stencil_texture_desc.size = texture_descriptor.size;
     stencil_texture_desc.format = PixelFormat::kS8UInt;
-    stencil_texture_desc.usage =
-        static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+    stencil_texture_desc.usage = TextureUsage::kRenderTarget;
     stencil0.texture =
         context->GetResourceAllocator()->CreateTexture(stencil_texture_desc);
 
@@ -477,9 +475,7 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
   texture_desc.format = PixelFormat::kR8G8B8A8UNormInt;
   texture_desc.size = {800, 600};
   texture_desc.mip_count = 1u;
-  texture_desc.usage =
-      static_cast<TextureUsageMask>(TextureUsage::kRenderTarget) |
-      static_cast<TextureUsageMask>(TextureUsage::kShaderRead);
+  texture_desc.usage = TextureUsage::kRenderTarget | TextureUsage::kShaderRead;
   auto texture = context->GetResourceAllocator()->CreateTexture(texture_desc);
   ASSERT_TRUE(texture);
 
@@ -601,10 +597,8 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
   texture_desc.format = PixelFormat::kR8G8B8A8UNormInt;
   texture_desc.size = bridge->GetTextureDescriptor().size;
   texture_desc.mip_count = 1u;
-  texture_desc.usage =
-      static_cast<TextureUsageMask>(TextureUsage::kRenderTarget) |
-      static_cast<TextureUsageMask>(TextureUsage::kShaderWrite) |
-      static_cast<TextureUsageMask>(TextureUsage::kShaderRead);
+  texture_desc.usage = TextureUsage::kRenderTarget |
+                       TextureUsage::kShaderWrite | TextureUsage::kShaderRead;
   DeviceBufferDescriptor device_buffer_desc;
   device_buffer_desc.storage_mode = StorageMode::kHostVisible;
   device_buffer_desc.size =

--- a/impeller/scene/scene_encoder.cc
+++ b/impeller/scene/scene_encoder.cc
@@ -54,8 +54,7 @@ std::shared_ptr<CommandBuffer> SceneEncoder::BuildSceneCommandBuffer(
     ds_texture.type = TextureType::kTexture2DMultisample;
     ds_texture.format = PixelFormat::kD32FloatS8UInt;
     ds_texture.size = render_target.GetRenderTargetSize();
-    ds_texture.usage =
-        static_cast<TextureUsageMask>(TextureUsage::kRenderTarget);
+    ds_texture.usage = TextureUsage::kRenderTarget;
     ds_texture.sample_count = SampleCount::kCount4;
     ds_texture.storage_mode = StorageMode::kDeviceTransient;
     auto texture =

--- a/lib/gpu/texture.cc
+++ b/lib/gpu/texture.cc
@@ -86,7 +86,7 @@ bool InternalFlutterGpu_Texture_Initialize(Dart_Handle wrapper,
   desc.storage_mode = flutter::gpu::ToImpellerStorageMode(storage_mode);
   desc.size = {width, height};
   desc.format = flutter::gpu::ToImpellerPixelFormat(format);
-  desc.usage = 0;
+  desc.usage = {};
   if (enable_render_target_usage) {
     desc.usage |= static_cast<impeller::TextureUsageMask>(
         impeller::TextureUsage::kRenderTarget);

--- a/lib/gpu/texture.cc
+++ b/lib/gpu/texture.cc
@@ -88,16 +88,13 @@ bool InternalFlutterGpu_Texture_Initialize(Dart_Handle wrapper,
   desc.format = flutter::gpu::ToImpellerPixelFormat(format);
   desc.usage = {};
   if (enable_render_target_usage) {
-    desc.usage |= static_cast<impeller::TextureUsageMask>(
-        impeller::TextureUsage::kRenderTarget);
+    desc.usage |= impeller::TextureUsage::kRenderTarget;
   }
   if (enable_shader_read_usage) {
-    desc.usage |= static_cast<impeller::TextureUsageMask>(
-        impeller::TextureUsage::kShaderRead);
+    desc.usage |= impeller::TextureUsage::kShaderRead;
   }
   if (enable_shader_write_usage) {
-    desc.usage |= static_cast<impeller::TextureUsageMask>(
-        impeller::TextureUsage::kShaderWrite);
+    desc.usage |= impeller::TextureUsage::kShaderWrite;
   }
   switch (sample_count) {
     case 1:

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1048,9 +1048,8 @@ MakeRenderTargetFromBackingStoreImpeller(
   resolve_tex_desc.size = size;
   resolve_tex_desc.sample_count = impeller::SampleCount::kCount1;
   resolve_tex_desc.storage_mode = impeller::StorageMode::kDevicePrivate;
-  resolve_tex_desc.usage =
-      static_cast<uint64_t>(impeller::TextureUsage::kRenderTarget) |
-      static_cast<uint64_t>(impeller::TextureUsage::kShaderRead);
+  resolve_tex_desc.usage = impeller::TextureUsage::kRenderTarget |
+                           impeller::TextureUsage::kShaderRead;
 
   auto resolve_tex = impeller::WrapTextureMTL(
       resolve_tex_desc, metal->texture.texture,
@@ -1068,8 +1067,7 @@ MakeRenderTargetFromBackingStoreImpeller(
   msaa_tex_desc.sample_count = impeller::SampleCount::kCount4;
   msaa_tex_desc.format = resolve_tex->GetTextureDescriptor().format;
   msaa_tex_desc.size = size;
-  msaa_tex_desc.usage =
-      static_cast<uint64_t>(impeller::TextureUsage::kRenderTarget);
+  msaa_tex_desc.usage = impeller::TextureUsage::kRenderTarget;
 
   auto msaa_tex =
       aiks_context->GetContext()->GetResourceAllocator()->CreateTexture(


### PR DESCRIPTION
Uses the utility added in https://github.com/flutter/engine/pull/51361

I counted the removal of 58 static casts. There was one addition made to the original utility however. Vulkan HPP was promoting all enums to its own mask type. This in itself is problematic but we got away with it because there was no one else doing this kind of promotion. Till we added our own utility. To avoid polluting the namespace with methods that may cause ambiguity, enums that are masks must explicitly be marked as maskable with `IMPELLER_ENUM_IS_MASK` in the `impeller` namespace.

No change in functionality.