### PR TITLE
[CP] Return an empty optional in HardwareBuffer::GetSystemUniqueID if the …

### DIFF
--- a/impeller/toolkit/android/BUILD.gn
+++ b/impeller/toolkit/android/BUILD.gn
@@ -50,6 +50,8 @@ source_set("unittests_lib") {
     ":unittests_fixtures",
     "//flutter/testing",
   ]
+
+  defines = [ "TESTING" ]
 }
 
 executable("unittests") {

--- a/impeller/toolkit/android/hardware_buffer.cc
+++ b/impeller/toolkit/android/hardware_buffer.cc
@@ -108,7 +108,7 @@ std::optional<uint64_t> HardwareBuffer::GetSystemUniqueID() const {
 std::optional<uint64_t> HardwareBuffer::GetSystemUniqueID(
     AHardwareBuffer* buffer) {
   if (!GetProcTable().AHardwareBuffer_getId) {
-    return false;
+    return std::nullopt;
   }
   uint64_t out_id = 0u;
   if (GetProcTable().AHardwareBuffer_getId(buffer, &out_id) != 0) {

--- a/impeller/toolkit/android/proc_table.cc
+++ b/impeller/toolkit/android/proc_table.cc
@@ -14,6 +14,11 @@ const ProcTable& GetProcTable() {
   return gProcTable;
 }
 
+// Only used by tests.
+ProcTable& GetMutableProcTable() {
+  return const_cast<ProcTable&>(GetProcTable());
+}
+
 template <class T>
 void ResolveAndroidProc(
     AndroidProc<T>& proc,

--- a/impeller/toolkit/android/proc_table.h
+++ b/impeller/toolkit/android/proc_table.h
@@ -124,6 +124,10 @@ struct ProcTable {
 
 const ProcTable& GetProcTable();
 
+#ifdef TESTING
+ProcTable& GetMutableProcTable();
+#endif
+
 }  // namespace impeller::android
 
 #endif  // FLUTTER_IMPELLER_TOOLKIT_ANDROID_PROC_TABLE_H_


### PR DESCRIPTION
b/332811967

…underlying NDK API is unavailable (#51839)

