### PR TITLE
[skwasm] Throw when gradient color stops are invalid in debug mode.

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -33,6 +33,11 @@ class SkwasmGradient extends SkwasmNativeShader implements ui.Gradient {
     ui.TileMode tileMode = ui.TileMode.clamp,
     Float32List? matrix4,
   }) => withStackScope((StackScope scope) {
+    assert(() {
+      validateColorStops(colors, colorStops);
+      return true;
+    }());
+
     final RawPointArray endPoints =
       scope.convertPointArrayToNative(<ui.Offset>[from, to]);
     final RawColorArray nativeColors = scope.convertColorArrayToNative(colors);
@@ -61,6 +66,11 @@ class SkwasmGradient extends SkwasmNativeShader implements ui.Gradient {
     ui.TileMode tileMode = ui.TileMode.clamp,
     Float32List? matrix4,
   }) => withStackScope((StackScope scope) {
+    assert(() {
+      validateColorStops(colors, colorStops);
+      return true;
+    }());
+
     final RawColorArray rawColors = scope.convertColorArrayToNative(colors);
     final Pointer<Float> rawStops = colorStops != null
       ? scope.convertDoublesToNative(colorStops)
@@ -91,6 +101,11 @@ class SkwasmGradient extends SkwasmNativeShader implements ui.Gradient {
     ui.TileMode tileMode = ui.TileMode.clamp,
     Float32List? matrix4,
   }) => withStackScope((StackScope scope) {
+    assert(() {
+      validateColorStops(colors, colorStops);
+      return true;
+    }());
+
     final RawPointArray endPoints =
       scope.convertPointArrayToNative(<ui.Offset>[focal, center]);
     final RawColorArray rawColors = scope.convertColorArrayToNative(colors);
@@ -122,6 +137,11 @@ class SkwasmGradient extends SkwasmNativeShader implements ui.Gradient {
     required double endAngle,
     Float32List? matrix4,
   }) => withStackScope((StackScope scope) {
+    assert(() {
+      validateColorStops(colors, colorStops);
+      return true;
+    }());
+
     final RawColorArray rawColors = scope.convertColorArrayToNative(colors);
     final Pointer<Float> rawStops = colorStops != null
       ? scope.convertDoublesToNative(colorStops)

--- a/lib/web_ui/test/ui/gradient_test.dart
+++ b/lib/web_ui/test/ui/gradient_test.dart
@@ -75,4 +75,45 @@ Future<void> testMain() async {
       throwsA(const TypeMatcher<AssertionError>()),
     );
   });
+
+  test('gradients throw on invalid color stops', () {
+    expect(
+      () => Gradient.linear(
+        Offset.zero,
+        const Offset(1.0, 1.0),
+        const <Color>[
+          Color(0x11111111),
+          Color(0x22222222),
+          Color(0x33333333),
+        ],
+        const <double>[0.0, 1.0],
+      ),
+      throwsArgumentError
+    );
+    expect(
+      () => Gradient.radial(
+        Offset.zero,
+        5.0,
+        const <Color>[
+          Color(0x11111111),
+          Color(0x22222222),
+          Color(0x33333333),
+        ],
+        const <double>[0.0, 1.0],
+      ),
+      throwsArgumentError
+    );
+    expect(
+      () => Gradient.sweep(
+        Offset.zero,
+        const <Color>[
+          Color(0x11111111),
+          Color(0x22222222),
+          Color(0x33333333),
+        ],
+        const <double>[0.0, 1.0],
+      ),
+      throwsArgumentError
+    );
+  });
 }


### PR DESCRIPTION
One of many unit test failures that are appearing when running framework tests against skwasm.