### PR TITLE
[Impeller] Check for empty sizes when creating render targets in RenderTargetCache

### DIFF
--- a/impeller/entity/render_target_cache.cc
+++ b/impeller/entity/render_target_cache.cc
@@ -36,6 +36,10 @@ RenderTarget RenderTargetCache::CreateOffscreen(
     std::optional<RenderTarget::AttachmentConfig> stencil_attachment_config,
     const std::shared_ptr<Texture>& existing_color_texture,
     const std::shared_ptr<Texture>& existing_depth_stencil_texture) {
+  if (size.IsEmpty()) {
+    return {};
+  }
+
   FML_DCHECK(existing_color_texture == nullptr &&
              existing_depth_stencil_texture == nullptr);
   auto config = RenderTargetConfig{
@@ -81,6 +85,10 @@ RenderTarget RenderTargetCache::CreateOffscreenMSAA(
     const std::shared_ptr<Texture>& existing_color_msaa_texture,
     const std::shared_ptr<Texture>& existing_color_resolve_texture,
     const std::shared_ptr<Texture>& existing_depth_stencil_texture) {
+  if (size.IsEmpty()) {
+    return {};
+  }
+
   FML_DCHECK(existing_color_msaa_texture == nullptr &&
              existing_color_resolve_texture == nullptr &&
              existing_depth_stencil_texture == nullptr);

--- a/impeller/entity/render_target_cache_unittests.cc
+++ b/impeller/entity/render_target_cache_unittests.cc
@@ -112,5 +112,23 @@ TEST_P(RenderTargetCacheTest, CachedTextureGetsNewAttachmentConfig) {
   EXPECT_EQ(color2.clear_color, Color::Red());
 }
 
+TEST_P(RenderTargetCacheTest, CreateWithEmptySize) {
+  auto render_target_cache =
+      RenderTargetCache(GetContext()->GetResourceAllocator());
+
+  render_target_cache.Start();
+  RenderTarget empty_target =
+      render_target_cache.CreateOffscreen(*GetContext(), {100, 0}, 1);
+  RenderTarget empty_target_msaa =
+      render_target_cache.CreateOffscreenMSAA(*GetContext(), {0, 0}, 1);
+  render_target_cache.End();
+
+  {
+    ScopedValidationDisable disable_validation;
+    EXPECT_FALSE(empty_target.IsValid());
+    EXPECT_FALSE(empty_target_msaa.IsValid());
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
Using an empty size will result in an invalid RenderTarget. Calling IsValid on that target can produce Impeller validation warnings.