### PR TITLE
DNS: Try to run an engine test in the devicelab

### DIFF
--- a/ci/builders/linux_android_debug_engine.json
+++ b/ci/builders/linux_android_debug_engine.json
@@ -235,5 +235,35 @@
                 "language": "dart"
             }
         ]
-    }
+    },
+    "tests": [
+        {
+            "name": "Scenario App on Pixel 7 Pro",
+            "recipe": "engine_v2/tester_engine",
+            "drone_dimensions": [
+                "device_type=Pixel 7 Pro",
+                "os=Linux"
+            ],
+            "dependencies": [
+                "android_debug_arm64"
+            ],
+            "test_dependencies": [
+                {
+                    "dependency": "goldctl",
+                    "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
+                }
+            ],
+            "tasks": [
+                {
+                    "language": "python3",
+                    "name": "Scenario App Placeholder",
+                    "parameters": [
+                        "--target-directory",
+                        "../out/android_debug_arm64"
+                    ],
+                    "script": "build/ls.py"
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This example shows how to run a "global test" using the engine_v2 recipe from Engine CI on a Pixel 7 Pro in the devicelab.

To run the scenario app tests on a real device, we probably want to have the Android build it will use in a different json file than what I'm doing in this PR (maybe a new one to replace the Impeller `emulator` one).

The test has available to it all of the build output from the build it depends on and a full engine checkout.

The presub on this PR ran this: https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20Engine%20Drone/2120419/overview. Note the bot name `flutter-devicelab-linux-26`

cc @matanlurey @jonahwilliams @dnfield @gaaclarke 