### PR TITLE
[macOS] FlutterSurfaceManager should not return surfaces that are in use

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
@@ -32,7 +32,15 @@
 @property(readonly, nonatomic, nonnull) IOSurfaceRef ioSurface;
 @property(readonly, nonatomic) CGSize size;
 @property(readonly, nonatomic) int64_t textureId;
+// Age of the surface in frames. 0 means just returned from the compositor.
+@property(readwrite, nonatomic) int age;
+// Whether the surface is currently in use by the compositor.
+@property(readonly, nonatomic) BOOL isInUse;
 
+@end
+
+@interface FlutterSurface (Testing)
+@property(readwrite, nonatomic) BOOL isInUseOverride;
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERSURFACE_H_

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurface.h
@@ -32,8 +32,6 @@
 @property(readonly, nonatomic, nonnull) IOSurfaceRef ioSurface;
 @property(readonly, nonatomic) CGSize size;
 @property(readonly, nonatomic) int64_t textureId;
-// Age of the surface in frames. 0 means just returned from the compositor.
-@property(readwrite, nonatomic) int age;
 // Whether the surface is currently in use by the compositor.
 @property(readonly, nonatomic) BOOL isInUse;
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurface.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurface.mm
@@ -10,10 +10,21 @@
   CGSize _size;
   IOSurfaceRef _ioSurface;
   id<MTLTexture> _texture;
+  int _age;
+  // Used for testing.
+  BOOL _isInUseOverride;
 }
 @end
 
 @implementation FlutterSurface
+
+- (void)setAge:(int)age {
+  self->_age = age;
+}
+
+- (int)age {
+  return _age;
+}
 
 - (IOSurfaceRef)ioSurface {
   return _ioSurface;
@@ -25,6 +36,18 @@
 
 - (int64_t)textureId {
   return reinterpret_cast<int64_t>(_texture);
+}
+
+- (BOOL)isInUse {
+  return _isInUseOverride || IOSurfaceIsInUse(_ioSurface);
+}
+
+- (BOOL)isInUseOverride {
+  return _isInUseOverride;
+}
+
+- (void)setIsInUseOverride:(BOOL)isInUseOverride {
+  _isInUseOverride = isInUseOverride;
 }
 
 - (instancetype)initWithSize:(CGSize)size device:(id<MTLDevice>)device {

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurface.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurface.mm
@@ -10,21 +10,12 @@
   CGSize _size;
   IOSurfaceRef _ioSurface;
   id<MTLTexture> _texture;
-  int _age;
   // Used for testing.
   BOOL _isInUseOverride;
 }
 @end
 
 @implementation FlutterSurface
-
-- (void)setAge:(int)age {
-  self->_age = age;
-}
-
-- (int)age {
-  return _age;
-}
 
 - (IOSurfaceRef)ioSurface {
   return _ioSurface;

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
@@ -88,7 +88,7 @@
 /**
  * Removes all cached surfaces replacing them with new ones.
  */
-- (void)replaceSurfaces:(nonnull NSArray<FlutterSurface*>*)surfaces;
+- (void)returnSurfaces:(nonnull NSArray<FlutterSurface*>*)surfaces;
 
 /**
  * Returns number of surfaces currently in cache. Used for tests.

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -291,9 +291,9 @@ static const double kIdleDelay = 1.0;
 
     FlutterSurface* res;
 
-    // Returns youngest surface that is not in use. Inside [returnSurfaces:]
-    // surfaces over certain age are purged, returning youngest surface ensures
-    // that the cache doesn't keep more surfaces than it needs to.
+    // Returns youngest surface that is not in use. Returning youngest surface ensures
+    // that the cache doesn't keep more surfaces than it needs to, as the unused surfaces
+    // kept in cache will have their age kept increasing until purged (inside [returnSurfaces:]).
     for (FlutterSurface* surface in _surfaces) {
       if (!surface.isInUse && (res == nil || res.age > surface.age)) {
         res = surface;

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -267,6 +267,9 @@ static CGSize GetRequiredFrameSize(NSArray<FlutterSurfacePresentInfo*>* surfaces
 // Cached back buffers will be released after kIdleDelay if there is no activity.
 static const double kIdleDelay = 1.0;
 // Once surfaces reach kEvictionAge, they will be evicted from the cache.
+// The age of 30 has been chosen to reduce potential surface allocation churn.
+// For unused surface 30 frames means only half a second at 60fps, and there is
+// idle timeout of 1 second where all surfaces are evicted.
 static const int kSurfaceEvictionAge = 30;
 
 @interface FlutterBackBufferCache () {

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -215,53 +215,6 @@ TEST(FlutterSurfaceManager, BackingStoreCacheSurfaceStuckInUse) {
   EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
 }
 
-TEST(FlutterSurfaceManager, BackingStoreClampsNumberOfBuffers) {
-  TestView* testView = [[TestView alloc] init];
-  FlutterSurfaceManager* surfaceManager = CreateSurfaceManager(testView);
-
-  auto surface1 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
-  auto surface2 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
-  auto surface3 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
-
-  [surfaceManager presentSurfaces:@[
-    CreatePresentInfo(surface1),
-    CreatePresentInfo(surface2),
-    CreatePresentInfo(surface3),
-  ]
-                           atTime:0
-                           notify:nil];
-
-  auto surface4 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
-  auto surface5 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
-  auto surface6 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
-
-  [surfaceManager presentSurfaces:@[
-    CreatePresentInfo(surface4),
-    CreatePresentInfo(surface5),
-    CreatePresentInfo(surface6),
-  ]
-                           atTime:0
-                           notify:nil];
-
-  EXPECT_EQ(surfaceManager.backBufferCache.count, 3ul);
-  EXPECT_EQ(surfaceManager.frontSurfaces.count, 3ul);
-
-  auto surface7 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
-  auto surface8 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
-
-  [surfaceManager presentSurfaces:@[
-    CreatePresentInfo(surface7),
-    CreatePresentInfo(surface8),
-  ]
-                           atTime:0
-                           notify:nil];
-
-  // Number of back buffers gets trimmed to number of front surfaces.
-  // 2 buffers for age == 0 and 2 buffers for age == 1.
-  EXPECT_EQ(surfaceManager.backBufferCache.count, 4ul);
-  EXPECT_EQ(surfaceManager.frontSurfaces.count, 2ul);
-}
-
 inline bool operator==(const CGRect& lhs, const CGRect& rhs) {
   return CGRectEqualToRect(lhs, rhs);
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManagerTest.mm
@@ -117,6 +117,21 @@ TEST(FlutterSurfaceManager, BackBufferCacheDoesNotLeak) {
   auto surfaceFromCache = [surfaceManager surfaceForSize:CGSizeMake(110, 110)];
   EXPECT_EQ(surfaceFromCache, surface2);
 
+  // Submit empty surfaces until the one in cache gets to age > 4, in which case
+  // it should be removed.
+
+  [surfaceManager presentSurfaces:@[] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
+
+  [surfaceManager presentSurfaces:@[] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
+
+  [surfaceManager presentSurfaces:@[] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
+
+  [surfaceManager presentSurfaces:@[] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
+
   [surfaceManager presentSurfaces:@[] atTime:0 notify:nil];
   EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
 
@@ -161,6 +176,90 @@ TEST(FlutterSurfaceManager, SurfacesAreRecycled) {
   // Check that surface is properly reused.
   auto surface3 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
   EXPECT_EQ(surface3, surface1);
+}
+
+TEST(FlutterSurfaceManager, BackingStoreCacheSurfaceStuckInUse) {
+  TestView* testView = [[TestView alloc] init];
+  FlutterSurfaceManager* surfaceManager = CreateSurfaceManager(testView);
+
+  auto surface1 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface1) ] atTime:0 notify:nil];
+  // Pretend that compositor is holding on to the surface. The surface will be kept
+  // in cache until the age of 5 is reached, and then evicted.
+  surface1.isInUseOverride = YES;
+
+  auto surface2 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface2) ] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
+
+  auto surface3 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface3) ] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 2ul);
+
+  auto surface4 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface4) ] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 2ul);
+
+  auto surface5 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface5) ] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 2ul);
+
+  auto surface6 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface6) ] atTime:0 notify:nil];
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 2ul);
+
+  auto surface7 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  [surfaceManager presentSurfaces:@[ CreatePresentInfo(surface7) ] atTime:0 notify:nil];
+  // Surface in use should bet old enough at this point to be evicted.
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 1ul);
+}
+
+TEST(FlutterSurfaceManager, BackingStoreClampsNumberOfBuffers) {
+  TestView* testView = [[TestView alloc] init];
+  FlutterSurfaceManager* surfaceManager = CreateSurfaceManager(testView);
+
+  auto surface1 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  auto surface2 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  auto surface3 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+
+  [surfaceManager presentSurfaces:@[
+    CreatePresentInfo(surface1),
+    CreatePresentInfo(surface2),
+    CreatePresentInfo(surface3),
+  ]
+                           atTime:0
+                           notify:nil];
+
+  auto surface4 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  auto surface5 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  auto surface6 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+
+  [surfaceManager presentSurfaces:@[
+    CreatePresentInfo(surface4),
+    CreatePresentInfo(surface5),
+    CreatePresentInfo(surface6),
+  ]
+                           atTime:0
+                           notify:nil];
+
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 3ul);
+  EXPECT_EQ(surfaceManager.frontSurfaces.count, 3ul);
+
+  auto surface7 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+  auto surface8 = [surfaceManager surfaceForSize:CGSizeMake(100, 100)];
+
+  [surfaceManager presentSurfaces:@[
+    CreatePresentInfo(surface7),
+    CreatePresentInfo(surface8),
+  ]
+                           atTime:0
+                           notify:nil];
+
+  // Number of back buffers gets trimmed to number of front surfaces.
+  // 2 buffers for age == 0 and 2 buffers for age == 1.
+  EXPECT_EQ(surfaceManager.backBufferCache.count, 4ul);
+  EXPECT_EQ(surfaceManager.frontSurfaces.count, 2ul);
 }
 
 inline bool operator==(const CGRect& lhs, const CGRect& rhs) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/138936

Currently the engine hold a single backbuffer per flutter view layer, which gets swapped with front buffer. This however is too optimistic, as the front buffer in some cases might not get immediately picked up by the compositor. When that happens, during next frame the cache may return a backbuffer that is in fact still being used by the compositor. Rendering to such surface will result in artifacts seen in the video. This seems more likely to happen with busy platform thread. It is also more likely to happen with the presence of "heavy" platform views such as `WKWebView`.

IOSurface is able to report when it is being used by the compositor (`IOSurfaceIsInUse`). This PR ensures that the backing store cache never returns surface that is being used by compositor. This may result in transiently keeping more surfaces than before, as the compositor sometimes seems to holds on to the surface longer than it is displayed, but that's preferable outcome to visual glitches.

This PR adds `age` field to `FlutterSurface`. When returning buffers to the surface cache (during compositor commit), the age of each surface currently present in cache increases by one, while the newly returned surfaces have their age set to 0.

When returning surfaces from cache, a surface with lowest age that is not in use by compositor is returned.

Surfaces with age that reaches 5 are evicted from the pool. Reaching this age means one of two things:
- When surface is still in use at age 5 it means the compositor is holding on to it much longer than we expect. In this case just forget about the surface, we can't really do anything about it.
- When surface is not in use at age 5, it means it hasn't been removed from cache for 4 subsequent frames. That means the cache is holding more surfaces than needed.

Removing all surfaces from cache after idle period remains unchanged.

Before: 

https://github.com/flutter/engine/assets/96958/ba2bfc43-525e-4a88-b37c-61842994d3bc

After:

https://github.com/flutter/engine/assets/96958/8b5d393e-3031-46b1-b3f0-cb7f63f8d960


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
