### PR TITLE
Update one more use of deprecated GrDirectContext::MakeMetal

### DIFF
--- a/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.mm
@@ -8,6 +8,9 @@
 #include "flutter/fml/logging.h"
 #include "flutter/shell/common/context_options.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendContext.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlDirectContext.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -79,10 +82,12 @@ FLUTTER_ASSERT_ARC
                              commandQueue:(id<MTLCommandQueue>)commandQueue {
   const auto contextOptions =
       flutter::MakeDefaultContextOptions(flutter::ContextType::kRender, GrBackendApi::kMetal);
+  GrMtlBackendContext backendContext = {};
   // Skia expect arguments to `MakeMetal` transfer ownership of the reference in for release later
   // when the GrDirectContext is collected.
-  return GrDirectContext::MakeMetal((__bridge_retained void*)device,
-                                    (__bridge_retained void*)commandQueue, contextOptions);
+  backendContext.fDevice.reset((__bridge_retained void*)device);
+  backendContext.fQueue.reset((__bridge_retained void*)commandQueue);
+  return GrDirectContexts::MakeMetal(backendContext, contextOptions);
 }
 
 - (void)dealloc {


### PR DESCRIPTION
In #51537 I missed one call to `GrDirectContext::MakeMetal` which is going away.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
