### PR TITLE
[Impeller] Add 'flutter frame' MTLCaptureScope to support frame capture with FlutterMetalLayer.

### DIFF
--- a/impeller/renderer/backend/metal/context_mtl.h
+++ b/impeller/renderer/backend/metal/context_mtl.h
@@ -106,6 +106,16 @@ class ContextMTL final : public Context,
   // |Context|
   void StoreTaskForGPU(const std::function<void()>& task) override;
 
+  /// Begin an Xcode capture scope for frame debugging.
+  ///
+  /// All command buffers created after this method is called and until
+  /// [EndCaptureScope] is called will be recorded in the Xcode frame capture
+  /// tool.
+  void BeginCaptureScope() const;
+
+  /// End an Xcode capture scope for frame debugging.
+  void EndCaptureScope() const;
+
  private:
   class SyncSwitchObserver : public fml::SyncSwitch::Observer {
    public:
@@ -119,6 +129,7 @@ class ContextMTL final : public Context,
 
   id<MTLDevice> device_ = nullptr;
   id<MTLCommandQueue> command_queue_ = nullptr;
+  id<MTLCaptureScope> capture_scope_ = nullptr;
   std::shared_ptr<ShaderLibraryMTL> shader_library_;
   std::shared_ptr<PipelineLibraryMTL> pipeline_library_;
   std::shared_ptr<SamplerLibrary> sampler_library_;

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -133,6 +133,13 @@ ContextMTL::ContextMTL(
 #ifdef IMPELLER_DEBUG
   gpu_tracer_ = std::make_shared<GPUTracerMTL>();
 #endif  // IMPELLER_DEBUG
+
+  capture_scope_ = [[MTLCaptureManager sharedCaptureManager]
+      newCaptureScopeWithDevice:device_];
+  [capture_scope_ setLabel:(@"Flutter Frame")];
+  [[MTLCaptureManager sharedCaptureManager]
+      setDefaultCaptureScope:capture_scope_];
+
   is_valid_ = true;
 }
 
@@ -399,6 +406,14 @@ void ContextMTL::SyncSwitchObserver::OnSyncSwitchUpdate(bool new_is_disabled) {
 // |Context|
 std::shared_ptr<CommandQueue> ContextMTL::GetCommandQueue() const {
   return command_queue_ip_;
+}
+
+void ContextMTL::BeginCaptureScope() const {
+  [capture_scope_ beginScope];
+}
+
+void ContextMTL::EndCaptureScope() const {
+  [capture_scope_ endScope];
 }
 
 }  // namespace impeller

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -195,7 +195,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromMTLTextur
     const SkISize& frame_size) {
   GPUMTLTextureInfo texture_info = delegate_->GetMTLTexture(frame_size);
   id<MTLTexture> mtl_texture = (id<MTLTexture>)(texture_info.texture);
-
   if (!mtl_texture) {
     FML_LOG(ERROR) << "Invalid MTLTexture given by the embedder.";
     return nullptr;


### PR DESCRIPTION
The FlutterMetalLayer does not support frame capture out of the box, which is blocking us switching to it as the default. This adds a capture scope around a frame workload.

WIP because I don't have a test yet. FYI @knopp 