### PR TITLE
Remove intermediate APKs during build process.

### DIFF
--- a/testing/android/native_activity/native_activity_apk.py
+++ b/testing/android/native_activity/native_activity_apk.py
@@ -110,6 +110,10 @@ def main():
   ]
   run_command_checked(apksigner_command, env=env)
 
+  # Remove the intermediates so the out directory isn't full of large files.
+  os.remove(unaligned_apk_path)
+  os.remove(unsigned_apk_path)
+
   return 0
 
 


### PR DESCRIPTION
Found that these intermediates added a non-trivial amount of artifacts to the out directory. Folks run our of space because of the size of intermediates sometimes and this just exacerbates that problem.