### PR TITLE
Use Impeller geometry classes in DLMatrixClipTracker

### DIFF
--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -664,7 +664,8 @@ void DisplayListBuilder::saveLayer(const SkRect& bounds,
     // The filtered bounds will be clipped to the existing clip rect when
     // this layer is restored.
     // If bounds is null then the original cull_rect will be used.
-    tracker_.resetCullRect(in_options.bounds_from_caller() ? &bounds : nullptr);
+    tracker_.resetLocalCullRect(in_options.bounds_from_caller() ? &bounds
+                                                                : nullptr);
   } else if (in_options.bounds_from_caller()) {
     // Even though Skia claims that the bounds are only a hint, they actually
     // use them as the temporary layer bounds during rendering the layer, so

--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -9,89 +9,6 @@
 
 namespace flutter {
 
-class Data4x4 : public DisplayListMatrixClipTracker::Data {
- public:
-  Data4x4(const SkM44& m44, const SkRect& rect) : Data(rect), m44_(m44) {}
-  explicit Data4x4(const Data* copy)
-      : Data(copy->device_cull_rect()), m44_(copy->matrix_4x4()) {}
-
-  ~Data4x4() override = default;
-
-  bool is_4x4() const override { return true; }
-
-  SkMatrix matrix_3x3() const override { return m44_.asM33(); }
-  SkM44 matrix_4x4() const override { return m44_; }
-  SkRect local_cull_rect() const override;
-
-  void translate(SkScalar tx, SkScalar ty) override {
-    m44_.preTranslate(tx, ty);
-  }
-  void scale(SkScalar sx, SkScalar sy) override { m44_.preScale(sx, sy); }
-  void skew(SkScalar skx, SkScalar sky) override {
-    m44_.preConcat(SkMatrix::Skew(skx, sky));
-  }
-  void rotate(SkScalar degrees) override {
-    m44_.preConcat(SkMatrix::RotateDeg(degrees));
-  }
-  void transform(const SkMatrix& matrix) override { m44_.preConcat(matrix); }
-  void transform(const SkM44& m44) override { m44_.preConcat(m44); }
-  void setTransform(const SkMatrix& matrix) override { m44_ = SkM44(matrix); }
-  void setTransform(const SkM44& m44) override { m44_ = m44; }
-  void setIdentity() override { m44_.setIdentity(); }
-  bool mapRect(const SkRect& rect, SkRect* mapped) const override {
-    return m44_.asM33().mapRect(mapped, rect);
-  }
-  bool canBeInverted() const override { return m44_.asM33().invert(nullptr); }
-
- protected:
-  bool has_perspective() const override;
-
- private:
-  SkM44 m44_;
-};
-
-class Data3x3 : public DisplayListMatrixClipTracker::Data {
- public:
-  Data3x3(const SkMatrix& matrix, const SkRect& rect)
-      : Data(rect), matrix_(matrix) {}
-  explicit Data3x3(const Data* copy)
-      : Data(copy->device_cull_rect()), matrix_(copy->matrix_3x3()) {}
-
-  ~Data3x3() override = default;
-
-  bool is_4x4() const override { return false; }
-
-  SkMatrix matrix_3x3() const override { return matrix_; }
-  SkM44 matrix_4x4() const override { return SkM44(matrix_); }
-  SkRect local_cull_rect() const override;
-
-  void translate(SkScalar tx, SkScalar ty) override {
-    matrix_.preTranslate(tx, ty);
-  }
-  void scale(SkScalar sx, SkScalar sy) override { matrix_.preScale(sx, sy); }
-  void skew(SkScalar skx, SkScalar sky) override { matrix_.preSkew(skx, sky); }
-  void rotate(SkScalar degrees) override { matrix_.preRotate(degrees); }
-  void transform(const SkMatrix& matrix) override { matrix_.preConcat(matrix); }
-  void transform(const SkM44& m44) override {
-    FML_CHECK(false) << "SkM44 was concatenated without upgrading Data";
-  }
-  void setTransform(const SkMatrix& matrix) override { matrix_ = matrix; }
-  void setTransform(const SkM44& m44) override {
-    FML_CHECK(false) << "SkM44 was set without upgrading Data";
-  }
-  void setIdentity() override { matrix_.setIdentity(); }
-  bool mapRect(const SkRect& rect, SkRect* mapped) const override {
-    return matrix_.mapRect(mapped, rect);
-  }
-  bool canBeInverted() const override { return matrix_.invert(nullptr); }
-
- protected:
-  bool has_perspective() const override { return matrix_.hasPerspective(); }
-
- private:
-  SkMatrix matrix_;
-};
-
 bool DisplayListMatrixClipTracker::is_3x3(const SkM44& m) {
   // clang-format off
   return (                                      m.rc(0, 2) == 0 &&
@@ -101,77 +18,52 @@ bool DisplayListMatrixClipTracker::is_3x3(const SkM44& m) {
   // clang-format on
 }
 
+DisplayListMatrixClipState::DisplayListMatrixClipState(const DlRect& cull_rect,
+                                                       const DlMatrix& matrix)
+    : cull_rect_(cull_rect), matrix_(matrix) {}
+
+DisplayListMatrixClipState::DisplayListMatrixClipState(const SkRect& cull_rect,
+                                                       const SkMatrix& matrix)
+    : cull_rect_(ToDlRect(cull_rect)), matrix_(ToDlMatrix(matrix)) {}
+
+DisplayListMatrixClipState::DisplayListMatrixClipState(const SkRect& cull_rect,
+                                                       const SkM44& matrix)
+    : cull_rect_(ToDlRect(cull_rect)), matrix_(ToDlMatrix(matrix)) {}
+
 DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
-    const SkRect& cull_rect,
-    const SkMatrix& matrix)
-    : original_cull_rect_(cull_rect) {
+    const DlRect& cull_rect,
+    const DlMatrix& matrix) {
   // isEmpty protects us against NaN as we normalize any empty cull rects
-  SkRect cull = cull_rect.isEmpty() ? SkRect::MakeEmpty() : cull_rect;
-  saved_.emplace_back(std::make_unique<Data3x3>(matrix, cull));
+  DlRect cull = cull_rect.IsEmpty() ? DlRect() : cull_rect;
+  saved_.emplace_back(
+      std::make_unique<DisplayListMatrixClipState>(cull, matrix));
   current_ = saved_.back().get();
   save();  // saved_[0] will always be the initial settings
 }
 
 DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
     const SkRect& cull_rect,
-    const SkM44& m44)
-    : original_cull_rect_(cull_rect) {
+    const SkMatrix& matrix) {
   // isEmpty protects us against NaN as we normalize any empty cull rects
   SkRect cull = cull_rect.isEmpty() ? SkRect::MakeEmpty() : cull_rect;
-  if (is_3x3(m44)) {
-    saved_.emplace_back(std::make_unique<Data3x3>(m44.asM33(), cull));
-  } else {
-    saved_.emplace_back(std::make_unique<Data4x4>(m44, cull));
-  }
+  saved_.emplace_back(
+      std::make_unique<DisplayListMatrixClipState>(cull, matrix));
   current_ = saved_.back().get();
   save();  // saved_[0] will always be the initial settings
 }
 
-// clang-format off
-void DisplayListMatrixClipTracker::transform2DAffine(
-    SkScalar mxx, SkScalar mxy, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myt) {
-  if (!current_->is_4x4()) {
-    transform(SkMatrix::MakeAll(mxx, mxy, mxt,
-                                myx, myy, myt,
-                                0,   0,   1));
-  } else {
-    transform(SkM44(mxx, mxy, 0, mxt,
-                    myx, myy, 0, myt,
-                    0,   0,   1, 0,
-                    0,   0,   0, 1));
-  }
+DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
+    const SkRect& cull_rect,
+    const SkM44& m44) {
+  // isEmpty protects us against NaN as we normalize any empty cull rects
+  SkRect cull = cull_rect.isEmpty() ? SkRect::MakeEmpty() : cull_rect;
+  saved_.emplace_back(std::make_unique<DisplayListMatrixClipState>(cull, m44));
+  current_ = saved_.back().get();
+  save();  // saved_[0] will always be the initial settings
 }
-void DisplayListMatrixClipTracker::transformFullPerspective(
-    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
-  if (!current_->is_4x4()) {
-    if (                        mxz == 0 &&
-                                myz == 0 &&
-        mzx == 0 && mzy == 0 && mzz == 1 && mzt == 0 &&
-                                mwz == 0) {
-        transform(SkMatrix::MakeAll(mxx, mxy, mxt,
-                                    myx, myy, myt,
-                                    mwx, mwy, mwt));
-        return;
-    }
-  }
-
-  transform(SkM44(mxx, mxy, mxz, mxt,
-                  myx, myy, myz, myt,
-                  mzx, mzy, mzz, mzt,
-                  mwx, mwy, mwz, mwt));
-}
-// clang-format on
 
 void DisplayListMatrixClipTracker::save() {
-  if (current_->is_4x4()) {
-    saved_.emplace_back(std::make_unique<Data4x4>(current_));
-  } else {
-    saved_.emplace_back(std::make_unique<Data3x3>(current_));
-  }
+  saved_.emplace_back(std::make_unique<DisplayListMatrixClipState>(*current_));
   current_ = saved_.back().get();
 }
 
@@ -200,51 +92,25 @@ void DisplayListMatrixClipTracker::restoreToCount(int restore_count) {
   }
 }
 
-void DisplayListMatrixClipTracker::transform(const SkM44& m44) {
-  if (!current_->is_4x4()) {
-    if (is_3x3(m44)) {
-      current_->transform(m44.asM33());
-      return;
-    }
-    saved_.back() = std::make_unique<Data4x4>(current_);
-    current_ = saved_.back().get();
-  }
-  current_->transform(m44);
-}
-
-void DisplayListMatrixClipTracker::setTransform(const SkM44& m44) {
-  if (!current_->is_4x4()) {
-    if (is_3x3(m44)) {
-      current_->setTransform(m44.asM33());
-      return;
-    }
-    saved_.back() = std::make_unique<Data4x4>(current_);
-    current_ = saved_.back().get();
-  }
-  current_->setTransform(m44);
-}
-
-bool DisplayListMatrixClipTracker::inverseTransform(
-    const DisplayListMatrixClipTracker& tracker_) {
-  if (tracker_.using_4x4_matrix()) {
-    SkM44 inverse;
-    if (tracker_.matrix_4x4().invert(&inverse)) {
-      transform(inverse);
-      return true;
-    }
-  } else {
-    SkMatrix inverse;
-    if (tracker_.matrix_3x3().invert(&inverse)) {
-      transform(inverse);
-      return true;
-    }
+bool DisplayListMatrixClipState::inverseTransform(
+    const DisplayListMatrixClipState& tracker) {
+  if (tracker.is_matrix_invertable()) {
+    matrix_ = matrix_ * tracker.matrix_.Invert();
+    return true;
   }
   return false;
 }
 
-void DisplayListMatrixClipTracker::clipRRect(const SkRRect& rrect,
-                                             ClipOp op,
-                                             bool is_aa) {
+void DisplayListMatrixClipState::clipRect(const DlRect& rect,
+                                          ClipOp op,
+                                          bool is_aa) {
+  adjustCullRect(rect, op, is_aa);
+}
+
+void DisplayListMatrixClipState::clipRRect(const SkRRect& rrect,
+                                           ClipOp op,
+                                           bool is_aa) {
+  SkRect bounds = rrect.getBounds();
   switch (op) {
     case ClipOp::kIntersect:
       break;
@@ -254,11 +120,12 @@ void DisplayListMatrixClipTracker::clipRRect(const SkRRect& rrect,
       }
       break;
   }
-  current_->clipBounds(rrect.getBounds(), op, is_aa);
+  adjustCullRect(ToDlRect(bounds), op, is_aa);
 }
-void DisplayListMatrixClipTracker::clipPath(const SkPath& path,
-                                            ClipOp op,
-                                            bool is_aa) {
+
+void DisplayListMatrixClipState::clipPath(const SkPath& path,
+                                          ClipOp op,
+                                          bool is_aa) {
   // Map "kDifference of inverse path" to "kIntersect of the original path" and
   // map "kIntersect of inverse path" to "kDifference of the original path"
   if (path.isInverseFillType()) {
@@ -283,166 +150,93 @@ void DisplayListMatrixClipTracker::clipPath(const SkPath& path,
       }
       break;
   }
-  current_->clipBounds(bounds, op, is_aa);
+  adjustCullRect(ToDlRect(bounds), op, is_aa);
 }
 
-bool DisplayListMatrixClipTracker::Data::content_culled(
-    const SkRect& content_bounds) const {
-  if (cull_rect_.isEmpty() || content_bounds.isEmpty()) {
+bool DisplayListMatrixClipState::content_culled(
+    const DlRect& content_bounds) const {
+  if (cull_rect_.IsEmpty() || content_bounds.IsEmpty()) {
     return true;
   }
-  if (!canBeInverted()) {
+  if (!is_matrix_invertable()) {
     return true;
   }
   if (has_perspective()) {
     return false;
   }
-  SkRect mapped;
+  DlRect mapped;
   mapRect(content_bounds, &mapped);
-  return !mapped.intersects(cull_rect_);
+  return !mapped.IntersectsWithRect(cull_rect_);
 }
 
-void DisplayListMatrixClipTracker::Data::resetBounds(const SkRect& cull_rect) {
-  if (!cull_rect.isEmpty()) {
-    SkRect rect;
-    mapRect(cull_rect, &rect);
-    if (!rect.isEmpty()) {
-      cull_rect_ = rect;
-      return;
-    }
+void DisplayListMatrixClipState::resetCullRect(const DlRect& cull_rect) {
+  if (cull_rect.IsEmpty()) {
+    cull_rect_ = DlRect();
+  } else {
+    cull_rect_ = cull_rect;
   }
-  cull_rect_.setEmpty();
 }
 
-void DisplayListMatrixClipTracker::Data::clipBounds(const SkRect& clip,
-                                                    ClipOp op,
-                                                    bool is_aa) {
-  if (cull_rect_.isEmpty()) {
-    // No point in intersecting further.
+void DisplayListMatrixClipState::adjustCullRect(const DlRect& clip,
+                                                ClipOp op,
+                                                bool is_aa) {
+  if (cull_rect_.IsEmpty()) {
+    // No point in constraining further.
     return;
   }
-  if (has_perspective()) {
+  if (matrix_.HasPerspective()) {
     // We can conservatively ignore this clip.
     return;
   }
   switch (op) {
     case ClipOp::kIntersect: {
-      if (clip.isEmpty()) {
-        cull_rect_.setEmpty();
+      if (clip.IsEmpty()) {
+        cull_rect_ = DlRect();
         break;
       }
-      SkRect rect;
+      DlRect rect;
       mapRect(clip, &rect);
       if (is_aa) {
-        rect.roundOut(&rect);
+        rect = DlRect::RoundOut(rect);
       }
-      if (!cull_rect_.intersect(rect)) {
-        cull_rect_.setEmpty();
-      }
+      cull_rect_ = cull_rect_.Intersection(rect).value_or(DlRect());
       break;
     }
     case ClipOp::kDifference: {
-      if (clip.isEmpty()) {
+      if (clip.IsEmpty()) {
         break;
       }
-      SkRect rect;
+      DlRect rect;
       if (mapRect(clip, &rect)) {
         // This technique only works if the transform is rect -> rect
         if (is_aa) {
-          SkIRect rounded;
-          rect.round(&rounded);
-          if (rounded.isEmpty()) {
+          rect = DlRect::Round(rect);
+          if (rect.IsEmpty()) {
             break;
           }
-          rect.set(rounded);
         }
-        if (!rect.intersects(cull_rect_)) {
-          break;
-        }
-        if (rect.fLeft <= cull_rect_.fLeft &&
-            rect.fRight >= cull_rect_.fRight) {
-          // bounds spans entire width of cull_rect_
-          // therefore we can slice off a top or bottom
-          // edge of the cull_rect_.
-          SkScalar top = cull_rect_.fTop;
-          SkScalar btm = cull_rect_.fBottom;
-          if (rect.fTop <= top) {
-            top = rect.fBottom;
-          }
-          if (rect.fBottom >= btm) {
-            btm = rect.fTop;
-          }
-          if (top < btm) {
-            cull_rect_.fTop = top;
-            cull_rect_.fBottom = btm;
-          } else {
-            cull_rect_.setEmpty();
-          }
-        } else if (rect.fTop <= cull_rect_.fTop &&
-                   rect.fBottom >= cull_rect_.fBottom) {
-          // bounds spans entire height of cull_rect_
-          // therefore we can slice off a left or right
-          // edge of the cull_rect_.
-          SkScalar lft = cull_rect_.fLeft;
-          SkScalar rgt = cull_rect_.fRight;
-          if (rect.fLeft <= lft) {
-            lft = rect.fRight;
-          }
-          if (rect.fRight >= rgt) {
-            rgt = rect.fLeft;
-          }
-          if (lft < rgt) {
-            cull_rect_.fLeft = lft;
-            cull_rect_.fRight = rgt;
-          } else {
-            cull_rect_.setEmpty();
-          }
-        }
+        cull_rect_ = cull_rect_.CutoutOrEmpty(rect);
       }
       break;
     }
   }
 }
 
-SkRect Data4x4::local_cull_rect() const {
-  if (cull_rect_.isEmpty()) {
-    return cull_rect_;
-  }
-  SkMatrix inverse;
-  if (!m44_.asM33().invert(&inverse)) {
+SkRect DisplayListMatrixClipState::local_cull_rect() const {
+  if (cull_rect_.IsEmpty()) {
     return SkRect::MakeEmpty();
   }
-  if (has_perspective()) {
+  if (!is_matrix_invertable()) {
+    return SkRect::MakeEmpty();
+  }
+  if (matrix_.HasPerspective()) {
     // We could do a 4-point long-form conversion, but since this is
     // only used for culling, let's just return a non-constricting
     // cull rect.
     return DisplayListBuilder::kMaxCullRect;
   }
-  return inverse.mapRect(cull_rect_);
-}
-
-bool Data4x4::has_perspective() const {
-  return (m44_.rc(3, 0) != 0 ||  //
-          m44_.rc(3, 1) != 0 ||  //
-          m44_.rc(3, 2) != 0 ||  //
-          m44_.rc(3, 3) != 1);
-}
-
-SkRect Data3x3::local_cull_rect() const {
-  if (cull_rect_.isEmpty()) {
-    return cull_rect_;
-  }
-  SkMatrix inverse;
-  if (!matrix_.invert(&inverse)) {
-    return SkRect::MakeEmpty();
-  }
-  if (matrix_.hasPerspective()) {
-    // We could do a 4-point long-form conversion, but since this is
-    // only used for culling, let's just return a non-constricting
-    // cull rect.
-    return DisplayListBuilder::kMaxCullRect;
-  }
-  return inverse.mapRect(cull_rect_);
+  DlMatrix inverse = matrix_.Invert();
+  return ToSkRect(cull_rect_.TransformBounds(inverse));
 }
 
 }  // namespace flutter

--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -35,9 +35,8 @@ DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
     const DlMatrix& matrix) {
   // isEmpty protects us against NaN as we normalize any empty cull rects
   DlRect cull = cull_rect.IsEmpty() ? DlRect() : cull_rect;
-  saved_.emplace_back(
-      std::make_unique<DisplayListMatrixClipState>(cull, matrix));
-  current_ = saved_.back().get();
+  saved_.emplace_back(cull, matrix);
+  current_ = &saved_.back();
   save();  // saved_[0] will always be the initial settings
 }
 
@@ -46,9 +45,8 @@ DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
     const SkMatrix& matrix) {
   // isEmpty protects us against NaN as we normalize any empty cull rects
   SkRect cull = cull_rect.isEmpty() ? SkRect::MakeEmpty() : cull_rect;
-  saved_.emplace_back(
-      std::make_unique<DisplayListMatrixClipState>(cull, matrix));
-  current_ = saved_.back().get();
+  saved_.emplace_back(cull, matrix);
+  current_ = &saved_.back();
   save();  // saved_[0] will always be the initial settings
 }
 
@@ -57,27 +55,27 @@ DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
     const SkM44& m44) {
   // isEmpty protects us against NaN as we normalize any empty cull rects
   SkRect cull = cull_rect.isEmpty() ? SkRect::MakeEmpty() : cull_rect;
-  saved_.emplace_back(std::make_unique<DisplayListMatrixClipState>(cull, m44));
-  current_ = saved_.back().get();
+  saved_.emplace_back(cull, m44);
+  current_ = &saved_.back();
   save();  // saved_[0] will always be the initial settings
 }
 
 void DisplayListMatrixClipTracker::save() {
-  saved_.emplace_back(std::make_unique<DisplayListMatrixClipState>(*current_));
-  current_ = saved_.back().get();
+  saved_.emplace_back(*current_);
+  current_ = &saved_.back();
 }
 
 void DisplayListMatrixClipTracker::restore() {
   if (saved_.size() > 2) {
     saved_.pop_back();
-    current_ = saved_.back().get();
+    current_ = &saved_.back();
   }
 }
 
 void DisplayListMatrixClipTracker::reset() {
   while (saved_.size() > 1) {
     saved_.pop_back();
-    current_ = saved_.back().get();
+    current_ = &saved_.back();
   }
   save();  // saved_[0] will always be the initial settings
 }

--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -237,13 +237,15 @@ SkRect DisplayListMatrixClipState::local_cull_rect() const {
   if (!is_matrix_invertable()) {
     return SkRect::MakeEmpty();
   }
-  if (matrix_.HasPerspective()) {
+  if (matrix_.HasPerspective2D()) {
     // We could do a 4-point long-form conversion, but since this is
     // only used for culling, let's just return a non-constricting
     // cull rect.
     return DisplayListBuilder::kMaxCullRect;
   }
   DlMatrix inverse = matrix_.Invert();
+  // We eliminated perspective above so we can use the cheaper non-clipping
+  // bounds transform method.
   return ToSkRect(cull_rect_.TransformBounds(inverse));
 }
 

--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -167,12 +167,22 @@ bool DisplayListMatrixClipState::content_culled(
   return !mapped.IntersectsWithRect(cull_rect_);
 }
 
-void DisplayListMatrixClipState::resetCullRect(const DlRect& cull_rect) {
+void DisplayListMatrixClipState::resetDeviceCullRect(const DlRect& cull_rect) {
   if (cull_rect.IsEmpty()) {
     cull_rect_ = DlRect();
   } else {
     cull_rect_ = cull_rect;
   }
+}
+
+void DisplayListMatrixClipState::resetLocalCullRect(const DlRect& cull_rect) {
+  if (!cull_rect.IsEmpty()) {
+    mapRect(cull_rect, &cull_rect_);
+    if (!cull_rect_.IsEmpty()) {
+      return;
+    }
+  }
+  cull_rect_ = DlRect();
 }
 
 void DisplayListMatrixClipState::adjustCullRect(const DlRect& clip,

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -80,9 +80,13 @@ class DisplayListMatrixClipState {
   // layer into the enclosing clipped area.
   // Omitting the |cull_rect| argument, or passing nullptr, will restore the
   // cull rect to the initial value it had when the tracker was constructed.
-  void resetCullRect(const DlRect& cull_rect);
-  void resetCullRect(const SkRect& cull_rect) {
-    resetCullRect(ToDlRect(cull_rect));
+  void resetDeviceCullRect(const DlRect& cull_rect);
+  void resetDeviceCullRect(const SkRect& cull_rect) {
+    resetDeviceCullRect(ToDlRect(cull_rect));
+  }
+  void resetLocalCullRect(const DlRect& cull_rect);
+  void resetLocalCullRect(const SkRect& cull_rect) {
+    resetLocalCullRect(ToDlRect(cull_rect));
   }
 
   bool using_4x4_matrix() const { return !matrix_.IsAffine(); }
@@ -188,8 +192,8 @@ class DisplayListMatrixClipTracker {
   DisplayListMatrixClipTracker(const SkRect& cull_rect, const SkMatrix& matrix);
   DisplayListMatrixClipTracker(const SkRect& cull_rect, const SkM44& matrix);
 
-  // This method should almost never be used as it breaks the encapsulation
-  // of the enclosing clips. However it is needed for practical purposes in
+  // These methods should almost never be used as they breaks the encapsulation
+  // of the enclosing clips. However they are needed for practical purposes in
   // some rare cases - such as when a saveLayer is collecting rendering
   // operations prior to applying a filter on the entire layer bounds and
   // some of those operations fall outside the enclosing clip, but their
@@ -197,11 +201,33 @@ class DisplayListMatrixClipTracker {
   // layer into the enclosing clipped area.
   // Omitting the |cull_rect| argument, or passing nullptr, will restore the
   // cull rect to the initial value it had when the tracker was constructed.
-  void resetCullRect(const DlRect* cull_rect = nullptr) {
-    current_->resetCullRect(cull_rect ? *cull_rect : saved_[0].cull_rect_);
+  void resetDeviceCullRect(const DlRect* cull_rect = nullptr) {
+    if (cull_rect) {
+      current_->resetDeviceCullRect(*cull_rect);
+    } else {
+      current_->resetDeviceCullRect(saved_[0].cull_rect_);
+    }
   }
-  void resetCullRect(const SkRect* cull_rect = nullptr) {
-    current_->resetCullRect(cull_rect ? *cull_rect : base_device_cull_rect());
+  void resetDeviceCullRect(const SkRect* cull_rect = nullptr) {
+    if (cull_rect) {
+      current_->resetDeviceCullRect(*cull_rect);
+    } else {
+      current_->resetDeviceCullRect(saved_[0].cull_rect_);
+    }
+  }
+  void resetLocalCullRect(const DlRect* cull_rect = nullptr) {
+    if (cull_rect) {
+      current_->resetLocalCullRect(*cull_rect);
+    } else {
+      current_->resetDeviceCullRect(saved_[0].cull_rect_);
+    }
+  }
+  void resetLocalCullRect(const SkRect* cull_rect = nullptr) {
+    if (cull_rect) {
+      current_->resetLocalCullRect(*cull_rect);
+    } else {
+      current_->resetDeviceCullRect(saved_[0].cull_rect_);
+    }
   }
 
   static bool is_3x3(const SkM44& m44);

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -46,7 +46,6 @@ class DisplayListMatrixClipState {
   }
 
   static constexpr DlMatrix ToDlMatrix(const SkM44& matrix) {
-    // clang-format off
     DlMatrix dl_matrix;
     matrix.getColMajor(dl_matrix.m);
     return dl_matrix;
@@ -199,7 +198,7 @@ class DisplayListMatrixClipTracker {
   // Omitting the |cull_rect| argument, or passing nullptr, will restore the
   // cull rect to the initial value it had when the tracker was constructed.
   void resetCullRect(const DlRect* cull_rect = nullptr) {
-    current_->resetCullRect(cull_rect ? *cull_rect : saved_[0]->cull_rect_);
+    current_->resetCullRect(cull_rect ? *cull_rect : saved_[0].cull_rect_);
   }
   void resetCullRect(const SkRect* cull_rect = nullptr) {
     current_->resetCullRect(cull_rect ? *cull_rect : base_device_cull_rect());
@@ -207,7 +206,7 @@ class DisplayListMatrixClipTracker {
 
   static bool is_3x3(const SkM44& m44);
 
-  SkRect base_device_cull_rect() const { return saved_[0]->device_cull_rect(); }
+  SkRect base_device_cull_rect() const { return saved_[0].device_cull_rect(); }
 
   bool using_4x4_matrix() const { return current_->using_4x4_matrix(); }
 
@@ -292,7 +291,7 @@ class DisplayListMatrixClipTracker {
 
  private:
   DisplayListMatrixClipState* current_;
-  std::vector<std::unique_ptr<DisplayListMatrixClipState>> saved_;
+  std::vector<DisplayListMatrixClipState> saved_;
 };
 
 }  // namespace flutter

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -156,12 +156,12 @@ class DisplayListMatrixClipState {
 
   bool mapRect(DlRect* rect) const { return mapRect(*rect, rect); }
   bool mapRect(const DlRect& src, DlRect* mapped) const {
-    *mapped = src.TransformBounds(matrix_);
+    *mapped = src.TransformAndClipBounds(matrix_);
     return matrix_.IsAligned2D();
   }
   bool mapRect(SkRect* rect) const { return mapRect(*rect, rect); }
   bool mapRect(const SkRect& src, SkRect* mapped) const {
-    *mapped = ToSkRect(ToDlRect(src).TransformBounds(matrix_));
+    *mapped = ToSkRect(ToDlRect(src).TransformAndClipBounds(matrix_));
     return matrix_.IsAligned2D();
   }
 

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -9,6 +9,8 @@
 
 #include "flutter/display_list/dl_canvas.h"
 #include "flutter/fml/logging.h"
+#include "flutter/impeller/geometry/matrix.h"
+#include "flutter/impeller/geometry/rect.h"
 
 #include "third_party/skia/include/core/SkM44.h"
 #include "third_party/skia/include/core/SkMatrix.h"
@@ -19,11 +21,171 @@
 
 namespace flutter {
 
+class DisplayListMatrixClipState {
+ private:
+  using ClipOp = DlCanvas::ClipOp;
+  using DlRect = impeller::Rect;
+  using DlMatrix = impeller::Matrix;
+  using DlDegrees = impeller::Degrees;
+
+  static_assert(sizeof(SkRect) == sizeof(DlRect));
+
+  static const DlRect& ToDlRect(const SkRect& rect) {
+    return *reinterpret_cast<const DlRect*>(&rect);
+  }
+
+  static constexpr DlMatrix ToDlMatrix(const SkMatrix& matrix) {
+    // clang-format off
+    return DlMatrix::MakeColumn(
+        matrix[SkMatrix::kMScaleX], matrix[SkMatrix::kMSkewY],  0.0f, matrix[SkMatrix::kMPersp0],
+        matrix[SkMatrix::kMSkewX],  matrix[SkMatrix::kMScaleY], 0.0f, matrix[SkMatrix::kMPersp1],
+        0.0f,                       0.0f,                       1.0f, 0.0f,
+        matrix[SkMatrix::kMTransX], matrix[SkMatrix::kMTransY], 0.0f, matrix[SkMatrix::kMPersp2]
+    );
+    // clang-format on
+  }
+
+  static constexpr DlMatrix ToDlMatrix(const SkM44& matrix) {
+    // clang-format off
+    DlMatrix dl_matrix;
+    matrix.getColMajor(dl_matrix.m);
+    return dl_matrix;
+  }
+
+  static const SkRect& ToSkRect(const DlRect& rect) {
+    return *reinterpret_cast<const SkRect*>(&rect);
+  }
+
+  static constexpr SkMatrix ToSkMatrix(const DlMatrix& matrix) {
+    return SkMatrix::MakeAll(matrix.m[0], matrix.m[4], matrix.m[12],
+                             matrix.m[1], matrix.m[5], matrix.m[13],
+                             matrix.m[3], matrix.m[7], matrix.m[15]);
+  }
+
+  static constexpr SkM44 ToSkM44(const DlMatrix& matrix) {
+    return SkM44::ColMajor(matrix.m);
+  }
+
+ public:
+  DisplayListMatrixClipState(const DlRect& cull_rect, const DlMatrix& matrix);
+  DisplayListMatrixClipState(const SkRect& cull_rect, const SkMatrix& matrix);
+  DisplayListMatrixClipState(const SkRect& cull_rect, const SkM44& matrix);
+  DisplayListMatrixClipState(const DisplayListMatrixClipState& other) = default;
+
+  // This method should almost never be used as it breaks the encapsulation
+  // of the enclosing clips. However it is needed for practical purposes in
+  // some rare cases - such as when a saveLayer is collecting rendering
+  // operations prior to applying a filter on the entire layer bounds and
+  // some of those operations fall outside the enclosing clip, but their
+  // filtered content will spread out from where they were rendered on the
+  // layer into the enclosing clipped area.
+  // Omitting the |cull_rect| argument, or passing nullptr, will restore the
+  // cull rect to the initial value it had when the tracker was constructed.
+  void resetCullRect(const DlRect& cull_rect);
+  void resetCullRect(const SkRect& cull_rect) {
+    resetCullRect(ToDlRect(cull_rect));
+  }
+
+  bool using_4x4_matrix() const { return !matrix_.IsAffine(); }
+  bool is_matrix_invertable() const { return matrix_.GetDeterminant() != 0.0f; }
+  bool has_perspective() const { return matrix_.HasPerspective(); }
+
+  const DlMatrix& matrix() const { return matrix_; }
+  SkM44 matrix_4x4() const { return SkM44::ColMajor(matrix_.m); }
+  SkMatrix matrix_3x3() const { return ToSkMatrix(matrix_); }
+
+  SkRect local_cull_rect() const;
+  SkRect device_cull_rect() const { return ToSkRect(cull_rect_); }
+
+  bool content_culled(const DlRect& content_bounds) const;
+  bool content_culled(const SkRect& content_bounds) const {
+    return content_culled(ToDlRect(content_bounds));
+  }
+  bool is_cull_rect_empty() const { return cull_rect_.IsEmpty(); }
+
+  void translate(SkScalar tx, SkScalar ty) {
+    matrix_ = matrix_.Translate({tx, ty});
+  }
+  void scale(SkScalar sx, SkScalar sy) {
+    matrix_ = matrix_.Scale({sx, sy, 1.0f});
+  }
+  void skew(SkScalar skx, SkScalar sky) {
+    matrix_ = matrix_ * DlMatrix::MakeSkew(skx, sky);
+  }
+  void rotate(SkScalar degrees) {
+    matrix_ = matrix_ * DlMatrix::MakeRotationZ(DlDegrees(degrees));
+  }
+  void transform(const DlMatrix& matrix) { matrix_ = matrix_ * matrix; }
+  void transform(const SkM44& m44) { transform(ToDlMatrix(m44)); }
+  void transform(const SkMatrix& matrix) { transform(ToDlMatrix(matrix)); }
+  // clang-format off
+  void transform2DAffine(
+      SkScalar mxx, SkScalar mxy, SkScalar mxt,
+      SkScalar myx, SkScalar myy, SkScalar myt) {
+    matrix_ = matrix_ * DlMatrix::MakeColumn(
+         mxx,  myx, 0.0f, 0.0f,
+         mxy,  myy, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+         mxt,  myt, 0.0f, 1.0f
+    );
+  }
+  void transformFullPerspective(
+      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
+    matrix_ = matrix_ * DlMatrix::MakeColumn(
+        mxx, myx, mzx, mwx,
+        mxy, myy, mzy, mwy,
+        mxz, myz, mzz, mwz,
+        mxt, myt, mzt, mwt
+    );
+  }
+  // clang-format on
+  void setTransform(const DlMatrix& matrix) { matrix_ = matrix; }
+  void setTransform(const SkMatrix& matrix) { matrix_ = ToDlMatrix(matrix); }
+  void setTransform(const SkM44& m44) { matrix_ = ToDlMatrix(m44); }
+  void setIdentity() { matrix_ = DlMatrix(); }
+  // If the matrix in |other_tracker| is invertible then transform this
+  // tracker by the inverse of its matrix and return true. Otherwise,
+  // return false and leave this tracker unmodified.
+  bool inverseTransform(const DisplayListMatrixClipState& other_tracker);
+
+  bool mapRect(DlRect* rect) const { return mapRect(*rect, rect); }
+  bool mapRect(const DlRect& src, DlRect* mapped) const {
+    *mapped = src.TransformBounds(matrix_);
+    return matrix_.IsAligned2D();
+  }
+  bool mapRect(SkRect* rect) const { return mapRect(*rect, rect); }
+  bool mapRect(const SkRect& src, SkRect* mapped) const {
+    *mapped = ToSkRect(ToDlRect(src).TransformBounds(matrix_));
+    return matrix_.IsAligned2D();
+  }
+
+  void clipRect(const DlRect& rect, ClipOp op, bool is_aa);
+  void clipRect(const SkRect& rect, ClipOp op, bool is_aa) {
+    clipRect(ToDlRect(rect), op, is_aa);
+  }
+  void clipRRect(const SkRRect& rrect, ClipOp op, bool is_aa);
+  void clipPath(const SkPath& path, ClipOp op, bool is_aa);
+
+ private:
+  DlRect cull_rect_;
+  DlMatrix matrix_;
+
+  void adjustCullRect(const DlRect& clip, ClipOp op, bool is_aa);
+
+  friend class DisplayListMatrixClipTracker;
+};
+
 class DisplayListMatrixClipTracker {
  private:
   using ClipOp = DlCanvas::ClipOp;
+  using DlRect = impeller::Rect;
+  using DlMatrix = impeller::Matrix;
 
  public:
+  DisplayListMatrixClipTracker(const DlRect& cull_rect, const DlMatrix& matrix);
   DisplayListMatrixClipTracker(const SkRect& cull_rect, const SkMatrix& matrix);
   DisplayListMatrixClipTracker(const SkRect& cull_rect, const SkM44& matrix);
 
@@ -36,16 +198,20 @@ class DisplayListMatrixClipTracker {
   // layer into the enclosing clipped area.
   // Omitting the |cull_rect| argument, or passing nullptr, will restore the
   // cull rect to the initial value it had when the tracker was constructed.
+  void resetCullRect(const DlRect* cull_rect = nullptr) {
+    current_->resetCullRect(cull_rect ? *cull_rect : saved_[0]->cull_rect_);
+  }
   void resetCullRect(const SkRect* cull_rect = nullptr) {
-    current_->resetBounds(cull_rect ? *cull_rect : original_cull_rect_);
+    current_->resetCullRect(cull_rect ? *cull_rect : base_device_cull_rect());
   }
 
   static bool is_3x3(const SkM44& m44);
 
   SkRect base_device_cull_rect() const { return saved_[0]->device_cull_rect(); }
 
-  bool using_4x4_matrix() const { return current_->is_4x4(); }
+  bool using_4x4_matrix() const { return current_->using_4x4_matrix(); }
 
+  DlMatrix matrix() const { return current_->matrix(); }
   SkM44 matrix_4x4() const { return current_->matrix_4x4(); }
   SkMatrix matrix_3x3() const { return current_->matrix_3x3(); }
   SkRect local_cull_rect() const { return current_->local_cull_rect(); }
@@ -69,81 +235,64 @@ class DisplayListMatrixClipTracker {
   void scale(SkScalar sx, SkScalar sy) { current_->scale(sx, sy); }
   void skew(SkScalar skx, SkScalar sky) { current_->skew(skx, sky); }
   void rotate(SkScalar degrees) { current_->rotate(degrees); }
-  void transform(const SkM44& m44);
+  void transform(const DlMatrix& matrix) { current_->transform(matrix); }
+  void transform(const SkM44& m44) { current_->transform(m44); }
   void transform(const SkMatrix& matrix) { current_->transform(matrix); }
   // clang-format off
   void transform2DAffine(
       SkScalar mxx, SkScalar mxy, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myt);
+      SkScalar myx, SkScalar myy, SkScalar myt) {
+    current_->transform2DAffine(mxx, mxy, mxt, myx, myy, myt);
+  }
   void transformFullPerspective(
       SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
       SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
       SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt);
+      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
+    current_->transformFullPerspective(
+        mxx, mxy, mxz, mxt,
+        myx, myy, myz, myt,
+        mzx, mzy, mzz, mzt,
+        mwx, mwy, mwz, mwt
+    );
+  }
   // clang-format on
+  void setTransform(const DlMatrix& matrix) { current_->setTransform(matrix); }
   void setTransform(const SkMatrix& matrix) { current_->setTransform(matrix); }
-  void setTransform(const SkM44& m44);
+  void setTransform(const SkM44& m44) { current_->setTransform(m44); }
   void setIdentity() { current_->setIdentity(); }
   // If the matrix in |other_tracker| is invertible then transform this
   // tracker by the inverse of its matrix and return true. Otherwise,
   // return false and leave this tracker unmodified.
-  bool inverseTransform(const DisplayListMatrixClipTracker& other_tracker);
+  bool inverseTransform(const DisplayListMatrixClipTracker& other_tracker) {
+    return current_->inverseTransform(*other_tracker.current_);
+  }
 
+  bool mapRect(DlRect* rect) const { return current_->mapRect(*rect, rect); }
+  bool mapRect(const DlRect& src, DlRect* mapped) {
+    return current_->mapRect(src, mapped);
+  }
   bool mapRect(SkRect* rect) const { return current_->mapRect(*rect, rect); }
   bool mapRect(const SkRect& src, SkRect* mapped) {
     return current_->mapRect(src, mapped);
   }
 
-  void clipRect(const SkRect& rect, ClipOp op, bool is_aa) {
-    current_->clipBounds(rect, op, is_aa);
+  void clipRect(const DlRect& rect, ClipOp op, bool is_aa) {
+    current_->clipRect(rect, op, is_aa);
   }
-  void clipRRect(const SkRRect& rrect, ClipOp op, bool is_aa);
-  void clipPath(const SkPath& path, ClipOp op, bool is_aa);
+  void clipRect(const SkRect& rect, ClipOp op, bool is_aa) {
+    current_->clipRect(rect, op, is_aa);
+  }
+  void clipRRect(const SkRRect& rrect, ClipOp op, bool is_aa) {
+    current_->clipRRect(rrect, op, is_aa);
+  }
+  void clipPath(const SkPath& path, ClipOp op, bool is_aa) {
+    current_->clipPath(path, op, is_aa);
+  }
 
  private:
-  class Data {
-   public:
-    virtual ~Data() = default;
-
-    virtual bool is_4x4() const = 0;
-
-    virtual SkMatrix matrix_3x3() const = 0;
-    virtual SkM44 matrix_4x4() const = 0;
-
-    SkRect device_cull_rect() const { return cull_rect_; }
-    virtual SkRect local_cull_rect() const = 0;
-    virtual bool content_culled(const SkRect& content_bounds) const;
-    bool is_cull_rect_empty() const { return cull_rect_.isEmpty(); }
-
-    virtual void translate(SkScalar tx, SkScalar ty) = 0;
-    virtual void scale(SkScalar sx, SkScalar sy) = 0;
-    virtual void skew(SkScalar skx, SkScalar sky) = 0;
-    virtual void rotate(SkScalar degrees) = 0;
-    virtual void transform(const SkMatrix& matrix) = 0;
-    virtual void transform(const SkM44& m44) = 0;
-    virtual void setTransform(const SkMatrix& matrix) = 0;
-    virtual void setTransform(const SkM44& m44) = 0;
-    virtual void setIdentity() = 0;
-    virtual bool mapRect(const SkRect& rect, SkRect* mapped) const = 0;
-    virtual bool canBeInverted() const = 0;
-
-    virtual void clipBounds(const SkRect& clip, ClipOp op, bool is_aa);
-
-    virtual void resetBounds(const SkRect& cull_rect);
-
-   protected:
-    explicit Data(const SkRect& rect) : cull_rect_(rect) {}
-
-    virtual bool has_perspective() const = 0;
-
-    SkRect cull_rect_;
-  };
-  friend class Data3x3;
-  friend class Data4x4;
-
-  SkRect original_cull_rect_;
-  Data* current_;
-  std::vector<std::unique_ptr<Data>> saved_;
+  DisplayListMatrixClipState* current_;
+  std::vector<std::unique_ptr<DisplayListMatrixClipState>> saved_;
 };
 
 }  // namespace flutter

--- a/display_list/utils/dl_matrix_clip_tracker_unittests.cc
+++ b/display_list/utils/dl_matrix_clip_tracker_unittests.cc
@@ -3,273 +3,803 @@
 // found in the LICENSE file.
 
 #include "flutter/display_list/utils/dl_matrix_clip_tracker.h"
+#include "flutter/testing/assertions_skia.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
 namespace testing {
 
+using DlRect = impeller::Rect;
+using DlMatrix = impeller::Matrix;
+using Degrees = impeller::Degrees;
+
 TEST(DisplayListMatrixClipTracker, Constructor) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   const SkMatrix matrix = SkMatrix::Scale(4, 4);
   const SkM44 m44 = SkM44::Scale(4, 4);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 5, 15, 15);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
+  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
 
   DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
   DisplayListMatrixClipTracker tracker2(cull_rect, m44);
+  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
 
-  ASSERT_FALSE(tracker1.using_4x4_matrix());
-  ASSERT_EQ(tracker1.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker1.matrix_3x3(), matrix);
-  ASSERT_EQ(tracker1.matrix_4x4(), m44);
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_3x3(), matrix);
+  EXPECT_EQ(tracker1.matrix_4x4(), m44);
+  EXPECT_EQ(tracker1.matrix(), dl_matrix);
 
-  ASSERT_FALSE(tracker2.using_4x4_matrix());
-  ASSERT_EQ(tracker2.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker2.matrix_3x3(), matrix);
-  ASSERT_EQ(tracker2.matrix_4x4(), m44);
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_3x3(), matrix);
+  EXPECT_EQ(tracker2.matrix_4x4(), m44);
+  EXPECT_EQ(tracker2.matrix(), dl_matrix);
+
+  EXPECT_FALSE(tracker3.using_4x4_matrix());
+  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker3.matrix_3x3(), matrix);
+  EXPECT_EQ(tracker3.matrix_4x4(), m44);
+  EXPECT_EQ(tracker3.matrix(), dl_matrix);
+}
+
+TEST(DisplayListMatrixClipState, Constructor) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const SkMatrix matrix = SkMatrix::Scale(4, 4);
+  const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
+  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
+
+  DisplayListMatrixClipState state1(cull_rect, matrix);
+  DisplayListMatrixClipState state2(cull_rect, m44);
+  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
+
+  EXPECT_FALSE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_3x3(), matrix);
+  EXPECT_EQ(state1.matrix_4x4(), m44);
+  EXPECT_EQ(state1.matrix(), dl_matrix);
+
+  EXPECT_FALSE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_3x3(), matrix);
+  EXPECT_EQ(state2.matrix_4x4(), m44);
+  EXPECT_EQ(state2.matrix(), dl_matrix);
+
+  EXPECT_FALSE(state3.using_4x4_matrix());
+  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state3.matrix_3x3(), matrix);
+  EXPECT_EQ(state3.matrix_4x4(), m44);
+  EXPECT_EQ(state3.matrix(), dl_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, Constructor4x4) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   // clang-format off
   const SkM44 m44 = SkM44(4, 0, 0.5, 0,
                           0, 4, 0.5, 0,
                           0, 0, 4.0, 0,
                           0, 0, 0.0, 1);
+  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
+                                               0, 4, 0.5, 0,
+                                               0, 0, 4.0, 0,
+                                               0, 0, 0.0, 1);
   // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 5, 15, 15);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
 
-  DisplayListMatrixClipTracker tracker(cull_rect, m44);
+  DisplayListMatrixClipTracker tracker1(cull_rect, m44);
+  DisplayListMatrixClipTracker tracker2(dl_cull_rect, dl_matrix);
 
-  ASSERT_TRUE(tracker.using_4x4_matrix());
-  ASSERT_EQ(tracker.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker.matrix_4x4(), m44);
+  EXPECT_TRUE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_4x4(), m44);
+  EXPECT_EQ(tracker1.matrix(), dl_matrix);
+
+  EXPECT_TRUE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_4x4(), m44);
+  EXPECT_EQ(tracker2.matrix(), dl_matrix);
+}
+
+TEST(DisplayListMatrixClipState, Constructor4x4) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  // clang-format off
+  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
+                          0, 4, 0.5, 0,
+                          0, 0, 4.0, 0,
+                          0, 0, 0.0, 1);
+  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
+                                               0, 4, 0.5, 0,
+                                               0, 0, 4.0, 0,
+                                               0, 0, 0.0, 1);
+  // clang-format on
+  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
+
+  DisplayListMatrixClipState state1(cull_rect, m44);
+  DisplayListMatrixClipState state2(dl_cull_rect, dl_matrix);
+
+  EXPECT_TRUE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_4x4(), m44);
+  EXPECT_EQ(state1.matrix(), dl_matrix);
+
+  EXPECT_TRUE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_4x4(), m44);
+  EXPECT_EQ(state2.matrix(), dl_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, TransformTo4x4) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   // clang-format off
   const SkM44 m44 = SkM44(4, 0, 0.5, 0,
                           0, 4, 0.5, 0,
                           0, 0, 4.0, 0,
                           0, 0, 0.0, 1);
+  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
+                                               0, 4, 0.5, 0,
+                                               0, 0, 4.0, 0,
+                                               0, 0, 0.0, 1);
   // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 5, 15, 15);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
 
-  DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-  ASSERT_FALSE(tracker.using_4x4_matrix());
+  DisplayListMatrixClipTracker tracker1(cull_rect, SkMatrix::I());
+  DisplayListMatrixClipTracker tracker2(dl_cull_rect, DlMatrix());
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
 
-  tracker.transform(m44);
-  ASSERT_TRUE(tracker.using_4x4_matrix());
-  ASSERT_EQ(tracker.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker.matrix_4x4(), m44);
+  tracker1.transform(m44);
+  EXPECT_TRUE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_4x4(), m44);
+  EXPECT_EQ(tracker1.matrix(), dl_matrix);
+
+  tracker2.transform(dl_matrix);
+  EXPECT_TRUE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_4x4(), m44);
+  EXPECT_EQ(tracker2.matrix(), dl_matrix);
+}
+
+TEST(DisplayListMatrixClipState, TransformTo4x4) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  // clang-format off
+  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
+                          0, 4, 0.5, 0,
+                          0, 0, 4.0, 0,
+                          0, 0, 0.0, 1);
+  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
+                                               0, 4, 0.5, 0,
+                                               0, 0, 4.0, 0,
+                                               0, 0, 0.0, 1);
+  // clang-format on
+  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
+
+  DisplayListMatrixClipTracker state1(cull_rect, SkMatrix::I());
+  DisplayListMatrixClipTracker state2(dl_cull_rect, DlMatrix());
+  EXPECT_FALSE(state1.using_4x4_matrix());
+  EXPECT_FALSE(state2.using_4x4_matrix());
+
+  state1.transform(m44);
+  EXPECT_TRUE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_4x4(), m44);
+  EXPECT_EQ(state1.matrix(), dl_matrix);
+
+  state2.transform(dl_matrix);
+  EXPECT_TRUE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_4x4(), m44);
+  EXPECT_EQ(state2.matrix(), dl_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, SetTo4x4) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   // clang-format off
   const SkM44 m44 = SkM44(4, 0, 0.5, 0,
                           0, 4, 0.5, 0,
                           0, 0, 4.0, 0,
                           0, 0, 0.0, 1);
+  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
+                                               0, 4, 0.5, 0,
+                                               0, 0, 4.0, 0,
+                                               0, 0, 0.0, 1);
   // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 5, 15, 15);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
 
-  DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-  ASSERT_FALSE(tracker.using_4x4_matrix());
+  DisplayListMatrixClipTracker tracker1(cull_rect, SkMatrix::I());
+  DisplayListMatrixClipTracker tracker2(dl_cull_rect, DlMatrix());
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
 
-  tracker.setTransform(m44);
-  ASSERT_TRUE(tracker.using_4x4_matrix());
-  ASSERT_EQ(tracker.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker.matrix_4x4(), m44);
+  tracker1.setTransform(m44);
+  EXPECT_TRUE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_4x4(), m44);
+  EXPECT_EQ(tracker1.matrix(), dl_matrix);
+
+  tracker2.setTransform(dl_matrix);
+  EXPECT_TRUE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_4x4(), m44);
+  EXPECT_EQ(tracker2.matrix(), dl_matrix);
+}
+
+TEST(DisplayListMatrixClipState, SetTo4x4) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  // clang-format off
+  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
+                          0, 4, 0.5, 0,
+                          0, 0, 4.0, 0,
+                          0, 0, 0.0, 1);
+  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
+                                               0, 4, 0.5, 0,
+                                               0, 0, 4.0, 0,
+                                               0, 0, 0.0, 1);
+  // clang-format on
+  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
+
+  DisplayListMatrixClipState state1(cull_rect, SkMatrix::I());
+  DisplayListMatrixClipState state2(dl_cull_rect, DlMatrix());
+  EXPECT_FALSE(state1.using_4x4_matrix());
+  EXPECT_FALSE(state2.using_4x4_matrix());
+
+  state1.setTransform(m44);
+  EXPECT_TRUE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_4x4(), m44);
+  EXPECT_EQ(state1.matrix(), dl_matrix);
+
+  state2.setTransform(dl_matrix);
+  EXPECT_TRUE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_4x4(), m44);
+  EXPECT_EQ(state2.matrix(), dl_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, UpgradeTo4x4SaveAndRestore) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   // clang-format off
   const SkM44 m44 = SkM44(4, 0, 0.5, 0,
                           0, 4, 0.5, 0,
                           0, 0, 4.0, 0,
                           0, 0, 0.0, 1);
+  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
+                                               0, 4, 0.5, 0,
+                                               0, 0, 4.0, 0,
+                                               0, 0, 0.0, 1);
   // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 5, 15, 15);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
 
-  DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-  ASSERT_FALSE(tracker.using_4x4_matrix());
+  DisplayListMatrixClipTracker tracker1(cull_rect, SkMatrix::I());
+  DisplayListMatrixClipTracker tracker2(dl_cull_rect, DlMatrix());
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
 
-  tracker.save();
-  ASSERT_FALSE(tracker.using_4x4_matrix());
+  tracker1.save();
+  tracker2.save();
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
 
-  tracker.transform(m44);
-  ASSERT_TRUE(tracker.using_4x4_matrix());
-  ASSERT_EQ(tracker.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker.matrix_4x4(), m44);
+  tracker1.transform(m44);
+  EXPECT_TRUE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_4x4(), m44);
+  EXPECT_EQ(tracker1.matrix(), dl_matrix);
 
-  tracker.restore();
-  ASSERT_FALSE(tracker.using_4x4_matrix());
-  ASSERT_EQ(tracker.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker.local_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker.matrix_4x4(), SkM44());
+  tracker1.restore();
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.matrix_4x4(), SkM44());
+  EXPECT_EQ(tracker1.matrix(), DlMatrix());
+
+  tracker2.transform(dl_matrix);
+  EXPECT_TRUE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_4x4(), m44);
+  EXPECT_EQ(tracker2.matrix(), dl_matrix);
+
+  tracker2.restore();
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.matrix_4x4(), SkM44());
+  EXPECT_EQ(tracker2.matrix(), DlMatrix());
 }
 
+// No "State" version of UpgradeTo4x4SaveAndRestore since the State objects
+// do not have save and restore semantics.
+
 TEST(DisplayListMatrixClipTracker, Translate) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   const SkMatrix matrix = SkMatrix::Scale(4, 4);
   const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
   const SkMatrix translated_matrix =
       SkMatrix::Concat(matrix, SkMatrix::Translate(5, 1));
   const SkM44 translated_m44 = SkM44(translated_matrix);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 4, 10, 14);
+  const DlMatrix dl_translated_matrix =
+      dl_matrix * DlMatrix::MakeTranslation({5.0, 1.0});
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 9, 10, 19);
 
   DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
   DisplayListMatrixClipTracker tracker2(cull_rect, m44);
+  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
   tracker1.translate(5, 1);
   tracker2.translate(5, 1);
+  tracker3.translate(5, 1);
 
-  ASSERT_FALSE(tracker1.using_4x4_matrix());
-  ASSERT_EQ(tracker1.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker1.matrix_3x3(), translated_matrix);
-  ASSERT_EQ(tracker1.matrix_4x4(), translated_m44);
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_3x3(), translated_matrix);
+  EXPECT_EQ(tracker1.matrix_4x4(), translated_m44);
+  EXPECT_EQ(tracker1.matrix(), dl_translated_matrix);
 
-  ASSERT_FALSE(tracker2.using_4x4_matrix());
-  ASSERT_EQ(tracker2.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker2.matrix_3x3(), translated_matrix);
-  ASSERT_EQ(tracker2.matrix_4x4(), translated_m44);
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_3x3(), translated_matrix);
+  EXPECT_EQ(tracker2.matrix_4x4(), translated_m44);
+  EXPECT_EQ(tracker2.matrix(), dl_translated_matrix);
+
+  EXPECT_FALSE(tracker3.using_4x4_matrix());
+  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker3.matrix_3x3(), translated_matrix);
+  EXPECT_EQ(tracker3.matrix_4x4(), translated_m44);
+  EXPECT_EQ(tracker3.matrix(), dl_translated_matrix);
+}
+
+TEST(DisplayListMatrixClipState, Translate) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const SkMatrix matrix = SkMatrix::Scale(4, 4);
+  const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
+  const SkMatrix translated_matrix =
+      SkMatrix::Concat(matrix, SkMatrix::Translate(5, 1));
+  const SkM44 translated_m44 = SkM44(translated_matrix);
+  const DlMatrix dl_translated_matrix =
+      dl_matrix * DlMatrix::MakeTranslation({5.0, 1.0});
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 9, 10, 19);
+
+  DisplayListMatrixClipState state1(cull_rect, matrix);
+  DisplayListMatrixClipState state2(cull_rect, m44);
+  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
+  state1.translate(5, 1);
+  state2.translate(5, 1);
+  state3.translate(5, 1);
+
+  EXPECT_FALSE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_3x3(), translated_matrix);
+  EXPECT_EQ(state1.matrix_4x4(), translated_m44);
+  EXPECT_EQ(state1.matrix(), dl_translated_matrix);
+
+  EXPECT_FALSE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_3x3(), translated_matrix);
+  EXPECT_EQ(state2.matrix_4x4(), translated_m44);
+  EXPECT_EQ(state2.matrix(), dl_translated_matrix);
+
+  EXPECT_FALSE(state3.using_4x4_matrix());
+  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state3.matrix_3x3(), translated_matrix);
+  EXPECT_EQ(state3.matrix_4x4(), translated_m44);
+  EXPECT_EQ(state3.matrix(), dl_translated_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, Scale) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   const SkMatrix matrix = SkMatrix::Scale(4, 4);
   const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
+  // Scale factor carefully chosen to multiply cleanly and invert
+  // without any non-binary-power-of-2 approximation errors.
   const SkMatrix scaled_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::Scale(5, 2.5));
+      SkMatrix::Concat(matrix, SkMatrix::Scale(0.5, 2));
   const SkM44 scaled_m44 = SkM44(scaled_matrix);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(1, 2, 3, 6);
+  const DlMatrix scaled_dl_matrix = dl_matrix.Scale({0.5, 2, 1});
+  const SkRect local_cull_rect = SkRect::MakeLTRB(10, 5, 30, 10);
 
   DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
   DisplayListMatrixClipTracker tracker2(cull_rect, m44);
-  tracker1.scale(5, 2.5);
-  tracker2.scale(5, 2.5);
+  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
+  tracker1.scale(0.5, 2);
+  tracker2.scale(0.5, 2);
+  tracker3.scale(0.5, 2);
 
-  ASSERT_FALSE(tracker1.using_4x4_matrix());
-  ASSERT_EQ(tracker1.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker1.matrix_3x3(), scaled_matrix);
-  ASSERT_EQ(tracker1.matrix_4x4(), scaled_m44);
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_3x3(), scaled_matrix);
+  EXPECT_EQ(tracker1.matrix_4x4(), scaled_m44);
+  EXPECT_EQ(tracker1.matrix(), scaled_dl_matrix);
 
-  ASSERT_FALSE(tracker2.using_4x4_matrix());
-  ASSERT_EQ(tracker2.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker2.matrix_3x3(), scaled_matrix);
-  ASSERT_EQ(tracker2.matrix_4x4(), scaled_m44);
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_3x3(), scaled_matrix);
+  EXPECT_EQ(tracker2.matrix_4x4(), scaled_m44);
+  EXPECT_EQ(tracker2.matrix(), scaled_dl_matrix);
+
+  EXPECT_FALSE(tracker3.using_4x4_matrix());
+  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker3.matrix_3x3(), scaled_matrix);
+  EXPECT_EQ(tracker3.matrix_4x4(), scaled_m44);
+  EXPECT_EQ(tracker3.matrix(), scaled_dl_matrix);
+}
+
+TEST(DisplayListMatrixClipState, Scale) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const SkMatrix matrix = SkMatrix::Scale(4, 4);
+  const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
+  // Scale factor carefully chosen to multiply cleanly and invert
+  // without any non-binary-power-of-2 approximation errors.
+  const SkMatrix scaled_matrix =
+      SkMatrix::Concat(matrix, SkMatrix::Scale(0.5, 2));
+  const SkM44 scaled_m44 = SkM44(scaled_matrix);
+  const DlMatrix scaled_dl_matrix = dl_matrix.Scale({0.5, 2, 1});
+  const SkRect local_cull_rect = SkRect::MakeLTRB(10, 5, 30, 10);
+
+  DisplayListMatrixClipState state1(cull_rect, matrix);
+  DisplayListMatrixClipState state2(cull_rect, m44);
+  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
+  state1.scale(0.5, 2);
+  state2.scale(0.5, 2);
+  state3.scale(0.5, 2);
+
+  EXPECT_FALSE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_3x3(), scaled_matrix);
+  EXPECT_EQ(state1.matrix_4x4(), scaled_m44);
+  EXPECT_EQ(state1.matrix(), scaled_dl_matrix);
+
+  EXPECT_FALSE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_3x3(), scaled_matrix);
+  EXPECT_EQ(state2.matrix_4x4(), scaled_m44);
+  EXPECT_EQ(state2.matrix(), scaled_dl_matrix);
+
+  EXPECT_FALSE(state3.using_4x4_matrix());
+  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state3.matrix_3x3(), scaled_matrix);
+  EXPECT_EQ(state3.matrix_4x4(), scaled_m44);
+  EXPECT_EQ(state3.matrix(), scaled_dl_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, Skew) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   const SkMatrix matrix = SkMatrix::Scale(4, 4);
   const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
   const SkMatrix skewed_matrix =
       SkMatrix::Concat(matrix, SkMatrix::Skew(.25, 0));
   const SkM44 skewed_m44 = SkM44(skewed_matrix);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(1.25, 5, 13.75, 15);
+  const DlMatrix skewed_dl_matrix = dl_matrix * DlMatrix::MakeSkew(0.25, 0);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 10, 12.5, 20);
 
   DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
   DisplayListMatrixClipTracker tracker2(cull_rect, m44);
+  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
   tracker1.skew(.25, 0);
   tracker2.skew(.25, 0);
+  tracker3.skew(.25, 0);
 
-  ASSERT_FALSE(tracker1.using_4x4_matrix());
-  ASSERT_EQ(tracker1.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker1.matrix_3x3(), skewed_matrix);
-  ASSERT_EQ(tracker1.matrix_4x4(), skewed_m44);
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_3x3(), skewed_matrix);
+  EXPECT_EQ(tracker1.matrix_4x4(), skewed_m44);
+  EXPECT_EQ(tracker1.matrix(), skewed_dl_matrix);
 
-  ASSERT_FALSE(tracker2.using_4x4_matrix());
-  ASSERT_EQ(tracker2.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker2.matrix_3x3(), skewed_matrix);
-  ASSERT_EQ(tracker2.matrix_4x4(), skewed_m44);
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_3x3(), skewed_matrix);
+  EXPECT_EQ(tracker2.matrix_4x4(), skewed_m44);
+  EXPECT_EQ(tracker2.matrix(), skewed_dl_matrix);
+
+  EXPECT_FALSE(tracker3.using_4x4_matrix());
+  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker3.matrix_3x3(), skewed_matrix);
+  EXPECT_EQ(tracker3.matrix_4x4(), skewed_m44);
+  EXPECT_EQ(tracker3.matrix(), skewed_dl_matrix);
+}
+
+TEST(DisplayListMatrixClipState, Skew) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const SkMatrix matrix = SkMatrix::Scale(4, 4);
+  const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
+  const SkMatrix skewed_matrix =
+      SkMatrix::Concat(matrix, SkMatrix::Skew(.25, 0));
+  const SkM44 skewed_m44 = SkM44(skewed_matrix);
+  const DlMatrix skewed_dl_matrix = dl_matrix * DlMatrix::MakeSkew(0.25, 0);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 10, 12.5, 20);
+
+  DisplayListMatrixClipState state1(cull_rect, matrix);
+  DisplayListMatrixClipState state2(cull_rect, m44);
+  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
+  state1.skew(.25, 0);
+  state2.skew(.25, 0);
+  state3.skew(.25, 0);
+
+  EXPECT_FALSE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_3x3(), skewed_matrix);
+  EXPECT_EQ(state1.matrix_4x4(), skewed_m44);
+  EXPECT_EQ(state1.matrix(), skewed_dl_matrix);
+
+  EXPECT_FALSE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_3x3(), skewed_matrix);
+  EXPECT_EQ(state2.matrix_4x4(), skewed_m44);
+  EXPECT_EQ(state2.matrix(), skewed_dl_matrix);
+
+  EXPECT_FALSE(state3.using_4x4_matrix());
+  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state3.matrix_3x3(), skewed_matrix);
+  EXPECT_EQ(state3.matrix_4x4(), skewed_m44);
+  EXPECT_EQ(state3.matrix(), skewed_dl_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, Rotate) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   const SkMatrix matrix = SkMatrix::Scale(4, 4);
   const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
   const SkMatrix rotated_matrix =
       SkMatrix::Concat(matrix, SkMatrix::RotateDeg(90));
   const SkM44 rotated_m44 = SkM44(rotated_matrix);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, -15, 15, -5);
+  const DlMatrix rotated_dl_matrix =
+      dl_matrix * DlMatrix::MakeRotationZ(Degrees(90));
+  const SkRect local_cull_rect = SkRect::MakeLTRB(10, -15, 20, -5);
 
   DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
   DisplayListMatrixClipTracker tracker2(cull_rect, m44);
+  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
   tracker1.rotate(90);
   tracker2.rotate(90);
+  tracker3.rotate(90);
 
-  ASSERT_FALSE(tracker1.using_4x4_matrix());
-  ASSERT_EQ(tracker1.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker1.matrix_3x3(), rotated_matrix);
-  ASSERT_EQ(tracker1.matrix_4x4(), rotated_m44);
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_3x3(), rotated_matrix);
+  EXPECT_EQ(tracker1.matrix_4x4(), rotated_m44);
+  EXPECT_EQ(tracker1.matrix(), rotated_dl_matrix);
 
-  ASSERT_FALSE(tracker2.using_4x4_matrix());
-  ASSERT_EQ(tracker2.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker2.matrix_3x3(), rotated_matrix);
-  ASSERT_EQ(tracker2.matrix_4x4(), rotated_m44);
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_3x3(), rotated_matrix);
+  EXPECT_EQ(tracker2.matrix_4x4(), rotated_m44);
+  EXPECT_EQ(tracker2.matrix(), rotated_dl_matrix);
+
+  EXPECT_FALSE(tracker3.using_4x4_matrix());
+  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker3.matrix_3x3(), rotated_matrix);
+  EXPECT_EQ(tracker3.matrix_4x4(), rotated_m44);
+  EXPECT_EQ(tracker3.matrix(), rotated_dl_matrix);
+}
+
+TEST(DisplayListMatrixClipState, Rotate) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const SkMatrix matrix = SkMatrix::Scale(4, 4);
+  const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
+  const SkMatrix rotated_matrix =
+      SkMatrix::Concat(matrix, SkMatrix::RotateDeg(90));
+  const SkM44 rotated_m44 = SkM44(rotated_matrix);
+  const DlMatrix rotated_dl_matrix =
+      dl_matrix * DlMatrix::MakeRotationZ(Degrees(90));
+  const SkRect local_cull_rect = SkRect::MakeLTRB(10, -15, 20, -5);
+
+  DisplayListMatrixClipState state1(cull_rect, matrix);
+  DisplayListMatrixClipState state2(cull_rect, m44);
+  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
+  state1.rotate(90);
+  state2.rotate(90);
+  state3.rotate(90);
+
+  EXPECT_FALSE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_3x3(), rotated_matrix);
+  EXPECT_EQ(state1.matrix_4x4(), rotated_m44);
+  EXPECT_EQ(state1.matrix(), rotated_dl_matrix);
+
+  EXPECT_FALSE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_3x3(), rotated_matrix);
+  EXPECT_EQ(state2.matrix_4x4(), rotated_m44);
+  EXPECT_EQ(state2.matrix(), rotated_dl_matrix);
+
+  EXPECT_FALSE(state3.using_4x4_matrix());
+  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state3.matrix_3x3(), rotated_matrix);
+  EXPECT_EQ(state3.matrix_4x4(), rotated_m44);
+  EXPECT_EQ(state3.matrix(), rotated_dl_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, Transform2DAffine) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   const SkMatrix matrix = SkMatrix::Scale(4, 4);
   const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
 
   const SkMatrix transformed_matrix =
       SkMatrix::Concat(matrix, SkMatrix::MakeAll(2, 0, 5,  //
                                                  0, 2, 6,  //
                                                  0, 0, 1));
   const SkM44 transformed_m44 = SkM44(transformed_matrix);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, -0.5, 5, 4.5);
+  const DlMatrix transformed_dl_matrix =
+      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
+                                    0, 2, 0, 6,  //
+                                    0, 0, 1, 0,  //
+                                    0, 0, 0, 1);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
 
   DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
   DisplayListMatrixClipTracker tracker2(cull_rect, m44);
+  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
   tracker1.transform2DAffine(2, 0, 5,  //
                              0, 2, 6);
   tracker2.transform2DAffine(2, 0, 5,  //
                              0, 2, 6);
-  ASSERT_FALSE(tracker1.using_4x4_matrix());
-  ASSERT_EQ(tracker1.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker1.matrix_3x3(), transformed_matrix);
-  ASSERT_EQ(tracker1.matrix_4x4(), transformed_m44);
+  tracker3.transform2DAffine(2, 0, 5,  //
+                             0, 2, 6);
 
-  ASSERT_FALSE(tracker2.using_4x4_matrix());
-  ASSERT_EQ(tracker2.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker2.matrix_3x3(), transformed_matrix);
-  ASSERT_EQ(tracker2.matrix_4x4(), transformed_m44);
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(tracker1.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(tracker1.matrix(), transformed_dl_matrix);
+
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(tracker2.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(tracker2.matrix(), transformed_dl_matrix);
+
+  EXPECT_FALSE(tracker3.using_4x4_matrix());
+  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker3.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(tracker3.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(tracker3.matrix(), transformed_dl_matrix);
 }
 
-TEST(DisplayListMatrixClipTracker, TransformFullPerspectiveUsing3x3Matrix) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+TEST(DisplayListMatrixClipState, Transform2DAffine) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   const SkMatrix matrix = SkMatrix::Scale(4, 4);
   const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
 
   const SkMatrix transformed_matrix =
       SkMatrix::Concat(matrix, SkMatrix::MakeAll(2, 0, 5,  //
                                                  0, 2, 6,  //
                                                  0, 0, 1));
   const SkM44 transformed_m44 = SkM44(transformed_matrix);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, -0.5, 5, 4.5);
+  const DlMatrix transformed_dl_matrix =
+      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
+                                    0, 2, 0, 6,  //
+                                    0, 0, 1, 0,  //
+                                    0, 0, 0, 1);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
+
+  DisplayListMatrixClipState state1(cull_rect, matrix);
+  DisplayListMatrixClipState state2(cull_rect, m44);
+  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
+  state1.transform2DAffine(2, 0, 5,  //
+                           0, 2, 6);
+  state2.transform2DAffine(2, 0, 5,  //
+                           0, 2, 6);
+  state3.transform2DAffine(2, 0, 5,  //
+                           0, 2, 6);
+
+  EXPECT_FALSE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(state1.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(state1.matrix(), transformed_dl_matrix);
+
+  EXPECT_FALSE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(state2.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(state2.matrix(), transformed_dl_matrix);
+
+  EXPECT_FALSE(state3.using_4x4_matrix());
+  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state3.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(state3.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(state3.matrix(), transformed_dl_matrix);
+}
+
+TEST(DisplayListMatrixClipTracker, TransformFullPerspectiveUsing3x3Matrix) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const SkMatrix matrix = SkMatrix::Scale(4, 4);
+  const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
+
+  const SkMatrix transformed_matrix =
+      SkMatrix::Concat(matrix, SkMatrix::MakeAll(2, 0, 5,  //
+                                                 0, 2, 6,  //
+                                                 0, 0, 1));
+  const SkM44 transformed_m44 = SkM44(transformed_matrix);
+  const DlMatrix transformed_dl_matrix =
+      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
+                                    0, 2, 0, 6,  //
+                                    0, 0, 1, 0,  //
+                                    0, 0, 0, 1);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
 
   DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
   DisplayListMatrixClipTracker tracker2(cull_rect, m44);
+  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
   tracker1.transformFullPerspective(2, 0, 0, 5,  //
                                     0, 2, 0, 6,  //
                                     0, 0, 1, 0,  //
@@ -278,32 +808,111 @@ TEST(DisplayListMatrixClipTracker, TransformFullPerspectiveUsing3x3Matrix) {
                                     0, 2, 0, 6,  //
                                     0, 0, 1, 0,  //
                                     0, 0, 0, 1);
-  ASSERT_FALSE(tracker1.using_4x4_matrix());
-  ASSERT_EQ(tracker1.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker1.matrix_3x3(), transformed_matrix);
-  ASSERT_EQ(tracker1.matrix_4x4(), transformed_m44);
+  tracker3.transformFullPerspective(2, 0, 0, 5,  //
+                                    0, 2, 0, 6,  //
+                                    0, 0, 1, 0,  //
+                                    0, 0, 0, 1);
 
-  ASSERT_FALSE(tracker2.using_4x4_matrix());
-  ASSERT_EQ(tracker2.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker2.matrix_3x3(), transformed_matrix);
-  ASSERT_EQ(tracker2.matrix_4x4(), transformed_m44);
+  EXPECT_FALSE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(tracker1.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(tracker1.matrix(), transformed_dl_matrix);
+
+  EXPECT_FALSE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(tracker2.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(tracker2.matrix(), transformed_dl_matrix);
+
+  EXPECT_FALSE(tracker3.using_4x4_matrix());
+  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker3.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(tracker3.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(tracker3.matrix(), transformed_dl_matrix);
+}
+
+TEST(DisplayListMatrixClipState, TransformFullPerspectiveUsing3x3Matrix) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const SkMatrix matrix = SkMatrix::Scale(4, 4);
+  const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
+
+  const SkMatrix transformed_matrix =
+      SkMatrix::Concat(matrix, SkMatrix::MakeAll(2, 0, 5,  //
+                                                 0, 2, 6,  //
+                                                 0, 0, 1));
+  const SkM44 transformed_m44 = SkM44(transformed_matrix);
+  const DlMatrix transformed_dl_matrix =
+      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
+                                    0, 2, 0, 6,  //
+                                    0, 0, 1, 0,  //
+                                    0, 0, 0, 1);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
+
+  DisplayListMatrixClipState state1(cull_rect, matrix);
+  DisplayListMatrixClipState state2(cull_rect, m44);
+  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
+  state1.transformFullPerspective(2, 0, 0, 5,  //
+                                  0, 2, 0, 6,  //
+                                  0, 0, 1, 0,  //
+                                  0, 0, 0, 1);
+  state2.transformFullPerspective(2, 0, 0, 5,  //
+                                  0, 2, 0, 6,  //
+                                  0, 0, 1, 0,  //
+                                  0, 0, 0, 1);
+  state3.transformFullPerspective(2, 0, 0, 5,  //
+                                  0, 2, 0, 6,  //
+                                  0, 0, 1, 0,  //
+                                  0, 0, 0, 1);
+
+  EXPECT_FALSE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(state1.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(state1.matrix(), transformed_dl_matrix);
+
+  EXPECT_FALSE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(state2.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(state2.matrix(), transformed_dl_matrix);
+
+  EXPECT_FALSE(state3.using_4x4_matrix());
+  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state3.matrix_3x3(), transformed_matrix);
+  EXPECT_EQ(state3.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(state3.matrix(), transformed_dl_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, TransformFullPerspectiveUsing4x4Matrix) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 20, 60, 60);
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
   const SkMatrix matrix = SkMatrix::Scale(4, 4);
   const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
 
   const SkM44 transformed_m44 = SkM44(m44, SkM44(2, 0, 0, 5,  //
                                                  0, 2, 0, 6,  //
                                                  0, 0, 1, 7,  //
                                                  0, 0, 0, 1));
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, -0.5, 5, 4.5);
+  const DlMatrix transformed_dl_matrix =
+      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
+                                    0, 2, 0, 6,  //
+                                    0, 0, 1, 7,  //
+                                    0, 0, 0, 1);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
 
   DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
   DisplayListMatrixClipTracker tracker2(cull_rect, m44);
+  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
   tracker1.transformFullPerspective(2, 0, 0, 5,  //
                                     0, 2, 0, 6,  //
                                     0, 0, 1, 7,  //
@@ -312,15 +921,81 @@ TEST(DisplayListMatrixClipTracker, TransformFullPerspectiveUsing4x4Matrix) {
                                     0, 2, 0, 6,  //
                                     0, 0, 1, 7,  //
                                     0, 0, 0, 1);
-  ASSERT_TRUE(tracker1.using_4x4_matrix());
-  ASSERT_EQ(tracker1.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker1.matrix_4x4(), transformed_m44);
+  tracker3.transformFullPerspective(2, 0, 0, 5,  //
+                                    0, 2, 0, 6,  //
+                                    0, 0, 1, 7,  //
+                                    0, 0, 0, 1);
 
-  ASSERT_TRUE(tracker2.using_4x4_matrix());
-  ASSERT_EQ(tracker2.device_cull_rect(), cull_rect);
-  ASSERT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  ASSERT_EQ(tracker2.matrix_4x4(), transformed_m44);
+  EXPECT_TRUE(tracker1.using_4x4_matrix());
+  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker1.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(tracker1.matrix(), transformed_dl_matrix);
+
+  EXPECT_TRUE(tracker2.using_4x4_matrix());
+  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker2.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(tracker2.matrix(), transformed_dl_matrix);
+
+  EXPECT_TRUE(tracker3.using_4x4_matrix());
+  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(tracker3.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(tracker3.matrix(), transformed_dl_matrix);
+}
+
+TEST(DisplayListMatrixClipState, TransformFullPerspectiveUsing4x4Matrix) {
+  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
+  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
+  const SkMatrix matrix = SkMatrix::Scale(4, 4);
+  const SkM44 m44 = SkM44::Scale(4, 4);
+  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
+
+  const SkM44 transformed_m44 = SkM44(m44, SkM44(2, 0, 0, 5,  //
+                                                 0, 2, 0, 6,  //
+                                                 0, 0, 1, 7,  //
+                                                 0, 0, 0, 1));
+  const DlMatrix transformed_dl_matrix =
+      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
+                                    0, 2, 0, 6,  //
+                                    0, 0, 1, 7,  //
+                                    0, 0, 0, 1);
+  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
+
+  DisplayListMatrixClipState state1(cull_rect, matrix);
+  DisplayListMatrixClipState state2(cull_rect, m44);
+  DisplayListMatrixClipState state3(dl_cull_rect, dl_matrix);
+  state1.transformFullPerspective(2, 0, 0, 5,  //
+                                  0, 2, 0, 6,  //
+                                  0, 0, 1, 7,  //
+                                  0, 0, 0, 1);
+  state2.transformFullPerspective(2, 0, 0, 5,  //
+                                  0, 2, 0, 6,  //
+                                  0, 0, 1, 7,  //
+                                  0, 0, 0, 1);
+  state3.transformFullPerspective(2, 0, 0, 5,  //
+                                  0, 2, 0, 6,  //
+                                  0, 0, 1, 7,  //
+                                  0, 0, 0, 1);
+
+  EXPECT_TRUE(state1.using_4x4_matrix());
+  EXPECT_EQ(state1.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state1.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state1.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(state1.matrix(), transformed_dl_matrix);
+
+  EXPECT_TRUE(state2.using_4x4_matrix());
+  EXPECT_EQ(state2.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state2.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(state2.matrix(), transformed_dl_matrix);
+
+  EXPECT_TRUE(state3.using_4x4_matrix());
+  EXPECT_EQ(state3.device_cull_rect(), cull_rect);
+  EXPECT_EQ(state3.local_cull_rect(), local_cull_rect);
+  EXPECT_EQ(state3.matrix_4x4(), transformed_m44);
+  EXPECT_EQ(state3.matrix(), transformed_dl_matrix);
 }
 
 TEST(DisplayListMatrixClipTracker, ClipDifference) {
@@ -331,42 +1006,76 @@ TEST(DisplayListMatrixClipTracker, ClipDifference) {
     {
       DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
       tracker.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
-      ASSERT_EQ(tracker.device_cull_rect(), cull_rect) << label;
+      EXPECT_EQ(tracker.device_cull_rect(), cull_rect) << label;
     }
     {
       DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
       const SkRRect diff_rrect = SkRRect::MakeRect(diff_rect);
       tracker.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
-      ASSERT_EQ(tracker.device_cull_rect(), cull_rect) << label << " (RRect)";
+      EXPECT_EQ(tracker.device_cull_rect(), cull_rect) << label << " (RRect)";
     }
     {
       DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
       const SkPath diff_path = SkPath().addRect(diff_rect);
       tracker.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
-      ASSERT_EQ(tracker.device_cull_rect(), cull_rect) << label << " (RRect)";
+      EXPECT_EQ(tracker.device_cull_rect(), cull_rect) << label << " (RRect)";
+    }
+    {
+      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+      state.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
+      EXPECT_EQ(state.device_cull_rect(), cull_rect) << label;
+    }
+    {
+      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+      const SkRRect diff_rrect = SkRRect::MakeRect(diff_rect);
+      state.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
+      EXPECT_EQ(state.device_cull_rect(), cull_rect) << label << " (RRect)";
+    }
+    {
+      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+      const SkPath diff_path = SkPath().addRect(diff_rect);
+      state.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
+      EXPECT_EQ(state.device_cull_rect(), cull_rect) << label << " (RRect)";
     }
   };
 
   auto reducing = [&cull_rect](const SkRect& diff_rect,
                                const SkRect& result_rect,
                                const std::string& label) {
-    ASSERT_TRUE(result_rect.isEmpty() || cull_rect.contains(result_rect));
+    EXPECT_TRUE(result_rect.isEmpty() || cull_rect.contains(result_rect));
     {
       DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
       tracker.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
-      ASSERT_EQ(tracker.device_cull_rect(), result_rect) << label;
+      EXPECT_EQ(tracker.device_cull_rect(), result_rect) << label;
     }
     {
       DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
       const SkRRect diff_rrect = SkRRect::MakeRect(diff_rect);
       tracker.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
-      ASSERT_EQ(tracker.device_cull_rect(), result_rect) << label << " (RRect)";
+      EXPECT_EQ(tracker.device_cull_rect(), result_rect) << label << " (RRect)";
     }
     {
       DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
       const SkPath diff_path = SkPath().addRect(diff_rect);
       tracker.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
-      ASSERT_EQ(tracker.device_cull_rect(), result_rect) << label << " (RRect)";
+      EXPECT_EQ(tracker.device_cull_rect(), result_rect) << label << " (RRect)";
+    }
+    {
+      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+      state.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
+      EXPECT_EQ(state.device_cull_rect(), result_rect) << label;
+    }
+    {
+      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+      const SkRRect diff_rrect = SkRRect::MakeRect(diff_rect);
+      state.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
+      EXPECT_EQ(state.device_cull_rect(), result_rect) << label << " (RRect)";
+    }
+    {
+      DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+      const SkPath diff_path = SkPath().addRect(diff_rect);
+      state.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
+      EXPECT_EQ(state.device_cull_rect(), result_rect) << label << " (RRect)";
     }
   };
 
@@ -426,13 +1135,24 @@ TEST(DisplayListMatrixClipTracker, ClipDifference) {
 
 TEST(DisplayListMatrixClipTracker, ClipPathWithInvertFillType) {
   SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
-  DisplayListMatrixClipTracker builder(cull_rect, SkMatrix::I());
+  DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
   SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
   clip.setFillType(SkPathFillType::kInverseWinding);
-  builder.clipPath(clip, DlCanvas::ClipOp::kIntersect, false);
+  tracker.clipPath(clip, DlCanvas::ClipOp::kIntersect, false);
 
-  ASSERT_EQ(builder.local_cull_rect(), cull_rect);
-  ASSERT_EQ(builder.device_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker.local_cull_rect(), cull_rect);
+  EXPECT_EQ(tracker.device_cull_rect(), cull_rect);
+}
+
+TEST(DisplayListMatrixClipState, ClipPathWithInvertFillType) {
+  SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
+  DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
+  clip.setFillType(SkPathFillType::kInverseWinding);
+  state.clipPath(clip, DlCanvas::ClipOp::kIntersect, false);
+
+  EXPECT_EQ(state.local_cull_rect(), cull_rect);
+  EXPECT_EQ(state.device_cull_rect(), cull_rect);
 }
 
 TEST(DisplayListMatrixClipTracker, DiffClipPathWithInvertFillType) {
@@ -444,8 +1164,21 @@ TEST(DisplayListMatrixClipTracker, DiffClipPathWithInvertFillType) {
   SkRect clip_bounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
   tracker.clipPath(clip, DlCanvas::ClipOp::kDifference, false);
 
-  ASSERT_EQ(tracker.local_cull_rect(), clip_bounds);
-  ASSERT_EQ(tracker.device_cull_rect(), clip_bounds);
+  EXPECT_EQ(tracker.local_cull_rect(), clip_bounds);
+  EXPECT_EQ(tracker.device_cull_rect(), clip_bounds);
+}
+
+TEST(DisplayListMatrixClipState, DiffClipPathWithInvertFillType) {
+  SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
+  DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
+
+  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
+  clip.setFillType(SkPathFillType::kInverseWinding);
+  SkRect clip_bounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
+  state.clipPath(clip, DlCanvas::ClipOp::kDifference, false);
+
+  EXPECT_EQ(state.local_cull_rect(), clip_bounds);
+  EXPECT_EQ(state.device_cull_rect(), clip_bounds);
 }
 
 }  // namespace testing

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2514,7 +2514,11 @@ TEST_P(EntityTest, CoverageForStrokePathWithNegativeValuesInTransform) {
 
   auto transform = Matrix::MakeTranslation({300, 300}) *
                    Matrix::MakeRotationZ(Radians(kPiOver2));
-  EXPECT_LT(transform.e[0][0], 0.f);
+  // Note that e[0][0] used to be tested here, but it was -epsilon solely
+  // due to floating point inaccuracy in the transcendental trig functions.
+  // e[1][0] is the intended negative value that we care about (-1.0) as it
+  // comes from the rotation of pi/2.
+  EXPECT_LT(transform.e[1][0], 0.0f);
   auto coverage = geometry->GetCoverage(transform);
   ASSERT_RECT_NEAR(coverage.value(), Rect::MakeXYWH(102.5, 342.5, 85, 155));
 }

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -462,20 +462,6 @@ TEST(GeometryTest, MatrixGetDirectionScale) {
   }
 }
 
-TEST(GeometryTest, MatrixIsAligned) {
-  {
-    auto m = Matrix::MakeTranslation({1, 2, 3});
-    bool result = m.IsAligned();
-    ASSERT_TRUE(result);
-  }
-
-  {
-    auto m = Matrix::MakeRotationZ(Degrees{123});
-    bool result = m.IsAligned();
-    ASSERT_FALSE(result);
-  }
-}
-
 TEST(GeometryTest, MatrixTranslationScaleOnly) {
   {
     auto m = Matrix();

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -332,7 +332,7 @@ struct Matrix {
   }
 
   constexpr bool IsAligned2D(Scalar tolerance = 0) const {
-    if (HasPerspective()) {
+    if (HasPerspective2D()) {
       return false;
     }
     if (ScalarNearlyZero(m[1], tolerance) &&
@@ -347,6 +347,9 @@ struct Matrix {
   }
 
   constexpr bool IsAligned(Scalar tolerance = 0) const {
+    if (HasPerspective()) {
+      return false;
+    }
     int v[] = {!ScalarNearlyZero(m[0], tolerance),  //
                !ScalarNearlyZero(m[1], tolerance),  //
                !ScalarNearlyZero(m[2], tolerance),  //

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -148,12 +148,13 @@ struct Matrix {
     // clang-format on
   }
 
-  static Matrix MakeRotation(Scalar radians, const Vector4& r) {
+  static Matrix MakeRotation(Radians radians, const Vector4& r) {
     const Vector4 v = r.Normalize();
 
-    const Scalar cosine = cos(radians);
+    const Vector2 cos_sin = CosSin(radians);
+    const Scalar cosine = cos_sin.x;
     const Scalar cosp = 1.0f - cosine;
-    const Scalar sine = sin(radians);
+    const Scalar sine = cos_sin.y;
 
     // clang-format off
     return Matrix(
@@ -180,8 +181,10 @@ struct Matrix {
   }
 
   static Matrix MakeRotationX(Radians r) {
-    const Scalar cosine = cos(r.radians);
-    const Scalar sine = sin(r.radians);
+    const Vector2 cos_sin = CosSin(r);
+    const Scalar cosine = cos_sin.x;
+    const Scalar sine = cos_sin.y;
+
     // clang-format off
     return Matrix(
       1.0f,  0.0f,    0.0f,    0.0f,
@@ -193,8 +196,9 @@ struct Matrix {
   }
 
   static Matrix MakeRotationY(Radians r) {
-    const Scalar cosine = cos(r.radians);
-    const Scalar sine = sin(r.radians);
+    const Vector2 cos_sin = CosSin(r);
+    const Scalar cosine = cos_sin.x;
+    const Scalar sine = cos_sin.y;
 
     // clang-format off
     return Matrix(
@@ -207,8 +211,9 @@ struct Matrix {
   }
 
   static Matrix MakeRotationZ(Radians r) {
-    const Scalar cosine = cos(r.radians);
-    const Scalar sine = sin(r.radians);
+    const Vector2 cos_sin = CosSin(r);
+    const Scalar cosine = cos_sin.x;
+    const Scalar sine = cos_sin.y;
 
     // clang-format off
     return Matrix (
@@ -320,6 +325,21 @@ struct Matrix {
 
   constexpr bool HasPerspective() const {
     return m[3] != 0 || m[7] != 0 || m[11] != 0 || m[15] != 1;
+  }
+
+  constexpr bool IsAligned2D(Scalar tolerance = 0) const {
+    if (HasPerspective()) {
+      return false;
+    }
+    if (ScalarNearlyZero(m[1], tolerance) &&
+        ScalarNearlyZero(m[4], tolerance)) {
+      return true;
+    }
+    if (ScalarNearlyZero(m[0], tolerance) &&
+        ScalarNearlyZero(m[5], tolerance)) {
+      return true;
+    }
+    return false;
   }
 
   constexpr bool IsAligned(Scalar tolerance = 0) const {
@@ -509,6 +529,43 @@ struct Matrix {
       -right.Dot(position), -up.Dot(position), -forward.Dot(position), 1.0f
     };
     // clang-format on
+  }
+
+ private:
+  static constexpr Vector2 CosSin(Radians radians) {
+    // The precision of a float around 1.0 is much lower than it is
+    // around 0.0, so we end up with cases on quadrant rotations where
+    // we get a +/-1.0 for one of the values and a non-zero value for
+    // the other. This happens around quadrant rotations which makes it
+    // especially common and results in unclean quadrant rotation
+    // matrices which do not return true from |IsAligned[2D]| even
+    // though that is exactly where you need them to exhibit that property.
+    // It also injects small floating point mantissa errors into the
+    // matrices whenever you concatenate them with a quadrant rotation.
+    //
+    // This issue is also exacerbated by the fact that, in radians, the
+    // angles for quadrant rotations are irrational numbers. The measuring
+    // error for representing 90 degree multiples is small enough that
+    // either sin or cos will return a value near +/-1.0, but not small
+    // enough that the other value will be a clean 0.0.
+    //
+    // Some geometry packages simply discard very small numbers from
+    // sin/cos, but the following approach specifically targets just the
+    // area around a quadrant rotation (where either the sin or cos are
+    // measuring as +/-1.0) for symmetry of precision.
+
+    Scalar sin = std::sin(radians.radians);
+    if (std::abs(sin) == 1.0f) {
+      // 90 or 270 degrees (mod 360)
+      return {0.0f, sin};
+    } else {
+      Scalar cos = std::cos(radians.radians);
+      if (std::abs(cos) == 1.0f) {
+        // 0 or 180 degrees (mod 360)
+        return {cos, 0.0f};
+      }
+      return {cos, sin};
+    }
   }
 };
 

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -323,6 +323,10 @@ struct Matrix {
             m[9] == 0 && m[10] == 1 && m[11] == 0 && m[14] == 0 && m[15] == 1);
   }
 
+  constexpr bool HasPerspective2D() const {
+    return m[3] != 0 || m[7] != 0 || m[15] != 1;
+  }
+
   constexpr bool HasPerspective() const {
     return m[3] != 0 || m[7] != 0 || m[11] != 0 || m[15] != 1;
   }
@@ -451,6 +455,12 @@ struct Matrix {
       w = 1 / w;
     }
     return result * w;
+  }
+
+  constexpr Vector3 TransformHomogenous(const Point& v) const {
+    return Vector3(v.x * m[0] + v.y * m[4] + m[12],
+                   v.x * m[1] + v.y * m[5] + m[13],
+                   v.x * m[3] + v.y * m[7] + m[15]);
   }
 
   constexpr Vector4 TransformDirection(const Vector4& v) const {

--- a/impeller/geometry/matrix_unittests.cc
+++ b/impeller/geometry/matrix_unittests.cc
@@ -24,5 +24,134 @@ TEST(MatrixTest, Multiply) {
                                         11.0, 21.0, 0.0, 1.0)));
 }
 
+TEST(MatrixTest, HasPerspective2D) {
+  EXPECT_FALSE(Matrix().HasPerspective2D());
+
+  auto test = [](int index, bool expect) {
+    Matrix matrix;
+    EXPECT_FALSE(matrix.HasPerspective2D());
+    matrix.m[index] = 0.5f;
+    EXPECT_EQ(matrix.HasPerspective2D(), expect) << "index: " << index;
+  };
+
+  // clang-format off
+  test( 0, false);  test( 1, false);  test( 2, false);  test( 3, true);
+  test( 4, false);  test( 5, false);  test( 6, false);  test( 7, true);
+  test( 8, false);  test( 9, false);  test(10, false);  test(11, false);
+  test(12, false);  test(13, false);  test(14, false);  test(15, true);
+  // clang-format on
+}
+
+TEST(MatrixTest, HasPerspective) {
+  EXPECT_FALSE(Matrix().HasPerspective());
+
+  auto test = [](int index, bool expect) {
+    Matrix matrix;
+    EXPECT_FALSE(matrix.HasPerspective());
+    matrix.m[index] = 0.5f;
+    EXPECT_EQ(matrix.HasPerspective(), expect) << "index: " << index;
+  };
+
+  // clang-format off
+  test( 0, false);  test( 1, false);  test( 2, false);  test( 3, true);
+  test( 4, false);  test( 5, false);  test( 6, false);  test( 7, true);
+  test( 8, false);  test( 9, false);  test(10, false);  test(11, true);
+  test(12, false);  test(13, false);  test(14, false);  test(15, true);
+  // clang-format on
+}
+
+TEST(MatrixTest, IsAligned2D) {
+  EXPECT_TRUE(Matrix().IsAligned2D());
+  EXPECT_TRUE(Matrix::MakeScale({1.0f, 1.0f, 2.0f}).IsAligned2D());
+
+  auto test = [](int index, bool expect) {
+    Matrix matrix;
+    EXPECT_TRUE(matrix.IsAligned2D());
+    matrix.m[index] = 0.5f;
+    EXPECT_EQ(matrix.IsAligned2D(), expect) << "index: " << index;
+  };
+
+  // clang-format off
+  test( 0, true);   test( 1, false);  test( 2, true);   test( 3, false);
+  test( 4, false);  test( 5, true);   test( 6, true);   test( 7, false);
+  test( 8, true);   test( 9, true);   test(10, true);   test(11, true);
+  test(12, true);   test(13, true);   test(14, true);   test(15, false);
+  // clang-format on
+
+  // True for quadrant rotations from -250 to +250 full circles
+  for (int i = -1000; i < 1000; i++) {
+    Degrees d = Degrees(i * 90);
+    Matrix matrix = Matrix::MakeRotationZ(Degrees(d));
+    EXPECT_TRUE(matrix.IsAligned2D()) << "degrees: " << d.degrees;
+  }
+
+  // False for half degree rotations from -999.5 to +1000.5 degrees
+  for (int i = -1000; i < 1000; i++) {
+    Degrees d = Degrees(i + 0.5f);
+    Matrix matrix = Matrix::MakeRotationZ(Degrees(d));
+    EXPECT_FALSE(matrix.IsAligned2D()) << "degrees: " << d.degrees;
+  }
+}
+
+TEST(MatrixTest, IsAligned) {
+  EXPECT_TRUE(Matrix().IsAligned());
+  EXPECT_TRUE(Matrix::MakeScale({1.0f, 1.0f, 2.0f}).IsAligned());
+
+  // Begin Legacy tests transferred over from geometry_unittests.cc
+  {
+    auto m = Matrix::MakeTranslation({1, 2, 3});
+    bool result = m.IsAligned();
+    ASSERT_TRUE(result);
+  }
+
+  {
+    auto m = Matrix::MakeRotationZ(Degrees{123});
+    bool result = m.IsAligned();
+    ASSERT_FALSE(result);
+  }
+  // End Legacy tests transferred over from geometry_unittests.cc
+
+  auto test = [](int index, bool expect) {
+    Matrix matrix;
+    EXPECT_TRUE(matrix.IsAligned());
+    matrix.m[index] = 0.5f;
+    EXPECT_EQ(matrix.IsAligned(), expect) << "index: " << index;
+  };
+
+  // clang-format off
+  test( 0, true);   test( 1, false);  test( 2, false);  test( 3, false);
+  test( 4, false);  test( 5, true);   test( 6, false);  test( 7, false);
+  test( 8, false);  test( 9, false);  test(10, true);   test(11, false);
+  test(12, true);   test(13, true);   test(14, true);   test(15, false);
+  // clang-format on
+
+  // True for quadrant rotations from -250 to +250 full circles
+  for (int i = -1000; i < 1000; i++) {
+    Degrees d = Degrees(i * 90);
+    Matrix matrix = Matrix::MakeRotationZ(Degrees(d));
+    EXPECT_TRUE(matrix.IsAligned()) << "degrees: " << d.degrees;
+  }
+
+  // False for half degree rotations from -999.5 to +1000.5 degrees
+  for (int i = -1000; i < 1000; i++) {
+    Degrees d = Degrees(i + 0.5f);
+    Matrix matrix = Matrix::MakeRotationZ(Degrees(d));
+    EXPECT_FALSE(matrix.IsAligned()) << "degrees: " << d.degrees;
+  }
+}
+
+TEST(MatrixTest, TransformHomogenous) {
+  Matrix matrix = Matrix::MakeColumn(
+      // clang-format off
+       2.0f,  3.0f,  5.0f,  7.0f,
+      11.0f, 13.0f, 17.0f, 19.0f,
+      23.0f, 29.0f, 31.0f, 37.0f,
+      41.0f, 43.0f, 47.0f, 53.0f
+      // clang-format on
+  );
+  EXPECT_EQ(matrix.TransformHomogenous({1.0f, -1.0f}),
+            Vector3(32.0f, 33.0f, 41.0f));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -401,6 +401,41 @@ struct TRect {
   }
 
   /// @brief  Creates a new bounding box that contains this transformed
+  ///         rectangle, clipped against the near clipping plane if
+  ///         necessary.
+  [[nodiscard]] constexpr TRect TransformAndClipBounds(
+      const Matrix& transform) const {
+    if (!transform.HasPerspective2D()) {
+      return TransformBounds(transform);
+    }
+
+    if (IsEmpty()) {
+      return {};
+    }
+
+    auto ul = transform.TransformHomogenous({left_, top_});
+    auto ur = transform.TransformHomogenous({right_, top_});
+    auto ll = transform.TransformHomogenous({left_, bottom_});
+    auto lr = transform.TransformHomogenous({right_, bottom_});
+
+    // It can probably be proven that we only ever have 5 points at most
+    // which happens when only 1 corner is clipped and we get 2 points
+    // in return for it as we interpolate against its neighbors.
+    Point points[8];
+    int index = 0;
+
+    // Process (clip and interpolate) each point against its 2 neighbors:
+    //                                 left, pt, right
+    index = ClipAndInsert(points, index, ll, ul, ur);
+    index = ClipAndInsert(points, index, ul, ur, lr);
+    index = ClipAndInsert(points, index, ur, lr, ll);
+    index = ClipAndInsert(points, index, lr, ll, ul);
+
+    auto bounds = TRect::MakePointBounds(points, points + index);
+    return bounds.value_or(TRect{});
+  }
+
+  /// @brief  Creates a new bounding box that contains this transformed
   ///         rectangle.
   [[nodiscard]] constexpr TRect TransformBounds(const Matrix& transform) const {
     if (IsEmpty()) {
@@ -664,6 +699,48 @@ struct TRect {
   Type top_;
   Type right_;
   Type bottom_;
+
+  static constexpr Scalar kMinimumHomogenous = 1.0f / (1 << 14);
+
+  // Clip p against the near clipping plane (W = kMinimumHomogenous)
+  // and interpolate a crossing point against the nearby neighbors
+  // left and right if p is clipped and either of them is not.
+  // This method can produce 0, 1, or 2 points per call depending on
+  // how many of the points are clipped.
+  // 0 - all points are clipped
+  // 1 - p is unclipped OR
+  //     p is clipped and exactly one of the neighbors is not
+  // 2 - p is clipped and both neighbors are not
+  static constexpr int ClipAndInsert(Point clipped[],
+                                     int index,
+                                     const Vector3& left,
+                                     const Vector3& p,
+                                     const Vector3& right) {
+    if (p.z >= kMinimumHomogenous) {
+      clipped[index++] = {p.x / p.z, p.y / p.z};
+    } else {
+      index = InterpolateAndInsert(clipped, index, p, left);
+      index = InterpolateAndInsert(clipped, index, p, right);
+    }
+    return index;
+  }
+
+  // Interpolate (a clipped) point p against one of its neighbors
+  // and insert the point into the array where the line between them
+  // veers from clipped space to unclipped, if such a point exists.
+  static constexpr int InterpolateAndInsert(Point clipped[],
+                                            int index,
+                                            const Vector3& p,
+                                            const Vector3& neighbor) {
+    if (neighbor.z >= kMinimumHomogenous) {
+      auto t = (kMinimumHomogenous - p.z) / (neighbor.z - p.z);
+      clipped[index++] = {
+          (t * p.x + (1.0f - t) * neighbor.x) / kMinimumHomogenous,
+          (t * p.y + (1.0f - t) * neighbor.y) / kMinimumHomogenous,
+      };
+    }
+    return index;
+  }
 };
 
 using Rect = TRect<Scalar>;

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -612,6 +612,14 @@ struct TRect {
                            saturated::Cast<U, Type>(ceil(r.GetBottom())));
   }
 
+  ONLY_ON_FLOAT_M([[nodiscard]] constexpr static, TRect)
+  Round(const TRect<U>& r) {
+    return TRect::MakeLTRB(saturated::Cast<U, Type>(round(r.GetLeft())),
+                           saturated::Cast<U, Type>(round(r.GetTop())),
+                           saturated::Cast<U, Type>(round(r.GetRight())),
+                           saturated::Cast<U, Type>(round(r.GetBottom())));
+  }
+
   [[nodiscard]] constexpr static std::optional<TRect> Union(
       const TRect& a,
       const std::optional<TRect> b) {

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -2840,25 +2840,188 @@ TEST(RectTest, RectProject) {
 
 TEST(RectTest, RectRoundOut) {
   {
-    auto r = Rect::MakeLTRB(-100, -100, 100, 100);
+    auto r = Rect::MakeLTRB(-100, -200, 300, 400);
     EXPECT_EQ(Rect::RoundOut(r), r);
   }
   {
-    auto r = Rect::MakeLTRB(-100.1, -100.1, 100.1, 100.1);
-    EXPECT_EQ(Rect::RoundOut(r), Rect::MakeLTRB(-101, -101, 101, 101));
+    auto r = Rect::MakeLTRB(-100.1, -200.1, 300.1, 400.1);
+    EXPECT_EQ(Rect::RoundOut(r), Rect::MakeLTRB(-101, -201, 301, 401));
   }
 }
 
 TEST(RectTest, IRectRoundOut) {
   {
-    auto r = Rect::MakeLTRB(-100, -100, 100, 100);
-    auto ir = IRect::MakeLTRB(-100, -100, 100, 100);
+    auto r = Rect::MakeLTRB(-100, -200, 300, 400);
+    auto ir = IRect::MakeLTRB(-100, -200, 300, 400);
     EXPECT_EQ(IRect::RoundOut(r), ir);
   }
   {
-    auto r = Rect::MakeLTRB(-100.1, -100.1, 100.1, 100.1);
-    auto ir = IRect::MakeLTRB(-101, -101, 101, 101);
+    auto r = Rect::MakeLTRB(-100.1, -200.1, 300.1, 400.1);
+    auto ir = IRect::MakeLTRB(-101, -201, 301, 401);
     EXPECT_EQ(IRect::RoundOut(r), ir);
+  }
+}
+
+TEST(RectTest, RectRound) {
+  {
+    auto r = Rect::MakeLTRB(-100, -200, 300, 400);
+    EXPECT_EQ(Rect::Round(r), r);
+  }
+  {
+    auto r = Rect::MakeLTRB(-100.4, -200.4, 300.4, 400.4);
+    EXPECT_EQ(Rect::Round(r), Rect::MakeLTRB(-100, -200, 300, 400));
+  }
+  {
+    auto r = Rect::MakeLTRB(-100.5, -200.5, 300.5, 400.5);
+    EXPECT_EQ(Rect::Round(r), Rect::MakeLTRB(-101, -201, 301, 401));
+  }
+}
+
+TEST(RectTest, IRectRound) {
+  {
+    auto r = Rect::MakeLTRB(-100, -200, 300, 400);
+    auto ir = IRect::MakeLTRB(-100, -200, 300, 400);
+    EXPECT_EQ(IRect::Round(r), ir);
+  }
+  {
+    auto r = Rect::MakeLTRB(-100.4, -200.4, 300.4, 400.4);
+    auto ir = IRect::MakeLTRB(-100, -200, 300, 400);
+    EXPECT_EQ(IRect::Round(r), ir);
+  }
+  {
+    auto r = Rect::MakeLTRB(-100.5, -200.5, 300.5, 400.5);
+    auto ir = IRect::MakeLTRB(-101, -201, 301, 401);
+    EXPECT_EQ(IRect::Round(r), ir);
+  }
+}
+
+TEST(RectTest, TransformAndClipBounds) {
+  {
+    // This matrix should clip no corners.
+    auto matrix = impeller::Matrix::MakeColumn(
+        // clang-format off
+        2.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 4.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 8.0f
+        // clang-format on
+    );
+    Rect src = Rect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+    // None of these should have a W<0
+    EXPECT_EQ(matrix.TransformHomogenous(src.GetLeftTop()),
+              Vector3(200.0f, 400.0f, 8.0f));
+    EXPECT_EQ(matrix.TransformHomogenous(src.GetRightTop()),
+              Vector3(400.0f, 400.0f, 8.0f));
+    EXPECT_EQ(matrix.TransformHomogenous(src.GetLeftBottom()),
+              Vector3(200.0f, 800.0f, 8.0f));
+    EXPECT_EQ(matrix.TransformHomogenous(src.GetRightBottom()),
+              Vector3(400.0f, 800.0f, 8.0f));
+
+    Rect expect = Rect::MakeLTRB(25.0f, 50.0f, 50.0f, 100.0f);
+    EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
+    EXPECT_EQ(src.TransformAndClipBounds(matrix), expect);
+  }
+
+  {
+    // This matrix should clip one corner.
+    auto matrix = impeller::Matrix::MakeColumn(
+        // clang-format off
+        2.0f, 0.0f, 0.0f, -0.01f,
+        0.0f, 2.0f, 0.0f, -0.006f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 3.0f
+        // clang-format on
+    );
+    Rect src = Rect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+    // Exactly one of these should have a W<0
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetLeftTop()),
+                        Vector3(200.0f, 200.0f, 1.4f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetRightTop()),
+                        Vector3(400.0f, 200.0f, 0.4f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetLeftBottom()),
+                        Vector3(200.0f, 400.0f, 0.8f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetRightBottom()),
+                        Vector3(400.0f, 400.0f, -0.2f));
+
+    Rect expect = Rect::MakeLTRB(142.85715f, 142.85715f, 6553600.f, 6553600.f);
+    EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
+    EXPECT_RECT_NEAR(src.TransformAndClipBounds(matrix), expect);
+  }
+
+  {
+    // This matrix should clip two corners.
+    auto matrix = impeller::Matrix::MakeColumn(
+        // clang-format off
+        2.0f, 0.0f, 0.0f, -.015f,
+        0.0f, 2.0f, 0.0f, -.006f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 3.0f
+        // clang-format on
+    );
+    Rect src = Rect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+    // Exactly two of these should have a W<0
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetLeftTop()),
+                        Vector3(200.0f, 200.0f, 0.9f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetRightTop()),
+                        Vector3(400.0f, 200.0f, -0.6f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetLeftBottom()),
+                        Vector3(200.0f, 400.0f, 0.3f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetRightBottom()),
+                        Vector3(400.0f, 400.0f, -1.2f));
+
+    Rect expect = Rect::MakeLTRB(222.2222f, 222.2222f, 5898373.f, 6553600.f);
+    EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
+    EXPECT_RECT_NEAR(src.TransformAndClipBounds(matrix), expect);
+  }
+
+  {
+    // This matrix should clip three corners.
+    auto matrix = impeller::Matrix::MakeColumn(
+        // clang-format off
+        2.0f, 0.0f, 0.0f, -.02f,
+        0.0f, 2.0f, 0.0f, -.006f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 3.0f
+        // clang-format on
+    );
+    Rect src = Rect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+    // Exactly three of these should have a W<0
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetLeftTop()),
+                        Vector3(200.0f, 200.0f, 0.4f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetRightTop()),
+                        Vector3(400.0f, 200.0f, -1.6f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetLeftBottom()),
+                        Vector3(200.0f, 400.0f, -0.2f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetRightBottom()),
+                        Vector3(400.0f, 400.0f, -2.2f));
+
+    Rect expect = Rect::MakeLTRB(499.99988f, 499.99988f, 5898340.f, 4369400.f);
+    EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
+    EXPECT_RECT_NEAR(src.TransformAndClipBounds(matrix), expect);
+  }
+
+  {
+    // This matrix should clip all four corners.
+    auto matrix = impeller::Matrix::MakeColumn(
+        // clang-format off
+        2.0f, 0.0f, 0.0f, -.025f,
+        0.0f, 2.0f, 0.0f, -.006f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 3.0f
+        // clang-format on
+    );
+    Rect src = Rect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f);
+    // All of these should have a W<0
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetLeftTop()),
+                        Vector3(200.0f, 200.0f, -0.1f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetRightTop()),
+                        Vector3(400.0f, 200.0f, -2.6f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetLeftBottom()),
+                        Vector3(200.0f, 400.0f, -0.7f));
+    EXPECT_VECTOR3_NEAR(matrix.TransformHomogenous(src.GetRightBottom()),
+                        Vector3(400.0f, 400.0f, -3.2f));
+
+    EXPECT_TRUE(src.TransformAndClipBounds(matrix).IsEmpty());
   }
 }
 

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -2895,6 +2895,22 @@ TEST(RectTest, IRectRound) {
   }
 }
 
+// EXPECT_RECT_NEAR will allow a fixed difference between the values that
+// assumes a compatible range of values being tested. Some of the values
+// below are well outside that range and so if the values are a single
+// "bit" off, then they will differ by far more than the fixed allowable
+// difference. The EXPECT_FLOAT_EQ macro will compare the values and
+// fail only if their difference in mantissa is in the last N bits,
+// which is a range agnostic way to compare floats with allowances for
+// bit errors in computations.
+#define EXPECT_RECT_EQ(a, b)                       \
+  do {                                             \
+    EXPECT_FLOAT_EQ(a.GetLeft(), b.GetLeft());     \
+    EXPECT_FLOAT_EQ(a.GetTop(), b.GetTop());       \
+    EXPECT_FLOAT_EQ(a.GetRight(), b.GetRight());   \
+    EXPECT_FLOAT_EQ(a.GetBottom(), b.GetBottom()); \
+  } while (0)
+
 TEST(RectTest, TransformAndClipBounds) {
   {
     // This matrix should clip no corners.
@@ -2945,7 +2961,7 @@ TEST(RectTest, TransformAndClipBounds) {
 
     Rect expect = Rect::MakeLTRB(142.85715f, 142.85715f, 6553600.f, 6553600.f);
     EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
-    EXPECT_RECT_NEAR(src.TransformAndClipBounds(matrix), expect);
+    EXPECT_RECT_EQ(src.TransformAndClipBounds(matrix), expect);
   }
 
   {
@@ -2971,7 +2987,7 @@ TEST(RectTest, TransformAndClipBounds) {
 
     Rect expect = Rect::MakeLTRB(222.2222f, 222.2222f, 5898373.f, 6553600.f);
     EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
-    EXPECT_RECT_NEAR(src.TransformAndClipBounds(matrix), expect);
+    EXPECT_RECT_EQ(src.TransformAndClipBounds(matrix), expect);
   }
 
   {
@@ -2997,7 +3013,7 @@ TEST(RectTest, TransformAndClipBounds) {
 
     Rect expect = Rect::MakeLTRB(499.99988f, 499.99988f, 5898340.f, 4369400.f);
     EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
-    EXPECT_RECT_NEAR(src.TransformAndClipBounds(matrix), expect);
+    EXPECT_RECT_EQ(src.TransformAndClipBounds(matrix), expect);
   }
 
   {

--- a/impeller/scene/scene_unittests.cc
+++ b/impeller/scene/scene_unittests.cc
@@ -164,7 +164,7 @@ TEST_P(SceneTest, TwoTriangles) {
     ImGui::End();
     Node& node = *scene.GetRoot().GetChildren()[0];
     node.SetLocalTransform(node.GetLocalTransform() *
-                           Matrix::MakeRotation(0.02, {0, 1, 0, 0}));
+                           Matrix::MakeRotation(Radians(0.02), {0, 1, 0, 0}));
 
     static ImVec2 mouse_pos_prev = ImGui::GetMousePos();
     ImVec2 mouse_pos = ImGui::GetMousePos();
@@ -269,7 +269,7 @@ TEST_P(SceneTest, Dash) {
     ImGui::End();
     Node& node = *scene.GetRoot().GetChildren()[0];
     node.SetLocalTransform(node.GetLocalTransform() *
-                           Matrix::MakeRotation(0.02, {0, 1, 0, 0}));
+                           Matrix::MakeRotation(Radians(0.02), {0, 1, 0, 0}));
 
     static ImVec2 mouse_pos_prev = ImGui::GetMousePos();
     ImVec2 mouse_pos = ImGui::GetMousePos();


### PR DESCRIPTION
The `DisplayListMatrixClipTracker` class performs the working of maintaining a stack of cull rects and transforms for classes in the engine that require such functionality (such as `DisplayListBuilder`, `DiffContext`, and `LayerStateStack`.

Until now it has been using a mixture of SkMatrix and SkM44 along with an SkRect to maintain this information, but that complexity involves overhead and implementation complexity which complicates future work on these areas.

By reimplementing the class to use Impeller geometry objects, the internal architecture is greatly simplified allowing for easier future maintenance.