### PR TITLE
Pass the flutter test font by default.

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -578,16 +578,13 @@ final class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implemen
     ui.TextLeadingDistribution? leadingDistribution,
   }) {
     final StrutStyleHandle handle = strutStyleCreate();
-    if (fontFamily != null || fontFamilyFallback != null) {
-      final List<String> fontFamilies = <String>[
-        if (fontFamily != null) fontFamily,
-        if (fontFamilyFallback != null) ...fontFamilyFallback,
-      ];
-      if (fontFamilies.isNotEmpty) {
-        withScopedFontList(_computeEffectiveFontFamilies(fontFamilies),
-          (Pointer<SkStringHandle> families, int count) =>
-            strutStyleSetFontFamilies(handle, families, count));
-      }
+    final List<String> effectiveFontFamilies = _computeEffectiveFontFamilies(<String>[
+      if (fontFamily != null) fontFamily,
+      if (fontFamilyFallback != null) ...fontFamilyFallback,
+    ]);
+    if (effectiveFontFamilies.isNotEmpty) {
+      withScopedFontList(effectiveFontFamilies, (Pointer<SkStringHandle> families, int count) =>
+          strutStyleSetFontFamilies(handle, families, count));
     }
     if (fontSize != null) {
       strutStyleSetFontSize(handle, fontSize);
@@ -730,9 +727,11 @@ class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle> implem
       (renderer.fontCollection as SkwasmFontCollection).defaultTextStyle.copy();
     final TextStyleHandle textStyleHandle = textStyle.handle;
 
-    if (fontFamily != null) {
-      withScopedFontList(_computeEffectiveFontFamilies(<String>[fontFamily]),
-        (Pointer<SkStringHandle> families, int count) =>
+    final List<String> effectiveFontFamilies = _computeEffectiveFontFamilies(<String>[
+      if (fontFamily != null) fontFamily
+    ]);
+    if (effectiveFontFamilies.isNotEmpty) {
+      withScopedFontList(effectiveFontFamilies, (Pointer<SkStringHandle> families, int count) =>
           textStyleAddFontFamilies(textStyleHandle, families, count));
     }
     if (fontSize != null) {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -15,10 +15,12 @@ const int _kSoftLineBreak = 0;
 const int _kHardLineBreak = 100;
 
 final List<String> _testFonts = <String>['FlutterTest', 'Ahem'];
-String _computeEffectiveFontFamily(String fontFamily) {
-  return ui_web.debugEmulateFlutterTesterEnvironment && !_testFonts.contains(fontFamily)
-    ? _testFonts.first
-    : fontFamily;
+List<String> _computeEffectiveFontFamilies(List<String> fontFamilies) {
+  if (!ui_web.debugEmulateFlutterTesterEnvironment) {
+    return fontFamilies;
+  }
+  final Iterable<String> filteredFonts = fontFamilies.where(_testFonts.contains);
+  return filteredFonts.isEmpty ? _testFonts : filteredFonts.toList();
 }
 
 class SkwasmLineMetrics extends SkwasmObjectWrapper<RawLineMetrics> implements ui.LineMetrics {
@@ -359,7 +361,7 @@ class SkwasmTextStyle implements ui.TextStyle {
       textStyleSetTextBaseline(handle, textBaseline!.index);
     }
 
-    final List<String> effectiveFontFamilies = fontFamilies;
+    final List<String> effectiveFontFamilies = _computeEffectiveFontFamilies(fontFamilies);
     if (effectiveFontFamilies.isNotEmpty) {
       withScopedFontList(effectiveFontFamilies,
         (Pointer<SkStringHandle> families, int count) =>
@@ -438,8 +440,8 @@ class SkwasmTextStyle implements ui.TextStyle {
   }
 
   List<String> get fontFamilies => <String>[
-    if (fontFamily != null) _computeEffectiveFontFamily(fontFamily!),
-    if (fontFamilyFallback != null) ...fontFamilyFallback!.map(_computeEffectiveFontFamily),
+    if (fontFamily != null) fontFamily!,
+    if (fontFamilyFallback != null) ...fontFamilyFallback!,
   ];
 
   final ui.Color? color;
@@ -582,7 +584,7 @@ final class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implemen
         if (fontFamilyFallback != null) ...fontFamilyFallback,
       ];
       if (fontFamilies.isNotEmpty) {
-        withScopedFontList(fontFamilies,
+        withScopedFontList(_computeEffectiveFontFamilies(fontFamilies),
           (Pointer<SkStringHandle> families, int count) =>
             strutStyleSetFontFamilies(handle, families, count));
       }
@@ -729,7 +731,7 @@ class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle> implem
     final TextStyleHandle textStyleHandle = textStyle.handle;
 
     if (fontFamily != null) {
-      withScopedFontList(<String>[fontFamily],
+      withScopedFontList(_computeEffectiveFontFamilies(<String>[fontFamily]),
         (Pointer<SkStringHandle> families, int count) =>
           textStyleAddFontFamilies(textStyleHandle, families, count));
     }

--- a/lib/web_ui/test/ui/line_metrics_test.dart
+++ b/lib/web_ui/test/ui/line_metrics_test.dart
@@ -117,7 +117,7 @@ Future<void> testMain() async {
     }
   }, skip: isHtml); // The rounding hack doesn't apply to the html renderer
 
-  test('uses flutter test fonts when debugEmulateFlutterTesterEnvironment is enabled', () {
+  test('overrides with flutter test font when debugEmulateFlutterTesterEnvironment is enabled', () {
     final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle());
     builder.pushStyle(ui.TextStyle(
       fontSize: 10.0,
@@ -128,6 +128,26 @@ Future<void> testMain() async {
     paragraph.layout(const ui.ParagraphConstraints(width: 400));
 
     expect(paragraph.numberOfLines, 1);
+    expect(paragraph.height, 10);
+
+    final ui.LineMetrics? metrics = paragraph.getLineMetricsAt(0);
+    expect(metrics, isNotNull);
+
+    // FlutterTest font's 'X' character is a square, so it's the font size (10.0) * 4 characters.
+    expect(metrics!.width, 40.0);
+  });
+
+  test('uses flutter test font by default when debugEmulateFlutterTesterEnvironment is enabled', () {
+    final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle());
+    builder.pushStyle(ui.TextStyle(
+      fontSize: 10.0,
+    ));
+    builder.addText('XXXX');
+    final ui.Paragraph paragraph = builder.build();
+    paragraph.layout(const ui.ParagraphConstraints(width: 400));
+
+    expect(paragraph.numberOfLines, 1);
+    expect(paragraph.height, 10);
 
     final ui.LineMetrics? metrics = paragraph.getLineMetricsAt(0);
     expect(metrics, isNotNull);

--- a/lib/web_ui/test/ui/line_metrics_test.dart
+++ b/lib/web_ui/test/ui/line_metrics_test.dart
@@ -162,16 +162,19 @@ Future<void> testMain() async {
 
     final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle());
     builder.pushStyle(ui.TextStyle(
-      fontSize: 14.0,
+      fontSize: 16.0,
       fontFamily: 'Roboto',
     ));
-    builder.addText('XXXX');
+    builder.addText('O');
     final ui.Paragraph paragraph = builder.build();
-    paragraph.layout(const ui.ParagraphConstraints(width: 400000));
+    paragraph.layout(const ui.ParagraphConstraints(width: 400));
 
     expect(paragraph.numberOfLines, 1);
 
-    // Roboto has 2 points of leading around the font, whereas the test font does not.
-    expect(paragraph.height, 16);
-  });
+    final ui.LineMetrics? metrics = paragraph.getLineMetricsAt(0);
+    expect(metrics, isNotNull);
+
+    // In Roboto, the width should be 11 here. In the test font, it would be square (16 points)
+    expect(metrics!.width, 11);
+  }, solo: true);
 }

--- a/lib/web_ui/test/ui/line_metrics_test.dart
+++ b/lib/web_ui/test/ui/line_metrics_test.dart
@@ -5,6 +5,7 @@
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web/testing.dart';
 
 import '../common/test_initialization.dart';
 import 'utils.dart';
@@ -121,7 +122,7 @@ Future<void> testMain() async {
     final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle());
     builder.pushStyle(ui.TextStyle(
       fontSize: 10.0,
-      fontFamily: 'SomeOtherFontFamily',
+      fontFamily: 'Roboto',
     ));
     builder.addText('XXXX');
     final ui.Paragraph paragraph = builder.build();
@@ -154,5 +155,23 @@ Future<void> testMain() async {
 
     // FlutterTest font's 'X' character is a square, so it's the font size (10.0) * 4 characters.
     expect(metrics!.width, 40.0);
+  });
+
+  test('uses specified font when debugEmulateFlutterTesterEnvironment is disabled', () {
+    debugEmulateFlutterTesterEnvironment = false;
+
+    final ui.ParagraphBuilder builder = ui.ParagraphBuilder(ui.ParagraphStyle());
+    builder.pushStyle(ui.TextStyle(
+      fontSize: 14.0,
+      fontFamily: 'Roboto',
+    ));
+    builder.addText('XXXX');
+    final ui.Paragraph paragraph = builder.build();
+    paragraph.layout(const ui.ParagraphConstraints(width: 400000));
+
+    expect(paragraph.numberOfLines, 1);
+
+    // Roboto has 2 points of leading around the font, whereas the test font does not.
+    expect(paragraph.height, 16);
   });
 }


### PR DESCRIPTION
In the default case, where no fonts are specified, we should specify the flutter test font. This fixes a swath of framework tests in skwasm.