### PR TITLE
Add more explicit logging (just to `stderr`) if a try-job detects an untriaged image

### DIFF
--- a/testing/skia_gold_client/lib/skia_gold_client.dart
+++ b/testing/skia_gold_client/lib/skia_gold_client.dart
@@ -423,6 +423,7 @@ interface class SkiaGoldClient {
       }
       // ... but we want to know about them anyway.
       // See https://github.com/flutter/flutter/issues/145219.
+      // TODO(matanlurey): Update the documentation to reflect the new behavior.
       if (isUntriaged) {
         _stderr
           ..writeln('NOTE: Untriaged image detected in tryjob.')

--- a/testing/skia_gold_client/lib/skia_gold_client.dart
+++ b/testing/skia_gold_client/lib/skia_gold_client.dart
@@ -428,11 +428,6 @@ interface class SkiaGoldClient {
           ..writeln('NOTE: Untriaged image detected in tryjob.')
           ..writeln('Triage should be required by the "Flutter Gold" check')
           ..writeln('stdout:\n$resultStdout');
-      } else if (isNegative) {
-        _stderr
-          ..writeln('NOTE: Negative image detected in tryjob.')
-          ..writeln('Triage should be required by the "Flutter Gold" check')
-          ..writeln('stdout:\n$resultStdout');
       }
     }
   }

--- a/testing/skia_gold_client/test/skia_gold_client_test.dart
+++ b/testing/skia_gold_client/test/skia_gold_client_test.dart
@@ -327,6 +327,10 @@ void main() {
         io.File(p.join(fixture.workDirectory.path, 'temp', 'golden.png')),
         screenshotSize: 1000,
       );
+
+      // Expect a stderr log message.
+      final String log = fixture.outputSink.toString();
+      expect(log, contains('Untriaged image detected'));
     } finally {
       fixture.dispose();
     }


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/145219.

Previously all logging would be silent in the case that `test_foo` uploads a digest that is considered "untriaged", and we'd be entirely reliant on the `flutter-gold` check to pick this up asynchronously. 

As part of debugging https://github.com/flutter/flutter/issues/145219 (but probably to keep this code indefinitely, it's not harmful), we now unconditionally log the swallowed failures to `stderr` so they will show up in our LUCI logs.

/cc @gaaclarke @jonahwilliams