### PR TITLE
Dl text frame iterator prototypes

### DIFF
--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -60,6 +60,7 @@ source_set("display_list") {
     "effects/dl_path_effect.h",
     "effects/dl_runtime_effect.cc",
     "effects/dl_runtime_effect.h",
+    "geometry/dl_geometry_types.h",
     "geometry/dl_region.cc",
     "geometry/dl_region.h",
     "geometry/dl_rtree.cc",

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -9,8 +9,11 @@
 #include <optional>
 
 #include "flutter/display_list/dl_sampling_options.h"
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/display_list/geometry/dl_rtree.h"
 #include "flutter/fml/logging.h"
+
+#include "flutter/impeller/typographer/text_frame.h"
 
 // The Flutter DisplayList mechanism encapsulates a persistent sequence of
 // rendering operations.
@@ -306,6 +309,22 @@ class DisplayList : public SkRefCnt {
   bool modifies_transparent_black() const {
     return modifies_transparent_black_;
   }
+
+ private:
+  using TextFrame = impeller::TextFrame;
+
+ public:
+  typedef std::function<void(const TextFrame&,  //
+                             const DlMatrix&,   //
+                             SkScalar x,        //
+                             SkScalar y)>
+      TextFrameIterator;
+
+  void IterateTextFrames(const TextFrameIterator& iterator,
+                         const DlMatrix& initial_matrix) const;
+
+  void IterateTextFrames2(const TextFrameIterator& iterator,
+                          const DlMatrix& initial_matrix) const;
 
  private:
   DisplayList(DisplayListStorage&& ptr,

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -1397,7 +1397,7 @@ void DisplayListBuilder::DrawDisplayList(const sk_sp<DisplayList> display_list,
   }
 
   DlPaint current_paint = current_;
-  Push<DrawDisplayListOp>(0, 1, display_list,
+  Push<DrawDisplayListOp>(0, 1, display_list, tracker_.matrix(),
                           opacity < SK_Scalar1 ? opacity : SK_Scalar1);
   is_ui_thread_safe_ = is_ui_thread_safe_ && display_list->isUIThreadSafe();
   // Not really necessary if the developer is interacting with us via
@@ -1477,7 +1477,7 @@ void DisplayListBuilder::drawTextFrame(
   unclipped = true;
 #endif  // OS_FUCHSIA
   if (unclipped) {
-    Push<DrawTextFrameOp>(0, 1, text_frame, x, y);
+    Push<DrawTextFrameOp>(0, 1, text_frame, tracker_.matrix(), x, y);
     // There is no way to query if the glyphs of a text blob overlap and
     // there are no current guarantees from either Skia or Impeller that
     // they will protect overlapping glyphs from the effects of overdraw

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -1028,11 +1028,13 @@ struct DrawDisplayListOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawDisplayList;
 
   explicit DrawDisplayListOp(const sk_sp<DisplayList>& display_list,
+                             const DlMatrix& matrix,
                              SkScalar opacity)
-      : opacity(opacity), display_list(display_list) {}
+      : opacity(opacity), display_list(display_list), matrix(matrix) {}
 
   SkScalar opacity;
   const sk_sp<DisplayList> display_list;
+  DlMatrix matrix;
 
   void dispatch(DispatchContext& ctx) const {
     if (op_needed(ctx)) {
@@ -1071,13 +1073,15 @@ struct DrawTextFrameOp final : DrawOpBase {
   static const auto kType = DisplayListOpType::kDrawTextFrame;
 
   DrawTextFrameOp(const std::shared_ptr<impeller::TextFrame>& text_frame,
+                  const impeller::Matrix matrix,
                   SkScalar x,
                   SkScalar y)
-      : x(x), y(y), text_frame(text_frame) {}
+      : x(x), y(y), text_frame(text_frame), matrix(matrix) {}
 
   const SkScalar x;
   const SkScalar y;
   const std::shared_ptr<impeller::TextFrame> text_frame;
+  const impeller::Matrix matrix;
 
   void dispatch(DispatchContext& ctx) const {
     if (op_needed(ctx)) {

--- a/display_list/geometry/dl_geometry_types.h
+++ b/display_list/geometry/dl_geometry_types.h
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_H_
+#define FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_H_
+
+#include "flutter/impeller/geometry/matrix.h"
+#include "flutter/impeller/geometry/rect.h"
+
+namespace flutter {
+  
+using DlRect = impeller::Rect;
+using DlMatrix = impeller::Matrix;
+using DlDegrees = impeller::Degrees;
+
+}  // namespace flutter
+
+#endif  // FLUTTER_DISPLAY_LIST_GEOMETRY_DL_GEOMETRY_TYPES_H_

--- a/display_list/geometry/dl_geometry_types.h
+++ b/display_list/geometry/dl_geometry_types.h
@@ -9,7 +9,7 @@
 #include "flutter/impeller/geometry/rect.h"
 
 namespace flutter {
-  
+
 using DlRect = impeller::Rect;
 using DlMatrix = impeller::Matrix;
 using DlDegrees = impeller::Degrees;

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -890,13 +890,13 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
       {"DrawDisplayList",
        {
            // cv.drawDL does not exist
-           {1, 16, -1, 16,
+           {1, 80, -1, 80,
             [](DlOpReceiver& r) { r.drawDisplayList(TestDisplayList1, 1.0); }},
-           {1, 16, -1, 16,
+           {1, 80, -1, 80,
             [](DlOpReceiver& r) { r.drawDisplayList(TestDisplayList1, 0.5); }},
-           {1, 16, -1, 16,
+           {1, 80, -1, 80,
             [](DlOpReceiver& r) { r.drawDisplayList(TestDisplayList2, 1.0); }},
-           {1, 16, -1, 16,
+           {1, 80, -1, 80,
             [](DlOpReceiver& r) {
               r.drawDisplayList(MakeTestDisplayList(10, 10, SK_ColorRED), 1.0);
             }},

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -8,9 +8,8 @@
 #include <vector>
 
 #include "flutter/display_list/dl_canvas.h"
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/fml/logging.h"
-#include "flutter/impeller/geometry/matrix.h"
-#include "flutter/impeller/geometry/rect.h"
 
 #include "third_party/skia/include/core/SkM44.h"
 #include "third_party/skia/include/core/SkMatrix.h"
@@ -24,9 +23,6 @@ namespace flutter {
 class DisplayListMatrixClipState {
  private:
   using ClipOp = DlCanvas::ClipOp;
-  using DlRect = impeller::Rect;
-  using DlMatrix = impeller::Matrix;
-  using DlDegrees = impeller::Degrees;
 
   static_assert(sizeof(SkRect) == sizeof(DlRect));
 
@@ -184,8 +180,6 @@ class DisplayListMatrixClipState {
 class DisplayListMatrixClipTracker {
  private:
   using ClipOp = DlCanvas::ClipOp;
-  using DlRect = impeller::Rect;
-  using DlMatrix = impeller::Matrix;
 
  public:
   DisplayListMatrixClipTracker(const DlRect& cull_rect, const DlMatrix& matrix);
@@ -236,7 +230,7 @@ class DisplayListMatrixClipTracker {
 
   bool using_4x4_matrix() const { return current_->using_4x4_matrix(); }
 
-  DlMatrix matrix() const { return current_->matrix(); }
+  const DlMatrix& matrix() const { return current_->matrix(); }
   SkM44 matrix_4x4() const { return current_->matrix_4x4(); }
   SkMatrix matrix_3x3() const { return current_->matrix_3x3(); }
   SkRect local_cull_rect() const { return current_->local_cull_rect(); }


### PR DESCRIPTION
This is a draft pull request to demonstrate 3 different ways of iterating over all TextFrame objects in a DisplayList (with recursion).

The Iterate method tracks transform operations as it goes so it can report them to the Iterator.

The Iterate2 method relies on the Builder to have stashed the matrices in the DL op records so it can just focus on finding the required records and calling the Iterator on them.

The benchmark also has an example of a custom Dispatcher that tracks all of the matrix operations and calls an iterator whenever a DrawTextFrame operation is dispatched. This method requires no changes to the DL mechanism, but has additional overhead.