### PR TITLE
[Impeller] Use type safe masks for HardwareBufferUsage.

### DIFF
--- a/impeller/toolkit/android/hardware_buffer.cc
+++ b/impeller/toolkit/android/hardware_buffer.cc
@@ -24,16 +24,13 @@ static AHardwareBuffer_Desc ToAHardwareBufferDesc(
   ahb_desc.height = desc.size.height;
   ahb_desc.format = ToAHardwareBufferFormat(desc.format);
   ahb_desc.layers = 1u;
-  if (desc.usage & static_cast<HardwareBufferUsage>(
-                       HardwareBufferUsageFlags::kFrameBufferAttachment)) {
+  if (desc.usage & HardwareBufferUsageFlags::kFrameBufferAttachment) {
     ahb_desc.usage |= AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER;
   }
-  if (desc.usage & static_cast<HardwareBufferUsage>(
-                       HardwareBufferUsageFlags::kCompositorOverlay)) {
+  if (desc.usage & HardwareBufferUsageFlags::kCompositorOverlay) {
     ahb_desc.usage |= AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY;
   }
-  if (desc.usage & static_cast<HardwareBufferUsage>(
-                       HardwareBufferUsageFlags::kSampledImage)) {
+  if (desc.usage & HardwareBufferUsageFlags::kSampledImage) {
     ahb_desc.usage |= AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
   }
   return ahb_desc;
@@ -80,12 +77,9 @@ HardwareBufferDescriptor HardwareBufferDescriptor::MakeForSwapchainImage(
   desc.format = HardwareBufferFormat::kR8G8B8A8UNormInt;
   // Zero sized hardware buffers cannot be allocated.
   desc.size = size.Max(ISize{1u, 1u});
-  desc.usage =
-      static_cast<HardwareBufferUsage>(
-          HardwareBufferUsageFlags::kFrameBufferAttachment) |
-      static_cast<HardwareBufferUsage>(
-          HardwareBufferUsageFlags::kCompositorOverlay) |
-      static_cast<HardwareBufferUsage>(HardwareBufferUsageFlags::kSampledImage);
+  desc.usage = HardwareBufferUsageFlags::kFrameBufferAttachment |
+               HardwareBufferUsageFlags::kCompositorOverlay |
+               HardwareBufferUsageFlags::kSampledImage;
   return desc;
 }
 

--- a/impeller/toolkit/android/hardware_buffer.h
+++ b/impeller/toolkit/android/hardware_buffer.h
@@ -8,6 +8,7 @@
 #include <optional>
 
 #include "flutter/fml/unique_object.h"
+#include "impeller/base/mask.h"
 #include "impeller/geometry/size.h"
 #include "impeller/toolkit/android/proc_table.h"
 
@@ -26,13 +27,14 @@ enum class HardwareBufferFormat {
   kR8G8B8A8UNormInt,
 };
 
-using HardwareBufferUsage = uint8_t;
-
-enum class HardwareBufferUsageFlags : HardwareBufferUsage {
+enum class HardwareBufferUsageFlags {
+  kNone = 0u,
   kFrameBufferAttachment = 1u << 0u,
   kCompositorOverlay = 1u << 1u,
   kSampledImage = 1u << 2u,
 };
+
+using HardwareBufferUsage = Mask<HardwareBufferUsageFlags>;
 
 //------------------------------------------------------------------------------
 /// @brief      A descriptor use to specify hardware buffer allocations.
@@ -40,7 +42,7 @@ enum class HardwareBufferUsageFlags : HardwareBufferUsage {
 struct HardwareBufferDescriptor {
   HardwareBufferFormat format = HardwareBufferFormat::kR8G8B8A8UNormInt;
   ISize size;
-  HardwareBufferUsage usage = 0u;
+  HardwareBufferUsage usage = HardwareBufferUsageFlags::kNone;
 
   //----------------------------------------------------------------------------
   /// @brief      Create a descriptor of the given size that is suitable for use
@@ -145,5 +147,11 @@ class HardwareBuffer {
 };
 
 }  // namespace impeller::android
+
+namespace impeller {
+
+IMPELLER_ENUM_IS_MASK(android::HardwareBufferUsageFlags);
+
+}  // namespace impeller
 
 #endif  // FLUTTER_IMPELLER_TOOLKIT_ANDROID_HARDWARE_BUFFER_H_


### PR DESCRIPTION
These were added to //impeller/base/mask.h recently. No change in functionality. Removes a bunch of casts.
