### PR TITLE
Add the platform isolate API to the files included in the sky_engine package

### DIFF
--- a/lib/ui/dart_ui.gni
+++ b/lib/ui/dart_ui.gni
@@ -16,6 +16,7 @@ dart_ui_files = [
   "//flutter/lib/ui/natives.dart",
   "//flutter/lib/ui/painting.dart",
   "//flutter/lib/ui/platform_dispatcher.dart",
+  "//flutter/lib/ui/platform_isolate.dart",
   "//flutter/lib/ui/plugins.dart",
   "//flutter/lib/ui/pointer.dart",
   "//flutter/lib/ui/semantics.dart",


### PR DESCRIPTION
This makes the API available to Flutter framework users.

See https://github.com/flutter/flutter/issues/136314