### PR TITLE
Never panic in `finally { ... }`, check output logs on success only.

### DIFF
--- a/testing/scenario_app/bin/utils/logs.dart
+++ b/testing/scenario_app/bin/utils/logs.dart
@@ -39,11 +39,13 @@ void logWarning(String msg) {
   _logWithColor(_yellow, msg);
 }
 
+void logError(String msg) {
+  _logWithColor(_red, msg);
+}
+
 final class Panic extends Error {}
 
 Never panic(List<String> messages) {
-  for (final String message in messages) {
-    _logWithColor(_red, message);
-  }
+  messages.forEach(logError);
   throw Panic();
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/145988.

Should be a NO-OP in behavior, but hopefully make some of the false negatives less confusing (i.e. getting "missing X outputted files when the test is about to fail anyway".