### PR TITLE
[CP] Revert "[Impeller] stencil buffer record/replay instead of MSAA storage.

### DIFF
--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -21,7 +21,6 @@
 namespace impeller {
 
 class ContentContext;
-class EntityPassClipRecorder;
 
 class EntityPass {
  public:
@@ -295,8 +294,6 @@ class EntityPass {
   bool flood_clip_ = false;
   bool enable_offscreen_debug_checkerboard_ = false;
   std::optional<Rect> bounds_limit_;
-  std::unique_ptr<EntityPassClipRecorder> clip_replay_ =
-      std::make_unique<EntityPassClipRecorder>();
 
   /// These values are incremented whenever something is added to the pass that
   /// requires reading from the backdrop texture. Currently, this can happen in
@@ -319,26 +316,6 @@ class EntityPass {
   EntityPass(const EntityPass&) = delete;
 
   EntityPass& operator=(const EntityPass&) = delete;
-};
-
-/// @brief A class that tracks all clips that have been recorded in the current
-///        entity pass stencil.
-///
-///        These clips are replayed when restoring the backdrop so that the
-///        stencil buffer is left in an identical state.
-class EntityPassClipRecorder {
- public:
-  EntityPassClipRecorder();
-
-  ~EntityPassClipRecorder() = default;
-
-  /// @brief Record the entity based on the provided coverage [type].
-  void RecordEntity(const Entity& entity, Contents::ClipCoverage::Type type);
-
-  const std::vector<Entity>& GetReplayEntities() const;
-
- private:
-  std::vector<Entity> rendered_clip_entities_;
 };
 
 }  // namespace impeller

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -23,6 +23,7 @@ InlinePassContext::InlinePassContext(
     : context_(std::move(context)),
       pass_target_(pass_target),
       entity_count_(entity_count),
+      total_pass_reads_(pass_texture_reads),
       is_collapsed_(collapsed_parent_pass.has_value()) {
   if (collapsed_parent_pass.has_value()) {
     pass_ = collapsed_parent_pass.value().pass;
@@ -141,9 +142,17 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
     return {};
   }
 
-  stencil->load_action = LoadAction::kClear;
-  stencil->store_action = StoreAction::kDontCare;
+  // Only clear the stencil if this is the very first pass of the
+  // layer.
+  stencil->load_action =
+      pass_count_ > 0 ? LoadAction::kLoad : LoadAction::kClear;
+  // If we're on the last pass of the layer, there's no need to store the
+  // stencil because nothing needs to read it.
+  stencil->store_action = pass_count_ == total_pass_reads_
+                              ? StoreAction::kDontCare
+                              : StoreAction::kStore;
   pass_target_.target_.SetStencilAttachment(stencil.value());
+
   pass_target_.target_.SetColorAttachment(color0, 0);
 
   pass_ = command_buffer_->CreateRenderPass(pass_target_.GetRenderTarget());

--- a/impeller/entity/inline_pass_context.h
+++ b/impeller/entity/inline_pass_context.h
@@ -51,7 +51,7 @@ class InlinePassContext {
   std::shared_ptr<RenderPass> pass_;
   uint32_t pass_count_ = 0;
   uint32_t entity_count_ = 0;
-
+  uint32_t total_pass_reads_ = 0;
   // Whether this context is collapsed into a parent entity pass.
   bool is_collapsed_ = false;
 


### PR DESCRIPTION
Reverts #47397 to fix https://github.com/flutter/flutter/issues/144211 in 3.19.

This reverts commit 04329c5d00d7c36509c0f2bfaa8b7393fc9a08d7.
