### PR TITLE
Post Dart message handling tasks directly to the platform task runner for isolates running on the platform thread

### DIFF
--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -470,7 +470,8 @@ class DartIsolate : public UIDartState {
   ///
   [[nodiscard]] bool Initialize(Dart_Isolate dart_isolate);
 
-  void SetMessageHandlingTaskRunner(const fml::RefPtr<fml::TaskRunner>& runner);
+  void SetMessageHandlingTaskRunner(const fml::RefPtr<fml::TaskRunner>& runner,
+                                    bool post_directly_to_runner);
 
   bool LoadKernel(const std::shared_ptr<const fml::Mapping>& mapping,
                   bool last_piece);

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -60,6 +60,12 @@ void invokePlatformTaskRunner() {
   PlatformDispatcher.instance.sendPlatformMessage('OhHi', null, null);
 }
 
+@pragma('vm:entry-point')
+void invokePlatformThreadIsolate() {
+  signalNativeTest();
+  runOnPlatformThread(ffiSignalNativeTest);
+}
+
 Float64List kTestTransform = () {
   final Float64List values = Float64List(16);
   values[0] = 1.0; // scaleX
@@ -86,6 +92,9 @@ external void notifySemanticsEnabled(bool enabled);
 external void notifyAccessibilityFeatures(bool reduceMotion);
 @pragma('vm:external-name', 'NotifySemanticsAction')
 external void notifySemanticsAction(int nodeId, int action, List<int> data);
+
+@ffi.Native<ffi.Void Function()>(symbol: 'FFISignalNativeTest')
+external void ffiSignalNativeTest();
 
 /// Returns a future that completes when
 /// `PlatformDispatcher.instance.onSemanticsEnabledChanged` fires.


### PR DESCRIPTION
Some embedders use a custom platform task runner that does not support fml::MessageLoopTaskQueues and may not have an fml::MessageLoop.

To support those embedders, DartIsolate::SetMessageHandlingTaskRunner will not use fml::MessageLoopTaskQueues for platform isolates.

See https://github.com/flutter/engine/pull/48551#issuecomment-1962190896