### PR TITLE
Fix the Dart language version for Fuchsia's build of the args package

### DIFF
--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -124,7 +124,7 @@ dart_library("args") {
   package_root = "$dart_src/third_party/pkg/args"
   package_name = "args"
 
-  pubspec = "$package_root/pubspec.yaml"
+  language_version = "2.17"
 
   deps = []
 


### PR DESCRIPTION
This is required for the next Dart roll (see https://github.com/flutter/engine/pull/52077)