### PR TITLE
[Impeller] Remove old clip height tracking from Entity.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -2959,10 +2959,10 @@ TEST_P(AiksTest, CorrectClipDepthAssignedToEntities) {
 
   picture.pass->IterateAllElements([&](EntityPass::Element& element) -> bool {
     if (auto* subpass = std::get_if<std::unique_ptr<EntityPass>>(&element)) {
-      actual.push_back(subpass->get()->GetNewClipDepth());
+      actual.push_back(subpass->get()->GetClipDepth());
     }
     if (Entity* entity = std::get_if<Entity>(&element)) {
-      actual.push_back(entity->GetNewClipDepth());
+      actual.push_back(entity->GetClipDepth());
     }
     return true;
   });

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -244,7 +244,7 @@ void Canvas::Save(bool create_subpass,
     subpass->SetBlendMode(blend_mode);
     current_pass_ = GetCurrentPass().AddSubpass(std::move(subpass));
     current_pass_->SetTransform(transform_stack_.back().transform);
-    current_pass_->SetClipDepth(transform_stack_.back().clip_height);
+    current_pass_->SetClipHeight(transform_stack_.back().clip_height);
   }
   transform_stack_.emplace_back(entry);
 }
@@ -336,7 +336,6 @@ void Canvas::RestoreToCount(size_t count) {
 void Canvas::DrawPath(const Path& path, const Paint& paint) {
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(CreatePathContentsWithFilters(paint, path));
 
@@ -346,7 +345,6 @@ void Canvas::DrawPath(const Path& path, const Paint& paint) {
 void Canvas::DrawPaint(const Paint& paint) {
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(CreateCoverContentsWithFilters(paint));
 
@@ -427,7 +425,6 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
 
     Entity blurred_rrect_entity;
     blurred_rrect_entity.SetTransform(GetCurrentTransform());
-    blurred_rrect_entity.SetClipDepth(GetClipHeight());
     blurred_rrect_entity.SetBlendMode(rrect_paint.blend_mode);
 
     rrect_paint.mask_blur_descriptor = std::nullopt;
@@ -447,7 +444,6 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
       // Then, draw the non-blurred RRect on top.
       Entity entity;
       entity.SetTransform(GetCurrentTransform());
-      entity.SetClipDepth(GetClipHeight());
       entity.SetBlendMode(rrect_paint.blend_mode);
       entity.SetContents(CreateContentsForGeometryWithFilters(
           rrect_paint, Geometry::MakeRoundRect(rect, corner_radii)));
@@ -474,7 +470,6 @@ bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
 void Canvas::DrawLine(const Point& p0, const Point& p1, const Paint& paint) {
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(CreateContentsForGeometryWithFilters(
       paint, Geometry::MakeLine(p0, p1, paint.stroke_width, paint.stroke_cap)));
@@ -494,7 +489,6 @@ void Canvas::DrawRect(const Rect& rect, const Paint& paint) {
 
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(
       CreateContentsForGeometryWithFilters(paint, Geometry::MakeRect(rect)));
@@ -521,7 +515,6 @@ void Canvas::DrawOval(const Rect& rect, const Paint& paint) {
 
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(
       CreateContentsForGeometryWithFilters(paint, Geometry::MakeOval(rect)));
@@ -539,7 +532,6 @@ void Canvas::DrawRRect(const Rect& rect,
   if (paint.style == Paint::Style::kFill) {
     Entity entity;
     entity.SetTransform(GetCurrentTransform());
-    entity.SetClipDepth(GetClipHeight());
     entity.SetBlendMode(paint.blend_mode);
     entity.SetContents(CreateContentsForGeometryWithFilters(
         paint, Geometry::MakeRoundRect(rect, corner_radii)));
@@ -568,7 +560,6 @@ void Canvas::DrawCircle(const Point& center,
 
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
   auto geometry =
       paint.style == Paint::Style::kStroke
@@ -680,7 +671,6 @@ void Canvas::ClipGeometry(const std::shared_ptr<Geometry>& geometry,
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
   entity.SetContents(std::move(contents));
-  entity.SetClipDepth(GetClipHeight());
 
   GetCurrentPass().PushClip(std::move(entity));
 
@@ -735,7 +725,6 @@ void Canvas::DrawPoints(std::vector<Point> points,
 
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(CreateContentsForGeometryWithFilters(
       paint,
@@ -791,7 +780,6 @@ void Canvas::DrawImageRect(const std::shared_ptr<Image>& image,
 
   Entity entity;
   entity.SetBlendMode(paint.blend_mode);
-  entity.SetClipDepth(GetClipHeight());
   entity.SetContents(paint.WithFilters(contents));
   entity.SetTransform(GetCurrentTransform());
 
@@ -867,7 +855,6 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
                            Point position,
                            const Paint& paint) {
   Entity entity;
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
 
   auto text_contents = std::make_shared<TextContents>();
@@ -919,7 +906,6 @@ void Canvas::DrawVertices(const std::shared_ptr<VerticesGeometry>& vertices,
 
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
 
   // If there are no vertex color or texture coordinates. Or if there
@@ -1012,7 +998,6 @@ void Canvas::DrawAtlas(const std::shared_ptr<Image>& atlas,
 
   Entity entity;
   entity.SetTransform(GetCurrentTransform());
-  entity.SetClipDepth(GetClipHeight());
   entity.SetBlendMode(paint.blend_mode);
   entity.SetContents(paint.WithFilters(contents));
 

--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -163,7 +163,7 @@ Canvas::~Canvas() = default;
 void Canvas::Initialize(std::optional<Rect> cull_rect) {
   initial_cull_rect_ = cull_rect;
   base_pass_ = std::make_unique<EntityPass>();
-  base_pass_->SetNewClipDepth(++current_depth_);
+  base_pass_->SetClipDepth(++current_depth_);
   current_pass_ = base_pass_.get();
   transform_stack_.emplace_back(CanvasStackEntry{.cull_rect = cull_rect});
   FML_DCHECK(GetSaveCount() == 1u);
@@ -259,7 +259,7 @@ bool Canvas::Restore() {
 
   if (transform_stack_.back().rendering_mode ==
       Entity::RenderingMode::kSubpass) {
-    current_pass_->SetNewClipDepth(++current_depth_);
+    current_pass_->SetClipDepth(++current_depth_);
     current_pass_ = GetCurrentPass().GetSuperpass();
     FML_DCHECK(current_pass_);
   }
@@ -812,7 +812,7 @@ size_t Canvas::GetClipHeight() const {
 }
 
 void Canvas::AddEntityToCurrentPass(Entity entity) {
-  entity.SetNewClipDepth(++current_depth_);
+  entity.SetClipDepth(++current_depth_);
   GetCurrentPass().AddEntity(std::move(entity));
 }
 

--- a/impeller/entity/contents/clip_contents.cc
+++ b/impeller/entity/contents/clip_contents.cc
@@ -19,8 +19,8 @@ static Scalar GetShaderClipDepth(const Entity& entity) {
   // Draw the clip at the max of the clip entity's depth slice, so that other
   // draw calls with this same depth value will be culled even if they have a
   // perspective transform.
-  return std::nextafterf(
-      Entity::GetShaderClipDepth(entity.GetNewClipDepth() + 1), 0.0f);
+  return std::nextafterf(Entity::GetShaderClipDepth(entity.GetClipDepth() + 1),
+                         0.0f);
 }
 
 /*******************************************************************************

--- a/impeller/entity/contents/filters/filter_contents.cc
+++ b/impeller/entity/contents/filters/filter_contents.cc
@@ -144,7 +144,7 @@ bool FilterContents::Render(const ContentContext& renderer,
   if (!maybe_entity.has_value()) {
     return true;
   }
-  maybe_entity->SetNewClipDepth(entity.GetNewClipDepth());
+  maybe_entity->SetClipDepth(entity.GetClipDepth());
   return maybe_entity->Render(renderer, pass);
 }
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -226,10 +226,10 @@ Entity ApplyClippedBlurStyle(Entity::ClipOperation clip_operation,
        blur_transform](const ContentContext& renderer, const Entity& entity,
                        RenderPass& pass) mutable {
         bool result = true;
-        clipper.SetNewClipDepth(entity.GetNewClipDepth());
+        clipper.SetClipDepth(entity.GetClipDepth());
         clipper.SetTransform(entity.GetTransform() * entity_transform);
         result = clipper.Render(renderer, pass) && result;
-        blur_entity.SetNewClipDepth(entity.GetNewClipDepth());
+        blur_entity.SetClipDepth(entity.GetClipDepth());
         blur_entity.SetTransform(entity.GetTransform() * blur_transform);
         result = blur_entity.Render(renderer, pass) && result;
         return result;
@@ -277,12 +277,12 @@ Entity ApplyBlurStyle(FilterContents::BlurStyle blur_style,
                                 const Entity& entity,
                                 RenderPass& pass) mutable {
             bool result = true;
-            blur_entity.SetNewClipDepth(entity.GetNewClipDepth());
+            blur_entity.SetClipDepth(entity.GetClipDepth());
             blur_entity.SetTransform(entity.GetTransform() * blurred_transform);
             result = result && blur_entity.Render(renderer, pass);
             snapshot_entity.SetTransform(entity.GetTransform() *
                                          snapshot_transform);
-            snapshot_entity.SetNewClipDepth(entity.GetNewClipDepth());
+            snapshot_entity.SetClipDepth(entity.GetClipDepth());
             result = result && snapshot_entity.Render(renderer, pass);
             return result;
           }),

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -95,14 +95,6 @@ const std::shared_ptr<Contents>& Entity::GetContents() const {
   return contents_;
 }
 
-void Entity::SetClipDepth(uint32_t clip_depth) {
-  clip_depth_ = clip_depth;
-}
-
-uint32_t Entity::GetClipDepth() const {
-  return clip_depth_;
-}
-
 void Entity::SetNewClipDepth(uint32_t clip_depth) {
   new_clip_depth_ = clip_depth;
 }
@@ -118,10 +110,6 @@ Scalar Entity::GetShaderClipDepth() const {
 Scalar Entity::GetShaderClipDepth(uint32_t clip_depth) {
   Scalar result = std::clamp(clip_depth * kDepthEpsilon, 0.0f, 1.0f);
   return std::min(result, 1.0f - kDepthEpsilon);
-}
-
-void Entity::IncrementStencilDepth(uint32_t increment) {
-  clip_depth_ += increment;
 }
 
 void Entity::SetBlendMode(BlendMode blend_mode) {

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -95,16 +95,16 @@ const std::shared_ptr<Contents>& Entity::GetContents() const {
   return contents_;
 }
 
-void Entity::SetNewClipDepth(uint32_t clip_depth) {
-  new_clip_depth_ = clip_depth;
+void Entity::SetClipDepth(uint32_t clip_depth) {
+  clip_depth_ = clip_depth;
 }
 
-uint32_t Entity::GetNewClipDepth() const {
-  return new_clip_depth_;
+uint32_t Entity::GetClipDepth() const {
+  return clip_depth_;
 }
 
 Scalar Entity::GetShaderClipDepth() const {
-  return Entity::GetShaderClipDepth(new_clip_depth_);
+  return Entity::GetShaderClipDepth(clip_depth_);
 }
 
 Scalar Entity::GetShaderClipDepth(uint32_t clip_depth) {

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -99,12 +99,6 @@ class Entity {
 
   const std::shared_ptr<Contents>& GetContents() const;
 
-  void SetClipDepth(uint32_t clip_depth);
-
-  void IncrementStencilDepth(uint32_t increment);
-
-  uint32_t GetClipDepth() const;
-
   void SetNewClipDepth(uint32_t clip_depth);
 
   uint32_t GetNewClipDepth() const;
@@ -141,7 +135,6 @@ class Entity {
   Matrix transform_;
   std::shared_ptr<Contents> contents_;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
-  uint32_t clip_depth_ = 0u;
   uint32_t new_clip_depth_ = 1u;
   mutable Capture capture_;
 };

--- a/impeller/entity/entity.h
+++ b/impeller/entity/entity.h
@@ -99,9 +99,9 @@ class Entity {
 
   const std::shared_ptr<Contents>& GetContents() const;
 
-  void SetNewClipDepth(uint32_t clip_depth);
+  void SetClipDepth(uint32_t clip_depth);
 
-  uint32_t GetNewClipDepth() const;
+  uint32_t GetClipDepth() const;
 
   float GetShaderClipDepth() const;
 
@@ -135,7 +135,7 @@ class Entity {
   Matrix transform_;
   std::shared_ptr<Contents> contents_;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
-  uint32_t new_clip_depth_ = 1u;
+  uint32_t clip_depth_ = 1u;
   mutable Capture capture_;
 };
 

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -591,7 +591,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
               Point(),                       // local_pass_position
               pass_depth,                    // pass_depth
               clip_coverage_stack,           // clip_coverage_stack
-              clip_height_,                   // clip_height_floor
+              clip_height_,                  // clip_height_floor
               nullptr,                       // backdrop_filter_contents
               pass_context.GetRenderPass(pass_depth)  // collapsed_parent_pass
               )) {
@@ -704,7 +704,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
                 global_pass_position,         // local_pass_position
             ++pass_depth,                     // pass_depth
             clip_coverage_stack,              // clip_coverage_stack
-            subpass->clip_height_,             // clip_height_floor
+            subpass->clip_height_,            // clip_height_floor
             subpass_backdrop_filter_contents  // backdrop_filter_contents
             )) {
       // Validation error messages are triggered for all `OnRender()` failure

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -591,7 +591,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
               Point(),                       // local_pass_position
               pass_depth,                    // pass_depth
               clip_coverage_stack,           // clip_coverage_stack
-              clip_depth_,                   // clip_height_floor
+              clip_height_,                   // clip_height_floor
               nullptr,                       // backdrop_filter_contents
               pass_context.GetRenderPass(pass_depth)  // collapsed_parent_pass
               )) {
@@ -690,7 +690,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     // save layers may transform the subpass texture after it's rendered,
     // causing parent clip coverage to get misaligned with the actual area that
     // the subpass will affect in the parent pass.
-    clip_coverage_stack.PushSubpass(subpass_coverage, subpass->clip_depth_);
+    clip_coverage_stack.PushSubpass(subpass_coverage, subpass->clip_height_);
 
     // Stencil textures aren't shared between EntityPasses (as much of the
     // time they are transient).
@@ -704,7 +704,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
                 global_pass_position,         // local_pass_position
             ++pass_depth,                     // pass_depth
             clip_coverage_stack,              // clip_coverage_stack
-            subpass->clip_depth_,             // clip_height_floor
+            subpass->clip_height_,             // clip_height_floor
             subpass_backdrop_filter_contents  // backdrop_filter_contents
             )) {
       // Validation error messages are triggered for all `OnRender()` failure
@@ -741,7 +741,6 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     element_entity.SetNewClipDepth(subpass->new_clip_depth_);
     element_entity.SetCapture(subpass_texture_capture);
     element_entity.SetContents(std::move(offscreen_texture_contents));
-    element_entity.SetClipDepth(subpass->clip_depth_);
     element_entity.SetBlendMode(subpass->blend_mode_);
     element_entity.SetTransform(subpass_texture_capture.AddMatrix(
         "Transform",
@@ -919,7 +918,6 @@ bool EntityPass::OnRender(
     backdrop_entity.SetContents(std::move(backdrop_filter_contents));
     backdrop_entity.SetTransform(
         Matrix::MakeTranslation(Vector3(-local_pass_position)));
-    backdrop_entity.SetClipDepth(clip_height_floor);
     backdrop_entity.SetNewClipDepth(std::numeric_limits<uint32_t>::max());
 
     RenderElement(backdrop_entity, clip_height_floor, pass_context, pass_depth,
@@ -1156,12 +1154,12 @@ void EntityPass::SetTransform(Matrix transform) {
   transform_ = transform;
 }
 
-void EntityPass::SetClipDepth(size_t clip_depth) {
-  clip_depth_ = clip_depth;
+void EntityPass::SetClipHeight(size_t clip_height) {
+  clip_height_ = clip_height;
 }
 
-size_t EntityPass::GetClipDepth() const {
-  return clip_depth_;
+size_t EntityPass::GetClipHeight() const {
+  return clip_height_;
 }
 
 void EntityPass::SetNewClipDepth(size_t clip_depth) {

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -133,7 +133,7 @@ void EntityPass::PopClips(size_t num_clips, uint64_t depth) {
     FML_DCHECK(active_clips_.back() < elements_.size());
     Entity* element = std::get_if<Entity>(&elements_[active_clips_.back()]);
     FML_DCHECK(element);
-    element->SetNewClipDepth(depth);
+    element->SetClipDepth(depth);
     active_clips_.pop_back();
   }
 }
@@ -738,7 +738,7 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     Entity element_entity;
     Capture subpass_texture_capture =
         capture.CreateChild("Entity (Subpass texture)");
-    element_entity.SetNewClipDepth(subpass->new_clip_depth_);
+    element_entity.SetClipDepth(subpass->clip_depth_);
     element_entity.SetCapture(subpass_texture_capture);
     element_entity.SetContents(std::move(offscreen_texture_contents));
     element_entity.SetBlendMode(subpass->blend_mode_);
@@ -799,7 +799,7 @@ bool EntityPass::RenderElement(Entity& element_entity,
     Entity msaa_backdrop_entity;
     msaa_backdrop_entity.SetContents(std::move(msaa_backdrop_contents));
     msaa_backdrop_entity.SetBlendMode(BlendMode::kSource);
-    msaa_backdrop_entity.SetNewClipDepth(std::numeric_limits<uint32_t>::max());
+    msaa_backdrop_entity.SetClipDepth(std::numeric_limits<uint32_t>::max());
     if (!msaa_backdrop_entity.Render(renderer, *result.pass)) {
       VALIDATION_LOG << "Failed to render MSAA backdrop filter entity.";
       return false;
@@ -918,7 +918,7 @@ bool EntityPass::OnRender(
     backdrop_entity.SetContents(std::move(backdrop_filter_contents));
     backdrop_entity.SetTransform(
         Matrix::MakeTranslation(Vector3(-local_pass_position)));
-    backdrop_entity.SetNewClipDepth(std::numeric_limits<uint32_t>::max());
+    backdrop_entity.SetClipDepth(std::numeric_limits<uint32_t>::max());
 
     RenderElement(backdrop_entity, clip_height_floor, pass_context, pass_depth,
                   renderer, clip_coverage_stack, global_pass_position);
@@ -1162,12 +1162,12 @@ size_t EntityPass::GetClipHeight() const {
   return clip_height_;
 }
 
-void EntityPass::SetNewClipDepth(size_t clip_depth) {
-  new_clip_depth_ = clip_depth;
+void EntityPass::SetClipDepth(size_t clip_depth) {
+  clip_depth_ = clip_depth;
 }
 
-uint32_t EntityPass::GetNewClipDepth() const {
-  return new_clip_depth_;
+uint32_t EntityPass::GetClipDepth() const {
+  return clip_depth_;
 }
 
 void EntityPass::SetBlendMode(BlendMode blend_mode) {

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -161,9 +161,9 @@ class EntityPass {
 
   void SetTransform(Matrix transform);
 
-  void SetClipDepth(size_t clip_depth);
+  void SetClipHeight(size_t clip_height);
 
-  size_t GetClipDepth() const;
+  size_t GetClipHeight() const;
 
   void SetNewClipDepth(size_t clip_depth);
 
@@ -337,7 +337,7 @@ class EntityPass {
 
   EntityPass* superpass_ = nullptr;
   Matrix transform_;
-  size_t clip_depth_ = 0u;
+  size_t clip_height_ = 0u;
   uint32_t new_clip_depth_ = 1u;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   bool flood_clip_ = false;

--- a/impeller/entity/entity_pass.h
+++ b/impeller/entity/entity_pass.h
@@ -165,9 +165,9 @@ class EntityPass {
 
   size_t GetClipHeight() const;
 
-  void SetNewClipDepth(size_t clip_depth);
+  void SetClipDepth(size_t clip_depth);
 
-  uint32_t GetNewClipDepth() const;
+  uint32_t GetClipDepth() const;
 
   void SetBlendMode(BlendMode blend_mode);
 
@@ -338,7 +338,7 @@ class EntityPass {
   EntityPass* superpass_ = nullptr;
   Matrix transform_;
   size_t clip_height_ = 0u;
-  uint32_t new_clip_depth_ = 1u;
+  uint32_t clip_depth_ = 1u;
   BlendMode blend_mode_ = BlendMode::kSourceOver;
   bool flood_clip_ = false;
   bool enable_offscreen_debug_checkerboard_ = false;

--- a/impeller/entity/entity_pass_clip_stack.cc
+++ b/impeller/entity/entity_pass_clip_stack.cc
@@ -103,7 +103,7 @@ EntityPassClipStack::ClipStateResult EntityPassClipStack::ApplyClipState(
       FML_DCHECK(restoration_index < subpass_state.clip_coverage.size());
 
       // We only need to restore the area that covers the coverage of the
-      // clip rect at target depth + 1.
+      // clip rect at target height + 1.
       std::optional<Rect> restore_coverage =
           (restoration_index + 1 < subpass_state.clip_coverage.size())
               ? subpass_state.clip_coverage[restoration_index + 1].coverage

--- a/impeller/entity/entity_pass_unittests.cc
+++ b/impeller/entity/entity_pass_unittests.cc
@@ -97,7 +97,6 @@ TEST(EntityPassClipStackTest, AppendAndRestoreClipCoverage) {
 
   // Push a clip.
   Entity entity;
-  entity.SetClipDepth(0);
   EntityPassClipStack::ClipStateResult result = recorder.ApplyClipState(
       Contents::ClipCoverage{
           .type = Contents::ClipCoverage::Type::kAppend,
@@ -166,7 +165,6 @@ TEST(EntityPassClipStackTest, ClipAndRestoreWithSubpasses) {
 
   // Push a clip.
   Entity entity;
-  entity.SetClipDepth(0u);
   {
     EntityPassClipStack::ClipStateResult result = recorder.ApplyClipState(
         Contents::ClipCoverage{
@@ -190,7 +188,6 @@ TEST(EntityPassClipStackTest, ClipAndRestoreWithSubpasses) {
   EXPECT_EQ(recorder.GetClipCoverageLayers()[0].coverage,
             Rect::MakeLTRB(50, 50, 55, 55));
 
-  entity.SetClipDepth(1);
   {
     EntityPassClipStack::ClipStateResult result = recorder.ApplyClipState(
         Contents::ClipCoverage{


### PR DESCRIPTION
And rename clip depth accessors and members.

After this, I'm going to attempt to remove the need for tracking clip height altogether in EntityPass as well.