### PR TITLE
Run and record `adb shell screenrecord` during Android scenario app

### DIFF
--- a/testing/scenario_app/bin/run_android_tests.dart
+++ b/testing/scenario_app/bin/run_android_tests.dart
@@ -488,8 +488,8 @@ Future<void> _run({
 
         // Pull the screen recording from the device.
         final String screenRecordingPath = join(
-          _emulatorStoragePath, 
-          'tmp', 
+          _emulatorStoragePath,
+          'tmp',
           'screen.mp4',
         );
         final String screenRecordingLocalPath = join(

--- a/testing/scenario_app/bin/run_android_tests.dart
+++ b/testing/scenario_app/bin/run_android_tests.dart
@@ -401,7 +401,7 @@ Future<void> _run({
         'am',
         'instrument',
         '-w',
-	      '--no-window-animation',
+        '--no-window-animation',
         if (smokeTestFullPath != null)
           '-e class $smokeTestFullPath',
         if (enableImpeller)

--- a/testing/scenario_app/bin/utils/options.dart
+++ b/testing/scenario_app/bin/utils/options.dart
@@ -165,6 +165,11 @@ extension type const Options._(ArgResults _args) {
         defaultsTo: environment.isCi,
         hide: hideUnusualOptions,
       )
+      ..addFlag(
+        'record-screen',
+        help: 'Whether to record the screen during the test run.',
+        defaultsTo: environment.isCi,
+      )
       ..addOption(
         'impeller-backend',
         help: 'The graphics backend to use when --enable-impeller is true. '
@@ -285,6 +290,9 @@ extension type const Options._(ArgResults _args) {
 
   /// Whether to enable Impeller as the graphics backend.
   bool get enableImpeller => _args['enable-impeller'] as bool;
+
+  /// Whether to record the screen during the test run.
+  bool get recordScreen => _args['record-screen'] as bool;
 
   /// The graphics backend to use when --enable-impeller is true.
   String get impellerBackend => _args['impeller-backend'] as String;


### PR DESCRIPTION
More grasping at straws to solve https://github.com/flutter/flutter/issues/145988.

At some point this could be moved to `--verbose` if it isn't useful.

This will automatically be copied into `${FLUTTER_LOGS_DIR}`, yay!

Example:

https://github.com/flutter/engine/assets/168174/c8caca7a-88ec-4d09-88bd-ebfc531f6512

