### PR TITLE
Roll buildroot to dcd71b5b237e1e58f2ad8a7e51bead0c2a3755a9

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -288,7 +288,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'ba3ca696f4f95e998707523be755c15440c6bf3f',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'dcd71b5b237e1e58f2ad8a7e51bead0c2a3755a9',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',


### PR DESCRIPTION
To pick up https://github.com/flutter/buildroot/pull/843
