### PR TITLE
[Impeller] fix unbalanced restores.

### DIFF
--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -272,6 +272,7 @@ impeller_component("entity_unittests") {
     "contents/tiled_texture_contents_unittests.cc",
     "contents/vertices_contents_unittests.cc",
     "entity_pass_target_unittests.cc",
+    "entity_pass_unittests.cc",
     "entity_playground.cc",
     "entity_playground.h",
     "entity_unittests.cc",

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -869,7 +869,9 @@ bool EntityPass::RenderElement(Entity& element_entity,
 
       if constexpr (ContentContext::kEnableStencilThenCover) {
         // Skip all clip restores when stencil-then-cover is enabled.
-        clip_replay_->RecordEntity(element_entity, clip_coverage.type);
+        if (clip_coverage_stack.back().coverage.has_value()) {
+          clip_replay_->RecordEntity(element_entity, clip_coverage.type);
+        }
         return true;
       }
 
@@ -1269,7 +1271,9 @@ void EntityPassClipRecorder::RecordEntity(const Entity& entity,
       rendered_clip_entities_.push_back(entity.Clone());
       break;
     case Contents::ClipCoverage::Type::kRestore:
-      rendered_clip_entities_.pop_back();
+      if (!rendered_clip_entities_.empty()) {
+        rendered_clip_entities_.pop_back();
+      }
       break;
   }
 }

--- a/impeller/entity/entity_pass_unittests.cc
+++ b/impeller/entity/entity_pass_unittests.cc
@@ -1,0 +1,52 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"
+#include "gtest/gtest.h"
+#include "impeller/entity/entity_pass.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(EntityPassClipRecorderTest, CanPushAndPopEntities) {
+  EntityPassClipRecorder recorder = EntityPassClipRecorder();
+
+  EXPECT_TRUE(recorder.GetReplayEntities().empty());
+
+  Entity entity;
+  recorder.RecordEntity(entity, Contents::ClipCoverage::Type::kAppend);
+  EXPECT_EQ(recorder.GetReplayEntities().size(), 1u);
+
+  recorder.RecordEntity(entity, Contents::ClipCoverage::Type::kAppend);
+  EXPECT_EQ(recorder.GetReplayEntities().size(), 2u);
+
+  recorder.RecordEntity(entity, Contents::ClipCoverage::Type::kRestore);
+  EXPECT_EQ(recorder.GetReplayEntities().size(), 1u);
+
+  recorder.RecordEntity(entity, Contents::ClipCoverage::Type::kRestore);
+  EXPECT_TRUE(recorder.GetReplayEntities().empty());
+}
+
+TEST(EntityPassClipRecorderTest, CanPopEntitiesSafely) {
+  EntityPassClipRecorder recorder = EntityPassClipRecorder();
+
+  EXPECT_TRUE(recorder.GetReplayEntities().empty());
+
+  Entity entity;
+  recorder.RecordEntity(entity, Contents::ClipCoverage::Type::kRestore);
+  EXPECT_TRUE(recorder.GetReplayEntities().empty());
+}
+
+TEST(EntityPassClipRecorderTest, CanAppendNoChange) {
+  EntityPassClipRecorder recorder = EntityPassClipRecorder();
+
+  EXPECT_TRUE(recorder.GetReplayEntities().empty());
+
+  Entity entity;
+  recorder.RecordEntity(entity, Contents::ClipCoverage::Type::kNoChange);
+  EXPECT_TRUE(recorder.GetReplayEntities().empty());
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/145528 by checking if the clip coverage stack is empty for restoring. Adds a protective empty check in clip replay.

I have a plan to pull the clip stack into something more testable to make this better.
