### PR TITLE
Migrate FlutterDartVMServicePublisher to ARC

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -61,6 +61,8 @@ source_set("flutter_framework_source_arc") {
   sources = [
     "framework/Source/FlutterCallbackCache.mm",
     "framework/Source/FlutterCallbackCache_Internal.h",
+    "framework/Source/FlutterDartVMServicePublisher.h",
+    "framework/Source/FlutterDartVMServicePublisher.mm",
     "framework/Source/FlutterEmbedderKeyResponder.h",
     "framework/Source/FlutterEmbedderKeyResponder.mm",
     "framework/Source/FlutterKeyPrimaryResponder.h",
@@ -89,6 +91,7 @@ source_set("flutter_framework_source_arc") {
 
   deps += [
     "//flutter/lib/ui",
+    "//flutter/runtime",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
   ]
 }
@@ -109,8 +112,6 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterChannelKeyResponder.mm",
     "framework/Source/FlutterDartProject.mm",
     "framework/Source/FlutterDartProject_Internal.h",
-    "framework/Source/FlutterDartVMServicePublisher.h",
-    "framework/Source/FlutterDartVMServicePublisher.mm",
     "framework/Source/FlutterEngine.mm",
     "framework/Source/FlutterEngineGroup.mm",
     "framework/Source/FlutterEngine_Internal.h",

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.h
@@ -14,7 +14,7 @@
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-@property(nonatomic, retain, readonly) NSURL* url;
+@property(nonatomic, strong, readonly) NSURL* url;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.h
@@ -14,7 +14,7 @@
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-@property(nonatomic, strong, readonly) NSURL* url;
+@property(nonatomic, readonly) NSURL* url;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.mm
@@ -40,10 +40,12 @@
 #include <net/if.h>
 
 #include "flutter/fml/logging.h"
-#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/runtime/dart_service_isolate.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+
+FLUTTER_ASSERT_ARC
 
 @protocol FlutterDartVMServicePublisherDelegate
 - (void)publishServiceProtocolPort:(NSURL*)uri;
@@ -54,7 +56,7 @@
 + (NSData*)createTxtData:(NSURL*)url;
 
 @property(readonly, class) NSString* serviceName;
-@property(readonly) fml::scoped_nsobject<NSObject<FlutterDartVMServicePublisherDelegate>> delegate;
+@property(readonly) NSObject<FlutterDartVMServicePublisherDelegate>* delegate;
 @property(nonatomic, readwrite) NSURL* url;
 @property(readonly) BOOL enableVMServicePublication;
 
@@ -139,32 +141,30 @@ static void DNSSD_API RegistrationCallback(DNSServiceRef sdRef,
 
 @implementation FlutterDartVMServicePublisher {
   flutter::DartServiceIsolate::CallbackHandle _callbackHandle;
-  std::unique_ptr<fml::WeakPtrFactory<FlutterDartVMServicePublisher>> _weakFactory;
 }
 
 - (instancetype)initWithEnableVMServicePublication:(BOOL)enableVMServicePublication {
   self = [super init];
   NSAssert(self, @"Super must not return null on init.");
 
-  _delegate.reset([[DartVMServiceDNSServiceDelegate alloc] init]);
+  _delegate = [[DartVMServiceDNSServiceDelegate alloc] init];
   _enableVMServicePublication = enableVMServicePublication;
-  _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterDartVMServicePublisher>>(self);
+  __weak __typeof(self) weakSelf = self;
 
   fml::MessageLoop::EnsureInitializedForCurrentThread();
 
   _callbackHandle = flutter::DartServiceIsolate::AddServerStatusCallback(
-      [weak = _weakFactory->GetWeakPtr(),
-       runner = fml::MessageLoop::GetCurrent().GetTaskRunner()](const std::string& uri) {
+      [weakSelf, runner = fml::MessageLoop::GetCurrent().GetTaskRunner()](const std::string& uri) {
         if (!uri.empty()) {
-          runner->PostTask([weak, uri]() {
+          runner->PostTask([weakSelf, uri]() {
             // uri comes in as something like 'http://127.0.0.1:XXXXX/' where XXXXX is the port
             // number.
-            if (weak) {
-              NSURL* url = [[[NSURL alloc]
-                  initWithString:[NSString stringWithUTF8String:uri.c_str()]] autorelease];
-              weak.get().url = url;
-              if (weak.get().enableVMServicePublication) {
-                [[weak.get() delegate] publishServiceProtocolPort:url];
+            if (weakSelf) {
+              NSURL* url =
+                  [[NSURL alloc] initWithString:[NSString stringWithUTF8String:uri.c_str()]];
+              weakSelf.url = url;
+              if (weakSelf.enableVMServicePublication) {
+                [[weakSelf delegate] publishServiceProtocolPort:url];
               }
             }
           });
@@ -190,15 +190,9 @@ static void DNSSD_API RegistrationCallback(DNSServiceRef sdRef,
 }
 
 - (void)dealloc {
-  // It will be destroyed and invalidate its weak pointers
-  // before any other members are destroyed.
-  _weakFactory.reset();
-
   [_delegate stopService];
-  [_url release];
 
   flutter::DartServiceIsolate::RemoveServerStatusCallback(_callbackHandle);
-  [super dealloc];
 }
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.mm
@@ -157,14 +157,15 @@ static void DNSSD_API RegistrationCallback(DNSServiceRef sdRef,
       [weakSelf, runner = fml::MessageLoop::GetCurrent().GetTaskRunner()](const std::string& uri) {
         if (!uri.empty()) {
           runner->PostTask([weakSelf, uri]() {
+            FlutterDartVMServicePublisher* strongSelf = weakSelf;
             // uri comes in as something like 'http://127.0.0.1:XXXXX/' where XXXXX is the port
             // number.
-            if (weakSelf) {
+            if (strongSelf) {
               NSURL* url =
                   [[NSURL alloc] initWithString:[NSString stringWithUTF8String:uri.c_str()]];
-              weakSelf.url = url;
-              if (weakSelf.enableVMServicePublication) {
-                [[weakSelf delegate] publishServiceProtocolPort:url];
+              strongSelf.url = url;
+              if (strongSelf.enableVMServicePublication) {
+                [[strongSelf delegate] publishServiceProtocolPort:url];
               }
             }
           });


### PR DESCRIPTION
Smart pointers support ARC as of https://github.com/flutter/engine/pull/47612, and the unit tests were migrated in https://github.com/flutter/engine/pull/48162.

Migrate `FlutterDartVMServicePublisher` from MRC to ARC.  I validated `flutter attach` works on this engine PR, so the VM service URL is being advertised and the tool is discovering it.

Part of https://github.com/flutter/flutter/issues/137801.
