### PR TITLE
Migrate FlutterCallbackCache and FlutterKeyboardManager to ARC

### DIFF
--- a/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
@@ -168,7 +168,7 @@ FLUTTER_ASSERT_ARC
   [binaryMessenger stopMocking];
 }
 
-- (bool)testSetWarnsOnOverflow {
+- (void)testSetWarnsOnOverflow {
   NSString* channelName = @"flutter/test";
   id binaryMessenger = OCMStrictProtocolMock(@protocol(FlutterBinaryMessenger));
   id codec = OCMProtocolMock(@protocol(FlutterMethodCodec));

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -59,10 +59,14 @@ source_set("flutter_framework_source_arc") {
   public_configs = [ "//flutter:config" ]
 
   sources = [
+    "framework/Source/FlutterCallbackCache.mm",
+    "framework/Source/FlutterCallbackCache_Internal.h",
     "framework/Source/FlutterEmbedderKeyResponder.h",
     "framework/Source/FlutterEmbedderKeyResponder.mm",
     "framework/Source/FlutterKeyPrimaryResponder.h",
     "framework/Source/FlutterKeySecondaryResponder.h",
+    "framework/Source/FlutterKeyboardManager.h",
+    "framework/Source/FlutterKeyboardManager.mm",
     "framework/Source/FlutterMetalLayer.h",
     "framework/Source/FlutterMetalLayer.mm",
     "framework/Source/FlutterRestorationPlugin.h",
@@ -83,7 +87,10 @@ source_set("flutter_framework_source_arc") {
     "IOSurface.framework",
   ]
 
-  deps += [ "//flutter/shell/platform/embedder:embedder_as_internal_library" ]
+  deps += [
+    "//flutter/lib/ui",
+    "//flutter/shell/platform/embedder:embedder_as_internal_library",
+  ]
 }
 
 source_set("flutter_framework_source") {
@@ -98,8 +105,6 @@ source_set("flutter_framework_source") {
     # New files are highly encouraged to be in ARC.
     # To add new files in ARC, add them to the `flutter_framework_source_arc` target.
     "framework/Source/FlutterAppDelegate.mm",
-    "framework/Source/FlutterCallbackCache.mm",
-    "framework/Source/FlutterCallbackCache_Internal.h",
     "framework/Source/FlutterChannelKeyResponder.h",
     "framework/Source/FlutterChannelKeyResponder.mm",
     "framework/Source/FlutterDartProject.mm",
@@ -110,8 +115,6 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterEngineGroup.mm",
     "framework/Source/FlutterEngine_Internal.h",
     "framework/Source/FlutterHeadlessDartRunner.mm",
-    "framework/Source/FlutterKeyboardManager.h",
-    "framework/Source/FlutterKeyboardManager.mm",
     "framework/Source/FlutterOverlayView.h",
     "framework/Source/FlutterOverlayView.mm",
     "framework/Source/FlutterPlatformPlugin.h",

--- a/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm
@@ -7,15 +7,9 @@
 #include "flutter/fml/logging.h"
 #include "flutter/lib/ui/plugins/callback_cache.h"
 
+FLUTTER_ASSERT_ARC
+
 @implementation FlutterCallbackInformation
-
-- (void)dealloc {
-  [_callbackName release];
-  [_callbackClassName release];
-  [_callbackLibraryPath release];
-  [super dealloc];
-}
-
 @end
 
 @implementation FlutterCallbackCache
@@ -25,7 +19,7 @@
   if (info == nullptr) {
     return nil;
   }
-  FlutterCallbackInformation* new_info = [[[FlutterCallbackInformation alloc] init] autorelease];
+  FlutterCallbackInformation* new_info = [[FlutterCallbackInformation alloc] init];
   new_info.callbackName = [NSString stringWithUTF8String:info->name.c_str()];
   new_info.callbackClassName = [NSString stringWithUTF8String:info->class_name.c_str()];
   new_info.callbackLibraryPath = [NSString stringWithUTF8String:info->library_path.c_str()];

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
@@ -16,12 +16,13 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
 /**
  * The primary responders added by addPrimaryResponder.
  */
-@property(nonatomic, readonly) NSMutableArray<id<FlutterKeyPrimaryResponder>>* primaryResponders;
+@property(nonatomic, copy, readonly)
+    NSMutableArray<id<FlutterKeyPrimaryResponder>>* primaryResponders;
 
 /**
  * The secondary responders added by addSecondaryResponder.
  */
-@property(nonatomic, readonly)
+@property(nonatomic, copy, readonly)
     NSMutableArray<id<FlutterKeySecondaryResponder>>* secondaryResponders;
 
 - (void)dispatchToSecondaryResponders:(nonnull FlutterUIPressProxy*)press
@@ -47,11 +48,6 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
 
 - (void)addSecondaryResponder:(nonnull id<FlutterKeySecondaryResponder>)responder {
   [_secondaryResponders addObject:responder];
-}
-
-- (void)dealloc {
-  [_primaryResponders removeAllObjects];
-  [_secondaryResponders removeAllObjects];
 }
 
 - (void)handlePress:(nonnull FlutterUIPressProxy*)press

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
@@ -3,8 +3,11 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.h"
+
 #include "flutter/fml/platform/darwin/message_loop_darwin.h"
-#include "flutter/fml/platform/darwin/weak_nsobject.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+
+FLUTTER_ASSERT_ARC
 
 static constexpr CFTimeInterval kDistantFuture = 1.0e10;
 
@@ -28,16 +31,13 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
 
 @end
 
-@implementation FlutterKeyboardManager {
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterKeyboardManager>> _weakFactory;
-}
+@implementation FlutterKeyboardManager
 
 - (nonnull instancetype)init {
   self = [super init];
   if (self != nil) {
     _primaryResponders = [[NSMutableArray alloc] init];
     _secondaryResponders = [[NSMutableArray alloc] init];
-    _weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterKeyboardManager>>(self);
   }
   return self;
 }
@@ -51,21 +51,8 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
 }
 
 - (void)dealloc {
-  // It will be destroyed and invalidate its weak pointers
-  // before any other members are destroyed.
-  _weakFactory.reset();
-
   [_primaryResponders removeAllObjects];
   [_secondaryResponders removeAllObjects];
-  [_primaryResponders release];
-  [_secondaryResponders release];
-  _primaryResponders = nil;
-  _secondaryResponders = nil;
-  [super dealloc];
-}
-
-- (fml::WeakNSObject<FlutterKeyboardManager>)getWeakNSObject {
-  return _weakFactory->GetWeakNSObject();
 }
 
 - (void)handlePress:(nonnull FlutterUIPressProxy*)press
@@ -89,7 +76,7 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
       // encounter.
       NSAssert([_primaryResponders count] >= 0, @"At least one primary responder must be added.");
 
-      __block auto weakSelf = [self getWeakNSObject];
+      __block __weak __typeof(self) weakSelf = self;
       __block NSUInteger unreplied = [self.primaryResponders count];
       __block BOOL anyHandled = false;
       FlutterAsyncKeyCallback replyCallback = ^(BOOL handled) {
@@ -98,7 +85,7 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
         anyHandled = anyHandled || handled;
         if (unreplied == 0) {
           if (!anyHandled && weakSelf) {
-            [weakSelf.get() dispatchToSecondaryResponders:press complete:completeCallback];
+            [weakSelf dispatchToSecondaryResponders:press complete:completeCallback];
           } else {
             completeCallback(true, press);
           }

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.mm
@@ -16,13 +16,12 @@ static constexpr CFTimeInterval kDistantFuture = 1.0e10;
 /**
  * The primary responders added by addPrimaryResponder.
  */
-@property(nonatomic, retain, readonly)
-    NSMutableArray<id<FlutterKeyPrimaryResponder>>* primaryResponders;
+@property(nonatomic, readonly) NSMutableArray<id<FlutterKeyPrimaryResponder>>* primaryResponders;
 
 /**
  * The secondary responders added by addSecondaryResponder.
  */
-@property(nonatomic, retain, readonly)
+@property(nonatomic, readonly)
     NSMutableArray<id<FlutterKeySecondaryResponder>>* secondaryResponders;
 
 - (void)dispatchToSecondaryResponders:(nonnull FlutterUIPressProxy*)press

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
@@ -6,9 +6,7 @@
 #import <OCMock/OCMock.h>
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
-#include <_types/_uint32_t.h>
 
-#include "flutter/fml/platform/darwin/message_loop_darwin.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFakeKeyEvents.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManager.h"
@@ -17,364 +15,253 @@
 
 FLUTTER_ASSERT_ARC;
 
-namespace flutter {
-class PointerDataPacket {};
-}  // namespace flutter
-
 using namespace flutter::testing;
 
-/// Sometimes we have to use a custom mock to avoid retain cycles in ocmock.
-@interface FlutterEnginePartialMock : FlutterEngine
-@property(nonatomic, strong) FlutterBasicMessageChannel* lifecycleChannel;
-@property(nonatomic, weak) FlutterViewController* viewController;
-@property(nonatomic, assign) BOOL didCallNotifyLowMemory;
-@end
-
-@interface FlutterEngine ()
-- (BOOL)createShell:(NSString*)entrypoint
-         libraryURI:(NSString*)libraryURI
-       initialRoute:(NSString*)initialRoute;
-- (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
-@end
-
-@interface FlutterEngine (TestLowMemory)
-- (void)notifyLowMemory;
-@end
-
-extern NSNotificationName const FlutterViewControllerWillDealloc;
-
-/// A simple mock class for FlutterEngine.
-///
-/// OCMockClass can't be used for FlutterEngine sometimes because OCMock retains arguments to
-/// invocations and since the init for FlutterViewController calls a method on the
-/// FlutterEngine it creates a retain cycle that stops us from testing behaviors related to
-/// deleting FlutterViewControllers.
-@interface MockEngine : NSObject
-@end
-
-@interface FlutterKeyboardManagerUnittestsObjC : NSObject
-- (bool)nextResponderShouldThrowOnPressesEnded;
-- (bool)singlePrimaryResponder;
-- (bool)doublePrimaryResponder;
-- (bool)singleSecondaryResponder;
-- (bool)emptyNextResponder;
-@end
-
-namespace {
-
-typedef void (^KeyCallbackSetter)(FlutterUIPressProxy* press, FlutterAsyncKeyCallback callback)
-    API_AVAILABLE(ios(13.4));
-typedef BOOL (^BoolGetter)();
-
-}  // namespace
-
+// These tests were designed to run on iOS 13.4 or later.
+API_AVAILABLE(ios(13.4))
 @interface FlutterKeyboardManagerTest : XCTestCase
-@property(nonatomic, strong) id mockEngine;
-- (FlutterViewController*)mockOwnerWithPressesBeginOnlyNext API_AVAILABLE(ios(13.4));
 @end
 
 @implementation FlutterKeyboardManagerTest
 
-- (void)setUp {
-  // All of these tests were designed to run on iOS 13.4 or later.
-  if (@available(iOS 13.4, *)) {
-  } else {
-    XCTSkip(@"Required API not present for test.");
-  }
-
-  [super setUp];
-  self.mockEngine = OCMClassMock([FlutterEngine class]);
-}
-
-- (void)tearDown {
-  // We stop mocking here to avoid retain cycles that stop
-  // FlutterViewControllers from deallocing.
-  [self.mockEngine stopMocking];
-  self.mockEngine = nil;
-  [super tearDown];
-}
-
-- (id)checkKeyDownEvent:(UIKeyboardHIDUsage)keyCode API_AVAILABLE(ios(13.4)) {
-  return [OCMArg checkWithBlock:^BOOL(id value) {
-    if (![value isKindOfClass:[FlutterUIPressProxy class]]) {
-      return NO;
-    }
-    FlutterUIPressProxy* press = value;
-    return press.key.keyCode == keyCode;
-  }];
-}
-
-- (id<FlutterKeyPrimaryResponder>)mockPrimaryResponder:(KeyCallbackSetter)callbackSetter
-    API_AVAILABLE(ios(13.4)) {
-  id<FlutterKeyPrimaryResponder> mock =
-      OCMStrictProtocolMock(@protocol(FlutterKeyPrimaryResponder));
-  OCMStub([mock handlePress:[OCMArg any] callback:[OCMArg any]])
-      .andDo((^(NSInvocation* invocation) {
-        FlutterUIPressProxy* press;
-        FlutterAsyncKeyCallback callback;
-        [invocation getArgument:&press atIndex:2];
-        [invocation getArgument:&callback atIndex:3];
-        CFRunLoopPerformBlock(CFRunLoopGetCurrent(),
-                              fml::MessageLoopDarwin::kMessageLoopCFRunLoopMode, ^() {
-                                callbackSetter(press, callback);
-                              });
-      }));
-  return mock;
-}
-
-- (id<FlutterKeySecondaryResponder>)mockSecondaryResponder:(BoolGetter)resultGetter
-    API_AVAILABLE(ios(13.4)) {
-  id<FlutterKeySecondaryResponder> mock =
-      OCMStrictProtocolMock(@protocol(FlutterKeySecondaryResponder));
-  OCMStub([mock handlePress:[OCMArg any]]).andDo((^(NSInvocation* invocation) {
-    BOOL result = resultGetter();
-    [invocation setReturnValue:&result];
-  }));
-  return mock;
-}
-
-- (FlutterViewController*)mockOwnerWithPressesBeginOnlyNext API_AVAILABLE(ios(13.4)) {
+- (void)testNextResponderShouldThrowOnPressesEnded {
   // The nextResponder is a strict mock and hasn't stubbed pressesEnded.
   // An error will be thrown on pressesEnded.
   UIResponder* nextResponder = OCMStrictClassMock([UIResponder class]);
-  OCMStub([nextResponder pressesBegan:[OCMArg any] withEvent:[OCMArg any]]).andDo(nil);
+  OCMStub([nextResponder pressesBegan:OCMOCK_ANY withEvent:OCMOCK_ANY]);
 
-  FlutterViewController* viewController =
-      [[FlutterViewController alloc] initWithEngine:self.mockEngine nibName:nil bundle:nil];
+  id mockEngine = OCMClassMock([FlutterEngine class]);
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
   FlutterViewController* owner = OCMPartialMock(viewController);
   OCMStub([owner nextResponder]).andReturn(nextResponder);
-  return owner;
+
+  XCTAssertThrowsSpecificNamed([owner.nextResponder pressesEnded:[[NSSet alloc] init]
+                                                       withEvent:[[UIPressesEvent alloc] init]],
+                               NSException, NSInternalInconsistencyException);
+
+  [mockEngine stopMocking];
 }
 
-// Verify that the nextResponder returned from mockOwnerWithPressesBeginOnlyNext()
-// throws exception when pressesEnded is called.
-- (bool)testNextResponderShouldThrowOnPressesEnded API_AVAILABLE(ios(13.4)) {
-  FlutterViewController* owner = [self mockOwnerWithPressesBeginOnlyNext];
-  @try {
-    [owner.nextResponder pressesEnded:[NSSet init] withEvent:[[UIPressesEvent alloc] init]];
-    return false;
-  } @catch (...) {
-    return true;
-  }
-}
+- (void)testSinglePrimaryResponder {
+  const UIKeyboardHIDUsage keyId = (UIKeyboardHIDUsage)0x50;
 
-- (void)testSinglePrimaryResponder API_AVAILABLE(ios(13.4)) {
   FlutterKeyboardManager* manager = [[FlutterKeyboardManager alloc] init];
-  __block BOOL primaryResponse = FALSE;
-  __block int callbackCount = 0;
-  [manager addPrimaryResponder:[self mockPrimaryResponder:^(FlutterUIPressProxy* press,
-                                                            FlutterAsyncKeyCallback callback) {
-             callbackCount++;
-             callback(primaryResponse);
-           }]];
-  constexpr UIKeyboardHIDUsage keyId = (UIKeyboardHIDUsage)0x50;
-  // Case: The responder reports TRUE
-  __block bool completeHandled = true;
-  primaryResponse = TRUE;
+  id mockPrimaryResponder = OCMStrictProtocolMock(@protocol(FlutterKeyPrimaryResponder));
+  [manager addPrimaryResponder:mockPrimaryResponder];
+
+  // Case: The responder reports that is has handled the event (callback returns YES), and the
+  // manager should NOT call next action.
+  [[mockPrimaryResponder expect] handlePress:OCMOCK_ANY
+                                    callback:[OCMArg invokeBlockWithArgs:@YES, nil]];
+
+  XCTestExpectation* expectationPrimaryHandled =
+      [self expectationWithDescription:@"primary responder handled"];
+  expectationPrimaryHandled.inverted = YES;  // Fail if the manager "next action" is called.
   [manager handlePress:keyDownEvent(keyId)
             nextAction:^() {
-              completeHandled = false;
+              [expectationPrimaryHandled fulfill];
+              XCTFail();
             }];
-  XCTAssertEqual(callbackCount, 1);
-  XCTAssertTrue(completeHandled);
-  completeHandled = true;
-  callbackCount = 0;
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
 
-  // Case: The responder reports FALSE
-  primaryResponse = FALSE;
+  // Case: The responder reports that is has NOT handled the event (callback returns NO), and the
+  // manager SHOULD not call next action.
+  [[mockPrimaryResponder expect] handlePress:OCMOCK_ANY
+                                    callback:[OCMArg invokeBlockWithArgs:@NO, nil]];
+  id expectationPrimaryNotHandled =
+      [self expectationWithDescription:@"primary responder not handled"];
   [manager handlePress:keyUpEvent(keyId)
             nextAction:^() {
-              completeHandled = false;
+              [expectationPrimaryNotHandled fulfill];
             }];
-  XCTAssertEqual(callbackCount, 1);
-  XCTAssertFalse(completeHandled);
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
-- (void)testDoublePrimaryResponder API_AVAILABLE(ios(13.4)) {
+- (void)testDoublePrimaryResponder {
+  const UIKeyboardHIDUsage keyId = (UIKeyboardHIDUsage)0x50;
+
   FlutterKeyboardManager* manager = [[FlutterKeyboardManager alloc] init];
+  id mockPrimaryResponder1 = OCMStrictProtocolMock(@protocol(FlutterKeyPrimaryResponder));
+  id mockPrimaryResponder2 = OCMStrictProtocolMock(@protocol(FlutterKeyPrimaryResponder));
+  [manager addPrimaryResponder:mockPrimaryResponder1];
+  [manager addPrimaryResponder:mockPrimaryResponder2];
 
-  __block BOOL callback1Response = FALSE;
-  __block int callback1Count = 0;
-  [manager addPrimaryResponder:[self mockPrimaryResponder:^(FlutterUIPressProxy* press,
-                                                            FlutterAsyncKeyCallback callback) {
-             callback1Count++;
-             callback(callback1Response);
-           }]];
+  // Case: Both responders report they have handled the event (callbacks returns YES), and the
+  // manager should NOT call next action.
+  [[mockPrimaryResponder1 expect] handlePress:OCMOCK_ANY
+                                     callback:[OCMArg invokeBlockWithArgs:@YES, nil]];
+  [[mockPrimaryResponder2 expect] handlePress:OCMOCK_ANY
+                                     callback:[OCMArg invokeBlockWithArgs:@YES, nil]];
 
-  __block BOOL callback2Response = FALSE;
-  __block int callback2Count = 0;
-  [manager addPrimaryResponder:[self mockPrimaryResponder:^(FlutterUIPressProxy* press,
-                                                            FlutterAsyncKeyCallback callback) {
-             callback2Count++;
-             callback(callback2Response);
-           }]];
-
-  // Case: Both responders report TRUE.
-  __block bool somethingWasHandled = true;
-  constexpr UIKeyboardHIDUsage keyId = (UIKeyboardHIDUsage)0x50;
-  callback1Response = TRUE;
-  callback2Response = TRUE;
-  [manager handlePress:keyUpEvent(keyId)
-            nextAction:^() {
-              somethingWasHandled = false;
-            }];
-  XCTAssertEqual(callback1Count, 1);
-  XCTAssertEqual(callback2Count, 1);
-  XCTAssertTrue(somethingWasHandled);
-
-  somethingWasHandled = true;
-  callback1Count = 0;
-  callback2Count = 0;
-
-  // Case: One responder reports TRUE.
-  callback1Response = TRUE;
-  callback2Response = FALSE;
-  [manager handlePress:keyUpEvent(keyId)
-            nextAction:^() {
-              somethingWasHandled = false;
-            }];
-  XCTAssertEqual(callback1Count, 1);
-  XCTAssertEqual(callback2Count, 1);
-  XCTAssertTrue(somethingWasHandled);
-
-  somethingWasHandled = true;
-  callback1Count = 0;
-  callback2Count = 0;
-
-  // Case: Both responders report FALSE.
-  callback1Response = FALSE;
-  callback2Response = FALSE;
+  XCTestExpectation* expectationBothPrimariesHandled =
+      [self expectationWithDescription:@"both primary responders handled"];
+  expectationBothPrimariesHandled.inverted = YES;  // Fail if the manager "next action" is called.
   [manager handlePress:keyDownEvent(keyId)
             nextAction:^() {
-              somethingWasHandled = false;
+              [expectationBothPrimariesHandled fulfill];
+              XCTFail();
             }];
-  XCTAssertEqual(callback1Count, 1);
-  XCTAssertEqual(callback2Count, 1);
-  XCTAssertFalse(somethingWasHandled);
-}
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  OCMVerifyAll(mockPrimaryResponder1);
+  OCMVerifyAll(mockPrimaryResponder2);
 
-- (void)testSingleSecondaryResponder API_AVAILABLE(ios(13.4)) {
-  FlutterKeyboardManager* manager = [[FlutterKeyboardManager alloc] init];
+  // Case: Only one responder reports it has handled the event (callback returns YES), and the
+  // manager should NOT call next action.
+  [[mockPrimaryResponder1 expect] handlePress:OCMOCK_ANY
+                                     callback:[OCMArg invokeBlockWithArgs:@YES, nil]];
+  [[mockPrimaryResponder2 expect] handlePress:OCMOCK_ANY
+                                     callback:[OCMArg invokeBlockWithArgs:@NO, nil]];
 
-  __block BOOL primaryResponse = FALSE;
-  __block int callbackCount = 0;
-  [manager addPrimaryResponder:[self mockPrimaryResponder:^(FlutterUIPressProxy* press,
-                                                            FlutterAsyncKeyCallback callback) {
-             callbackCount++;
-             callback(primaryResponse);
-           }]];
-
-  __block BOOL secondaryResponse;
-  [manager addSecondaryResponder:[self mockSecondaryResponder:^() {
-             return secondaryResponse;
-           }]];
-
-  // Case: Primary responder responds TRUE. The event shouldn't be handled by
-  // the secondary responder.
-  constexpr UIKeyboardHIDUsage keyId = (UIKeyboardHIDUsage)0x50;
-  secondaryResponse = FALSE;
-  primaryResponse = TRUE;
-  __block bool completeHandled = true;
-  [manager handlePress:keyUpEvent(keyId)
-            nextAction:^() {
-              completeHandled = false;
-            }];
-  XCTAssertEqual(callbackCount, 1);
-  XCTAssertTrue(completeHandled);
-  completeHandled = true;
-  callbackCount = 0;
-
-  // Case: Primary responder responds FALSE. The secondary responder returns
-  // TRUE.
-  secondaryResponse = TRUE;
-  primaryResponse = FALSE;
-  [manager handlePress:keyUpEvent(keyId)
-            nextAction:^() {
-              completeHandled = false;
-            }];
-  XCTAssertEqual(callbackCount, 1);
-  XCTAssertTrue(completeHandled);
-  completeHandled = true;
-  callbackCount = 0;
-
-  // Case: Primary responder responds FALSE. The secondary responder returns FALSE.
-  secondaryResponse = FALSE;
-  primaryResponse = FALSE;
+  XCTestExpectation* expectationOnePrimaryHandled =
+      [self expectationWithDescription:@"one primary responder handled"];
+  expectationOnePrimaryHandled.inverted = YES;  // Fail if the manager "next action" is called.
   [manager handlePress:keyDownEvent(keyId)
             nextAction:^() {
-              completeHandled = false;
+              [expectationOnePrimaryHandled fulfill];
+              XCTFail();
             }];
-  XCTAssertEqual(callbackCount, 1);
-  XCTAssertFalse(completeHandled);
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  OCMVerifyAll(mockPrimaryResponder1);
+  OCMVerifyAll(mockPrimaryResponder2);
+
+  // Case: Both responders report they have NOT handled the event (callbacks returns NO), and the
+  // manager SHOULD not call next action.
+  [[mockPrimaryResponder1 expect] handlePress:OCMOCK_ANY
+                                     callback:[OCMArg invokeBlockWithArgs:@NO, nil]];
+  [[mockPrimaryResponder2 expect] handlePress:OCMOCK_ANY
+                                     callback:[OCMArg invokeBlockWithArgs:@NO, nil]];
+  id expectationPrimariesNotHandled =
+      [self expectationWithDescription:@"primary responders not handled"];
+  [manager handlePress:keyUpEvent(keyId)
+            nextAction:^() {
+              [expectationPrimariesNotHandled fulfill];
+            }];
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  OCMVerifyAll(mockPrimaryResponder1);
+  OCMVerifyAll(mockPrimaryResponder2);
 }
 
-- (void)testEventsProcessedSequentially API_AVAILABLE(ios(13.4)) {
-  constexpr UIKeyboardHIDUsage keyId1 = (UIKeyboardHIDUsage)0x50;
-  constexpr UIKeyboardHIDUsage keyId2 = (UIKeyboardHIDUsage)0x51;
+- (void)testPrimaryResponderHandlesNotSecondaryResponder {
+  const UIKeyboardHIDUsage keyId = (UIKeyboardHIDUsage)0x50;
+
+  FlutterKeyboardManager* manager = [[FlutterKeyboardManager alloc] init];
+  id mockPrimaryResponder = OCMStrictProtocolMock(@protocol(FlutterKeyPrimaryResponder));
+  id mockSecondaryResponder = OCMStrictProtocolMock(@protocol(FlutterKeySecondaryResponder));
+  [manager addPrimaryResponder:mockPrimaryResponder];
+  [manager addSecondaryResponder:mockSecondaryResponder];
+
+  // Primary responder responds TRUE. The event shouldn't be handled by
+  // the secondary responder, and the manager should NOT call next action.
+  [[mockPrimaryResponder expect] handlePress:OCMOCK_ANY
+                                    callback:[OCMArg invokeBlockWithArgs:@YES, nil]];
+  OCMReject([mockSecondaryResponder handlePress:OCMOCK_ANY]);
+
+  XCTestExpectation* nextActionExpectation = [self expectationWithDescription:@"next action"];
+  nextActionExpectation.inverted = YES;  // Fail if the manager "next action" is called.
+  [manager handlePress:keyDownEvent(keyId)
+            nextAction:^() {
+              [nextActionExpectation fulfill];
+              XCTFail();
+            }];
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  OCMVerifyAll(mockPrimaryResponder);
+  OCMVerifyAll(mockSecondaryResponder);
+}
+
+- (void)testSecondaryResponderHandles {
+  const UIKeyboardHIDUsage keyId = (UIKeyboardHIDUsage)0x50;
+
+  FlutterKeyboardManager* manager = [[FlutterKeyboardManager alloc] init];
+  id mockPrimaryResponder = OCMStrictProtocolMock(@protocol(FlutterKeyPrimaryResponder));
+  id mockSecondaryResponder = OCMStrictProtocolMock(@protocol(FlutterKeySecondaryResponder));
+  [manager addPrimaryResponder:mockPrimaryResponder];
+  [manager addSecondaryResponder:mockSecondaryResponder];
+
+  // Primary responder responds TRUE. The event shouldn't be handled by
+  // the secondary responder, and the manager should NOT call next action.
+  [[mockPrimaryResponder expect] handlePress:OCMOCK_ANY
+                                    callback:[OCMArg invokeBlockWithArgs:@NO, nil]];
+  OCMExpect([mockSecondaryResponder handlePress:OCMOCK_ANY]).andReturn(YES);
+
+  XCTestExpectation* nextActionExpectation = [self expectationWithDescription:@"next action"];
+  nextActionExpectation.inverted = YES;  // Fail if the manager "next action" is called.
+  [manager handlePress:keyDownEvent(keyId)
+            nextAction:^() {
+              [nextActionExpectation fulfill];
+              XCTFail();
+            }];
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  OCMVerifyAll(mockPrimaryResponder);
+  OCMVerifyAll(mockSecondaryResponder);
+}
+
+- (void)testPrimaryAndSecondaryResponderDoNotHandle {
+  const UIKeyboardHIDUsage keyId = (UIKeyboardHIDUsage)0x50;
+
+  FlutterKeyboardManager* manager = [[FlutterKeyboardManager alloc] init];
+  id mockPrimaryResponder = OCMStrictProtocolMock(@protocol(FlutterKeyPrimaryResponder));
+  id mockSecondaryResponder = OCMStrictProtocolMock(@protocol(FlutterKeySecondaryResponder));
+  [manager addPrimaryResponder:mockPrimaryResponder];
+  [manager addSecondaryResponder:mockSecondaryResponder];
+
+  // Primary responder responds TRUE. The event shouldn't be handled by
+  // the secondary responder, and the manager should NOT call next action.
+  [[mockPrimaryResponder expect] handlePress:OCMOCK_ANY
+                                    callback:[OCMArg invokeBlockWithArgs:@NO, nil]];
+  OCMExpect([mockSecondaryResponder handlePress:OCMOCK_ANY]).andReturn(NO);
+
+  XCTestExpectation* nextActionExpectation = [self expectationWithDescription:@"next action"];
+  [manager handlePress:keyDownEvent(keyId)
+            nextAction:^() {
+              [nextActionExpectation fulfill];
+            }];
+  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  OCMVerifyAll(mockPrimaryResponder);
+  OCMVerifyAll(mockSecondaryResponder);
+}
+
+- (void)testEventsProcessedSequentially {
+  FlutterKeyboardManager* manager = [[FlutterKeyboardManager alloc] init];
+  id<FlutterKeyPrimaryResponder> mockPrimaryResponder =
+      OCMStrictProtocolMock(@protocol(FlutterKeyPrimaryResponder));
+  [manager addPrimaryResponder:mockPrimaryResponder];
+
+  const UIKeyboardHIDUsage keyId1 = (UIKeyboardHIDUsage)0x50;
   FlutterUIPressProxy* event1 = keyDownEvent(keyId1);
+  id expectationEvent1Primary = [self expectationWithDescription:@"event1 primary responder"];
+  OCMExpect([mockPrimaryResponder handlePress:event1 callback:OCMOCK_ANY])
+      .andDo((^(NSInvocation* invocation) {
+        [expectationEvent1Primary fulfill];
+      }));
+
+  const UIKeyboardHIDUsage keyId2 = (UIKeyboardHIDUsage)0x51;
   FlutterUIPressProxy* event2 = keyDownEvent(keyId2);
-  __block FlutterAsyncKeyCallback key1Callback;
-  __block FlutterAsyncKeyCallback key2Callback;
-  __block bool key1Handled = true;
-  __block bool key2Handled = true;
+  id expectationEvent2Primary = [self expectationWithDescription:@"event2 primary responder"];
+  OCMExpect([mockPrimaryResponder handlePress:event2 callback:OCMOCK_ANY])
+      .andDo((^(NSInvocation* invocation) {
+        [expectationEvent2Primary fulfill];
+      }));
 
-  FlutterKeyboardManager* manager = [[FlutterKeyboardManager alloc] init];
-  [manager addPrimaryResponder:[self mockPrimaryResponder:^(FlutterUIPressProxy* press,
-                                                            FlutterAsyncKeyCallback callback) {
-             if (press == event1) {
-               key1Callback = callback;
-             } else if (press == event2) {
-               key2Callback = callback;
-             }
-           }]];
+  id expectationEvent1Action = [self expectationWithDescription:@"event1 action"];
+  [manager handlePress:event1
+            nextAction:^() {
+              [expectationEvent1Action fulfill];
+            }];
 
-  // Add both presses into the main CFRunLoop queue
-  CFRunLoopTimerRef timer0 = CFRunLoopTimerCreateWithHandler(
-      kCFAllocatorDefault, CFAbsoluteTimeGetCurrent(), 0, 0, 0, ^(CFRunLoopTimerRef timerRef) {
-        [manager handlePress:event1
-                  nextAction:^() {
-                    key1Handled = false;
-                  }];
-      });
-  CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer0, kCFRunLoopCommonModes);
-  CFRunLoopTimerRef timer1 = CFRunLoopTimerCreateWithHandler(
-      kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + 1, 0, 0, 0, ^(CFRunLoopTimerRef timerRef) {
-        // key1 should be completely finished by now
-        XCTAssertFalse(key1Handled);
-        [manager handlePress:event2
-                  nextAction:^() {
-                    key2Handled = false;
-                  }];
-        // End the nested CFRunLoop
-        CFRunLoopStop(CFRunLoopGetCurrent());
-      });
-  CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer1, kCFRunLoopCommonModes);
+  id expectationEvent2Action = [self expectationWithDescription:@"event2 action"];
+  [manager handlePress:event2
+            nextAction:^() {
+              [expectationEvent2Action fulfill];
+            }];
 
-  // Add the callbacks to the CFRunLoop with mode kMessageLoopCFRunLoopMode
-  // This allows them to interrupt the loop started within handlePress
-  CFRunLoopTimerRef timer2 = CFRunLoopTimerCreateWithHandler(
-      kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + 2, 0, 0, 0, ^(CFRunLoopTimerRef timerRef) {
-        // No processing should be done on key2 yet
-        XCTAssertTrue(key1Callback != nil);
-        XCTAssertTrue(key2Callback == nil);
-        key1Callback(false);
-      });
-  CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer2,
-                    fml::MessageLoopDarwin::kMessageLoopCFRunLoopMode);
-  CFRunLoopTimerRef timer3 = CFRunLoopTimerCreateWithHandler(
-      kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + 3, 0, 0, 0, ^(CFRunLoopTimerRef timerRef) {
-        // Both keys should be processed by now
-        XCTAssertTrue(key1Callback != nil);
-        XCTAssertTrue(key2Callback != nil);
-        key2Callback(false);
-      });
-  CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer3,
-                    fml::MessageLoopDarwin::kMessageLoopCFRunLoopMode);
-
-  // Start a nested CFRunLoop so we can wait for both presses to complete before exiting the test
-  CFRunLoopRun();
-  XCTAssertFalse(key2Handled);
-  XCTAssertFalse(key1Handled);
+  [self waitForExpectations:@[
+    expectationEvent1Primary, expectationEvent1Action, expectationEvent2Primary,
+    expectationEvent2Action
+  ]
+                    timeout:1.0
+               enforceOrder:YES];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
@@ -43,10 +43,16 @@ API_AVAILABLE(ios(13.4))
       OCMStrictProtocolMock(@protocol(FlutterKeyPrimaryResponder));
   OCMStub([mock handlePress:[OCMArg any] callback:[OCMArg any]])
       .andDo((^(NSInvocation* invocation) {
-        __unsafe_unretained FlutterUIPressProxy* press;
-        __unsafe_unretained FlutterAsyncKeyCallback callback;
-        [invocation getArgument:&press atIndex:2];
-        [invocation getArgument:&callback atIndex:3];
+        __unsafe_unretained FlutterUIPressProxy* pressUnsafe;
+        __unsafe_unretained FlutterAsyncKeyCallback callbackUnsafe;
+
+        [invocation getArgument:&pressUnsafe atIndex:2];
+        [invocation getArgument:&callbackUnsafe atIndex:3];
+
+        // Retain the unretained parameters so they can
+        // be run in the perform block when this invocation goes out of scope.
+        FlutterUIPressProxy* press = pressUnsafe;
+        FlutterAsyncKeyCallback callback = callbackUnsafe;
         CFRunLoopPerformBlock(CFRunLoopGetCurrent(),
                               fml::MessageLoopDarwin::kMessageLoopCFRunLoopMode, ^() {
                                 callbackSetter(press, callback);

--- a/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterKeyboardManagerTest.mm
@@ -262,6 +262,7 @@ API_AVAILABLE(ios(13.4))
   ]
                     timeout:1.0
                enforceOrder:YES];
+  OCMVerifyAll(mockPrimaryResponder);
 }
 
 @end


### PR DESCRIPTION
Smart pointers support ARC as of https://github.com/flutter/engine/pull/47612, and the unit tests were migrated in https://github.com/flutter/engine/pull/48162.

Migrate`FlutterCallbackCache` and `FlutterKeyboardManager` from MRC to ARC.  These files do not themselves import any MRC files, making them leaf nodes in the dependency graph of MRC files.  

Doing a few at a time to make the dependency graph manageable, and to easily revert if this causes retain cycles or other memory management issues.

Part of https://github.com/flutter/flutter/issues/137801.
