### PR TITLE
[Windows] Move keyboard initialization

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -473,6 +473,8 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
   settings_plugin_->StartWatching();
   settings_plugin_->SendSettings();
 
+  InitializeKeyboard();
+
   return true;
 }
 
@@ -497,7 +499,6 @@ std::unique_ptr<FlutterWindowsView> FlutterWindowsEngine::CreateView(
       kImplicitViewId, this, std::move(window), windows_proc_table_);
 
   views_[kImplicitViewId] = view.get();
-  InitializeKeyboard();
 
   return std::move(view);
 }
@@ -675,10 +676,6 @@ void FlutterWindowsEngine::SendSystemLocales() {
 }
 
 void FlutterWindowsEngine::InitializeKeyboard() {
-  if (views_.empty()) {
-    FML_LOG(ERROR) << "Cannot initialize keyboard on Windows headless mode.";
-  }
-
   auto internal_plugin_messenger = internal_plugin_registrar_->messenger();
   KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state = GetKeyState;
   KeyboardKeyEmbedderHandler::MapVirtualKeyToScanCode map_vk_to_scan =
@@ -773,9 +770,7 @@ void FlutterWindowsEngine::UpdateSemanticsEnabled(bool enabled) {
 
 void FlutterWindowsEngine::OnPreEngineRestart() {
   // Reset the keyboard's state on hot restart.
-  if (!views_.empty()) {
-    InitializeKeyboard();
-  }
+  InitializeKeyboard();
 }
 
 std::string FlutterWindowsEngine::GetExecutableName() const {

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -477,5 +477,43 @@ TEST_F(WindowsTest, Lifecycle) {
                /* bRepaint*/ false);
 }
 
+TEST_F(WindowsTest, GetKeyboardStateHeadless) {
+  // Run the test on its own thread so that it can pump its event loop while
+  // this thread waits.
+  fml::AutoResetWaitableEvent latch;
+  auto platform_task_runner = CreateNewThread("test_platform_thread");
+  platform_task_runner->PostTask([&]() {
+    auto& context = GetContext();
+    WindowsConfigBuilder builder(context);
+    builder.SetDartEntrypoint("sendGetKeyboardState");
+
+    bool done = false;
+    context.AddNativeFunction(
+        "SignalStringValue",
+        CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+          auto handle = Dart_GetNativeArgument(args, 0);
+          ASSERT_FALSE(Dart_IsError(handle));
+          auto value = tonic::DartConverter<std::string>::FromDart(handle);
+          EXPECT_EQ(value, "Success");
+          done = true;
+          latch.Signal();
+        }));
+
+    ViewControllerPtr controller{builder.Run()};
+    ASSERT_NE(controller, nullptr);
+
+    // Pump messages for the Windows platform task runner.
+    ::MSG msg;
+    while (!done) {
+      if (::GetMessage(&msg, nullptr, 0, 0)) {
+        ::TranslateMessage(&msg);
+        ::DispatchMessage(&msg);
+      }
+    }
+  });
+
+  latch.Wait();
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
Previously the keyboard was initialized after the view is created. This used to be necessary as the keyboard & text input plugins were strongly tied to a view (and would crash in headless modes). This is no longer necessary, and the keyboard can now be initialized normally as part of the engine initialization.

Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
