### PR TITLE
[Windows] Allow view controllers to not own the engine

### DIFF
--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -72,18 +72,24 @@ static FlutterDesktopTextureRegistrarRef HandleForTextureRegistrar(
   return reinterpret_cast<FlutterDesktopTextureRegistrarRef>(registrar);
 }
 
-FlutterDesktopViewControllerRef FlutterDesktopViewControllerCreate(
+// Creates a view controller that might own the engine.
+static FlutterDesktopViewControllerRef CreateViewController(
+    FlutterDesktopEngineRef engine_ref,
     int width,
     int height,
-    FlutterDesktopEngineRef engine_ref) {
+    bool owns_engine) {
   flutter::FlutterWindowsEngine* engine_ptr = EngineFromHandle(engine_ref);
   std::unique_ptr<flutter::WindowBindingHandler> window_wrapper =
       std::make_unique<flutter::FlutterWindow>(
           width, height, engine_ptr->windows_proc_table());
 
-  auto engine = std::unique_ptr<flutter::FlutterWindowsEngine>(engine_ptr);
+  std::unique_ptr<flutter::FlutterWindowsEngine> engine;
+  if (owns_engine) {
+    engine = std::unique_ptr<flutter::FlutterWindowsEngine>(engine_ptr);
+  }
+
   std::unique_ptr<flutter::FlutterWindowsView> view =
-      engine->CreateView(std::move(window_wrapper));
+      engine_ptr->CreateView(std::move(window_wrapper));
   auto controller = std::make_unique<flutter::FlutterWindowsViewController>(
       std::move(engine), std::move(view));
 
@@ -103,6 +109,20 @@ FlutterDesktopViewControllerRef FlutterDesktopViewControllerCreate(
   controller->engine()->UpdateAccessibilityFeatures();
 
   return HandleForViewController(controller.release());
+}
+
+FlutterDesktopViewControllerRef FlutterDesktopViewControllerCreate(
+    int width,
+    int height,
+    FlutterDesktopEngineRef engine) {
+  return CreateViewController(engine, width, height, /*owns_engine=*/true);
+}
+
+FlutterDesktopViewControllerRef FlutterDesktopEngineCreateViewController(
+    FlutterDesktopEngineRef engine,
+    const FlutterDesktopViewControllerProperties* properties) {
+  return CreateViewController(engine, properties->width, properties->height,
+                              /*owns_engine=*/false);
 }
 
 void FlutterDesktopViewControllerDestroy(FlutterDesktopViewControllerRef ref) {

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -73,6 +73,9 @@ static FlutterDesktopTextureRegistrarRef HandleForTextureRegistrar(
 }
 
 // Creates a view controller that might own the engine.
+//
+// If `owns_engine` is true, then the returned `FlutterDesktopViewControllerRef`
+// owns `engine_ref` and will deallocate `engine_ref` upon its own destruction.
 static FlutterDesktopViewControllerRef CreateViewController(
     FlutterDesktopEngineRef engine_ref,
     int width,

--- a/shell/platform/windows/flutter_windows_internal.h
+++ b/shell/platform/windows/flutter_windows_internal.h
@@ -14,6 +14,32 @@ extern "C" {
 // Declare functions that are currently in-progress and shall be exposed to the
 // public facing API upon completion.
 
+// Properties for configuring a Flutter view controller.
+typedef struct {
+  // The view's initial width.
+  int width;
+
+  // The view's initial height.
+  int height;
+
+} FlutterDesktopViewControllerProperties;
+
+// Creates a view for the given engine.
+//
+// The |engine| will be started if it is not already running.
+//
+// The caller owns the returned reference, and is responsible for calling
+// |FlutterDesktopViewControllerDestroy|. Returns a null pointer in the event of
+// an error.
+//
+// Unlike |FlutterDesktopViewControllerCreate|, this does *not* take ownership
+// of |engine| and |FlutterDesktopEngineDestroy| must be called to destroy
+// the engine.
+FLUTTER_EXPORT FlutterDesktopViewControllerRef
+FlutterDesktopEngineCreateViewController(
+    FlutterDesktopEngineRef engine,
+    const FlutterDesktopViewControllerProperties* properties);
+
 typedef int64_t PlatformViewId;
 
 typedef struct {

--- a/shell/platform/windows/flutter_windows_internal.h
+++ b/shell/platform/windows/flutter_windows_internal.h
@@ -21,7 +21,6 @@ typedef struct {
 
   // The view's initial height.
   int height;
-
 } FlutterDesktopViewControllerProperties;
 
 // Creates a view for the given engine.

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -120,6 +120,27 @@ TEST_F(WindowsTest, LaunchHeadlessEngine) {
   ASSERT_NE(engine, nullptr);
 }
 
+// Verify that the engine can return to headless mode.
+TEST_F(WindowsTest, EngineCanTransitionToHeadless) {
+  auto& context = GetContext();
+  WindowsConfigBuilder builder(context);
+  EnginePtr engine{builder.RunHeadless()};
+  ASSERT_NE(engine, nullptr);
+
+  // Create and then destroy a view controller that does not own its engine.
+  // This causes the engine to transition back to headless mode.
+  {
+    FlutterDesktopViewControllerProperties properties = {};
+    ViewControllerPtr controller{
+        FlutterDesktopEngineCreateViewController(engine.get(), &properties)};
+
+    ASSERT_NE(controller, nullptr);
+  }
+
+  // The engine is back in headless mode now.
+  ASSERT_NE(engine, nullptr);
+}
+
 // Verify that accessibility features are initialized when a view is created.
 TEST_F(WindowsTest, LaunchRefreshesAccessibility) {
   auto& context = GetContext();

--- a/shell/platform/windows/flutter_windows_view_controller.h
+++ b/shell/platform/windows/flutter_windows_view_controller.h
@@ -19,11 +19,18 @@ class FlutterWindowsViewController {
                                std::unique_ptr<FlutterWindowsView> view)
       : engine_(std::move(engine)), view_(std::move(view)) {}
 
-  FlutterWindowsEngine* engine() { return engine_.get(); }
+  FlutterWindowsEngine* engine() { return view_->GetEngine(); }
   FlutterWindowsView* view() { return view_.get(); }
 
  private:
+  // The engine owned by this view controller, if any.
+  // This is only used if the view controller was created
+  // using |FlutterDesktopViewControllerCreate| as that takes
+  // ownership of the engine. View controllers created using
+  // |FlutterDesktopEngineCreateViewController| do not take
+  // ownership of the engine and do not set this.
   std::unique_ptr<FlutterWindowsEngine> engine_;
+
   std::unique_ptr<FlutterWindowsView> view_;
 };
 

--- a/shell/platform/windows/flutter_windows_view_controller.h
+++ b/shell/platform/windows/flutter_windows_view_controller.h
@@ -24,11 +24,15 @@ class FlutterWindowsViewController {
 
  private:
   // The engine owned by this view controller, if any.
-  // This is only used if the view controller was created
+  //
+  // This is used only if the view controller was created
   // using |FlutterDesktopViewControllerCreate| as that takes
-  // ownership of the engine. View controllers created using
-  // |FlutterDesktopEngineCreateViewController| do not take
-  // ownership of the engine and do not set this.
+  // ownership of the engine. Destroying this view controller
+  // also destroys the engine.
+  //
+  // View controllers created using |FlutterDesktopEngineCreateViewController|
+  // do not take ownership of the engine and this will be null. Destroying
+  // this view controller does not destroy the engine.
   std::unique_ptr<FlutterWindowsEngine> engine_;
 
   std::unique_ptr<FlutterWindowsView> view_;

--- a/shell/platform/windows/testing/windows_test_config_builder.cc
+++ b/shell/platform/windows/testing/windows_test_config_builder.cc
@@ -108,6 +108,8 @@ ViewControllerPtr WindowsConfigBuilder::Run() const {
 
   int width = 600;
   int height = 400;
+
+  // Create a view controller that owns the engine.
   ViewControllerPtr controller{
       FlutterDesktopViewControllerCreate(width, height, engine.release())};
   if (!controller) {

--- a/shell/platform/windows/testing/windows_test_config_builder.h
+++ b/shell/platform/windows/testing/windows_test_config_builder.h
@@ -71,7 +71,7 @@ class WindowsConfigBuilder {
   EnginePtr RunHeadless() const;
 
   // Returns a configured and initialized view controller that runs the
-  // configured Dart entrypoint.
+  // configured Dart entrypoint and owns its engine.
   //
   // Returns null on failure.
   ViewControllerPtr Run() const;


### PR DESCRIPTION
Adds `FlutterDesktopEngineCreateViewController` to the Windows embedder's C API. Example usage:

```cpp
// Create the engine.
FlutterDesktopEngineProperties engine_properties = {};
auto engine = FlutterDesktopEngineCreate(&engine_properties);

// Create a views controller.
FlutterDesktopViewControllerProperties properties = {};
properties.width = 400;
properties.height = 400;

auto controller = FlutterDesktopEngineCreateViewController(engine, &properties);

// Run app...

// Destroy the view controller. This does not destroy the engine. 
FlutterDesktopViewControllerDestroy(controller);

// Destroy the engine.
FlutterDesktopEngineDestroy(engine);
```

This new API creates a view controller that does **not** own the engine, unlike the existing `FlutterDesktopEngineCreateViewController`. In the future, this new API will allow a Windows app to have multiple views that share a single engine.

This API is in the `flutter_windows_internal.h`, making it "pubternal". This API is not in the public Windows header files, however, one can link against this API for testing purposes. This API will be promoted to the public Windows header files once the Windows embedder is ready to have multiple views.

Relevant design documents:
1. https://flutter.dev/go/desktop-multi-view-runner-apis
1. http://flutter.dev/go/windows-multi-view-ownership-updates

Relevant issues:
1. https://github.com/flutter/flutter/issues/143767
1. https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
