### PR TITLE
Change JSBoxedDartObject to JSAny

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
@@ -21,7 +21,7 @@ import 'package:ui/src/engine.dart';
 /// 5. The finalizer function is called with the SkPaint as the sole argument.
 /// 6. We call `delete` on SkPaint.
 DomFinalizationRegistry _finalizationRegistry = DomFinalizationRegistry(
-  (JSBoxedDartObject boxedUniq) {
+  (JSAny boxedUniq) {
     final UniqueRef<Object> uniq = boxedUniq.fromJSWrapper as UniqueRef<Object>;
     uniq.collect();
   }.toJS


### PR DESCRIPTION
Closes https://github.com/dart-lang/sdk/issues/55256

https://github.com/flutter/engine/commit/fda5c694e77ba1e9166d659f0d69881657f7ae0b added code to avoid the less performant boxing of JSBoxedDartObject and instead use backend-specific logic to externalize and internalize the UniqueRef until we get a better solution from dart:js_interop. On the JS backends, this relied on casting to and from JSAny, as its representation type is just Object. However, this callback that takes in the UniqueRef as an arg is still typed as accepting JSBoxedDartObject, leading to a cast failure on the JS backends, since the representation type is JSObject.

The fix is to use JSAny. On dart2wasm, this makes no difference, as the underlying representation type does not change.
