### PR TITLE
Remove the view ID check in `macOS/FlutterCompositor`

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
@@ -54,10 +54,6 @@ bool FlutterCompositor::CreateBackingStore(const FlutterBackingStoreConfig* conf
 bool FlutterCompositor::Present(FlutterViewId view_id,
                                 const FlutterLayer** layers,
                                 size_t layers_count) {
-  // TODO(dkwingsmt): The macOS embedder only supports rendering to the implicit
-  // view for now. As it supports adding more views, this assertion should be
-  // lifted. https://github.com/flutter/flutter/issues/142845
-  FML_DCHECK(view_id == kFlutterImplicitViewId);
   FlutterView* view = [view_provider_ viewForId:view_id];
   if (!view) {
     return false;


### PR DESCRIPTION
This PR removes the view ID check added in https://github.com/flutter/engine/pull/51738, which has been causing a test `FlutterEngineTest.CompositorIgnoresUnknownView`, added in https://github.com/flutter/engine/pull/51436, to fail.

This problem was missed by the CI because the test and the view ID check were added in two PRs recently and they were not using the latest engine to check.

The view ID check is not needed anyway, and is only a temporary check until the multiview support is landed.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
