### PR TITLE
Small improvements to et lint command

### DIFF
--- a/tools/engine_tool/lib/main.dart
+++ b/tools/engine_tool/lib/main.dart
@@ -65,6 +65,13 @@ void main(List<String> args) async {
     configs: configs,
   );
 
-  io.exitCode = await runner.run(args);
+  try {
+    io.exitCode = await runner.run(args);
+  } on FatalError catch (e, st) {
+    environment.logger.error('FatalError caught in main. Please file a bug\n'
+        'error: $e\n'
+        'stack: $st');
+    io.exitCode = 1;
+  }
   return;
 }

--- a/tools/engine_tool/lib/src/dart_utils.dart
+++ b/tools/engine_tool/lib/src/dart_utils.dart
@@ -2,52 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ffi' as ffi show Abi;
-
 import 'package:path/path.dart' as p;
 import 'environment.dart';
 
-String _getAbiSubdirectory(ffi.Abi abi) {
-  switch (abi) {
-    case ffi.Abi.macosArm64:
-      return 'macos-arm64';
-    case ffi.Abi.macosX64:
-      return 'macos-x64';
-    case ffi.Abi.windowsArm64:
-      return 'windows-arm64';
-    case ffi.Abi.windowsX64:
-      return 'windows-x64';
-    case ffi.Abi.linuxArm:
-      return 'linux-arm';
-    case ffi.Abi.linuxArm64:
-      return 'linux-arm64';
-    case ffi.Abi.linuxIA32:
-      return 'linux-x86';
-    case ffi.Abi.linuxX64:
-      return 'linux-x64';
-    case ffi.Abi.androidArm:
-    case ffi.Abi.androidArm64:
-    case ffi.Abi.androidIA32:
-    case ffi.Abi.androidX64:
-    case ffi.Abi.androidRiscv64:
-    case ffi.Abi.fuchsiaArm64:
-    case ffi.Abi.fuchsiaX64:
-    case ffi.Abi.fuchsiaRiscv64:
-    case ffi.Abi.iosArm:
-    case ffi.Abi.iosArm64:
-    case ffi.Abi.iosX64:
-    case ffi.Abi.linuxRiscv32:
-    case ffi.Abi.linuxRiscv64:
-    case ffi.Abi.windowsIA32:
-    default:
-      throw UnsupportedError('Unsupported Abi $abi');
-  }
-}
-
 /// Returns a dart-sdk/bin directory path that is compatible with the host.
 String findDartBinDirectory(Environment env) {
-  return p.join(env.engine.flutterDir.path, 'prebuilts',
-      _getAbiSubdirectory(env.abi), 'dart-sdk', 'bin');
+  return p.dirname(env.platform.resolvedExecutable);
 }
 
 /// Returns a dart-sdk/bin/dart file pthat that is executable on the host.

--- a/tools/engine_tool/lib/src/json_utils.dart
+++ b/tools/engine_tool/lib/src/json_utils.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 void _appendTypeError(
   Map<String, Object?> map,
   String field,
@@ -77,3 +79,8 @@ int? intOfJson(
   }
   return map[field]! as int;
 }
+
+const JsonEncoder _jsonEncoder = JsonEncoder.withIndent('    ');
+
+/// Same as [jsonEncode] but is formatted to be human readable.
+String jsonEncodePretty(Object? object) => _jsonEncoder.convert(object);

--- a/tools/engine_tool/lib/src/proc_utils.dart
+++ b/tools/engine_tool/lib/src/proc_utils.dart
@@ -50,7 +50,7 @@ final class ProcessArtifacts {
     data['stderr'] = stderr;
     data['cwd'] = cwd.absolute.path;
     data['commandLine'] = commandLine;
-    file.writeAsStringSync(jsonEncode(data));
+    file.writeAsStringSync(jsonEncodePretty(data));
   }
 
   /// Creates a temporary file and saves the artifacts into it.

--- a/tools/engine_tool/test/build_command_test.dart
+++ b/tools/engine_tool/test/build_command_test.dart
@@ -60,7 +60,9 @@ void main() {
       Environment(
         abi: ffi.Abi.linuxX64,
         engine: engine,
-        platform: FakePlatform(operatingSystem: Platform.linux),
+        platform: FakePlatform(
+            operatingSystem: Platform.linux,
+            resolvedExecutable: io.Platform.resolvedExecutable),
         processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {
             runHistory.add(command);

--- a/tools/engine_tool/test/fetch_command_test.dart
+++ b/tools/engine_tool/test/fetch_command_test.dart
@@ -31,7 +31,9 @@ void main() {
       Environment(
         abi: ffi.Abi.linuxX64,
         engine: engine,
-        platform: FakePlatform(operatingSystem: Platform.linux),
+        platform: FakePlatform(
+            operatingSystem: Platform.linux,
+            resolvedExecutable: io.Platform.resolvedExecutable),
         processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {
             runHistory.add(command);
@@ -54,8 +56,7 @@ void main() {
       environment: env,
       configs: configs,
     );
-    final int result =
-        await runner.run(<String>['fetch']);
+    final int result = await runner.run(<String>['fetch']);
     expect(result, equals(0));
     expect(runHistory.length, greaterThanOrEqualTo(1));
     expect(
@@ -71,8 +72,7 @@ void main() {
       environment: env,
       configs: configs,
     );
-    final int result =
-        await runner.run(<String>['sync']);
+    final int result = await runner.run(<String>['sync']);
     expect(result, equals(0));
     expect(runHistory.length, greaterThanOrEqualTo(1));
     expect(

--- a/tools/engine_tool/test/lint_command_test.dart
+++ b/tools/engine_tool/test/lint_command_test.dart
@@ -58,7 +58,9 @@ void main() {
       Environment(
         abi: ffi.Abi.macosArm64,
         engine: engine,
-        platform: FakePlatform(operatingSystem: Platform.macOS),
+        platform: FakePlatform(
+            operatingSystem: Platform.macOS,
+            resolvedExecutable: io.Platform.resolvedExecutable),
         processRunner: ProcessRunner(
             processManager: FakeProcessManager(onStart: (List<String> command) {
           runHistory.add(command);

--- a/tools/engine_tool/test/logger_test.dart
+++ b/tools/engine_tool/test/logger_test.dart
@@ -79,6 +79,19 @@ void main() {
     expect(stringsFromLogs(logger.testLogs), equals(<String>['info']));
   });
 
+  test('fatal throws exception', () {
+    final Logger logger = Logger.test();
+    logger.level = Logger.infoLevel;
+    bool caught = false;
+    try {
+      logger.fatal('test', newline: false);
+    } on FatalError catch (_) {
+      caught = true;
+    }
+    expect(caught, equals(true));
+    expect(stringsFromLogs(logger.testLogs), equals(<String>['test']));
+  });
+
   test('fitToWidth', () {
     expect(Logger.fitToWidth('hello', 0), equals(''));
     expect(Logger.fitToWidth('hello', 1), equals('.'));
@@ -117,7 +130,9 @@ void main() {
     final Logger logger = Logger.test();
     bool called = false;
     final Spinner spinner = logger.startSpinner(
-      onFinish: () { called = true; },
+      onFinish: () {
+        called = true;
+      },
     );
     spinner.finish();
     expect(called, isTrue);

--- a/tools/engine_tool/test/proc_utils_test.dart
+++ b/tools/engine_tool/test/proc_utils_test.dart
@@ -31,7 +31,9 @@ void main() {
       Environment(
         abi: ffi.Abi.macosArm64,
         engine: engine,
-        platform: FakePlatform(operatingSystem: Platform.macOS),
+        platform: FakePlatform(
+            operatingSystem: Platform.macOS,
+            resolvedExecutable: io.Platform.resolvedExecutable),
         processRunner: ProcessRunner(
             processManager: FakeProcessManager(onStart: (List<String> command) {
           runHistory.add(command);

--- a/tools/engine_tool/test/query_command_test.dart
+++ b/tools/engine_tool/test/query_command_test.dart
@@ -58,7 +58,9 @@ void main() {
     return Environment(
       abi: ffi.Abi.linuxX64,
       engine: engine,
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+          operatingSystem: Platform.linux,
+          resolvedExecutable: io.Platform.resolvedExecutable),
       processRunner: ProcessRunner(
         processManager: FakeProcessManager(),
       ),

--- a/tools/engine_tool/test/run_command_test.dart
+++ b/tools/engine_tool/test/run_command_test.dart
@@ -60,7 +60,9 @@ void main() {
       Environment(
         abi: ffi.Abi.linuxX64,
         engine: engine,
-        platform: FakePlatform(operatingSystem: Platform.linux),
+        platform: FakePlatform(
+            operatingSystem: Platform.linux,
+            resolvedExecutable: io.Platform.resolvedExecutable),
         processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {
             runHistory.add(command);


### PR DESCRIPTION
- Default to dumping out lint logs (can be disabled with `--quiet` flag).
- Add Logger.fatal which logs an error and throws a FatalError which is caught in main.
- Simplify `findDartBinDirectory` implementation.
- Make JSON serialized process artifacts more human readable.
