### PR TITLE
Fail pre-submit if a negative image is encountered as part of `goldctl imgtest add`.

### DIFF
--- a/testing/skia_gold_client/lib/skia_gold_client.dart
+++ b/testing/skia_gold_client/lib/skia_gold_client.dart
@@ -13,7 +13,7 @@ import 'package:process/process.dart';
 
 import 'src/errors.dart';
 
-export 'src/errors.dart' show SkiaGoldProcessError;
+export 'src/errors.dart' show SkiaGoldNegativeImageError, SkiaGoldProcessError;
 
 const String _kGoldctlKey = 'GOLDCTL';
 const String _kPresubmitEnvName = 'GOLD_TRYJOB';
@@ -406,30 +406,46 @@ interface class SkiaGoldClient {
         _stderr.writeln('stderr:\n${result.stderr}');
       }
     } else {
-      // Neither of these conditions are considered failures during tryjobs.
-      final bool isUntriaged = resultStdout.contains('Untriaged');
-      final bool isNegative = resultStdout.contains('negative image');
-      if (!isUntriaged && !isNegative) {
-        final StringBuffer buf = StringBuffer()
-          ..writeln('Unexpected Gold tryjobAdd failure.')
-          ..writeln('Tryjob execution for golden file test $testName failed for')
-          ..writeln('a reason unrelated to pixel comparison.');
-        throw SkiaGoldProcessError(
-          command: tryjobCommand,
-          stdout: resultStdout,
-          stderr: result.stderr.toString(),
-          message: buf.toString(),
-        );
-      }
+      // Untriaged images are not considered failures during tryjobs.
       // ... but we want to know about them anyway.
       // See https://github.com/flutter/flutter/issues/145219.
       // TODO(matanlurey): Update the documentation to reflect the new behavior.
+      final bool isUntriaged = resultStdout.contains('Untriaged');
       if (isUntriaged) {
         _stderr
           ..writeln('NOTE: Untriaged image detected in tryjob.')
           ..writeln('Triage should be required by the "Flutter Gold" check')
           ..writeln('stdout:\n$resultStdout');
+        return;
       }
+      
+      // Negative images are considered failures during tryjobs.
+      //
+      // We don't actually use negative images as part of our workflow, but
+      // if they *are* used (i.e. someone accidentally marks a digest a
+      // negative image), we want to fail the tryjob - otherwise we just end up
+      // with a negative image in the tree (a post-submit failure).
+      final bool isNegative = resultStdout.contains('negative image');
+      if (isNegative) {
+        throw SkiaGoldNegativeImageError(
+          testName: testName,
+          command: tryjobCommand,
+          stdout: resultStdout,
+          stderr: result.stderr.toString(),
+        );
+      }
+
+      // If the tryjob failed for some other reason, throw an error.
+      final StringBuffer buf = StringBuffer()
+        ..writeln('Unexpected Gold tryjobAdd failure.')
+        ..writeln('Tryjob execution for golden file test $testName failed for')
+        ..writeln('a reason unrelated to pixel comparison.');
+      throw SkiaGoldProcessError(
+        command: tryjobCommand,
+        stdout: resultStdout,
+        stderr: result.stderr.toString(),
+        message: buf.toString(),
+      );
     }
   }
 

--- a/testing/skia_gold_client/lib/skia_gold_client.dart
+++ b/testing/skia_gold_client/lib/skia_gold_client.dart
@@ -418,7 +418,7 @@ interface class SkiaGoldClient {
           ..writeln('stdout:\n$resultStdout');
         return;
       }
-      
+
       // Negative images are considered failures during tryjobs.
       //
       // We don't actually use negative images as part of our workflow, but

--- a/testing/skia_gold_client/lib/src/errors.dart
+++ b/testing/skia_gold_client/lib/src/errors.dart
@@ -51,3 +51,22 @@ final class SkiaGoldProcessError extends Error {
     ].join('\n');
   }
 }
+
+/// Error thrown when the Skia Gold process exits due to a negative image.
+final class SkiaGoldNegativeImageError extends SkiaGoldProcessError {
+  /// Creates a new [SkiaGoldNegativeImageError] from the provided origin.
+  /// 
+  /// See [SkiaGoldProcessError.new] for more information.
+  SkiaGoldNegativeImageError({
+    required this.testName,
+    required super.command,
+    required super.stdout,
+    required super.stderr,
+  });
+
+  /// Name of the test that produced the negative image.
+  final String testName;
+
+  @override
+  String get message => 'Negative image detected for test: "$testName"';
+}

--- a/testing/skia_gold_client/lib/src/errors.dart
+++ b/testing/skia_gold_client/lib/src/errors.dart
@@ -55,7 +55,7 @@ final class SkiaGoldProcessError extends Error {
 /// Error thrown when the Skia Gold process exits due to a negative image.
 final class SkiaGoldNegativeImageError extends SkiaGoldProcessError {
   /// Creates a new [SkiaGoldNegativeImageError] from the provided origin.
-  /// 
+  ///
   /// See [SkiaGoldProcessError.new] for more information.
   SkiaGoldNegativeImageError({
     required this.testName,
@@ -68,5 +68,9 @@ final class SkiaGoldNegativeImageError extends SkiaGoldProcessError {
   final String testName;
 
   @override
-  String get message => 'Negative image detected for test: "$testName"';
+  String get message => 'Negative image detected for test: "$testName".\n\n'
+      'The flutter/engine workflow should never produce negative images; it is '
+      'possible that someone accidentally (or without knowing our policy) '
+      'marked a test as negative.\n\n'
+      'See https://github.com/flutter/flutter/issues/145043 for details.';
 }


### PR DESCRIPTION
`flutter/engine`-side fix for https://github.com/flutter/flutter/issues/145043.

- Before this PR, if a negative image was encountered, we'd silently pass pre-submit, merge, and turn the tree red.
- After this PR, a negative image both makes pre and post-submit red.

Added tests, and fixed up some unrelated tests that were accidentally setting `pid` instead of `exitCode`. Oops!

/cc @zanderso and @eyebrowsoffire (current engine sheriff).