### PR TITLE
[Impeller] Enable logging a warning when the user opts out of using Impeller.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -229,6 +229,9 @@ struct Settings {
   bool enable_impeller = false;
 #endif
 
+  // Log a warning during shell initialization if Impeller is not enabled.
+  bool warn_on_impeller_opt_out = false;
+
   // The selected Android rendering API.
   AndroidRenderingAPI android_rendering_api =
       AndroidRenderingAPI::kSkiaOpenGLES;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -450,6 +450,14 @@ Shell::Shell(DartVMRef vm,
       weak_factory_(this) {
   FML_CHECK(!settings.enable_software_rendering || !settings.enable_impeller)
       << "Software rendering is incompatible with Impeller.";
+  if (!settings.enable_impeller && settings.warn_on_impeller_opt_out) {
+    FML_LOG(IMPORTANT)
+        << "[Action Required] The application opted out of Impeller by either "
+           "using the --no-enable-impeller flag or FLTEnableImpeller=false "
+           "plist flag. This option is going to go away in an upcoming Flutter "
+           "release. Remove the explicit opt-out. If you need to opt-out, "
+           "report a bug describing the issue.";
+  }
   FML_CHECK(vm_) << "Must have access to VM to create a shell.";
   FML_DCHECK(task_runners_.IsValid());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -200,6 +200,8 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
     }
   }
 
+  settings.warn_on_impeller_opt_out = true;
+
   NSNumber* enableTraceSystrace = [mainBundle objectForInfoDictionaryKey:@"FLTTraceSystrace"];
   // Change the default only if the option is present.
   if (enableTraceSystrace != nil) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -235,6 +235,11 @@ FLUTTER_ASSERT_ARC
   [mockMainBundle stopMocking];
 }
 
+- (void)testRequestsWarningWhenImpellerOptOut {
+  auto settings = FLTDefaultSettingsForBundle();
+  XCTAssertEqual(settings.warn_on_impeller_opt_out, YES);
+}
+
 - (void)testEnableImpellerSettingIsCorrectlyParsed {
   id mockMainBundle = OCMPartialMock([NSBundle mainBundle]);
   OCMStub([mockMainBundle objectForInfoDictionaryKey:@"FLTEnableImpeller"]).andReturn(@"YES");


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/144439

This does two things:

* Logs a warning when the embedder requests a non-Impeller preference when creating a shell.
* Makes the iOS embedder request a warning be logged when Impeller is not used.

I decided to put the warning logs in the shell so that as we get more opinionated about Impeller on other platforms, those platforms can just flip a flag with common log origin.