### PR TITLE
Turn off internal retries for Android scenario app tests

### DIFF
--- a/ci/builders/linux_android_emulator.json
+++ b/ci/builders/linux_android_emulator.json
@@ -69,7 +69,7 @@
                     "language": "dart",
                     "name": "Android Scenario App Integration Tests (Impeller/Vulkan)",
                     "test_timeout_secs": 900,
-                    "max_attempts": 2,
+                    "max_attempts": 1,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",

--- a/ci/builders/linux_android_emulator_api_33.json
+++ b/ci/builders/linux_android_emulator_api_33.json
@@ -63,7 +63,7 @@
                     "language": "dart",
                     "name": "Scenario App Integration Tests",
                     "test_timeout_secs": 900,
-                    "max_attempts": 2,
+                    "max_attempts": 1,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",

--- a/ci/builders/linux_android_emulator_opengles.json
+++ b/ci/builders/linux_android_emulator_opengles.json
@@ -37,7 +37,7 @@
                     "language": "dart",
                     "name": "Android Scenario App Integration Tests (Impeller/OpenGLES)",
                     "test_timeout_secs": 900,
-                    "max_attempts": 2,
+                    "max_attempts": 1,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",
@@ -62,7 +62,7 @@
                     "language": "dart",
                     "name": "Android Scenario App Integration Tests (Impeller/OpenGLES, SurfaceTexture)",
                     "test_timeout_secs": 900,
-                    "max_attempts": 2,
+                    "max_attempts": 1,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",

--- a/ci/builders/linux_android_emulator_skia.json
+++ b/ci/builders/linux_android_emulator_skia.json
@@ -39,7 +39,7 @@
                     "language": "dart",
                     "name": "Android Scenario App Integration Tests (Skia)",
                     "test_timeout_secs": 900,
-                    "max_attempts": 2,
+                    "max_attempts": 1,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",
@@ -63,7 +63,7 @@
                     "language": "dart",
                     "name": "Android Scenario App Integration Tests (Skia, SurfaceTexture)",
                     "test_timeout_secs": 900,
-                    "max_attempts": 2,
+                    "max_attempts": 1,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",


### PR DESCRIPTION
The idea is to make flakes more visible on the dashboard.