### PR TITLE
Use moved GrBackendTexture factories for Skia's Metal backend

### DIFF
--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -9,6 +9,7 @@
 
 #include <utility>
 
+#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
@@ -27,7 +28,6 @@
 #include "third_party/skia/include/gpu/GpuTypes.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
-#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 #include "third_party/skia/include/ports/SkCFObject.h"
 
@@ -47,7 +47,8 @@ sk_sp<SkSurface> CreateSurfaceFromMetalTexture(GrDirectContext* context,
                                                SkSurface::ReleaseContext release_context) {
   GrMtlTextureInfo info;
   info.fTexture.reset([texture retain]);
-  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(texture.width, texture.height, skgpu::Mipmapped::kNo, info);
+  GrBackendTexture backend_texture =
+      GrBackendTextures::MakeMtl(texture.width, texture.height, skgpu::Mipmapped::kNo, info);
   return SkSurfaces::WrapBackendTexture(
       context, backend_texture, origin, static_cast<int>(sample_cnt), color_type,
       std::move(color_space), props, release_proc, release_context);

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -27,6 +27,8 @@
 #include "third_party/skia/include/gpu/GpuTypes.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 #include "third_party/skia/include/ports/SkCFObject.h"
 
 static_assert(!__has_feature(objc_arc), "ARC must be disabled.");
@@ -45,7 +47,7 @@ sk_sp<SkSurface> CreateSurfaceFromMetalTexture(GrDirectContext* context,
                                                SkSurface::ReleaseContext release_context) {
   GrMtlTextureInfo info;
   info.fTexture.reset([texture retain]);
-  GrBackendTexture backend_texture(texture.width, texture.height, skgpu::Mipmapped::kNo, info);
+  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(texture.width, texture.height, skgpu::Mipmapped::kNo, info);
   return SkSurfaces::WrapBackendTexture(
       context, backend_texture, origin, static_cast<int>(sample_cnt), color_type,
       std::move(color_space), props, release_proc, release_context);

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -9,7 +9,6 @@
 
 #include <utility>
 
-#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
@@ -29,6 +28,7 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/ports/SkCFObject.h"
 
 static_assert(!__has_feature(objc_arc), "ARC must be disabled.");

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h"
-#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "flutter/display_list/image/dl_image.h"
 #include "impeller/base/validation.h"
 #include "impeller/display_list/dl_image_impeller.h"
@@ -17,6 +16,7 @@
 #include "third_party/skia/include/gpu/GrYUVABackendTextures.h"
 #include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/ports/SkCFObject.h"
 
 FLUTTER_ASSERT_ARC

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h"
+#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "flutter/display_list/image/dl_image.h"
 #include "impeller/base/validation.h"
 #include "impeller/display_list/dl_image_impeller.h"
@@ -15,9 +16,8 @@
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/GrYUVABackendTextures.h"
 #include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
-#include "third_party/skia/include/ports/SkCFObject.h"
-#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#include "third_party/skia/include/ports/SkCFObject.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -296,18 +296,14 @@ FLUTTER_ASSERT_ARC
   ySkiaTextureInfo.fTexture = sk_cfp<const void*>{(__bridge_retained const void*)yTex};
 
   GrBackendTexture skiaBackendTextures[2];
-  skiaBackendTextures[0] = GrBackendTextures::MakeMtl(width,
-                                            height,
-                                            skgpu::Mipmapped::kNo,
-                                            ySkiaTextureInfo);
+  skiaBackendTextures[0] =
+      GrBackendTextures::MakeMtl(width, height, skgpu::Mipmapped::kNo, ySkiaTextureInfo);
 
   GrMtlTextureInfo uvSkiaTextureInfo;
   uvSkiaTextureInfo.fTexture = sk_cfp<const void*>{(__bridge_retained const void*)uvTex};
 
-  skiaBackendTextures[1] = GrBackendTextures::MakeMtl(width,
-                                            height,
-                                            skgpu::Mipmapped::kNo,
-                                            uvSkiaTextureInfo);
+  skiaBackendTextures[1] =
+      GrBackendTextures::MakeMtl(width, height, skgpu::Mipmapped::kNo, uvSkiaTextureInfo);
   SkYUVAInfo yuvaInfo(skiaBackendTextures[0].dimensions(), SkYUVAInfo::PlaneConfig::kY_UV,
                       SkYUVAInfo::Subsampling::k444, colorSpace);
   GrYUVABackendTextures yuvaBackendTextures(yuvaInfo, skiaBackendTextures,
@@ -325,10 +321,8 @@ FLUTTER_ASSERT_ARC
   GrMtlTextureInfo skiaTextureInfo;
   skiaTextureInfo.fTexture = sk_cfp<const void*>{(__bridge_retained const void*)rgbaTex};
 
-  GrBackendTexture skiaBackendTexture = GrBackendTextures::MakeMtl(width,
-                                      height,
-                                      skgpu::Mipmapped ::kNo,
-                                      skiaTextureInfo);
+  GrBackendTexture skiaBackendTexture =
+      GrBackendTextures::MakeMtl(width, height, skgpu::Mipmapped ::kNo, skiaTextureInfo);
 
   return SkImages::BorrowTextureFrom(grContext, skiaBackendTexture, kTopLeft_GrSurfaceOrigin,
                                      kBGRA_8888_SkColorType, kPremul_SkAlphaType,

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -16,6 +16,8 @@
 #include "third_party/skia/include/gpu/GrYUVABackendTextures.h"
 #include "third_party/skia/include/gpu/ganesh/SkImageGanesh.h"
 #include "third_party/skia/include/ports/SkCFObject.h"
+#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -294,18 +296,18 @@ FLUTTER_ASSERT_ARC
   ySkiaTextureInfo.fTexture = sk_cfp<const void*>{(__bridge_retained const void*)yTex};
 
   GrBackendTexture skiaBackendTextures[2];
-  skiaBackendTextures[0] = GrBackendTexture(/*width=*/width,
-                                            /*height=*/height,
-                                            /*mipMapped=*/skgpu::Mipmapped::kNo,
-                                            /*mtlInfo=*/ySkiaTextureInfo);
+  skiaBackendTextures[0] = GrBackendTextures::MakeMtl(width,
+                                            height,
+                                            skgpu::Mipmapped::kNo,
+                                            ySkiaTextureInfo);
 
   GrMtlTextureInfo uvSkiaTextureInfo;
   uvSkiaTextureInfo.fTexture = sk_cfp<const void*>{(__bridge_retained const void*)uvTex};
 
-  skiaBackendTextures[1] = GrBackendTexture(/*width=*/width,
-                                            /*height=*/height,
-                                            /*mipMapped=*/skgpu::Mipmapped::kNo,
-                                            /*mtlInfo=*/uvSkiaTextureInfo);
+  skiaBackendTextures[1] = GrBackendTextures::MakeMtl(width,
+                                            height,
+                                            skgpu::Mipmapped::kNo,
+                                            uvSkiaTextureInfo);
   SkYUVAInfo yuvaInfo(skiaBackendTextures[0].dimensions(), SkYUVAInfo::PlaneConfig::kY_UV,
                       SkYUVAInfo::Subsampling::k444, colorSpace);
   GrYUVABackendTextures yuvaBackendTextures(yuvaInfo, skiaBackendTextures,
@@ -323,10 +325,10 @@ FLUTTER_ASSERT_ARC
   GrMtlTextureInfo skiaTextureInfo;
   skiaTextureInfo.fTexture = sk_cfp<const void*>{(__bridge_retained const void*)rgbaTex};
 
-  GrBackendTexture skiaBackendTexture(/*width=*/width,
-                                      /*height=*/height,
-                                      /*mipMapped=*/skgpu::Mipmapped ::kNo,
-                                      /*mtlInfo=*/skiaTextureInfo);
+  GrBackendTexture skiaBackendTexture = GrBackendTextures::MakeMtl(width,
+                                      height,
+                                      skgpu::Mipmapped ::kNo,
+                                      skiaTextureInfo);
 
   return SkImages::BorrowTextureFrom(grContext, skiaBackendTexture, kTopLeft_GrSurfaceOrigin,
                                      kBGRA_8888_SkColorType, kPremul_SkAlphaType,

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -84,10 +84,10 @@ extern const intptr_t kPlatformStrongDillSize;
 #endif  // SHELL_ENABLE_GL
 
 #ifdef SHELL_ENABLE_METAL
+#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "flutter/shell/platform/embedder/embedder_surface_metal.h"
-#include "third_party/skia/include/ports/SkCFObject.h"
-#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#include "third_party/skia/include/ports/SkCFObject.h"
 #ifdef IMPELLER_SUPPORTS_RENDERING
 #include "flutter/shell/platform/embedder/embedder_render_target_impeller.h"  // nogncheck
 #include "flutter/shell/platform/embedder/embedder_surface_metal_impeller.h"  // nogncheck
@@ -749,10 +749,9 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
   texture_info.fID = texture->name;
   texture_info.fFormat = texture->format;
 
-  GrBackendTexture backend_texture = GrBackendTextures::MakeGL(config.size.width,
-                                                   config.size.height,
-                                                   skgpu::Mipmapped::kNo,
-                                                   texture_info);
+  GrBackendTexture backend_texture =
+      GrBackendTextures::MakeGL(config.size.width, config.size.height,
+                                skgpu::Mipmapped::kNo, texture_info);
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 
@@ -923,11 +922,12 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
   sk_cfp<FlutterMetalTextureHandle> mtl_texture;
   mtl_texture.retain(metal->texture.texture);
   texture_info.fTexture = mtl_texture;
-  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(config.size.width,      //
-                                   config.size.height,     //
-                                   skgpu::Mipmapped::kNo,  //
-                                   texture_info            //
-  );
+  GrBackendTexture backend_texture =
+      GrBackendTextures::MakeMtl(config.size.width,      //
+                                 config.size.height,     //
+                                 skgpu::Mipmapped::kNo,  //
+                                 texture_info            //
+      );
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -86,6 +86,8 @@ extern const intptr_t kPlatformStrongDillSize;
 #ifdef SHELL_ENABLE_METAL
 #include "flutter/shell/platform/embedder/embedder_surface_metal.h"
 #include "third_party/skia/include/ports/SkCFObject.h"
+#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 #ifdef IMPELLER_SUPPORTS_RENDERING
 #include "flutter/shell/platform/embedder/embedder_render_target_impeller.h"  // nogncheck
 #include "flutter/shell/platform/embedder/embedder_surface_metal_impeller.h"  // nogncheck
@@ -747,11 +749,10 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
   texture_info.fID = texture->name;
   texture_info.fFormat = texture->format;
 
-  auto backend_texture = GrBackendTextures::MakeGL(config.size.width,      //
-                                                   config.size.height,     //
-                                                   skgpu::Mipmapped::kNo,  //
-                                                   texture_info            //
-  );
+  GrBackendTexture backend_texture = GrBackendTextures::MakeGL(config.size.width,
+                                                   config.size.height,
+                                                   skgpu::Mipmapped::kNo,
+                                                   texture_info);
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 
@@ -922,7 +923,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
   sk_cfp<FlutterMetalTextureHandle> mtl_texture;
   mtl_texture.retain(metal->texture.texture);
   texture_info.fTexture = mtl_texture;
-  GrBackendTexture backend_texture(config.size.width,      //
+  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(config.size.width,      //
                                    config.size.height,     //
                                    skgpu::Mipmapped::kNo,  //
                                    texture_info            //

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -84,9 +84,9 @@ extern const intptr_t kPlatformStrongDillSize;
 #endif  // SHELL_ENABLE_GL
 
 #ifdef SHELL_ENABLE_METAL
-#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "flutter/shell/platform/embedder/embedder_surface_metal.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/ports/SkCFObject.h"
 #ifdef IMPELLER_SUPPORTS_RENDERING
 #include "flutter/shell/platform/embedder/embedder_render_target_impeller.h"  // nogncheck

--- a/shell/platform/embedder/tests/embedder_metal_unittests.mm
+++ b/shell/platform/embedder/tests/embedder_metal_unittests.mm
@@ -20,11 +20,11 @@
 #include "flutter/testing/assertions_skia.h"
 #include "flutter/testing/testing.h"
 
+#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GpuTypes.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
-#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 
 // CREATE_NATIVE_ENTRY is leaky by design
@@ -66,8 +66,8 @@ static sk_sp<SkSurface> GetSurfaceFromTexture(const sk_sp<GrDirectContext>& skia
                                               void* texture) {
   GrMtlTextureInfo info;
   info.fTexture.reset([(id<MTLTexture>)texture retain]);
-  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(texture_size.width(), texture_size.height(),
-                                   skgpu::Mipmapped::kNo, info);
+  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(
+      texture_size.width(), texture_size.height(), skgpu::Mipmapped::kNo, info);
 
   return SkSurfaces::WrapBackendTexture(skia_context.get(), backend_texture,
                                         kTopLeft_GrSurfaceOrigin, 1, kBGRA_8888_SkColorType,

--- a/shell/platform/embedder/tests/embedder_metal_unittests.mm
+++ b/shell/platform/embedder/tests/embedder_metal_unittests.mm
@@ -24,6 +24,8 @@
 #include "third_party/skia/include/gpu/GpuTypes.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 
 // CREATE_NATIVE_ENTRY is leaky by design
 // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)
@@ -64,7 +66,7 @@ static sk_sp<SkSurface> GetSurfaceFromTexture(const sk_sp<GrDirectContext>& skia
                                               void* texture) {
   GrMtlTextureInfo info;
   info.fTexture.reset([(id<MTLTexture>)texture retain]);
-  GrBackendTexture backend_texture(texture_size.width(), texture_size.height(),
+  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(texture_size.width(), texture_size.height(),
                                    skgpu::Mipmapped::kNo, info);
 
   return SkSurfaces::WrapBackendTexture(skia_context.get(), backend_texture,

--- a/shell/platform/embedder/tests/embedder_metal_unittests.mm
+++ b/shell/platform/embedder/tests/embedder_metal_unittests.mm
@@ -20,12 +20,12 @@
 #include "flutter/testing/assertions_skia.h"
 #include "flutter/testing/testing.h"
 
-#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GpuTypes.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 
 // CREATE_NATIVE_ENTRY is leaky by design
 // NOLINTBEGIN(clang-analyzer-core.StackAddressEscape)

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -27,7 +27,7 @@
 #endif  // SHELL_ENABLE_VULKAN
 
 #ifdef SHELL_ENABLE_METAL
-#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
+#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 #endif
 
@@ -286,8 +286,9 @@ bool EmbedderTestBackingStoreProducer::CreateMTLTexture(
 
   GrMtlTextureInfo skia_texture_info;
   skia_texture_info.fTexture.reset(SkCFSafeRetain(texture_info.texture));
-  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(surface_size.width(), surface_size.height(),
-                                   skgpu::Mipmapped::kNo, skia_texture_info);
+  GrBackendTexture backend_texture =
+      GrBackendTextures::MakeMtl(surface_size.width(), surface_size.height(),
+                                 skgpu::Mipmapped::kNo, skia_texture_info);
 
   sk_sp<SkSurface> surface = SkSurfaces::WrapBackendTexture(
       context_.get(), backend_texture, kTopLeft_GrSurfaceOrigin, 1,

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -27,8 +27,8 @@
 #endif  // SHELL_ENABLE_VULKAN
 
 #ifdef SHELL_ENABLE_METAL
-#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #endif
 
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -26,6 +26,11 @@
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #endif  // SHELL_ENABLE_VULKAN
 
+#ifdef SHELL_ENABLE_METAL
+#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#endif
+
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
 
@@ -281,7 +286,7 @@ bool EmbedderTestBackingStoreProducer::CreateMTLTexture(
 
   GrMtlTextureInfo skia_texture_info;
   skia_texture_info.fTexture.reset(SkCFSafeRetain(texture_info.texture));
-  GrBackendTexture backend_texture(surface_size.width(), surface_size.height(),
+  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(surface_size.width(), surface_size.height(),
                                    skgpu::Mipmapped::kNo, skia_texture_info);
 
   sk_sp<SkSurface> surface = SkSurfaces::WrapBackendTexture(

--- a/skia/flutter_defines.gni
+++ b/skia/flutter_defines.gni
@@ -11,9 +11,8 @@ flutter_defines = [
 
   # Staging
   "SK_LEGACY_IGNORE_DRAW_VERTICES_BLEND_WITH_NO_SHADER",
-  "SK_DISABLE_LEGACY_GRDIRECTCONTEXT_BOOLS",
-  "SK_DISABLE_LEGACY_GRDIRECTCONTEXT_FLUSH",
   "SK_RESOLVE_FILTERS_BEFORE_RESTORE",
+  "SK_DISABLE_LEGACY_METAL_BACKEND_SURFACE",
 
   # Fast low-precision software rendering isn't a priority for Flutter.
   "SK_DISABLE_LEGACY_SHADERCONTEXT",
@@ -23,12 +22,6 @@ flutter_defines = [
   # When running Metal, ensure that command buffers are scheduled before
   # returning from submit.
   "SK_METAL_WAIT_UNTIL_SCHEDULED",
-
-  # Staging for b/305780908
-  "SK_DEFAULT_TYPEFACE_IS_EMPTY",
-  "SK_DISABLE_LEGACY_DEFAULT_TYPEFACE",
-  "SK_DISABLE_LEGACY_FONTMGR_FACTORY",
-  "SK_DISABLE_LEGACY_FONTMGR_REFDEFAULT",
 ]
 
 if (!is_fuchsia) {

--- a/testing/test_metal_surface_impl.mm
+++ b/testing/test_metal_surface_impl.mm
@@ -18,6 +18,8 @@
 #include "third_party/skia/include/gpu/GpuTypes.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 
 namespace flutter {
 
@@ -27,7 +29,7 @@ void TestMetalSurfaceImpl::Init(const TestMetalContext::TextureInfo& texture_inf
 
   GrMtlTextureInfo skia_texture_info;
   skia_texture_info.fTexture.reset([texture retain]);
-  GrBackendTexture backend_texture(surface_size.width(), surface_size.height(),
+  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(surface_size.width(), surface_size.height(),
                                    skgpu::Mipmapped::kNo, skia_texture_info);
 
   sk_sp<SkSurface> surface = SkSurfaces::WrapBackendTexture(

--- a/testing/test_metal_surface_impl.mm
+++ b/testing/test_metal_surface_impl.mm
@@ -6,7 +6,6 @@
 
 #include <Metal/Metal.h>
 
-#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/testing/test_metal_context.h"
@@ -20,6 +19,7 @@
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
+#include "third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 
 namespace flutter {
 

--- a/testing/test_metal_surface_impl.mm
+++ b/testing/test_metal_surface_impl.mm
@@ -6,6 +6,7 @@
 
 #include <Metal/Metal.h>
 
+#include " third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/testing/test_metal_context.h"
@@ -18,7 +19,6 @@
 #include "third_party/skia/include/gpu/GpuTypes.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
-#include" third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 
 namespace flutter {
@@ -29,8 +29,8 @@ void TestMetalSurfaceImpl::Init(const TestMetalContext::TextureInfo& texture_inf
 
   GrMtlTextureInfo skia_texture_info;
   skia_texture_info.fTexture.reset([texture retain]);
-  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(surface_size.width(), surface_size.height(),
-                                   skgpu::Mipmapped::kNo, skia_texture_info);
+  GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(
+      surface_size.width(), surface_size.height(), skgpu::Mipmapped::kNo, skia_texture_info);
 
   sk_sp<SkSurface> surface = SkSurfaces::WrapBackendTexture(
       test_metal_context_.GetSkiaContext().get(), backend_texture, kTopLeft_GrSurfaceOrigin, 1,


### PR DESCRIPTION
In https://skia-review.googlesource.com/c/skia/+/833302, Skia moved the constructors for Metal versions of GrBackendTexture (and other functions/methods). This updates uses in Flutter to use the new APIs.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
