### PR TITLE
Remove always-true skia_enable_flutter_defines

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -21,12 +21,11 @@ config("skia_public") {
     "SK_CODEC_DECODES_BMP",
     "SK_CODEC_DECODES_WBMP",
   ]
+  defines += flutter_defines
+
   cflags_objcc = []
   if (is_fuchsia || is_linux) {
     defines += [ "SK_R32_SHIFT=16" ]
-  }
-  if (skia_enable_flutter_defines) {
-    defines += flutter_defines
   }
 
   # TODO(zra): Try using this.

--- a/tools/gn
+++ b/tools/gn
@@ -489,7 +489,6 @@ def to_gn_args(args):
     gn_args['enable_unittests'] = False
 
   # Skia GN args.
-  gn_args['skia_enable_flutter_defines'] = True  # Enable Flutter API guards in Skia.
   gn_args['skia_use_dng_sdk'] = False  # RAW image handling.
   gn_args['skia_use_sfntly'] = False  # PDF handling dependency.
   gn_args['skia_enable_pdf'] = False  # PDF handling.
@@ -851,7 +850,6 @@ def to_gn_args(args):
 # build are unused. This method is used instead.
 def to_gn_wasm_args(args, gn_args):
   gn_args['is_official_build'] = True
-  gn_args['skia_enable_flutter_defines'] = True
   gn_args['is_component_build'] = False
   gn_args['use_clang_static_analyzer'] = False
   gn_args['is_clang'] = True


### PR DESCRIPTION
Now that Flutter owns the list of defines to add to Skia's build, we don't need to toggle it on or off. This allows Skia to delete the setting (https://skia-review.googlesource.com/c/skia/+/826398)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
