### PR TITLE
Remove #if SHELL_ENABLE_METAL checks in iOS code

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -19,7 +19,7 @@ shell_gpu_configuration("ios_gpu_configuration") {
   enable_software = true
   enable_gl = false
   enable_vulkan = false
-  enable_metal = shell_enable_metal
+  enable_metal = true
 }
 
 # The headers that will be copied to the Flutter.framework and be accessed
@@ -147,12 +147,22 @@ source_set("flutter_framework_source") {
     "framework/Source/vsync_waiter_ios.mm",
     "ios_context.h",
     "ios_context.mm",
+    "ios_context_metal_impeller.h",
+    "ios_context_metal_impeller.mm",
+    "ios_context_metal_skia.h",
+    "ios_context_metal_skia.mm",
     "ios_context_software.h",
     "ios_context_software.mm",
+    "ios_external_texture_metal.h",
+    "ios_external_texture_metal.mm",
     "ios_external_view_embedder.h",
     "ios_external_view_embedder.mm",
     "ios_surface.h",
     "ios_surface.mm",
+    "ios_surface_metal_impeller.h",
+    "ios_surface_metal_impeller.mm",
+    "ios_surface_metal_skia.h",
+    "ios_surface_metal_skia.mm",
     "ios_surface_software.h",
     "ios_surface_software.mm",
     "platform_message_handler_ios.h",
@@ -170,23 +180,6 @@ source_set("flutter_framework_source") {
     defines += [ "APPLICATION_EXTENSION_API_ONLY=1" ]
   }
 
-  if (shell_enable_metal) {
-    sources += [
-      "ios_context_metal_impeller.h",
-      "ios_context_metal_impeller.mm",
-      "ios_context_metal_skia.h",
-      "ios_context_metal_skia.mm",
-      "ios_external_texture_metal.h",
-      "ios_external_texture_metal.mm",
-      "ios_surface_metal_impeller.h",
-      "ios_surface_metal_impeller.mm",
-      "ios_surface_metal_skia.h",
-      "ios_surface_metal_skia.mm",
-    ]
-
-    deps += [ "//flutter/shell/platform/darwin/graphics" ]
-  }
-
   deps += [
     ":ios_gpu_configuration",
     "//flutter/common",
@@ -200,6 +193,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/darwin/common",
     "//flutter/shell/platform/darwin/common:framework_common",
+    "//flutter/shell/platform/darwin/graphics"
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/profiling:profiling",
     "//flutter/skia",

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -193,7 +193,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/darwin/common",
     "//flutter/shell/platform/darwin/common:framework_common",
-    "//flutter/shell/platform/darwin/graphics"
+    "//flutter/shell/platform/darwin/graphics",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/profiling:profiling",
     "//flutter/skia",

--- a/shell/platform/darwin/ios/ios_context.mm
+++ b/shell/platform/darwin/ios/ios_context.mm
@@ -6,12 +6,9 @@
 #include "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 
 #include "flutter/fml/logging.h"
-#include "flutter/shell/platform/darwin/ios/ios_context_software.h"
-
-#if SHELL_ENABLE_METAL
 #include "flutter/shell/platform/darwin/ios/ios_context_metal_impeller.h"
 #include "flutter/shell/platform/darwin/ios/ios_context_metal_skia.h"
-#endif  // SHELL_ENABLE_METAL
+#include "flutter/shell/platform/darwin/ios/ios_context_software.h"
 
 namespace flutter {
 
@@ -32,7 +29,6 @@ std::unique_ptr<IOSContext> IOSContext::Create(
              "in an environment that does not support Metal. Enabling GPU pass through in your "
              "environment may fix this. If that is not possible, then disable Impeller.";
       return std::make_unique<IOSContextSoftware>();
-#if SHELL_ENABLE_METAL
     case IOSRenderingAPI::kMetal:
       switch (backend) {
         case IOSRenderingBackend::kSkia:
@@ -40,7 +36,6 @@ std::unique_ptr<IOSContext> IOSContext::Create(
         case IOSRenderingBackend::kImpeller:
           return std::make_unique<IOSContextMetalImpeller>(is_gpu_disabled_sync_switch);
       }
-#endif  // SHELL_ENABLE_METAL
     default:
       break;
   }

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -4,14 +4,10 @@
 
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
 
-#import "flutter/shell/platform/darwin/ios/ios_surface_software.h"
-
-#include "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
-
-#if SHELL_ENABLE_METAL
 #import "flutter/shell/platform/darwin/ios/ios_surface_metal_impeller.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface_metal_skia.h"
-#endif  // SHELL_ENABLE_METAL
+#import "flutter/shell/platform/darwin/ios/ios_surface_software.h"
+#include "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 
 namespace flutter {
 
@@ -20,7 +16,6 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(std::shared_ptr<IOSContext> conte
   FML_DCHECK(layer);
   FML_DCHECK(context);
 
-#if SHELL_ENABLE_METAL
   if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
     if ([layer.get() isKindOfClass:[CAMetalLayer class]]) {
       switch (context->GetBackend()) {
@@ -40,7 +35,6 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(std::shared_ptr<IOSContext> conte
       }
     }
   }
-#endif  // SHELL_ENABLE_METAL
 
   return std::make_unique<IOSSurfaceSoftware>(layer,              // layer
                                               std::move(context)  // context

--- a/shell/platform/darwin/ios/rendering_api_selection.mm
+++ b/shell/platform/darwin/ios/rendering_api_selection.mm
@@ -5,11 +5,9 @@
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 
 #include <Foundation/Foundation.h>
+#include <Metal/Metal.h>
 #include <QuartzCore/CAEAGLLayer.h>
 #import <QuartzCore/CAMetalLayer.h>
-#if SHELL_ENABLE_METAL
-#include <Metal/Metal.h>
-#endif  // SHELL_ENABLE_METAL
 #import <TargetConditionals.h>
 
 #include "flutter/fml/logging.h"
@@ -18,17 +16,12 @@
 
 namespace flutter {
 
-#if SHELL_ENABLE_METAL
 bool ShouldUseMetalRenderer() {
-  bool ios_version_supports_metal = false;
   if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
-    auto device = MTLCreateSystemDefaultDevice();
-    ios_version_supports_metal = [device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily1_v3];
-    [device release];
+    return YES;
   }
-  return ios_version_supports_metal;
+  return NO;
 }
-#endif  // SHELL_ENABLE_METAL
 
 IOSRenderingAPI GetRenderingAPIForProcess(bool force_software) {
 #if TARGET_OS_SIMULATOR
@@ -42,12 +35,9 @@ IOSRenderingAPI GetRenderingAPIForProcess(bool force_software) {
   }
 #endif  // TARGET_OS_SIMULATOR
 
-#if SHELL_ENABLE_METAL
-  static bool should_use_metal = ShouldUseMetalRenderer();
-  if (should_use_metal) {
+  if (ShouldUseMetalRenderer()) {
     return IOSRenderingAPI::kMetal;
   }
-#endif  // SHELL_ENABLE_METAL
 
   // When Metal isn't available we use Skia software rendering since it performs
   // a little better than emulated OpenGL. Also, omitting an OpenGL backend

--- a/shell/platform/darwin/ios/rendering_api_selection.mm
+++ b/shell/platform/darwin/ios/rendering_api_selection.mm
@@ -16,13 +16,6 @@
 
 namespace flutter {
 
-bool ShouldUseMetalRenderer() {
-  if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
-    return YES;
-  }
-  return NO;
-}
-
 IOSRenderingAPI GetRenderingAPIForProcess(bool force_software) {
 #if TARGET_OS_SIMULATOR
   if (force_software) {
@@ -35,7 +28,7 @@ IOSRenderingAPI GetRenderingAPIForProcess(bool force_software) {
   }
 #endif  // TARGET_OS_SIMULATOR
 
-  if (ShouldUseMetalRenderer()) {
+  if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
     return IOSRenderingAPI::kMetal;
   }
 


### PR DESCRIPTION
All physical iOS devices Flutter supports (iOS 12+) can run Metal.  The only time Flutter doesn't use Metal afaik is for iOS simulators running < iOS 13, which is covered by a few `if (@available(iOS METAL_IOS_VERSION_BASELINE, *))` checks.


https://github.com/flutter/engine/blob/8a51e124fbf168295a1b05f8d66459bfb29ae8a9/shell/platform/darwin/ios/rendering_api_selection.h#L37-L41

Remove hardware checks for physical devices.

Remove `shell_enable_metal` from the gn files and the `#if SHELL_ENABLE_METAL` checks in the iOS embedder.

I limited this PR to just iOS, but I imagine it's safe to remove `shell_enable_metal` everywhere? 
https://github.com/flutter/engine/blob/41da00ac46bc38a97a63ed0635450271d71afd9f/shell/platform/darwin/macos/BUILD.gn#L18
https://github.com/flutter/engine/blob/41da00ac46bc38a97a63ed0635450271d71afd9f/tools/gn#L673-L679
