### PR TITLE
[skwasm] Use test fonts while in debugEmulateFlutterTesterEnvironment mode

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -9,9 +9,17 @@ import 'dart:js_interop';
 import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 const int _kSoftLineBreak = 0;
 const int _kHardLineBreak = 100;
+
+final List<String> _testFonts = <String>['FlutterTest', 'Ahem'];
+String _computeEffectiveFontFamily(String fontFamily) {
+  return ui_web.debugEmulateFlutterTesterEnvironment && !_testFonts.contains(fontFamily)
+    ? _testFonts.first
+    : fontFamily;
+}
 
 class SkwasmLineMetrics extends SkwasmObjectWrapper<RawLineMetrics> implements ui.LineMetrics {
   factory SkwasmLineMetrics({
@@ -430,8 +438,8 @@ class SkwasmTextStyle implements ui.TextStyle {
   }
 
   List<String> get fontFamilies => <String>[
-    if (fontFamily != null) fontFamily!,
-    if (fontFamilyFallback != null) ...fontFamilyFallback!,
+    if (fontFamily != null) _computeEffectiveFontFamily(fontFamily!),
+    if (fontFamilyFallback != null) ...fontFamilyFallback!.map(_computeEffectiveFontFamily),
   ];
 
   final ui.Color? color;

--- a/lib/web_ui/test/ui/line_metrics_test.dart
+++ b/lib/web_ui/test/ui/line_metrics_test.dart
@@ -116,4 +116,23 @@ Future<void> testMain() async {
         expect(metrics, hasLength(1));
     }
   }, skip: isHtml); // The rounding hack doesn't apply to the html renderer
+
+  test('uses flutter test fonts when debugEmulateFlutterTesterEnvironment is enabled', () {
+    final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle());
+    builder.pushStyle(ui.TextStyle(
+      fontSize: 10.0,
+      fontFamily: 'SomeOtherFontFamily',
+    ));
+    builder.addText('XXXX');
+    final ui.Paragraph paragraph = builder.build();
+    paragraph.layout(const ui.ParagraphConstraints(width: 400));
+
+    expect(paragraph.numberOfLines, 1);
+
+    final ui.LineMetrics? metrics = paragraph.getLineMetricsAt(0);
+    expect(metrics, isNotNull);
+
+    // Ahem's 'X' character is a square, so it's the font size (10.0) * 4 characters.
+    expect(metrics!.width, 40.0);
+  });
 }

--- a/lib/web_ui/test/ui/line_metrics_test.dart
+++ b/lib/web_ui/test/ui/line_metrics_test.dart
@@ -132,7 +132,7 @@ Future<void> testMain() async {
     final ui.LineMetrics? metrics = paragraph.getLineMetricsAt(0);
     expect(metrics, isNotNull);
 
-    // Ahem's 'X' character is a square, so it's the font size (10.0) * 4 characters.
+    // FlutterTest font's 'X' character is a square, so it's the font size (10.0) * 4 characters.
     expect(metrics!.width, 40.0);
   });
 }


### PR DESCRIPTION
This brings the behavior in line with the other renderers. The framework sets this bit to make sure we render only using the Ahem font.