### PR TITLE
[Impeller] NumberNear implements precision-based comparisons

### DIFF
--- a/impeller/geometry/geometry_asserts.h
+++ b/impeller/geometry/geometry_asserts.h
@@ -16,8 +16,43 @@
 #include "impeller/geometry/vector.h"
 
 inline bool NumberNear(double a, double b) {
-  static const double epsilon = 1e-3;
-  return (a > (b - epsilon)) && (a < (b + epsilon));
+  if (a == b) {
+    return true;
+  }
+  if (std::isnan(a) || std::isnan(b)) {
+    return false;
+  }
+
+  // We used to compare based on an absolute difference of 1e-3 which
+  // would allow up to 10 bits of mantissa difference in a float
+  // (leaving 14 bits of accuracy being tested). Some numbers in the tests
+  // will fail with a bit difference of up to 19 (a little over 4 bits) even
+  // though the numbers print out identically using the float ostream output
+  // at the default output precision. Choosing a max "units of least precision"
+  // of 32 allows up to 5 bits of imprecision.
+  static constexpr float kImpellerTestingMaxULP = 32;
+
+  // We also impose a minimum step size so that cases of comparing numbers
+  // very close to 0.0 don't compute a huge number of ULPs due to the ever
+  // increasing precision near 0. This value is approximately the step size
+  // of numbers going less than 1.0f.
+  static constexpr float kMinimumULPStep = (1.0f / (1 << 24));
+
+  auto adjust_step = [](float v) {
+    if (v > -kMinimumULPStep && v < kMinimumULPStep) {
+      v = v < 0 ? -kMinimumULPStep : kMinimumULPStep;
+    }
+    return v;
+  };
+
+  float step_ab = adjust_step(a - std::nexttowardf(a, b));
+  float step_ba = adjust_step(b - std::nexttowardf(b, a));
+
+  float ab_ulps = (a - b) / step_ab;
+  float ba_ulps = (b - a) / step_ba;
+  FML_CHECK(ab_ulps >= 0 && ba_ulps >= 0);
+
+  return (std::min(ab_ulps, ba_ulps) < kImpellerTestingMaxULP);
 }
 
 inline ::testing::AssertionResult MatrixNear(impeller::Matrix a,

--- a/impeller/geometry/geometry_asserts.h
+++ b/impeller/geometry/geometry_asserts.h
@@ -39,10 +39,8 @@ inline bool NumberNear(double a, double b) {
   static constexpr float kMinimumULPStep = (1.0f / (1 << 24));
 
   auto adjust_step = [](float v) {
-    if (v > -kMinimumULPStep && v < kMinimumULPStep) {
-      v = v < 0 ? -kMinimumULPStep : kMinimumULPStep;
-    }
-    return v;
+    return (std::abs(v) < kMinimumULPStep) ? std::copysignf(kMinimumULPStep, v)
+                                           : v;
   };
 
   float step_ab = adjust_step(a - std::nexttowardf(a, b));

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -66,10 +66,12 @@ TEST(GeometryTest, MakeRow) {
 
 TEST(GeometryTest, RotationMatrix) {
   auto rotation = Matrix::MakeRotationZ(Radians{kPiOver4});
-  auto expect = Matrix{0.707107,  0.707107, 0, 0,  //
-                       -0.707107, 0.707107, 0, 0,  //
-                       0,         0,        1, 0,  //
-                       0,         0,        0, 1};
+  // clang-format off
+  auto expect = Matrix{k1OverSqrt2,  k1OverSqrt2, 0, 0,
+                       -k1OverSqrt2, k1OverSqrt2, 0, 0,
+                       0,            0,           1, 0,
+                       0,            0,           0, 1};
+  // clang-format on
   ASSERT_MATRIX_NEAR(rotation, expect);
 }
 
@@ -77,10 +79,12 @@ TEST(GeometryTest, InvertMultMatrix) {
   {
     auto rotation = Matrix::MakeRotationZ(Radians{kPiOver4});
     auto invert = rotation.Invert();
-    auto expect = Matrix{0.707107, -0.707107, 0, 0,  //
-                         0.707107, 0.707107,  0, 0,  //
-                         0,        0,         1, 0,  //
-                         0,        0,         0, 1};
+    // clang-format off
+    auto expect = Matrix{k1OverSqrt2, -k1OverSqrt2, 0, 0,
+                         k1OverSqrt2, k1OverSqrt2,  0, 0,
+                         0,           0,            1, 0,
+                         0,           0,            0, 1};
+    // clang-format on
     ASSERT_MATRIX_NEAR(invert, expect);
   }
   {

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -66,10 +66,10 @@ TEST(GeometryTest, MakeRow) {
 
 TEST(GeometryTest, RotationMatrix) {
   auto rotation = Matrix::MakeRotationZ(Radians{kPiOver4});
-  auto expect = Matrix{0.707,  0.707, 0, 0,  //
-                       -0.707, 0.707, 0, 0,  //
-                       0,      0,     1, 0,  //
-                       0,      0,     0, 1};
+  auto expect = Matrix{0.707107,  0.707107, 0, 0,  //
+                       -0.707107, 0.707107, 0, 0,  //
+                       0,         0,        1, 0,  //
+                       0,         0,        0, 1};
   ASSERT_MATRIX_NEAR(rotation, expect);
 }
 
@@ -77,10 +77,10 @@ TEST(GeometryTest, InvertMultMatrix) {
   {
     auto rotation = Matrix::MakeRotationZ(Radians{kPiOver4});
     auto invert = rotation.Invert();
-    auto expect = Matrix{0.707, -0.707, 0, 0,  //
-                         0.707, 0.707,  0, 0,  //
-                         0,     0,      1, 0,  //
-                         0,     0,      0, 1};
+    auto expect = Matrix{0.707107, -0.707107, 0, 0,  //
+                         0.707107, 0.707107,  0, 0,  //
+                         0,        0,         1, 0,  //
+                         0,        0,         0, 1};
     ASSERT_MATRIX_NEAR(invert, expect);
   }
   {

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -2895,22 +2895,6 @@ TEST(RectTest, IRectRound) {
   }
 }
 
-// EXPECT_RECT_NEAR will allow a fixed difference between the values that
-// assumes a compatible range of values being tested. Some of the values
-// below are well outside that range and so if the values are a single
-// "bit" off, then they will differ by far more than the fixed allowable
-// difference. The EXPECT_FLOAT_EQ macro will compare the values and
-// fail only if their difference in mantissa is in the last N bits,
-// which is a range agnostic way to compare floats with allowances for
-// bit errors in computations.
-#define EXPECT_RECT_EQ(a, b)                       \
-  do {                                             \
-    EXPECT_FLOAT_EQ(a.GetLeft(), b.GetLeft());     \
-    EXPECT_FLOAT_EQ(a.GetTop(), b.GetTop());       \
-    EXPECT_FLOAT_EQ(a.GetRight(), b.GetRight());   \
-    EXPECT_FLOAT_EQ(a.GetBottom(), b.GetBottom()); \
-  } while (0)
-
 TEST(RectTest, TransformAndClipBounds) {
   {
     // This matrix should clip no corners.
@@ -2961,7 +2945,7 @@ TEST(RectTest, TransformAndClipBounds) {
 
     Rect expect = Rect::MakeLTRB(142.85715f, 142.85715f, 6553600.f, 6553600.f);
     EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
-    EXPECT_RECT_EQ(src.TransformAndClipBounds(matrix), expect);
+    EXPECT_RECT_NEAR(src.TransformAndClipBounds(matrix), expect);
   }
 
   {
@@ -2987,7 +2971,7 @@ TEST(RectTest, TransformAndClipBounds) {
 
     Rect expect = Rect::MakeLTRB(222.2222f, 222.2222f, 5898373.f, 6553600.f);
     EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
-    EXPECT_RECT_EQ(src.TransformAndClipBounds(matrix), expect);
+    EXPECT_RECT_NEAR(src.TransformAndClipBounds(matrix), expect);
   }
 
   {
@@ -3013,7 +2997,7 @@ TEST(RectTest, TransformAndClipBounds) {
 
     Rect expect = Rect::MakeLTRB(499.99988f, 499.99988f, 5898340.f, 4369400.f);
     EXPECT_FALSE(src.TransformAndClipBounds(matrix).IsEmpty());
-    EXPECT_RECT_EQ(src.TransformAndClipBounds(matrix), expect);
+    EXPECT_RECT_NEAR(src.TransformAndClipBounds(matrix), expect);
   }
 
   {

--- a/impeller/scene/importer/importer_unittests.cc
+++ b/impeller/scene/importer/importer_unittests.cc
@@ -44,10 +44,10 @@ TEST(ImporterTest, CanParseUnskinnedGLTF) {
   ASSERT_VECTOR3_NEAR(position, Vector3(-0.0100185, -0.522907, 0.133178));
 
   Vector3 normal = ToVector3(vertex.normal());
-  ASSERT_VECTOR3_NEAR(normal, Vector3(0.556997, -0.810833, 0.179733));
+  ASSERT_VECTOR3_NEAR(normal, Vector3(0.556984, -0.810839, 0.179746));
 
   Vector4 tangent = ToVector4(vertex.tangent());
-  ASSERT_VECTOR4_NEAR(tangent, Vector4(0.155901, -0.110485, -0.981574, 1));
+  ASSERT_VECTOR4_NEAR(tangent, Vector4(0.155911, -0.110495, -0.981572, 1));
 
   Vector2 texture_coords = ToVector2(vertex.texture_coords());
   ASSERT_POINT_NEAR(texture_coords, Vector2(0.727937, 0.713817));

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -187,7 +187,8 @@ TEST(TessellatorTest, FilledCircleTessellationVertices) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
       double rsin = sin(angle) * radius;
-      double rcos = cos(angle) * radius;
+      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      double rcos = (i == quadrant_count - 1) ? 0.0f : cos(angle) * radius;
       EXPECT_POINT_NEAR(vertices[i * 2],
                         Point(center.x - rcos, center.y + rsin))
           << "vertex " << i << ", angle = " << degrees << std::endl;
@@ -234,7 +235,9 @@ TEST(TessellatorTest, StrokedCircleTessellationVertices) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
       double rsin = sin(angle) * (radius + half_width);
-      double rcos = cos(angle) * (radius + half_width);
+      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      double rcos =
+          (i == quadrant_count - 1) ? 0.0f : cos(angle) * (radius + half_width);
       EXPECT_POINT_NEAR(vertices[i * 2],
                         Point(center.x - rcos, center.y - rsin))
           << "vertex " << i << ", angle = " << degrees << std::endl;
@@ -254,7 +257,9 @@ TEST(TessellatorTest, StrokedCircleTessellationVertices) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
       double rsin = sin(angle) * (radius - half_width);
-      double rcos = cos(angle) * (radius - half_width);
+      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      double rcos =
+          (i == quadrant_count - 1) ? 0.0f : cos(angle) * (radius - half_width);
       EXPECT_POINT_NEAR(vertices[i * 2 + 1],
                         Point(center.x - rcos, center.y - rsin))
           << "vertex " << i << ", angle = " << degrees << std::endl;
@@ -306,7 +311,9 @@ TEST(TessellatorTest, RoundCapLineTessellationVertices) {
     for (size_t i = 0; i < quadrant_count; i++) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
-      Point relative_along = along * cos(angle);
+      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      Point relative_along =
+          along * ((i == quadrant_count - 1) ? 0.0f : cos(angle));
       Point relative_across = across * sin(angle);
       EXPECT_POINT_NEAR(vertices[i * 2],  //
                         p0 - relative_along + relative_across)
@@ -370,7 +377,9 @@ TEST(TessellatorTest, FilledEllipseTessellationVertices) {
     for (size_t i = 0; i < quadrant_count; i++) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
-      double rcos = cos(angle) * half_size.width;
+      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      double rcos =
+          (i == quadrant_count - 1) ? 0.0f : cos(angle) * half_size.width;
       double rsin = sin(angle) * half_size.height;
       EXPECT_POINT_NEAR(vertices[i * 2],
                         Point(center.x - rcos, center.y + rsin))
@@ -435,7 +444,8 @@ TEST(TessellatorTest, FilledRoundRectTessellationVertices) {
     for (size_t i = 0; i < quadrant_count; i++) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
-      double rcos = cos(angle) * radii.width;
+      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      double rcos = (i == quadrant_count - 1) ? 0.0f : cos(angle) * radii.width;
       double rsin = sin(angle) * radii.height;
       EXPECT_POINT_NEAR(vertices[i * 2],
                         Point(middle_left - rcos, middle_bottom + rsin))

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -187,7 +187,7 @@ TEST(TessellatorTest, FilledCircleTessellationVertices) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
       double rsin = sin(angle) * radius;
-      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      // Note that cos(radians(90 degrees)) isn't exactly 0.0 like it should be
       double rcos = (i == quadrant_count - 1) ? 0.0f : cos(angle) * radius;
       EXPECT_POINT_NEAR(vertices[i * 2],
                         Point(center.x - rcos, center.y + rsin))
@@ -235,7 +235,7 @@ TEST(TessellatorTest, StrokedCircleTessellationVertices) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
       double rsin = sin(angle) * (radius + half_width);
-      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      // Note that cos(radians(90 degrees)) isn't exactly 0.0 like it should be
       double rcos =
           (i == quadrant_count - 1) ? 0.0f : cos(angle) * (radius + half_width);
       EXPECT_POINT_NEAR(vertices[i * 2],
@@ -257,7 +257,7 @@ TEST(TessellatorTest, StrokedCircleTessellationVertices) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
       double rsin = sin(angle) * (radius - half_width);
-      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      // Note that cos(radians(90 degrees)) isn't exactly 0.0 like it should be
       double rcos =
           (i == quadrant_count - 1) ? 0.0f : cos(angle) * (radius - half_width);
       EXPECT_POINT_NEAR(vertices[i * 2 + 1],
@@ -311,7 +311,7 @@ TEST(TessellatorTest, RoundCapLineTessellationVertices) {
     for (size_t i = 0; i < quadrant_count; i++) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
-      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      // Note that cos(radians(90 degrees)) isn't exactly 0.0 like it should be
       Point relative_along =
           along * ((i == quadrant_count - 1) ? 0.0f : cos(angle));
       Point relative_across = across * sin(angle);
@@ -377,7 +377,7 @@ TEST(TessellatorTest, FilledEllipseTessellationVertices) {
     for (size_t i = 0; i < quadrant_count; i++) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
-      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      // Note that cos(radians(90 degrees)) isn't exactly 0.0 like it should be
       double rcos =
           (i == quadrant_count - 1) ? 0.0f : cos(angle) * half_size.width;
       double rsin = sin(angle) * half_size.height;
@@ -444,7 +444,7 @@ TEST(TessellatorTest, FilledRoundRectTessellationVertices) {
     for (size_t i = 0; i < quadrant_count; i++) {
       double angle = kPiOver2 * i / (quadrant_count - 1);
       double degrees = angle * 180.0 / kPi;
-      // Note that cos(radians(90 degrees) isn't exactly 0.0 like it should be)
+      // Note that cos(radians(90 degrees)) isn't exactly 0.0 like it should be
       double rcos = (i == quadrant_count - 1) ? 0.0f : cos(angle) * radii.width;
       double rsin = sin(angle) * radii.height;
       EXPECT_POINT_NEAR(vertices[i * 2],


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/146455

Fuzzy comparisons based on the IEEE floating precision of the numbers being compared will help ensure that comparing large numbers and very small numbers (in unit tests) both have similar accuracy.