### PR TITLE
[et] Prepare local_engine.json for CI, namespace CI builds.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -49,6 +49,14 @@ platform_properties:
 # https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/android/avd/proto
 # You may use those names for the android_virtual_device version.
 targets:
+  - name: Linux local_engine_builds
+    bringup: true
+    enabled_branches:
+      - main
+    recipe: engine_v2/engine_v2
+    properties:
+      config_name: local_engine
+
   - name: Linux linux_android_emulator_tests
     enabled_branches:
       - main

--- a/ci/builders/local_engine.json
+++ b/ci/builders/local_engine.json
@@ -1,29 +1,89 @@
 {
   "builds": [
     {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "debug",
         "--android",
         "--android-cpu=arm64",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "android_debug_arm64",
+      "name": "macos/android_debug_arm64",
       "ninja": {
         "config": "android_debug_arm64",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/android_debug_arm64",
+      "ninja": {
+        "config": "android_debug_arm64",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/android_debug_arm64",
+      "ninja": {
+        "config": "android_debug_arm64",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "debug",
@@ -50,79 +110,356 @@
         "--android",
         "--android-cpu=arm64",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "android_profile_arm64",
+      "name": "macos/android_profile_arm64",
       "ninja": {
         "config": "android_profile_arm64",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/android_profile_arm64",
+      "ninja": {
+        "config": "android_profile_arm64",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "cpu=x86|arm64",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/android_profile_arm64",
+      "ninja": {
+        "config": "android_profile_arm64",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "release",
         "--android",
         "--android-cpu=arm64",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "android_release_arm64",
+      "name": "macos/android_release_arm64",
       "ninja": {
         "config": "android_release_arm64",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/android_release_arm64",
+      "ninja": {
+        "config": "android_release_arm64",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/android_release_arm64",
+      "ninja": {
+        "config": "android_release_arm64",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "debug",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "host_debug",
+      "name": "macos/host_debug",
       "ninja": {
         "config": "host_debug",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/host_debug",
+      "ninja": {
+        "config": "host_debug",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/host_debug",
+      "ninja": {
+        "config": "host_debug",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "profile",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "host_profile",
+      "name": "macos/host_profile",
       "ninja": {
         "config": "host_profile",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/host_profile",
+      "ninja": {
+        "config": "host_profile",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/host_profile",
+      "ninja": {
+        "config": "host_profile",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "release",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--rbe",
+        "--no-goma",
+        "--xcode-symlinks"
       ],
-      "name": "host_release",
+      "name": "macos/host_release",
+      "ninja": {
+        "config": "host_release",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma",
+        "--xcode-symlinks"
+      ],
+      "name": "linux/host_release",
+      "ninja": {
+        "config": "host_release",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma",
+        "--xcode-symlinks"
+      ],
+      "name": "windows/host_release",
       "ninja": {
         "config": "host_release",
         "targets": []

--- a/tools/engine_tool/lib/src/build_utils.dart
+++ b/tools/engine_tool/lib/src/build_utils.dart
@@ -65,6 +65,37 @@ void debugCheckBuilds(List<Build> builds) {
   }
 }
 
+/// Transform the name of a build into the name presented and accepted by the
+/// CLI
+///
+/// If a name starts with '$OS/', it is a local development build, and the
+/// mangled name has the '$OS/' part stripped off.
+///
+/// If the name does not start with '$OS/', it is a CI build whose main purpose
+/// is to produce artifacts for consumption by the Flutter framework, and the
+/// mangled name has 'ci/' prepended onto `name`.
+String mangleConfigName(Environment environment, String name) {
+  final String os = '${environment.platform.operatingSystem}/';
+  if (name.startsWith(os)) {
+    return name.substring(os.length);
+  }
+  return 'ci/$name';
+}
+
+/// Transform the mangled name of a build into its true name in the build
+/// config json file.
+///
+/// This does the reverse of [mangleConfigName] taking the operating system
+/// name from `environment`.
+String demangleConfigName(Environment environment, String name) {
+  const String ci = 'ci/';
+  if (name.startsWith(ci)) {
+    return name.substring(ci.length);
+  }
+  final String os = environment.platform.operatingSystem;
+  return '$os/$name';
+}
+
 /// Build the build target in the environment.
 Future<int> runBuild(
   Environment environment,

--- a/tools/engine_tool/lib/src/commands/build_command.dart
+++ b/tools/engine_tool/lib/src/commands/build_command.dart
@@ -24,11 +24,11 @@ final class BuildCommand extends CommandBase {
       help: 'Specify the build config to use',
       allowed: <String>[
         for (final Build config in runnableBuilds(environment, configs))
-          config.name,
+          mangleConfigName(environment, config.name),
       ],
       allowedHelp: <String, String>{
         for (final Build config in runnableBuilds(environment, configs))
-          config.name: config.gn.join(' '),
+          mangleConfigName(environment, config.name): config.gn.join(' '),
       },
     );
     argParser.addFlag(
@@ -52,17 +52,17 @@ final class BuildCommand extends CommandBase {
   Future<int> run() async {
     final String configName = argResults![configFlag] as String;
     final bool useRbe = argResults![rbeFlag] as bool;
+    final String demangledName = demangleConfigName(environment, configName);
+    environment.logger.info('demangled name = "$demangledName"');
     final Build? build =
-        builds.where((Build build) => build.name == configName).firstOrNull;
+        builds.where((Build build) => build.name == demangledName).firstOrNull;
     if (build == null) {
       environment.logger.error('Could not find config $configName');
       return 1;
     }
-
     final List<String> extraGnArgs = <String>[
       if (!useRbe) '--no-rbe',
     ];
-
     // TODO(loic-sharma): Fetch dependencies if needed.
     return runBuild(environment, build, extraGnArgs: extraGnArgs);
   }

--- a/tools/engine_tool/lib/src/commands/command_runner.dart
+++ b/tools/engine_tool/lib/src/commands/command_runner.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:engine_build_configs/engine_build_configs.dart';
 
 import '../environment.dart';
+import '../logger.dart';
 import 'build_command.dart';
 import 'fetch_command.dart';
 import 'flags.dart';
@@ -59,8 +61,13 @@ final class ToolCommandRunner extends CommandRunner<int> {
 
   @override
   Future<int> run(Iterable<String> args) async {
+    final ArgResults argResults = parse(args);
+    final bool verbose = argResults[verboseFlag]! as bool;
+    if (verbose) {
+      environment.logger.level = Logger.infoLevel;
+    }
     try {
-      return await runCommand(parse(args)) ?? 0;
+      return await runCommand(argResults) ?? 0;
     } on FormatException catch (e) {
       environment.logger.error(e);
       return 1;

--- a/tools/engine_tool/test/fixtures.dart
+++ b/tools/engine_tool/test/fixtures.dart
@@ -122,6 +122,35 @@ String testConfig(String os) => '''
 }
 ''';
 
+const String configsToTestNamespacing = '''
+{
+  "builds": [
+    {
+      "drone_dimensions": [
+        "os=Linux"
+      ],
+      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "name": "linux/host_debug",
+      "ninja": {
+        "config": "local_host_debug",
+        "targets": ["ninja_target"]
+      }
+    },
+    {
+      "drone_dimensions": [
+        "os=Linux"
+      ],
+      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "name": "host_debug",
+      "ninja": {
+        "config": "ci_host_debug",
+        "targets": ["ninja_target"]
+      }
+    }
+  ]
+}
+''';
+
 String attachedDevices() => '''
 [
   {

--- a/tools/pkg/engine_build_configs/lib/src/build_config.dart
+++ b/tools/pkg/engine_build_configs/lib/src/build_config.dart
@@ -803,17 +803,20 @@ final class GlobalArchive extends BuildConfigBase {
 }
 
 bool _canRunOn(List<String> droneDimensions, Platform platform) {
-  String? os;
+  Iterable<String>? supported;
   for (final String dimension in droneDimensions) {
-    os ??= switch (dimension.split('=')) {
-      ['os', 'Linux'] => Platform.linux,
-      ['os', final String win] when win.startsWith('Windows') =>
-        Platform.windows,
-      ['os', final String mac] when mac.startsWith('Mac') => Platform.macOS,
-      _ => null,
-    };
+    if (!dimension.startsWith('os=')) {
+      continue;
+    }
+    supported ??= dimension.substring(3).split('|').map(
+      (String os) => switch(os) {
+        'Linux' => Platform.linux,
+        final String win when win.startsWith('Windows') => Platform.windows,
+        final String mac when mac.startsWith('Mac') => Platform.macOS,
+        _ => '',
+    }).where((String s) => s.isNotEmpty);
   }
-  return os == platform.operatingSystem;
+  return supported?.contains(platform.operatingSystem) ?? false;
 }
 
 void appendTypeError(

--- a/tools/pkg/engine_build_configs/test/build_config_test.dart
+++ b/tools/pkg/engine_build_configs/test/build_config_test.dart
@@ -319,5 +319,30 @@ int main() {
           'For field "name", expected type: string, actual type: int.',
         ));
   });
+
+  test('canRunOn handles multiple OSs separated by |', () {
+    final BuilderConfig buildConfig = BuilderConfig.fromJson(
+      path: 'linux_test_config',
+      map: convert.jsonDecode(fixtures.multiOSBuilderConfig) as Map<String, Object?>,
+    );
+    expect(buildConfig.valid, isTrue);
+    expect(buildConfig.errors, isNull);
+    expect(buildConfig.builds.length, equals(1));
+
+    final Build globalBuild = buildConfig.builds[0];
+    expect(
+      globalBuild.canRunOn(FakePlatform(operatingSystem: Platform.linux)),
+      isTrue,
+    );
+    expect(
+      globalBuild.canRunOn(FakePlatform(operatingSystem: Platform.macOS)),
+      isTrue,
+    );
+    expect(
+      globalBuild.canRunOn(FakePlatform(operatingSystem: Platform.windows)),
+      isFalse,
+    );
+  });
+
   return 0;
 }

--- a/tools/pkg/engine_build_configs/test/fixtures.dart
+++ b/tools/pkg/engine_build_configs/test/fixtures.dart
@@ -86,3 +86,29 @@ const String buildConfigJson = '''
   ]
 }
 ''';
+
+const String multiOSBuilderConfig = '''
+{
+  "builds": [
+    {
+      "drone_dimensions": [
+        "os=Mac-13|Linux"
+      ],
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--enable-impeller-vulkan",
+        "--no-lto"
+      ],
+      "name": "android_debug_arm64",
+      "ninja": {
+        "config": "android_debug_arm64",
+        "targets": []
+      }
+    }
+  ]
+}
+''';


### PR DESCRIPTION
This PR does two things:
1. Adds builds to local_engine.json, so that each configuration can be built on Windows/macOS/Linux in CI. Each build in the file needs a distinct name, and the drone dimensions for each build need to specify exactly one OS so that we're guaranteed that each config is tested on each OS.
2. Since the local build names have to be prepended with the OS name anyway, and the assumption is that the local builds will be the ones most commonly used for local dev workflows, this PR introduces namspacing of builds as follows:  local_engine.json builds have their usual names like `host_debug`, and are distinguished on the command line from the rest of the CI builds by namespacing the CI builds under `ci/`.

For example, on a mac:
```bash
# Uses the config macos/host_debug in local_engine.json
$ et build -c host_debug

# Uses the config in mac_host_engine.json
$ et build -c ci/host_debug
```

This is not intended to be an ideal end-state. What I would like is for the contents of both the local_engine.json and CI builds to be generated from a nicer config format. However, to smooth the migration from Goma to RBE, which may need to be completed by the end of the month, we need a way in the short term to use `et` to build with RBE while a nicer solution to this problem is designed and implemented.