### PR TITLE
[Impeller] Use MTLPixelFormatBGRA10_XR for wide gamut.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -259,6 +259,9 @@ extern CFTimeInterval display_link_target;
   } else if (self.pixelFormat == MTLPixelFormatBGRA8Unorm) {
     pixelFormat = kCVPixelFormatType_32BGRA;
     bytesPerElement = 4;
+  } else if (self.pixelFormat == MTLPixelFormatBGRA10_XR) {
+    // TODO;
+    return nil;
   } else {
     FML_LOG(ERROR) << "Unsupported pixel format: " << self.pixelFormat;
     return nil;

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -62,7 +62,7 @@
     if (pixelFormat == MTLPixelFormatRGBA16Float) {
       self->_colorSpaceRef = fml::CFRef(CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB));
       layer.colorspace = self->_colorSpaceRef;
-    } else if (pixelFormat == MTLPixelFormatBGR10_XR) {
+    } else if (pixelFormat == MTLPixelFormatBGRA10_XR) {
       self->_colorSpaceRef = fml::CFRef(CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB));
       layer.colorspace = self->_colorSpaceRef;
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -62,6 +62,9 @@
     if (pixelFormat == MTLPixelFormatRGBA16Float) {
       self->_colorSpaceRef = fml::CFRef(CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB));
       layer.colorspace = self->_colorSpaceRef;
+    } else if (pixelFormat == MTLPixelFormatBGR10_XR) {
+      self->_colorSpaceRef = fml::CFRef(CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB));
+      layer.colorspace = self->_colorSpaceRef;
     }
   }
   return self;

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -122,9 +122,9 @@ static void PrintWideGamutWarningOnce() {
       CGColorSpaceRef srgb = CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB);
       layer.colorspace = srgb;
       CFRelease(srgb);
-      // MTLPixelFormatBGR10_XR was chosen since it is compatible with
+      // MTLPixelFormatBGRA10_XR was chosen since it is compatible with
       // impeller's offscreen buffers which need to have transparency.
-      layer.pixelFormat = MTLPixelFormatBGR10_XR;
+      layer.pixelFormat = MTLPixelFormatBGRA10_XR;
     } else if (_isWideGamutEnabled && !isWideGamutSupported) {
       PrintWideGamutWarningOnce();
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -122,11 +122,9 @@ static void PrintWideGamutWarningOnce() {
       CGColorSpaceRef srgb = CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB);
       layer.colorspace = srgb;
       CFRelease(srgb);
-      // MTLPixelFormatRGBA16Float was chosen since it is compatible with
-      // impeller's offscreen buffers which need to have transparency.  Also,
-      // F16 was chosen over BGRA10_XR since Skia does not support decoding
-      // BGRA10_XR.
-      layer.pixelFormat = MTLPixelFormatRGBA16Float;
+      // MTLPixelFormatBGR10_XR was chosen since it is compatible with
+      // impeller's offscreen buffers which need to have transparency.
+      layer.pixelFormat = MTLPixelFormatBGR10_XR;
     } else if (_isWideGamutEnabled && !isWideGamutSupported) {
       PrintWideGamutWarningOnce();
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/142549

[MTLPixelFormatBGRA10_XR](https://developer.apple.com/documentation/metal/mtlpixelformat/mtlpixelformatbgra10_xr) is a clamped alpha format. While Skia can't decode images to this format, that doesn't matter since we're only ever sampling images and never attaching them as render targets.