### PR TITLE
Use `fml::ScopedCleanupClosure` instead of `DeathRattle`.

### DIFF
--- a/impeller/renderer/backend/vulkan/resource_manager_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/resource_manager_vk_unittests.cc
@@ -6,6 +6,7 @@
 #include <functional>
 #include <memory>
 #include <utility>
+#include "fml/closure.h"
 #include "fml/synchronization/waitable_event.h"
 #include "gtest/gtest.h"
 #include "impeller/renderer/backend/vulkan/resource_manager_vk.h"
@@ -20,39 +21,19 @@ TEST(ResourceManagerVKTest, CreatesANewInstance) {
   EXPECT_NE(a, b);
 }
 
-namespace {
-
-// Invokes the provided callback when the destructor is called.
-//
-// Can be moved, but not copied.
-class DeathRattle final {
- public:
-  explicit DeathRattle(std::function<void()> callback)
-      : callback_(std::move(callback)) {}
-
-  DeathRattle(DeathRattle&&) = default;
-  DeathRattle& operator=(DeathRattle&&) = default;
-
-  ~DeathRattle() { callback_(); }
-
- private:
-  std::function<void()> callback_;
-};
-
-}  // namespace
-
 TEST(ResourceManagerVKTest, ReclaimMovesAResourceAndDestroysIt) {
   auto const manager = ResourceManagerVK::Create();
 
   auto waiter = fml::AutoResetWaitableEvent();
   auto dead = false;
-  auto rattle = DeathRattle([&waiter]() { waiter.Signal(); });
+  auto rattle = fml::ScopedCleanupClosure([&waiter]() { waiter.Signal(); });
 
   // Not killed immediately.
   EXPECT_FALSE(waiter.IsSignaledForTest());
 
   {
-    auto resource = UniqueResourceVKT<DeathRattle>(manager, std::move(rattle));
+    auto resource = UniqueResourceVKT<fml::ScopedCleanupClosure>(
+        manager, std::move(rattle));
   }
 
   waiter.Wait();


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/146105.

Originally when we authored these suites, `ScopedCleanupClosure` disallowed move-semantics, but that was fixed in https://github.com/flutter/engine/pull/45772, so there is no reason to have a copy of these in different tests.

/cc @jonahwilliams 