### PR TITLE
Move scenario_app integration tests back to `max_attempts: 2`.

### DIFF
--- a/ci/builders/linux_android_emulator_skia.json
+++ b/ci/builders/linux_android_emulator_skia.json
@@ -39,7 +39,7 @@
                     "language": "dart",
                     "name": "Android Scenario App Integration Tests (Skia)",
                     "test_timeout_secs": 900,
-                    "max_attempts": 1,
+                    "max_attempts": 2,
                     "test_dependencies": [
                         {
                             "dependency": "android_virtual_device",


### PR DESCRIPTION
This seems to be the flakiest target, and is/was making our CI red all day.

Related: https://github.com/flutter/flutter/issues/145988.