### PR TITLE
Fix the `clangd` builders, and make Linux non-bringup.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -279,7 +279,6 @@ targets:
 
   - name: Linux clangd
     recipe: engine_v2/engine_v2
-    bringup: true
     properties:
       config_name: linux_unopt_debug_no_rbe
 
@@ -370,7 +369,6 @@ targets:
 
   - name: Mac clangd
     recipe: engine_v2/engine_v2
-    bringup: true
     properties:
       config_name: mac_unopt_debug_no_rbe
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -368,7 +368,11 @@ targets:
       - os=Mac-13
 
   - name: Mac clangd
+    bringup: true
     recipe: engine_v2/engine_v2
+    # Avoid using a Mac orchestrator to save ~5 minutes of Mac host time.
+    drone_dimensions:
+      - os=Linux
     properties:
       config_name: mac_unopt_debug_no_rbe
 

--- a/ci/builders/linux_unopt_debug_no_rbe.json
+++ b/ci/builders/linux_unopt_debug_no_rbe.json
@@ -1,7 +1,11 @@
 {
   "_comment": [
     "This build is only used to generate compile_commands.json for clangd ",
-    "and should not be used for any other purpose."
+    "and should not be used for any other purpose.",
+    "",
+    "Note the `flutter/tools/font_subset` target is only used because if no ",
+    "targets are specified, the build will fail, and if an empty list of ",
+    "targets are specified, all targets are built (wasteful/slow)"
   ],
   "builds": [
     {
@@ -18,6 +22,10 @@
         "linux_unopt_debug_no_rbe"
       ],
       "name": "linux_unopt_debug_no_rbe",
+      "ninja": {
+        "config": "linux_unopt_debug_no_rbe",
+        "targets": ["flutter/tools/font_subset"]
+      },
       "tests": [
         {
           "language": "dart",

--- a/ci/builders/linux_unopt_debug_no_rbe.json
+++ b/ci/builders/linux_unopt_debug_no_rbe.json
@@ -12,11 +12,13 @@
         "--unoptimized",
         "--prebuilt-dart-sdk",
         "--no-rbe",
-        "--no-goma"
+        "--no-goma",
+        "--target-dir",
+        "linux_unopt_debug_no_rbe"
       ],
       "name": "linux_unopt_debug_no_rbe",
       "ninja": {
-        "config": "host_debug_unopt",
+        "config": "linux_unopt_debug_no_rbe",
         "targets": []
       },
       "tests": [

--- a/ci/builders/linux_unopt_debug_no_rbe.json
+++ b/ci/builders/linux_unopt_debug_no_rbe.json
@@ -12,13 +12,11 @@
         "--unoptimized",
         "--prebuilt-dart-sdk",
         "--no-rbe",
-        "--no-goma",
-        "--out-dir",
-        "linux_unopt_debug_no_rbe"
+        "--no-goma"
       ],
       "name": "linux_unopt_debug_no_rbe",
       "ninja": {
-        "config": "linux_unopt_debug_no_rbe",
+        "config": "host_debug_unopt",
         "targets": []
       },
       "tests": [

--- a/ci/builders/linux_unopt_debug_no_rbe.json
+++ b/ci/builders/linux_unopt_debug_no_rbe.json
@@ -12,7 +12,9 @@
         "--unoptimized",
         "--prebuilt-dart-sdk",
         "--no-rbe",
-        "--no-goma"
+        "--no-goma",
+        "--out-dir",
+        "linux_unopt_debug_no_rbe"
       ],
       "name": "linux_unopt_debug_no_rbe",
       "ninja": {

--- a/ci/builders/linux_unopt_debug_no_rbe.json
+++ b/ci/builders/linux_unopt_debug_no_rbe.json
@@ -17,7 +17,7 @@
       "name": "linux_unopt_debug_no_rbe",
       "ninja": {
         "config": "linux_unopt_debug_no_rbe",
-        "targets": ["flutter/build/dart:copy_dart_sdk"]
+        "targets": []
       },
       "tests": [
         {

--- a/ci/builders/linux_unopt_debug_no_rbe.json
+++ b/ci/builders/linux_unopt_debug_no_rbe.json
@@ -11,16 +11,13 @@
         "debug",
         "--unoptimized",
         "--prebuilt-dart-sdk",
+        "--no-lto",
         "--no-rbe",
         "--no-goma",
         "--target-dir",
         "linux_unopt_debug_no_rbe"
       ],
       "name": "linux_unopt_debug_no_rbe",
-      "ninja": {
-        "config": "linux_unopt_debug_no_rbe",
-        "targets": []
-      },
       "tests": [
         {
           "language": "dart",

--- a/ci/builders/mac_unopt_debug_no_rbe.json
+++ b/ci/builders/mac_unopt_debug_no_rbe.json
@@ -16,6 +16,7 @@
         "debug",
         "--unoptimized",
         "--prebuilt-dart-sdk",
+        "--no-lto",
         "--no-rbe",
         "--no-goma",
         "--xcode-symlinks",
@@ -23,10 +24,6 @@
         "mac_unopt_debug_no_rbe"
       ],
       "name": "mac_unopt_debug_no_rbe",
-      "ninja": {
-        "config": "mac_unopt_debug_no_rbe",
-        "targets": []
-      },
       "tests": [
         {
           "language": "dart",

--- a/ci/builders/mac_unopt_debug_no_rbe.json
+++ b/ci/builders/mac_unopt_debug_no_rbe.json
@@ -1,7 +1,11 @@
 {
   "_comment": [
     "This build is only used to generate compile_commands.json for clangd ",
-    "and should not be used for any other purpose."
+    "and should not be used for any other purpose.",
+    "",
+    "Note the `flutter/tools/font_subset` target is only used because if no ",
+    "targets are specified, the build will fail, and if an empty list of ",
+    "targets are specified, all targets are built (wasteful/slow)"
   ],
   "builds": [
     {
@@ -24,6 +28,10 @@
         "mac_unopt_debug_no_rbe"
       ],
       "name": "mac_unopt_debug_no_rbe",
+      "ninja": {
+        "config": "mac_unopt_debug_no_rbe",
+        "targets": ["flutter/tools/font_subset"]
+      },
       "tests": [
         {
           "language": "dart",

--- a/ci/builders/mac_unopt_debug_no_rbe.json
+++ b/ci/builders/mac_unopt_debug_no_rbe.json
@@ -18,13 +18,11 @@
         "--prebuilt-dart-sdk",
         "--no-rbe",
         "--no-goma",
-        "--xcode-symlinks",
-        "--out-dir",
-        "mac_unopt_debug_no_rbe"
+        "--xcode-symlinks"
       ],
       "name": "mac_unopt_debug_no_rbe",
       "ninja": {
-        "config": "mac_unopt_debug_no_rbe",
+        "config": "host_debug_unopt",
         "targets": []
       },
       "tests": [

--- a/ci/builders/mac_unopt_debug_no_rbe.json
+++ b/ci/builders/mac_unopt_debug_no_rbe.json
@@ -18,11 +18,13 @@
         "--prebuilt-dart-sdk",
         "--no-rbe",
         "--no-goma",
-        "--xcode-symlinks"
+        "--xcode-symlinks",
+        "--target-dir",
+        "mac_unopt_debug_no_rbe"
       ],
       "name": "mac_unopt_debug_no_rbe",
       "ninja": {
-        "config": "host_debug_unopt",
+        "config": "mac_unopt_debug_no_rbe",
         "targets": []
       },
       "tests": [

--- a/ci/builders/mac_unopt_debug_no_rbe.json
+++ b/ci/builders/mac_unopt_debug_no_rbe.json
@@ -18,7 +18,9 @@
         "--prebuilt-dart-sdk",
         "--no-rbe",
         "--no-goma",
-        "--xcode-symlinks"
+        "--xcode-symlinks",
+        "--out-dir",
+        "mac_unopt_debug_no_rbe"
       ],
       "name": "mac_unopt_debug_no_rbe",
       "ninja": {

--- a/ci/builders/mac_unopt_debug_no_rbe.json
+++ b/ci/builders/mac_unopt_debug_no_rbe.json
@@ -23,7 +23,7 @@
       "name": "mac_unopt_debug_no_rbe",
       "ninja": {
         "config": "mac_unopt_debug_no_rbe",
-        "targets": ["flutter/build/dart:copy_dart_sdk"]
+        "targets": []
       },
       "tests": [
         {


### PR DESCRIPTION
Further work towards https://github.com/flutter/flutter/issues/141641.

I could imagine making things `presubmit: false` if we think it's not worth the presubmit capacity.

Removed `:copy_dart_sdk` which seems (a) not to work and (b) not needed to use the pre-builts.