### PR TITLE
Revert "Prevent `solo: true` from being committed"

### DIFF
--- a/lib/web_ui/analysis_options.yaml
+++ b/lib/web_ui/analysis_options.yaml
@@ -6,12 +6,6 @@
 
 include: ../../analysis_options.yaml
 
-analyzer:
-  errors:
-    # We need this in the web engine in order to prevent committing `solo: true`
-    # in tests.
-    deprecated_member_use: true
-
 linter:
   rules:
     avoid_dynamic_calls: false

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -22,7 +22,6 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:skia_gold_client/skia_gold_client.dart';
 import 'package:stream_channel/stream_channel.dart';
 
-// ignore: deprecated_member_use
 import 'package:test_core/backend.dart' hide Compiler;
 // TODO(ditman): Fix ignores when https://github.com/flutter/flutter/issues/143599 is resolved.
 import 'package:test_core/src/runner/environment.dart'; // ignore: implementation_imports


### PR DESCRIPTION
Reverts flutter/engine#51712

Reason for revert: As discussed in https://github.com/flutter/flutter/issues/143312, and in https://discord.com/channels/608014603317936148/1224499330824802375. I apologize if this seems hasty and not fully justified, but it is important that the engine repo follows policies like this to make it easier for our various teams to work together.