### PR TITLE
[et] Run GN before looking for targets. Default to build config targets

### DIFF
--- a/tools/engine_tool/lib/src/commands/query_command.dart
+++ b/tools/engine_tool/lib/src/commands/query_command.dart
@@ -2,11 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:engine_build_configs/engine_build_configs.dart';
-
-import 'package:path/path.dart' as p;
 
 import '../build_utils.dart';
 import '../gn_utils.dart';
@@ -180,15 +176,24 @@ et query targets //flutter/fml/...  # List all targets under `//flutter/fml`
       environment.logger.error('Could not find config $configName');
       return 1;
     }
-    final Map<String, BuildTarget> allTargets = await findTargets(environment,
-        Directory(p.join(environment.engine.outDir.path, build.ninja.config)));
-    final Set<BuildTarget> selectedTargets =
-        selectTargets(argResults!.rest, allTargets);
-    if (selectedTargets.isEmpty) {
-      environment.logger.error(
-          'No build targets matched ${argResults!.rest}\nRun `et query targets` to see list of targets.');
+
+    final List<BuildTarget>? selectedTargets = await targetsFromCommandLine(
+      environment,
+      build,
+      argResults!.rest,
+      defaultToAll: true,
+    );
+    if (selectedTargets == null) {
+      // The user typed something wrong and targetsFromCommandLine has already
+      // logged the error message.
       return 1;
     }
+    if (selectedTargets.isEmpty) {
+      environment.logger.fatal(
+        'targetsFromCommandLine unexpectedly returned an empty list',
+      );
+    }
+
     for (final BuildTarget target in selectedTargets) {
       if (testOnly &&
           (!target.testOnly || target.type != BuildTargetType.executable)) {

--- a/tools/engine_tool/test/query_command_test.dart
+++ b/tools/engine_tool/test/query_command_test.dart
@@ -3,11 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:convert' as convert;
-import 'dart:ffi' as ffi show Abi;
-import 'dart:io' as io;
 
 import 'package:engine_build_configs/engine_build_configs.dart';
-import 'package:engine_repo_tools/engine_repo_tools.dart';
 import 'package:engine_tool/src/commands/command_runner.dart';
 import 'package:engine_tool/src/environment.dart';
 import 'package:litetest/litetest.dart';
@@ -18,15 +15,6 @@ import 'fixtures.dart' as fixtures;
 import 'utils.dart';
 
 void main() {
-  final Engine engine;
-  try {
-    engine = Engine.findWithin();
-  } catch (e) {
-    io.stderr.writeln(e);
-    io.exitCode = 1;
-    return;
-  }
-
   final BuilderConfig linuxTestConfig = BuilderConfig.fromJson(
     path: 'ci/builders/linux_test_config.json',
     map: convert.jsonDecode(fixtures.testConfig('Linux', Platform.linux))
@@ -62,54 +50,21 @@ void main() {
   ];
 
   test('query command returns builds for the host platform.', () async {
-    final TestEnvironment testEnvironment = TestEnvironment(engine,
-        abi: ffi.Abi.linuxX64, cannedProcesses: cannedProcesses);
-    final Environment env = testEnvironment.environment;
-    final ToolCommandRunner runner = ToolCommandRunner(
-      environment: env,
-      configs: configs,
+    final TestEnvironment testEnvironment = TestEnvironment.withTestEngine(
+      cannedProcesses: cannedProcesses,
     );
-    final int result = await runner.run(<String>[
-      'query',
-      'builders',
-    ]);
-    expect(result, equals(0));
-    expect(
-      stringsFromLogs(env.logger.testLogs),
-      equals(<String>[
-        'Add --verbose to see detailed information about each builder\n',
-        '\n',
-        '"linux_test_config" builder:\n',
-        '   "ci/build_name" config\n',
-        '   "linux/host_debug" config\n',
-        '   "linux/android_debug_arm64" config\n',
-        '   "ci/android_debug_rbe_arm64" config\n',
-        '"linux_test_config2" builder:\n',
-        '   "ci/build_name" config\n',
-        '   "linux/host_debug" config\n',
-        '   "linux/android_debug_arm64" config\n',
-        '   "ci/android_debug_rbe_arm64" config\n',
-      ]),
-    );
-  });
-
-  test('query command with --builder returns only from the named builder.',
-      () async {
-    final TestEnvironment testEnvironment = TestEnvironment(engine,
-        abi: ffi.Abi.linuxX64, cannedProcesses: cannedProcesses);
-    final Environment env = testEnvironment.environment;
-    final ToolCommandRunner runner = ToolCommandRunner(
-      environment: env,
-      configs: configs,
-    );
-    final int result = await runner.run(<String>[
-      'query',
-      'builders',
-      '--builder',
-      'linux_test_config',
-    ]);
-    expect(result, equals(0));
-    expect(
+    try {
+      final Environment env = testEnvironment.environment;
+      final ToolCommandRunner runner = ToolCommandRunner(
+        environment: env,
+        configs: configs,
+      );
+      final int result = await runner.run(<String>[
+        'query',
+        'builders',
+      ]);
+      expect(result, equals(0));
+      expect(
         stringsFromLogs(env.logger.testLogs),
         equals(<String>[
           'Add --verbose to see detailed information about each builder\n',
@@ -119,47 +74,100 @@ void main() {
           '   "linux/host_debug" config\n',
           '   "linux/android_debug_arm64" config\n',
           '   "ci/android_debug_rbe_arm64" config\n',
-        ]));
+          '"linux_test_config2" builder:\n',
+          '   "ci/build_name" config\n',
+          '   "linux/host_debug" config\n',
+          '   "linux/android_debug_arm64" config\n',
+          '   "ci/android_debug_rbe_arm64" config\n',
+        ]),
+      );
+    } finally {
+      testEnvironment.cleanup();
+    }
+  });
+
+  test('query command with --builder returns only from the named builder.',
+      () async {
+    final TestEnvironment testEnvironment = TestEnvironment.withTestEngine(
+      cannedProcesses: cannedProcesses,
+    );
+    try {
+      final Environment env = testEnvironment.environment;
+      final ToolCommandRunner runner = ToolCommandRunner(
+        environment: env,
+        configs: configs,
+      );
+      final int result = await runner.run(<String>[
+        'query',
+        'builders',
+        '--builder',
+        'linux_test_config',
+      ]);
+      expect(result, equals(0));
+      expect(
+          stringsFromLogs(env.logger.testLogs),
+          equals(<String>[
+            'Add --verbose to see detailed information about each builder\n',
+            '\n',
+            '"linux_test_config" builder:\n',
+            '   "ci/build_name" config\n',
+            '   "linux/host_debug" config\n',
+            '   "linux/android_debug_arm64" config\n',
+            '   "ci/android_debug_rbe_arm64" config\n',
+          ]));
+    } finally {
+      testEnvironment.cleanup();
+    }
   });
 
   test('query command with --all returns all builds.', () async {
-    final TestEnvironment testEnvironment = TestEnvironment(engine,
-        abi: ffi.Abi.linuxX64, cannedProcesses: cannedProcesses);
-    final Environment env = testEnvironment.environment;
-    final ToolCommandRunner runner = ToolCommandRunner(
-      environment: env,
-      configs: configs,
+    final TestEnvironment testEnvironment = TestEnvironment.withTestEngine(
+      cannedProcesses: cannedProcesses,
     );
-    final int result = await runner.run(<String>[
-      'query',
-      'builders',
-      '--all',
-    ]);
-    expect(result, equals(0));
-    expect(
-      env.logger.testLogs.length,
-      equals(30),
-    );
+    try {
+      final Environment env = testEnvironment.environment;
+      final ToolCommandRunner runner = ToolCommandRunner(
+        environment: env,
+        configs: configs,
+      );
+      final int result = await runner.run(<String>[
+        'query',
+        'builders',
+        '--all',
+      ]);
+      expect(result, equals(0));
+      expect(
+        env.logger.testLogs.length,
+        equals(30),
+      );
+    } finally {
+      testEnvironment.cleanup();
+    }
   });
 
   test('query targets', () async {
-    final TestEnvironment testEnvironment = TestEnvironment(engine,
-        abi: ffi.Abi.linuxX64, cannedProcesses: cannedProcesses);
-    final Environment env = testEnvironment.environment;
-    final ToolCommandRunner runner = ToolCommandRunner(
-      environment: env,
-      configs: configs,
+    final TestEnvironment testEnvironment = TestEnvironment.withTestEngine(
+      cannedProcesses: cannedProcesses,
     );
-    final int result = await runner.run(<String>[
-      'query',
-      'targets',
-    ]);
-    expect(result, equals(0));
-    expect(
-      env.logger.testLogs.length,
-      equals(3),
-    );
-    expect(env.logger.testLogs[0].message,
-        startsWith('//flutter/display_list:display_list_unittests'));
+    try {
+      final Environment env = testEnvironment.environment;
+      final ToolCommandRunner runner = ToolCommandRunner(
+        environment: env,
+        configs: configs,
+      );
+      final int result = await runner.run(<String>[
+        'query',
+        'targets',
+      ]);
+      expect(result, equals(0));
+      expect(
+        env.logger.testLogs.length,
+        equals(4),
+      );
+      expect(env.logger.testLogs[1].message,
+          startsWith('//flutter/display_list:display_list_unittests'));
+    } finally {
+      testEnvironment.cleanup();
+    }
   });
 }


### PR DESCRIPTION
Addresses the notes I left on https://github.com/flutter/engine/pull/51868. Mainly fixes an issue in which the `build`, `query`, and `test` commands would fail if GN had not yet been run for the requested configuration. Instead, in this PR, if the build output directory doesn't exist yet, then it will run GN before querying the targets.

Additionally, for the `build` command, if no targets are specified on the command line, the PR uses the targets in the build config as the default rather than all targets. `query` and `test` keep the same behavior.