### PR TITLE
[Impeller] Simplify calculation of Matrix::GetMaxBasisXY()

### DIFF
--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -352,6 +352,18 @@ TEST(GeometryTest, MatrixGetMaxBasisLengthXY) {
     auto m = Matrix::MakeScale({-3, 4, 7});
     ASSERT_EQ(m.GetMaxBasisLengthXY(), 4);
   }
+
+  {
+    // clang-format off
+    auto m = Matrix::MakeColumn(
+        1.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f, 0.0f,
+        4.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f
+    );
+    // clang-format on
+    ASSERT_EQ(m.GetMaxBasisLengthXY(), 1.0f);
+  }
 }
 
 TEST(GeometryTest, MatrixMakeOrthographic) {

--- a/impeller/geometry/matrix.cc
+++ b/impeller/geometry/matrix.cc
@@ -202,14 +202,6 @@ Scalar Matrix::GetMaxBasisLength() const {
   return std::sqrt(max);
 }
 
-Scalar Matrix::GetMaxBasisLengthXY() const {
-  Scalar max = 0;
-  for (int i = 0; i < 3; i++) {
-    max = std::max(max, e[i][0] * e[i][0] + e[i][1] * e[i][1]);
-  }
-  return std::sqrt(max);
-}
-
 /*
  *  Adapted for Impeller from Graphics Gems:
  *  http://www.realtimerendering.com/resources/GraphicsGems/gemsii/unmatrix.c

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -292,7 +292,10 @@ struct Matrix {
 
   Scalar GetMaxBasisLength() const;
 
-  Scalar GetMaxBasisLengthXY() const;
+  constexpr Scalar GetMaxBasisLengthXY() const {
+    return std::sqrt(std::max(e[0][0] * e[0][0] + e[0][1] * e[0][1],
+                              e[1][0] * e[1][0] + e[1][1] * e[1][1]));
+  }
 
   constexpr Vector3 GetBasisX() const { return Vector3(m[0], m[1], m[2]); }
 


### PR DESCRIPTION
Since 2D coordinates have a `Z` value of `0.0`, they don't need to include the Z basis vector in calculating a scale.