### PR TITLE
[Fuchsia] Assert renders are only to the implicit view

### DIFF
--- a/shell/platform/fuchsia/flutter/external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/external_view_embedder.cc
@@ -115,6 +115,10 @@ void ExternalViewEmbedder::BeginFrame(
 void ExternalViewEmbedder::PrepareFlutterView(int64_t flutter_view_id,
                                               SkISize frame_size,
                                               double device_pixel_ratio) {
+  // TODO(team-fuchsia): Support multiple views. For now, Fuchsia can render
+  // only into the implicit view.
+  FML_DCHECK(flutter_view_id == kFlutterImplicitViewId);
+
   // Reset for new view.
   Reset();
   frame_size_ = frame_size;

--- a/shell/platform/fuchsia/flutter/external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/external_view_embedder.cc
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 #include "external_view_embedder.h"
+
 #include <algorithm>
 #include <cstdint>
 
+#include "flutter/common/constants.h"
 #include "flutter/fml/trace_event.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSurface.h"

--- a/shell/platform/fuchsia/flutter/external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/external_view_embedder.cc
@@ -117,8 +117,7 @@ void ExternalViewEmbedder::BeginFrame(
 void ExternalViewEmbedder::PrepareFlutterView(int64_t flutter_view_id,
                                               SkISize frame_size,
                                               double device_pixel_ratio) {
-  // TODO(team-fuchsia): Support multiple views. For now, Fuchsia can render
-  // only into the implicit view.
+  // Fuchsia only supports operating the implicit view for now.
   FML_DCHECK(flutter_view_id == flutter::kFlutterImplicitViewId);
 
   // Reset for new view.

--- a/shell/platform/fuchsia/flutter/external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/external_view_embedder.cc
@@ -119,7 +119,7 @@ void ExternalViewEmbedder::PrepareFlutterView(int64_t flutter_view_id,
                                               double device_pixel_ratio) {
   // TODO(team-fuchsia): Support multiple views. For now, Fuchsia can render
   // only into the implicit view.
-  FML_DCHECK(flutter_view_id == kFlutterImplicitViewId);
+  FML_DCHECK(flutter_view_id == flutter::kFlutterImplicitViewId);
 
   // Reset for new view.
   Reset();


### PR DESCRIPTION
Fuchsia does not support multiple view rendering yet. This asserts only the implicit view is rendered to, to mirror the existing Android and iOS assertion.

Prepares for:
1. https://github.com/flutter/flutter/issues/144806
1. https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
