### PR TITLE
[Embedder API] Fix test helper's present callback registration

### DIFF
--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -377,14 +377,6 @@ void EmbedderConfigBuilder::SetCompositor(bool avoid_backing_store_cache,
             ->CollectBackingStore(backing_store);
       };
   if (use_present_layers_callback) {
-    compositor_.present_view_callback = [](const FlutterPresentViewInfo* info) {
-      auto compositor =
-          reinterpret_cast<EmbedderTestCompositor*>(info->user_data);
-
-      return compositor->Present(info->view_id, info->layers,
-                                 info->layers_count);
-    };
-  } else {
     compositor_.present_layers_callback = [](const FlutterLayer** layers,
                                              size_t layers_count,
                                              void* user_data) {
@@ -393,6 +385,14 @@ void EmbedderConfigBuilder::SetCompositor(bool avoid_backing_store_cache,
       // The present layers callback is incompatible with multiple views;
       // it can only be used to render the implicit view.
       return compositor->Present(kFlutterImplicitViewId, layers, layers_count);
+    };
+  } else {
+    compositor_.present_view_callback = [](const FlutterPresentViewInfo* info) {
+      auto compositor =
+          reinterpret_cast<EmbedderTestCompositor*>(info->user_data);
+
+      return compositor->Present(info->view_id, info->layers,
+                                 info->layers_count);
     };
   }
   compositor_.avoid_backing_store_cache = avoid_backing_store_cache;


### PR DESCRIPTION
https://github.com/flutter/engine/pull/51293 added a new present callback that supports multiple views. However, the test helper incorrectly inversed the single-view and multi-view present callbacks. This didn't affect the existing tests as we don't any multi-view tests yet.

Prepares for https://github.com/flutter/flutter/issues/144810

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exexpt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
