### PR TITLE
Use RBE in mac builds in presubmit but not postsubmit

### DIFF
--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -75,7 +75,8 @@
                 "cpu=x86"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -83,7 +84,10 @@
                 "--runtime-mode",
                 "profile",
                 "--android",
-                "--android-cpu=arm64"
+                "--android-cpu=arm64",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/android_profile_arm64",
             "description": "Produces profile mode artifacts to target 64-bit arm Android from a macOS host.",
@@ -92,6 +96,18 @@
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/android_profile_arm64",
+                    "--runtime-mode",
+                    "profile",
+                    "--android",
+                    "--android-cpu=arm64",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -118,7 +134,8 @@
                 "cpu=x86"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -126,7 +143,10 @@
                 "--runtime-mode",
                 "profile",
                 "--android",
-                "--android-cpu=x64"
+                "--android-cpu=x64",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/android_profile_x64",
             "description": "Produces profile mode artifacts to target x64 Android from a macOS host.",
@@ -135,6 +155,18 @@
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/android_profile_x64",
+                    "--runtime-mode",
+                    "profile",
+                    "--android",
+                    "--android-cpu=x64",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -161,14 +193,18 @@
                 "cpu=x86"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
                 "ci/android_release",
                 "--runtime-mode",
                 "release",
-                "--android"
+                "--android",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/android_release",
             "description": "Produces release mode artifacts to target 32-bit arm Android from a macOS host.",
@@ -177,6 +213,17 @@
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/android_release",
+                    "--runtime-mode",
+                    "release",
+                    "--android",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -203,7 +250,8 @@
                 "cpu=x86"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -211,7 +259,10 @@
                 "--runtime-mode",
                 "release",
                 "--android",
-                "--android-cpu=arm64"
+                "--android-cpu=arm64",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/android_release_arm64",
             "description": "Produces release mode artifacts to target 64-bit arm Android from a macOS host.",
@@ -220,6 +271,18 @@
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/android_release_arm64",
+                    "--runtime-mode",
+                    "release",
+                    "--android",
+                    "--android-cpu=arm64",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -246,7 +309,8 @@
                 "cpu=x86"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -254,7 +318,10 @@
                 "--runtime-mode",
                 "release",
                 "--android",
-                "--android-cpu=x64"
+                "--android-cpu=x64",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/android_release_x64",
             "description": "Produces release mode artifacts to target x64 Android from a macOS host.",
@@ -263,6 +330,18 @@
                 "targets": [
                     "flutter/lib/snapshot",
                     "flutter/shell/platform/android:gen_snapshot"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/android_release_x64",
+                    "--runtime-mode",
+                    "release",
+                    "--android",
+                    "--android-cpu=x64",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -20,7 +20,8 @@
                 "mac_model=Macmini8,1"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -30,7 +31,11 @@
                 "--no-lto",
                 "--prebuilt-dart-sdk",
                 "--build-embedder-examples",
-                "--use-glfw-swiftshader"
+                "--use-glfw-swiftshader",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
+
             ],
             "name": "ci/host_debug",
             "description": "Produces debug mode x64 macOS host-side tooling and builds host-side unit tests for x64 macOS.",
@@ -45,6 +50,20 @@
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter/tools/font_subset",
                     "flutter:unittests"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/host_debug",
+                    "--runtime-mode",
+                    "debug",
+                    "--no-lto",
+                    "--prebuilt-dart-sdk",
+                    "--build-embedder-examples",
+                    "--use-glfw-swiftshader",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -86,7 +105,8 @@
                 "mac_model=Macmini8,1"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -95,7 +115,10 @@
                 "profile",
                 "--no-lto",
                 "--prebuilt-dart-sdk",
-                "--build-embedder-examples"
+                "--build-embedder-examples",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/host_profile",
             "description": "Produces profile mode x64 macOS host-side tooling and builds host-side unit tests for x64 macOS.",
@@ -107,6 +130,19 @@
                     "flutter/build/archives:artifacts",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter:unittests"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/host_profile",
+                    "--runtime-mode",
+                    "profile",
+                    "--no-lto",
+                    "--prebuilt-dart-sdk",
+                    "--build-embedder-examples",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -155,7 +191,8 @@
                 }
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -165,7 +202,10 @@
                 "--no-lto",
                 "--prebuilt-dart-sdk",
                 "--build-embedder-examples",
-                "--use-glfw-swiftshader"
+                "--use-glfw-swiftshader",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/host_release",
             "description": "Produces release mode x64 macOS host-side tooling and builds host-side unit tests for x64 macOS.",
@@ -179,6 +219,20 @@
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter/tools/font_subset",
                     "flutter:unittests"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/host_release",
+                    "--runtime-mode",
+                    "release",
+                    "--no-lto",
+                    "--prebuilt-dart-sdk",
+                    "--build-embedder-examples",
+                    "--use-glfw-swiftshader",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -219,7 +273,8 @@
                 "cpu=x86"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -230,7 +285,10 @@
                 "--runtime-mode",
                 "debug",
                 "--no-lto",
-                "--prebuilt-dart-sdk"
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/mac_debug_arm64",
             "description": "Produces debug mode arm64 macOS host-side tooling.",
@@ -243,6 +301,21 @@
                     "flutter/build/archives:dart_sdk_archive",
                     "flutter/build/archives:flutter_embedder_framework",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/mac_debug_arm64",
+                    "--mac",
+                    "--mac-cpu",
+                    "arm64",
+                    "--runtime-mode",
+                    "debug",
+                    "--no-lto",
+                    "--prebuilt-dart-sdk",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -269,7 +342,8 @@
                 "cpu=x86"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -280,7 +354,10 @@
                 "--runtime-mode",
                 "profile",
                 "--no-lto",
-                "--prebuilt-dart-sdk"
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/mac_profile_arm64",
             "description": "Produces profile mode arm64 macOS host-side tooling.",
@@ -289,6 +366,21 @@
                 "targets": [
                     "flutter/build/archives:artifacts",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework"
+                ]
+            },
+           "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/mac_profile_arm64",
+                    "--mac",
+                    "--mac-cpu",
+                    "arm64",
+                    "--runtime-mode",
+                    "profile",
+                    "--no-lto",
+                    "--prebuilt-dart-sdk",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -316,7 +408,8 @@
                 "cpu=x86"
             ],
             "gclient_variables": {
-                "download_android_deps": false
+                "download_android_deps": false,
+                "use_rbe": true
             },
             "gn": [
                 "--target-dir",
@@ -327,7 +420,10 @@
                 "--runtime-mode",
                 "release",
                 "--no-lto",
-                "--prebuilt-dart-sdk"
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/mac_release_arm64",
             "description": "Produces release mode arm64 macOS host-side tooling.",
@@ -337,6 +433,21 @@
                     "flutter/tools/font_subset",
                     "flutter/build/archives:artifacts",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework"
+                ]
+            },
+           "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/mac_release_arm64",
+                    "--mac",
+                    "--mac-cpu",
+                    "arm64",
+                    "--runtime-mode",
+                    "release",
+                    "--no-lto",
+                    "--prebuilt-dart-sdk",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -6,6 +6,10 @@
                 "os=Mac-13",
                 "cpu=x86"
             ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
             "gn": [
                 "--target-dir",
                 "ci/ios_debug_sim",
@@ -13,63 +17,27 @@
                 "--runtime-mode",
                 "debug",
                 "--simulator",
-                "--no-lto"
+                "--no-lto",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/ios_debug_sim",
             "description": "Produces debug mode artifacts to target the x64 iOS simulator.",
             "ninja": {
                 "config": "ci/ios_debug_sim"
             },
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "sdk_version": "15a240d"
-                }
-            }
-        },
-        {
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-13"
-            ],
-            "gn": [
-                "--target-dir",
-                "ci/ios_debug_sim_arm64",
-                "--ios",
-                "--runtime-mode",
-                "debug",
-                "--simulator",
-                "--simulator-cpu=arm64",
-                "--no-lto"
-            ],
-            "name": "ci/ios_debug_sim_arm64",
-            "description": "Produces debug mode artifacts to target the arm64 iOS simulator.",
-            "ninja": {
-                "config": "ci/ios_debug_sim_arm64"
-            },
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "sdk_version": "15a240d"
-                }
-            }
-        },
-        {
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-13"
-            ],
-            "gn": [
-                "--target-dir",
-                "ci/ios_debug",
-                "--ios",
-                "--runtime-mode",
-                "debug"
-            ],
-            "name": "ci/ios_debug",
-            "description": "Produces debug mode artifacts to target iOS.",
-            "ninja": {
-                "config": "ci/ios_debug",
-                "targets": [
-                    "flutter/shell/platform/darwin/ios:flutter_framework"
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_debug_sim",
+                    "--ios",
+                    "--runtime-mode",
+                    "debug",
+                    "--simulator",
+                    "--no-lto",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -83,12 +51,110 @@
                 "device_type=none",
                 "os=Mac-13"
             ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/ios_debug_sim_arm64",
+                "--ios",
+                "--runtime-mode",
+                "debug",
+                "--simulator",
+                "--simulator-cpu=arm64",
+                "--no-lto",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
+            ],
+            "name": "ci/ios_debug_sim_arm64",
+            "description": "Produces debug mode artifacts to target the arm64 iOS simulator.",
+            "ninja": {
+                "config": "ci/ios_debug_sim_arm64"
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_debug_sim_arm64",
+                    "--ios",
+                    "--runtime-mode",
+                    "debug",
+                    "--simulator",
+                    "--simulator-cpu=arm64",
+                    "--no-lto",
+                    "--no-rbe",
+                    "--no-goma"
+                ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "15a240d"
+                }
+            }
+        },
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-13"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/ios_debug",
+                "--ios",
+                "--runtime-mode",
+                "debug",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
+            ],
+            "name": "ci/ios_debug",
+            "description": "Produces debug mode artifacts to target iOS.",
+            "ninja": {
+                "config": "ci/ios_debug",
+                "targets": [
+                    "flutter/shell/platform/darwin/ios:flutter_framework"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_debug",
+                    "--ios",
+                    "--runtime-mode",
+                    "debug",
+                    "--no-rbe",
+                    "--no-goma"
+                ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "15a240d"
+                }
+            }
+        },
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-13"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
             "gn": [
                 "--target-dir",
                 "ci/ios_profile",
                 "--ios",
                 "--runtime-mode",
-                "profile"
+                "profile",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/ios_profile",
             "description": "Produces profile mode artifacts to target iOS.",
@@ -99,6 +165,17 @@
                     "flutter/lib/snapshot:generate_snapshot_bin"
                 ]
             },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_profile",
+                    "--ios",
+                    "--runtime-mode",
+                    "profile",
+                    "--no-rbe",
+                    "--no-goma"
+                ]
+            },
             "properties": {
                 "$flutter/osx_sdk": {
                     "sdk_version": "15a240d"
@@ -110,12 +187,19 @@
                 "device_type=none",
                 "os=Mac-13"
             ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
             "gn": [
                 "--target-dir",
                 "ci/ios_release",
                 "--ios",
                 "--runtime-mode",
-                "release"
+                "release",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/ios_release",
             "description": "Produces release mode artifacts to target iOS.",
@@ -124,6 +208,17 @@
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_release",
+                    "--ios",
+                    "--runtime-mode",
+                    "release",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -138,6 +233,10 @@
                 "os=Mac-13",
                 "cpu=x86"
             ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
             "gn": [
                 "--target-dir",
                 "ci/ios_debug_sim_extension_safe",
@@ -146,65 +245,28 @@
                 "debug",
                 "--simulator",
                 "--no-lto",
-                "--darwin-extension-safe"
+                "--darwin-extension-safe",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/ios_debug_sim_extension_safe",
             "description": "Produces extension safe debug mode artifacts to target the x64 iOS simulator.",
             "ninja": {
                 "config": "ci/ios_debug_sim_extension_safe"
             },
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "sdk_version": "15a240d"
-                }
-            }
-        },
-        {
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-13"
-            ],
-            "gn": [
-                "--target-dir",
-                "ci/ios_debug_sim_arm64_extension_safe",
-                "--ios",
-                "--runtime-mode",
-                "debug",
-                "--simulator",
-                "--simulator-cpu=arm64",
-                "--no-lto",
-                "--darwin-extension-safe"
-            ],
-            "name": "ci/ios_debug_sim_arm64_extension_safe",
-            "description": "Produces extension safe debug mode artifacts to target the arm64 iOS simulator.",
-            "ninja": {
-                "config": "ci/ios_debug_sim_arm64_extension_safe"
-            },
-            "properties": {
-                "$flutter/osx_sdk": {
-                    "sdk_version": "15a240d"
-                }
-            }
-        },
-        {
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Mac-13"
-            ],
-            "gn": [
-                "--target-dir",
-                "ci/ios_debug_extension_safe",
-                "--ios",
-                "--runtime-mode",
-                "debug",
-                "--darwin-extension-safe"
-            ],
-            "name": "ci/ios_debug_extension_safe",
-            "description": "Produces extension safe debug mode artifacts to target iOS.",
-            "ninja": {
-                "config": "ci/ios_debug_extension_safe",
-                "targets": [
-                    "flutter/shell/platform/darwin/ios:flutter_framework"
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_debug_sim_extension_safe",
+                    "--ios",
+                    "--runtime-mode",
+                    "debug",
+                    "--simulator",
+                    "--no-lto",
+                    "--darwin-extension-safe",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {
@@ -218,13 +280,115 @@
                 "device_type=none",
                 "os=Mac-13"
             ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/ios_debug_sim_arm64_extension_safe",
+                "--ios",
+                "--runtime-mode",
+                "debug",
+                "--simulator",
+                "--simulator-cpu=arm64",
+                "--no-lto",
+                "--darwin-extension-safe",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
+            ],
+            "name": "ci/ios_debug_sim_arm64_extension_safe",
+            "description": "Produces extension safe debug mode artifacts to target the arm64 iOS simulator.",
+            "ninja": {
+                "config": "ci/ios_debug_sim_arm64_extension_safe"
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_debug_sim_arm64_extension_safe",
+                    "--ios",
+                    "--runtime-mode",
+                    "debug",
+                    "--simulator",
+                    "--simulator-cpu=arm64",
+                    "--no-lto",
+                    "--darwin-extension-safe",
+                    "--no-rbe",
+                    "--no-goma"
+                ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "15a240d"
+                }
+            }
+        },
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-13"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/ios_debug_extension_safe",
+                "--ios",
+                "--runtime-mode",
+                "debug",
+                "--darwin-extension-safe",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
+            ],
+            "name": "ci/ios_debug_extension_safe",
+            "description": "Produces extension safe debug mode artifacts to target iOS.",
+            "ninja": {
+                "config": "ci/ios_debug_extension_safe",
+                "targets": [
+                    "flutter/shell/platform/darwin/ios:flutter_framework"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_debug_extension_safe",
+                    "--ios",
+                    "--runtime-mode",
+                    "debug",
+                    "--darwin-extension-safe",
+                    "--no-rbe",
+                    "--no-goma"
+                ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "15a240d"
+                }
+            }
+        },
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-13"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
             "gn": [
                 "--target-dir",
                 "ci/ios_profile_extension_safe",
                 "--ios",
                 "--runtime-mode",
                 "profile",
-                "--darwin-extension-safe"
+                "--darwin-extension-safe",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/ios_profile_extension_safe",
             "description": "Produces extension safe profile mode artifacts to target iOS.",
@@ -235,6 +399,18 @@
                     "flutter/lib/snapshot:generate_snapshot_bin"
                 ]
             },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_profile_extension_safe",
+                    "--ios",
+                    "--runtime-mode",
+                    "profile",
+                    "--darwin-extension-safe",
+                    "--no-rbe",
+                    "--no-goma"
+                ]
+            },
             "properties": {
                 "$flutter/osx_sdk": {
                     "sdk_version": "15a240d"
@@ -246,13 +422,20 @@
                 "device_type=none",
                 "os=Mac-13"
             ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "use_rbe": true
+            },
             "gn": [
                 "--target-dir",
                 "ci/ios_release_extension_safe",
                 "--ios",
                 "--runtime-mode",
                 "release",
-                "--darwin-extension-safe"
+                "--darwin-extension-safe",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
             ],
             "name": "ci/ios_release_extension_safe",
             "description": "Produces extension safe release mode artifacts to target iOS.",
@@ -261,6 +444,18 @@
                 "targets": [
                     "flutter/shell/platform/darwin/ios:flutter_framework",
                     "flutter/lib/snapshot:generate_snapshot_bin"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_release_extension_safe",
+                    "--ios",
+                    "--runtime-mode",
+                    "release",
+                    "--darwin-extension-safe",
+                    "--no-rbe",
+                    "--no-goma"
                 ]
             },
             "properties": {


### PR DESCRIPTION
This also disables goma in both pre- and post-submit for mac builds.