### PR TITLE
Update embedder example apps to run with the current engine tree

### DIFF
--- a/examples/glfw/BUILD.gn
+++ b/examples/glfw/BUILD.gn
@@ -10,6 +10,8 @@ if (build_embedder_examples) {
 
     sources = [ "FlutterEmbedderGLFW.cc" ]
 
+    ldflags = [ "-rdynamic" ]
+
     deps = [
       "//flutter/shell/platform/embedder:embedder",
       "//flutter/third_party/glfw",

--- a/examples/glfw/main.dart
+++ b/examples/glfw/main.dart
@@ -107,7 +107,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
           ],
         ),

--- a/examples/glfw/run.sh
+++ b/examples/glfw/run.sh
@@ -35,4 +35,4 @@ cd -
 #################################################################
 # Run the Flutter Engine Embedder
 #################################################################
-./flutter_glfw ./myapp ../../../../third_party/icu/common/icudtl.dat
+./flutter_glfw ./myapp ../../../third_party/icu/common/icudtl.dat

--- a/examples/glfw_drm/BUILD.gn
+++ b/examples/glfw_drm/BUILD.gn
@@ -10,6 +10,8 @@ if (build_embedder_examples) {
 
     sources = [ "FlutterEmbedderGLFW.cc" ]
 
+    ldflags = [ "-rdynamic" ]
+
     deps = [
       "//flutter/shell/platform/embedder:embedder",
       "//flutter/third_party/glfw",

--- a/examples/glfw_drm/run.sh
+++ b/examples/glfw_drm/run.sh
@@ -31,4 +31,4 @@ cd -
 #################################################################
 # Run the Flutter Engine Embedder
 #################################################################
-./flutter_glfw ./myapp ../../../../third_party/icu/common/icudtl.dat
+./flutter_glfw ./myapp ../../../third_party/icu/common/icudtl.dat

--- a/examples/vulkan_glfw/BUILD.gn
+++ b/examples/vulkan_glfw/BUILD.gn
@@ -10,6 +10,8 @@ executable("vulkan_glfw") {
 
   sources = [ "src/main.cc" ]
 
+  ldflags = [ "-rdynamic" ]
+
   deps = [
     "//flutter/shell/platform/embedder:embedder",
     "//flutter/third_party/glfw",

--- a/examples/vulkan_glfw/run.sh
+++ b/examples/vulkan_glfw/run.sh
@@ -25,6 +25,6 @@ popd > /dev/null
 #################################################################
 # Run the Flutter Engine Embedder
 #################################################################
-./embedder_example_vulkan ./myapp ../../../../third_party/icu/common/icudtl.dat
+./embedder_example_vulkan ./myapp ../../../third_party/icu/common/icudtl.dat
 
 popd > /dev/null


### PR DESCRIPTION
* Update ICU data paths for the move of third_party/icu out of the buildroot
* Link with -rdynamic to enable lookup of Dart resource symbols within the app executables
* Use Material 3 text styles that are supported by the current Flutter framework