### PR TITLE
[Android] Drops semantics query when app is not attached

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -24,6 +24,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
+import io.flutter.Build.API_LEVELS;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine.EngineLifecycleListener;
 import io.flutter.embedding.engine.dart.PlatformMessageHandler;
@@ -429,7 +430,9 @@ public class FlutterJNI {
 
   @VisibleForTesting
   public long performNativeAttach(@NonNull FlutterJNI flutterJNI) {
-    return nativeAttach(flutterJNI);
+    // return nativeAttach(flutterJNI);
+    io.flutter.Log.e("TEST!!!!!!", "in actual function");
+    return 0;
   }
 
   private native long nativeAttach(@NonNull FlutterJNI flutterJNI);
@@ -873,22 +876,26 @@ public class FlutterJNI {
   @UiThread
   public void setSemanticsEnabled(boolean enabled) {
     ensureRunningOnMainThread();
-    ensureAttachedToNative();
-    nativeSetSemanticsEnabled(nativeShellHolderId, enabled);
+    if (isAttached()) {
+      nativeSetSemanticsEnabled(nativeShellHolderId, enabled);
+    }
   }
 
-  private native void nativeSetSemanticsEnabled(long nativeShellHolderId, boolean enabled);
+  @VisibleForTesting
+  public native void nativeSetSemanticsEnabled(long nativeShellHolderId, boolean enabled);
 
   // TODO(mattcarroll): figure out what flags are supported and add javadoc about when/why/where to
   // use this.
   @UiThread
   public void setAccessibilityFeatures(int flags) {
     ensureRunningOnMainThread();
-    ensureAttachedToNative();
-    nativeSetAccessibilityFeatures(nativeShellHolderId, flags);
+    if (isAttached()) {
+      nativeSetAccessibilityFeatures(nativeShellHolderId, flags);
+    }
   }
 
-  private native void nativeSetAccessibilityFeatures(long nativeShellHolderId, int flags);
+  @VisibleForTesting
+  public native void nativeSetAccessibilityFeatures(long nativeShellHolderId, int flags);
   // ------ End Accessibility Support ----
 
   // ------ Start Texture Registration Support -----

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -24,7 +24,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
-import io.flutter.Build.API_LEVELS;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine.EngineLifecycleListener;
 import io.flutter.embedding.engine.dart.PlatformMessageHandler;
@@ -430,9 +429,7 @@ public class FlutterJNI {
 
   @VisibleForTesting
   public long performNativeAttach(@NonNull FlutterJNI flutterJNI) {
-    // return nativeAttach(flutterJNI);
-    io.flutter.Log.e("TEST!!!!!!", "in actual function");
-    return 0;
+    return nativeAttach(flutterJNI);
   }
 
   private native long nativeAttach(@NonNull FlutterJNI flutterJNI);
@@ -881,8 +878,7 @@ public class FlutterJNI {
     }
   }
 
-  @VisibleForTesting
-  public native void nativeSetSemanticsEnabled(long nativeShellHolderId, boolean enabled);
+  private native void nativeSetSemanticsEnabled(long nativeShellHolderId, boolean enabled);
 
   // TODO(mattcarroll): figure out what flags are supported and add javadoc about when/why/where to
   // use this.
@@ -894,8 +890,7 @@ public class FlutterJNI {
     }
   }
 
-  @VisibleForTesting
-  public native void nativeSetAccessibilityFeatures(long nativeShellHolderId, int flags);
+  private native void nativeSetAccessibilityFeatures(long nativeShellHolderId, int flags);
   // ------ End Accessibility Support ----
 
   // ------ Start Texture Registration Support -----

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -874,8 +874,13 @@ public class FlutterJNI {
   public void setSemanticsEnabled(boolean enabled) {
     ensureRunningOnMainThread();
     if (isAttached()) {
-      nativeSetSemanticsEnabled(nativeShellHolderId, enabled);
+      setSemanticsEnabledInNative(enabled);
     }
+  }
+
+  @VisibleForTesting
+  public void setSemanticsEnabledInNative(boolean enabled) {
+    nativeSetSemanticsEnabled(nativeShellHolderId, enabled);
   }
 
   private native void nativeSetSemanticsEnabled(long nativeShellHolderId, boolean enabled);
@@ -886,8 +891,13 @@ public class FlutterJNI {
   public void setAccessibilityFeatures(int flags) {
     ensureRunningOnMainThread();
     if (isAttached()) {
-      nativeSetAccessibilityFeatures(nativeShellHolderId, flags);
+      setAccessibilityFeaturesInNative(flags);
     }
+  }
+
+  @VisibleForTesting
+  public void setAccessibilityFeaturesInNative(int flags) {
+    nativeSetAccessibilityFeatures(nativeShellHolderId, flags);
   }
 
   private native void nativeSetAccessibilityFeatures(long nativeShellHolderId, int flags);

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
@@ -2,6 +2,8 @@ package io.flutter.embedding.engine;
 
 import static io.flutter.Build.API_LEVELS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -151,6 +153,32 @@ public class FlutterJNITest {
     assertEquals(result[2], "");
   }
 
+  @Test
+  public void setAccessibilityIfAttached() {
+    // --- Test Setup ---
+    FlutterJNITester flutterJNI = new FlutterJNITester(true);
+    int expectedFlag = 100;
+    
+    flutterJNI.setAccessibilityFeatures(expectedFlag);
+    assertEquals(flutterJNI.flags, expectedFlag);
+
+    flutterJNI.setSemanticsEnabled(true);
+    assertTrue(flutterJNI.semanticsEnabled);
+  }
+
+  @Test
+  public void doesNotSetAccessibilityIfNotAttached() {
+    // --- Test Setup ---
+    FlutterJNITester flutterJNI = new FlutterJNITester(false);
+    int flags = 100;
+    
+    flutterJNI.setAccessibilityFeatures(flags);
+    assertEquals(flutterJNI.flags, 0);
+
+    flutterJNI.setSemanticsEnabled(true);
+    assertFalse(flutterJNI.semanticsEnabled);
+  }
+
   public void onDisplayPlatformView_callsPlatformViewsController() {
     PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
 
@@ -255,5 +283,29 @@ public class FlutterJNITest {
     flutterJNI.setRefreshRateFPS(120.0f);
     // --- Verify Results ---
     verify(flutterJNI, times(1)).updateRefreshRate();
+  }
+
+  static class FlutterJNITester extends FlutterJNI {
+    FlutterJNITester(boolean attached) {
+      this.isAttached = attached;
+    }
+    final boolean isAttached;
+    boolean semanticsEnabled = false;
+    int flags = 0;
+
+    @Override
+    public boolean isAttached() {
+      return isAttached;
+    }
+
+    @Override
+    public void setSemanticsEnabledInNative(boolean enabled) {
+      semanticsEnabled = enabled;
+    }
+
+    @Override
+    public void setAccessibilityFeaturesInNative(int flags) {
+      this.flags = flags; 
+    }
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
@@ -158,7 +158,7 @@ public class FlutterJNITest {
     // --- Test Setup ---
     FlutterJNITester flutterJNI = new FlutterJNITester(true);
     int expectedFlag = 100;
-    
+
     flutterJNI.setAccessibilityFeatures(expectedFlag);
     assertEquals(flutterJNI.flags, expectedFlag);
 
@@ -171,7 +171,7 @@ public class FlutterJNITest {
     // --- Test Setup ---
     FlutterJNITester flutterJNI = new FlutterJNITester(false);
     int flags = 100;
-    
+
     flutterJNI.setAccessibilityFeatures(flags);
     assertEquals(flutterJNI.flags, 0);
 
@@ -289,6 +289,7 @@ public class FlutterJNITest {
     FlutterJNITester(boolean attached) {
       this.isAttached = attached;
     }
+
     final boolean isAttached;
     boolean semanticsEnabled = false;
     int flags = 0;
@@ -305,7 +306,7 @@ public class FlutterJNITest {
 
     @Override
     public void setAccessibilityFeaturesInNative(int flags) {
-      this.flags = flags; 
+      this.flags = flags;
     }
   }
 }


### PR DESCRIPTION
Is seems automatic test may send a11y query before the engine is attached. Add a guard to guard against it.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
