### PR TITLE
[Engine] allow --enable-asserts flag to be passed to dart vm in profile mode.

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -65,6 +65,7 @@ static const std::string kAllowedDartFlags[] = {
     "--null_assertions",
     "--strict_null_safety_checks",
     "--max_subtype_cache_entries",
+    "--enable-asserts",
 };
 // clang-format on
 

--- a/shell/common/switches_unittests.cc
+++ b/shell/common/switches_unittests.cc
@@ -123,17 +123,15 @@ TEST(SwitchesTest, NoEnableImpeller) {
   }
 }
 
+#if !FLUTTER_RELEASE
 TEST(SwitchesTest, EnableAsserts) {
   fml::CommandLine command_line = fml::CommandLineFromInitializerList(
       {"command", "--dart-flags=--enable-asserts"});
   Settings settings = SettingsFromCommandLine(command_line);
-#if !FLUTTER_RELEASE
   ASSERT_EQ(settings.dart_flags.size(), 1ul);
   EXPECT_EQ(settings.dart_flags[0], "--enable-asserts");
-#else
-  EXPECT_TRUE(settings.dart_flags.empty());
-#endif
 }
+#endif 
 
 }  // namespace testing
 }  // namespace flutter

--- a/shell/common/switches_unittests.cc
+++ b/shell/common/switches_unittests.cc
@@ -123,6 +123,18 @@ TEST(SwitchesTest, NoEnableImpeller) {
   }
 }
 
+TEST(SwitchesTest, EnableAsserts) {
+  fml::CommandLine command_line = fml::CommandLineFromInitializerList(
+      {"command", "--dart-flags=--enable-asserts"});
+  Settings settings = SettingsFromCommandLine(command_line);
+#if !FLUTTER_RELEASE
+  ASSERT_EQ(settings.dart_flags.size(), 1ul);
+  EXPECT_EQ(settings.dart_flags[0], "--enable-asserts");
+#else
+  EXPECT_TRUE(settings.dart_flags.empty());
+#endif
+}
+
 }  // namespace testing
 }  // namespace flutter
 

--- a/shell/common/switches_unittests.cc
+++ b/shell/common/switches_unittests.cc
@@ -131,7 +131,7 @@ TEST(SwitchesTest, EnableAsserts) {
   ASSERT_EQ(settings.dart_flags.size(), 1ul);
   EXPECT_EQ(settings.dart_flags[0], "--enable-asserts");
 }
-#endif 
+#endif
 
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
Allows https://github.com/flutter/flutter/issues/145729
