### PR TITLE
[Skwasm] Respect the `debugDisableFallbackFonts` flag.

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -113,7 +113,7 @@ class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Pa
   @override
   void layout(ui.ParagraphConstraints constraints) {
     paragraphLayout(handle, constraints.width);
-    if (!_hasCheckedForMissingCodePoints) {
+    if (!debugDisableFontFallbacks && !_hasCheckedForMissingCodePoints) {
       _hasCheckedForMissingCodePoints = true;
       final int missingCodePointCount = paragraphGetUnresolvedCodePoints(handle, nullptr, 0);
       if (missingCodePointCount > 0) {

--- a/lib/web_ui/test/ui/fallback_fonts_golden_test.dart
+++ b/lib/web_ui/test/ui/fallback_fonts_golden_test.dart
@@ -432,7 +432,7 @@ void testMain() {
       }
     });
 
-    test('fallback fonts do not download when debugDisableFontFallbacks is disabled', () async {
+    test('fallback fonts do not download when debugDisableFontFallbacks is set', () async {
       debugDisableFontFallbacks = true;
 
       expect(renderer.fontCollection.fontFallbackManager!.globalFontFallbacks, <String>['Roboto']);

--- a/lib/web_ui/test/ui/fallback_fonts_golden_test.dart
+++ b/lib/web_ui/test/ui/fallback_fonts_golden_test.dart
@@ -431,6 +431,26 @@ void testMain() {
         }
       }
     });
+
+    test('fallback fonts do not download when debugDisableFontFallbacks is disabled', () async {
+      debugDisableFontFallbacks = true;
+
+      expect(renderer.fontCollection.fontFallbackManager!.globalFontFallbacks, <String>['Roboto']);
+
+      // Creating this paragraph would cause us to start to download the
+      // fallback font if we didn't disable font fallbacks.
+      final ui.ParagraphBuilder pb = ui.ParagraphBuilder(
+        ui.ParagraphStyle(),
+      );
+      pb.addText('Hello 😊');
+      pb.build().layout(const ui.ParagraphConstraints(width: 1000));
+
+      await renderer.fontCollection.fontFallbackManager!.debugWhenIdle();
+
+      // Make sure we didn't download the fallback font.
+      expect(renderer.fontCollection.fontFallbackManager!.globalFontFallbacks,
+          isNot(contains('Noto Color Emoji')));
+    });
   },
   // HTML renderer doesn't use the fallback font manager.
   skip: isHtml,


### PR DESCRIPTION
Skwasm needs to respect the `debugDisableFallbackFonts` flag, which is used by framework tests.