### PR TITLE
Replace `WindowInsetsController...` with `adb shell` commands

### DIFF
--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestActivity.java
@@ -9,12 +9,8 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.view.Window;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.loader.FlutterLoader;
@@ -29,7 +25,6 @@ public abstract class TestActivity extends TestableFlutterActivity {
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    hideSystemBars(getWindow());
     testFlutterLoaderCallbackWhenInitializedTwice();
   }
 
@@ -108,14 +103,5 @@ public abstract class TestActivity extends TestableFlutterActivity {
                 "Failed test: FlutterLoader#ensureInitializationCompleteAsync() did not invoke its callback.");
           }
         });
-  }
-
-  private static void hideSystemBars(Window window) {
-    final WindowInsetsControllerCompat insetController =
-        WindowCompat.getInsetsController(window, window.getDecorView());
-    assert insetController != null;
-    insetController.setSystemBarsBehavior(
-        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
-    insetController.hide(WindowInsetsCompat.Type.systemBars());
   }
 }

--- a/testing/scenario_app/bin/run_android_tests.dart
+++ b/testing/scenario_app/bin/run_android_tests.dart
@@ -298,17 +298,23 @@ Future<void> _run({
     });
 
     await step('Configuring emulator...', () async {
-      final int exitCode = await pm.runAndForward(<String>[
-        adb.path,
-        'shell',
-        'settings',
-        'put',
-        'secure',
-        'immersive_mode_confirmations',
-        'confirmed',
-      ]);
-      if (exitCode != 0) {
-        panic(<String>['could not configure emulator']);
+      final List<List<String>> adbShellCommands = <List<String>> [
+        // Try to close all OS popups in the emulator, like "System UI stopped working".
+        <String>['am', 'broadcast', '-a', 'android.intent.action.CLOSE_SYSTEM_DIALOGS'],
+
+        // Don't show "this is how you exit fullscreen mode".
+        <String>['settings', 'put', 'secure', 'immersive_mode_confirmations', 'confirmed'],
+
+        // Hide all system bars.
+        <String>['settings', 'put', 'global', 'policy_control', 'immersive.full=*'],
+      ];
+
+      // Run all the commands.
+      for (final List<String> command in adbShellCommands) {
+        final int exitCode = await pm.runAndForward(<String>[adb.path, 'shell', ...command]);
+        if (exitCode != 0) {
+          panic(<String>['could not run command: ${command.join(' ')}']);
+        }
       }
     });
 


### PR DESCRIPTION
Previously our screenshots looked like this (when they ran correctly):
![image](https://github.com/flutter/engine/assets/168174/14d46a7a-9b60-4c5d-b786-a6cbee823ef9)

Now, sometimes (only on CI unfortunately) they look like this:
![image](https://github.com/flutter/engine/assets/168174/f4e49258-dcde-4864-b622-19c36c52f8b7)

This started happening after https://github.com/flutter/engine/pull/51832, but the change should be future-proof as well even if we disable the screen recording feature.

h/t @reidbaker 