### PR TITLE
[Impeller] Set RGBA8888 as the default Vulkan color format before the app acquires a surface

### DIFF
--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -297,7 +297,7 @@ static bool HasSuitableDepthStencilFormat(const vk::PhysicalDevice& device,
 static bool PhysicalDeviceSupportsRequiredFormats(
     const vk::PhysicalDevice& device) {
   const auto has_color_format =
-      HasSuitableColorFormat(device, vk::Format::eB8G8R8A8Unorm);
+      HasSuitableColorFormat(device, vk::Format::eR8G8B8A8Unorm);
   const auto has_stencil_format =
       HasSuitableDepthStencilFormat(device, vk::Format::eD32SfloatS8Uint) ||
       HasSuitableDepthStencilFormat(device, vk::Format::eD24UnormS8Uint);
@@ -412,6 +412,12 @@ void CapabilitiesVK::SetOffscreenFormat(PixelFormat pixel_format) const {
 }
 
 bool CapabilitiesVK::SetPhysicalDevice(const vk::PhysicalDevice& device) {
+  if (HasSuitableColorFormat(device, vk::Format::eR8G8B8A8Unorm)) {
+    default_color_format_ = PixelFormat::kR8G8B8A8UNormInt;
+  } else {
+    default_color_format_ = PixelFormat::kUnknown;
+  }
+
   if (HasSuitableDepthStencilFormat(device, vk::Format::eD32SfloatS8Uint)) {
     default_depth_stencil_format_ = PixelFormat::kD32FloatS8UInt;
   } else if (HasSuitableDepthStencilFormat(device,

--- a/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -167,7 +167,7 @@ TEST(CapabilitiesVKTest, ContextInitializesWithNoStencilFormat) {
           .SetPhysicalDeviceFormatPropertiesCallback(
               [](VkPhysicalDevice physicalDevice, VkFormat format,
                  VkFormatProperties* pFormatProperties) {
-                if (format == VK_FORMAT_B8G8R8A8_UNORM) {
+                if (format == VK_FORMAT_R8G8B8A8_UNORM) {
                   pFormatProperties->optimalTilingFeatures =
                       static_cast<VkFormatFeatureFlags>(
                           vk::FormatFeatureFlagBits::eColorAttachment);
@@ -200,7 +200,7 @@ TEST(CapabilitiesVKTest,
           .SetPhysicalDeviceFormatPropertiesCallback(
               [](VkPhysicalDevice physicalDevice, VkFormat format,
                  VkFormatProperties* pFormatProperties) {
-                if (format == VK_FORMAT_B8G8R8A8_UNORM) {
+                if (format == VK_FORMAT_R8G8B8A8_UNORM) {
                   pFormatProperties->optimalTilingFeatures =
                       static_cast<VkFormatFeatureFlags>(
                           vk::FormatFeatureFlagBits::eColorAttachment);
@@ -220,6 +220,14 @@ TEST(ContextVKTest, WarmUpFunctionCreatesRenderPass) {
   auto functions = GetMockVulkanFunctions(context->GetDevice());
   ASSERT_TRUE(std::find(functions->begin(), functions->end(),
                         "vkCreateRenderPass") != functions->end());
+}
+
+TEST(ContextVKTest, HasDefaultColorFormat) {
+  std::shared_ptr<ContextVK> context = MockVulkanContextBuilder().Build();
+
+  const CapabilitiesVK* capabilites_vk =
+      reinterpret_cast<const CapabilitiesVK*>(context->GetCapabilities().get());
+  ASSERT_NE(capabilites_vk->GetDefaultColorFormat(), PixelFormat::kUnknown);
 }
 
 }  // namespace testing

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -894,7 +894,7 @@ MockVulkanContextBuilder::MockVulkanContextBuilder()
       format_properties_callback_([](VkPhysicalDevice physicalDevice,
                                      VkFormat format,
                                      VkFormatProperties* pFormatProperties) {
-        if (format == VK_FORMAT_B8G8R8A8_UNORM) {
+        if (format == VK_FORMAT_R8G8B8A8_UNORM) {
           pFormatProperties->optimalTilingFeatures =
               static_cast<VkFormatFeatureFlags>(
                   vk::FormatFeatureFlagBits::eColorAttachment);


### PR DESCRIPTION
An app may render offscreen images before it gets a window. The ContextVK needs to have a default color format so that render passes can be created before the ContextVK is updated to use the window's format.