### PR TITLE
[Impeller] render empty filled paths without crashing.

### DIFF
--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2812,6 +2812,31 @@ TEST_P(EntityTest, FailOnValidationError) {
       "");
 }
 
+TEST_P(EntityTest, CanRenderEmptyPathsWithoutCrashing) {
+  PathBuilder builder = {};
+  builder.AddRect(Rect::MakeLTRB(0, 0, 0, 0));
+  Path path = builder.TakePath();
+
+  EXPECT_TRUE(path.GetBoundingBox()->IsEmpty());
+
+  auto geom = Geometry::MakeFillPath(path);
+
+  Entity entity;
+  RenderTarget target =
+      GetContentContext()->GetRenderTargetCache()->CreateOffscreen(
+          *GetContext(), {1, 1}, 1u);
+  testing::MockRenderPass render_pass(GetContext(), target);
+  auto position_result =
+      geom->GetPositionBuffer(*GetContentContext(), entity, render_pass);
+
+  auto uv_result =
+      geom->GetPositionUVBuffer(Rect::MakeLTRB(0, 0, 100, 100), Matrix(),
+                                *GetContentContext(), entity, render_pass);
+
+  EXPECT_EQ(position_result.vertex_buffer.vertex_count, 0u);
+  EXPECT_EQ(uv_result.vertex_buffer.vertex_count, 0u);
+}
+
 }  // namespace testing
 }  // namespace impeller
 

--- a/impeller/entity/geometry/geometry_unittests.cc
+++ b/impeller/entity/geometry/geometry_unittests.cc
@@ -2,11 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <memory>
 #include "flutter/testing/testing.h"
+#include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/geometry/geometry.h"
 #include "impeller/entity/geometry/stroke_path_geometry.h"
 #include "impeller/geometry/geometry_asserts.h"
 #include "impeller/geometry/path_builder.h"
+#include "impeller/renderer/testing/mocks.h"
 
 inline ::testing::AssertionResult SolidVerticesNear(
     std::vector<impeller::SolidFillVertexShader::PerVertexData> a,

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -58,6 +58,7 @@ static int ToTessWindingRule(FillType fill_type) {
 Tessellator::Result Tessellator::Tessellate(const Path& path,
                                             Scalar tolerance,
                                             const BuilderCallback& callback) {
+  FML_DCHECK(!path.GetBoundingBox()->IsEmpty());
   if (!callback) {
     return Result::kInputError;
   }
@@ -178,7 +179,9 @@ Path::Polyline Tessellator::CreateTempPolyline(const Path& path,
 
 std::vector<Point> Tessellator::TessellateConvex(const Path& path,
                                                  Scalar tolerance) {
+  FML_DCHECK(!path.GetBoundingBox()->IsEmpty());
   FML_DCHECK(point_buffer_);
+
   std::vector<Point> output;
   point_buffer_->clear();
   auto polyline =


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/145823

If we try to render a solid filled empty size path, the subpath division code creates an obscene number of vertices that hits overflow errors. Just No-op instead.