### PR TITLE
Save and restore OpenGL bindings that are changed by fl_renderer_render

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -213,6 +213,7 @@ executable("flutter_linux_unittests") {
     "fl_pixel_buffer_texture_test.cc",
     "fl_platform_plugin_test.cc",
     "fl_plugin_registrar_test.cc",
+    "fl_renderer_test.cc",
     "fl_scrolling_manager_test.cc",
     "fl_settings_plugin_test.cc",
     "fl_settings_portal_test.cc",

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -7,6 +7,7 @@
 #include <epoxy/egl.h>
 #include <epoxy/gl.h>
 
+#include "flutter/fml/closure.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_backing_store_provider.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
@@ -324,6 +325,12 @@ void fl_renderer_render(FlRenderer* self, int width, int height) {
   GLint saved_array_buffer_binding;
   glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &saved_array_buffer_binding);
 
+  fml::ScopedCleanupClosure restore_bindings([&] {
+    glBindTexture(GL_TEXTURE_2D, saved_texture_binding);
+    glBindVertexArray(saved_vao_binding);
+    glBindBuffer(GL_ARRAY_BUFFER, saved_array_buffer_binding);
+  });
+
   glClearColor(0.0, 0.0, 0.0, 1.0);
   glClear(GL_COLOR_BUFFER_BIT);
 
@@ -374,10 +381,6 @@ void fl_renderer_render(FlRenderer* self, int width, int height) {
   }
 
   glFlush();
-
-  glBindTexture(GL_TEXTURE_2D, saved_texture_binding);
-  glBindVertexArray(saved_vao_binding);
-  glBindBuffer(GL_ARRAY_BUFFER, saved_array_buffer_binding);
 }
 
 void fl_renderer_cleanup(FlRenderer* self) {

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -314,6 +314,16 @@ void fl_renderer_render(FlRenderer* self, int width, int height) {
 
   g_return_if_fail(FL_IS_RENDERER(self));
 
+  // Save bindings that are set by this function.  All bindings must be restored
+  // to their original values because Skia expects that its bindings have not
+  // been altered.
+  GLint saved_texture_binding;
+  glGetIntegerv(GL_TEXTURE_BINDING_2D, &saved_texture_binding);
+  GLint saved_vao_binding;
+  glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &saved_vao_binding);
+  GLint saved_array_buffer_binding;
+  glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &saved_array_buffer_binding);
+
   glClearColor(0.0, 0.0, 0.0, 1.0);
   glClear(GL_COLOR_BUFFER_BIT);
 
@@ -364,6 +374,10 @@ void fl_renderer_render(FlRenderer* self, int width, int height) {
   }
 
   glFlush();
+
+  glBindTexture(GL_TEXTURE_2D, saved_texture_binding);
+  glBindVertexArray(saved_vao_binding);
+  glBindBuffer(GL_ARRAY_BUFFER, saved_array_buffer_binding);
 }
 
 void fl_renderer_cleanup(FlRenderer* self) {

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -7,7 +7,6 @@
 #include <epoxy/egl.h>
 #include <epoxy/gl.h>
 
-#include "flutter/fml/closure.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_backing_store_provider.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
@@ -325,12 +324,6 @@ void fl_renderer_render(FlRenderer* self, int width, int height) {
   GLint saved_array_buffer_binding;
   glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &saved_array_buffer_binding);
 
-  fml::ScopedCleanupClosure restore_bindings([&] {
-    glBindTexture(GL_TEXTURE_2D, saved_texture_binding);
-    glBindVertexArray(saved_vao_binding);
-    glBindBuffer(GL_ARRAY_BUFFER, saved_array_buffer_binding);
-  });
-
   glClearColor(0.0, 0.0, 0.0, 1.0);
   glClear(GL_COLOR_BUFFER_BIT);
 
@@ -381,6 +374,10 @@ void fl_renderer_render(FlRenderer* self, int width, int height) {
   }
 
   glFlush();
+
+  glBindTexture(GL_TEXTURE_2D, saved_texture_binding);
+  glBindVertexArray(saved_vao_binding);
+  glBindBuffer(GL_ARRAY_BUFFER, saved_array_buffer_binding);
 }
 
 void fl_renderer_cleanup(FlRenderer* self) {

--- a/shell/platform/linux/fl_renderer_test.cc
+++ b/shell/platform/linux/fl_renderer_test.cc
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gtest/gtest.h"
+
+#include <epoxy/egl.h>
+
+#include "flutter/fml/logging.h"
+#include "flutter/shell/platform/linux/fl_backing_store_provider.h"
+#include "flutter/shell/platform/linux/testing/fl_test_gtk_logs.h"
+#include "flutter/shell/platform/linux/testing/mock_renderer.h"
+
+TEST(FlRendererTest, RestoresGLState) {
+  constexpr int kWidth = 100;
+  constexpr int kHeight = 100;
+
+  flutter::testing::fl_ensure_gtk_init();
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlView) view = fl_view_new(project);
+  g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
+  g_autoptr(FlBackingStoreProvider) backing_store_provider =
+      fl_backing_store_provider_new(kWidth, kHeight);
+
+  fl_renderer_start(FL_RENDERER(renderer), view);
+  fl_renderer_wait_for_frame(FL_RENDERER(renderer), kWidth, kHeight);
+
+  FlutterBackingStore backing_store;
+  backing_store.type = kFlutterBackingStoreTypeOpenGL;
+  backing_store.open_gl.framebuffer.user_data = backing_store_provider;
+
+  FlutterLayer layer;
+  layer.type = kFlutterLayerContentTypeBackingStore;
+  layer.backing_store = &backing_store;
+  layer.offset = {0, 0};
+  layer.size = {kWidth, kHeight};
+
+  std::array<const FlutterLayer*, 1> layers = {&layer};
+
+  constexpr GLuint kFakeTextureName = 123;
+  glBindTexture(GL_TEXTURE_2D, kFakeTextureName);
+
+  fl_renderer_present_layers(FL_RENDERER(renderer), layers.data(),
+                             layers.size());
+  fl_renderer_render(FL_RENDERER(renderer), kWidth, kHeight);
+
+  GLuint texture_2d_binding;
+  glGetIntegerv(GL_TEXTURE_BINDING_2D,
+                reinterpret_cast<GLint*>(&texture_2d_binding));
+  EXPECT_EQ(texture_2d_binding, kFakeTextureName);
+
+  g_object_ref_sink(view);
+}


### PR DESCRIPTION
fl_renderer_render uses the raster thread GL context that is also used by Skia.  Skia expects that its bindings have not been changed elsewhere.