### PR TITLE
Add additional dependencies to const_finder's pubspec.yaml

### DIFF
--- a/tools/const_finder/pubspec.yaml
+++ b/tools/const_finder/pubspec.yaml
@@ -25,11 +25,15 @@ dev_dependencies:
   path: any
 
 dependency_overrides:
+  _fe_analyzer_shared:
+    path: ../../third_party/dart/pkg/_fe_analyzer_shared
   args:
     path: ../../third_party/dart/third_party/pkg/args
   collection:
     path: ../../third_party/dart/third_party/pkg/collection
   kernel:
     path: ../../third_party/dart/pkg/kernel
+  meta:
+    path: ../../third_party/dart/pkg/meta
   path:
     path: ../../third_party/dart/third_party/pkg/path


### PR DESCRIPTION
The Dart commit https://dart-review.googlesource.com/c/sdk/+/361781 added dependencies upon packages meta and _fe_analyzer_shared to the kernel package.  Path overrides for these need to be added to the const_finder package in flutter/engine.
