### PR TITLE
Do not use `adb shell screenrecord` during CI runs.

### DIFF
--- a/testing/scenario_app/bin/utils/options.dart
+++ b/testing/scenario_app/bin/utils/options.dart
@@ -168,7 +168,6 @@ extension type const Options._(ArgResults _args) {
       ..addFlag(
         'record-screen',
         help: 'Whether to record the screen during the test run.',
-        defaultsTo: environment.isCi,
       )
       ..addOption(
         'impeller-backend',


### PR DESCRIPTION
This introduced quite a bit of flakiness because the system UI sometimes (???) reappears:

![image](https://github.com/flutter/engine/assets/168174/c74a3b88-0d0c-4d03-894a-19837cb4f383)
