### PR TITLE
Manual roll ICU from a622de35ac31 to bad7ddbf9213 (7 revisions)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -318,7 +318,7 @@ deps = {
    Var('chromium_git') + '/external/github.com/google/flatbuffers' + '@' + '0a80646371179f8a7a5c1f42c31ee1d44dcf6709',
 
   'src/flutter/third_party/icu':
-   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + 'a622de35ac311c5ad390a7af80724634e5dc61ed',
+   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + 'bad7ddbf921358177e56fd723c2f59f8041a370f',
 
    'src/flutter/third_party/gtest-parallel':
    Var('chromium_git') + '/external/github.com/google/gtest-parallel' + '@' + '38191e2733d7cbaeaef6a3f1a942ddeb38a2ad14',


### PR DESCRIPTION
Manual roll requested by zra@google.com

https://chromium.googlesource.com/chromium/deps/icu.git/+log/a622de35ac31..bad7ddbf9213

2024-03-05 dayeung@chromium.org Update TZ to 2024a 2024-02-26 dayeung@chromium.org Fix ICU update.sh script and clean up some things in the readme 2024-02-21 dayeung@chromium.org Patch a buffer write error in uloc_tag.cpp. 2024-02-16 syg@chromium.org Fix null termination in revert_realpath.patch 2024-01-29 mkember@google.com [fxbug.dev] Migrate bug numbers 2023-12-05 zcbenz@gmail.com Fix link error when cross-compiling for Windows on Linux 2023-11-02 ftang@chromium.org Add dayeung@ and syg@ to OWNERS file

If this roll has caused a breakage, revert this CL and stop the roller using the controls here:
https://autoroll.skia.org/r/icu-sdk-flutter-engine Please CC chinmaygarde@google.com,tq-i18n-team@google.com,zra@google.com on the revert to ensure that a human is aware of the problem.

To file a bug in ICU: https://github.com/unicode-org/icu
To file a bug in Flutter Engine: https://github.com/flutter/flutter/issues/new/choose

To report a problem with the AutoRoller itself, please file a bug: https://issues.skia.org/issues/new?component=1389291&template=1850622

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md

