### PR TITLE
[Impeller] add missing null check.

### DIFF
--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -150,6 +150,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
         auto surface = impeller::SurfaceMTL::MakeFromMetalLayerDrawable(renderer->GetContext(),
                                                                         drawable, clip_rect);
 
+        // The surface may be null if we failed to allocate the onscreen render target
+        // due to running out of memory.
         if (!surface) {
           return false;
         }

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -150,6 +150,10 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
         auto surface = impeller::SurfaceMTL::MakeFromMetalLayerDrawable(renderer->GetContext(),
                                                                         drawable, clip_rect);
 
+        if (!surface) {
+          return false;
+        }
+
         if (clip_rect && clip_rect->IsEmpty()) {
           return surface->Present();
         }


### PR DESCRIPTION
surface can return null if we failed to allocate MSAA or depth/stencil textures.