### PR TITLE
Be slightly more lenient about the assertion, as it differs on different backends.

### DIFF
--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -417,7 +417,7 @@ void testMain() {
       } on AssertionError catch (error) {
         expect(
           error.toString(),
-          'Assertion failed: "Cannot render platform views: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15. These views have not been created, or they have been deleted."',
+          contains('Cannot render platform views: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15. These views have not been created, or they have been deleted.'),
         );
       }
 


### PR DESCRIPTION
We shouldn't assume the exact format of the assertion string here, as the exact output is slightly different on dart2js vs ddc vs dart2wasm. They should all contain the message text, however.