### PR TITLE
Remove `--verbose` from clang_tidy execution on CI.

### DIFF
--- a/ci/builders/linux_clang_tidy.json
+++ b/ci/builders/linux_clang_tidy.json
@@ -68,7 +68,6 @@
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
-                        "--verbose",
                         "--variant",
                         "host_debug_clang_tidy",
                         "--lint-all",
@@ -98,7 +97,6 @@
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
-                        "--verbose",
                         "--variant",
                         "host_debug_clang_tidy",
                         "--lint-all",
@@ -128,7 +126,6 @@
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
-                        "--verbose",
                         "--variant",
                         "host_debug_clang_tidy",
                         "--lint-all",
@@ -158,7 +155,6 @@
                 {
                     "name": "test: lint host_debug",
                     "parameters": [
-                        "--verbose",
                         "--variant",
                         "host_debug_clang_tidy",
                         "--lint-all",
@@ -186,7 +182,6 @@
                 {
                     "name": "test: lint android_debug_arm64",
                     "parameters": [
-                        "--verbose",
                         "--variant",
                         "android_debug_arm64_clang_tidy",
                         "--lint-all",


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/145926.

This was likely left on by accident (if not, we should utilize `FLUTTER_LOGS_DIR` instead of this flag).

/cc @zanderso