### PR TITLE
[iOS] setDisableActions on platform view CATransaction.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -907,6 +907,7 @@ void FlutterPlatformViewsController::BeginCATransaction() {
   FML_DCHECK([[NSThread currentThread] isMainThread]);
   FML_DCHECK(!catransaction_added_);
   [CATransaction begin];
+  [CATransaction setDisableActions:YES];
   catransaction_added_ = true;
 }
 


### PR DESCRIPTION
In theory we could trigger animations by touching certain CALayer/UIView properties, this just explicitly disables them for our compositor.