### PR TITLE
Revert "Disable cleaning up ImageReaders in memory pressure callback"

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -414,11 +414,6 @@ public class FlutterRenderer implements TextureRegistry {
     // Flip when debugging to see verbose logs.
     private static final boolean VERBOSE_LOGS = false;
 
-    // If we cleanup the ImageReaders on memory pressure it breaks VirtualDisplay
-    // backed platform views. Disable for now as this is only necessary to work
-    // around a Samsung-specific Android 14 bug.
-    private static final boolean CLEANUP_ON_MEMORY_PRESSURE = false;
-
     private final long id;
 
     private boolean released;
@@ -654,9 +649,6 @@ public class FlutterRenderer implements TextureRegistry {
 
     @Override
     public void onTrimMemory(int level) {
-      if (!CLEANUP_ON_MEMORY_PRESSURE) {
-        return;
-      }
       cleanup();
       createNewReader = true;
     }

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -648,12 +648,11 @@ public class FlutterRendererTest {
     assertEquals(1, texture.numImages());
 
     // Invoke the onTrimMemory callback.
-    // This should do nothing.
     texture.onTrimMemory(0);
     shadowOf(Looper.getMainLooper()).idle();
 
-    assertEquals(1, texture.numImageReaders());
-    assertEquals(1, texture.numImages());
+    assertEquals(0, texture.numImageReaders());
+    assertEquals(0, texture.numImages());
   }
 
   // A 0x0 ImageReader is a runtime error.


### PR DESCRIPTION
Reverts flutter/engine#51391

Reason for revert: b/330184547 - I believe there is a good chance that the investigation on that issue was not really adequate to justify this revert, but this change can be easily relanded if reverting this was the wrong choice.