### PR TITLE
[Impeller] batch up filter graph command buffers.

### DIFF
--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -783,8 +783,9 @@ class ContentContext {
   /// @brief  Creates a new texture of size `texture_size` and calls
   ///         `subpass_callback` with a `RenderPass` for drawing to the texture.
   fml::StatusOr<RenderTarget> MakeSubpass(
-      const std::string& label,
+      std::string_view label,
       ISize texture_size,
+      const std::shared_ptr<CommandBuffer>& command_buffer,
       const SubpassCallback& subpass_callback,
       bool msaa_enabled = true,
       bool depth_stencil_enabled = false,
@@ -792,8 +793,9 @@ class ContentContext {
 
   /// Makes a subpass that will render to `subpass_target`.
   fml::StatusOr<RenderTarget> MakeSubpass(
-      const std::string& label,
+      std::string_view label,
       const RenderTarget& subpass_target,
+      const std::shared_ptr<CommandBuffer>& command_buffer,
       const SubpassCallback& subpass_callback) const;
 
   const std::shared_ptr<LazyGlyphAtlas>& GetLazyGlyphAtlas() const {

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -115,7 +115,7 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
   }
   if (!renderer.GetContext()
            ->GetCommandQueue()
-           ->Submit({std::move(command_buffer)})
+           ->Submit(/*buffers=*/{std::move(command_buffer)})
            .ok()) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -76,6 +76,12 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
     return std::nullopt;
   }
 
+  std::shared_ptr<CommandBuffer> command_buffer =
+      renderer.GetContext()->CreateCommandBuffer();
+  if (!command_buffer) {
+    return std::nullopt;
+  }
+
   // Pad Contents snapshots with 1 pixel borders to ensure correct sampling
   // behavior. Not doing so results in a coverage leak for filters that support
   // customizing the input sampling mode. Snapshots of contents should be
@@ -91,7 +97,7 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
 
   ISize subpass_size = ISize::Ceil(coverage->GetSize());
   fml::StatusOr<RenderTarget> render_target = renderer.MakeSubpass(
-      label, subpass_size,
+      label, subpass_size, command_buffer,
       [&contents = *this, &entity, &coverage](const ContentContext& renderer,
                                               RenderPass& pass) -> bool {
         Entity sub_entity;
@@ -105,6 +111,12 @@ std::optional<Snapshot> Contents::RenderToSnapshot(
       std::min(mip_count, static_cast<int32_t>(subpass_size.MipCount())));
 
   if (!render_target.ok()) {
+    return std::nullopt;
+  }
+  if (!renderer.GetContext()
+           ->GetCommandQueue()
+           ->Submit({std::move(command_buffer)})
+           .ok()) {
     return std::nullopt;
   }
 

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -223,9 +223,21 @@ static std::optional<Entity> AdvancedBlend(
     return pass.Draw().ok();
   };
 
+  std::shared_ptr<CommandBuffer> command_buffer =
+      renderer.GetContext()->CreateCommandBuffer();
+  if (!command_buffer) {
+    return std::nullopt;
+  }
   fml::StatusOr<RenderTarget> render_target = renderer.MakeSubpass(
-      "Advanced Blend Filter", ISize(subpass_coverage.GetSize()), callback);
+      "Advanced Blend Filter", ISize(subpass_coverage.GetSize()),
+      command_buffer, callback);
   if (!render_target.ok()) {
+    return std::nullopt;
+  }
+  if (!renderer.GetContext()
+           ->GetCommandQueue()
+           ->Submit({std::move(command_buffer)})
+           .ok()) {
     return std::nullopt;
   }
 
@@ -525,10 +537,24 @@ static std::optional<Entity> PipelineBlend(
     return true;
   };
 
+  std::shared_ptr<CommandBuffer> command_buffer =
+      renderer.GetContext()->CreateCommandBuffer();
+  if (!command_buffer) {
+    return std::nullopt;
+  }
+
   fml::StatusOr<RenderTarget> render_target = renderer.MakeSubpass(
-      "Pipeline Blend Filter", ISize(subpass_coverage.GetSize()), callback);
+      "Pipeline Blend Filter", ISize(subpass_coverage.GetSize()),
+      command_buffer, callback);
 
   if (!render_target.ok()) {
+    return std::nullopt;
+  }
+
+  if (!renderer.GetContext()
+           ->GetCommandQueue()
+           ->Submit({std::move(command_buffer)})
+           .ok()) {
     return std::nullopt;
   }
 

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -236,7 +236,7 @@ static std::optional<Entity> AdvancedBlend(
   }
   if (!renderer.GetContext()
            ->GetCommandQueue()
-           ->Submit({std::move(command_buffer)})
+           ->Submit(/*buffers=*/{std::move(command_buffer)})
            .ok()) {
     return std::nullopt;
   }
@@ -553,7 +553,7 @@ static std::optional<Entity> PipelineBlend(
 
   if (!renderer.GetContext()
            ->GetCommandQueue()
-           ->Submit({std::move(command_buffer)})
+           ->Submit(/*buffers=*/{std::move(command_buffer)})
            .ok()) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -540,7 +540,7 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
 
   if (!renderer.GetContext()
            ->GetCommandQueue()
-           ->Submit({command_buffer})
+           ->Submit(/*buffers=*/{command_buffer})
            .ok()) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -77,6 +77,7 @@ void SetTileMode(SamplerDescriptor* descriptor,
 /// transparent gutter required for the blur halo.
 fml::StatusOr<RenderTarget> MakeDownsampleSubpass(
     const ContentContext& renderer,
+    const std::shared_ptr<CommandBuffer>& command_buffer,
     std::shared_ptr<Texture> input_texture,
     const SamplerDescriptor& sampler_descriptor,
     const Quad& uvs,
@@ -118,12 +119,13 @@ fml::StatusOr<RenderTarget> MakeDownsampleSubpass(
         return pass.Draw().ok();
       };
   fml::StatusOr<RenderTarget> render_target = renderer.MakeSubpass(
-      "Gaussian Blur Filter", subpass_size, subpass_callback);
+      "Gaussian Blur Filter", subpass_size, command_buffer, subpass_callback);
   return render_target;
 }
 
 fml::StatusOr<RenderTarget> MakeBlurSubpass(
     const ContentContext& renderer,
+    const std::shared_ptr<CommandBuffer>& command_buffer,
     const RenderTarget& input_pass,
     const SamplerDescriptor& sampler_descriptor,
     Entity::TileMode tile_mode,
@@ -184,10 +186,11 @@ fml::StatusOr<RenderTarget> MakeBlurSubpass(
       };
   if (destination_target.has_value()) {
     return renderer.MakeSubpass("Gaussian Blur Filter",
-                                destination_target.value(), subpass_callback);
+                                destination_target.value(), command_buffer,
+                                subpass_callback);
   } else {
     return renderer.MakeSubpass("Gaussian Blur Filter", subpass_size,
-                                subpass_callback);
+                                command_buffer, subpass_callback);
   }
 }
 
@@ -459,9 +462,15 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
   Quad uvs = CalculateUVs(inputs[0], entity, source_rect_padded,
                           input_snapshot->texture->GetSize());
 
+  std::shared_ptr<CommandBuffer> command_buffer =
+      renderer.GetContext()->CreateCommandBuffer();
+  if (!command_buffer) {
+    return std::nullopt;
+  }
+
   fml::StatusOr<RenderTarget> pass1_out = MakeDownsampleSubpass(
-      renderer, input_snapshot->texture, input_snapshot->sampler_descriptor,
-      uvs, subpass_size, tile_mode_);
+      renderer, command_buffer, input_snapshot->texture,
+      input_snapshot->sampler_descriptor, uvs, subpass_size, tile_mode_);
 
   if (!pass1_out.ok()) {
     return std::nullopt;
@@ -494,7 +503,7 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
   }
 
   fml::StatusOr<RenderTarget> pass2_out = MakeBlurSubpass(
-      renderer, /*input_pass=*/pass1_out.value(),
+      renderer, command_buffer, /*input_pass=*/pass1_out.value(),
       input_snapshot->sampler_descriptor, tile_mode_,
       BlurParameters{
           .blur_uv_offset = Point(0.0, pass1_pixel_size.y),
@@ -515,7 +524,7 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
                                : std::optional<RenderTarget>(std::nullopt);
 
   fml::StatusOr<RenderTarget> pass3_out = MakeBlurSubpass(
-      renderer, /*input_pass=*/pass2_out.value(),
+      renderer, command_buffer, /*input_pass=*/pass2_out.value(),
       input_snapshot->sampler_descriptor, tile_mode_,
       BlurParameters{
           .blur_uv_offset = Point(pass1_pixel_size.x, 0.0),
@@ -526,6 +535,13 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
       pass3_destination, blur_uvs);
 
   if (!pass3_out.ok()) {
+    return std::nullopt;
+  }
+
+  if (!renderer.GetContext()
+           ->GetCommandQueue()
+           ->Submit({command_buffer})
+           .ok()) {
     return std::nullopt;
   }
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -89,7 +89,7 @@ class GaussianBlurFilterContentsTest : public EntityPlayground {
              ->GetCommandQueue()
              ->Submit({command_buffer})
              .ok()) {
-      return nullptr
+      return nullptr;
     }
 
     if (render_target.ok()) {

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -87,7 +87,7 @@ class GaussianBlurFilterContentsTest : public EntityPlayground {
     if (!GetContentContext()
              ->GetContext()
              ->GetCommandQueue()
-             ->Submit({command_buffer})
+             ->Submit(/*buffers=*/{command_buffer})
              .ok()) {
       return nullptr;
     }

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -74,9 +74,24 @@ class GaussianBlurFilterContentsTest : public EntityPlayground {
  public:
   /// Create a texture that has been cleared to transparent black.
   std::shared_ptr<Texture> MakeTexture(ISize size) {
+    std::shared_ptr<CommandBuffer> command_buffer =
+        GetContentContext()->GetContext()->CreateCommandBuffer();
+    if (!command_buffer) {
+      return nullptr;
+    }
+
     auto render_target = GetContentContext()->MakeSubpass(
-        "Clear Subpass", size,
+        "Clear Subpass", size, command_buffer,
         [](const ContentContext&, RenderPass&) { return true; });
+
+    if (!GetContentContext()
+             ->GetContext()
+             ->GetCommandQueue()
+             ->Submit({command_buffer})
+             .ok()) {
+      return nullptr
+    }
+
     if (render_target.ok()) {
       return render_target.value().GetRenderTargetTexture();
     }

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -148,7 +148,7 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
   }
   if (!renderer.GetContext()
            ->GetCommandQueue()
-           ->Submit({std::move(command_buffer)})
+           ->Submit(/*buffers=*/{std::move(command_buffer)})
            .ok()) {
     return std::nullopt;
   }

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -134,10 +134,22 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
 
     return pass.Draw().ok();
   };
+  std::shared_ptr<CommandBuffer> command_buffer =
+      renderer.GetContext()->CreateCommandBuffer();
+  if (command_buffer == nullptr) {
+    return std::nullopt;
+  }
 
-  fml::StatusOr<RenderTarget> render_target = renderer.MakeSubpass(
-      "Directional Morphology Filter", ISize(coverage.GetSize()), callback);
+  fml::StatusOr<RenderTarget> render_target =
+      renderer.MakeSubpass("Directional Morphology Filter",
+                           ISize(coverage.GetSize()), command_buffer, callback);
   if (!render_target.ok()) {
+    return std::nullopt;
+  }
+  if (!renderer.GetContext()
+           ->GetCommandQueue()
+           ->Submit({std::move(command_buffer)})
+           .ok()) {
     return std::nullopt;
   }
 


### PR DESCRIPTION
The filter graph frequently creates and submits command buffers in serial. This has some unnecessary overhead, esp on Vulkan where submitting a command buffer has a non-trivial cost. While previously I had tried to batch up all submissions, doing this in a limited manner in the filter graph should be more straightforward.

For gaussians this makes a big difference, as there is a mipmap generation, downsample, then 2 render passes, so we can compress the 4 command buffers into 1.


https://github.com/flutter/flutter/issues/142545