### PR TITLE
[web] Avoid using `js_util.{jsify,dartify}()` in dart2wasm for converting to JS wrappers

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
@@ -34,7 +34,7 @@ NativeMemoryFinalizationRegistry nativeMemoryFinalizationRegistry = NativeMemory
 class NativeMemoryFinalizationRegistry {
   void register(Object owner, UniqueRef<Object> ref) {
     if (browserSupportsFinalizationRegistry) {
-      _finalizationRegistry.register(owner, ref.toJSBox);
+      _finalizationRegistry.register(owner.toJSAnyShallow, ref.toJSBox);
     }
   }
 }

--- a/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
@@ -22,7 +22,7 @@ import 'package:ui/src/engine.dart';
 /// 6. We call `delete` on SkPaint.
 DomFinalizationRegistry _finalizationRegistry = DomFinalizationRegistry(
   (JSBoxedDartObject boxedUniq) {
-    final UniqueRef<Object> uniq = boxedUniq.toDart as UniqueRef<Object>;
+    final UniqueRef<Object> uniq = boxedUniq.fromJSWrapper as UniqueRef<Object>;
     uniq.collect();
   }.toJS
 );
@@ -34,7 +34,7 @@ NativeMemoryFinalizationRegistry nativeMemoryFinalizationRegistry = NativeMemory
 class NativeMemoryFinalizationRegistry {
   void register(Object owner, UniqueRef<Object> ref) {
     if (browserSupportsFinalizationRegistry) {
-      _finalizationRegistry.register(owner.toJSAnyShallow, ref.toJSBox);
+      _finalizationRegistry.register(owner.toJSWrapper, ref.toJSWrapper);
     }
   }
 }

--- a/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
@@ -20,7 +20,7 @@ import 'package:ui/src/engine.dart';
 /// 4. GC decides to perform a GC cycle and collects CkPaint.
 /// 5. The finalizer function is called with the SkPaint as the sole argument.
 /// 6. We call `delete` on SkPaint.
-DomFinalizationRegistry _finalizationRegistry = createDomFinalizationRegistry(
+DomFinalizationRegistry _finalizationRegistry = DomFinalizationRegistry(
   (JSBoxedDartObject boxedUniq) {
     final UniqueRef<Object> uniq = boxedUniq.toDart as UniqueRef<Object>;
     uniq.collect();

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -3649,17 +3649,9 @@ extension DomTextDecoderExtension on DomTextDecoder {
 
 @JS('window.FinalizationRegistry')
 @staticInterop
-class DomFinalizationRegistry {}
-
-@JS('window.FinalizationRegistry')
-external JSAny? get _finalizationRegistryConstructor;
-
-// Note: We don't use a factory constructor here because there is an issue in
-// dart2js that causes a crash in the Google3 build if we do use a factory
-// constructor. See b/284478971
-DomFinalizationRegistry createDomFinalizationRegistry(JSFunction cleanup) =>
-    js_util.callConstructor(
-        _finalizationRegistryConstructor!.toObjectShallow, <Object>[cleanup]);
+class DomFinalizationRegistry {
+  external factory DomFinalizationRegistry(JSFunction cleanup);
+}
 
 extension DomFinalizationRegistryExtension on DomFinalizationRegistry {
   @JS('register')
@@ -3671,6 +3663,9 @@ extension DomFinalizationRegistryExtension on DomFinalizationRegistry {
   @JS('unregister')
   external JSVoid unregister(JSAny token);
 }
+
+@JS('window.FinalizationRegistry')
+external JSAny? get _finalizationRegistryConstructor;
 
 /// Whether the current browser supports `FinalizationRegistry`.
 bool browserSupportsFinalizationRegistry =

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -7,9 +7,9 @@ import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:ui/src/engine/skwasm/skwasm_stub.dart' if (dart.library.ffi) 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:js/js_util.dart' as js_util;
 import 'package:meta/meta.dart';
+import 'package:ui/src/engine/skwasm/skwasm_stub.dart' if (dart.library.ffi) 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 
 import 'browser_detection.dart';
 

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -9,8 +9,7 @@ import 'dart:typed_data';
 
 import 'package:js/js_util.dart' as js_util;
 import 'package:meta/meta.dart';
-import 'package:ui/src/engine/skwasm/skwasm_stub.dart'
-    if (dart.library.ffi) 'package:ui/src/engine/skwasm/skwasm_impl.dart';
+import 'package:ui/src/engine/skwasm/skwasm_stub.dart' if (dart.library.ffi) 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 
 import 'browser_detection.dart';
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl.dart
@@ -11,6 +11,7 @@ import 'dart:ffi';
 
 export 'skwasm_impl/canvas.dart';
 export 'skwasm_impl/codecs.dart';
+export 'skwasm_impl/dart_js_conversion.dart';
 export 'skwasm_impl/filters.dart';
 export 'skwasm_impl/font_collection.dart';
 export 'skwasm_impl/image.dart';

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/dart_js_conversion.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/dart_js_conversion.dart
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:_wasm';
+import 'dart:js_interop';
+
+@pragma('wasm:prefer-inline')
+@pragma('dart2js:tryInline')
+JSAny dartToJsWrapper(Object object) =>
+    WasmAnyRef.fromObject(object).externalize().toJS;
+
+@pragma('wasm:prefer-inline')
+@pragma('dart2js:tryInline')
+Object jsWrapperToDart(JSAny jsWrapper) =>
+    externRefForJSAny(jsWrapper).internalize()!.toObject();

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -36,11 +36,14 @@ class SkwasmFinalizationRegistry<T extends NativeType> {
   final DisposeFunction<T> dispose;
 
   void register(SkwasmObjectWrapper<T> wrapper) {
-    registry.register(wrapper, wrapper.handle.address, wrapper);
+    final JSAny jsWrapper = wrapper.toJSAnyShallow;
+    registry.registerWithToken(
+        jsWrapper, wrapper.handle.address.toJS, jsWrapper);
   }
 
   void evict(SkwasmObjectWrapper<T> wrapper) {
-    registry.unregister(wrapper);
+    final JSAny jsWrapper = wrapper.toJSAnyShallow;
+    registry.unregister(jsWrapper);
     dispose(wrapper.handle);
   }
 }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -36,13 +36,13 @@ class SkwasmFinalizationRegistry<T extends NativeType> {
   final DisposeFunction<T> dispose;
 
   void register(SkwasmObjectWrapper<T> wrapper) {
-    final JSAny jsWrapper = wrapper.toJSAnyShallow;
+    final JSAny jsWrapper = wrapper.toJSWrapper;
     registry.registerWithToken(
         jsWrapper, wrapper.handle.address.toJS, jsWrapper);
   }
 
   void evict(SkwasmObjectWrapper<T> wrapper) {
-    final JSAny jsWrapper = wrapper.toJSAnyShallow;
+    final JSAny jsWrapper = wrapper.toJSWrapper;
     registry.unregister(jsWrapper);
     dispose(wrapper.handle);
   }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -28,7 +28,7 @@ typedef DisposeFunction<T extends NativeType> = void Function(Pointer<T>);
 
 class SkwasmFinalizationRegistry<T extends NativeType> {
   SkwasmFinalizationRegistry(this.dispose)
-    : registry = createDomFinalizationRegistry(((JSNumber address) =>
+    : registry = DomFinalizationRegistry(((JSNumber address) =>
       dispose(Pointer<T>.fromAddress(address.toDartDouble.toInt()))
     ).toJS);
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_stub.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_stub.dart
@@ -6,4 +6,5 @@
 // ignore: unnecessary_library_directive
 library skwasm_stub;
 
+export 'skwasm_stub/dart_js_conversion.dart';
 export 'skwasm_stub/renderer.dart';

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/dart_js_conversion.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/dart_js_conversion.dart
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+
+@pragma('wasm:prefer-inline')
+@pragma('dart2js:tryInline')
+JSAny dartToJsWrapper(Object object) => object as JSAny;
+
+@pragma('wasm:prefer-inline')
+@pragma('dart2js:tryInline')
+Object jsWrapperToDart(JSAny jsWrapper) => jsWrapper;

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1928,7 +1928,7 @@ void _paragraphTests() {
     // FinalizationRegistry because it depends on GC, which cannot be controlled,
     // So the test simply tests that a FinalizationRegistry can be constructed
     // and its `register` method can be called.
-    final DomFinalizationRegistry registry = createDomFinalizationRegistry((String arg) {}.toJS);
+    final DomFinalizationRegistry registry = DomFinalizationRegistry((String arg) {}.toJS);
     registry.register(Object().toJSAnyShallow, Object().toJSAnyShallow);
   });
 }

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1929,7 +1929,7 @@ void _paragraphTests() {
     // So the test simply tests that a FinalizationRegistry can be constructed
     // and its `register` method can be called.
     final DomFinalizationRegistry registry = DomFinalizationRegistry((String arg) {}.toJS);
-    registry.register(Object().toJSAnyShallow, Object().toJSAnyShallow);
+    registry.register(Object().toJSWrapper, Object().toJSWrapper);
   });
 }
 

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1929,7 +1929,7 @@ void _paragraphTests() {
     // So the test simply tests that a FinalizationRegistry can be constructed
     // and its `register` method can be called.
     final DomFinalizationRegistry registry = createDomFinalizationRegistry((String arg) {}.toJS);
-    registry.register(Object(), Object());
+    registry.register(Object().toJSAnyShallow, Object().toJSAnyShallow);
   });
 }
 


### PR DESCRIPTION
The `js_util.jsify()` related code shows up in CPU profile of wonderous.

=> Any `SkwasmObjectWrapper` object invokes this logic in the constructor and dispose method.

This PR

* makes `DomFinalizationRegistryExtension` accept `JSAny` types instead of Dart types and internally converting
  => Callsites can call more precise `<>.toJS*` extension methods
  => Will avoids extra type checks on the objects when we can call `Object.toJSBox` directly

* avoids making `toJSAnyShallow` delegate to `toJSAnyDeep` in wasm
  => `toJSAnyDeep` uses `js_util.jsify()` which is slow
  => We cannot use `Object.toJSBox` due to it being slower to create JS boxes as it semantically does something different atm (see issue below)
  => Instead use conditional import of `dart:_wasm` which provides the necessary primitives
  => Similar for going from JS to Dart.

* Avoid calling converting from Dart object to `JSAny` more than needed (we did the operation twice for each registration and once for unregistration)

Issue https://github.com/dart-lang/sdk/issues/55183