### PR TITLE
Prefix non-local build config names with ci/

### DIFF
--- a/build/copy_info_plist.py
+++ b/build/copy_info_plist.py
@@ -8,8 +8,6 @@
 Copies the Info.plist and adds extra fields to it like the git hash of the
 engine.
 
-Precondition: $CWD/../../flutter is the path to the flutter engine repo.
-
 usage: copy_info_plist.py --source <src_path> --destination <dest_path>
                           --minversion=<deployment_target>
 """
@@ -20,10 +18,13 @@ import subprocess
 
 import git_revision
 
+_script_dir = os.path.abspath(os.path.join(os.path.realpath(__file__), '..'))
+_src_root_dir = os.path.join(_script_dir, '..', '..')
+
 
 def get_clang_version():
   clang_executable = str(
-      os.path.join('..', '..', 'flutter', 'buildtools', 'mac-x64', 'clang', 'bin', 'clang++')
+      os.path.join(_src_root_dir, 'flutter', 'buildtools', 'mac-x64', 'clang', 'bin', 'clang++')
   )
   version = subprocess.check_output([clang_executable, '--version'])
   return version.splitlines()[0]
@@ -47,7 +48,7 @@ def main():
   args = parser.parse_args()
 
   text = open(args.source).read()
-  engine_path = os.path.join(os.getcwd(), '..', '..', 'flutter')
+  engine_path = os.path.join(_src_root_dir, 'flutter')
   revision = git_revision.get_repository_version(engine_path)
   clang_version = get_clang_version()
   text = text.format(revision=revision, clang_version=clang_version, min_version=args.minversion)

--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -35,9 +35,12 @@ FLUTTER_DIR="$SRC_DIR/flutter"
 # directory. If not specified, we default to the build output for
 # host_debug_unopt.
 if [[ $# -eq 0 ]] ; then
-DART_BIN="$SRC_DIR/out/host_debug_unopt/dart-sdk/bin"
+  DART_BIN="$SRC_DIR/out/host_debug_unopt/dart-sdk/bin"
+  if [[ ! -d "$DART_BIN" ]]; then
+    DART_BIN="$SRC_DIR/out/ci/host_debug_unopt/dart-sdk/bin"
+  fi
 else
-DART_BIN="$1"
+  DART_BIN="$1"
 fi
 
 DART="$DART_BIN/dart"

--- a/ci/builders/linux_android_aot_engine.json
+++ b/ci/builders/linux_android_aot_engine.json
@@ -3,14 +3,14 @@
         {
             "archives": [
                 {
-                    "name": "android_profile",
+                    "name": "ci/android_profile",
                     "type": "gcs",
-                    "base_path": "out/android_profile/zip_archives/",
+                    "base_path": "out/ci/android_profile/zip_archives/",
                     "include_paths": [
-                        "out/android_profile/zip_archives/android-arm-profile/artifacts.zip",
-                        "out/android_profile/zip_archives/android-arm-profile/linux-x64.zip",
-                        "out/android_profile/zip_archives/android-arm-profile/symbols.zip",
-                        "out/android_profile/zip_archives/download.flutter.io"
+                        "out/ci/android_profile/zip_archives/android-arm-profile/artifacts.zip",
+                        "out/ci/android_profile/zip_archives/android-arm-profile/linux-x64.zip",
+                        "out/ci/android_profile/zip_archives/android-arm-profile/symbols.zip",
+                        "out/ci/android_profile/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -23,6 +23,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_profile",
                 "--runtime-mode",
                 "profile",
                 "--android",
@@ -31,9 +33,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_profile",
+            "name": "ci/android_profile",
             "ninja": {
-                "config": "android_profile",
+                "config": "ci/android_profile",
                 "targets": [
                     "default",
                     "clang_x64/gen_snapshot",
@@ -45,14 +47,14 @@
         {
             "archives": [
                 {
-                    "name": "android_release",
+                    "name": "ci/android_release",
                     "type": "gcs",
-                    "base_path": "out/android_release/zip_archives/",
+                    "base_path": "out/ci/android_release/zip_archives/",
                     "include_paths": [
-                        "out/android_release/zip_archives/android-arm-release/artifacts.zip",
-                        "out/android_release/zip_archives/android-arm-release/linux-x64.zip",
-                        "out/android_release/zip_archives/android-arm-release/symbols.zip",
-                        "out/android_release/zip_archives/download.flutter.io"
+                        "out/ci/android_release/zip_archives/android-arm-release/artifacts.zip",
+                        "out/ci/android_release/zip_archives/android-arm-release/linux-x64.zip",
+                        "out/ci/android_release/zip_archives/android-arm-release/symbols.zip",
+                        "out/ci/android_release/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -65,6 +67,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_release",
                 "--runtime-mode",
                 "release",
                 "--android",
@@ -73,9 +77,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_release",
+            "name": "ci/android_release",
             "ninja": {
-                "config": "android_release",
+                "config": "ci/android_release",
                 "targets": [
                     "default",
                     "clang_x64/gen_snapshot",
@@ -87,15 +91,15 @@
         {
             "archives": [
                 {
-                    "name": "android_release_arm64",
+                    "name": "ci/android_release_arm64",
                     "type": "gcs",
-                    "base_path": "out/android_release_arm64/zip_archives/",
+                    "base_path": "out/ci/android_release_arm64/zip_archives/",
                     "include_paths": [
-                        "out/android_release_arm64/zip_archives/android-arm64-release/artifacts.zip",
-                        "out/android_release_arm64/zip_archives/android-arm64-release/linux-x64.zip",
-                        "out/android_release_arm64/zip_archives/android-arm64-release/symbols.zip",
-                        "out/android_release_arm64/zip_archives/android-arm64-release/analyze-snapshot-linux-x64.zip",
-                        "out/android_release_arm64/zip_archives/download.flutter.io"
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/artifacts.zip",
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/linux-x64.zip",
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/symbols.zip",
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/analyze-snapshot-linux-x64.zip",
+                        "out/ci/android_release_arm64/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -108,6 +112,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_release_arm64",
                 "--runtime-mode",
                 "release",
                 "--android",
@@ -116,9 +122,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_release_arm64",
+            "name": "ci/android_release_arm64",
             "ninja": {
-                "config": "android_release_arm64",
+                "config": "ci/android_release_arm64",
                 "targets": [
                     "default",
                     "clang_x64/gen_snapshot",
@@ -132,7 +138,7 @@
                     "language": "bash",
                     "script": "flutter/ci/binary_size_treemap.sh",
                     "parameters": [
-                        "../../src/out/android_release_arm64/libflutter.so",
+                        "../../src/out/ci/android_release_arm64/libflutter.so",
                         "${FLUTTER_LOGS_DIR}"
                     ]
                 }
@@ -141,15 +147,15 @@
         {
             "archives": [
                 {
-                    "name": "android_profile_arm64",
+                    "name": "ci/android_profile_arm64",
                     "type": "gcs",
-                    "base_path": "out/android_profile_arm64/zip_archives/",
+                    "base_path": "out/ci/android_profile_arm64/zip_archives/",
                     "include_paths": [
-                        "out/android_profile_arm64/zip_archives/android-arm64-profile/artifacts.zip",
-                        "out/android_profile_arm64/zip_archives/android-arm64-profile/linux-x64.zip",
-                        "out/android_profile_arm64/zip_archives/android-arm64-profile/symbols.zip",
-                        "out/android_profile_arm64/zip_archives/android-arm64-profile/analyze-snapshot-linux-x64.zip",
-                        "out/android_profile_arm64/zip_archives/download.flutter.io"
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/artifacts.zip",
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/linux-x64.zip",
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/symbols.zip",
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/analyze-snapshot-linux-x64.zip",
+                        "out/ci/android_profile_arm64/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -162,6 +168,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_profile_arm64",
                 "--android",
                 "--runtime-mode",
                 "profile",
@@ -170,9 +178,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_profile_arm64",
+            "name": "ci/android_profile_arm64",
             "ninja": {
-                "config": "android_profile_arm64",
+                "config": "ci/android_profile_arm64",
                 "targets": [
                     "clang_x64/gen_snapshot",
                     "default",
@@ -192,7 +200,7 @@
                     "script": "flutter/ci/firebase_testlab.py",
                     "parameters": [
                         "--variant",
-                        "android_profile_arm64"
+                        "ci/android_profile_arm64"
                     ],
                     "test_if": "main"
                 }
@@ -201,15 +209,15 @@
         {
             "archives": [
                 {
-                    "name": "android_profile_x64",
+                    "name": "ci/android_profile_x64",
                     "type": "gcs",
-                    "base_path": "out/android_profile_x64/zip_archives/",
+                    "base_path": "out/ci/android_profile_x64/zip_archives/",
                     "include_paths": [
-                        "out/android_profile_x64/zip_archives/android-x64-profile/artifacts.zip",
-                        "out/android_profile_x64/zip_archives/android-x64-profile/linux-x64.zip",
-                        "out/android_profile_x64/zip_archives/android-x64-profile/symbols.zip",
-                        "out/android_profile_x64/zip_archives/android-x64-profile/analyze-snapshot-linux-x64.zip",
-                        "out/android_profile_x64/zip_archives/download.flutter.io"
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/artifacts.zip",
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/linux-x64.zip",
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/symbols.zip",
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/analyze-snapshot-linux-x64.zip",
+                        "out/ci/android_profile_x64/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -222,6 +230,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_profile_x64",
                 "--runtime-mode",
                 "profile",
                 "--android",
@@ -230,9 +240,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_profile_x64",
+            "name": "ci/android_profile_x64",
             "ninja": {
-                "config": "android_profile_x64",
+                "config": "ci/android_profile_x64",
                 "targets": [
                     "default",
                     "clang_x64/gen_snapshot",
@@ -244,15 +254,15 @@
         {
             "archives": [
                 {
-                    "name": "android_release_x64",
+                    "name": "ci/android_release_x64",
                     "type": "gcs",
-                    "base_path": "out/android_release_x64/zip_archives/",
+                    "base_path": "out/ci/android_release_x64/zip_archives/",
                     "include_paths": [
-                        "out/android_release_x64/zip_archives/android-x64-release/artifacts.zip",
-                        "out/android_release_x64/zip_archives/android-x64-release/linux-x64.zip",
-                        "out/android_release_x64/zip_archives/android-x64-release/symbols.zip",
-                        "out/android_release_x64/zip_archives/android-x64-release/analyze-snapshot-linux-x64.zip",
-                        "out/android_release_x64/zip_archives/download.flutter.io"
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/artifacts.zip",
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/linux-x64.zip",
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/symbols.zip",
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/analyze-snapshot-linux-x64.zip",
+                        "out/ci/android_release_x64/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -265,6 +275,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_release_x64",
                 "--runtime-mode",
                 "release",
                 "--android",
@@ -273,9 +285,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_release_x64",
+            "name": "ci/android_release_x64",
             "ninja": {
-                "config": "android_release_x64",
+                "config": "ci/android_release_x64",
                 "targets": [
                     "default",
                     "clang_x64/gen_snapshot",
@@ -290,7 +302,8 @@
             {
                 "name": "Verify-export-symbols-release-binaries",
                 "parameters": [
-                    "src/out"
+                    "src/out/ci",
+                    "src/flutter/buildtools"
                 ],
                 "script": "flutter/testing/symbols/verify_exported.dart",
                 "language": "dart"

--- a/ci/builders/linux_android_debug_engine.json
+++ b/ci/builders/linux_android_debug_engine.json
@@ -3,12 +3,12 @@
         {
             "archives": [
                 {
-                    "name": "android_jit_release_x86",
+                    "name": "ci/android_jit_release_x86",
                     "type": "gcs",
-                    "base_path": "out/android_jit_release_x86/zip_archives/",
+                    "base_path": "out/ci/android_jit_release_x86/zip_archives/",
                     "include_paths": [
-                        "out/android_jit_release_x86/zip_archives/android-x86-jit-release/artifacts.zip",
-                        "out/android_jit_release_x86/zip_archives/download.flutter.io"
+                        "out/ci/android_jit_release_x86/zip_archives/android-x86-jit-release/artifacts.zip",
+                        "out/ci/android_jit_release_x86/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -21,15 +21,17 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_jit_release_x86",
                 "--android",
                 "--android-cpu=x86",
                 "--runtime-mode=jit_release",
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_jit_release_x86",
+            "name": "ci/android_jit_release_x86",
             "ninja": {
-                "config": "android_jit_release_x86",
+                "config": "ci/android_jit_release_x86",
                 "targets": [
                     "flutter",
                     "flutter/shell/platform/android:embedding_jars",
@@ -44,12 +46,12 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "android_jit_release_x86",
+                        "ci/android_jit_release_x86",
                         "--type",
                         "java",
                         "--engine-capture-core-dump",
                         "--android-variant",
-                        "android_jit_release_x86"
+                        "ci/android_jit_release_x86"
                     ]
                 }
             ]
@@ -57,15 +59,15 @@
         {
             "archives": [
                 {
-                    "name": "android_debug",
+                    "name": "ci/android_debug",
                     "type": "gcs",
-                    "base_path": "out/android_debug/zip_archives/",
+                    "base_path": "out/ci/android_debug/zip_archives/",
                     "include_paths": [
-                        "out/android_debug/zip_archives/android-arm/artifacts.zip",
-                        "out/android_debug/zip_archives/android-arm/symbols.zip",
-                        "out/android_debug/zip_archives/download.flutter.io",
-                        "out/android_debug/zip_archives/sky_engine.zip",
-                        "out/android_debug/zip_archives/android-javadoc.zip"
+                        "out/ci/android_debug/zip_archives/android-arm/artifacts.zip",
+                        "out/ci/android_debug/zip_archives/android-arm/symbols.zip",
+                        "out/ci/android_debug/zip_archives/download.flutter.io",
+                        "out/ci/android_debug/zip_archives/sky_engine.zip",
+                        "out/ci/android_debug/zip_archives/android-javadoc.zip"
                     ],
                     "realm": "production"
                 }
@@ -78,15 +80,17 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_debug",
                 "--android",
                 "--android-cpu=arm",
                 "--no-lto",
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_debug",
+            "name": "ci/android_debug",
             "ninja": {
-                "config": "android_debug",
+                "config": "ci/android_debug",
                 "targets": [
                     "flutter",
                     "flutter/sky/dist:zip_old_location",
@@ -102,12 +106,12 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "android_debug",
+                        "ci/android_debug",
                         "--type",
                         "java",
                         "--engine-capture-core-dump",
                         "--android-variant",
-                        "android_debug"
+                        "ci/android_debug"
                     ]
                 }
             ]
@@ -115,13 +119,13 @@
         {
             "archives": [
                 {
-                    "name": "android_debug_arm64",
+                    "name": "ci/android_debug_arm64",
                     "type": "gcs",
-                    "base_path": "out/android_debug_arm64/zip_archives/",
+                    "base_path": "out/ci/android_debug_arm64/zip_archives/",
                     "include_paths": [
-                        "out/android_debug_arm64/zip_archives/android-arm64/artifacts.zip",
-                        "out/android_debug_arm64/zip_archives/android-arm64/symbols.zip",
-                        "out/android_debug_arm64/zip_archives/download.flutter.io"
+                        "out/ci/android_debug_arm64/zip_archives/android-arm64/artifacts.zip",
+                        "out/ci/android_debug_arm64/zip_archives/android-arm64/symbols.zip",
+                        "out/ci/android_debug_arm64/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -134,15 +138,17 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_debug_arm64",
                 "--android",
                 "--android-cpu=arm64",
                 "--no-lto",
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_debug_arm64",
+            "name": "ci/android_debug_arm64",
             "ninja": {
-                "config": "android_debug_arm64",
+                "config": "ci/android_debug_arm64",
                 "targets": [
                     "flutter",
                     "flutter/shell/platform/android:abi_jars"
@@ -152,13 +158,13 @@
         {
             "archives": [
                 {
-                    "name": "android_debug_x86",
+                    "name": "ci/android_debug_x86",
                     "type": "gcs",
-                    "base_path": "out/android_debug_x86/zip_archives/",
+                    "base_path": "out/ci/android_debug_x86/zip_archives/",
                     "include_paths": [
-                        "out/android_debug_x86/zip_archives/android-x86/artifacts.zip",
-                        "out/android_debug_x86/zip_archives/android-x86/symbols.zip",
-                        "out/android_debug_x86/zip_archives/download.flutter.io"
+                        "out/ci/android_debug_x86/zip_archives/android-x86/artifacts.zip",
+                        "out/ci/android_debug_x86/zip_archives/android-x86/symbols.zip",
+                        "out/ci/android_debug_x86/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -171,15 +177,17 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_debug_x86",
                 "--android",
                 "--android-cpu=x86",
                 "--no-lto",
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_debug_x86",
+            "name": "ci/android_debug_x86",
             "ninja": {
-                "config": "android_debug_x86",
+                "config": "ci/android_debug_x86",
                 "targets": [
                     "flutter",
                     "flutter/shell/platform/android:abi_jars"
@@ -189,13 +197,13 @@
         {
             "archives": [
                 {
-                    "name": "android_debug_x64",
+                    "name": "ci/android_debug_x64",
                     "type": "gcs",
-                    "base_path": "out/android_debug_x64/zip_archives/",
+                    "base_path": "out/ci/android_debug_x64/zip_archives/",
                     "include_paths": [
-                        "out/android_debug_x64/zip_archives/android-x64/artifacts.zip",
-                        "out/android_debug_x64/zip_archives/android-x64/symbols.zip",
-                        "out/android_debug_x64/zip_archives/download.flutter.io"
+                        "out/ci/android_debug_x64/zip_archives/android-x64/artifacts.zip",
+                        "out/ci/android_debug_x64/zip_archives/android-x64/symbols.zip",
+                        "out/ci/android_debug_x64/zip_archives/download.flutter.io"
                     ],
                     "realm": "production"
                 }
@@ -208,15 +216,17 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_debug_x64",
                 "--android",
                 "--android-cpu=x64",
                 "--no-lto",
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_debug_x64",
+            "name": "ci/android_debug_x64",
             "ninja": {
-                "config": "android_debug_x64",
+                "config": "ci/android_debug_x64",
                 "targets": [
                     "flutter",
                     "flutter/shell/platform/android:abi_jars"
@@ -229,7 +239,8 @@
             {
                 "name": "Verify-export-symbols-release-binaries",
                 "parameters": [
-                    "src/out"
+                    "src/out/ci",
+                    "src/flutter/buildtools"
                 ],
                 "script": "flutter/testing/symbols/verify_exported.dart",
                 "language": "dart"

--- a/ci/builders/linux_android_emulator.json
+++ b/ci/builders/linux_android_emulator.json
@@ -17,7 +17,7 @@
                 "--rbe",
                 "--no-goma",
                 "--target-dir",
-                "android_emulator_debug_x64"
+                "ci/android_emulator_debug_x64"
             ],
             "dependencies": [
                 {
@@ -25,9 +25,9 @@
                     "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
                 }
             ],
-            "name": "android_emulator_debug_x64",
+            "name": "ci/android_emulator_debug_x64",
             "ninja": {
-                "config": "android_emulator_debug_x64",
+                "config": "ci/android_emulator_debug_x64",
                 "targets": [
                     "flutter/impeller/toolkit/android:unittests",
                     "flutter/shell/platform/android:flutter_shell_native_unittests",
@@ -54,7 +54,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                             "--android-variant",
-                            "android_emulator_debug_x64",
+                            "ci/android_emulator_debug_x64",
                             "--type",
                             "android"
                     ]
@@ -85,7 +85,7 @@
                     ],
                     "script": "flutter/testing/scenario_app/bin/run_android_tests.dart",
                     "parameters": [
-                        "--out-dir=../out/android_emulator_debug_x64",
+                        "--out-dir=../out/ci/android_emulator_debug_x64",
                         "--enable-impeller",
                         "--impeller-backend=vulkan"
                     ]
@@ -109,7 +109,7 @@
                 "--rbe",
                 "--no-goma",
                 "--target-dir",
-                "android_emulator_debug_x86"
+                "ci/android_emulator_debug_x86"
             ],
             "dependencies": [
                 {
@@ -117,9 +117,9 @@
                     "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
                 }
             ],
-            "name": "android_emulator_debug_x86",
+            "name": "ci/android_emulator_debug_x86",
             "ninja": {
-                "config": "android_emulator_debug_x86",
+                "config": "ci/android_emulator_debug_x86",
                 "targets": [
                     "flutter/impeller/toolkit/android:unittests",
                     "flutter/shell/platform/android:flutter_shell_native_unittests",
@@ -146,7 +146,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                             "--android-variant",
-                            "android_emulator_debug_x86",
+                            "ci/android_emulator_debug_x86",
                             "--type",
                             "android"
                     ]

--- a/ci/builders/linux_android_emulator_skia.json
+++ b/ci/builders/linux_android_emulator_skia.json
@@ -17,7 +17,7 @@
                 "--rbe",
                 "--no-goma",
                 "--target-dir",
-                "android_emulator_skia_debug_x64"
+                "ci/android_emulator_skia_debug_x64"
             ],
             "dependencies": [
                 {
@@ -25,9 +25,9 @@
                     "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
                 }
             ],
-            "name": "android_emulator_skia_debug_x64",
+            "name": "ci/android_emulator_skia_debug_x64",
             "ninja": {
-                "config": "android_emulator_skia_debug_x64",
+                "config": "ci/android_emulator_skia_debug_x64",
                 "targets": [
                     "flutter/impeller/toolkit/android:unittests",
                     "flutter/shell/platform/android:flutter_shell_native_unittests",
@@ -55,7 +55,7 @@
                     ],
                     "script": "flutter/testing/scenario_app/bin/run_android_tests.dart",
                     "parameters": [
-                        "--out-dir=../out/android_emulator_skia_debug_x64",
+                        "--out-dir=../out/ci/android_emulator_skia_debug_x64",
                         "--no-enable-impeller"
                     ]
                 },
@@ -79,7 +79,7 @@
                     ],
                     "script": "flutter/testing/scenario_app/bin/run_android_tests.dart",
                     "parameters": [
-                        "--out-dir=../out/android_emulator_skia_debug_x64",
+                        "--out-dir=../out/ci/android_emulator_skia_debug_x64",
                         "--no-enable-impeller",
                         "--force-surface-producer-surface-texture"
                     ]

--- a/ci/builders/linux_arm_host_engine.json
+++ b/ci/builders/linux_arm_host_engine.json
@@ -3,11 +3,11 @@
         {
             "archives": [
                 {
-                    "name": "linux_profile_arm64",
+                    "name": "ci/linux_profile_arm64",
                     "type": "gcs",
-                    "base_path": "out/linux_profile_arm64/zip_archives/",
+                    "base_path": "out/ci/linux_profile_arm64/zip_archives/",
                     "include_paths": [
-                        "out/linux_profile_arm64/zip_archives/linux-arm64-profile/linux-arm64-flutter-gtk.zip"
+                        "out/ci/linux_profile_arm64/zip_archives/linux-arm64-profile/linux-arm64-flutter-gtk.zip"
                     ],
                     "realm": "production"
                 }
@@ -21,6 +21,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/linux_profile_arm64",
                 "--runtime-mode",
                 "profile",
                 "--no-lto",
@@ -30,9 +32,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "linux_profile_arm64",
+            "name": "ci/linux_profile_arm64",
             "ninja": {
-                "config": "linux_profile_arm64",
+                "config": "ci/linux_profile_arm64",
                 "targets": [
                     "flutter/shell/platform/linux:flutter_gtk"
                 ]
@@ -41,14 +43,14 @@
         {
             "archives": [
                 {
-                    "name": "linux_debug_arm64",
+                    "name": "ci/linux_debug_arm64",
                     "type": "gcs",
-                    "base_path": "out/linux_debug_arm64/zip_archives/",
+                    "base_path": "out/ci/linux_debug_arm64/zip_archives/",
                     "include_paths": [
-                        "out/linux_debug_arm64/zip_archives/linux-arm64/artifacts.zip",
-                        "out/linux_debug_arm64/zip_archives/linux-arm64/font-subset.zip",
-                        "out/linux_debug_arm64/zip_archives/linux-arm64-debug/linux-arm64-flutter-gtk.zip",
-                        "out/linux_debug_arm64/zip_archives/dart-sdk-linux-arm64.zip"
+                        "out/ci/linux_debug_arm64/zip_archives/linux-arm64/artifacts.zip",
+                        "out/ci/linux_debug_arm64/zip_archives/linux-arm64/font-subset.zip",
+                        "out/ci/linux_debug_arm64/zip_archives/linux-arm64-debug/linux-arm64-flutter-gtk.zip",
+                        "out/ci/linux_debug_arm64/zip_archives/dart-sdk-linux-arm64.zip"
                     ],
                     "realm": "production"
                 }
@@ -62,6 +64,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/linux_debug_arm64",
                 "--runtime-mode",
                 "debug",
                 "--target-os=linux",
@@ -70,9 +74,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "linux_debug_arm64",
+            "name": "ci/linux_debug_arm64",
             "ninja": {
-                "config": "linux_debug_arm64",
+                "config": "ci/linux_debug_arm64",
                 "targets": [
                     "flutter/build/archives:artifacts",
                     "flutter/build/archives:dart_sdk_archive",
@@ -84,11 +88,11 @@
         {
             "archives": [
                 {
-                    "name": "linux_release_arm64",
+                    "name": "ci/linux_release_arm64",
                     "type": "gcs",
-                    "base_path": "out/linux_release_arm64/zip_archives/",
+                    "base_path": "out/ci/linux_release_arm64/zip_archives/",
                     "include_paths": [
-                        "out/linux_release_arm64/zip_archives/linux-arm64-release/linux-arm64-flutter-gtk.zip"
+                        "out/ci/linux_release_arm64/zip_archives/linux-arm64-release/linux-arm64-flutter-gtk.zip"
                     ],
                     "realm": "production"
                 }
@@ -102,6 +106,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/linux_release_arm64",
                 "--runtime-mode",
                 "release",
                 "--target-os=linux",
@@ -110,9 +116,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "linux_release_arm64",
+            "name": "ci/linux_release_arm64",
             "ninja": {
-                "config": "linux_release_arm64",
+                "config": "ci/linux_release_arm64",
                 "targets": [
                     "flutter/shell/platform/linux:flutter_gtk"
                 ]

--- a/ci/builders/linux_clang_tidy.json
+++ b/ci/builders/linux_clang_tidy.json
@@ -15,13 +15,13 @@
                 "arm64",
                 "--no-lto",
                 "--target-dir",
-                "android_debug_arm64_clang_tidy",
+                "ci/android_debug_arm64_clang_tidy",
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_debug_arm64_clang_tidy",
+            "name": "ci/android_debug_arm64_clang_tidy",
             "ninja": {
-                "config": "android_debug_arm64_clang_tidy"
+                "config": "ci/android_debug_arm64_clang_tidy"
             }
         },
         {
@@ -39,13 +39,13 @@
                 "--prebuilt-dart-sdk",
                 "--no-lto",
                 "--target-dir",
-                "host_debug_clang_tidy",
+                "ci/host_debug_clang_tidy",
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "host_debug_clang_tidy",
+            "name": "ci/host_debug_clang_tidy",
             "ninja": {
-                "config": "host_debug_clang_tidy"
+                "config": "ci/host_debug_clang_tidy"
             }
         }
     ],
@@ -62,17 +62,17 @@
                 "download_android_deps": false
             },
             "dependencies": [
-                "host_debug_clang_tidy"
+                "ci/host_debug_clang_tidy"
             ],
             "tasks": [
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
                         "--variant",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--lint-all",
                         "--shard-id=0",
-                        "--shard-variants=host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
@@ -91,17 +91,17 @@
                 "download_android_deps": false
             },
             "dependencies": [
-                "host_debug_clang_tidy"
+                "ci/host_debug_clang_tidy"
             ],
             "tasks": [
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
                         "--variant",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--lint-all",
                         "--shard-id=1",
-                        "--shard-variants=host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
@@ -120,17 +120,17 @@
                 "download_android_deps": false
             },
             "dependencies": [
-                "host_debug_clang_tidy"
+                "ci/host_debug_clang_tidy"
             ],
             "tasks": [
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
                         "--variant",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--lint-all",
                         "--shard-id=2",
-                        "--shard-variants=host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
@@ -149,17 +149,17 @@
                 "download_android_deps": false
             },
             "dependencies": [
-                "host_debug_clang_tidy"
+                "ci/host_debug_clang_tidy"
             ],
             "tasks": [
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
                         "--variant",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--lint-all",
                         "--shard-id=3",
-                        "--shard-variants=host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
@@ -175,18 +175,18 @@
                 "cores=32"
             ],
             "dependencies": [
-                "host_debug_clang_tidy",
-                "android_debug_arm64_clang_tidy"
+                "ci/host_debug_clang_tidy",
+                "ci/android_debug_arm64_clang_tidy"
             ],
             "tasks": [
                 {
                     "name": "test: lint android_debug_arm64",
                     "parameters": [
                         "--variant",
-                        "android_debug_arm64_clang_tidy",
+                        "ci/android_debug_arm64_clang_tidy",
                         "--lint-all",
                         "--shard-id=0",
-                        "--shard-variants=host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"

--- a/ci/builders/linux_fuchsia.json
+++ b/ci/builders/linux_fuchsia.json
@@ -10,6 +10,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_profile_arm64",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "arm64",
@@ -18,9 +20,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_profile_arm64",
+            "name": "ci/fuchsia_profile_arm64",
             "ninja": {
-                "config": "fuchsia_profile_arm64",
+                "config": "ci/fuchsia_profile_arm64",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
@@ -39,6 +41,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_profile_arm64_tester",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "arm64",
@@ -48,9 +52,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_profile_arm64_tester",
+            "name": "ci/fuchsia_profile_arm64_tester",
             "ninja": {
-                "config": "fuchsia_profile_arm64",
+                "config": "ci/fuchsia_profile_arm64_tester",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia",
                     "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
@@ -64,7 +68,7 @@
                     "script": "flutter/tools/fuchsia/with_envs.py",
                     "parameters": [
                         "testing/fuchsia/run_tests.py",
-                        "fuchsia_profile_arm64"
+                        "ci/fuchsia_profile_arm64_tester"
                     ]
                 }
             ]
@@ -79,6 +83,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_release_arm64",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "arm64",
@@ -87,9 +93,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_release_arm64",
+            "name": "ci/fuchsia_release_arm64",
             "ninja": {
-                "config": "fuchsia_release_arm64",
+                "config": "ci/fuchsia_release_arm64",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
@@ -108,6 +114,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_release_arm64_tester",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "arm64",
@@ -117,9 +125,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_release_arm64_tester",
+            "name": "ci/fuchsia_release_arm64_tester",
             "ninja": {
-                "config": "fuchsia_release_arm64",
+                "config": "ci/fuchsia_release_arm64_tester",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia",
                     "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
@@ -133,7 +141,7 @@
                     "script": "flutter/tools/fuchsia/with_envs.py",
                     "parameters": [
                         "testing/fuchsia/run_tests.py",
-                        "fuchsia_release_arm64"
+                        "ci/fuchsia_release_arm64_tester"
                     ]
                 }
             ]
@@ -148,6 +156,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_debug_arm64",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "arm64",
@@ -157,9 +167,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_debug_arm64",
+            "name": "ci/fuchsia_debug_arm64",
             "ninja": {
-                "config": "fuchsia_debug_arm64",
+                "config": "ci/fuchsia_debug_arm64",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
@@ -172,7 +182,7 @@
                     "script": "flutter/tools/fuchsia/upload_to_symbol_server.py",
                     "parameters": [
                         "--symbol-dir",
-                        "out/fuchsia_debug_arm64/.build-id",
+                        "out/ci/fuchsia_debug_arm64/.build-id",
                         "--engine-version",
                         "${REVISION}",
                         "--upload"
@@ -193,6 +203,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_debug_arm64_tester",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "arm64",
@@ -202,9 +214,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_debug_arm64_tester",
+            "name": "ci/fuchsia_debug_arm64_tester",
             "ninja": {
-                "config": "fuchsia_debug_arm64",
+                "config": "ci/fuchsia_debug_arm64_tester",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia",
                     "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
@@ -218,7 +230,7 @@
                     "script": "flutter/tools/fuchsia/with_envs.py",
                     "parameters": [
                         "testing/fuchsia/run_tests.py",
-                        "fuchsia_debug_arm64"
+                        "ci/fuchsia_debug_arm64_tester"
                     ]
                 }
             ]
@@ -233,6 +245,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_profile_x64",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "x64",
@@ -241,9 +255,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_profile_x64",
+            "name": "ci/fuchsia_profile_x64",
             "ninja": {
-                "config": "fuchsia_profile_x64",
+                "config": "ci/fuchsia_profile_x64",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
@@ -262,6 +276,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_profile_x64_tester",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "x64",
@@ -271,9 +287,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_profile_x64_tester",
+            "name": "ci/fuchsia_profile_x64_tester",
             "ninja": {
-                "config": "fuchsia_profile_x64",
+                "config": "ci/fuchsia_profile_x64_tester",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia",
                     "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
@@ -287,7 +303,7 @@
                     "script": "flutter/tools/fuchsia/with_envs.py",
                     "parameters": [
                         "testing/fuchsia/run_tests.py",
-                        "fuchsia_profile_x64"
+                        "ci/fuchsia_profile_x64_tester"
                     ]
                 }
             ]
@@ -303,6 +319,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_release_x64",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "x64",
@@ -311,9 +329,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_release_x64",
+            "name": "ci/fuchsia_release_x64",
             "ninja": {
-                "config": "fuchsia_release_x64",
+                "config": "ci/fuchsia_release_x64",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
@@ -332,6 +350,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_release_x64_tester",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "x64",
@@ -341,9 +361,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_release_x64_tester",
+            "name": "ci/fuchsia_release_x64_tester",
             "ninja": {
-                "config": "fuchsia_release_x64",
+                "config": "ci/fuchsia_release_x64_tester",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia",
                     "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
@@ -357,7 +377,7 @@
                     "script": "flutter/tools/fuchsia/with_envs.py",
                     "parameters": [
                         "testing/fuchsia/run_tests.py",
-                        "fuchsia_release_x64"
+                        "ci/fuchsia_release_x64_tester"
                     ]
                 }
             ]
@@ -373,6 +393,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_debug_x64",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "x64",
@@ -382,9 +404,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_debug_x64",
+            "name": "ci/fuchsia_debug_x64",
             "ninja": {
-                "config": "fuchsia_debug_x64",
+                "config": "ci/fuchsia_debug_x64",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
@@ -397,7 +419,7 @@
                     "script": "flutter/tools/fuchsia/upload_to_symbol_server.py",
                     "parameters": [
                         "--symbol-dir",
-                        "out/fuchsia_debug_x64/.build-id",
+                        "out/ci/fuchsia_debug_x64/.build-id",
                         "--engine-version",
                         "${REVISION}",
                         "--upload"
@@ -418,6 +440,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/fuchsia_debug_x64_tester",
                 "--fuchsia",
                 "--fuchsia-cpu",
                 "x64",
@@ -427,9 +451,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "fuchsia_debug_x64_tester",
+            "name": "ci/fuchsia_debug_x64_tester",
             "ninja": {
-                "config": "fuchsia_debug_x64",
+                "config": "ci/fuchsia_debug_x64_tester",
                 "targets": [
                     "flutter/shell/platform/fuchsia:fuchsia",
                     "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
@@ -450,7 +474,8 @@
                     "language": "python3",
                     "script": "flutter/tools/fuchsia/with_envs.py",
                     "parameters": [
-                        "testing/fuchsia/run_tests.py"
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_debug_x64_tester"
                     ]
                 }
             ]
@@ -480,9 +505,9 @@
                     "--out-dir",
                     "${LUCI_CLEANUP}",
                     "--symbol-dirs",
-                    "out/fuchsia_debug_arm64/.build-id",
-                    "out/fuchsia_profile_arm64/.build-id",
-                    "out/fuchsia_release_arm64/.build-id"
+                    "out/ci/fuchsia_debug_arm64/.build-id",
+                    "out/ci/fuchsia_profile_arm64/.build-id",
+                    "out/ci/fuchsia_release_arm64/.build-id"
                 ],
                 "script": "flutter/tools/fuchsia/merge_and_upload_debug_symbols.py",
                 "language": "python3"
@@ -498,9 +523,9 @@
                     "--out-dir",
                     "${LUCI_CLEANUP}",
                     "--symbol-dirs",
-                    "out/fuchsia_debug_x64/.build-id",
-                    "out/fuchsia_profile_x64/.build-id",
-                    "out/fuchsia_release_x64/.build-id"
+                    "out/ci/fuchsia_debug_x64/.build-id",
+                    "out/ci/fuchsia_profile_x64/.build-id",
+                    "out/ci/fuchsia_release_x64/.build-id"
                 ],
                 "script": "flutter/tools/fuchsia/merge_and_upload_debug_symbols.py",
                 "language": "python3"
@@ -508,7 +533,8 @@
             {
                 "name": "Verify-export-symbols-release-binaries",
                 "parameters": [
-                    "src/out"
+                    "src/out/ci",
+                    "src/flutter/buildtools"
                 ],
                 "script": "flutter/testing/symbols/verify_exported.dart",
                 "language": "dart"

--- a/ci/builders/linux_host_desktop_engine.json
+++ b/ci/builders/linux_host_desktop_engine.json
@@ -3,11 +3,11 @@
         {
             "archives": [
                 {
-                    "name": "host_debug",
-                    "base_path": "out/host_debug_desktop/zip_archives/",
+                    "name": "ci/host_debug_desktop",
+                    "base_path": "out/ci/host_debug_desktop/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_debug_desktop/zip_archives/linux-x64-debug/linux-x64-flutter-gtk.zip"
+                        "out/ci/host_debug_desktop/zip_archives/linux-x64-debug/linux-x64-flutter-gtk.zip"
                     ],
                     "realm": "production"
                 }
@@ -28,11 +28,11 @@
                 "--rbe",
                 "--no-goma",
                 "--target-dir",
-                "host_debug_desktop"
+                "ci/host_debug_desktop"
             ],
-            "name": "host_debug_desktop",
+            "name": "ci/host_debug_desktop",
             "ninja": {
-                "config": "host_debug_desktop",
+                "config": "ci/host_debug_desktop",
                 "targets": [
                     "flutter/shell/platform/linux:flutter_gtk"
                 ]
@@ -41,11 +41,11 @@
         {
             "archives": [
                 {
-                    "name": "host_profile",
-                    "base_path": "out/host_profile_desktop/zip_archives/",
+                    "name": "ci/host_profile_desktop",
+                    "base_path": "out/ci/host_profile_desktop/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_profile_desktop/zip_archives/linux-x64-profile/linux-x64-flutter-gtk.zip"
+                        "out/ci/host_profile_desktop/zip_archives/linux-x64-profile/linux-x64-flutter-gtk.zip"
                     ],
                     "realm": "production"
                 }
@@ -67,11 +67,11 @@
                 "--rbe",
                 "--no-goma",
                 "--target-dir",
-                "host_profile_desktop"
+                "ci/host_profile_desktop"
             ],
-            "name": "host_profile_desktop",
+            "name": "ci/host_profile_desktop",
             "ninja": {
-                "config": "host_profile_desktop",
+                "config": "ci/host_profile_desktop",
                 "targets": [
                     "flutter/shell/platform/linux:flutter_gtk"
                 ]
@@ -80,11 +80,11 @@
         {
             "archives": [
                 {
-                    "name": "host_release",
-                    "base_path": "out/host_release_desktop/zip_archives/",
+                    "name": "ci/host_release_desktop",
+                    "base_path": "out/ci/host_release_desktop/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_release_desktop/zip_archives/linux-x64-release/linux-x64-flutter-gtk.zip"
+                        "out/ci/host_release_desktop/zip_archives/linux-x64-release/linux-x64-flutter-gtk.zip"
                     ],
                     "realm": "production"
                 }
@@ -105,11 +105,11 @@
                 "--rbe",
                 "--no-goma",
                 "--target-dir",
-                "host_release_desktop"
+                "ci/host_release_desktop"
             ],
-            "name": "host_release_desktop",
+            "name": "ci/host_release_desktop",
             "ninja": {
-                "config": "host_release_desktop",
+                "config": "ci/host_release_desktop",
                 "targets": [
                     "flutter/shell/platform/linux:flutter_gtk"
                 ]

--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -3,15 +3,15 @@
         {
             "archives": [
                 {
-                    "name": "host_debug",
-                    "base_path": "out/host_debug/zip_archives/",
+                    "name": "ci/host_debug",
+                    "base_path": "out/ci/host_debug/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_debug/zip_archives/linux-x64/artifacts.zip",
-                        "out/host_debug/zip_archives/linux-x64/linux-x64-embedder.zip",
-                        "out/host_debug/zip_archives/linux-x64/font-subset.zip",
-                        "out/host_debug/zip_archives/flutter_patched_sdk.zip",
-                        "out/host_debug/zip_archives/dart-sdk-linux-x64.zip"
+                        "out/ci/host_debug/zip_archives/linux-x64/artifacts.zip",
+                        "out/ci/host_debug/zip_archives/linux-x64/linux-x64-embedder.zip",
+                        "out/ci/host_debug/zip_archives/linux-x64/font-subset.zip",
+                        "out/ci/host_debug/zip_archives/flutter_patched_sdk.zip",
+                        "out/ci/host_debug/zip_archives/dart-sdk-linux-x64.zip"
                     ],
                     "realm": "production"
                 }
@@ -25,6 +25,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/host_debug",
                 "--runtime-mode",
                 "debug",
                 "--prebuilt-dart-sdk",
@@ -32,9 +34,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "host_debug",
+            "name": "ci/host_debug",
             "ninja": {
-                "config": "host_debug",
+                "config": "ci/host_debug",
                 "targets": [
                     "flutter:unittests",
                     "flutter/build/archives:artifacts",
@@ -52,7 +54,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_debug",
+                        "ci/host_debug",
                         "--type",
                         "dart,dart-host",
                         "--engine-capture-core-dump"
@@ -63,8 +65,8 @@
         {
             "archives": [
                 {
-                    "name": "host_profile",
-                    "base_path": "out/host_profile/zip_archives/",
+                    "name": "ci/host_profile",
+                    "base_path": "out/ci/host_profile/zip_archives/",
                     "type": "gcs",
                     "include_paths": []
                 }
@@ -78,6 +80,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/host_profile",
                 "--runtime-mode",
                 "profile",
                 "--no-lto",
@@ -86,9 +90,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "host_profile",
+            "name": "ci/host_profile",
             "ninja": {
-                "config": "host_profile",
+                "config": "ci/host_profile",
                 "targets": [
                     "flutter/build/dart:copy_dart_sdk",
                     "flutter/shell/testing",
@@ -103,7 +107,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_profile",
+                        "ci/host_profile",
                         "--type",
                         "dart,dart-host,engine",
                         "--engine-capture-core-dump"
@@ -114,11 +118,11 @@
         {
             "archives": [
                 {
-                    "name": "host_release",
-                    "base_path": "out/host_release/zip_archives/",
+                    "name": "ci/host_release",
+                    "base_path": "out/ci/host_release/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_release/zip_archives/flutter_patched_sdk_product.zip"
+                        "out/ci/host_release/zip_archives/flutter_patched_sdk_product.zip"
                     ],
                     "realm": "production"
                 }
@@ -138,6 +142,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/host_release",
                 "--runtime-mode",
                 "release",
                 "--prebuilt-dart-sdk",
@@ -145,9 +151,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "host_release",
+            "name": "ci/host_release",
             "ninja": {
-                "config": "host_release",
+                "config": "ci/host_release",
                 "targets": [
                     "flutter/build/dart:copy_dart_sdk",
                     "flutter/display_list:display_list_benchmarks",
@@ -173,7 +179,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_release",
+                        "ci/host_release",
                         "--type",
                         "dart,dart-host,engine,benchmarks",
                         "--engine-capture-core-dump"
@@ -182,13 +188,17 @@
                 {
                     "language": "bash",
                     "name": "Generate metrics test",
-                    "script": "flutter/testing/benchmark/generate_metrics.sh"
+                    "script": "flutter/testing/benchmark/generate_metrics.sh",
+                    "parameters": [
+                        "ci/host_release"
+                    ]
                 },
                 {
                     "language": "bash",
                     "name": "Upload metrics dry-run",
                     "script": "flutter/testing/benchmark/upload_metrics.sh",
                     "parameters": [
+                        "ci/host_release",
                         "--no-upload"
                     ]
                 }
@@ -200,7 +210,8 @@
             {
                 "name": "Verify-export-symbols-release-binaries",
                 "parameters": [
-                    "src/out"
+                    "src/out/ci",
+                    "src/flutter/buildtools"
                 ],
                 "script": "flutter/testing/symbols/verify_exported.dart",
                 "language": "dart"

--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -10,6 +10,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/host_debug_unopt",
                 "--runtime-mode",
                 "debug",
                 "--unoptimized",
@@ -20,9 +22,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "host_debug_unopt",
+            "name": "ci/host_debug_unopt",
             "ninja": {
-                "config": "host_debug_unopt",
+                "config": "ci/host_debug_unopt",
                 "targets": [
                     "flutter/tools/font_subset",
                     "flutter:unittests",
@@ -62,7 +64,7 @@
                         "--logs-dir",
                         "${FLUTTER_LOGS_DIR}",
                         "--variant",
-                        "host_debug_unopt",
+                        "ci/host_debug_unopt",
                         "--type",
                         "dart,dart-host,engine",
                         "--engine-capture-core-dump",
@@ -82,7 +84,7 @@
                     "name": "test: observatory and service protocol",
                     "script": "flutter/shell/testing/observatory/test.dart",
                     "parameters": [
-                        "out/host_debug_unopt/flutter_tester",
+                        "out/ci/host_debug_unopt/flutter_tester",
                         "flutter/shell/testing/observatory/empty_main.dart"
                     ]
                 },
@@ -119,14 +121,14 @@
                 "--unoptimized",
                 "--prebuilt-dart-sdk",
                 "--target-dir",
-                "host_debug_unopt_impeller_tests",
+                "ci/host_debug_unopt_impeller_tests",
                 "--rbe",
                 "--no-goma",
                 "--use-glfw-swiftshader"
             ],
-            "name": "host_debug_unopt_impeller_tests",
+            "name": "ci/host_debug_unopt_impeller_tests",
             "ninja": {
-                "config": "host_debug_unopt_impeller_tests",
+                "config": "ci/host_debug_unopt_impeller_tests",
                 "targets": [
                     "flutter",
                     "flutter/sky/packages"
@@ -139,7 +141,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_debug_unopt_impeller_tests",
+                        "ci/host_debug_unopt_impeller_tests",
                         "--type",
                         "impeller",
                         "--engine-capture-core-dump"
@@ -161,14 +163,14 @@
                 "--android",
                 "--embedder-for-target",
                 "--target-dir",
-                "android_embedder_debug_unopt",
+                "ci/android_embedder_debug_unopt",
                 "--unoptimized",
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_embedder_debug_unopt",
+            "name": "ci/android_embedder_debug_unopt",
             "ninja": {
-                "config": "android_embedder_debug_unopt",
+                "config": "ci/android_embedder_debug_unopt",
                 "targets": [
                     "flutter/shell/platform/embedder:flutter_engine"
                 ]
@@ -184,6 +186,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_debug_arm64_validation_layers",
                 "--android",
                 "--android-cpu=arm64",
                 "--no-lto",
@@ -191,9 +195,9 @@
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_debug_arm64_validation_layers",
+            "name": "ci/android_debug_arm64_validation_layers",
             "ninja": {
-                "config": "android_debug_arm64",
+                "config": "ci/android_debug_arm64_validation_layers",
                 "targets": [
                     "flutter",
                     "flutter/shell/platform/android:abi_jars"
@@ -215,14 +219,16 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_debug_unopt",
                 "--android",
                 "--unoptimized",
                 "--rbe",
                 "--no-goma"
             ],
-            "name": "android_debug_unopt",
+            "name": "ci/android_debug_unopt",
             "ninja": {
-                "config": "android_debug_unopt",
+                "config": "ci/android_debug_unopt",
                 "targets": [
                     "flutter/impeller",
                     "flutter/shell/platform/android:android_jar",
@@ -236,12 +242,12 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "android_debug_unopt",
+                        "ci/android_debug_unopt",
                         "--type",
                         "java",
                         "--engine-capture-core-dump",
                         "--android-variant",
-                        "android_debug_unopt"
+                        "ci/android_debug_unopt"
                     ]
                 },
                 {
@@ -252,7 +258,7 @@
                         "--before-relative-to-src",
                         "flutter/impeller/tools/malioc.json",
                         "--after-relative-to-src",
-                        "out/android_debug_unopt/gen/malioc",
+                        "out/ci/android_debug_unopt/gen/malioc",
                         "--print-diff"
                     ]
                 }

--- a/ci/builders/linux_unopt_debug_no_rbe.json
+++ b/ci/builders/linux_unopt_debug_no_rbe.json
@@ -19,11 +19,11 @@
         "--no-rbe",
         "--no-goma",
         "--target-dir",
-        "linux_unopt_debug_no_rbe"
+        "ci/linux_unopt_debug_no_rbe"
       ],
-      "name": "linux_unopt_debug_no_rbe",
+      "name": "ci/linux_unopt_debug_no_rbe",
       "ninja": {
-        "config": "linux_unopt_debug_no_rbe",
+        "config": "ci/linux_unopt_debug_no_rbe",
         "targets": ["flutter/tools/font_subset"]
       },
       "tests": [
@@ -31,7 +31,10 @@
           "language": "dart",
           "name": "clangd",
           "script": "flutter/tools/clangd_check/bin/main.dart",
-          "parameters": ["--clangd=buildtools/linux-x64/clang/bin/clangd"]
+          "parameters": [
+            "--clangd=buildtools/linux-x64/clang/bin/clangd",
+            "--compile-commands-dir=../out/ci/linux_unopt_debug_no_rbe"
+          ]
         }
       ]
     }

--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -3,12 +3,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_profile/zip_archives/",
+                    "base_path": "out/ci/android_profile/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_profile/zip_archives/android-arm-profile/darwin-x64.zip"
+                        "out/ci/android_profile/zip_archives/android-arm-profile/darwin-x64.zip"
                     ],
-                    "name": "android_profile",
+                    "name": "ci/android_profile",
                     "realm": "production"
                 }
             ],
@@ -21,13 +21,15 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/android_profile",
                 "--runtime-mode",
                 "profile",
                 "--android"
             ],
-            "name": "android_profile",
+            "name": "ci/android_profile",
             "ninja": {
-                "config": "android_profile",
+                "config": "ci/android_profile",
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
@@ -42,12 +44,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_profile_arm64/zip_archives/",
+                    "base_path": "out/ci/android_profile_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_profile_arm64/zip_archives/android-arm64-profile/darwin-x64.zip"
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/darwin-x64.zip"
                     ],
-                    "name": "android_profile_arm64",
+                    "name": "ci/android_profile_arm64",
                     "realm": "production"
                 }
             ],
@@ -60,14 +62,16 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/android_profile_arm64",
                 "--runtime-mode",
                 "profile",
                 "--android",
                 "--android-cpu=arm64"
             ],
-            "name": "android_profile_arm64",
+            "name": "ci/android_profile_arm64",
             "ninja": {
-                "config": "android_profile_arm64",
+                "config": "ci/android_profile_arm64",
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
@@ -82,12 +86,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_profile_x64/zip_archives/",
+                    "base_path": "out/ci/android_profile_x64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_profile_x64/zip_archives/android-x64-profile/darwin-x64.zip"
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/darwin-x64.zip"
                     ],
-                    "name": "android_profile_x64",
+                    "name": "ci/android_profile_x64",
                     "realm": "production"
                 }
             ],
@@ -100,14 +104,16 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/android_profile_x64",
                 "--runtime-mode",
                 "profile",
                 "--android",
                 "--android-cpu=x64"
             ],
-            "name": "android_profile_x64",
+            "name": "ci/android_profile_x64",
             "ninja": {
-                "config": "android_profile_x64",
+                "config": "ci/android_profile_x64",
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
@@ -122,12 +128,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_release/zip_archives/",
+                    "base_path": "out/ci/android_release/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_release/zip_archives/android-arm-release/darwin-x64.zip"
+                        "out/ci/android_release/zip_archives/android-arm-release/darwin-x64.zip"
                     ],
-                    "name": "android_release",
+                    "name": "ci/android_release",
                     "realm": "production"
                 }
             ],
@@ -140,13 +146,15 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/android_release",
                 "--runtime-mode",
                 "release",
                 "--android"
             ],
-            "name": "android_release",
+            "name": "ci/android_release",
             "ninja": {
-                "config": "android_release",
+                "config": "ci/android_release",
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
@@ -161,12 +169,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_release_arm64/zip_archives/",
+                    "base_path": "out/ci/android_release_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_release_arm64/zip_archives/android-arm64-release/darwin-x64.zip"
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/darwin-x64.zip"
                     ],
-                    "name": "android_release_arm64",
+                    "name": "ci/android_release_arm64",
                     "realm": "production"
                 }
             ],
@@ -179,14 +187,16 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/android_release_arm64",
                 "--runtime-mode",
                 "release",
                 "--android",
                 "--android-cpu=arm64"
             ],
-            "name": "android_release_arm64",
+            "name": "ci/android_release_arm64",
             "ninja": {
-                "config": "android_release_arm64",
+                "config": "ci/android_release_arm64",
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
@@ -201,12 +211,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_release_x64/zip_archives/",
+                    "base_path": "out/ci/android_release_x64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_release_x64/zip_archives/android-x64-release/darwin-x64.zip"
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/darwin-x64.zip"
                     ],
-                    "name": "android_release_x64",
+                    "name": "ci/android_release_x64",
                     "realm": "production"
                 }
             ],
@@ -219,14 +229,16 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/android_release_x64",
                 "--runtime-mode",
                 "release",
                 "--android",
                 "--android-cpu=x64"
             ],
-            "name": "android_release_x64",
+            "name": "ci/android_release_x64",
             "ninja": {
-                "config": "android_release_x64",
+                "config": "ci/android_release_x64",
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"

--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -17,14 +17,14 @@
                 "--no-lto",
                 "--force-mac-arm64",
                 "--target-dir",
-                "host_debug_clang_tidy",
+                "ci/host_debug_clang_tidy",
                 "--rbe",
                 "--no-goma",
                 "--xcode-symlinks"
             ],
-            "name": "host_debug_clang_tidy",
+            "name": "ci/host_debug_clang_tidy",
             "ninja": {
-                "config": "host_debug_clang_tidy"
+                "config": "ci/host_debug_clang_tidy"
             }
         },
         {
@@ -45,14 +45,14 @@
                 "--no-lto",
                 "--force-mac-arm64",
                 "--target-dir",
-                "ios_debug_sim_clang_tidy",
+                "ci/ios_debug_sim_clang_tidy",
                 "--rbe",
                 "--no-goma",
                 "--xcode-symlinks"
             ],
-            "name": "ios_debug_sim_clang_tidy",
+            "name": "ci/ios_debug_sim_clang_tidy",
             "ninja": {
-                "config": "ios_debug_sim_clang_tidy"
+                "config": "ci/ios_debug_sim_clang_tidy"
             }
         }
     ],
@@ -70,7 +70,7 @@
                 "use_rbe": true
             },
             "dependencies": [
-                "host_debug_clang_tidy"
+                "ci/host_debug_clang_tidy"
             ],
             "contexts": [
                 "osx_sdk"
@@ -87,7 +87,7 @@
                         "--no-lto",
                         "--force-mac-arm64",
                         "--target-dir",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--rbe",
                         "--no-goma",
                         "--xcode-symlinks"
@@ -97,10 +97,10 @@
                     "name": "test: lint host_debug",
                     "parameters": [
                         "--variant",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--lint-all",
                         "--shard-id=0",
-                        "--shard-variants=host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
@@ -120,7 +120,7 @@
                 "use_rbe": true
             },
             "dependencies": [
-                "host_debug_clang_tidy"
+                "ci/host_debug_clang_tidy"
             ],
             "contexts": [
                 "osx_sdk"
@@ -137,7 +137,7 @@
                         "--no-lto",
                         "--force-mac-arm64",
                         "--target-dir",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--rbe",
                         "--no-goma",
                         "--xcode-symlinks"
@@ -147,10 +147,10 @@
                     "name": "test: lint host_debug",
                     "parameters": [
                         "--variant",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--lint-all",
                         "--shard-id=1",
-                        "--shard-variants=host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
@@ -170,7 +170,7 @@
                 "use_rbe": true
             },
             "dependencies": [
-                "host_debug_clang_tidy"
+                "ci/host_debug_clang_tidy"
             ],
             "contexts": [
                 "osx_sdk"
@@ -187,7 +187,7 @@
                         "--no-lto",
                         "--force-mac-arm64",
                         "--target-dir",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--rbe",
                         "--no-goma",
                         "--xcode-symlinks"
@@ -197,10 +197,10 @@
                     "name": "test: lint host_debug",
                     "parameters": [
                         "--variant",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--lint-all",
                         "--shard-id=2",
-                        "--shard-variants=host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
@@ -220,7 +220,7 @@
                 "use_rbe": true
             },
             "dependencies": [
-                "host_debug_clang_tidy"
+                "ci/host_debug_clang_tidy"
             ],
             "contexts": [
                 "osx_sdk"
@@ -237,7 +237,7 @@
                         "--no-lto",
                         "--force-mac-arm64",
                         "--target-dir",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--rbe",
                         "--no-goma",
                         "--xcode-symlinks"
@@ -247,10 +247,10 @@
                     "name": "test: lint host_debug",
                     "parameters": [
                         "--variant",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--lint-all",
                         "--shard-id=3",
-                        "--shard-variants=host_debug_clang_tidy,host_debug_clang_tidy,host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy,ci/host_debug_clang_tidy,ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"
@@ -270,8 +270,8 @@
                 "use_rbe": true
             },
             "dependencies": [
-                "host_debug_clang_tidy",
-                "ios_debug_sim_clang_tidy"
+                "ci/host_debug_clang_tidy",
+                "ci/ios_debug_sim_clang_tidy"
             ],
             "contexts": [
                 "osx_sdk"
@@ -288,7 +288,7 @@
                         "--no-lto",
                         "--force-mac-arm64",
                         "--target-dir",
-                        "host_debug_clang_tidy",
+                        "ci/host_debug_clang_tidy",
                         "--rbe",
                         "--no-goma",
                         "--xcode-symlinks"
@@ -306,7 +306,7 @@
                         "--no-lto",
                         "--force-mac-arm64",
                         "--target-dir",
-                        "ios_debug_sim_clang_tidy",
+                        "ci/ios_debug_sim_clang_tidy",
                         "--rbe",
                         "--no-goma",
                         "--xcode-symlinks"
@@ -316,10 +316,10 @@
                     "name": "test: lint ios_debug_sim",
                     "parameters": [
                         "--variant",
-                        "ios_debug_sim_clang_tidy",
+                        "ci/ios_debug_sim_clang_tidy",
                         "--lint-all",
                         "--shard-id=0",
-                        "--shard-variants=host_debug_clang_tidy"
+                        "--shard-variants=ci/host_debug_clang_tidy"
                     ],
                     "max_attempts": 1,
                     "script": "flutter/ci/clang_tidy.sh"

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -3,13 +3,13 @@
         {
             "archives": [
                 {
-                    "base_path": "out/host_debug/zip_archives/",
+                    "base_path": "out/ci/host_debug/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_debug/zip_archives/darwin-x64/artifacts.zip",
-                        "out/host_debug/zip_archives/dart-sdk-darwin-x64.zip"
+                        "out/ci/host_debug/zip_archives/darwin-x64/artifacts.zip",
+                        "out/ci/host_debug/zip_archives/dart-sdk-darwin-x64.zip"
                     ],
-                    "name": "host_debug",
+                    "name": "ci/host_debug",
                     "realm": "production"
                 }
             ],
@@ -23,6 +23,8 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/host_debug",
                 "--runtime-mode",
                 "debug",
                 "--no-lto",
@@ -30,9 +32,9 @@
                 "--build-embedder-examples",
                 "--use-glfw-swiftshader"
             ],
-            "name": "host_debug",
+            "name": "ci/host_debug",
             "ninja": {
-                "config": "host_debug",
+                "config": "ci/host_debug",
                 "targets": [
                     "flutter/build/archives:archive_gen_snapshot",
                     "flutter/build/archives:artifacts",
@@ -56,7 +58,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_debug",
+                        "ci/host_debug",
                         "--type",
                         "dart,dart-host,engine",
                         "--engine-capture-core-dump"
@@ -67,12 +69,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/host_profile/zip_archives/",
+                    "base_path": "out/ci/host_profile/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_profile/zip_archives/darwin-x64-profile/artifacts.zip"
+                        "out/ci/host_profile/zip_archives/darwin-x64-profile/artifacts.zip"
                     ],
-                    "name": "host_profile",
+                    "name": "ci/host_profile",
                     "realm": "production"
                 }
             ],
@@ -86,15 +88,17 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/host_profile",
                 "--runtime-mode",
                 "profile",
                 "--no-lto",
                 "--prebuilt-dart-sdk",
                 "--build-embedder-examples"
             ],
-            "name": "host_profile",
+            "name": "ci/host_profile",
             "ninja": {
-                "config": "host_profile",
+                "config": "ci/host_profile",
                 "targets": [
                     "flutter/build/dart:copy_dart_sdk",
                     "flutter/build/archives:archive_gen_snapshot",
@@ -115,7 +119,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_profile",
+                        "ci/host_profile",
                         "--type",
                         "dart,dart-host,engine",
                         "--engine-capture-core-dump"
@@ -126,13 +130,13 @@
         {
             "archives": [
                 {
-                    "base_path": "out/host_release/zip_archives/",
+                    "base_path": "out/ci/host_release/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_release/zip_archives/darwin-x64-release/artifacts.zip",
-                        "out/host_release/zip_archives/darwin-x64/font-subset.zip"
+                        "out/ci/host_release/zip_archives/darwin-x64-release/artifacts.zip",
+                        "out/ci/host_release/zip_archives/darwin-x64/font-subset.zip"
                     ],
-                    "name": "host_release",
+                    "name": "ci/host_release",
                     "realm": "production"
                 }
             ],
@@ -152,6 +156,8 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/host_release",
                 "--runtime-mode",
                 "release",
                 "--no-lto",
@@ -159,9 +165,9 @@
                 "--build-embedder-examples",
                 "--use-glfw-swiftshader"
             ],
-            "name": "host_release",
+            "name": "ci/host_release",
             "ninja": {
-                "config": "host_release",
+                "config": "ci/host_release",
                 "targets": [
                     "flutter/build/archives:archive_gen_snapshot",
                     "flutter/build/archives:artifacts",
@@ -184,7 +190,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_release",
+                        "ci/host_release",
                         "--type",
                         "dart,dart-host,engine,impeller-golden"
                     ]
@@ -194,13 +200,13 @@
         {
             "archives": [
                 {
-                    "base_path": "out/mac_debug_arm64/zip_archives/",
+                    "base_path": "out/ci/mac_debug_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/mac_debug_arm64/zip_archives/darwin-arm64/artifacts.zip",
-                        "out/mac_debug_arm64/zip_archives/dart-sdk-darwin-arm64.zip"
+                        "out/ci/mac_debug_arm64/zip_archives/darwin-arm64/artifacts.zip",
+                        "out/ci/mac_debug_arm64/zip_archives/dart-sdk-darwin-arm64.zip"
                     ],
-                    "name": "mac_debug_arm64",
+                    "name": "ci/mac_debug_arm64",
                     "realm": "production"
                 }
             ],
@@ -213,6 +219,8 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/mac_debug_arm64",
                 "--mac",
                 "--mac-cpu",
                 "arm64",
@@ -221,9 +229,9 @@
                 "--no-lto",
                 "--prebuilt-dart-sdk"
             ],
-            "name": "mac_debug_arm64",
+            "name": "ci/mac_debug_arm64",
             "ninja": {
-                "config": "mac_debug_arm64",
+                "config": "ci/mac_debug_arm64",
                 "targets": [
                     "flutter/tools/font_subset",
                     "flutter/build/archives:archive_gen_snapshot",
@@ -242,12 +250,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/mac_profile_arm64/zip_archives/",
+                    "base_path": "out/ci/mac_profile_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/mac_profile_arm64/zip_archives/darwin-arm64-profile/artifacts.zip"
+                        "out/ci/mac_profile_arm64/zip_archives/darwin-arm64-profile/artifacts.zip"
                     ],
-                    "name": "mac_profile_arm64",
+                    "name": "ci/mac_profile_arm64",
                     "realm": "production"
                 }
             ],
@@ -260,6 +268,8 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/mac_profile_arm64",
                 "--mac",
                 "--mac-cpu",
                 "arm64",
@@ -268,9 +278,9 @@
                 "--no-lto",
                 "--prebuilt-dart-sdk"
             ],
-            "name": "mac_profile_arm64",
+            "name": "ci/mac_profile_arm64",
             "ninja": {
-                "config": "mac_profile_arm64",
+                "config": "ci/mac_profile_arm64",
                 "targets": [
                     "flutter/build/archives:artifacts",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework"
@@ -285,11 +295,11 @@
         {
             "archives": [
                 {
-                    "base_path": "out/mac_release_arm64/zip_archives/",
+                    "base_path": "out/ci/mac_release_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/mac_release_arm64/zip_archives/darwin-arm64/font-subset.zip",
-                        "out/mac_release_arm64/zip_archives/darwin-arm64-release/artifacts.zip"
+                        "out/ci/mac_release_arm64/zip_archives/darwin-arm64/font-subset.zip",
+                        "out/ci/mac_release_arm64/zip_archives/darwin-arm64-release/artifacts.zip"
                     ],
                     "name": "mac_release_arm64",
                     "realm": "production"
@@ -304,6 +314,8 @@
                 "download_android_deps": false
             },
             "gn": [
+                "--target-dir",
+                "ci/mac_release_arm64",
                 "--mac",
                 "--mac-cpu",
                 "arm64",
@@ -312,9 +324,9 @@
                 "--no-lto",
                 "--prebuilt-dart-sdk"
             ],
-            "name": "mac_release_arm64",
+            "name": "ci/mac_release_arm64",
             "ninja": {
-                "config": "mac_release_arm64",
+                "config": "ci/mac_release_arm64",
                 "targets": [
                     "flutter/tools/font_subset",
                     "flutter/build/archives:artifacts",
@@ -336,9 +348,9 @@
                     "--dst",
                     "out/debug/framework",
                     "--arm64-out-dir",
-                    "out/mac_debug_arm64",
+                    "out/ci/mac_debug_arm64",
                     "--x64-out-dir",
-                    "out/host_debug",
+                    "out/ci/host_debug",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_embedder_framework.py"
@@ -349,9 +361,9 @@
                     "--dst",
                     "out/release/framework",
                     "--arm64-out-dir",
-                    "out/mac_release_arm64",
+                    "out/ci/mac_release_arm64",
                     "--x64-out-dir",
-                    "out/host_release",
+                    "out/ci/host_release",
                     "--dsym",
                     "--strip",
                     "--zip"
@@ -364,9 +376,9 @@
                     "--dst",
                     "out/debug/framework",
                     "--arm64-out-dir",
-                    "out/mac_debug_arm64",
+                    "out/ci/mac_debug_arm64",
                     "--x64-out-dir",
-                    "out/host_debug",
+                    "out/ci/host_debug",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
@@ -377,9 +389,9 @@
                     "--dst",
                     "out/profile/framework",
                     "--arm64-out-dir",
-                    "out/mac_profile_arm64",
+                    "out/ci/mac_profile_arm64",
                     "--x64-out-dir",
-                    "out/host_profile",
+                    "out/ci/host_profile",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_framework.py"
@@ -387,7 +399,8 @@
             {
                 "name": "Verify-export-symbols",
                 "parameters": [
-                    "src/out"
+                    "src/out/ci",
+                    "src/flutter/buildtools"
                 ],
                 "script": "flutter/testing/symbols/verify_exported.dart",
                 "language": "dart"
@@ -398,9 +411,9 @@
                     "--dst",
                     "out/debug/snapshot",
                     "--arm64-out-dir",
-                    "out/mac_debug_arm64",
+                    "out/ci/mac_debug_arm64",
                     "--x64-out-dir",
-                    "out/host_debug",
+                    "out/ci/host_debug",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
@@ -411,9 +424,9 @@
                     "--dst",
                     "out/profile/snapshot",
                     "--arm64-out-dir",
-                    "out/mac_profile_arm64",
+                    "out/ci/mac_profile_arm64",
                     "--x64-out-dir",
-                    "out/host_profile",
+                    "out/ci/host_profile",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
@@ -424,9 +437,9 @@
                     "--dst",
                     "out/release/snapshot",
                     "--arm64-out-dir",
-                    "out/mac_release_arm64",
+                    "out/ci/mac_release_arm64",
                     "--x64-out-dir",
-                    "out/host_release",
+                    "out/ci/host_release",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"

--- a/ci/builders/mac_impeller_cmake_example.json
+++ b/ci/builders/mac_impeller_cmake_example.json
@@ -1,7 +1,8 @@
 {
     "builds": [
         {
-            "name": "impeller-cmake-example",
+            "cas_archive": false,
+            "name": "ci/impeller-cmake-example",
             "archives": [],
             "drone_dimensions": [
                 "device_type=none",

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -7,15 +7,17 @@
                 "cpu=x86"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_debug_sim",
                 "--ios",
                 "--runtime-mode",
                 "debug",
                 "--simulator",
                 "--no-lto"
             ],
-            "name": "ios_debug_sim",
+            "name": "ci/ios_debug_sim",
             "ninja": {
-                "config": "ios_debug_sim"
+                "config": "ci/ios_debug_sim"
             },
             "properties": {
                 "$flutter/osx_sdk": {
@@ -29,6 +31,8 @@
                 "os=Mac-13"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_debug_sim_arm64",
                 "--ios",
                 "--runtime-mode",
                 "debug",
@@ -36,9 +40,9 @@
                 "--simulator-cpu=arm64",
                 "--no-lto"
             ],
-            "name": "ios_debug_sim_arm64",
+            "name": "ci/ios_debug_sim_arm64",
             "ninja": {
-                "config": "ios_debug_sim_arm64"
+                "config": "ci/ios_debug_sim_arm64"
             },
             "properties": {
                 "$flutter/osx_sdk": {
@@ -52,13 +56,15 @@
                 "os=Mac-13"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_debug",
                 "--ios",
                 "--runtime-mode",
                 "debug"
             ],
-            "name": "ios_debug",
+            "name": "ci/ios_debug",
             "ninja": {
-                "config": "ios_debug",
+                "config": "ci/ios_debug",
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework"
                 ]
@@ -75,13 +81,15 @@
                 "os=Mac-13"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_profile",
                 "--ios",
                 "--runtime-mode",
                 "profile"
             ],
-            "name": "ios_profile",
+            "name": "ci/ios_profile",
             "ninja": {
-                "config": "ios_profile",
+                "config": "ci/ios_profile",
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
@@ -99,13 +107,15 @@
                 "os=Mac-13"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_release",
                 "--ios",
                 "--runtime-mode",
                 "release"
             ],
-            "name": "ios_release",
+            "name": "ci/ios_release",
             "ninja": {
-                "config": "ios_release",
+                "config": "ci/ios_release",
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
@@ -124,6 +134,8 @@
                 "cpu=x86"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_debug_sim_extension_safe",
                 "--ios",
                 "--runtime-mode",
                 "debug",
@@ -131,9 +143,9 @@
                 "--no-lto",
                 "--darwin-extension-safe"
             ],
-            "name": "ios_debug_sim_extension_safe",
+            "name": "ci/ios_debug_sim_extension_safe",
             "ninja": {
-                "config": "ios_debug_sim_extension_safe"
+                "config": "ci/ios_debug_sim_extension_safe"
             },
             "properties": {
                 "$flutter/osx_sdk": {
@@ -147,6 +159,8 @@
                 "os=Mac-13"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_debug_sim_arm64_extension_safe",
                 "--ios",
                 "--runtime-mode",
                 "debug",
@@ -155,9 +169,9 @@
                 "--no-lto",
                 "--darwin-extension-safe"
             ],
-            "name": "ios_debug_sim_arm64_extension_safe",
+            "name": "ci/ios_debug_sim_arm64_extension_safe",
             "ninja": {
-                "config": "ios_debug_sim_arm64_extension_safe"
+                "config": "ci/ios_debug_sim_arm64_extension_safe"
             },
             "properties": {
                 "$flutter/osx_sdk": {
@@ -171,14 +185,16 @@
                 "os=Mac-13"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_debug_extension_safe",
                 "--ios",
                 "--runtime-mode",
                 "debug",
                 "--darwin-extension-safe"
             ],
-            "name": "ios_debug_extension_safe",
+            "name": "ci/ios_debug_extension_safe",
             "ninja": {
-                "config": "ios_debug_extension_safe",
+                "config": "ci/ios_debug_extension_safe",
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework"
                 ]
@@ -195,14 +211,16 @@
                 "os=Mac-13"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_profile_extension_safe",
                 "--ios",
                 "--runtime-mode",
                 "profile",
                 "--darwin-extension-safe"
             ],
-            "name": "ios_profile_extension_safe",
+            "name": "ci/ios_profile_extension_safe",
             "ninja": {
-                "config": "ios_profile_extension_safe",
+                "config": "ci/ios_profile_extension_safe",
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
@@ -220,14 +238,16 @@
                 "os=Mac-13"
             ],
             "gn": [
+                "--target-dir",
+                "ci/ios_release_extension_safe",
                 "--ios",
                 "--runtime-mode",
                 "release",
                 "--darwin-extension-safe"
             ],
-            "name": "ios_release_extension_safe",
+            "name": "ci/ios_release_extension_safe",
             "ninja": {
-                "config": "ios_release_extension_safe",
+                "config": "ci/ios_release_extension_safe",
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
@@ -248,11 +268,11 @@
                     "--dst",
                     "out/debug",
                     "--arm64-out-dir",
-                    "out/ios_debug",
+                    "out/ci/ios_debug",
                     "--simulator-x64-out-dir",
-                    "out/ios_debug_sim",
+                    "out/ci/ios_debug_sim",
                     "--simulator-arm64-out-dir",
-                    "out/ios_debug_sim_arm64"
+                    "out/ci/ios_debug_sim_arm64"
                 ],
                 "script": "flutter/sky/tools/create_full_ios_framework.py",
                 "language": "python3"
@@ -263,11 +283,11 @@
                     "--dst",
                     "out/profile",
                     "--arm64-out-dir",
-                    "out/ios_profile",
+                    "out/ci/ios_profile",
                     "--simulator-x64-out-dir",
-                    "out/ios_debug_sim",
+                    "out/ci/ios_debug_sim",
                     "--simulator-arm64-out-dir",
-                    "out/ios_debug_sim_arm64"
+                    "out/ci/ios_debug_sim_arm64"
                 ],
                 "script": "flutter/sky/tools/create_full_ios_framework.py",
                 "language": "python3"
@@ -278,11 +298,11 @@
                     "--dst",
                     "out/release",
                     "--arm64-out-dir",
-                    "out/ios_release",
+                    "out/ci/ios_release",
                     "--simulator-x64-out-dir",
-                    "out/ios_debug_sim",
+                    "out/ci/ios_debug_sim",
                     "--simulator-arm64-out-dir",
-                    "out/ios_debug_sim_arm64",
+                    "out/ci/ios_debug_sim_arm64",
                     "--dsym",
                     "--strip"
                 ],
@@ -295,7 +315,7 @@
                     "--dst",
                     "out/release",
                     "--arm64-out-dir",
-                    "out/ios_release"
+                    "out/ci/ios_release"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py",
                 "language": "python3"
@@ -303,7 +323,8 @@
             {
                 "name": "Verify-export-symbols-release-binaries",
                 "parameters": [
-                    "src/out"
+                    "src/out/ci",
+                    "src/flutter/buildtools"
                 ],
                 "script": "flutter/testing/symbols/verify_exported.dart",
                 "language": "dart"

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -12,6 +12,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/host_debug_unopt",
                 "--runtime-mode",
                 "debug",
                 "--unoptimized",
@@ -22,9 +24,9 @@
                 "--no-goma",
                 "--xcode-symlinks"
             ],
-            "name": "host_debug_unopt",
+            "name": "ci/host_debug_unopt",
             "ninja": {
-                "config": "host_debug_unopt",
+                "config": "ci/host_debug_unopt",
                 "targets": []
             },
             "properties": {
@@ -39,7 +41,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_debug_unopt",
+                        "ci/host_debug_unopt",
                         "--type",
                         "dart,dart-host,engine",
                         "--engine-capture-core-dump"
@@ -80,11 +82,11 @@
                 "--no-goma",
                 "--xcode-symlinks",
                 "--target-dir",
-                "ios_debug_unopt_sim"
+                "ci/ios_debug_unopt_sim"
             ],
-            "name": "ios_debug_unopt_sim",
+            "name": "ci/ios_debug_unopt_sim",
             "ninja": {
-                "config": "ios_debug_unopt_sim",
+                "config": "ci/ios_debug_unopt_sim",
                 "targets": [
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
@@ -97,18 +99,18 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "ios_debug_unopt_sim",
+                        "ci/ios_debug_unopt_sim",
                         "--type",
                         "objc",
                         "--engine-capture-core-dump",
                         "--ios-variant",
-                        "ios_debug_unopt_sim"
+                        "ci/ios_debug_unopt_sim"
                     ]
                 },
                 {
                     "name": "Scenario App Integration Tests",
                     "parameters": [
-                        "ios_debug_unopt_sim"
+                        "ci/ios_debug_unopt_sim"
                     ],
                     "script": "flutter/testing/scenario_app/run_ios_tests.sh"
                 }
@@ -125,22 +127,24 @@
                 "use_rbe": true
             },
             "gn": [
-               "--runtime-mode",
-               "debug",
-               "--unoptimized",
-               "--no-lto",
-               "--prebuilt-dart-sdk",
-               "--force-mac-arm64",
-               "--mac-cpu",
-               "arm64",
-               "--rbe",
-               "--no-goma",
-               "--xcode-symlinks",
-               "--use-glfw-swiftshader"
+                "--target-dir",
+                "ci/host_debug_unopt_arm64",
+                "--runtime-mode",
+                "debug",
+                "--unoptimized",
+                "--no-lto",
+                "--prebuilt-dart-sdk",
+                "--force-mac-arm64",
+                "--mac-cpu",
+                "arm64",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks",
+                "--use-glfw-swiftshader"
             ],
-            "name": "host_debug_unopt_arm64",
+            "name": "ci/host_debug_unopt_arm64",
             "ninja": {
-                "config": "host_debug_unopt_arm64",
+                "config": "ci/host_debug_unopt_arm64",
                 "targets": [
                 ]
             },
@@ -156,7 +160,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_debug_unopt_arm64",
+                        "ci/host_debug_unopt_arm64",
                         "--type",
                         "dart,dart-host,engine,impeller-golden",
                         "--engine-capture-core-dump"
@@ -195,11 +199,11 @@
                 "--no-goma",
                 "--xcode-symlinks",
                 "--target-dir",
-                "ios_debug_unopt_sim_arm64"
+                "ci/ios_debug_unopt_sim_arm64"
             ],
-            "name": "ios_debug_unopt_sim_arm64",
+            "name": "ci/ios_debug_unopt_sim_arm64",
             "ninja": {
-                "config": "ios_debug_unopt_sim_arm64",
+                "config": "ci/ios_debug_unopt_sim_arm64",
                 "targets": [
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
@@ -212,18 +216,18 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "ios_debug_unopt_sim_arm64",
+                        "ci/ios_debug_unopt_sim_arm64",
                         "--type",
                         "objc",
                         "--engine-capture-core-dump",
                         "--ios-variant",
-                        "ios_debug_unopt_sim_arm64"
+                        "ci/ios_debug_unopt_sim_arm64"
                     ]
                 },
                 {
                     "name": "Scenario App Integration Tests",
                     "parameters": [
-                        "ios_debug_unopt_sim_arm64"
+                        "ci/ios_debug_unopt_sim_arm64"
                     ],
                     "script": "flutter/testing/scenario_app/run_ios_tests.sh"
                 }
@@ -262,11 +266,11 @@
                 "--no-goma",
                 "--xcode-symlinks",
                 "--target-dir",
-                "ios_debug_unopt_sim_arm64_extension_safe"
+                "ci/ios_debug_unopt_sim_arm64_extension_safe"
             ],
-            "name": "ios_debug_unopt_sim_arm64_extension_safe",
+            "name": "ci/ios_debug_unopt_sim_arm64_extension_safe",
             "ninja": {
-                "config": "ios_debug_unopt_sim_arm64_extension_safe",
+                "config": "ci/ios_debug_unopt_sim_arm64_extension_safe",
                 "targets": [
                     "flutter/testing/scenario_app",
                     "flutter/shell/platform/darwin/ios:ios_test_flutter"
@@ -279,18 +283,18 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "ios_debug_unopt_sim_arm64_extension_safe",
+                        "ci/ios_debug_unopt_sim_arm64_extension_safe",
                         "--type",
                         "objc",
                         "--engine-capture-core-dump",
                         "--ios-variant",
-                        "ios_debug_unopt_sim_arm64_extension_safe"
+                        "ci/ios_debug_unopt_sim_arm64_extension_safe"
                     ]
                 },
                 {
                     "name": "Scenario App Integration Tests",
                     "parameters": [
-                        "ios_debug_unopt_sim_arm64_extension_safe"
+                        "ci/ios_debug_unopt_sim_arm64_extension_safe"
                     ],
                     "script": "flutter/testing/scenario_app/run_ios_tests.sh"
                 }

--- a/ci/builders/mac_unopt_debug_no_rbe.json
+++ b/ci/builders/mac_unopt_debug_no_rbe.json
@@ -25,11 +25,11 @@
         "--no-goma",
         "--xcode-symlinks",
         "--target-dir",
-        "mac_unopt_debug_no_rbe"
+        "ci/mac_unopt_debug_no_rbe"
       ],
-      "name": "mac_unopt_debug_no_rbe",
+      "name": "ci/mac_unopt_debug_no_rbe",
       "ninja": {
-        "config": "mac_unopt_debug_no_rbe",
+        "config": "ci/mac_unopt_debug_no_rbe",
         "targets": ["flutter/tools/font_subset"]
       },
       "properties": {
@@ -42,7 +42,10 @@
           "language": "dart",
           "name": "clangd",
           "script": "flutter/tools/clangd_check/bin/main.dart",
-          "parameters": ["--clangd=buildtools/mac-x64/clang/bin/clangd"]
+          "parameters": [
+            "--clangd=buildtools/mac-x64/clang/bin/clangd",
+            "--compile-commands-dir=../out/ci/mac_unopt_debug_no_rbe"
+          ]
         }
       ]
     }

--- a/ci/builders/standalone/linux_benchmarks.json
+++ b/ci/builders/standalone/linux_benchmarks.json
@@ -8,6 +8,8 @@
         "use_rbe": true
     },
     "gn": [
+        "--target-dir",
+        "ci/host_release_benchmarks",
         "--runtime-mode",
         "release",
         "--prebuilt-dart-sdk",
@@ -15,9 +17,9 @@
         "--rbe",
         "--no-goma"
     ],
-    "name": "host_release",
+    "name": "ci/host_release_benchmarks",
     "ninja": {
-        "config": "host_release",
+        "config": "ci/host_release_benchmarks",
         "targets": [
             "flutter/build/dart:copy_dart_sdk",
             "flutter/display_list:display_list_benchmarks",
@@ -40,7 +42,10 @@
         {
             "language": "bash",
             "name": "Generate metrics test",
-            "script": "flutter/testing/benchmark/generate_metrics.sh"
+            "script": "flutter/testing/benchmark/generate_metrics.sh",
+            "parameters": [
+                "ci/host_release_benchmarks"
+            ]
         },
         {
             "contexts": [
@@ -48,7 +53,10 @@
             ],
             "language": "bash",
             "name": "Upload metrics",
-            "script": "flutter/testing/benchmark/upload_metrics.sh"
+            "script": "flutter/testing/benchmark/upload_metrics.sh",
+            "parameters": [
+                "ci/host_release_benchmarks"
+            ]
         }
     ]
 }

--- a/ci/builders/standalone/windows_unopt.json
+++ b/ci/builders/standalone/windows_unopt.json
@@ -14,6 +14,8 @@
         }
     ],
     "gn": [
+        "--target-dir",
+        "ci/host_debug_unopt",
         "--runtime-mode",
         "debug",
         "--unoptimized",
@@ -21,9 +23,9 @@
         "--rbe",
         "--no-goma"
     ],
-    "name": "host_debug_unopt",
+    "name": "ci\\host_debug_unopt",
     "ninja": {
-        "config": "host_debug_unopt"
+        "config": "ci/host_debug_unopt"
     },
     "tests": [
         {
@@ -32,7 +34,7 @@
             "script": "flutter/testing/run_tests.py",
             "parameters": [
                 "--variant",
-                "host_debug_unopt",
+                "ci/host_debug_unopt",
                 "--type",
                 "engine",
                 "--engine-capture-core-dump"

--- a/ci/builders/windows_android_aot_engine.json
+++ b/ci/builders/windows_android_aot_engine.json
@@ -3,12 +3,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_profile/zip_archives/",
+                    "base_path": "out/ci/android_profile/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_profile/zip_archives/android-arm-profile/windows-x64.zip"
+                        "out/ci/android_profile/zip_archives/android-arm-profile/windows-x64.zip"
                     ],
-                    "name": "android_profile",
+                    "name": "ci/android_profile",
                     "realm": "production"
                 }
             ],
@@ -20,15 +20,17 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_profile",
                 "--runtime-mode",
                 "profile",
                 "--android",
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "android_profile",
+            "name": "ci\\android_profile",
             "ninja": {
-                "config": "android_profile",
+                "config": "ci/android_profile",
                 "targets": [
                     "flutter/build/archives:archive_win_gen_snapshot"
                 ]
@@ -37,12 +39,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_profile_arm64/zip_archives/",
+                    "base_path": "out/ci/android_profile_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_profile_arm64/zip_archives/android-arm64-profile/windows-x64.zip"
+                        "out/ci/android_profile_arm64/zip_archives/android-arm64-profile/windows-x64.zip"
                     ],
-                    "name": "android_profile_arm64",
+                    "name": "ci/android_profile_arm64",
                     "realm": "production"
                 }
             ],
@@ -54,6 +56,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_profile_arm64",
                 "--runtime-mode",
                 "profile",
                 "--android",
@@ -61,9 +65,9 @@
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "android_profile_arm64",
+            "name": "ci\\android_profile_arm64",
             "ninja": {
-                "config": "android_profile_arm64",
+                "config": "ci/android_profile_arm64",
                 "targets": [
                     "flutter/build/archives:archive_win_gen_snapshot"
                 ]
@@ -72,12 +76,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_profile_x64/zip_archives/",
+                    "base_path": "out/ci/android_profile_x64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_profile_x64/zip_archives/android-x64-profile/windows-x64.zip"
+                        "out/ci/android_profile_x64/zip_archives/android-x64-profile/windows-x64.zip"
                     ],
-                    "name": "android_profile_x64",
+                    "name": "ci/android_profile_x64",
                     "realm": "production"
                 }
             ],
@@ -89,6 +93,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_profile_x64",
                 "--runtime-mode",
                 "profile",
                 "--android",
@@ -96,9 +102,9 @@
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "android_profile_x64",
+            "name": "ci\\android_profile_x64",
             "ninja": {
-                "config": "android_profile_x64",
+                "config": "ci/android_profile_x64",
                 "targets": [
                     "flutter/build/archives:archive_win_gen_snapshot"
                 ]
@@ -107,12 +113,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_release/zip_archives/",
+                    "base_path": "out/ci/android_release/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_release/zip_archives/android-arm-release/windows-x64.zip"
+                        "out/ci/android_release/zip_archives/android-arm-release/windows-x64.zip"
                     ],
-                    "name": "android_release",
+                    "name": "ci/android_release",
                     "realm": "production"
                 }
             ],
@@ -124,15 +130,17 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_release",
                 "--runtime-mode",
                 "release",
                 "--android",
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "android_release",
+            "name": "ci\\android_release",
             "ninja": {
-                "config": "android_release",
+                "config": "ci/android_release",
                 "targets": [
                     "flutter/build/archives:archive_win_gen_snapshot"
                 ]
@@ -141,12 +149,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_release_arm64/zip_archives/",
+                    "base_path": "out/ci/android_release_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_release_arm64/zip_archives/android-arm64-release/windows-x64.zip"
+                        "out/ci/android_release_arm64/zip_archives/android-arm64-release/windows-x64.zip"
                     ],
-                    "name": "android_release_arm64",
+                    "name": "ci/android_release_arm64",
                     "realm": "production"
                 }
             ],
@@ -158,6 +166,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_release_arm64",
                 "--runtime-mode",
                 "release",
                 "--android",
@@ -165,9 +175,9 @@
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "android_release_arm64",
+            "name": "ci\\android_release_arm64",
             "ninja": {
-                "config": "android_release_arm64",
+                "config": "ci/android_release_arm64",
                 "targets": [
                     "flutter/build/archives:archive_win_gen_snapshot"
                 ]
@@ -176,12 +186,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/android_release_x64/zip_archives/",
+                    "base_path": "out/ci/android_release_x64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/android_release_x64/zip_archives/android-x64-release/windows-x64.zip"
+                        "out/ci/android_release_x64/zip_archives/android-x64-release/windows-x64.zip"
                     ],
-                    "name": "android_release_x64",
+                    "name": "ci/android_release_x64",
                     "realm": "production"
                 }
             ],
@@ -193,6 +203,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/android_release_x64",
                 "--runtime-mode",
                 "release",
                 "--android",
@@ -200,9 +212,9 @@
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "android_release_x64",
+            "name": "ci\\android_release_x64",
             "ninja": {
-                "config": "android_release_x64",
+                "config": "ci/android_release_x64",
                 "targets": [
                     "flutter/build/archives:archive_win_gen_snapshot"
                 ]

--- a/ci/builders/windows_arm_host_engine.json
+++ b/ci/builders/windows_arm_host_engine.json
@@ -3,17 +3,17 @@
         {
             "archives": [
                 {
-                    "base_path": "out/host_debug_arm64/zip_archives/",
+                    "base_path": "out/ci/host_debug_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_debug_arm64/zip_archives/windows-arm64/artifacts.zip",
-                        "out/host_debug_arm64/zip_archives/windows-arm64/windows-arm64-embedder.zip",
-                        "out/host_debug_arm64/zip_archives/windows-arm64/font-subset.zip",
-                        "out/host_debug_arm64/zip_archives/dart-sdk-windows-arm64.zip",
-                        "out/host_debug_arm64/zip_archives/windows-arm64-debug/windows-arm64-flutter.zip",
-                        "out/host_debug_arm64/zip_archives/windows-arm64/flutter-cpp-client-wrapper.zip"
+                        "out/ci/host_debug_arm64/zip_archives/windows-arm64/artifacts.zip",
+                        "out/ci/host_debug_arm64/zip_archives/windows-arm64/windows-arm64-embedder.zip",
+                        "out/ci/host_debug_arm64/zip_archives/windows-arm64/font-subset.zip",
+                        "out/ci/host_debug_arm64/zip_archives/dart-sdk-windows-arm64.zip",
+                        "out/ci/host_debug_arm64/zip_archives/windows-arm64-debug/windows-arm64-flutter.zip",
+                        "out/ci/host_debug_arm64/zip_archives/windows-arm64/flutter-cpp-client-wrapper.zip"
                     ],
-                    "name": "host_debug_arm64",
+                    "name": "ci/host_debug_arm64",
                     "realm": "production"
                 }
             ],
@@ -26,6 +26,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/host_debug_arm64",
                 "--runtime-mode",
                 "debug",
                 "--no-lto",
@@ -34,9 +36,9 @@
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "host_debug_arm64",
+            "name": "ci\\host_debug_arm64",
             "ninja": {
-                "config": "host_debug_arm64",
+                "config": "ci/host_debug_arm64",
                 "targets": [
                     "flutter/build/archives:artifacts",
                     "flutter/build/archives:embedder",
@@ -50,12 +52,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/host_profile_arm64/zip_archives/",
+                    "base_path": "out/ci/host_profile_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_profile_arm64/zip_archives/windows-arm64-profile/windows-arm64-flutter.zip"
+                        "out/ci/host_profile_arm64/zip_archives/windows-arm64-profile/windows-arm64-flutter.zip"
                     ],
-                    "name": "host_profile_arm64",
+                    "name": "ci/host_profile_arm64",
                     "realm": "production"
                 }
             ],
@@ -68,6 +70,8 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/host_profile_arm64",
                 "--runtime-mode",
                 "profile",
                 "--no-lto",
@@ -76,9 +80,9 @@
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "host_profile_arm64",
+            "name": "ci\\host_profile_arm64",
             "ninja": {
-                "config": "host_profile_arm64",
+                "config": "ci/host_profile_arm64",
                 "targets": [
                     "windows",
                     "gen_snapshot",
@@ -89,12 +93,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/host_release_arm64/zip_archives/",
+                    "base_path": "out/ci/host_release_arm64/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_release_arm64/zip_archives/windows-arm64-release/windows-arm64-flutter.zip"
+                        "out/ci/host_release_arm64/zip_archives/windows-arm64-release/windows-arm64-flutter.zip"
                     ],
-                    "name": "host_profile_arm64",
+                    "name": "ci/host_profile_arm64",
                     "realm": "production"
                 }
             ],
@@ -108,6 +112,8 @@
             },
             "generators": {},
             "gn": [
+                "--target-dir",
+                "ci/host_release_arm64",
                 "--runtime-mode",
                 "release",
                 "--no-lto",
@@ -116,9 +122,9 @@
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "host_release_arm64",
+            "name": "ci\\host_release_arm64",
             "ninja": {
-                "config": "host_release_arm64",
+                "config": "ci/host_release_arm64",
                 "targets": [
                     "windows",
                     "gen_snapshot",

--- a/ci/builders/windows_host_engine.json
+++ b/ci/builders/windows_host_engine.json
@@ -3,17 +3,17 @@
         {
             "archives": [
                 {
-                    "base_path": "out/host_debug/zip_archives/",
+                    "base_path": "out/ci/host_debug/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_debug/zip_archives/windows-x64/artifacts.zip",
-                        "out/host_debug/zip_archives/windows-x64/windows-x64-embedder.zip",
-                        "out/host_debug/zip_archives/windows-x64/font-subset.zip",
-                        "out/host_debug/zip_archives/dart-sdk-windows-x64.zip",
-                        "out/host_debug/zip_archives/windows-x64-debug/windows-x64-flutter.zip",
-                        "out/host_debug/zip_archives/windows-x64/flutter-cpp-client-wrapper.zip"
+                        "out/ci/host_debug/zip_archives/windows-x64/artifacts.zip",
+                        "out/ci/host_debug/zip_archives/windows-x64/windows-x64-embedder.zip",
+                        "out/ci/host_debug/zip_archives/windows-x64/font-subset.zip",
+                        "out/ci/host_debug/zip_archives/dart-sdk-windows-x64.zip",
+                        "out/ci/host_debug/zip_archives/windows-x64-debug/windows-x64-flutter.zip",
+                        "out/ci/host_debug/zip_archives/windows-x64/flutter-cpp-client-wrapper.zip"
                     ],
-                    "name": "host_debug",
+                    "name": "ci/host_debug",
                     "realm": "production"
                 }
             ],
@@ -26,15 +26,17 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/host_debug",
                 "--runtime-mode",
                 "debug",
                 "--no-lto",
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "host_debug",
+            "name": "ci\\host_debug",
             "ninja": {
-                "config": "host_debug",
+                "config": "ci/host_debug",
                 "targets": [
                     "flutter:unittests",
                     "flutter/build/archives:artifacts",
@@ -52,7 +54,7 @@
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
                         "--variant",
-                        "host_debug",
+                        "ci/host_debug",
                         "--type",
                         "engine"
                     ]
@@ -62,12 +64,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/host_profile/zip_archives/",
+                    "base_path": "out/ci/host_profile/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_profile/zip_archives/windows-x64-profile/windows-x64-flutter.zip"
+                        "out/ci/host_profile/zip_archives/windows-x64-profile/windows-x64-flutter.zip"
                     ],
-                    "name": "host_profile",
+                    "name": "ci/host_profile",
                     "realm": "production"
                 }
             ],
@@ -80,15 +82,17 @@
                 "use_rbe": true
             },
             "gn": [
+                "--target-dir",
+                "ci/host_profile",
                 "--runtime-mode",
                 "profile",
                 "--no-lto",
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "host_profile",
+            "name": "ci\\host_profile",
             "ninja": {
-                "config": "host_profile",
+                "config": "ci/host_profile",
                 "targets": [
                     "windows",
                     "gen_snapshot",
@@ -99,12 +103,12 @@
         {
             "archives": [
                 {
-                    "base_path": "out/host_release/zip_archives/",
+                    "base_path": "out/ci/host_release/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/host_release/zip_archives/windows-x64-release/windows-x64-flutter.zip"
+                        "out/ci/host_release/zip_archives/windows-x64-release/windows-x64-flutter.zip"
                     ],
-                    "name": "host_release",
+                    "name": "ci/host_release",
                     "realm": "production"
                 }
             ],
@@ -118,15 +122,17 @@
             },
             "generators": {},
             "gn": [
+                "--target-dir",
+                "ci/host_release",
                 "--runtime-mode",
                 "release",
                 "--no-lto",
                 "--no-goma",
                 "--rbe"
             ],
-            "name": "host_release",
+            "name": "ci\\host_release",
             "ninja": {
-                "config": "host_release",
+                "config": "ci/host_release",
                 "targets": [
                     "windows",
                     "gen_snapshot",

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -101,8 +101,7 @@ source_set("skia") {
 }
 
 dart_snapshot_kernel("vmservice_kernel") {
-  dart_main =
-      rebase_path("//flutter/shell/vmservice/empty.dart", root_build_dir)
+  dart_main = "//flutter/shell/vmservice/empty.dart"
   dart_kernel = "$target_gen_dir/assets/vmservice_kernel.bin"
 }
 

--- a/testing/benchmark/generate_metrics.sh
+++ b/testing/benchmark/generate_metrics.sh
@@ -4,17 +4,19 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 #
-# This script expects $ENGINE_PATH to be set. It is currently used only
+# This script expects ${ENGINE_PATH} to be set. It is currently used only
 # by automation to collect and upload metrics.
 
 set -ex
 
-$ENGINE_PATH/src/out/host_release/txt_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/txt_benchmarks.json
-$ENGINE_PATH/src/out/host_release/fml_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/fml_benchmarks.json
-$ENGINE_PATH/src/out/host_release/shell_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/shell_benchmarks.json
-$ENGINE_PATH/src/out/host_release/ui_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/ui_benchmarks.json
-$ENGINE_PATH/src/out/host_release/display_list_builder_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/display_list_builder_benchmarks.json
-$ENGINE_PATH/src/out/host_release/display_list_region_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/display_list_region_benchmarks.json
-$ENGINE_PATH/src/out/host_release/display_list_transform_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/display_list_transform_benchmarks.json
-$ENGINE_PATH/src/out/host_release/geometry_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/geometry_benchmarks.json
-$ENGINE_PATH/src/out/host_release/canvas_benchmarks --benchmark_format=json > $ENGINE_PATH/src/out/host_release/canvas_benchmarks.json
+VARIANT=$1
+
+${ENGINE_PATH}/src/out/${VARIANT}/txt_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/txt_benchmarks.json
+${ENGINE_PATH}/src/out/${VARIANT}/fml_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/fml_benchmarks.json
+${ENGINE_PATH}/src/out/${VARIANT}/shell_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/shell_benchmarks.json
+${ENGINE_PATH}/src/out/${VARIANT}/ui_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/ui_benchmarks.json
+${ENGINE_PATH}/src/out/${VARIANT}/display_list_builder_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/display_list_builder_benchmarks.json
+${ENGINE_PATH}/src/out/${VARIANT}/display_list_region_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/display_list_region_benchmarks.json
+${ENGINE_PATH}/src/out/${VARIANT}/display_list_transform_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/display_list_transform_benchmarks.json
+${ENGINE_PATH}/src/out/${VARIANT}/geometry_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/geometry_benchmarks.json
+${ENGINE_PATH}/src/out/${VARIANT}/canvas_benchmarks --benchmark_format=json > ${ENGINE_PATH}/src/out/${VARIANT}/canvas_benchmarks.json

--- a/testing/benchmark/upload_metrics.sh
+++ b/testing/benchmark/upload_metrics.sh
@@ -43,22 +43,25 @@ SRC_DIR="$(cd "$SCRIPT_DIR/../../.."; pwd -P)"
 DART_BIN=$(dart_bin "$SRC_DIR")
 DART="${DART_BIN}/dart"
 
+VARIANT=$1
+shift 1
+
 cd "$SCRIPT_DIR"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
-  --json $ENGINE_PATH/src/out/host_release/txt_benchmarks.json "$@"
+  --json $ENGINE_PATH/src/out/${VARIANT}/txt_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
-  --json $ENGINE_PATH/src/out/host_release/fml_benchmarks.json "$@"
+  --json $ENGINE_PATH/src/out/${VARIANT}/fml_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
-  --json $ENGINE_PATH/src/out/host_release/shell_benchmarks.json "$@"
+  --json $ENGINE_PATH/src/out/${VARIANT}/shell_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
-  --json $ENGINE_PATH/src/out/host_release/ui_benchmarks.json "$@"
+  --json $ENGINE_PATH/src/out/${VARIANT}/ui_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
-  --json $ENGINE_PATH/src/out/host_release/display_list_builder_benchmarks.json "$@"
+  --json $ENGINE_PATH/src/out/${VARIANT}/display_list_builder_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
-  --json $ENGINE_PATH/src/out/host_release/display_list_region_benchmarks.json "$@"
+  --json $ENGINE_PATH/src/out/${VARIANT}/display_list_region_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
-  --json $ENGINE_PATH/src/out/host_release/display_list_transform_benchmarks.json "$@"
+  --json $ENGINE_PATH/src/out/${VARIANT}/display_list_transform_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
-  --json $ENGINE_PATH/src/out/host_release/geometry_benchmarks.json "$@"
+  --json $ENGINE_PATH/src/out/${VARIANT}/geometry_benchmarks.json "$@"
 "$DART" --disable-dart-dev bin/parse_and_send.dart \
-  --json $ENGINE_PATH/src/out/host_release/canvas_benchmarks.json "$@"
+  --json $ENGINE_PATH/src/out/${VARIANT}/canvas_benchmarks.json "$@"

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -55,7 +55,7 @@ tests = [
 
 foreach(test, tests) {
   flutter_build_dir = rebase_path("$root_gen_dir")
-  flutter_src_dir = rebase_path("$root_out_dir/../../flutter")
+  flutter_src_dir = rebase_path("//flutter")
   skia_gold_work_dir = rebase_path("$root_gen_dir/skia_gold_$test")
   flutter_frontend_server("compile_$test") {
     main_dart = test

--- a/testing/fuchsia/run_tests.py
+++ b/testing/fuchsia/run_tests.py
@@ -142,7 +142,7 @@ if __name__ == '__main__':
   logging.basicConfig(level=logging.INFO)
   logging.info('Running tests in %s', OUT_DIR)
   sys.argv.append('--out-dir=' + OUT_DIR)
-  if VARIANT.endswith('_arm64'):
+  if VARIANT.endswith('_arm64') or VARIANT.endswith('_arm64_tester'):
     sys.argv.append('--product=terminal.qemu-arm64')
   # The 'flutter-test-type' is a place holder and has no specific meaning; the
   # _get_test_runner is overrided.

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -1326,7 +1326,12 @@ Flutter Wiki page on the subject: https://github.com/flutter/flutter/wiki/Testin
     run_engine_benchmarks(build_dir, engine_filter)
 
   variants_to_skip = ['host_release', 'host_profile']
-  if ('engine' in types or 'font-subset' in types) and args.variant not in variants_to_skip:
+
+  def should_skip(variant):
+    matches = [variant for variant in variants_to_skip if variant in args.variant]
+    return len(matches) > 0
+
+  if ('engine' in types or 'font-subset' in types) and not should_skip(args.variant):
     cmd = ['python3', 'test.py', '--variant', args.variant]
     if 'arm64' in args.variant:
       cmd += ['--target-cpu', 'arm64']

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -213,6 +213,7 @@ Future<int> main(List<String> args) async {
   test('clang-tidy specified', () async {
     _withTempFile('shard-id-valid', (String path) {
       final Options options = Options.fromCommandLine( <String>[
+          '--compile-commands=$path',
           '--clang-tidy=foo/bar',
         ],);
       expect(options.clangTidyPath, isNotNull);

--- a/tools/clangd_check/bin/main.dart
+++ b/tools/clangd_check/bin/main.dart
@@ -58,10 +58,11 @@ void main(List<String> args) {
   final String checkFile;
   if (entry case {
     'command': final String command,
+    'directory': final String directory,
     'file': final String file,
   }) {
     // Given a path like ../../flutter/foo.cc, we want to check foo.cc.
-    checkFile = p.split(file).skip(3).join(p.separator);
+    checkFile = p.join(directory, file);
     // On CI, the command path is different from the local path.
     // Find the engine root and derive the clangd path from there.
     if (clangd == null) {

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -22,7 +22,7 @@ from gen_package import CreateFarPackage
 
 _script_dir = os.path.abspath(os.path.join(os.path.realpath(__file__), '..'))
 _src_root_dir = os.path.join(_script_dir, '..', '..', '..')
-_out_dir = os.path.join(_src_root_dir, 'out')
+_out_dir = os.path.join(_src_root_dir, 'out', 'ci')
 _bucket_directory = os.path.join(_out_dir, 'fuchsia_bucket')
 
 

--- a/tools/pkg/engine_build_configs/bin/check.dart
+++ b/tools/pkg/engine_build_configs/bin/check.dart
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' as io;
+import 'dart:io' as io show Directory, exitCode, stderr;
 
 import 'package:engine_build_configs/engine_build_configs.dart';
 import 'package:engine_repo_tools/engine_repo_tools.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 
 // Usage:
 // $ dart bin/check.dart [/path/to/engine/src]
@@ -55,30 +56,102 @@ void main(List<String> args) {
   }
 
   // Check the parsed build configs for validity.
+  final List<String> invalidErrors = checkForInvalidConfigs(configs);
+  if (invalidErrors.isNotEmpty) {
+    invalidErrors.forEach(io.stderr.writeln);
+    io.exitCode = 1;
+  }
+
+  // We require all builds within a builder config to be uniquely named.
+  final List<String> duplicateErrors = checkForDuplicateConfigs(configs);
+  if (duplicateErrors.isNotEmpty) {
+    duplicateErrors.forEach(io.stderr.writeln);
+    io.exitCode = 1;
+  }
+
+  // We require all builds to be named in a way that is understood by et.
+  final List<String> buildNameErrors = checkForInvalidBuildNames(configs);
+  if (buildNameErrors.isNotEmpty) {
+    buildNameErrors.forEach(io.stderr.writeln);
+    io.exitCode = 1;
+  }
+}
+
+// This check ensures that all the json files were deserialized without errors.
+List<String> checkForInvalidConfigs(Map<String, BuilderConfig> configs) {
+  final List<String> errors = <String>[];
   for (final String name in configs.keys) {
     final BuilderConfig buildConfig = configs[name]!;
     final List<String> buildConfigErrors = buildConfig.check(name);
     if (buildConfigErrors.isNotEmpty) {
-      io.stderr.writeln('Errors in ${buildConfig.path}:');
-      io.exitCode = 1;
+      errors.add('Errors in ${buildConfig.path}:');
     }
     for (final String error in buildConfigErrors) {
-      io.stderr.writeln('    $error');
-      io.exitCode = 1;
+      errors.add('    $error');
     }
   }
+  return errors;
+}
 
-  // We require all builds within a builder config to be uniquely named.
+// Thjs check ensures that json files do not contain builds with duplicate
+// names.
+List<String> checkForDuplicateConfigs(Map<String, BuilderConfig> configs) {
+  final List<String> errors = <String>[];
   final Map<String, Set<String>> builderBuildSet = <String, Set<String>>{};
+  _forEachBuild(configs, (String name, BuilderConfig config, Build build) {
+    final Set<String> builds = builderBuildSet.putIfAbsent(name, () => <String>{});
+    if (builds.contains(build.name)) {
+      errors.add('${build.name} is duplicated in $name\n');
+    } else {
+      builds.add(build.name);
+    }
+  });
+  return errors;
+}
+
+// This check ensures that builds are named in a way that is understood by
+// `et`.
+List<String> checkForInvalidBuildNames(Map<String, BuilderConfig> configs) {
+  final List<String> errors = <String>[];
+
+  // In local_engine.json, allowed OS names are linux, macos, and windows.
+  final List<String> osNames = <String>[
+    Platform.linux, Platform.macOS, Platform.windows,
+  ].expand((String s) => <String>['$s/', '$s\\']).toList();
+
+  // In all other build json files, allowed prefix names are ci and web_tests.
+  final List<String> ciNames = <String>[
+    'ci', 'web_tests'
+  ].expand((String s) => <String>['$s/', '$s\\']).toList();
+
+  _forEachBuild(configs, (String name, BuilderConfig config, Build build) {
+    final List<String> goodPrefixes = name.contains('local_engine')
+      ? osNames
+      : ciNames;
+    if (!goodPrefixes.any(build.name.startsWith)) {
+      if (name.contains('local_engine')) {
+        // TODO(zanderso): Check these builds as well after local_engine is
+        // fixed.
+        // https://github.com/flutter/flutter/issues/145263
+        return;
+      }
+      errors.add(
+        '${build.name} in $name must start with one of '
+        '{${goodPrefixes.join(', ')}}',
+      );
+    }
+  });
+  return errors;
+}
+
+void _forEachBuild(
+  Map<String, BuilderConfig> configs,
+  void Function(String configName, BuilderConfig config, Build build) fn,
+) {
   for (final String builderName in configs.keys) {
     final BuilderConfig builderConfig = configs[builderName]!;
-    final Set<String> builds =
-        builderBuildSet.putIfAbsent(builderName, () => <String>{});
     for (final Build build in builderConfig.builds) {
-      if (builds.contains(build.name)) {
-        io.stderr.writeln('${build.name} is duplicated in $builderName\n');
-        io.exitCode = 1;
-      }
+      fn(builderName, builderConfig, build);
     }
   }
 }


### PR DESCRIPTION
Part 1 of https://github.com/flutter/flutter/issues/145263

This PR updates the names of builds outside of `local_engine.json` to be prefixed with the string `ci/` (or `ci\` on Windows). For better or worse, the "name" field of a build is used to construct a path used as the source directory of a copy operation (I think the CAS archive step?). Because of that, changing the name of a build also requires updating the build output directory of the ninja build.

This PR also adds tests to make sure the naming of these builds remains consistent.