### PR TITLE
[Windows] Refactor client wrapper to prepare for multi-view

### DIFF
--- a/shell/platform/windows/client_wrapper/flutter_engine.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine.cc
@@ -50,7 +50,7 @@ bool FlutterEngine::Run(const char* entry_point) {
     std::cerr << "Cannot run an engine that failed creation." << std::endl;
     return false;
   }
-  if (has_been_run_) {
+  if (run_succeeded_) {
     std::cerr << "Cannot run an engine more than once." << std::endl;
     return false;
   }
@@ -58,7 +58,7 @@ bool FlutterEngine::Run(const char* entry_point) {
   if (!run_succeeded) {
     std::cerr << "Failed to start engine." << std::endl;
   }
-  has_been_run_ = true;
+  run_succeeded_ = true;
   return run_succeeded;
 }
 

--- a/shell/platform/windows/client_wrapper/flutter_view_controller.cc
+++ b/shell/platform/windows/client_wrapper/flutter_view_controller.cc
@@ -12,7 +12,7 @@ namespace flutter {
 FlutterViewController::FlutterViewController(int width,
                                              int height,
                                              const DartProject& project) {
-  engine_ = std::make_unique<FlutterEngine>(project);
+  engine_ = std::make_shared<FlutterEngine>(project);
   controller_ = FlutterDesktopViewControllerCreate(width, height,
                                                    engine_->RelinquishEngine());
   if (!controller_) {

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
@@ -95,7 +95,7 @@ class FlutterEngine : public PluginRegistry {
                                                       LPARAM lparam);
 
  private:
-  // For access to RelinquishEngine.
+  // For access to the engine handle.
   friend class FlutterViewController;
 
   // Gives up ownership of |engine_|, but keeps a weak reference to it.
@@ -113,10 +113,11 @@ class FlutterEngine : public PluginRegistry {
   // Whether or not this wrapper owns |engine_|.
   bool owns_engine_ = true;
 
-  // Whether the engine has been run. This will be true if Run has been called,
-  // or if RelinquishEngine has been called (since the view controller will
-  // run the engine if it hasn't already been run).
-  bool has_been_run_ = false;
+  // Whether |Run| has been called successfully.
+  //
+  // This is used to improve error messages. This can be false while the engine
+  // is running if the engine was started by creating a view.
+  bool run_succeeded_ = false;
 
   // The callback to execute once the next frame is drawn.
   std::function<void()> next_frame_callback_ = nullptr;

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
@@ -27,10 +27,10 @@ class FlutterViewController {
   // Creates a FlutterView that can be parented into a Windows View hierarchy
   // either using HWNDs.
   //
+  // This also creates a new FlutterEngine.
+  //
   // |dart_project| will be used to configure the engine backing this view.
-  explicit FlutterViewController(int width,
-                                 int height,
-                                 const DartProject& project);
+  FlutterViewController(int width, int height, const DartProject& project);
 
   virtual ~FlutterViewController();
 
@@ -65,7 +65,7 @@ class FlutterViewController {
   FlutterDesktopViewControllerRef controller_ = nullptr;
 
   // The backing engine
-  std::unique_ptr<FlutterEngine> engine_;
+  std::shared_ptr<FlutterEngine> engine_;
 
   // The owned FlutterView.
   std::unique_ptr<FlutterView> view_;


### PR DESCRIPTION
_This is a refactoring with no semantic changes. No new public APIs are introduced by this change._

In the future, a new constructor will be added to `FlutterViewController` to allow it to use an existing `std::shared_ptr<FlutterEngine>` to create the view controller. This updates `FlutterViewController` to store a `std::shared_ptr` and other minor tweaks.

For context, we plan to not land the new multi-window `FlutterViewController` constructor until Window's multi-window support is productionized. Until then, we will maintain a [patch](https://github.com/flutter/flutter/issues/143767#issuecomment-2050741185) for folks that want to experiment with multi-window. This change makes that patch as small as possible.

Design doc: [flutter.dev/go/desktop-multi-view-runner-apis](https://flutter.dev/go/desktop-multi-view-runner-apis)

Part of https://github.com/flutter/flutter/issues/143767
Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
