### PR TITLE
Fix slash in chromium path.

### DIFF
--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -504,7 +504,7 @@ class BrowserPlatform extends PlatformPlugin {
         extension == '.mjs' ||
         extension == '.html';
       return shelf.Response.ok(
-        fileInDirectory.readAsBytesSync(),
+        fileInDirectory.openRead(),
         headers: <String, Object>{
           HttpHeaders.contentTypeHeader: contentType,
           if (isScript && needsCrossOriginIsolated)

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -485,7 +485,7 @@ class BrowserPlatform extends PlatformPlugin {
         request.url.path,
       ));
 
-      if (!fileInDirectory.existsSync()) {
+      if (request.url.path.contains('//') || !fileInDirectory.existsSync()) {
         return shelf.Response.notFound('File not found: ${request.url.path}');
       }
 
@@ -504,7 +504,7 @@ class BrowserPlatform extends PlatformPlugin {
         extension == '.mjs' ||
         extension == '.html';
       return shelf.Response.ok(
-        fileInDirectory.openRead(),
+        fileInDirectory.readAsBytesSync(),
         headers: <String, Object>{
           HttpHeaders.contentTypeHeader: contentType,
           if (isScript && needsCrossOriginIsolated)

--- a/lib/web_ui/flutter_js/src/canvaskit_loader.js
+++ b/lib/web_ui/flutter_js/src/canvaskit_loader.js
@@ -17,7 +17,7 @@ export const loadCanvasKit = (deps, config, browserEnvironment, engineRevision) 
     const useChromiumCanvasKit = supportsChromiumCanvasKit && (config.canvasKitVariant !== "full");
     let baseUrl = config.canvasKitBaseUrl ?? `https://www.gstatic.com/flutter-canvaskit/${engineRevision}/`;
     if (useChromiumCanvasKit) {
-      baseUrl = `${baseUrl}/chromium/`;
+      baseUrl = `${baseUrl}chromium/`;
     }
     let canvasKitUrl = `${baseUrl}canvaskit.js`;
     if (deps.flutterTT.policy) {


### PR DESCRIPTION
The previous code here introduced an extra slash. Our test platform was tolerant to this extra slash and essentially ignored it, but this probably won't work for most hosting solutions. I went ahead and added some extra validation to the URL when fetching so that we won't serve URLs that have the double slash in their path, in order to catch this if it regresses again.