### PR TITLE
Revert "Clear the surface to transparent black when creating a PlatformViewWrapper"

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -61,16 +61,6 @@ public class PlatformViewWrapper extends FrameLayout {
       @NonNull Context context, @NonNull PlatformViewRenderTarget renderTarget) {
     this(context);
     this.renderTarget = renderTarget;
-
-    Surface surface = renderTarget.getSurface();
-    if (surface != null) {
-      final Canvas canvas = surface.lockHardwareCanvas();
-      try {
-        canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
-      } finally {
-        surface.unlockCanvasAndPost(canvas);
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
Reverts flutter/engine#52047

I suspect this is causing the scenario app flakiness, if not we'll reland and investigate elsewhere


![image](https://github.com/flutter/engine/assets/8975114/48acd0b3-b0b1-4fe7-9820-1489c375aedd)
