### PR TITLE
[Impeller] Avoid loading redundant Vulkan extensions.

### DIFF
--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -167,14 +167,6 @@ static const char* GetExtensionName(RequiredAndroidDeviceExtensionVK ext) {
     case RequiredAndroidDeviceExtensionVK::
         kANDROIDExternalMemoryAndroidHardwareBuffer:
       return "VK_ANDROID_external_memory_android_hardware_buffer";
-    case RequiredAndroidDeviceExtensionVK::kKHRSamplerYcbcrConversion:
-      return VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME;
-    case RequiredAndroidDeviceExtensionVK::kKHRExternalMemory:
-      return VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME;
-    case RequiredAndroidDeviceExtensionVK::kEXTQueueFamilyForeign:
-      return VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME;
-    case RequiredAndroidDeviceExtensionVK::kKHRDedicatedAllocation:
-      return VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME;
     case RequiredAndroidDeviceExtensionVK::kLast:
       return "Unknown";
   }
@@ -373,9 +365,7 @@ CapabilitiesVK::GetEnabledDeviceFeatures(
     required.fillModeNonSolid = supported.fillModeNonSolid;
   }
   // VK_KHR_sampler_ycbcr_conversion features.
-  if (IsExtensionInList(
-          enabled_extensions.value(),
-          RequiredAndroidDeviceExtensionVK::kKHRSamplerYcbcrConversion)) {
+  {
     auto& required =
         required_chain
             .get<vk::PhysicalDeviceSamplerYcbcrConversionFeaturesKHR>();

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -50,34 +50,6 @@ enum class RequiredAndroidDeviceExtensionVK : uint32_t {
   ///
   kANDROIDExternalMemoryAndroidHardwareBuffer,
 
-  //----------------------------------------------------------------------------
-  /// Dependency of kANDROIDExternalMemoryAndroidHardwareBuffer.
-  ///
-  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_sampler_ycbcr_conversion.html
-  ///
-  kKHRSamplerYcbcrConversion,
-
-  //----------------------------------------------------------------------------
-  /// Dependency of kANDROIDExternalMemoryAndroidHardwareBuffer.
-  ///
-  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_memory.html
-  ///
-  kKHRExternalMemory,
-
-  //----------------------------------------------------------------------------
-  /// Dependency of kANDROIDExternalMemoryAndroidHardwareBuffer.
-  ///
-  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_queue_family_foreign.html
-  ///
-  kEXTQueueFamilyForeign,
-
-  //----------------------------------------------------------------------------
-  /// Dependency of kANDROIDExternalMemoryAndroidHardwareBuffer.
-  ///
-  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_dedicated_allocation.html
-  ///
-  kKHRDedicatedAllocation,
-
   kLast,
 };
 


### PR DESCRIPTION
All dependencies of VK_ANDROID_external_memory_android_hardware_buffer were enabled earlier. But I didn't realize that those extensions became core in Vulkan 1.1. There is no need to load them unnecessarily. It just makes the extensions requirements look more complicated than they are.

Just deletes code. No change in functionality.