### PR TITLE
Move `Shell::Add/RemoveView` to `PlatformView` and refine embedder API doc

### DIFF
--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -90,11 +90,12 @@ void PlatformView::ScheduleFrame() {
 void PlatformView::AddView(int64_t view_id,
                            const ViewportMetrics& viewport_metrics,
                            AddViewCallback callback) {
-  delegate_.OnPlatformViewAddView(view_id, viewport_metrics, callback);
+  delegate_.OnPlatformViewAddView(view_id, viewport_metrics,
+                                  std::move(callback));
 }
 
 void PlatformView::RemoveView(int64_t view_id, RemoveViewCallback callback) {
-  delegate_.OnPlatformViewRemoveView(view_id, callback);
+  delegate_.OnPlatformViewRemoveView(view_id, std::move(callback));
 }
 
 sk_sp<GrDirectContext> PlatformView::CreateResourceContext() const {

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -87,6 +87,16 @@ void PlatformView::ScheduleFrame() {
   delegate_.OnPlatformViewScheduleFrame();
 }
 
+void PlatformView::AddView(int64_t view_id,
+                           const ViewportMetrics& viewport_metrics,
+                           AddViewCallback callback) {
+  delegate_.OnPlatformViewAddView(view_id, viewport_metrics, callback);
+}
+
+void PlatformView::RemoveView(int64_t view_id, RemoveViewCallback callback) {
+  delegate_.OnPlatformViewRemoveView(view_id, callback);
+}
+
 sk_sp<GrDirectContext> PlatformView::CreateResourceContext() const {
   FML_DLOG(WARNING) << "This platform does not set up the resource "
                        "context on the IO thread for async texture uploads.";

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -51,6 +51,8 @@ namespace flutter {
 ///
 class PlatformView {
  public:
+  using AddViewCallback = std::function<void(bool added)>;
+  using RemoveViewCallback = std::function<void(bool removed)>;
   //----------------------------------------------------------------------------
   /// @brief      Used to forward events from the platform view to interested
   ///             subsystems. This forwarding is done by the shell which sets
@@ -58,6 +60,8 @@ class PlatformView {
   ///
   class Delegate {
    public:
+    using AddViewCallback = PlatformView::AddViewCallback;
+    using RemoveViewCallback = PlatformView::RemoveViewCallback;
     using KeyDataResponse = std::function<void(bool)>;
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the platform view was created
@@ -83,6 +87,42 @@ class PlatformView {
     ///             frame to regenerate the layer tree and redraw the surface.
     ///
     virtual void OnPlatformViewScheduleFrame() = 0;
+
+    /// @brief  Allocate resources for a new non-implicit view and inform
+    ///         Dart about the view, and on success, schedules a new frame.
+    ///
+    ///         After the operation, |callback| should be invoked with whether
+    ///         the operation is successful.
+    ///
+    ///         Adding |kFlutterImplicitViewId| or an existing view ID should
+    ///         result in failure.
+    ///
+    /// @param[in]  view_id           The view ID of the new view.
+    /// @param[in]  viewport_metrics  The initial viewport metrics for the view.
+    /// @param[in]  callback          The callback that's invoked once the shell
+    ///                               has attempted to add the view.
+    ///
+    virtual void OnPlatformViewAddView(
+        int64_t view_id,
+        const ViewportMetrics& viewport_metrics,
+        PlatformView::AddViewCallback callback) = 0;
+
+    /// @brief  Deallocate resources for a removed view and inform
+    ///         Dart about the removal.
+    ///
+    ///         After the operation, |callback| should be invoked with whether
+    ///         the operation is successful.
+    ///
+    ///         Removing |kFlutterImplicitViewId| or an non-existent view ID
+    ///         should result in failure.
+    ///
+    /// @param[in]  view_id     The view ID of the view to be removed.
+    /// @param[in]  callback    The callback that's invoked once the shell has
+    ///                         attempted to remove the view.
+    ///
+    virtual void OnPlatformViewRemoveView(
+        int64_t view_id,
+        PlatformView::RemoveViewCallback callback) = 0;
 
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the specified callback needs to
@@ -516,6 +556,53 @@ class PlatformView {
   ///             call, the framework may need to start generating a new frame.
   ///
   void ScheduleFrame();
+
+  /// @brief  Used by embedders to notify the shell of a new non-implicit view.
+  ///
+  ///         This method notifies the shell to allocate resources and inform
+  ///         Dart about the view, and on success, schedules a new frame.
+  ///         Finally, it invokes |callback| with whether the operation is
+  ///         successful.
+  ///
+  ///         This operation is asynchronous; avoid using the view until
+  ///         |callback| returns true. Embedders should prepare resources in
+  ///         advance but be ready to clean up on failure.
+  ///
+  ///         Do not use for implicit views, which are added internally during
+  ///         shell initialization. Adding |kFlutterImplicitViewId| or an
+  ///         existing view ID will fail, indicated by |callback| returning
+  ///         false.
+  ///
+  /// @param[in]  view_id           The view ID of the new view.
+  /// @param[in]  viewport_metrics  The initial viewport metrics for the view.
+  /// @param[in]  callback          The callback that's invoked once the shell
+  ///                               has attempted to add the view.
+  ///
+  void AddView(int64_t view_id,
+               const ViewportMetrics& viewport_metrics,
+               AddViewCallback callback);
+
+  /// @brief  Used by embedders to notify the shell of a removed non-implicit
+  ///         view.
+  ///
+  ///         This method notifies the shell to deallocate resources and inform
+  ///         Dart about the removal. Finally, it invokes |callback| with
+  ///         whether the operation is successful.
+  ///
+  ///         This operation is asynchronous. Embedders should not deallocate
+  ///         resources until the |callback| is invoked.
+  ///
+  ///         Do not use for implicit views, which are never removed throughout
+  ///         the lifetime of the app.
+  ///         Removing |kFlutterImplicitViewId| or an
+  ///         non-existent view ID will fail, indicated by |callback| returning
+  ///         false.
+  ///
+  /// @param[in]  view_id     The view ID of the view to be removed.
+  /// @param[in]  callback    The callback that's invoked once the shell has
+  ///                         attempted to remove the view.
+  ///
+  void RemoveView(int64_t view_id, RemoveViewCallback callback);
 
   //----------------------------------------------------------------------------
   /// @brief      Used by the shell to obtain a Skia GPU context that is capable

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -102,10 +102,9 @@ class PlatformView {
     /// @param[in]  callback          The callback that's invoked once the shell
     ///                               has attempted to add the view.
     ///
-    virtual void OnPlatformViewAddView(
-        int64_t view_id,
-        const ViewportMetrics& viewport_metrics,
-        PlatformView::AddViewCallback callback) = 0;
+    virtual void OnPlatformViewAddView(int64_t view_id,
+                                       const ViewportMetrics& viewport_metrics,
+                                       AddViewCallback callback) = 0;
 
     /// @brief  Deallocate resources for a removed view and inform
     ///         Dart about the removal.
@@ -120,9 +119,8 @@ class PlatformView {
     /// @param[in]  callback    The callback that's invoked once the shell has
     ///                         attempted to remove the view.
     ///
-    virtual void OnPlatformViewRemoveView(
-        int64_t view_id,
-        PlatformView::RemoveViewCallback callback) = 0;
+    virtual void OnPlatformViewRemoveView(int64_t view_id,
+                                          RemoveViewCallback callback) = 0;
 
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the specified callback needs to
@@ -565,8 +563,10 @@ class PlatformView {
   ///         successful.
   ///
   ///         This operation is asynchronous; avoid using the view until
-  ///         |callback| returns true. Embedders should prepare resources in
-  ///         advance but be ready to clean up on failure.
+  ///         |callback| returns true. Callers should prepare resources for the
+  ///         view (if any) in advance but be ready to clean up on failure.
+  ///
+  ///         The callback is called on a different thread.
   ///
   ///         Do not use for implicit views, which are added internally during
   ///         shell initialization. Adding |kFlutterImplicitViewId| or an
@@ -589,8 +589,10 @@ class PlatformView {
   ///         Dart about the removal. Finally, it invokes |callback| with
   ///         whether the operation is successful.
   ///
-  ///         This operation is asynchronous. Embedders should not deallocate
+  ///         This operation is asynchronous. The embedder should not deallocate
   ///         resources until the |callback| is invoked.
+  ///
+  ///         The callback is called on a different thread.
   ///
   ///         Do not use for implicit views, which are never removed throughout
   ///         the lifetime of the app.

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -2114,9 +2114,9 @@ bool Shell::OnServiceProtocolReloadAssetFonts(
   return true;
 }
 
-void Shell::AddView(int64_t view_id,
-                    const ViewportMetrics& viewport_metrics,
-                    AddViewCallback callback) {
+void Shell::OnPlatformViewAddView(int64_t view_id,
+                                  const ViewportMetrics& viewport_metrics,
+                                  AddViewCallback callback) {
   TRACE_EVENT0("flutter", "Shell::AddView");
   FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
@@ -2135,7 +2135,8 @@ void Shell::AddView(int64_t view_id,
   });
 }
 
-void Shell::RemoveView(int64_t view_id, RemoveViewCallback callback) {
+void Shell::OnPlatformViewRemoveView(int64_t view_id,
+                                     RemoveViewCallback callback) {
   TRACE_EVENT0("flutter", "Shell::RemoveView");
   FML_DCHECK(is_set_up_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -133,8 +133,6 @@ class Shell final : public PlatformView::Delegate,
       const std::shared_ptr<fml::SyncSwitch>& gpu_disabled_switch,
       impeller::RuntimeStageBackend runtime_stage_type)>
       EngineCreateCallback;
-  using AddViewCallback = std::function<void(bool added)>;
-  using RemoveViewCallback = std::function<void(bool removed)>;
 
   //----------------------------------------------------------------------------
   /// @brief      Creates a shell instance using the provided settings. The
@@ -303,43 +301,6 @@ class Shell final : public PlatformView::Delegate,
   ///             not change for the life-cycle of the shell.
   ///
   bool IsSetup() const;
-
-  /// @brief  Allocates resources for a new non-implicit view.
-  ///
-  ///         This method returns immediately and does not wait for the task on
-  ///         the UI thread to finish. This is safe because operations are
-  ///         either initiated from the UI thread (such as rendering), or are
-  ///         sent as posted tasks that are queued. In either case, it's ok for
-  ///         the engine to have views that the Dart VM doesn't.
-  ///
-  ///         The implicit view should never be added with this function.
-  ///         Instead, it is added internally on Shell initialization. Trying to
-  ///         add `kFlutterImplicitViewId` triggers an assertion.
-  ///
-  /// @param[in]  view_id           The view ID of the new view.
-  /// @param[in]  viewport_metrics  The initial viewport metrics for the view.
-  /// @param[in]  callback          The callback that's invoked once the engine
-  ///                               has attempted to add the view.
-  ///
-  void AddView(int64_t view_id,
-               const ViewportMetrics& viewport_metrics,
-               AddViewCallback callback);
-
-  /// @brief  Deallocates resources for a non-implicit view.
-  ///
-  ///         This method returns immediately and does not wait for the task on
-  ///         the UI thread to finish. This means that the Dart VM might still
-  ///         send messages regarding this view ID for a short while, even
-  ///         though this view ID is already invalid.
-  ///
-  ///         The implicit view should never be removed. Trying to remove
-  ///         `kFlutterImplicitViewId` triggers an assertion.
-  ///
-  /// @param[in]  view_id     The view ID of the view to be removed.
-  /// @param[in]  callback    The callback that's invoked once the engine has
-  ///                         attempted to remove the view.
-  ///
-  void RemoveView(int64_t view_id, RemoveViewCallback callback);
 
   //----------------------------------------------------------------------------
   /// @brief      Captures a screenshot and optionally Base64 encodes the data
@@ -599,6 +560,15 @@ class Shell final : public PlatformView::Delegate,
 
   // |PlatformView::Delegate|
   void OnPlatformViewScheduleFrame() override;
+
+  // |PlatformView::Delegate|
+  void OnPlatformViewAddView(int64_t view_id,
+                             const ViewportMetrics& viewport_metrics,
+                             AddViewCallback callback) override;
+
+  // |PlatformView::Delegate|
+  void OnPlatformViewRemoveView(int64_t view_id,
+                                RemoveViewCallback callback) override;
 
   // |PlatformView::Delegate|
   void OnPlatformViewSetViewportMetrics(

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -23,6 +23,10 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewCreated(std::unique_ptr<Surface> surface) override {}
   void OnPlatformViewDestroyed() override {}
   void OnPlatformViewScheduleFrame() override {}
+  void OnPlatformViewAddView(int64_t view_id,
+                             const ViewportMetrics& viewport_metrics,
+                             AddViewCallback callback) override {}
+  void OnPlatformViewRemoveView(int64_t view_id, RemoveViewCallback callback) override {}
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) override {}
   void OnPlatformViewSetViewportMetrics(int64_t view_id, const ViewportMetrics& metrics) override {}
   const flutter::Settings& OnPlatformViewGetSettings() const override { return settings_; }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -88,6 +88,10 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewCreated(std::unique_ptr<Surface> surface) override {}
   void OnPlatformViewDestroyed() override {}
   void OnPlatformViewScheduleFrame() override {}
+  void OnPlatformViewAddView(int64_t view_id,
+                             const ViewportMetrics& viewport_metrics,
+                             AddViewCallback callback) override {}
+  void OnPlatformViewRemoveView(int64_t view_id, RemoveViewCallback callback) override {}
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) override {}
   void OnPlatformViewSetViewportMetrics(int64_t view_id, const ViewportMetrics& metrics) override {}
   const flutter::Settings& OnPlatformViewGetSettings() const override { return settings_; }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -71,6 +71,10 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewCreated(std::unique_ptr<Surface> surface) override {}
   void OnPlatformViewDestroyed() override {}
   void OnPlatformViewScheduleFrame() override {}
+  void OnPlatformViewAddView(int64_t view_id,
+                             const ViewportMetrics& viewport_metrics,
+                             AddViewCallback callback) override {}
+  void OnPlatformViewRemoveView(int64_t view_id, RemoveViewCallback callback) override {}
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) override {}
   void OnPlatformViewSetViewportMetrics(int64_t view_id, const ViewportMetrics& metrics) override {}
   const flutter::Settings& OnPlatformViewGetSettings() const override { return settings_; }

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2229,7 +2229,7 @@ FlutterEngineResult FlutterEngineAddView(FLUTTER_API_SYMBOL(FlutterEngine)
     return LOG_EMBEDDER_ERROR(kInvalidArguments, "Engine handle was invalid.");
   }
 
-  flutter::Shell::AddViewCallback callback =
+  flutter::PlatformView::AddViewCallback callback =
       [c_callback = info->add_view_callback,
        user_data = info->user_data](bool added) {
         FlutterAddViewResult result = {};
@@ -2239,7 +2239,8 @@ FlutterEngineResult FlutterEngineAddView(FLUTTER_API_SYMBOL(FlutterEngine)
         c_callback(&result);
       };
 
-  embedder_engine->GetShell().AddView(view_id, metrics, callback);
+  embedder_engine->GetShell().GetPlatformView()->AddView(view_id, metrics,
+                                                         callback);
   return kSuccess;
 }
 
@@ -2271,7 +2272,7 @@ FlutterEngineResult FlutterEngineRemoveView(FLUTTER_API_SYMBOL(FlutterEngine)
     return LOG_EMBEDDER_ERROR(kInvalidArguments, "Engine handle was invalid.");
   }
 
-  flutter::Shell::RemoveViewCallback callback =
+  flutter::PlatformView::RemoveViewCallback callback =
       [c_callback = info->remove_view_callback,
        user_data = info->user_data](bool removed) {
         FlutterRemoveViewResult result = {};
@@ -2281,7 +2282,8 @@ FlutterEngineResult FlutterEngineRemoveView(FLUTTER_API_SYMBOL(FlutterEngine)
         c_callback(&result);
       };
 
-  embedder_engine->GetShell().RemoveView(info->view_id, callback);
+  embedder_engine->GetShell().GetPlatformView()->RemoveView(info->view_id,
+                                                            callback);
   return kSuccess;
 }
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -2582,23 +2582,20 @@ FlutterEngineResult FlutterEngineRunInitialized(
 //------------------------------------------------------------------------------
 /// @brief      Adds a view.
 ///
-///             This operation notifies the engine to allocate resources and
-///             inform Dart about the view, and on success, schedules a new
-///             frame. Finally, it invokes |info.add_view_callback| with whether
-///             the operation is successful.
+///             This is an asynchronous operation. The view should not be used
+///             until the |info.add_view_callback| is invoked with an |added|
+///             value of true. The embedder should prepare resources in advance
+///             but be ready to clean up on failure.
 ///
-///             This operation is asynchronous; avoid using the view until
-///             |info.add_view_callback| returns true. The embedder should
-///             prepare resources in advance but be ready to clean up on
-///             failure.
+///             A frame is scheduled if the operation succeeds.
 ///
-///             The callback is called on a different thread managed by the
-///             engine. The embedder must re-thread if needed.
+///             The callback is invoked on a thread managed by the engine. The
+///             embedder should re-thread if needed.
 ///
-///             Do not use for implicit views, which are added internally during
-///             initialization. Adding the implicit view ID or an existing view
-///             ID will fail, indicated by |info.add_view_callback| returning
-///             false.
+///             Attempting to add the implicit view will fail and will return
+///             kInvalidArguments. Attempting to add a view with an already
+///             existing view ID will fail, and |info.add_view_callback| will be
+///             invoked with an |added| value of false.
 ///
 /// @param[in]  engine  A running engine instance.
 /// @param[in]  info    The add view arguments. This can be deallocated
@@ -2615,18 +2612,17 @@ FlutterEngineResult FlutterEngineAddView(FLUTTER_API_SYMBOL(FlutterEngine)
 //------------------------------------------------------------------------------
 /// @brief      Removes a view.
 ///
-///             This operation notifies the engine to deallocate resources and
-///             inform Dart about the removal. Finally, it invokes
-///             |info.remove_view_callback| with whether the operation is
-///             successful.
+///             This is an asynchronous operation. The view's resources must not
+///             be cleaned up until |info.remove_view_callback| is invoked with
+///             a |removed| value of true.
 ///
-///             This operation is asynchronous. The embedder should not
-///             deallocate resources until the |callback| is invoked.
+///             The callback is invoked on a thread managed by the engine. The
+///             embedder should re-thread if needed.
 ///
-///             Do not use for implicit views, which are never removed
-///             throughout the lifetime of the app.  Removing
-///             |kFlutterImplicitViewId| or an non-existent view ID will fail,
-///             indicated by |callback| returning false.
+///             Attempting to remove the implicit view will fail and will return
+///             kInvalidArguments. Attempting to remove a view with a
+///             non-existent view ID will fail, and |info.remove_view_callback|
+///             will be invoked with a |removed| value of false.
 ///
 /// @param[in]  engine  A running engine instance.
 /// @param[in]  info    The remove view arguments. This can be deallocated

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -2582,9 +2582,23 @@ FlutterEngineResult FlutterEngineRunInitialized(
 //------------------------------------------------------------------------------
 /// @brief      Adds a view.
 ///
-///             This is an asynchronous operation. The view should not be used
-///             until the |add_view_callback| is invoked with an `added` of
-///             `true`.
+///             This operation notifies the engine to allocate resources and
+///             inform Dart about the view, and on success, schedules a new
+///             frame. Finally, it invokes |info.add_view_callback| with whether
+///             the operation is successful.
+///
+///             This operation is asynchronous; avoid using the view until
+///             |info.add_view_callback| returns true. The embedder should
+///             prepare resources in advance but be ready to clean up on
+///             failure.
+///
+///             The callback is called on a different thread managed by the
+///             engine. The embedder must re-thread if needed.
+///
+///             Do not use for implicit views, which are added internally during
+///             initialization. Adding the implicit view ID or an existing view
+///             ID will fail, indicated by |info.add_view_callback| returning
+///             false.
 ///
 /// @param[in]  engine  A running engine instance.
 /// @param[in]  info    The add view arguments. This can be deallocated
@@ -2601,9 +2615,18 @@ FlutterEngineResult FlutterEngineAddView(FLUTTER_API_SYMBOL(FlutterEngine)
 //------------------------------------------------------------------------------
 /// @brief      Removes a view.
 ///
-///             This is an asynchronous operation. The view's resources must not
-///             be cleaned up until the |remove_view_callback| is invoked with
-///             a |removed| value of `true`.
+///             This operation notifies the engine to deallocate resources and
+///             inform Dart about the removal. Finally, it invokes
+///             |info.remove_view_callback| with whether the operation is
+///             successful.
+///
+///             This operation is asynchronous. The embedder should not
+///             deallocate resources until the |callback| is invoked.
+///
+///             Do not use for implicit views, which are never removed
+///             throughout the lifetime of the app.  Removing
+///             |kFlutterImplicitViewId| or an non-existent view ID will fail,
+///             indicated by |callback| returning false.
 ///
 /// @param[in]  engine  A running engine instance.
 /// @param[in]  info    The remove view arguments. This can be deallocated

--- a/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -23,6 +23,16 @@ class MockDelegate : public PlatformView::Delegate {
   MOCK_METHOD(void, OnPlatformViewDestroyed, (), (override));
   MOCK_METHOD(void, OnPlatformViewScheduleFrame, (), (override));
   MOCK_METHOD(void,
+              OnPlatformViewAddView,
+              (int64_t view_id,
+               const ViewportMetrics& viewport_metrics,
+               AddViewCallback callback),
+              (override));
+  MOCK_METHOD(void,
+              OnPlatformViewRemoveView,
+              (int64_t view_id, RemoveViewCallback callback),
+              (override));
+  MOCK_METHOD(void,
               OnPlatformViewSetNextFrameCallback,
               (const fml::closure& closure),
               (override));

--- a/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -89,7 +89,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
   void OnPlatformViewScheduleFrame() {}
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewAddView(int64_t view_id,
-                             const ViewportMetrics& viewport_metrics,
+                             const flutter::ViewportMetrics& viewport_metrics,
                              AddViewCallback callback) override {}
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewRemoveView(int64_t view_id,

--- a/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -88,6 +88,13 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewScheduleFrame() {}
   // |flutter::PlatformView::Delegate|
+  void OnPlatformViewAddView(int64_t view_id,
+                             const ViewportMetrics& viewport_metrics,
+                             AddViewCallback callback) override {}
+  // |flutter::PlatformView::Delegate|
+  void OnPlatformViewRemoveView(int64_t view_id,
+                                RemoveViewCallback callback) override {}
+  // |flutter::PlatformView::Delegate|
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) {}
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewSetViewportMetrics(


### PR DESCRIPTION
This PR moves the methods to add or remove views from `Shell` to `PlatformView`. By design, the `Shell` is supposed to be a messenger that glues classes together, while `PlatformView` is the operator that embedders that do not use the embedder API should operate on. The current design was made due to lack of knowledge to this design.

This also makes `PlatformView` aware of views, which might be a prerequisite to https://github.com/flutter/engine/pull/51925.

This PR also adds some details to embedder API `AddView` and `RemoveView`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
