### PR TITLE
[skwasm] Use text position affinity when calculating word boundaries.

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -236,7 +236,7 @@ class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Pa
     final int characterPosition = switch (position.affinity) {
       ui.TextAffinity.upstream => position.offset - 1,
       ui.TextAffinity.downstream => position.offset,
-    }
+    };
     paragraphGetWordBoundary(handle, characterPosition, outRange);
     return ui.TextRange(start: outRange[0], end: outRange[1]);
   });

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -233,7 +233,14 @@ class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Pa
   @override
   ui.TextRange getWordBoundary(ui.TextPosition position) => withStackScope((StackScope scope) {
     final Pointer<Int32> outRange = scope.allocInt32Array(2);
-    paragraphGetWordBoundary(handle, position.offset, outRange);
+    final int characterPosition;
+    switch (position.affinity) {
+      case ui.TextAffinity.upstream:
+        characterPosition = position.offset - 1;
+      case ui.TextAffinity.downstream:
+        characterPosition = position.offset;
+    }
+    paragraphGetWordBoundary(handle, characterPosition, outRange);
     return ui.TextRange(start: outRange[0], end: outRange[1]);
   });
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -233,12 +233,9 @@ class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Pa
   @override
   ui.TextRange getWordBoundary(ui.TextPosition position) => withStackScope((StackScope scope) {
     final Pointer<Int32> outRange = scope.allocInt32Array(2);
-    final int characterPosition;
-    switch (position.affinity) {
-      case ui.TextAffinity.upstream:
-        characterPosition = position.offset - 1;
-      case ui.TextAffinity.downstream:
-        characterPosition = position.offset;
+    final int characterPosition = switch (position.affinity) {
+      ui.TextAffinity.upstream => position.offset - 1,
+      ui.TextAffinity.downstream => position.offset,
     }
     paragraphGetWordBoundary(handle, characterPosition, outRange);
     return ui.TextRange(start: outRange[0], end: outRange[1]);

--- a/lib/web_ui/test/ui/paragraph_builder_test.dart
+++ b/lib/web_ui/test/ui/paragraph_builder_test.dart
@@ -40,6 +40,25 @@ Future<void> testMain() async {
     expect(() => builder.build(), returnsNormally);
   });
 
+  test('getWordBoundary respects position affinity', () {
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
+    builder.addText('hello world');
+
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: double.infinity));
+
+    final TextRange downstreamWordBoundary = paragraph.getWordBoundary(const TextPosition(
+      offset: 5,
+    ));
+    expect(downstreamWordBoundary, const TextRange(start: 5, end: 6));
+
+    final TextRange upstreamWordBoundary = paragraph.getWordBoundary(const TextPosition(
+      offset: 5,
+      affinity: TextAffinity.upstream,
+    ));
+    expect(upstreamWordBoundary, const TextRange(start: 0, end: 5));
+  });
+
   test('build and layout a paragraph with an empty addText', () {
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
     builder.addText('');


### PR DESCRIPTION
I had failed to take position affinity into account when calculating word boundaries on skwasm. This brings skwasm's behavior in line with canvaskit's.