### PR TITLE
[Windows] Fix EGL surface destruction race

### DIFF
--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -8,6 +8,7 @@
 
 #include "flutter/common/constants.h"
 #include "flutter/fml/platform/win/wstring_conversion.h"
+#include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/shell/platform/common/accessibility_bridge.h"
 #include "flutter/shell/platform/windows/keyboard_key_channel_handler.h"
 #include "flutter/shell/platform/windows/text_input_plugin.h"
@@ -81,6 +82,26 @@ void UpdateVsync(const FlutterWindowsEngine& engine,
   }
 }
 
+/// Destroys a rendering surface that backs a Flutter view.
+void DestroyWindowSurface(const FlutterWindowsEngine& engine,
+                          egl::WindowSurface& surface) {
+  // EGL surfaces are used on the raster thread if the engine is running.
+  // There may be pending raster tasks that use this surface. Destroy the
+  // surface on the raster thread to avoid concurrent uses.
+  if (engine.running()) {
+    fml::AutoResetWaitableEvent latch;
+    engine.PostRasterThreadTask([&]() {
+      surface.Destroy();
+      latch.Signal();
+    });
+    latch.Wait();
+  } else {
+    // There's no raster thread if engine isn't running. The surface can be
+    // destroyed on the platform thread.
+    surface.Destroy();
+  }
+}
+
 }  // namespace
 
 FlutterWindowsView::FlutterWindowsView(
@@ -105,7 +126,9 @@ FlutterWindowsView::~FlutterWindowsView() {
   // Notify the engine the view's child window will no longer be visible.
   engine_->OnWindowStateEvent(GetWindowHandle(), WindowStateEvent::kHide);
 
-  DestroyRenderSurface();
+  if (surface_) {
+    DestroyWindowSurface(*engine_, *surface_);
+  }
 }
 
 bool FlutterWindowsView::OnEmptyFrameGenerated() {
@@ -704,12 +727,6 @@ bool FlutterWindowsView::ResizeRenderSurface(size_t width, size_t height) {
 
   surface_ = std::move(resized_surface);
   return true;
-}
-
-void FlutterWindowsView::DestroyRenderSurface() {
-  if (surface_) {
-    surface_->Destroy();
-  }
 }
 
 egl::WindowSurface* FlutterWindowsView::surface() const {

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -50,9 +50,6 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate {
   // Should be called before calling FlutterEngineRun using this view.
   void CreateRenderSurface();
 
-  // Destroys current rendering surface if one has been allocated.
-  void DestroyRenderSurface();
-
   // Get the EGL surface that backs the Flutter view.
   //
   // This might be nullptr or an invalid surface.


### PR DESCRIPTION
This fixes the `WindowsTest.EngineCanTransitionToHeadless` flakiness reported by @matanlurey.

EGL surfaces can only be used by a single thread at a time. Concurrent operations are unsafe.

Previously, the EGL surface was destroyed on the platform thread. This was safe as this always happened after the engine was shutdown and the raster thread was stopped. However, in a multi-view world a view can be destroyed while the engine is running. There may be pending raster tasks that operate on the render surface. Thus, the EGL surfaces should be destroyed on the raster thread when it is available.

This bug was introduced by https://github.com/flutter/engine/pull/51681
Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
