### PR TITLE
font_subset tests: name correct variant in exception

### DIFF
--- a/tools/font_subset/test.py
+++ b/tools/font_subset/test.py
@@ -180,8 +180,7 @@ def main():
   )
   if not os.path.isfile(font_subset):
     raise Exception(
-        'Could not locate font-subset%s in host_debug or host_debug_unopt - build before running this script.'
-        % exe
+        'Could not locate font-subset%s in %s - build before running this script.' % (exe, variant)
     )
 
   print('Using font subset binary at %s (%s)' % (font_subset, font_subset_zip))


### PR DESCRIPTION
font_subset tests now respect `--variant`, but the exception message hasn't been changed

*List which issues are fixed by this PR. You must list at least one issue.*
closes https://github.com/flutter/flutter/issues/145412

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
