### PR TITLE
[et] Prepare local_engine.json for CI, teach et to understand local build names

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -49,6 +49,14 @@ platform_properties:
 # https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/android/avd/proto
 # You may use those names for the android_virtual_device version.
 targets:
+  - name: Linux local_engine_builds
+    bringup: true
+    enabled_branches:
+      - main
+    recipe: engine_v2/engine_v2
+    properties:
+      config_name: local_engine
+
   - name: Linux linux_android_emulator_tests
     enabled_branches:
       - main

--- a/ci/builders/local_engine.json
+++ b/ci/builders/local_engine.json
@@ -1,29 +1,95 @@
 {
   "builds": [
     {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "debug",
         "--android",
         "--android-cpu=arm64",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "android_debug_arm64",
+      "name": "macos/android_debug_arm64",
+      "ninja": {
+        "config": "android_debug_arm64",
+        "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/android_debug_arm64",
       "ninja": {
         "config": "android_debug_arm64",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/android_debug_arm64",
+      "ninja": {
+        "config": "android_debug_arm64",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "debug",
@@ -31,18 +97,26 @@
         "--android",
         "--android-cpu=arm64",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "android_debug_unopt_arm64",
+      "name": "macos/android_debug_unopt_arm64",
       "ninja": {
         "config": "android_debug_unopt_arm64",
         "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
       }
     },
     {
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
       "gn": [
         "--runtime-mode",
@@ -50,79 +124,384 @@
         "--android",
         "--android-cpu=arm64",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "android_profile_arm64",
+      "name": "macos/android_profile_arm64",
+      "ninja": {
+        "config": "android_profile_arm64",
+        "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/android_profile_arm64",
       "ninja": {
         "config": "android_profile_arm64",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/android_profile_arm64",
+      "ninja": {
+        "config": "android_profile_arm64",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "release",
         "--android",
         "--android-cpu=arm64",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "android_release_arm64",
+      "name": "macos/android_release_arm64",
+      "ninja": {
+        "config": "android_release_arm64",
+        "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/android_release_arm64",
       "ninja": {
         "config": "android_release_arm64",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--android",
+        "--android-cpu=arm64",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/android_release_arm64",
+      "ninja": {
+        "config": "android_release_arm64",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "debug",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "host_debug",
+      "name": "macos/host_debug",
+      "ninja": {
+        "config": "host_debug",
+        "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/host_debug",
       "ninja": {
         "config": "host_debug",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/host_debug",
+      "ninja": {
+        "config": "host_debug",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "profile",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "host_profile",
+      "name": "macos/host_profile",
+      "ninja": {
+        "config": "host_profile",
+        "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "linux/host_profile",
       "ninja": {
         "config": "host_profile",
         "targets": []
       }
     },
     {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "windows/host_profile",
+      "ninja": {
+        "config": "host_profile",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
       "drone_dimensions": [
         "os=Mac-13",
-        "os=Linux"
+        "device_type=none"
       ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
       "gn": [
         "--runtime-mode",
         "release",
         "--no-stripped",
-        "--no-lto"
+        "--no-lto",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
       ],
-      "name": "host_release",
+      "name": "macos/host_release",
+      "ninja": {
+        "config": "host_release",
+        "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Linux",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma",
+        "--xcode-symlinks"
+      ],
+      "name": "linux/host_release",
+      "ninja": {
+        "config": "host_release",
+        "targets": []
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Windows-10",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--no-stripped",
+        "--no-lto",
+        "--rbe",
+        "--no-goma",
+        "--xcode-symlinks"
+      ],
+      "name": "windows/host_release",
       "ninja": {
         "config": "host_release",
         "targets": []

--- a/tools/engine_tool/lib/src/build_utils.dart
+++ b/tools/engine_tool/lib/src/build_utils.dart
@@ -65,6 +65,57 @@ void debugCheckBuilds(List<Build> builds) {
   }
 }
 
+String _ciPrefix(Environment env) => 'ci${env.platform.pathSeparator}';
+String _osPrefix(Environment env) => '${env.platform.operatingSystem}/';
+const String _webTestsPrefix = 'web_tests/';
+
+bool _doNotMangle(Environment env, String name) {
+  return name.startsWith(_ciPrefix(env)) || name.startsWith(_webTestsPrefix);
+}
+
+/// Transform the name of a build into the name presented and accepted by the
+/// CLI
+///
+/// If a name starts with '$OS/', it is a local development build, and the
+/// mangled name has the '$OS/' part stripped off, where $OS is the value of
+/// `platform.operatingSystem` in the passed-in `environment`.
+///
+/// If the name does not start with '$OS/', then it must start with 'ci/',
+/// 'ci\', or 'web_tests/' in which case the name is returned unchanged.
+///
+/// Examples:
+///   macos/host_debug -> host_debug
+///   ci/ios_release -> ci/ios_release
+///   ci\host_profile -> ci\host_profile
+///   web_tests/artifacts -> web_tests/artifacts
+String mangleConfigName(Environment env, String name) {
+  final String osPrefix = _osPrefix(env);
+  if (name.startsWith(osPrefix)) {
+    return name.substring(osPrefix.length);
+  }
+  if (_doNotMangle(env, name)) {
+    return name;
+  }
+  throw ArgumentError(
+    'name argument "$name" must start with a valid platform name or "ci"',
+  );
+}
+
+/// Transform the mangled (CLI) name of a build into its true name in the build
+/// config json file.
+///
+/// This does the reverse of [mangleConfigName] taking the operating system
+/// name from `environment`.
+///
+/// Examples:
+///   host_debug -> macos/host_debug
+///   ci/ios_release -> ci/ios_release
+///   ci\host_profile -> ci\host_profile
+///   web_tests/artifacts -> web_tests/artifacts
+String demangleConfigName(Environment env, String name) {
+  return _doNotMangle(env, name) ? name : '${_osPrefix(env)}$name';
+}
+
 /// Build the build target in the environment.
 Future<int> runBuild(Environment environment, Build build,
     {List<String> extraGnArgs = const <String>[],

--- a/tools/engine_tool/lib/src/commands/build_command.dart
+++ b/tools/engine_tool/lib/src/commands/build_command.dart
@@ -17,7 +17,9 @@ final class BuildCommand extends CommandBase {
   }) {
     builds = runnableBuilds(environment, configs);
     debugCheckBuilds(builds);
-    addConfigOption(argParser, runnableBuilds(environment, configs));
+    addConfigOption(
+      environment, argParser, runnableBuilds(environment, configs),
+    );
     argParser.addFlag(
       rbeFlag,
       defaultsTo: true,
@@ -39,8 +41,9 @@ final class BuildCommand extends CommandBase {
   Future<int> run() async {
     final String configName = argResults![configFlag] as String;
     final bool useRbe = argResults![rbeFlag] as bool;
+    final String demangledName = demangleConfigName(environment, configName);
     final Build? build =
-        builds.where((Build build) => build.name == configName).firstOrNull;
+        builds.where((Build build) => build.name == demangledName).firstOrNull;
     if (build == null) {
       environment.logger.error('Could not find config $configName');
       return 1;

--- a/tools/engine_tool/lib/src/commands/command.dart
+++ b/tools/engine_tool/lib/src/commands/command.dart
@@ -6,6 +6,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:engine_build_configs/engine_build_configs.dart';
 
+import '../build_utils.dart';
 import '../environment.dart';
 import 'flags.dart';
 
@@ -19,18 +20,24 @@ abstract base class CommandBase extends Command<int> {
 }
 
 /// Adds the -c (--config) option to the parser.
-void addConfigOption(ArgParser parser, List<Build> builds,
-    {String defaultsTo = 'host_debug'}) {
+void addConfigOption(
+  Environment environment,
+  ArgParser parser,
+  List<Build> builds, {
+  String defaultsTo = 'host_debug',
+}) {
   parser.addOption(
     configFlag,
     abbr: 'c',
     defaultsTo: defaultsTo,
     help: 'Specify the build config to use',
     allowed: <String>[
-      for (final Build config in builds) config.name,
+      for (final Build config in builds)
+        mangleConfigName(environment, config.name),
     ],
     allowedHelp: <String, String>{
-      for (final Build config in builds) config.name: config.gn.join(' '),
+      for (final Build config in builds)
+        mangleConfigName(environment, config.name): config.gn.join(' '),
     },
   );
 }

--- a/tools/engine_tool/lib/src/commands/command_runner.dart
+++ b/tools/engine_tool/lib/src/commands/command_runner.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:engine_build_configs/engine_build_configs.dart';
 
 import '../environment.dart';
+import '../logger.dart';
 import 'build_command.dart';
 import 'fetch_command.dart';
 import 'flags.dart';
@@ -61,8 +63,13 @@ final class ToolCommandRunner extends CommandRunner<int> {
 
   @override
   Future<int> run(Iterable<String> args) async {
+    final ArgResults argResults = parse(args);
+    final bool verbose = argResults[verboseFlag]! as bool;
+    if (verbose) {
+      environment.logger.level = Logger.infoLevel;
+    }
     try {
-      return await runCommand(parse(args)) ?? 0;
+      return await runCommand(argResults) ?? 0;
     } on FormatException catch (e) {
       environment.logger.error(e);
       return 1;

--- a/tools/engine_tool/lib/src/commands/query_command.dart
+++ b/tools/engine_tool/lib/src/commands/query_command.dart
@@ -140,7 +140,9 @@ final class QueryTestsCommand extends CommandBase {
   }) {
     builds = runnableBuilds(environment, configs);
     debugCheckBuilds(builds);
-    addConfigOption(argParser, runnableBuilds(environment, configs));
+    addConfigOption(
+      environment, argParser, runnableBuilds(environment, configs),
+    );
   }
 
   /// Build configurations loaded from the engine from under ci/builders.
@@ -158,8 +160,9 @@ final class QueryTestsCommand extends CommandBase {
   @override
   Future<int> run() async {
     final String configName = argResults![configFlag] as String;
+    final String demangledName = demangleConfigName(environment, configName);
     final Build? build =
-        builds.where((Build build) => build.name == configName).firstOrNull;
+        builds.where((Build build) => build.name == demangledName).firstOrNull;
     if (build == null) {
       environment.logger.error('Could not find config $configName');
       return 1;

--- a/tools/engine_tool/lib/src/commands/test_command.dart
+++ b/tools/engine_tool/lib/src/commands/test_command.dart
@@ -23,7 +23,9 @@ final class TestCommand extends CommandBase {
   }) {
     builds = runnableBuilds(environment, configs);
     debugCheckBuilds(builds);
-    addConfigOption(argParser, runnableBuilds(environment, configs));
+    addConfigOption(
+      environment, argParser, runnableBuilds(environment, configs),
+    );
   }
 
   /// List of compatible builds.
@@ -40,8 +42,9 @@ final class TestCommand extends CommandBase {
   @override
   Future<int> run() async {
     final String configName = argResults![configFlag] as String;
+    final String demangledName = demangleConfigName(environment, configName);
     final Build? build =
-        builds.where((Build build) => build.name == configName).firstOrNull;
+        builds.where((Build build) => build.name == demangledName).firstOrNull;
     if (build == null) {
       environment.logger.error('Could not find config $configName');
       return 1;

--- a/tools/engine_tool/test/fetch_command_test.dart
+++ b/tools/engine_tool/test/fetch_command_test.dart
@@ -33,7 +33,8 @@ void main() {
         engine: engine,
         platform: FakePlatform(
             operatingSystem: Platform.linux,
-            resolvedExecutable: io.Platform.resolvedExecutable),
+            resolvedExecutable: io.Platform.resolvedExecutable,
+            pathSeparator: '/'),
         processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {
             runHistory.add(command);

--- a/tools/engine_tool/test/fixtures.dart
+++ b/tools/engine_tool/test/fixtures.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-String testConfig(String os) => '''
+String testConfig(String osDimension, String osPlatform) => '''
 {
   "builds": [
     {
@@ -16,13 +16,13 @@ String testConfig(String os) => '''
         }
       ],
       "drone_dimensions": [
-        "os=$os"
+        "os=$osDimension"
       ],
       "gclient_variables": {
         "variable": false
       },
       "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
-      "name": "build_name",
+      "name": "ci/build_name",
       "ninja": {
         "config": "build_name",
         "targets": ["ninja_target"]
@@ -51,10 +51,10 @@ String testConfig(String os) => '''
     {},
     {
       "drone_dimensions": [
-        "os=$os"
+        "os=$osDimension"
       ],
       "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
-      "name": "host_debug",
+      "name": "$osPlatform/host_debug",
       "ninja": {
         "config": "host_debug",
         "targets": ["ninja_target"]
@@ -62,10 +62,10 @@ String testConfig(String os) => '''
     },
     {
       "drone_dimensions": [
-        "os=$os"
+        "os=$osDimension"
       ],
       "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
-      "name": "android_debug_arm64",
+      "name": "$osPlatform/android_debug_arm64",
       "ninja": {
         "config": "android_debug_arm64",
         "targets": ["ninja_target"]
@@ -73,10 +73,10 @@ String testConfig(String os) => '''
     },
     {
       "drone_dimensions": [
-        "os=$os"
+        "os=$osDimension"
       ],
       "gn": ["--gn-arg", "--lto", "--no-goma", "--rbe"],
-      "name": "android_debug_rbe_arm64",
+      "name": "ci/android_debug_rbe_arm64",
       "ninja": {
         "config": "android_debug_rbe_arm64",
         "targets": ["ninja_target"]
@@ -98,7 +98,7 @@ String testConfig(String os) => '''
       "name": "global test",
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
-        "os=$os"
+        "os=$osDimension"
       ],
       "gclient_variables": {
         "variable": false
@@ -117,6 +117,35 @@ String testConfig(String os) => '''
           "script": "global/test/script.py"
         }
       ]
+    }
+  ]
+}
+''';
+
+const String configsToTestNamespacing = '''
+{
+  "builds": [
+    {
+      "drone_dimensions": [
+        "os=Linux"
+      ],
+      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "name": "linux/host_debug",
+      "ninja": {
+        "config": "local_host_debug",
+        "targets": ["ninja_target"]
+      }
+    },
+    {
+      "drone_dimensions": [
+        "os=Linux"
+      ],
+      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "name": "ci/host_debug",
+      "ninja": {
+        "config": "ci/host_debug",
+        "targets": ["ninja_target"]
+      }
     }
   ]
 }

--- a/tools/engine_tool/test/format_command_test.dart
+++ b/tools/engine_tool/test/format_command_test.dart
@@ -34,6 +34,7 @@ void main() {
       platform: FakePlatform(
         resolvedExecutable: '/dart',
         operatingSystem: Platform.linux,
+        pathSeparator: '/',
       ),
       processRunner: ProcessRunner(
         processManager: processManager,

--- a/tools/engine_tool/test/lint_command_test.dart
+++ b/tools/engine_tool/test/lint_command_test.dart
@@ -29,19 +29,19 @@ void main() {
   }
   final BuilderConfig linuxTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/linux_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Linux'))
+    map: convert.jsonDecode(fixtures.testConfig('Linux', Platform.linux))
         as Map<String, Object?>,
   );
 
   final BuilderConfig macTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/mac_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Mac-12'))
+    map: convert.jsonDecode(fixtures.testConfig('Mac-12', Platform.macOS))
         as Map<String, Object?>,
   );
 
   final BuilderConfig winTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/win_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Windows-11'))
+    map: convert.jsonDecode(fixtures.testConfig('Windows-11', Platform.windows))
         as Map<String, Object?>,
   );
 
@@ -60,7 +60,8 @@ void main() {
         engine: engine,
         platform: FakePlatform(
             operatingSystem: Platform.macOS,
-            resolvedExecutable: io.Platform.resolvedExecutable),
+            resolvedExecutable: io.Platform.resolvedExecutable,
+            pathSeparator: '/'),
         processRunner: ProcessRunner(
             processManager: FakeProcessManager(onStart: (List<String> command) {
           runHistory.add(command);

--- a/tools/engine_tool/test/proc_utils_test.dart
+++ b/tools/engine_tool/test/proc_utils_test.dart
@@ -33,7 +33,8 @@ void main() {
         engine: engine,
         platform: FakePlatform(
             operatingSystem: Platform.macOS,
-            resolvedExecutable: io.Platform.resolvedExecutable),
+            resolvedExecutable: io.Platform.resolvedExecutable,
+            pathSeparator: '/'),
         processRunner: ProcessRunner(
             processManager: FakeProcessManager(onStart: (List<String> command) {
           runHistory.add(command);

--- a/tools/engine_tool/test/query_command_test.dart
+++ b/tools/engine_tool/test/query_command_test.dart
@@ -12,6 +12,7 @@ import 'package:engine_tool/src/commands/command_runner.dart';
 import 'package:engine_tool/src/environment.dart';
 import 'package:litetest/litetest.dart';
 import 'package:logging/logging.dart' as log;
+import 'package:platform/platform.dart';
 
 import 'fixtures.dart' as fixtures;
 import 'utils.dart';
@@ -28,19 +29,19 @@ void main() {
 
   final BuilderConfig linuxTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/linux_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Linux'))
+    map: convert.jsonDecode(fixtures.testConfig('Linux', Platform.linux))
         as Map<String, Object?>,
   );
 
   final BuilderConfig macTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/mac_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Mac-12'))
+    map: convert.jsonDecode(fixtures.testConfig('Mac-12', Platform.macOS))
         as Map<String, Object?>,
   );
 
   final BuilderConfig winTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/win_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Windows-11'))
+    map: convert.jsonDecode(fixtures.testConfig('Windows-11', Platform.windows))
         as Map<String, Object?>,
   );
 
@@ -89,15 +90,15 @@ fml_arc_unittests
         'Add --verbose to see detailed information about each builder\n',
         '\n',
         '"linux_test_config" builder:\n',
-        '   "build_name" config\n',
-        '   "host_debug" config\n',
-        '   "android_debug_arm64" config\n',
-        '   "android_debug_rbe_arm64" config\n',
+        '   "ci/build_name" config\n',
+        '   "linux/host_debug" config\n',
+        '   "linux/android_debug_arm64" config\n',
+        '   "ci/android_debug_rbe_arm64" config\n',
         '"linux_test_config2" builder:\n',
-        '   "build_name" config\n',
-        '   "host_debug" config\n',
-        '   "android_debug_arm64" config\n',
-        '   "android_debug_rbe_arm64" config\n',
+        '   "ci/build_name" config\n',
+        '   "linux/host_debug" config\n',
+        '   "linux/android_debug_arm64" config\n',
+        '   "ci/android_debug_rbe_arm64" config\n',
       ]),
     );
   });
@@ -124,10 +125,10 @@ fml_arc_unittests
           'Add --verbose to see detailed information about each builder\n',
           '\n',
           '"linux_test_config" builder:\n',
-          '   "build_name" config\n',
-          '   "host_debug" config\n',
-          '   "android_debug_arm64" config\n',
-          '   "android_debug_rbe_arm64" config\n',
+          '   "ci/build_name" config\n',
+          '   "linux/host_debug" config\n',
+          '   "linux/android_debug_arm64" config\n',
+          '   "ci/android_debug_rbe_arm64" config\n',
         ]));
   });
 

--- a/tools/engine_tool/test/run_command_test.dart
+++ b/tools/engine_tool/test/run_command_test.dart
@@ -31,19 +31,19 @@ void main() {
 
   final BuilderConfig linuxTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/linux_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Linux'))
+    map: convert.jsonDecode(fixtures.testConfig('Linux', Platform.linux))
         as Map<String, Object?>,
   );
 
   final BuilderConfig macTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/mac_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Mac-12'))
+    map: convert.jsonDecode(fixtures.testConfig('Mac-12', Platform.macOS))
         as Map<String, Object?>,
   );
 
   final BuilderConfig winTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/win_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Windows-11'))
+    map: convert.jsonDecode(fixtures.testConfig('Windows-11', Platform.windows))
         as Map<String, Object?>,
   );
 
@@ -62,7 +62,8 @@ void main() {
         engine: engine,
         platform: FakePlatform(
             operatingSystem: Platform.linux,
-            resolvedExecutable: io.Platform.resolvedExecutable),
+            resolvedExecutable: io.Platform.resolvedExecutable,
+            pathSeparator: '/'),
         processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {
             runHistory.add(command);
@@ -152,9 +153,9 @@ void main() {
           'flutter',
           'run',
           '--local-engine',
-          'android_debug_arm64',
+          'linux/android_debug_arm64',
           '--local-engine-host',
-          'host_debug',
+          'linux/host_debug',
           '-d',
           'emulator'
         ]));

--- a/tools/engine_tool/test/test_command_test.dart
+++ b/tools/engine_tool/test/test_command_test.dart
@@ -11,6 +11,7 @@ import 'package:engine_repo_tools/engine_repo_tools.dart';
 import 'package:engine_tool/src/commands/command_runner.dart';
 import 'package:engine_tool/src/environment.dart';
 import 'package:litetest/litetest.dart';
+import 'package:platform/platform.dart';
 
 import 'fixtures.dart' as fixtures;
 import 'utils.dart';
@@ -27,19 +28,19 @@ void main() {
 
   final BuilderConfig linuxTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/linux_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Linux'))
+    map: convert.jsonDecode(fixtures.testConfig('Linux', Platform.linux))
         as Map<String, Object?>,
   );
 
   final BuilderConfig macTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/mac_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Mac-12'))
+    map: convert.jsonDecode(fixtures.testConfig('Mac-12', Platform.macOS))
         as Map<String, Object?>,
   );
 
   final BuilderConfig winTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/win_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Windows-11'))
+    map: convert.jsonDecode(fixtures.testConfig('Windows-11', Platform.windows))
         as Map<String, Object?>,
   );
 

--- a/tools/engine_tool/test/utils.dart
+++ b/tools/engine_tool/test/utils.dart
@@ -61,7 +61,8 @@ class TestEnvironment {
       engine: engine,
       platform: FakePlatform(
           operatingSystem: _operatingSystemForAbi(abi),
-          resolvedExecutable: io.Platform.resolvedExecutable),
+          resolvedExecutable: io.Platform.resolvedExecutable,
+          pathSeparator: _pathSeparatorForAbi(abi)),
       processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {
         final FakeProcess processResult =
@@ -99,6 +100,17 @@ String _operatingSystemForAbi(ffi.Abi abi) {
       return Platform.macOS;
     default:
       throw UnimplementedError('Unhandled abi=$abi');
+  }
+}
+
+String _pathSeparatorForAbi(ffi.Abi abi) {
+  switch (abi) {
+    case ffi.Abi.windowsArm64:
+    case ffi.Abi.windowsIA32:
+    case ffi.Abi.windowsX64:
+      return r'\';
+    default:
+      return '/';
   }
 }
 

--- a/tools/engine_tool/test/worker_pool_test.dart
+++ b/tools/engine_tool/test/worker_pool_test.dart
@@ -73,7 +73,10 @@ void main() {
       Environment(
         abi: ffi.Abi.macosArm64,
         engine: engine,
-        platform: FakePlatform(operatingSystem: Platform.macOS),
+        platform: FakePlatform(
+          operatingSystem: Platform.macOS,
+          pathSeparator: '/',
+        ),
         processRunner: ProcessRunner(
             processManager: FakeProcessManager(onStart: (List<String> command) {
           runHistory.add(command);

--- a/tools/pkg/engine_build_configs/bin/check.dart
+++ b/tools/pkg/engine_build_configs/bin/check.dart
@@ -129,12 +129,6 @@ List<String> checkForInvalidBuildNames(Map<String, BuilderConfig> configs) {
       ? osNames
       : ciNames;
     if (!goodPrefixes.any(build.name.startsWith)) {
-      if (name.contains('local_engine')) {
-        // TODO(zanderso): Check these builds as well after local_engine is
-        // fixed.
-        // https://github.com/flutter/flutter/issues/145263
-        return;
-      }
       errors.add(
         '${build.name} in $name must start with one of '
         '{${goodPrefixes.join(', ')}}',


### PR DESCRIPTION
This is steps (2) and (3) of https://github.com/flutter/flutter/issues/145263.

The next steps after this are to:
1. Fix any issues that come up when running `local_engine.json` in CI.
1. Step (4) of https://github.com/flutter/flutter/issues/145263
1. Fill in some missing builds in `local_engine.json`.