### PR TITLE
Add DisplayList Region and Transform benchmarks to CI

### DIFF
--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -152,6 +152,8 @@
                     "flutter/build/dart:copy_dart_sdk",
                     "flutter/display_list:display_list_benchmarks",
                     "flutter/display_list:display_list_builder_benchmarks",
+                    "flutter/display_list:display_list_region_benchmarks",
+                    "flutter/display_list:display_list_transform_benchmarks",
                     "flutter/fml:fml_benchmarks",
                     "flutter/impeller/geometry:geometry_benchmarks",
                     "flutter/impeller/aiks:canvas_benchmarks",

--- a/testing/benchmark/generate_metrics.sh
+++ b/testing/benchmark/generate_metrics.sh
@@ -14,5 +14,7 @@ $ENGINE_PATH/src/out/host_release/fml_benchmarks --benchmark_format=json > $ENGI
 $ENGINE_PATH/src/out/host_release/shell_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/shell_benchmarks.json
 $ENGINE_PATH/src/out/host_release/ui_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/ui_benchmarks.json
 $ENGINE_PATH/src/out/host_release/display_list_builder_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/display_list_builder_benchmarks.json
+$ENGINE_PATH/src/out/host_release/display_list_region_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/display_list_region_benchmarks.json
+$ENGINE_PATH/src/out/host_release/display_list_transform_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/display_list_transform_benchmarks.json
 $ENGINE_PATH/src/out/host_release/geometry_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/geometry_benchmarks.json
 $ENGINE_PATH/src/out/host_release/canvas_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/canvas_benchmarks.json

--- a/testing/benchmark/upload_metrics.sh
+++ b/testing/benchmark/upload_metrics.sh
@@ -55,6 +55,10 @@ cd "$SCRIPT_DIR"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
   --json $ENGINE_PATH/src/out/host_release/display_list_builder_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
+  --json $ENGINE_PATH/src/out/host_release/display_list_region_benchmarks.json "$@"
+"$DART" --disable-dart-dev bin/parse_and_send.dart \
+  --json $ENGINE_PATH/src/out/host_release/display_list_transform_benchmarks.json "$@"
+"$DART" --disable-dart-dev bin/parse_and_send.dart \
   --json $ENGINE_PATH/src/out/host_release/geometry_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
   --json $ENGINE_PATH/src/out/host_release/canvas_benchmarks.json "$@"


### PR DESCRIPTION
These benchmark results aren't shown in Skia perf because they were never added to the CI tasks to run.