### PR TITLE
Add buildtools as an excluded root directory in header_filter_regex_text on the 3.19 release branch

### DIFF
--- a/tools/clang_tidy/test/header_filter_regex_test.dart
+++ b/tools/clang_tidy/test/header_filter_regex_test.dart
@@ -38,6 +38,7 @@ void main() {
     const Set<String> intentionallyOmitted = <String>{
       '.git',
       '.github',
+      'buildtools',
       'prebuilts',
       'third_party',
     };


### PR DESCRIPTION
//buildtools was moved to //flutter/buildtools in the main branch.  But running "gclient sync -D" on a release branch that precedes this change may not delete all of the directories in flutter/buildtools if the filesystem was previously synced to the main branch.

header_filter_regex_text will then see a stale flutter/buildtools directory and warn that it is not covered in the .clang-tidy file

This change adds flutter/buildtools to the header_filter_regex_text excluded directory list so the test will work in this configuration.