### PR TITLE
Clear the surface to transparent black when creating a PlatformViewWrapper

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -61,6 +61,14 @@ public class PlatformViewWrapper extends FrameLayout {
       @NonNull Context context, @NonNull PlatformViewRenderTarget renderTarget) {
     this(context);
     this.renderTarget = renderTarget;
+
+    Surface surface = renderTarget.getSurface();
+    final Canvas canvas = surface.lockHardwareCanvas();
+    try {
+      canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+    } finally {
+      surface.unlockCanvasAndPost(canvas);
+    }
   }
 
   /**

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -63,11 +63,13 @@ public class PlatformViewWrapper extends FrameLayout {
     this.renderTarget = renderTarget;
 
     Surface surface = renderTarget.getSurface();
-    final Canvas canvas = surface.lockHardwareCanvas();
-    try {
-      canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
-    } finally {
-      surface.unlockCanvasAndPost(canvas);
+    if (surface != null) {
+      final Canvas canvas = surface.lockHardwareCanvas();
+      try {
+        canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+      } finally {
+        surface.unlockCanvasAndPost(canvas);
+      }
     }
   }
 


### PR DESCRIPTION
Without this, an opaque black surface may briefly flash onscreen when the platform view is shown (see internal issue b/332379081)

This matches the behavior used before to the introduction of PlatformViewRenderTarget in https://github.com/flutter/engine/commit/204625490ca1b8a3a9fd939d9399a8b0242ca207

That commit moved the clearing of the surface into SurfaceTexturePlatformViewRenderTarget.  But that caused surface clearing to happen in scenarios where there was no PlatformViewWrapper, resulting in the issue seen in https://github.com/flutter/flutter/issues/141068

Later the surface clearing was removed from SurfaceTexturePlatformViewRenderTarget, causing the flashing black screen.