### PR TITLE
Silence gn warning about unused Skia flag

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -490,7 +490,6 @@ def to_gn_args(args):
 
   # Skia GN args.
   gn_args['skia_use_dng_sdk'] = False  # RAW image handling.
-  gn_args['skia_use_sfntly'] = False  # PDF handling dependency.
   gn_args['skia_enable_pdf'] = False  # PDF handling.
   gn_args['skia_use_x11'] = False  # Never add the X11 dependency (only takes effect on Linux).
   gn_args['skia_use_wuffs'] = True


### PR DESCRIPTION
This flag was generating an unused warning when running gn. The builds would still be created and would build fine, but the warning is noise.