### PR TITLE
[Impeller] revert glyph atlas texture recycling.

### DIFF
--- a/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -450,20 +450,6 @@ std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
   }
   atlas_context_skia.UpdateBitmap(bitmap);
 
-  // If the new atlas size is the same size as the previous texture, reuse the
-  // texture and treat this as an updated that replaces all glyphs.
-  if (last_atlas && last_atlas->GetTexture()) {
-    std::shared_ptr<Texture> last_texture = last_atlas->GetTexture();
-    if (atlas_size == last_texture->GetSize()) {
-      if (!UpdateGlyphTextureAtlas(bitmap, last_texture)) {
-        return nullptr;
-      }
-
-      glyph_atlas->SetTexture(last_texture);
-      return glyph_atlas;
-    }
-  }
-
   // ---------------------------------------------------------------------------
   // Step 7b: Upload the atlas as a texture.
   // ---------------------------------------------------------------------------

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -338,7 +338,8 @@ TEST_P(TypographerTest, RectanglePackerAddsNonoverlapingRectangles) {
   ASSERT_EQ(packer->percentFull(), 0);
 }
 
-TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledWhenContentsAreRecreated) {
+TEST_P(TypographerTest,
+       GlyphAtlasTextureIsRecycledWhenContentsAreNotRecreated) {
   auto context = TypographerContextSkia::Make();
   auto atlas_context = context->CreateGlyphAtlasContext();
   ASSERT_TRUE(context && context->IsValid());
@@ -370,7 +371,7 @@ TEST_P(TypographerTest, GlyphAtlasTextureIsRecycledWhenContentsAreRecreated) {
 
   auto new_packer = atlas_context->GetRectPacker();
 
-  ASSERT_EQ(second_texture, first_texture);
+  ASSERT_NE(second_texture, first_texture);
   ASSERT_NE(old_packer, new_packer);
 }
 


### PR DESCRIPTION
This is a speculative fix for https://github.com/flutter/flutter/issues/144331 . I don't have a repro, but I think this may be due to https://github.com/flutter/flutter/issues/144498 , wherein setting the contents of a texture is unsynchronized.