### PR TITLE
[Impeller] Do not apply mask filters to a DrawPaint cover geometry

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -44,8 +44,10 @@ static std::shared_ptr<Contents> CreateContentsForGeometryWithFilters(
     }
   }
 
+  bool can_apply_mask_filter = geometry->CanApplyMaskFilter();
   contents->SetGeometry(std::move(geometry));
-  if (paint.mask_blur_descriptor.has_value()) {
+
+  if (can_apply_mask_filter && paint.mask_blur_descriptor.has_value()) {
     // If there's a mask blur and we need to apply the color filter on the GPU,
     // we need to be careful to only apply the color filter to the source
     // colors. CreateMaskBlur is able to handle this case.

--- a/impeller/display_list/dl_unittests.cc
+++ b/impeller/display_list/dl_unittests.cc
@@ -1834,5 +1834,28 @@ TEST_P(DisplayListTest, SceneColorSource) {
 }
 #endif
 
+TEST_P(DisplayListTest, DrawPaintIgnoresMaskFilter) {
+  flutter::DisplayListBuilder builder;
+  builder.DrawPaint(flutter::DlPaint().setColor(flutter::DlColor::kWhite()));
+
+  auto filter = flutter::DlBlurMaskFilter(flutter::DlBlurStyle::kNormal, 10.0f);
+  builder.DrawCircle({300, 300}, 200,
+                     flutter::DlPaint().setMaskFilter(&filter));
+
+  std::vector<flutter::DlColor> colors = {flutter::DlColor::kGreen(),
+                                          flutter::DlColor::kGreen()};
+  const float stops[2] = {0.0, 1.0};
+  auto linear = flutter::DlColorSource::MakeLinear(
+      {100.0, 100.0}, {300.0, 300.0}, 2, colors.data(), stops,
+      flutter::DlTileMode::kRepeat);
+  flutter::DlPaint blend_paint =
+      flutter::DlPaint()           //
+          .setColorSource(linear)  //
+          .setBlendMode(flutter::DlBlendMode::kScreen);
+  builder.DrawPaint(blend_paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/entity/geometry/cover_geometry.cc
+++ b/impeller/entity/geometry/cover_geometry.cc
@@ -58,4 +58,8 @@ bool CoverGeometry::CoversArea(const Matrix& transform,
   return true;
 }
 
+bool CoverGeometry::CanApplyMaskFilter() const {
+  return false;
+}
+
 }  // namespace impeller

--- a/impeller/entity/geometry/cover_geometry.h
+++ b/impeller/entity/geometry/cover_geometry.h
@@ -20,6 +20,8 @@ class CoverGeometry final : public Geometry {
   // |Geometry|
   bool CoversArea(const Matrix& transform, const Rect& rect) const override;
 
+  bool CanApplyMaskFilter() const override;
+
  private:
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -240,4 +240,8 @@ bool Geometry::IsAxisAlignedRect() const {
   return false;
 }
 
+bool Geometry::CanApplyMaskFilter() const {
+  return true;
+}
+
 }  // namespace impeller

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -148,6 +148,8 @@ class Geometry {
 
   virtual bool IsAxisAlignedRect() const;
 
+  virtual bool CanApplyMaskFilter() const;
+
  protected:
   static GeometryResult ComputePositionGeometry(
       const ContentContext& renderer,


### PR DESCRIPTION
The DisplayListBuilder only updates the paint attributes that are relevant to a given operation.  DrawPaint does not support mask filters, so DisplayListBuilder::DrawPaint will not modify the mask filter state. So a call to DrawPaint in the display list dispatcher may receive a paint containing a mask filter set by a previous call.

Aiks Canvas::DrawPaint should ignore any mask filter set on the paint (matching the spec for Skia's SkCanvas::drawPaint)

Fixes https://github.com/flutter/flutter/issues/145442