### PR TITLE
[Windows] Don't always stop engine on view destruction

### DIFF
--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -87,6 +87,7 @@ source_set("flutter_windows_source") {
     "flutter_windows_texture_registrar.h",
     "flutter_windows_view.cc",
     "flutter_windows_view.h",
+    "flutter_windows_view_controller.cc",
     "flutter_windows_view_controller.h",
     "keyboard_handler_base.h",
     "keyboard_key_channel_handler.cc",

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -130,6 +130,7 @@ FlutterDesktopViewControllerRef FlutterDesktopEngineCreateViewController(
 
 void FlutterDesktopViewControllerDestroy(FlutterDesktopViewControllerRef ref) {
   auto controller = ViewControllerFromHandle(ref);
+  controller->Destroy();
   delete controller;
 }
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -502,6 +502,24 @@ std::unique_ptr<FlutterWindowsView> FlutterWindowsEngine::CreateView(
   return std::move(view);
 }
 
+void FlutterWindowsEngine::RemoveView(FlutterViewId view_id) {
+  FML_DCHECK(running());
+  FML_DCHECK(views_.find(view_id) != views_.end());
+
+  if (view_id == kImplicitViewId) {
+    // The engine and framework assume the implicit view always exists.
+    // Attempts to render to the implicit view will be ignored.
+    views_.erase(view_id);
+    return;
+  }
+
+  // TODO(loicsharma): Remove the view from the engine using the
+  // `FlutterEngineRemoveView` embedder API. Windows does not
+  // support views other than the implicit view yet.
+  // https://github.com/flutter/flutter/issues/144810
+  FML_UNREACHABLE();
+}
+
 void FlutterWindowsEngine::OnVsync(intptr_t baton) {
   std::chrono::nanoseconds current_time =
       std::chrono::nanoseconds(embedder_api_.GetCurrentTime());

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -124,6 +124,9 @@ class FlutterWindowsEngine {
   std::unique_ptr<FlutterWindowsView> CreateView(
       std::unique_ptr<WindowBindingHandler> window);
 
+  // Remove a view. The engine will no longer render into it.
+  virtual void RemoveView(FlutterViewId view_id);
+
   // Get a view that displays this engine's content.
   //
   // Returns null if the view does not exist.

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -139,6 +139,9 @@ TEST_F(WindowsTest, EngineCanTransitionToHeadless) {
 
   // The engine is back in headless mode now.
   ASSERT_NE(engine, nullptr);
+
+  auto engine_ptr = reinterpret_cast<FlutterWindowsEngine*>(engine.get());
+  ASSERT_TRUE(engine_ptr->running());
 }
 
 // Verify that accessibility features are initialized when a view is created.

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -105,10 +105,6 @@ FlutterWindowsView::~FlutterWindowsView() {
   // Notify the engine the view's child window will no longer be visible.
   engine_->OnWindowStateEvent(GetWindowHandle(), WindowStateEvent::kHide);
 
-  // The engine renders into the view's surface. The engine must be
-  // shutdown before the view's resources can be destroyed.
-  engine_->Stop();
-
   DestroyRenderSurface();
 }
 

--- a/shell/platform/windows/flutter_windows_view_controller.cc
+++ b/shell/platform/windows/flutter_windows_view_controller.cc
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/flutter_windows_view_controller.h"
+
+namespace flutter {
+
+FlutterWindowsViewController::~FlutterWindowsViewController() {
+  Destroy();
+}
+
+void FlutterWindowsViewController::Destroy() {
+  if (!view_) {
+    return;
+  }
+
+  // Prevent the engine from rendering into this view.
+  if (view_->GetEngine()->running()) {
+    auto view_id = view_->view_id();
+
+    view_->GetEngine()->RemoveView(view_id);
+  }
+
+  // Destroy the view, followed by the engine if it is owned by this controller.
+  view_.reset();
+  engine_.reset();
+}
+
+}  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view_controller.h
+++ b/shell/platform/windows/flutter_windows_view_controller.h
@@ -7,8 +7,9 @@
 
 #include <memory>
 
-#include "flutter_windows_engine.h"
-#include "flutter_windows_view.h"
+#include "flutter/fml/macros.h"
+#include "flutter/shell/platform/windows/flutter_windows_engine.h"
+#include "flutter/shell/platform/windows/flutter_windows_view.h"
 
 namespace flutter {
 
@@ -18,6 +19,13 @@ class FlutterWindowsViewController {
   FlutterWindowsViewController(std::unique_ptr<FlutterWindowsEngine> engine,
                                std::unique_ptr<FlutterWindowsView> view)
       : engine_(std::move(engine)), view_(std::move(view)) {}
+
+  ~FlutterWindowsViewController();
+
+  // Destroy this view controller and its view.
+  //
+  // If this view controller owns the engine, the engine is also destroyed.
+  void Destroy();
 
   FlutterWindowsEngine* engine() { return view_->GetEngine(); }
   FlutterWindowsView* view() { return view_.get(); }
@@ -36,6 +44,8 @@ class FlutterWindowsViewController {
   std::unique_ptr<FlutterWindowsEngine> engine_;
 
   std::unique_ptr<FlutterWindowsView> view_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsViewController);
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Currently destroying a view also shuts down the engine. This makes sense as in single-view world where the view also always owns the engine. However, in a multi-view world the views will share the engine. Destroying one view shouldn't necessarily shut down the engine unless that view owns the engine.

Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
