### PR TITLE
[Impeller] handle fill polylines with zero area.

### DIFF
--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -187,6 +187,9 @@ std::vector<Point> Tessellator::TessellateConvex(const Path& path,
                           [this](Path::Polyline::PointBufferPtr point_buffer) {
                             point_buffer_ = std::move(point_buffer);
                           });
+  if (polyline.points->size() == 0) {
+    return output;
+  }
 
   output.reserve(polyline.points->size() +
                  (4 * (polyline.contours.size() - 1)));

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -480,6 +480,19 @@ TEST(TessellatorTest, FilledRoundRectTessellationVertices) {
        Rect::MakeXYWH(5000, 10000, 2000, 3000), {50, 70});
 }
 
+TEST(TessellatorTest, EarlyReturnEmptyConvexShape) {
+  // This path is not technically empty (it has a size in one dimension),
+  // but is otherwise completely flat.
+  auto tessellator = std::make_shared<Tessellator>();
+  PathBuilder builder;
+  builder.MoveTo({0, 0});
+  builder.MoveTo({10, 10}, /*relative=*/true);
+
+  auto points = tessellator->TessellateConvex(builder.TakePath(), 3.0);
+
+  EXPECT_TRUE(points.empty());
+}
+
 #if !NDEBUG
 TEST(TessellatorTest, ChecksConcurrentPolylineUsage) {
   auto tessellator = std::make_shared<Tessellator>();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/146362

Sometimes we can have effectively zero area in a way that doesn't seem to register with the Skia bounding box logic we're using. Add a sanity check for zero points in the polyline.