### PR TITLE
Add `et query tests` and `et test` commands

### DIFF
--- a/tools/engine_tool/lib/src/build_utils.dart
+++ b/tools/engine_tool/lib/src/build_utils.dart
@@ -66,11 +66,9 @@ void debugCheckBuilds(List<Build> builds) {
 }
 
 /// Build the build target in the environment.
-Future<int> runBuild(
-  Environment environment,
-  Build build, {
-  List<String> extraGnArgs = const <String>[],
-}) async {
+Future<int> runBuild(Environment environment, Build build,
+    {List<String> extraGnArgs = const <String>[],
+    List<String> targets = const <String>[]}) async {
   // If RBE config files aren't in the tree, then disable RBE.
   final String rbeConfigPath = p.join(
     environment.engine.srcDir.path,
@@ -79,10 +77,11 @@ Future<int> runBuild(
     'rbe',
   );
   final List<String> gnArgs = <String>[
-    ...extraGnArgs,
     if (!io.Directory(rbeConfigPath).existsSync()) '--no-rbe',
+    ...extraGnArgs,
   ];
 
+  // TODO(loic-sharma): Fetch dependencies if needed.
   final BuildRunner buildRunner = BuildRunner(
     platform: environment.platform,
     processRunner: environment.processRunner,
@@ -91,6 +90,7 @@ Future<int> runBuild(
     build: build,
     extraGnArgs: gnArgs,
     runTests: false,
+    extraNinjaArgs: targets,
   );
 
   Spinner? spinner;

--- a/tools/engine_tool/lib/src/commands/build_command.dart
+++ b/tools/engine_tool/lib/src/commands/build_command.dart
@@ -17,25 +17,12 @@ final class BuildCommand extends CommandBase {
   }) {
     builds = runnableBuilds(environment, configs);
     debugCheckBuilds(builds);
-    argParser.addOption(
-      configFlag,
-      abbr: 'c',
-      defaultsTo: 'host_debug',
-      help: 'Specify the build config to use',
-      allowed: <String>[
-        for (final Build config in runnableBuilds(environment, configs))
-          config.name,
-      ],
-      allowedHelp: <String, String>{
-        for (final Build config in runnableBuilds(environment, configs))
-          config.name: config.gn.join(' '),
-      },
-    );
+    addConfigOption(argParser, runnableBuilds(environment, configs));
     argParser.addFlag(
       rbeFlag,
       defaultsTo: true,
       help: 'RBE is enabled by default when available. Use --no-rbe to '
-            'disable it.',
+          'disable it.',
     );
   }
 
@@ -63,7 +50,6 @@ final class BuildCommand extends CommandBase {
       if (!useRbe) '--no-rbe',
     ];
 
-    // TODO(loic-sharma): Fetch dependencies if needed.
     return runBuild(environment, build, extraGnArgs: extraGnArgs);
   }
 }

--- a/tools/engine_tool/lib/src/commands/command.dart
+++ b/tools/engine_tool/lib/src/commands/command.dart
@@ -2,17 +2,35 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:engine_build_configs/engine_build_configs.dart';
 
 import '../environment.dart';
+import 'flags.dart';
 
 /// The base class that all commands and subcommands should inherit from.
 abstract base class CommandBase extends Command<int> {
   /// Constructs the base command.
-  CommandBase({
-    required this.environment
-  });
+  CommandBase({required this.environment});
 
   /// The host system environment.
   final Environment environment;
+}
+
+/// Adds the -c (--config) option to the parser.
+void addConfigOption(ArgParser parser, List<Build> builds,
+    {String defaultsTo = 'host_debug'}) {
+  parser.addOption(
+    configFlag,
+    abbr: 'c',
+    defaultsTo: defaultsTo,
+    help: 'Specify the build config to use',
+    allowed: <String>[
+      for (final Build config in builds) config.name,
+    ],
+    allowedHelp: <String, String>{
+      for (final Build config in builds) config.name: config.gn.join(' '),
+    },
+  );
 }

--- a/tools/engine_tool/lib/src/commands/command_runner.dart
+++ b/tools/engine_tool/lib/src/commands/command_runner.dart
@@ -13,6 +13,7 @@ import 'format_command.dart';
 import 'lint_command.dart';
 import 'query_command.dart';
 import 'run_command.dart';
+import 'test_command.dart';
 
 const int _usageLineLength = 80;
 
@@ -31,6 +32,7 @@ final class ToolCommandRunner extends CommandRunner<int> {
       BuildCommand(environment: environment, configs: configs),
       RunCommand(environment: environment, configs: configs),
       LintCommand(environment: environment),
+      TestCommand(environment: environment, configs: configs),
     ];
     commands.forEach(addCommand);
 

--- a/tools/engine_tool/lib/src/commands/run_command.dart
+++ b/tools/engine_tool/lib/src/commands/run_command.dart
@@ -21,27 +21,15 @@ final class RunCommand extends CommandBase {
   }) {
     builds = runnableBuilds(environment, configs);
     debugCheckBuilds(builds);
-
-    argParser.addOption(
-      configFlag,
-      abbr: 'c',
-      defaultsTo: '',
-      help:
-          'Specify the build config to use for the target build (usually auto detected)',
-      allowed: <String>[
-        for (final Build build in runnableBuilds(environment, configs))
-          build.name,
-      ],
-      allowedHelp: <String, String>{
-        for (final Build build in runnableBuilds(environment, configs))
-          build.name: build.gn.join(' '),
-      },
-    );
+    // We default to nothing in order to automatically detect attached devices
+    // and select an appropriate target from them.
+    addConfigOption(argParser, runnableBuilds(environment, configs),
+        defaultsTo: '');
     argParser.addFlag(
       rbeFlag,
       defaultsTo: true,
       help: 'RBE is enabled by default when available. Use --no-rbe to '
-            'disable it.',
+          'disable it.',
     );
   }
 

--- a/tools/engine_tool/lib/src/commands/test_command.dart
+++ b/tools/engine_tool/lib/src/commands/test_command.dart
@@ -1,0 +1,81 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:engine_build_configs/engine_build_configs.dart';
+import 'package:path/path.dart' as p;
+
+import '../build_utils.dart';
+import '../gn_utils.dart';
+import '../proc_utils.dart';
+import '../worker_pool.dart';
+import 'command.dart';
+import 'flags.dart';
+
+/// The root 'test' command.
+final class TestCommand extends CommandBase {
+  /// Constructs the 'test' command.
+  TestCommand({
+    required super.environment,
+    required Map<String, BuilderConfig> configs,
+  }) {
+    builds = runnableBuilds(environment, configs);
+    debugCheckBuilds(builds);
+    addConfigOption(argParser, runnableBuilds(environment, configs));
+  }
+
+  /// List of compatible builds.
+  late final List<Build> builds;
+
+  @override
+  String get name => 'test';
+
+  @override
+  String get description => 'Runs a test target'
+      'et test //flutter/fml/...             # Run all test targets in `//flutter/fml/`'
+      'et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/fml/`';
+
+  @override
+  Future<int> run() async {
+    final String configName = argResults![configFlag] as String;
+    final Build? build =
+        builds.where((Build build) => build.name == configName).firstOrNull;
+    if (build == null) {
+      environment.logger.error('Could not find config $configName');
+      return 1;
+    }
+
+    final Map<String, TestTarget> allTargets = await findTestTargets(
+        environment,
+        Directory(p.join(environment.engine.outDir.path, build.ninja.config)));
+    final Set<TestTarget> selectedTargets =
+        selectTargets(argResults!.rest, allTargets);
+    if (selectedTargets.isEmpty) {
+      environment.logger.error(
+          'No build targets matched ${argResults!.rest}\nRun `et query tests` to see list of targets.');
+      return 1;
+    }
+    // Chop off the '//' prefix.
+    final List<String> buildTargets = selectedTargets
+        .map<String>((TestTarget target) => target.label.substring('//'.length))
+        .toList();
+    // TODO(johnmccutchan): runBuild manipulates buildTargets and adds some
+    // targets listed in Build. Fix this.
+    final int buildExitCode =
+        await runBuild(environment, build, targets: buildTargets);
+    if (buildExitCode != 0) {
+      return buildExitCode;
+    }
+    final WorkerPool workerPool =
+        WorkerPool(environment, ProcessTaskProgressReporter(environment));
+    final Set<ProcessTask> tasks = <ProcessTask>{};
+    for (final TestTarget target in selectedTargets) {
+      final List<String> commandLine = <String>[target.executable.path];
+      tasks.add(ProcessTask(
+          target.label, environment, environment.engine.srcDir, commandLine));
+    }
+    return await workerPool.run(tasks) ? 0 : 1;
+  }
+}

--- a/tools/engine_tool/lib/src/gn_utils.dart
+++ b/tools/engine_tool/lib/src/gn_utils.dart
@@ -1,0 +1,137 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:process_runner/process_runner.dart';
+
+import 'environment.dart';
+import 'proc_utils.dart';
+
+/// Canonicalized build targets start with this prefix.
+const String buildTargetPrefix = '//';
+
+/// A suffix to build targets that recursively selects all child build targets.
+const String _buildTargetGlobSuffix = '/...';
+
+/// Information about a test build target.
+final class TestTarget {
+  /// Construct a test target.
+  TestTarget(this.label, this.executable);
+
+  /// The build target label. `//flutter/fml:fml_unittests`
+  final String label;
+
+  /// The executable file produced after the build target is built.
+  final File executable;
+
+  @override
+  String toString() {
+    return 'target=$label executable=${executable.path}';
+  }
+}
+
+/// Returns test targets for a given build directory.
+Future<Map<String, TestTarget>> findTestTargets(
+    Environment environment, Directory buildDir) async {
+  final Map<String, TestTarget> r = <String, TestTarget>{};
+  final List<String> getLabelsCommandLine = <String>[
+    gnBinPath(environment),
+    'ls',
+    buildDir.path,
+    '--type=executable',
+    '--testonly=true',
+    '--as=label',
+  ];
+  final List<String> getOutputsCommandLine = <String>[
+    gnBinPath(environment),
+    'ls',
+    buildDir.path,
+    '--type=executable',
+    '--testonly=true',
+    '--as=output'
+  ];
+
+  // Spawn the two processes concurrently.
+  final Future<ProcessRunnerResult> futureLabelsResult =
+      environment.processRunner.runProcess(getLabelsCommandLine,
+          workingDirectory: environment.engine.srcDir, failOk: true);
+  final Future<ProcessRunnerResult> futureOutputsResult =
+      environment.processRunner.runProcess(getOutputsCommandLine,
+          workingDirectory: environment.engine.srcDir, failOk: true);
+
+  // Await the futures, we need both to complete so the order doesn't matter.
+  final ProcessRunnerResult labelsResult = await futureLabelsResult;
+  final ProcessRunnerResult outputsResult = await futureOutputsResult;
+
+  // Handle any process failures.
+  fatalIfFailed(environment, getLabelsCommandLine, labelsResult);
+  fatalIfFailed(environment, getOutputsCommandLine, outputsResult);
+
+  // Extract the labels
+  final String rawLabels = labelsResult.stdout;
+  final String rawOutputs = outputsResult.stdout;
+  final List<String> labels = rawLabels.split('\n');
+  final List<String> outputs = rawOutputs.split('\n');
+  if (labels.length != outputs.length) {
+    environment.logger.fatal(
+        'gn ls output is inconsistent A and B should be the same length:\nA=$labels\nB=$outputs');
+  }
+  // Drop the empty line at the end of the output.
+  if (labels.isNotEmpty) {
+    if (labels.last.isNotEmpty || outputs.last.isNotEmpty) {
+      throw AssertionError('expected last line of output to be blank.');
+    }
+    labels.removeLast();
+    outputs.removeLast();
+  }
+  for (int i = 0; i < labels.length; i++) {
+    final String label = labels[i];
+    final String output = outputs[i];
+    if (label.isEmpty) {
+      throw AssertionError('expected line to not be empty.');
+    }
+    if (output.isEmpty) {
+      throw AssertionError('expected line to not be empty.');
+    }
+    r[label] = TestTarget(label, File(p.join(buildDir.path, output)));
+  }
+  return r;
+}
+
+/// Process selectors and filter allTargets for matches.
+///
+/// We support:
+///   1) Exact label matches (the '//' prefix will be stripped off).
+///   2) '/...' suffix which selects all targets that match the prefix.
+Set<TestTarget> selectTargets(
+    List<String> selectors, Map<String, TestTarget> allTargets) {
+  final Set<TestTarget> selected = <TestTarget>{};
+  for (String selector in selectors) {
+    if (!selector.startsWith(buildTargetPrefix)) {
+      // Insert the prefix when necessary.
+      selector = '$buildTargetPrefix$selector';
+    }
+    final bool recursiveMatch = selector.endsWith(_buildTargetGlobSuffix);
+    if (recursiveMatch) {
+      // Remove the /... suffix.
+      selector = selector.substring(
+          0, selector.length - _buildTargetGlobSuffix.length);
+      // TODO(johnmccutchan): Accelerate this by using a trie.
+      for (final TestTarget target in allTargets.values) {
+        if (target.label.startsWith(selector)) {
+          selected.add(target);
+        }
+      }
+    } else {
+      for (final TestTarget target in allTargets.values) {
+        if (target.label == selector) {
+          selected.add(target);
+        }
+      }
+    }
+  }
+  return selected;
+}

--- a/tools/engine_tool/lib/src/proc_utils.dart
+++ b/tools/engine_tool/lib/src/proc_utils.dart
@@ -5,12 +5,14 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:path/path.dart' as p;
 import 'package:process_runner/process_runner.dart';
 
 import 'environment.dart';
 import 'json_utils.dart';
+import 'logger.dart';
 import 'worker_pool.dart';
 
 /// Artifacts from an exited sub-process.
@@ -19,6 +21,15 @@ final class ProcessArtifacts {
   ProcessArtifacts(
       this.cwd, this.commandLine, this.exitCode, this.stdout, this.stderr,
       {this.pid});
+
+  /// Constructs an instance of ProcessArtifacts from a ProcessRunnerResult
+  /// and the spawning context.
+  factory ProcessArtifacts.fromResult(
+      Directory cwd, List<String> commandLine, ProcessRunnerResult result) {
+    return ProcessArtifacts(
+        cwd, commandLine, result.exitCode, result.stdout, result.stderr,
+        pid: result.pid);
+  }
 
   /// Constructs an instance of ProcessArtifacts from serialized JSON text.
   factory ProcessArtifacts.fromJson(String serialized) {
@@ -31,7 +42,9 @@ final class ProcessArtifacts {
     final int exitCode = intOfJson(artifact, 'exitCode', errors)!;
     final String stdout = stringOfJson(artifact, 'stdout', errors)!;
     final String stderr = stringOfJson(artifact, 'stderr', errors)!;
-    return ProcessArtifacts(cwd, commandLine, exitCode, stdout, stderr);
+    final int? pid = intOfJson(artifact, 'pid', errors);
+    return ProcessArtifacts(cwd, commandLine, exitCode, stdout, stderr,
+        pid: pid);
   }
 
   /// Constructs an instance of ProcessArtifacts from a file containing JSON.
@@ -115,4 +128,128 @@ class ProcessTask extends WorkerTask {
   String get processArtifactsPath {
     return _processArtifactsPath!;
   }
+}
+
+/// A WorkerPoolProgressReporter designed to work with ProcessTasks.
+class ProcessTaskProgressReporter implements WorkerPoolProgressReporter {
+  /// Construct a new reporter.
+  ProcessTaskProgressReporter(this._environment);
+
+  final Environment _environment;
+  Spinner? _spinner;
+  bool _finished = false;
+  int _longestName = 0;
+  int _doneCount = 0;
+  int _totalCount = 0;
+
+  @override
+  void onRun(Set<WorkerTask> tasks) {
+    _totalCount = tasks.length;
+    for (final WorkerTask task in tasks) {
+      assert(task is ProcessTask);
+      _longestName = max(_longestName, task.name.length);
+    }
+  }
+
+  @override
+  void onFinish() {
+    _finished = true;
+    _updateSpinner(<ProcessTask>{});
+  }
+
+  @override
+  void onTaskStart(WorkerPool pool, WorkerTask task) {
+    _updateSpinner(pool.running);
+  }
+
+  @override
+  void onTaskDone(WorkerPool pool, WorkerTask task, [Object? err]) {
+    _doneCount++;
+    task as ProcessTask;
+    final ProcessArtifacts pa = task.processArtifacts;
+    final String dt = _formatDurationShort(task.runTime);
+    if (pa.exitCode != 0) {
+      final String paPath = task.processArtifactsPath;
+      _environment.logger.clearLine();
+      _environment.logger.status('FAIL: $dt ${task.name} [details in $paPath]');
+    } else {
+      _environment.logger.clearLine();
+      _environment.logger.status('OKAY: $dt ${task.name}');
+    }
+    _updateSpinner(pool.running);
+  }
+
+  void _updateSpinner(Set<WorkerTask> tasks) {
+    if (_spinner != null) {
+      _spinner!.finish();
+      _spinner = null;
+    }
+    if (_finished) {
+      return;
+    }
+    _environment.logger.clearLine();
+    final String taskName = tasks.isEmpty ? '' : tasks.first.name;
+    final String etc = tasks.length > 1 ? '... [${tasks.length}]' : '';
+    _environment.logger.status(
+        'Running $_doneCount/$_totalCount $taskName$etc ',
+        newline: false);
+    _spinner = _environment.logger.startSpinner();
+  }
+
+  String _formatDurationShort(Duration dur) {
+    int micros = dur.inMicroseconds;
+    String r = '';
+    if (micros >= Duration.microsecondsPerMinute) {
+      final int minutes = micros ~/ Duration.microsecondsPerMinute;
+      micros -= minutes * Duration.microsecondsPerMinute;
+      r += '${minutes}m';
+    }
+    if (micros >= Duration.microsecondsPerSecond) {
+      final int seconds = micros ~/ Duration.microsecondsPerSecond;
+      micros -= seconds * Duration.microsecondsPerSecond;
+      if (r.isNotEmpty) {
+        r += '.';
+      }
+      r += '${seconds}s';
+    }
+    if (micros >= Duration.microsecondsPerMillisecond) {
+      final int millis = micros ~/ Duration.microsecondsPerMillisecond;
+      micros -= millis * Duration.microsecondsPerMillisecond;
+      if (r.isNotEmpty) {
+        r += '.';
+      }
+      r += '${millis}ms';
+    }
+    return r.padLeft(15);
+  }
+}
+
+/// If result.exitCode != 0, will call logger.fatal with relevant information
+/// and terminate the program.
+void fatalIfFailed(Environment environment, List<String> commandLine,
+    ProcessRunnerResult result) {
+  if (result.exitCode == 0) {
+    return;
+  }
+  environment.logger.fatal(
+      'Process "${commandLine.join(' ')}" failed exitCode=${result.exitCode}\n'
+      'STDOUT:\n${result.stdout}'
+      'STDERR:\n${result.stderr}');
+}
+
+/// Ensures that pathToBinary includes a '.exe' suffix on relevant platforms.
+String exePath(Environment environment, String pathToBinary) {
+  String suffix = '';
+  if (environment.platform.isWindows) {
+    suffix = '.exe';
+  }
+  return '$pathToBinary$suffix';
+}
+
+/// Returns the path to the gn binary.
+String gnBinPath(Environment environment) {
+  return exePath(
+      environment,
+      p.join(environment.engine.srcDir.path, 'flutter', 'third_party', 'gn',
+          'gn'));
 }

--- a/tools/engine_tool/test/fixtures.dart
+++ b/tools/engine_tool/test/fixtures.dart
@@ -194,3 +194,15 @@ String attachedDevices() => '''
   }
 ]
 ''';
+
+// NOTE: The final empty line is intentional.
+String gnLsTestOutputs() => '''
+display_list_unittests
+flow_unittests
+fml_arc_unittests''';
+
+// NOTE: The empty blank line is intentional.
+String gnLsTestLabels() => '''
+//flutter/display_list:display_list_unittests
+//flutter/flow:flow_unittests
+//flutter/fml:fml_arc_unittests''';

--- a/tools/engine_tool/test/gn_utils_test.dart
+++ b/tools/engine_tool/test/gn_utils_test.dart
@@ -1,0 +1,75 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:engine_repo_tools/engine_repo_tools.dart';
+import 'package:engine_tool/src/environment.dart';
+import 'package:engine_tool/src/gn_utils.dart';
+import 'package:litetest/litetest.dart';
+
+import 'utils.dart';
+
+void main() {
+  final Engine engine;
+  try {
+    engine = Engine.findWithin();
+  } catch (e) {
+    io.stderr.writeln(e);
+    io.exitCode = 1;
+    return;
+  }
+
+  final List<CannedProcess> cannedProcesses = <CannedProcess>[
+    CannedProcess((List<String> command) => command.contains('--as=label'),
+        stdout: '''
+//flutter/display_list:display_list_unittests
+//flutter/flow:flow_unittests
+//flutter/fml:fml_arc_unittests
+'''),
+    CannedProcess((List<String> command) => command.contains('--as=output'),
+        stdout: '''
+display_list_unittests
+flow_unittests
+fml_arc_unittests
+''')
+  ];
+
+  test('find test targets', () async {
+    final TestEnvironment testEnvironment =
+        TestEnvironment(engine, cannedProcesses: cannedProcesses);
+    final Environment env = testEnvironment.environment;
+    final Map<String, TestTarget> testTargets =
+        await findTestTargets(env, engine.outDir);
+    expect(testTargets.length, equals(3));
+    expect(testTargets['//flutter/display_list:display_list_unittests'],
+        notEquals(null));
+    expect(
+        testTargets['//flutter/display_list:display_list_unittests']!
+            .executable
+            .path,
+        endsWith('display_list_unittests'));
+  });
+
+  test('process queue failure', () async {
+    final TestEnvironment testEnvironment =
+        TestEnvironment(engine, cannedProcesses: cannedProcesses);
+    final Environment env = testEnvironment.environment;
+    final Map<String, TestTarget> testTargets =
+        await findTestTargets(env, engine.outDir);
+    expect(selectTargets(<String>['//...'], testTargets).length, equals(3));
+    expect(
+        selectTargets(<String>['//flutter/display_list'], testTargets).length,
+        equals(0));
+    expect(
+        selectTargets(<String>['//flutter/display_list/...'], testTargets)
+            .length,
+        equals(1));
+    expect(
+        selectTargets(<String>['//flutter/display_list:display_list_unittests'],
+                testTargets)
+            .length,
+        equals(1));
+  });
+}

--- a/tools/engine_tool/test/test_command_test.dart
+++ b/tools/engine_tool/test/test_command_test.dart
@@ -1,0 +1,86 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert' as convert;
+import 'dart:ffi' as ffi show Abi;
+import 'dart:io' as io;
+
+import 'package:engine_build_configs/engine_build_configs.dart';
+import 'package:engine_repo_tools/engine_repo_tools.dart';
+import 'package:engine_tool/src/commands/command_runner.dart';
+import 'package:engine_tool/src/environment.dart';
+import 'package:litetest/litetest.dart';
+
+import 'fixtures.dart' as fixtures;
+import 'utils.dart';
+
+void main() {
+  final Engine engine;
+  try {
+    engine = Engine.findWithin();
+  } catch (e) {
+    io.stderr.writeln(e);
+    io.exitCode = 1;
+    return;
+  }
+
+  final BuilderConfig linuxTestConfig = BuilderConfig.fromJson(
+    path: 'ci/builders/linux_test_config.json',
+    map: convert.jsonDecode(fixtures.testConfig('Linux'))
+        as Map<String, Object?>,
+  );
+
+  final BuilderConfig macTestConfig = BuilderConfig.fromJson(
+    path: 'ci/builders/mac_test_config.json',
+    map: convert.jsonDecode(fixtures.testConfig('Mac-12'))
+        as Map<String, Object?>,
+  );
+
+  final BuilderConfig winTestConfig = BuilderConfig.fromJson(
+    path: 'ci/builders/win_test_config.json',
+    map: convert.jsonDecode(fixtures.testConfig('Windows-11'))
+        as Map<String, Object?>,
+  );
+
+  final Map<String, BuilderConfig> configs = <String, BuilderConfig>{
+    'linux_test_config': linuxTestConfig,
+    'linux_test_config2': linuxTestConfig,
+    'mac_test_config': macTestConfig,
+    'win_test_config': winTestConfig,
+  };
+
+  final List<CannedProcess> cannedProcesses = <CannedProcess>[
+    CannedProcess((List<String> command) => command.contains('--as=label'),
+        stdout: '''
+//flutter/display_list:display_list_unittests
+//flutter/flow:flow_unittests
+//flutter/fml:fml_arc_unittests
+'''),
+    CannedProcess((List<String> command) => command.contains('--as=output'),
+        stdout: '''
+display_list_unittests
+flow_unittests
+fml_arc_unittests
+''')
+  ];
+
+  test('test command executes test', () async {
+    final TestEnvironment testEnvironment = TestEnvironment(engine,
+        abi: ffi.Abi.linuxX64, cannedProcesses: cannedProcesses);
+    final Environment env = testEnvironment.environment;
+    final ToolCommandRunner runner = ToolCommandRunner(
+      environment: env,
+      configs: configs,
+    );
+    final int result = await runner.run(<String>[
+      'test',
+      '//flutter/display_list:display_list_unittests',
+    ]);
+    expect(result, equals(0));
+    expect(testEnvironment.processHistory.length, greaterThan(3));
+    final int offset = testEnvironment.processHistory.length - 1;
+    expect(testEnvironment.processHistory[offset].command[0],
+        endsWith('display_list_unittests'));
+  });
+}

--- a/tools/engine_tool/test/utils.dart
+++ b/tools/engine_tool/test/utils.dart
@@ -1,0 +1,114 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi' as ffi show Abi;
+import 'dart:io' as io;
+
+import 'package:engine_repo_tools/engine_repo_tools.dart';
+import 'package:engine_tool/src/environment.dart';
+import 'package:engine_tool/src/logger.dart';
+import 'package:platform/platform.dart';
+import 'package:process_fakes/process_fakes.dart';
+import 'package:process_runner/process_runner.dart';
+
+/// Each CannedProcess has a command matcher and the result of an executed
+/// process. The matcher is used to determine when to use a registered
+/// CannedProcess.
+class CannedProcess {
+  CannedProcess(
+    this.commandMatcher, {
+    int exitCode = 0,
+    String stdout = '',
+    String stderr = '',
+  })  : _exitCode = exitCode,
+        _stdout = stdout,
+        _stderr = stderr;
+
+  final bool Function(List<String> command) commandMatcher;
+  final int _exitCode;
+  final String _stdout;
+  final String _stderr;
+
+  FakeProcess get fakeProcess {
+    return FakeProcess(exitCode: _exitCode, stdout: _stdout, stderr: _stderr);
+  }
+}
+
+/// ExecutedProcess includes the command and the result.
+class ExecutedProcess {
+  ExecutedProcess(this.command, this.result);
+  final List<String> command;
+  final FakeProcess result;
+
+  @override
+  String toString() {
+    return command.join(' ');
+  }
+}
+
+/// TestEnvironment includes an Environment with some test-specific extras.
+class TestEnvironment {
+  TestEnvironment(
+    Engine engine, {
+    Logger? logger,
+    ffi.Abi abi = ffi.Abi.macosArm64,
+    this.cannedProcesses = const <CannedProcess>[],
+  }) {
+    logger ??= Logger.test();
+    environment = Environment(
+      abi: abi,
+      engine: engine,
+      platform: FakePlatform(
+          operatingSystem: _operatingSystemForAbi(abi),
+          resolvedExecutable: io.Platform.resolvedExecutable),
+      processRunner: ProcessRunner(
+          processManager: FakeProcessManager(onStart: (List<String> command) {
+        final FakeProcess processResult =
+            _getCannedResult(command, cannedProcesses);
+        processHistory.add(ExecutedProcess(command, processResult));
+        return processResult;
+      }, onRun: (List<String> command) {
+        throw UnimplementedError('onRun');
+      })),
+      logger: logger,
+    );
+  }
+
+  /// Environment.
+  late final Environment environment;
+
+  /// List of CannedProcesses that are registered in this environment.
+  final List<CannedProcess> cannedProcesses;
+
+  /// A history of all executed processes.
+  final List<ExecutedProcess> processHistory = <ExecutedProcess>[];
+}
+
+String _operatingSystemForAbi(ffi.Abi abi) {
+  switch (abi) {
+    case ffi.Abi.linuxArm:
+    case ffi.Abi.linuxArm64:
+    case ffi.Abi.linuxIA32:
+    case ffi.Abi.linuxX64:
+    case ffi.Abi.linuxRiscv32:
+    case ffi.Abi.linuxRiscv64:
+      return Platform.linux;
+    case ffi.Abi.macosArm64:
+    case ffi.Abi.macosX64:
+      return Platform.macOS;
+    default:
+      throw UnimplementedError('Unhandled abi=$abi');
+  }
+}
+
+FakeProcess _getCannedResult(
+    List<String> command, List<CannedProcess> cannedProcesses) {
+  for (final CannedProcess cp in cannedProcesses) {
+    final bool matched = cp.commandMatcher(command);
+    if (matched) {
+      return cp.fakeProcess;
+    }
+  }
+  return FakeProcess();
+}


### PR DESCRIPTION
- `et query tests` enumerates all test binaries encoded in BUILD.gn files.
- `et test` builds, then, runs a set of tests in parallel
- Tests