### PR TITLE
[skwasm] Fix `Paragraph.getLineBoundary`

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -77,6 +77,9 @@ class SkwasmLineMetrics extends SkwasmObjectWrapper<RawLineMetrics> implements u
 
   @override
   int get lineNumber => lineMetricsGetLineNumber(handle);
+
+  int get startIndex => lineMetricsGetStartIndex(handle);
+  int get endIndex => lineMetricsGetEndIndex(handle);
 }
 
 class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Paragraph {
@@ -243,15 +246,13 @@ class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Pa
 
   @override
   ui.TextRange getLineBoundary(ui.TextPosition position) {
-    final int lineNumber = paragraphGetLineNumberAt(handle, position.offset);
-    final LineMetricsHandle metricsHandle =
-      paragraphGetLineMetricsAtIndex(handle, lineNumber);
-    final ui.TextRange range = ui.TextRange(
-      start: lineMetricsGetStartIndex(metricsHandle),
-      end: lineMetricsGetEndIndex(metricsHandle),
-    );
-    lineMetricsDispose(metricsHandle);
-    return range;
+    final int offset = position.offset;
+    for (final SkwasmLineMetrics metrics in computeLineMetrics()) {
+      if (offset >= metrics.startIndex && offset <= metrics.endIndex) {
+        return ui.TextRange(start: metrics.startIndex, end: metrics.endIndex);
+      }
+    }
+    return ui.TextRange.empty;
   }
 
   @override

--- a/lib/web_ui/test/ui/paragraph_builder_test.dart
+++ b/lib/web_ui/test/ui/paragraph_builder_test.dart
@@ -59,6 +59,19 @@ Future<void> testMain() async {
     expect(upstreamWordBoundary, const TextRange(start: 0, end: 5));
   });
 
+  test('getLineBoundary at the last character position gives correct results', () {
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
+    builder.addText('hello world');
+
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: double.infinity));
+
+    final TextRange lineBoundary = paragraph.getLineBoundary(const TextPosition(
+      offset: 11,
+    ));
+    expect(lineBoundary, const TextRange(start: 0, end: 11));
+  });
+
   test('build and layout a paragraph with an empty addText', () {
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
     builder.addText('');


### PR DESCRIPTION
The Skia APIs I was previously using were returning `-1` for `paragraphGetLineNumberAt` when querying at the end of the string. I changed the implementation to be identical to what CanvasKit and the native Paragraph object are doing.