### PR TITLE
[scenarios] test disabling surface clear.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -62,6 +62,9 @@ public class FlutterRenderer implements TextureRegistry {
    */
   @VisibleForTesting public static boolean debugForceSurfaceProducerGlTextures = false;
 
+  /** Whether to disable clearing of the Surface used to render platform views. */
+  @VisibleForTesting public static boolean debugDisableSurfaceClear = false;
+
   private static final String TAG = "FlutterRenderer";
 
   @NonNull private final FlutterJNI flutterJNI;

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -63,7 +63,7 @@ public class PlatformViewWrapper extends FrameLayout {
     this.renderTarget = renderTarget;
 
     Surface surface = renderTarget.getSurface();
-    if (surface != null) {
+    if (surface != null && !FlutterRenderer.debugDisableSurfaceClear) {
       final Canvas canvas = surface.lockHardwareCanvas();
       try {
         canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewWrapper.java
@@ -26,6 +26,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.Log;
 import io.flutter.embedding.android.AndroidTouchProcessor;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.util.ViewUtils;
 
 /**

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/TestRunner.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/TestRunner.java
@@ -24,6 +24,7 @@ public class TestRunner extends AndroidJUnitRunner {
             "--impeller-backend=" + arguments.getString("impeller-backend", "vulkan")
           };
     }
+    FlutterRenderer.debugDisableSurfaceClear = true;
     if ("true".equals(arguments.getString("force-surface-producer-surface-texture"))) {
       // Set a test flag to force the SurfaceProducer to use SurfaceTexture.
       FlutterRenderer.debugForceSurfaceProducerGlTextures = true;


### PR DESCRIPTION
I suspect that the change to clear the surface is the result of the scenario app instability. just a guess: the screenshots looks like we're missing the platform view. maybe the clearing of the surface is causing an extra frame to be pushed. That frame is getting picked up in the golden due to a race condition that is hard to hit locally


Testing disabling of this functionality in the golden test. If this pass a real fix involves some sort of hook into the rendering to verify it has fully completed before screenshotting.
