### PR TITLE
Migrate vsync_waiter_ios to ARC

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -82,6 +82,8 @@ source_set("flutter_framework_source_arc") {
     "framework/Source/KeyCodeMap_Internal.h",
     "framework/Source/UIViewController+FlutterScreenAndSceneIfLoaded.h",
     "framework/Source/UIViewController+FlutterScreenAndSceneIfLoaded.mm",
+    "framework/Source/vsync_waiter_ios.h",
+    "framework/Source/vsync_waiter_ios.mm",
   ]
 
   frameworks = [
@@ -90,8 +92,10 @@ source_set("flutter_framework_source_arc") {
   ]
 
   deps += [
+    "//flutter/common:common",
     "//flutter/lib/ui",
     "//flutter/runtime",
+    "//flutter/shell/common",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
   ]
 }
@@ -149,8 +153,6 @@ source_set("flutter_framework_source") {
     "framework/Source/platform_message_response_darwin.mm",
     "framework/Source/profiler_metrics_ios.h",
     "framework/Source/profiler_metrics_ios.mm",
-    "framework/Source/vsync_waiter_ios.h",
-    "framework/Source/vsync_waiter_ios.mm",
     "ios_context.h",
     "ios_context.mm",
     "ios_context_metal_impeller.h",

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -176,7 +176,7 @@ extern CFTimeInterval display_link_target;
     _availableTextures = [[NSMutableSet alloc] init];
 
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onDisplayLink:)];
-    [self setMaxRefreshRate:[DisplayLinkManager displayRefreshRate] forceMax:NO];
+    [self setMaxRefreshRate:DisplayLinkManager.displayRefreshRate forceMax:NO];
     [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didEnterBackground:)
@@ -214,7 +214,7 @@ extern CFTimeInterval display_link_target;
   if (_displayLinkPauseCountdown == 3) {
     _displayLink.paused = YES;
     if (_displayLinkForcedMaxRate) {
-      [self setMaxRefreshRate:[DisplayLinkManager displayRefreshRate] forceMax:NO];
+      [self setMaxRefreshRate:DisplayLinkManager.displayRefreshRate forceMax:NO];
       _displayLinkForcedMaxRate = NO;
     }
   } else {
@@ -395,7 +395,7 @@ extern CFTimeInterval display_link_target;
     _didSetContentsDuringThisDisplayLinkPeriod = YES;
   } else if (!_displayLinkForcedMaxRate) {
     _displayLinkForcedMaxRate = YES;
-    [self setMaxRefreshRate:[DisplayLinkManager displayRefreshRate] forceMax:YES];
+    [self setMaxRefreshRate:DisplayLinkManager.displayRefreshRate forceMax:YES];
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1321,7 +1321,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     return;
   }
 
-  double displayRefreshRate = [DisplayLinkManager displayRefreshRate];
+  double displayRefreshRate = DisplayLinkManager.displayRefreshRate;
   const double epsilon = 0.1;
   if (displayRefreshRate < 60.0 + epsilon) {  // displayRefreshRate <= 60.0
 

--- a/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
@@ -127,4 +127,20 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
   XCTAssertTrue(link.isPaused);
 }
 
+- (void)testReleasesLinkOnInvalidation {
+  __weak CADisplayLink* weakLink;
+  @autoreleasepool {
+    auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
+    VSyncClient* vsyncClient = [[VSyncClient alloc]
+        initWithTaskRunner:thread_task_runner
+                  callback:[](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {}];
+
+    weakLink = [vsyncClient getDisplayLink];
+    XCTAssertNotNil(weakLink);
+    [vsyncClient invalidate];
+  }
+  // VSyncClient has released the CADisplayLink.
+  XCTAssertNil(weakLink);
+}
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -29,7 +29,7 @@
 ///
 /// @return     The refresh rate in frames per second.
 ///
-+ (double)displayRefreshRate;
+@property(class, nonatomic, readonly) double displayRefreshRate;
 
 @end
 
@@ -52,9 +52,10 @@
 
 - (void)pause;
 
+//------------------------------------------------------------------------------
+/// @brief      Call invalidate before releasing this object to remove from runloops.
+///
 - (void)invalidate;
-
-- (double)getRefreshRate;
 
 - (void)setMaxRefreshRate:(double)refreshRate;
 

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -8,8 +8,6 @@
 #include <QuartzCore/CADisplayLink.h>
 
 #include "flutter/fml/macros.h"
-#include "flutter/fml/memory/weak_ptr.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/common/variable_refresh_rate_reporter.h"
 #include "flutter/shell/common/vsync_waiter.h"
 
@@ -73,15 +71,12 @@ class VsyncWaiterIOS final : public VsyncWaiter, public VariableRefreshRateRepor
   // |VariableRefreshRateReporter|
   double GetRefreshRate() const override;
 
-  // Made public for testing.
-  fml::scoped_nsobject<VSyncClient> GetVsyncClient() const;
-
   // |VsyncWaiter|
   // Made public for testing.
   void AwaitVSync() override;
 
  private:
-  fml::scoped_nsobject<VSyncClient> client_;
+  VSyncClient* client_;
   double max_refresh_rate_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterIOS);


### PR DESCRIPTION
Smart pointers support ARC as of https://github.com/flutter/engine/pull/47612, and the unit tests were migrated in https://github.com/flutter/engine/pull/48162.

Migrate `vsync_waiter_ios`  from MRC to ARC.

Part of https://github.com/flutter/flutter/issues/137801.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
