### PR TITLE
#145418 Provide shim for reinterpret_pointer_cast for Android NDK < 26

### DIFF
--- a/impeller/typographer/backends/stb/typographer_context_stb.cc
+++ b/impeller/typographer/backends/stb/typographer_context_stb.cc
@@ -22,6 +22,16 @@ constexpr auto kColorFontBitsPerPixel = 1;
 constexpr auto kColorFontBitsPerPixel = 4;
 #endif
 
+#if __ANDROID__ && __NDK_MAJOR__ < 26
+template <typename To, typename From>
+inline std::shared_ptr<To> reinterpret_pointer_cast(
+    std::shared_ptr<From> const& ptr) noexcept {
+  return std::shared_ptr<To>(ptr, reinterpret_cast<To*>(ptr.get()));
+}
+#else
+using std::reinterpret_pointer_cast;
+#endif
+
 namespace impeller {
 
 constexpr size_t kPadding = 1;
@@ -61,7 +71,7 @@ static size_t PairsFitInAtlasOfSize(
     // We downcast to the correct typeface type to access `stb` specific
     // methods.
     std::shared_ptr<TypefaceSTB> typeface_stb =
-        std::reinterpret_pointer_cast<TypefaceSTB>(font.GetTypeface());
+        reinterpret_pointer_cast<TypefaceSTB>(font.GetTypeface());
     // Conversion factor to scale font size in Points to pixels.
     // Note this assumes typical DPI.
     float text_size_pixels =
@@ -119,7 +129,7 @@ static bool CanAppendToExistingAtlas(
 
     // We downcast to the correct typeface type to access `stb` specific methods
     std::shared_ptr<TypefaceSTB> typeface_stb =
-        std::reinterpret_pointer_cast<TypefaceSTB>(font.GetTypeface());
+        reinterpret_pointer_cast<TypefaceSTB>(font.GetTypeface());
     // Conversion factor to scale font size in Points to pixels.
     // Note this assumes typical DPI.
     float text_size_pixels =
@@ -206,7 +216,7 @@ static void DrawGlyph(BitmapSTB* bitmap,
   auto typeface = font.GetTypeface();
   // We downcast to the correct typeface type to access `stb` specific methods
   std::shared_ptr<TypefaceSTB> typeface_stb =
-      std::reinterpret_pointer_cast<TypefaceSTB>(typeface);
+      reinterpret_pointer_cast<TypefaceSTB>(typeface);
   // Conversion factor to scale font size in Points to pixels.
   // Note this assumes typical DPI.
   float text_size_pixels = metrics.point_size * TypefaceSTB::kPointsToPixels;


### PR DESCRIPTION
See the associated issue [#145418 available here](https://github.com/flutter/flutter/issues/145418) for a more detailed description.

Basically this attempts to provide a shim `reinterpret_pointer_cast` implementation for Android NDK < 26.

This looks a little controversial so I'm open to alternate approaches or putting the shim somewhere else.

## Pre-launch Checklist

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
