### PR TITLE
Initiating the switch to Impeller geometry classes in the engine

### DIFF
--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -60,6 +60,8 @@ source_set("display_list") {
     "effects/dl_path_effect.h",
     "effects/dl_runtime_effect.cc",
     "effects/dl_runtime_effect.h",
+    "geometry/dl_geometry_types.h",
+    "geometry/dl_geometry_types_skia_aliases.h",
     "geometry/dl_region.cc",
     "geometry/dl_region.h",
     "geometry/dl_rtree.cc",

--- a/display_list/geometry/dl_geometry_types.h
+++ b/display_list/geometry/dl_geometry_types.h
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_H_
+#define FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_H_
+
+// For now only the skia aliases implementation exists
+//
+// Soon, adapter class implementations will be added to ease the transition
+// from Skia to Impeller.
+//
+// Finally, Impeller aliases will be added and eventually be the one and only
+// final implementation.
+
+#include "flutter/display_list/geometry/dl_geometry_types_skia_aliases.h"
+
+#endif  // FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_H_

--- a/display_list/geometry/dl_geometry_types_skia_aliases.h
+++ b/display_list/geometry/dl_geometry_types_skia_aliases.h
@@ -1,0 +1,20 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_SKIA_ALIASES_H_
+#define FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_SKIA_ALIASES_H_
+
+#include "third_party/skia/include/core/SkM44.h"
+#include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkRect.h"
+
+using DlScalar = SkScalar;
+using DlIPoint = SkIPoint;
+using DlPoint = SkPoint;
+using DlIRect = SkIRect;
+using DlRect = SkRect;
+using DlTransform3x3 = SkMatrix;
+using DlTransform4x4 = SkM44;
+
+#endif  // FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_SKIA_ALIASES_H_

--- a/display_list/geometry/dl_geometry_types_skia_aliases.h
+++ b/display_list/geometry/dl_geometry_types_skia_aliases.h
@@ -5,16 +5,29 @@
 #ifndef FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_SKIA_ALIASES_H_
 #define FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_SKIA_ALIASES_H_
 
+#include "third_party/skia/include/core/SkColor.h"
 #include "third_party/skia/include/core/SkM44.h"
 #include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkRect.h"
 
 using DlScalar = SkScalar;
+
 using DlIPoint = SkIPoint;
 using DlPoint = SkPoint;
+using DlPoint3 = SkPoint3;
+using DlVector2 = SkVector;
+
+using DlSize = SkSize;
+using DlISize = SkISize;
+
 using DlIRect = SkIRect;
 using DlRect = SkRect;
+
+using DlRRect = SkRRect;
+
 using DlTransform3x3 = SkMatrix;
 using DlTransform4x4 = SkM44;
+using DlRSTransform = SkRSXform;
 
 #endif  // FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_SKIA_ALIASES_H_


### PR DESCRIPTION
For now this PR will have no effect, but allows us to start migrating all geometry references in the engine and DisplayList code to migrate to the final naming that will be used to switch the implementation over to Impeller objects.

No tests as this is only a new, as yet unused, header file that is preparing for "name only" changes, there are no tests.