### PR TITLE
[Impeller] Ignore warnign about shader stages not consuming outputs.

### DIFF
--- a/impeller/renderer/backend/vulkan/debug_report_vk.cc
+++ b/impeller/renderer/backend/vulkan/debug_report_vk.cc
@@ -110,6 +110,13 @@ DebugReportVK::Result DebugReportVK::OnDebugCallback(
   if (data->messageIdNumber == 0x2c36905d) {
     return Result::kContinue;
   }
+  // This is a performance warning when a fragment stage does not consume all
+  // varyings from the vertex stage. We ignore this as we want to use a single
+  // vertex stage for the runtime effect shader without trying to determine if
+  // the fragment consumes it or not.
+  if (data->messageIdNumber == 0x609A13B) {
+    return Result::kContinue;
+  }
 
   std::vector<std::pair<std::string, std::string>> items;
 

--- a/impeller/scene/shaders/unlit.frag
+++ b/impeller/scene/shaders/unlit.frag
@@ -17,13 +17,8 @@ in vec4 v_color;
 
 out vec4 frag_color;
 
-float consume_unused() {
-  return (v_position.x + v_tangent_space[0][0]) * 0.001;
-}
-
 void main() {
   vec4 vertex_color = mix(vec4(1), v_color, frag_info.vertex_color_weight);
   frag_color = texture(base_color_texture, v_texture_coords) * vertex_color *
-                   frag_info.color +
-               consume_unused();
+               frag_info.color;
 }


### PR DESCRIPTION
Otherwise it really complicates runtime_effect, as we'd need two vertex shaders.

Fixes https://github.com/flutter/flutter/issues/145860
