### PR TITLE
Update iOS KeyCodeMap dictionary literal and migrate to ARC

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -68,6 +68,8 @@ source_set("flutter_framework_source_arc") {
     "framework/Source/FlutterTextInputPlugin.mm",
     "framework/Source/FlutterTextureRegistryRelay.h",
     "framework/Source/FlutterTextureRegistryRelay.mm",
+    "framework/Source/KeyCodeMap.g.mm",
+    "framework/Source/KeyCodeMap_Internal.h",
     "framework/Source/UIViewController+FlutterScreenAndSceneIfLoaded.h",
     "framework/Source/UIViewController+FlutterScreenAndSceneIfLoaded.mm",
   ]
@@ -129,8 +131,6 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterView.mm",
     "framework/Source/FlutterViewController.mm",
     "framework/Source/FlutterViewController_Internal.h",
-    "framework/Source/KeyCodeMap.g.mm",
-    "framework/Source/KeyCodeMap_Internal.h",
     "framework/Source/SemanticsObject.h",
     "framework/Source/SemanticsObject.mm",
     "framework/Source/accessibility_bridge.h",

--- a/shell/platform/darwin/ios/framework/Source/KeyCodeMap.g.mm
+++ b/shell/platform/darwin/ios/framework/Source/KeyCodeMap.g.mm
@@ -329,7 +329,7 @@ const std::set<uint32_t> functionKeyCodes = {
 };
 
 API_AVAILABLE(ios(13.4))
-NSDictionary<NSString*, NSNumber*>* specialKeyMapping = [[NSDictionary alloc] initWithDictionary:@{
+NSDictionary<NSString*, NSNumber*>* specialKeyMapping = @{
   @"UIKeyInputEscape" : @(0x10000001b),
   @"UIKeyInputF1" : @(0x100000801),
   @"UIKeyInputF2" : @(0x100000802),
@@ -351,7 +351,7 @@ NSDictionary<NSString*, NSNumber*>* specialKeyMapping = [[NSDictionary alloc] in
   @"UIKeyInputEnd" : @(0x10000000d),
   @"UIKeyInputPageUp" : @(0x100000308),
   @"UIKeyInputPageDown" : @(0x100000307),
-}];
+};
 
 const uint64_t kCapsLockPhysicalKey = 0x00070039;
 const uint64_t kCapsLockLogicalKey = 0x100000104;


### PR DESCRIPTION
Framework template updated in https://github.com/flutter/flutter/pull/146481.  See [gen_keycodes README](https://github.com/flutter/flutter/tree/master/dev/tools/gen_keycodes ) for details.

Fixes https://github.com/flutter/flutter/issues/146480 `-Wobjc-redundant-literal-use` error.

Note `-Wobjc-redundant-literal-use` is already on for clang-tidy 
https://github.com/flutter/engine/blob/6dc91bff96a56513a57ed5dd036fb16d25c945fd/.clang-tidy#L13 but in this case it's only true triggered when the file is compiled with ARC.  When I migrated this file to ARC as part of https://github.com/flutter/flutter/issues/137801, it triggered the error.