### PR TITLE
[Impeller] Optimize away intersect clips that cover the entire pass target.

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -144,6 +144,7 @@
 ../../../flutter/impeller/display_list/skia_conversions_unittests.cc
 ../../../flutter/impeller/docs
 ../../../flutter/impeller/entity/contents/checkerboard_contents_unittests.cc
+../../../flutter/impeller/entity/contents/clip_contents_unittests.cc
 ../../../flutter/impeller/entity/contents/content_context_unittests.cc
 ../../../flutter/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
 ../../../flutter/impeller/entity/contents/filters/inputs/filter_input_unittests.cc

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -267,6 +267,7 @@ impeller_component("entity_unittests") {
 
   sources = [
     "contents/checkerboard_contents_unittests.cc",
+    "contents/clip_contents_unittests.cc",
     "contents/content_context_unittests.cc",
     "contents/filters/gaussian_blur_filter_contents_unittests.cc",
     "contents/filters/inputs/filter_input_unittests.cc",

--- a/impeller/entity/contents/clip_contents_unittests.cc
+++ b/impeller/entity/contents/clip_contents_unittests.cc
@@ -1,0 +1,59 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <memory>
+#include <optional>
+
+#include "gtest/gtest.h"
+
+#include "impeller/entity/contents/checkerboard_contents.h"
+#include "impeller/entity/contents/clip_contents.h"
+#include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/contents/contents.h"
+#include "impeller/entity/contents/test/recording_render_pass.h"
+#include "impeller/entity/entity.h"
+#include "impeller/entity/entity_playground.h"
+#include "impeller/renderer/render_target.h"
+
+namespace impeller {
+namespace testing {
+
+using EntityTest = EntityPlayground;
+
+TEST_P(EntityTest, ClipContentsOptimizesFullScreenIntersectClips) {
+  if (!ContentContext::kEnableStencilThenCover) {
+    GTEST_SKIP();
+    return;
+  }
+
+  // Set up mock environment.
+
+  auto content_context = GetContentContext();
+  auto buffer = content_context->GetContext()->CreateCommandBuffer();
+  auto render_target =
+      GetContentContext()->GetRenderTargetCache()->CreateOffscreenMSAA(
+          *content_context->GetContext(), {100, 100},
+          /*mip_count=*/1);
+  auto render_pass = buffer->CreateRenderPass(render_target);
+  auto recording_pass = std::make_shared<RecordingRenderPass>(
+      render_pass, GetContext(), render_target);
+
+  // Set up clip contents.
+
+  auto contents = std::make_shared<ClipContents>();
+  contents->SetClipOperation(Entity::ClipOperation::kIntersect);
+  contents->SetGeometry(Geometry::MakeCover());
+
+  Entity entity;
+  entity.SetContents(std::move(contents));
+
+  // Render the clip contents.
+
+  ASSERT_TRUE(recording_pass->GetCommands().empty());
+  ASSERT_TRUE(entity.Render(*content_context, *recording_pass));
+  ASSERT_FALSE(recording_pass->GetCommands().empty());
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
I tested against a few example apps and found this case is actually very common. These full screen/pass clips render nothing to the depth buffer can be particularly troublesome in the presence of backdrop filters (due to clip replay).

While this case doesn't actually result in anything getting written to the depth buffer, we still end up overwriting the entire stencil buffer twice: Once for the preparation draw, and again for the depth buffer transfer/stencil cleanup draw.