### PR TITLE
Add missing baseline check in text layout tests

### DIFF
--- a/lib/web_ui/test/html/text/layout_service_helper.dart
+++ b/lib/web_ui/test/html/text/layout_service_helper.dart
@@ -107,6 +107,13 @@ void expectLines(CanvasParagraph paragraph, List<TestLine> expectedLines) {
             'line #$i had a different `left` value: "${line.left}" vs. "${expectedLine.left}"',
       );
     }
+    if (expectedLine.baseline != null) {
+      expect(
+        line.baseline,
+        expectedLine.baseline,
+        reason: 'line #$i had a different `baseline` value: "${line.baseline}" vs. "${expectedLine.baseline}"',
+      );
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a check for the `baseline` value in text layout service tests that appears to be missing.

Test-exempt: increasing test coverage only.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
