### PR TITLE
[et] Adds --lto flag to build. Plumbs verbose flag differently.

### DIFF
--- a/tools/engine_tool/lib/main.dart
+++ b/tools/engine_tool/lib/main.dart
@@ -16,6 +16,8 @@ import 'src/environment.dart';
 import 'src/logger.dart';
 
 void main(List<String> args) async {
+  final bool verbose = args.contains('--verbose') || args.contains('-v');
+
   // Find the engine repo.
   final Engine engine;
   try {
@@ -63,6 +65,7 @@ void main(List<String> args) async {
   final ToolCommandRunner runner = ToolCommandRunner(
     environment: environment,
     configs: configs,
+    verbose: verbose,
   );
 
   try {

--- a/tools/engine_tool/lib/src/build_utils.dart
+++ b/tools/engine_tool/lib/src/build_utils.dart
@@ -47,9 +47,11 @@ List<Build> filterBuilds(Map<String, BuilderConfig> input, BuildFilter test) {
 }
 
 /// Returns a list of runnable builds.
-List<Build> runnableBuilds(Environment env, Map<String, BuilderConfig> input) {
+List<Build> runnableBuilds(
+    Environment env, Map<String, BuilderConfig> input, bool verbose) {
   return filterBuilds(input, (String configName, Build build) {
-    return build.canRunOn(env.platform);
+    return build.canRunOn(env.platform) &&
+           (verbose || build.name.startsWith(env.platform.operatingSystem));
   });
 }
 
@@ -148,6 +150,7 @@ Future<int> runBuild(Environment environment, Build build,
   void handler(RunnerEvent event) {
     switch (event) {
       case RunnerStart():
+        environment.logger.info('$event: ${event.command.join(' ')}');
         environment.logger.status('$event     ', newline: false);
         spinner = environment.logger.startSpinner();
       case RunnerProgress(done: true):

--- a/tools/engine_tool/lib/src/commands/build_command.dart
+++ b/tools/engine_tool/lib/src/commands/build_command.dart
@@ -15,19 +15,24 @@ final class BuildCommand extends CommandBase {
   BuildCommand({
     required super.environment,
     required Map<String, BuilderConfig> configs,
+    super.verbose = false,
   }) {
-    builds = runnableBuilds(environment, configs);
+    builds = runnableBuilds(environment, configs, verbose);
     debugCheckBuilds(builds);
     addConfigOption(
       environment,
       argParser,
-      runnableBuilds(environment, configs),
+      builds,
     );
     argParser.addFlag(
       rbeFlag,
       defaultsTo: true,
       help: 'RBE is enabled by default when available. Use --no-rbe to '
           'disable it.',
+    );
+    argParser.addFlag(
+      ltoFlag,
+      help: 'Whether LTO should be enabled for a build. Default is disabled',
     );
   }
 
@@ -48,6 +53,7 @@ et build //flutter/fml:fml_benchmarks  # Build a specific target in `//flutter/f
   Future<int> run() async {
     final String configName = argResults![configFlag] as String;
     final bool useRbe = argResults![rbeFlag] as bool;
+    final bool useLto = argResults![ltoFlag] as bool;
     final String demangledName = demangleConfigName(environment, configName);
     final Build? build =
         builds.where((Build build) => build.name == demangledName).firstOrNull;
@@ -58,6 +64,8 @@ et build //flutter/fml:fml_benchmarks  # Build a specific target in `//flutter/f
 
     final List<String> extraGnArgs = <String>[
       if (!useRbe) '--no-rbe',
+      if (useLto) '--lto',
+      if (!useLto) '--no-lto',
     ];
 
     final List<BuildTarget>? selectedTargets = await targetsFromCommandLine(

--- a/tools/engine_tool/lib/src/commands/command.dart
+++ b/tools/engine_tool/lib/src/commands/command.dart
@@ -13,10 +13,16 @@ import 'flags.dart';
 /// The base class that all commands and subcommands should inherit from.
 abstract base class CommandBase extends Command<int> {
   /// Constructs the base command.
-  CommandBase({required this.environment});
+  CommandBase({
+    required this.environment,
+    this.verbose = false,
+  });
 
   /// The host system environment.
   final Environment environment;
+
+  /// Whether verbose logging is enabled.
+  final bool verbose;
 }
 
 /// Adds the -c (--config) option to the parser.
@@ -30,7 +36,8 @@ void addConfigOption(
     configFlag,
     abbr: 'c',
     defaultsTo: defaultsTo,
-    help: 'Specify the build config to use',
+    help: 'Specify the build config to use. Run "et help build --verbose" to '
+        'see the full list of runnable configurations.',
     allowed: <String>[
       for (final Build config in builds)
         mangleConfigName(environment, config.name),

--- a/tools/engine_tool/lib/src/commands/command_runner.dart
+++ b/tools/engine_tool/lib/src/commands/command_runner.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:engine_build_configs/engine_build_configs.dart';
 
@@ -26,15 +25,16 @@ final class ToolCommandRunner extends CommandRunner<int> {
   ToolCommandRunner({
     required this.environment,
     required this.configs,
+    this.verbose = false,
   }) : super(toolName, toolDescription, usageLineLength: _usageLineLength) {
     final List<Command<int>> commands = <Command<int>>[
       FetchCommand(environment: environment),
       FormatCommand(environment: environment),
-      QueryCommand(environment: environment, configs: configs),
-      BuildCommand(environment: environment, configs: configs),
-      RunCommand(environment: environment, configs: configs),
+      QueryCommand(environment: environment, configs: configs, verbose: verbose),
+      BuildCommand(environment: environment, configs: configs, verbose: verbose),
+      RunCommand(environment: environment, configs: configs, verbose: verbose),
       LintCommand(environment: environment),
-      TestCommand(environment: environment, configs: configs),
+      TestCommand(environment: environment, configs: configs, verbose: verbose),
     ];
     commands.forEach(addCommand);
 
@@ -61,15 +61,16 @@ final class ToolCommandRunner extends CommandRunner<int> {
   /// Build configurations loaded from the engine from under ci/builders.
   final Map<String, BuilderConfig> configs;
 
+  /// Whether et should emit verbose logs.
+  final bool verbose;
+
   @override
   Future<int> run(Iterable<String> args) async {
-    final ArgResults argResults = parse(args);
-    final bool verbose = argResults[verboseFlag]! as bool;
     if (verbose) {
       environment.logger.level = Logger.infoLevel;
     }
     try {
-      return await runCommand(argResults) ?? 0;
+      return await runCommand(parse(args)) ?? 0;
     } on FormatException catch (e) {
       environment.logger.error(e);
       return 1;

--- a/tools/engine_tool/lib/src/commands/flags.dart
+++ b/tools/engine_tool/lib/src/commands/flags.dart
@@ -15,6 +15,7 @@ const String allFlag = 'all';
 const String builderFlag = 'builder';
 const String configFlag = 'config';
 const String dryRunFlag = 'dry-run';
+const String ltoFlag = 'lto';
 const String quietFlag = 'quiet';
 const String rbeFlag = 'rbe';
 const String runTestsFlag = 'run-tests';

--- a/tools/engine_tool/lib/src/commands/query_command.dart
+++ b/tools/engine_tool/lib/src/commands/query_command.dart
@@ -15,6 +15,7 @@ final class QueryCommand extends CommandBase {
   QueryCommand({
     required super.environment,
     required this.configs,
+    super.verbose = false,
   }) {
     // Add options here that are common to all queries.
     argParser
@@ -33,7 +34,6 @@ final class QueryCommand extends CommandBase {
             if (entry.value.canRunOn(environment.platform)) entry.key,
         ],
         allowedHelp: <String, String>{
-          // TODO(zanderso): Add human readable descriptions to the json files.
           for (final MapEntry<String, BuilderConfig> entry in configs.entries)
             if (entry.value.canRunOn(environment.platform))
               entry.key: entry.value.path,
@@ -43,10 +43,12 @@ final class QueryCommand extends CommandBase {
     addSubcommand(QueryBuildersCommand(
       environment: environment,
       configs: configs,
+      verbose: verbose,
     ));
     addSubcommand(QueryTargetsCommand(
       environment: environment,
       configs: configs,
+      verbose: verbose,
     ));
   }
 
@@ -67,6 +69,7 @@ final class QueryBuildersCommand extends CommandBase {
   QueryBuildersCommand({
     required super.environment,
     required this.configs,
+    super.verbose = false,
   });
 
   /// Build configurations loaded from the engine from under ci/builders.
@@ -85,7 +88,6 @@ final class QueryBuildersCommand extends CommandBase {
     // current platform.
     final bool all = parent!.argResults![allFlag]! as bool;
     final String? builderName = parent!.argResults![builderFlag] as String?;
-    final bool verbose = globalResults![verboseFlag]! as bool;
     if (!verbose) {
       environment.logger.status(
         'Add --verbose to see detailed information about each builder',
@@ -133,13 +135,14 @@ final class QueryTargetsCommand extends CommandBase {
   QueryTargetsCommand({
     required super.environment,
     required this.configs,
+    super.verbose = false,
   }) {
-    builds = runnableBuilds(environment, configs);
+    builds = runnableBuilds(environment, configs, verbose);
     debugCheckBuilds(builds);
     addConfigOption(
       environment,
       argParser,
-      runnableBuilds(environment, configs),
+      builds,
     );
     argParser.addFlag(
       testOnlyFlag,

--- a/tools/engine_tool/lib/src/commands/run_command.dart
+++ b/tools/engine_tool/lib/src/commands/run_command.dart
@@ -18,13 +18,14 @@ final class RunCommand extends CommandBase {
   RunCommand({
     required super.environment,
     required Map<String, BuilderConfig> configs,
+    super.verbose = false,
   }) {
-    builds = runnableBuilds(environment, configs);
+    builds = runnableBuilds(environment, configs, verbose);
     debugCheckBuilds(builds);
     // We default to nothing in order to automatically detect attached devices
     // and select an appropriate target from them.
     addConfigOption(
-      environment, argParser, runnableBuilds(environment, configs),
+      environment, argParser, builds,
       defaultsTo: '',
     );
     argParser.addFlag(

--- a/tools/engine_tool/lib/src/commands/test_command.dart
+++ b/tools/engine_tool/lib/src/commands/test_command.dart
@@ -17,13 +17,14 @@ final class TestCommand extends CommandBase {
   TestCommand({
     required super.environment,
     required Map<String, BuilderConfig> configs,
+    super.verbose = false,
   }) {
-    builds = runnableBuilds(environment, configs);
+    builds = runnableBuilds(environment, configs, verbose);
     debugCheckBuilds(builds);
     addConfigOption(
       environment,
       argParser,
-      runnableBuilds(environment, configs),
+      builds,
     );
   }
 

--- a/tools/engine_tool/test/build_command_test.dart
+++ b/tools/engine_tool/test/build_command_test.dart
@@ -51,7 +51,7 @@ void main() {
       cannedProcesses: cannedProcesses,
     );
     try {
-      final List<Build> result = runnableBuilds(testEnv.environment, configs);
+      final List<Build> result = runnableBuilds(testEnv.environment, configs, true);
       expect(result.length, equals(8));
       expect(result[0].name, equals('ci/build_name'));
     } finally {
@@ -67,6 +67,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -89,6 +90,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -111,6 +113,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -136,6 +139,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -158,6 +162,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -167,7 +172,7 @@ void main() {
       expect(result, equals(0));
       expect(testEnv.processHistory[0].command[0],
           contains(path.join('tools', 'gn')));
-      expect(testEnv.processHistory[0].command[4], equals('--rbe'));
+      expect(testEnv.processHistory[0].command[3], equals('--rbe'));
       expect(testEnv.processHistory[1].command[0],
           contains(path.join('reclient', 'bootstrap')));
     } finally {
@@ -184,6 +189,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -212,6 +218,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -285,6 +292,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -318,6 +326,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: env,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -341,6 +350,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -369,6 +379,7 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
+        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',

--- a/tools/engine_tool/test/gn_utils_test.dart
+++ b/tools/engine_tool/test/gn_utils_test.dart
@@ -84,7 +84,7 @@ void main() {
     );
     try {
       final Environment env = testEnv.environment;
-      final List<Build> builds = runnableBuilds(env, configs);
+      final List<Build> builds = runnableBuilds(env, configs, true);
       final Build? build = builds.where(
         (Build build) => build.name == 'linux/host_debug',
       ).firstOrNull;
@@ -104,7 +104,7 @@ void main() {
     );
     try {
       final Environment env = testEnv.environment;
-      final List<Build> builds = runnableBuilds(env, configs);
+      final List<Build> builds = runnableBuilds(env, configs, true);
       final Build? build = builds.where(
         (Build build) => build.name == 'linux/host_debug',
       ).firstOrNull;


### PR DESCRIPTION
This PR does two things. First, in many of the `ci` builds, LTO is enabled by default. This is usually not what we want when doing local builds, so this PR adds an `--lto` flag to the `build` command which is disabled by default, causing `--no-lto` to be passed to GN. When `--lto` is passed to the `build` command, `--lto` is passed to GN, which results in the build using LTO.

Second, this PR eagerly parses the `--verbose` flag out of the command line so that help messages can optionally show less information. In particular, in this PR, `ci` and `web_test` builds are only displayed by `help build` when `--verbose` is passed to the `help` command. There's some extra text in the help message as well indicating that passing `--verbose` to `help` will show more builds.