### PR TITLE
Add an engine switch that controls whether the platform isolate API is available.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -356,6 +356,11 @@ struct Settings {
   ///
   /// This is currently only used by iOS.
   bool enable_embedder_api = false;
+
+  /// Enable support for isolates that run on the platform thread.
+  ///
+  /// This is used by the runOnPlatformThread API.
+  bool enable_platform_isolates = false;
 };
 
 }  // namespace flutter

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -386,6 +386,14 @@ void DartUI::InitForIsolate(const Settings& settings) {
     }
   }
 
+  if (settings.enable_platform_isolates) {
+    result =
+        Dart_SetField(dart_ui, ToDart("_platformIsolatesEnabled"), Dart_True());
+    if (Dart_IsError(result)) {
+      Dart_PropagateError(result);
+    }
+  }
+
   result = Dart_SetField(dart_ui, ToDart("_implicitViewId"),
                          Dart_NewInteger(kFlutterImplicitViewId));
   if (Dart_IsError(result)) {

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -121,3 +121,8 @@ bool _impellerEnabled = false;
 // determine the current implicit view, if any.
 @pragma('vm:entry-point')
 int? _implicitViewId;
+
+// Used internally to indicate whether isolates running on the platform thread
+// are enabled.
+@pragma('vm:entry-point')
+bool _platformIsolatesEnabled = false;

--- a/lib/ui/platform_isolate.dart
+++ b/lib/ui/platform_isolate.dart
@@ -27,6 +27,10 @@ part of dart.ui;
 ///
 /// This API is currently experimental.
 Future<R> runOnPlatformThread<R>(FutureOr<R> Function() computation) {
+  if (!_platformIsolatesEnabled) {
+    throw UnsupportedError(
+        'Platform thread isolates are not supported by this platform.');
+  }
   if (isRunningOnPlatformThread) {
     return Future<R>(computation);
   }

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -542,6 +542,9 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
     }
   }
 
+  settings.enable_platform_isolates =
+      command_line.HasOption(FlagForSwitch(Switch::EnablePlatformIsolates));
+
   return settings;
 }
 

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -298,6 +298,9 @@ DEF_SWITCH(
 DEF_SWITCH(EnableEmbedderAPI,
            "enable-embedder-api",
            "Enable the embedder api. Defaults to false. iOS only.")
+DEF_SWITCH(EnablePlatformIsolates,
+           "enable-platform-isolates",
+           "Enable support for isolates that run on the platform thread.")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -150,6 +150,8 @@ void FlutterMain::Init(JNIEnv* env,
                         static_cast<int>(message.size()), message.c_str());
   };
 
+  settings.enable_platform_isolates = true;
+
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   // There are no ownership concerns here as all mappings are owned by the
   // embedder and not the engine.

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -91,6 +91,8 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
     syslog(LOG_ALERT, "%.*s", (int)log.size(), log.c_str());
   };
 
+  settings.enable_platform_isolates = true;
+
   // The command line arguments may not always be complete. If they aren't, attempt to fill in
   // defaults.
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -3057,6 +3057,7 @@ TEST_F(EmbedderTest, PlatformThreadIsolatesWithCustomPlatformTaskRunner) {
     builder.SetSoftwareRendererConfig();
     builder.SetPlatformTaskRunner(&task_runner_description);
     builder.SetDartEntrypoint("invokePlatformThreadIsolate");
+    builder.AddCommandLineArgument("--enable-platform-isolates");
     engine = builder.LaunchEngine();
     ASSERT_TRUE(engine.is_valid());
   });

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -641,6 +641,7 @@ int main(int argc, char* argv[]) {
   }
 
   settings.leak_vm = false;
+  settings.enable_platform_isolates = true;
 
   if (settings.icu_data_path.empty()) {
     settings.icu_data_path = "icudtl.dat";


### PR DESCRIPTION
Platform isolates are currently supported only on Android and iOS.

See https://github.com/flutter/flutter/issues/136314