### PR TITLE
Revert "Prevent `solo: true` from being committed (#51712)"

### DIFF
--- a/lib/web_ui/analysis_options.yaml
+++ b/lib/web_ui/analysis_options.yaml
@@ -6,12 +6,6 @@
 
 include: ../../analysis_options.yaml
 
-analyzer:
-  errors:
-    # We need this in the web engine in order to prevent committing `solo: true`
-    # in tests.
-    deprecated_member_use: true
-
 linter:
   rules:
     avoid_dynamic_calls: false

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -22,7 +22,6 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:skia_gold_client/skia_gold_client.dart';
 import 'package:stream_channel/stream_channel.dart';
 
-// ignore: deprecated_member_use
 import 'package:test_core/backend.dart' hide Compiler;
 // TODO(ditman): Fix ignores when https://github.com/flutter/flutter/issues/143599 is resolved.
 import 'package:test_core/src/runner/environment.dart'; // ignore: implementation_imports


### PR DESCRIPTION
This reverts commit 4e6692c8ea82f60dd69c1bfe445cea5bf886529d.

Reportedly it is urgent that we ignore deprecated API usage, so removing the lint and accepting the risk of unintentionally skipped tests.