### PR TITLE
[skwasm] Reify the SkPicture pointer as the right type.

### DIFF
--- a/lib/web_ui/skwasm/surface.cpp
+++ b/lib/web_ui/skwasm/surface.cpp
@@ -259,8 +259,8 @@ SKWASM_EXPORT void surface_renderPicturesOnWorker(Surface* surface,
                                                   uint32_t callbackId,
                                                   double rasterStart) {
   // This will release the pictures when they leave scope.
-  std::unique_ptr<sk_sp<SkPicture>> picturesPointer =
-      std::unique_ptr<sk_sp<SkPicture>>(pictures);
+  std::unique_ptr<sk_sp<SkPicture>[]> picturesPointer =
+      std::unique_ptr<sk_sp<SkPicture>[]>(pictures);
   surface->renderPicturesOnWorker(pictures, pictureCount, callbackId,
                                   rasterStart);
 }


### PR DESCRIPTION
When recreating this `unique_ptr`, we need to ensure it matches the type in `Surface::renderPictures` which is released. See here:

```
  std::unique_ptr<sk_sp<SkPicture>[]> picturePointers =
      std::make_unique<sk_sp<SkPicture>[]>(count);
  for (int i = 0; i < count; i++) {
    picturePointers[i] = sk_ref_sp(pictures[i]);
  }
  // Releasing picturePointers here and will recreate the unique_ptr on the
  // other thread See surface_renderPicturesOnWorker
  skwasm_dispatchRenderPictures(_thread, this, picturePointers.release(), count,
                                callbackId);
```