### PR TITLE
Fix flakiness in FlutterVSyncWaiterTest.VSyncWorks and FlutterDisplayLinkTest.WorkaroundForFB13482573

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterDisplayLink.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDisplayLink.mm
@@ -262,8 +262,11 @@ static NSString* const kFlutterDisplayLinkViewDidMoveToWindow =
 - (void)invalidate {
   @synchronized(self) {
     FML_DCHECK([NSThread isMainThread]);
-    [_view removeFromSuperview];
+    // Unregister observer before removing the view to ensure
+    // that the viewDidChangeWindow notification is not received
+    // while in @synchronized block.
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [_view removeFromSuperview];
     _view = nil;
     _delegate = nil;
   }


### PR DESCRIPTION
- Removes potential source of flakiness where the tests assumes that scheduled block will be performed within certain time period, which, despite the tolerances may not be the case on test runner.

- Ensures that `viewDidChangeWindow` notification is not received while invalidating the displayLink and removing the display link view, which could deadlock at the end of `WorkaroundForFB13482573` test because the notification would come while `FlutterDisplayLink` is in `@synchronized` block.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x]  I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
