### PR TITLE
better output from engine layer unit test failures

### DIFF
--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -15,6 +15,7 @@
 
 #include "flutter/flow/testing/mock_raster_cache.h"
 #include "flutter/fml/macros.h"
+#include "flutter/testing/assertions_skia.h"
 #include "flutter/testing/canvas_test.h"
 #include "flutter/testing/display_list_testing.h"
 #include "flutter/testing/mock_canvas.h"


### PR DESCRIPTION
The engine has ostream conversions for most Skia objects, but none of the test files include the files where they are defined. Adding the include file to the `layer_test.h` file will include them on any file which does unit testing on the engine layers.