### PR TITLE
[Impeller] Use the scissor to limit all draws by clip coverage.

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -848,14 +848,17 @@ bool EntityPass::RenderElement(Entity& element_entity,
   element_entity.GetContents()->SetCoverageHint(
       Rect::Intersection(element_coverage_hint, current_clip_coverage));
 
-  bool should_render = clip_coverage_stack.ApplyClipState(
-      clip_coverage, element_entity, clip_depth_floor, global_pass_position);
+  EntityPassClipStack::ClipStateResult clip_state_result =
+      clip_coverage_stack.ApplyClipState(clip_coverage, element_entity,
+                                         clip_depth_floor,
+                                         global_pass_position);
 
-  SetClipScissor(clip_coverage_stack.CurrentClipCoverage(), *result.pass,
-                 global_pass_position);
+  if (clip_state_result.clip_did_change) {
+    SetClipScissor(clip_coverage_stack.CurrentClipCoverage(), *result.pass,
+                   global_pass_position);
+  }
 
-  if (!should_render) {
-    // `ApplyClipState` returns false if the Entity can be safely skipped.
+  if (!clip_state_result.should_render) {
     return true;
   }
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -25,6 +25,7 @@
 #include "impeller/entity/inline_pass_context.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/rect.h"
+#include "impeller/geometry/size.h"
 #include "impeller/renderer/command_buffer.h"
 
 #ifdef IMPELLER_DEBUG
@@ -752,6 +753,25 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
   FML_UNREACHABLE();
 }
 
+static void SetClipScissor(std::optional<Rect> clip_coverage,
+                           RenderPass& pass,
+                           Point global_pass_position) {
+  if constexpr (!ContentContext::kEnableStencilThenCover) {
+    return;
+  }
+  // Set the scissor to the clip coverage area. We do this prior to rendering
+  // the clip itself and all its contents.
+  IRect scissor;
+  if (clip_coverage.has_value()) {
+    clip_coverage = clip_coverage->Shift(-global_pass_position);
+    scissor = IRect::MakeLTRB(std::floor(clip_coverage->GetLeft()),
+                              std::floor(clip_coverage->GetTop()),
+                              std::ceil(clip_coverage->GetRight()),
+                              std::ceil(clip_coverage->GetBottom()));
+  }
+  pass.SetScissor(scissor);
+}
+
 bool EntityPass::RenderElement(Entity& element_entity,
                                size_t clip_depth_floor,
                                InlinePassContext& pass_context,
@@ -771,8 +791,10 @@ bool EntityPass::RenderElement(Entity& element_entity,
     // Restore any clips that were recorded before the backdrop filter was
     // applied.
     auto& replay_entities = clip_coverage_stack.GetReplayEntities();
-    for (const auto& entity : replay_entities) {
-      if (!entity.Render(renderer, *result.pass)) {
+    for (const auto& replay : replay_entities) {
+      SetClipScissor(clip_coverage_stack.CurrentClipCoverage(), *result.pass,
+                     global_pass_position);
+      if (!replay.entity.Render(renderer, *result.pass)) {
         VALIDATION_LOG << "Failed to render entity for clip restore.";
       }
     }
@@ -826,11 +848,14 @@ bool EntityPass::RenderElement(Entity& element_entity,
   element_entity.GetContents()->SetCoverageHint(
       Rect::Intersection(element_coverage_hint, current_clip_coverage));
 
-  if (!clip_coverage_stack.AppendClipCoverage(clip_coverage, element_entity,
-                                              clip_depth_floor,
-                                              global_pass_position)) {
-    // If the entity's coverage change did not change the clip coverage, we
-    // don't need to render it.
+  bool should_render = clip_coverage_stack.ApplyClipState(
+      clip_coverage, element_entity, clip_depth_floor, global_pass_position);
+
+  SetClipScissor(clip_coverage_stack.CurrentClipCoverage(), *result.pass,
+                 global_pass_position);
+
+  if (!should_render) {
+    // `ApplyClipState` returns false if the Entity can be safely skipped.
     return true;
   }
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -764,10 +764,8 @@ static void SetClipScissor(std::optional<Rect> clip_coverage,
   IRect scissor;
   if (clip_coverage.has_value()) {
     clip_coverage = clip_coverage->Shift(-global_pass_position);
-    scissor = IRect::MakeLTRB(std::floor(clip_coverage->GetLeft()),
-                              std::floor(clip_coverage->GetTop()),
-                              std::ceil(clip_coverage->GetRight()),
-                              std::ceil(clip_coverage->GetBottom()));
+    scissor = IRect::RoundOut(clip_coverage.value());
+    // The scissor rect must not exceed the size of the render target.
     scissor = scissor.Intersection(IRect::MakeSize(pass.GetRenderTargetSize()))
                   .value_or(IRect());
   }
@@ -856,6 +854,7 @@ bool EntityPass::RenderElement(Entity& element_entity,
                                          global_pass_position);
 
   if (clip_state_result.clip_did_change) {
+    // We only need to update the pass scissor if the clip state has changed.
     SetClipScissor(clip_coverage_stack.CurrentClipCoverage(), *result.pass,
                    global_pass_position);
   }

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -768,6 +768,8 @@ static void SetClipScissor(std::optional<Rect> clip_coverage,
                               std::floor(clip_coverage->GetTop()),
                               std::ceil(clip_coverage->GetRight()),
                               std::ceil(clip_coverage->GetBottom()));
+    scissor = scissor.Intersection(IRect::MakeSize(pass.GetRenderTargetSize()))
+                  .value_or(IRect());
   }
   pass.SetScissor(scissor);
 }

--- a/impeller/entity/entity_pass_clip_stack.h
+++ b/impeller/entity/entity_pass_clip_stack.h
@@ -6,6 +6,8 @@
 #define FLUTTER_IMPELLER_ENTITY_ENTITY_PASS_CLIP_STACK_H_
 
 #include "impeller/entity/contents/contents.h"
+#include "impeller/entity/entity.h"
+#include "impeller/geometry/rect.h"
 
 namespace impeller {
 
@@ -21,6 +23,11 @@ struct ClipCoverageLayer {
 ///        stencil buffer is left in an identical state.
 class EntityPassClipStack {
  public:
+  struct ReplayResult {
+    Entity entity;
+    std::optional<Rect> clip_coverage;
+  };
+
   /// Create a new [EntityPassClipStack] with an initialized coverage rect.
   explicit EntityPassClipStack(const Rect& initial_coverage_rect);
 
@@ -34,24 +41,29 @@ class EntityPassClipStack {
 
   bool HasCoverage() const;
 
-  /// Returns true if entity should be rendered.
-  bool AppendClipCoverage(Contents::ClipCoverage clip_coverage,
-                          Entity& entity,
-                          size_t clip_depth_floor,
-                          Point global_pass_position);
+  /// @brief  Applies the current clip state to an Entity. If the given Entity
+  ///         is a clip operation, then the clip state is updated accordingly.
+  ///
+  /// @return true if the Entity should be rendered.
+  bool ApplyClipState(Contents::ClipCoverage global_clip_coverage,
+                      Entity& entity,
+                      size_t clip_depth_floor,
+                      Point global_pass_position);
 
   // Visible for testing.
-  void RecordEntity(const Entity& entity, Contents::ClipCoverage::Type type);
+  void RecordEntity(const Entity& entity,
+                    Contents::ClipCoverage::Type type,
+                    std::optional<Rect> clip_coverage);
 
   // Visible for testing.
-  const std::vector<Entity>& GetReplayEntities() const;
+  const std::vector<ReplayResult>& GetReplayEntities() const;
 
   // Visible for testing.
   const std::vector<ClipCoverageLayer> GetClipCoverageLayers() const;
 
  private:
   struct SubpassState {
-    std::vector<Entity> rendered_clip_entities;
+    std::vector<ReplayResult> rendered_clip_entities;
     std::vector<ClipCoverageLayer> clip_coverage;
   };
 

--- a/impeller/entity/entity_pass_clip_stack.h
+++ b/impeller/entity/entity_pass_clip_stack.h
@@ -28,6 +28,11 @@ class EntityPassClipStack {
     std::optional<Rect> clip_coverage;
   };
 
+  struct ClipStateResult {
+    bool should_render = false;
+    bool clip_did_change = false;
+  };
+
   /// Create a new [EntityPassClipStack] with an initialized coverage rect.
   explicit EntityPassClipStack(const Rect& initial_coverage_rect);
 
@@ -43,12 +48,10 @@ class EntityPassClipStack {
 
   /// @brief  Applies the current clip state to an Entity. If the given Entity
   ///         is a clip operation, then the clip state is updated accordingly.
-  ///
-  /// @return true if the Entity should be rendered.
-  bool ApplyClipState(Contents::ClipCoverage global_clip_coverage,
-                      Entity& entity,
-                      size_t clip_depth_floor,
-                      Point global_pass_position);
+  ClipStateResult ApplyClipState(Contents::ClipCoverage global_clip_coverage,
+                                 Entity& entity,
+                                 size_t clip_depth_floor,
+                                 Point global_pass_position);
 
   // Visible for testing.
   void RecordEntity(const Entity& entity,

--- a/impeller/entity/entity_pass_clip_stack.h
+++ b/impeller/entity/entity_pass_clip_stack.h
@@ -29,7 +29,11 @@ class EntityPassClipStack {
   };
 
   struct ClipStateResult {
+    /// Whether or not the Entity should be rendered. If false, the Entity may
+    /// be safely skipped.
     bool should_render = false;
+    /// Whether or not the current clip coverage changed during the call to
+    /// `ApplyClipState`.
     bool clip_did_change = false;
   };
 

--- a/impeller/entity/entity_pass_unittests.cc
+++ b/impeller/entity/entity_pass_unittests.cc
@@ -26,10 +26,12 @@ TEST(EntityPassClipStackTest, CanPushAndPopEntities) {
   EXPECT_EQ(recorder.GetReplayEntities().size(), 2u);
   ASSERT_TRUE(recorder.GetReplayEntities()[0].clip_coverage.has_value());
   ASSERT_TRUE(recorder.GetReplayEntities()[1].clip_coverage.has_value());
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   EXPECT_EQ(recorder.GetReplayEntities()[0].clip_coverage.value(),
             Rect::MakeLTRB(0, 0, 100, 100));
   EXPECT_EQ(recorder.GetReplayEntities()[1].clip_coverage.value(),
             Rect::MakeLTRB(0, 0, 50, 50));
+  // NOLINTEND(bugprone-unchecked-optional-access)
 
   recorder.RecordEntity(entity, Contents::ClipCoverage::Type::kRestore, Rect());
   EXPECT_EQ(recorder.GetReplayEntities().size(), 1u);


### PR DESCRIPTION
Attempts to improve https://github.com/flutter/flutter/issues/145274.

Our new clipping technique paints walls on the depth buffer "in front" of the Entities that will be affected by said clips. So when an intersect clip is drawn (the common case), the clip will cover the whole framebuffer.

Depth is divvied up such that deeper clips get drawn _behind_ shallower clips, and so many clips actually don't end up drawing depth across the whole framebuffer. However, if the app does a lot of transitioning from a huge clips to a small clips, a lot of unnecessary depth churn occurs (very common in Flutter -- this happens with both the app bar and floating action button in the counter template, for example).

Since progressively deeper layers in the clip coverage stack always subset their parent layers, we can reduce waste for small intersect clips by setting the scissor to the clip coverage rect instead of drawing the clip to the whole screen.

Note that this change _does not_ help much with huge/fullscreen clips.

Also, we could potentially improve this further by computing much stricter bounds. Rather than just using clip coverage for the scissor, we could intersect it with the union of all draws affected by the clip at the cost of a bit more CPU churn per draw. I don't think that's enough juice for the squeeze though.

Before (`Play/AiksTest.CanRenderNestedClips/Metal`):

https://github.com/flutter/engine/assets/919017/7858400f-793a-4f7b-a0e4-fa3581198beb

After (`Play/AiksTest.CanRenderNestedClips/Metal`):

https://github.com/flutter/engine/assets/919017/b2f7c96d-a820-454d-91df-f5fae4976e91

