### PR TITLE
[Impeller] dont inc shared_ptr count for every command/pipeline in render_pass_vk

### DIFF
--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -24,7 +24,6 @@
 #include "impeller/renderer/backend/vulkan/sampler_vk.h"
 #include "impeller/renderer/backend/vulkan/shared_object_vk.h"
 #include "impeller/renderer/backend/vulkan/texture_vk.h"
-#include "impeller/renderer/backend/vulkan/vk.h"
 #include "vulkan/vulkan_handles.hpp"
 
 namespace impeller {
@@ -298,8 +297,7 @@ SharedHandleVK<vk::Framebuffer> RenderPassVK::CreateVKFramebuffer(
 // |RenderPass|
 void RenderPassVK::SetPipeline(
     const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline) {
-  pipeline_ = pipeline;
-
+  pipeline_ = pipeline.get();
   if (!pipeline_) {
     return;
   }
@@ -456,7 +454,7 @@ fml::Status RenderPassVK::Draw() {
           fml::StatusCode::kAborted,
           "Could not create pipeline variant with immutable sampler.");
     }
-    pipeline_ = std::move(pipeline_variant);
+    pipeline_ = pipeline_variant.get();
   }
 
   const auto& context_vk = ContextVK::Cast(*context_);

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -49,7 +49,7 @@ class RenderPassVK final : public RenderPass {
   size_t vertex_count_ = 0u;
   bool has_index_buffer_ = false;
   bool has_label_ = false;
-  std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline_;
+  const Pipeline<PipelineDescriptor>* pipeline_;
   bool pipeline_uses_input_attachments_ = false;
   std::shared_ptr<SamplerVK> immutable_sampler_;
 


### PR DESCRIPTION
We have to pay to inc/dec the shared_ptr, but all pipelines are persisted indefinitely so we shouldn't need to worry about dangling ptrs.