### PR TITLE
Only print "gclient sync" warning once during rebase

### DIFF
--- a/tools/githooks/lib/src/messages.dart
+++ b/tools/githooks/lib/src/messages.dart
@@ -10,6 +10,9 @@ const String _reset = '\x1B[0m';
 /// Prints a reminder to stdout to run `gclient sync -D`. Uses colors when
 /// stdout supports ANSI escape codes.
 void printGclientSyncReminder(String command) {
+  if (command == 'pre-rebase') {
+    return;
+  }
   final String prefix = io.stdout.supportsAnsiEscapes ? _redBoldUnderline : '';
   final String postfix = io.stdout.supportsAnsiEscapes ? _reset : '';
   io.stderr.writeln('$command: The engine source tree has been updated.');


### PR DESCRIPTION
Skip the "pre-rebase" message since it will also be printed "post-checkout" at the end.

Fixes https://github.com/flutter/flutter/issues/146781

Before this PR:

![rebase](https://github.com/flutter/engine/assets/682784/db7279c7-ca27-4ccf-9f6b-f9c4ad10c20a)


On this PR it's only printed once

![Screenshot 2024-04-15 at 2 06 24 PM](https://github.com/flutter/engine/assets/682784/bc80a6bc-9fd9-447f-b060-18f3a5b05775)

Fixes https://github.com/flutter/flutter/issues/146781
