### PR TITLE
Disable cleaning up ImageReaders in memory pressure callback

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -414,6 +414,11 @@ public class FlutterRenderer implements TextureRegistry {
     // Flip when debugging to see verbose logs.
     private static final boolean VERBOSE_LOGS = false;
 
+    // If we cleanup the ImageReaders on memory pressure it breaks VirtualDisplay
+    // backed platform views. Disable for now as this is only necessary to work
+    // around a Samsung-specific Android 14 bug.
+    private static final boolean CLEANUP_ON_MEMORY_PRESSURE = false;
+
     private final long id;
 
     private boolean released;
@@ -649,6 +654,9 @@ public class FlutterRenderer implements TextureRegistry {
 
     @Override
     public void onTrimMemory(int level) {
+      if (!CLEANUP_ON_MEMORY_PRESSURE) {
+        return;
+      }
       cleanup();
       createNewReader = true;
     }

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -648,11 +648,12 @@ public class FlutterRendererTest {
     assertEquals(1, texture.numImages());
 
     // Invoke the onTrimMemory callback.
+    // This should do nothing.
     texture.onTrimMemory(0);
     shadowOf(Looper.getMainLooper()).idle();
 
-    assertEquals(0, texture.numImageReaders());
-    assertEquals(0, texture.numImages());
+    assertEquals(1, texture.numImageReaders());
+    assertEquals(1, texture.numImages());
   }
 
   // A 0x0 ImageReader is a runtime error.


### PR DESCRIPTION
We originally added this cleanup code to work around a Samsung-specific Android 14 bug where after resuming an application any ImageReaders are busted. According to the Android team what Samsung is doing is a violation of the "spec".

The fix ended up breaking VirtualDisplay platform views after a suspend/resume because the surface we pass to the VirtualDisplay is no longer valid after the resume and we have no way of fixing that.

This PR removes the Samsung-specific hacky fix, restoring the behaviour of VirtualDisplay backed platform views.

We have an internal bug with Samsung to address the root cause.