### PR TITLE
Update fuchsia_libs.gni

### DIFF
--- a/tools/fuchsia/fuchsia_libs.gni
+++ b/tools/fuchsia/fuchsia_libs.gni
@@ -53,6 +53,10 @@ common_libs = [
     path = rebase_path("$sysroot_dist_lib/$ld_so_path")
     output_path = ld_so_path
   },
+  {
+    name = "libvfs_internal.so"
+    path = rebase_path("$fuchsia_sdk_dist")
+  },
 ]
 
 # Note, for clang libs we use the md5 hashes here because of gn limitations of


### PR DESCRIPTION
### Motivation of the change:

The Fuchsia SDK target //sdk/lib/vfs/cpp is being migrated to a shared library in https://fxrev.dev/981373. The shared library has already been included in the SDK as a dependency, but is missing from the OOT copies of the runners used in tests ([shell/platform/fuchsia/flutter/BUILD.gn](https://github.com/flutter/engine/blob/main/shell/platform/fuchsia/flutter/BUILD.gn)). This change adds the missing .so to these prebuilts.

### Blocking issue:

As part of an ongoing Fuchsia SDK migration effort, this library requires migration in order to continue ongoing maintenance efforts.  See https://fxbug.dev/293936429 for details.

### Solutions:

This library is already included licensed under the exsting Fuchsia SDK license.  It can be verified as already existing in the distributed IDKs due to it being added as a dependency early.  The OOT test archives are the last remaining step before switching the library to start using the new .so.

Bug: [b/293936429](https://fxbug.dev/293936429)

FYI: @zijiehe

## Pre-launch Checklist
* [x]  I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
* [X]  I read the [Tree Hygiene] wiki page, which explains my responsibilities.
* [x]  I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
* [X]  I listed at least one issue that this PR fixes in the description above.
* [x]  I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
* [X]  I updated/added relevant documentation (doc comments with `///`).
* [x]  I signed the [CLA]. (I am a Googler)
* [x]  All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat

