### PR TITLE
[Windows] Add/remove view failures should not hang

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -534,10 +534,10 @@ std::unique_ptr<FlutterWindowsView> FlutterWindowsEngine::CreateView(
 
     FlutterEngineResult result = embedder_api_.AddView(engine_, &info);
     if (result != kSuccess) {
-      // Starting the add view operation failed. This is unexpected and
-      // indicates a bug in the Windows embedder.
-      FML_LOG(ERROR) << "FlutterEngineAddView returned unexpected result: "
-                     << result;
+      FML_DCHECK(false)
+          << "Starting the add view operation failed. FlutterEngineAddView "
+             "returned an unexpected result: "
+          << result << ". This indicates a bug in the Windows embedder.";
       return nullptr;
     }
 
@@ -590,10 +590,11 @@ void FlutterWindowsEngine::RemoveView(FlutterViewId view_id) {
 
     FlutterEngineResult result = embedder_api_.RemoveView(engine_, &info);
     if (result != kSuccess) {
-      // Starting the remove view operation failed. This is unexpected and
-      // indicates a bug in the Windows embedder.
-      FML_LOG(ERROR) << "FlutterEngineRemoveView returned unexpected result: "
-                     << result;
+      FML_DCHECK(false) << "Starting the remove view operation failed. "
+                           "FlutterEngineRemoveView "
+                           "returned an unexpected result: "
+                        << result
+                        << ". This indicates a bug in the Windows embedder.";
       return;
     }
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -534,10 +534,11 @@ std::unique_ptr<FlutterWindowsView> FlutterWindowsEngine::CreateView(
 
     FlutterEngineResult result = embedder_api_.AddView(engine_, &info);
     if (result != kSuccess) {
-      FML_DCHECK(false)
+      FML_LOG(ERROR)
           << "Starting the add view operation failed. FlutterEngineAddView "
              "returned an unexpected result: "
           << result << ". This indicates a bug in the Windows embedder.";
+      FML_DCHECK(false);
       return nullptr;
     }
 
@@ -590,11 +591,12 @@ void FlutterWindowsEngine::RemoveView(FlutterViewId view_id) {
 
     FlutterEngineResult result = embedder_api_.RemoveView(engine_, &info);
     if (result != kSuccess) {
-      FML_DCHECK(false) << "Starting the remove view operation failed. "
-                           "FlutterEngineRemoveView "
-                           "returned an unexpected result: "
-                        << result
-                        << ". This indicates a bug in the Windows embedder.";
+      FML_LOG(ERROR) << "Starting the remove view operation failed. "
+                        "FlutterEngineRemoveView "
+                        "returned an unexpected result: "
+                     << result
+                     << ". This indicates a bug in the Windows embedder.";
+      FML_DCHECK(false);
       return;
     }
 

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -1292,18 +1292,12 @@ TEST_F(FlutterWindowsEngineTest, AddViewFailureDoesNotHang) {
 
   // Create a second view. The embedder attempts to add it to the engine.
   auto second_window = std::make_unique<NiceMock<MockWindowBindingHandler>>();
-  std::unique_ptr<FlutterWindowsView> second_view =
-      engine->CreateView(std::move(second_window));
 
-  EXPECT_FALSE(second_view);
-  EXPECT_NE(
-      log_capture.str().find("FlutterEngineAddView returned unexpected result"),
-      std::string::npos);
+  EXPECT_DEBUG_DEATH(engine->CreateView(std::move(second_window)),
+                     "FlutterEngineAddView returned an unexpected result");
 }
 
 TEST_F(FlutterWindowsEngineTest, RemoveViewFailureDoesNotHang) {
-  fml::testing::LogCapture log_capture;
-
   FlutterWindowsEngineBuilder builder{GetContext()};
   builder.SetDartEntrypoint("sendCreatePlatformViewMethod");
   auto engine = builder.Build();
@@ -1317,11 +1311,8 @@ TEST_F(FlutterWindowsEngineTest, RemoveViewFailureDoesNotHang) {
          const FlutterRemoveViewInfo* info) { return kInternalInconsistency; });
 
   ASSERT_TRUE(engine->Run());
-  engine->RemoveView(123);
-
-  EXPECT_NE(log_capture.str().find(
-                "FlutterEngineRemoveView returned unexpected result"),
-            std::string::npos);
+  EXPECT_DEBUG_DEATH(engine->RemoveView(123),
+                     "FlutterEngineRemoveView returned an unexpected result");
 }
 
 }  // namespace testing

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -1266,8 +1266,6 @@ TEST_F(FlutterWindowsEngineTest, ReceivePlatformViewMessage) {
 }
 
 TEST_F(FlutterWindowsEngineTest, AddViewFailureDoesNotHang) {
-  fml::testing::LogCapture log_capture;
-
   FlutterWindowsEngineBuilder builder{GetContext()};
   auto engine = builder.Build();
 

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -1265,5 +1265,64 @@ TEST_F(FlutterWindowsEngineTest, ReceivePlatformViewMessage) {
   }
 }
 
+TEST_F(FlutterWindowsEngineTest, AddViewFailureDoesNotHang) {
+  fml::testing::LogCapture log_capture;
+
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  auto engine = builder.Build();
+
+  EngineModifier modifier{engine.get()};
+
+  modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
+  modifier.embedder_api().AddView = MOCK_ENGINE_PROC(
+      AddView,
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         const FlutterAddViewInfo* info) { return kInternalInconsistency; });
+
+  ASSERT_TRUE(engine->Run());
+
+  // Create the first view. This is the implicit view and isn't added to the
+  // engine.
+  auto implicit_window = std::make_unique<NiceMock<MockWindowBindingHandler>>();
+
+  std::unique_ptr<FlutterWindowsView> implicit_view =
+      engine->CreateView(std::move(implicit_window));
+
+  EXPECT_TRUE(implicit_view);
+
+  // Create a second view. The embedder attempts to add it to the engine.
+  auto second_window = std::make_unique<NiceMock<MockWindowBindingHandler>>();
+  std::unique_ptr<FlutterWindowsView> second_view =
+      engine->CreateView(std::move(second_window));
+
+  EXPECT_FALSE(second_view);
+  EXPECT_NE(
+      log_capture.str().find("FlutterEngineAddView returned unexpected result"),
+      std::string::npos);
+}
+
+TEST_F(FlutterWindowsEngineTest, RemoveViewFailureDoesNotHang) {
+  fml::testing::LogCapture log_capture;
+
+  FlutterWindowsEngineBuilder builder{GetContext()};
+  builder.SetDartEntrypoint("sendCreatePlatformViewMethod");
+  auto engine = builder.Build();
+
+  EngineModifier modifier{engine.get()};
+
+  modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
+  modifier.embedder_api().RemoveView = MOCK_ENGINE_PROC(
+      RemoveView,
+      [](FLUTTER_API_SYMBOL(FlutterEngine) engine,
+         const FlutterRemoveViewInfo* info) { return kInternalInconsistency; });
+
+  ASSERT_TRUE(engine->Run());
+  engine->RemoveView(123);
+
+  EXPECT_NE(log_capture.str().find(
+                "FlutterEngineRemoveView returned unexpected result"),
+            std::string::npos);
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
If the embedder API's `FlutterEngineAddView` and `FlutterEngineRemoveView` don't return `kSuccess`, their callbacks won't be invoked. See: [flutter.dev/go/multi-view-embedder-apis](https://flutter.dev/go/multi-view-embedder-apis).

Previously, the Windows embedder would hang in this scenario as it blocks until the callbacks are invoked. Now, the Windows embedder only blocks if these embedder APIs return `kSuccess`.

Kudos to @dkwingsmt for catching this!

Part of https://github.com/flutter/flutter/issues/144810
Part of https://github.com/flutter/flutter/issues/142845

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
