### PR TITLE
Roll buildroot to 2a16784938d3be059014d4112f00ac70a386fa0c

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -289,7 +289,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'bce07474ce354afc8ea6bb1b695cc86ef376260d',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '2a16784938d3be059014d4112f00ac70a386fa0c',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',


### PR DESCRIPTION
To pick up https://github.com/flutter/buildroot/pull/841
