### PR TITLE
[fuchsia] route fuchsia.sysmem2.Allocator

### DIFF
--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/BUILD.gn
@@ -26,6 +26,8 @@ executable("flutter-embedder-test-bin") {
   deps = [
     "${fuchsia_sdk}/fidl/fuchsia.inspect",
     "${fuchsia_sdk}/fidl/fuchsia.logger",
+    "${fuchsia_sdk}/fidl/fuchsia.sysmem",
+    "${fuchsia_sdk}/fidl/fuchsia.sysmem2",
     "${fuchsia_sdk}/fidl/fuchsia.tracing.provider",
     "${fuchsia_sdk}/fidl/fuchsia.ui.app",
     "${fuchsia_sdk}/fidl/fuchsia.ui.composition",

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
@@ -4,6 +4,8 @@
 
 #include <fuchsia/inspect/cpp/fidl.h>
 #include <fuchsia/logger/cpp/fidl.h>
+#include <fuchsia/sysmem/cpp/fidl.h>
+#include <fuchsia/sysmem2/cpp/fidl.h>
 #include <fuchsia/tracing/provider/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>
 #include <fuchsia/ui/composition/cpp/fidl.h>

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/meta/flutter-embedder-test.cml
@@ -21,6 +21,7 @@
                 "fuchsia.inspect.InspectSink",
                 "fuchsia.logger.LogSink",
                 "fuchsia.sysmem.Allocator",
+                "fuchsia.sysmem2.Allocator",
                 "fuchsia.tracing.provider.Registry",
                 "fuchsia.vulkan.loader.Loader",
             ],

--- a/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/text-input/meta/text-input-test.cml
@@ -30,6 +30,7 @@
                 "fuchsia.logger.LogSink",
                 "fuchsia.scheduler.ProfileProvider",
                 "fuchsia.sysmem.Allocator",
+                "fuchsia.sysmem2.Allocator",
                 "fuchsia.tracing.provider.Registry",
                 "fuchsia.ui.input.ImeService",
                 "fuchsia.vulkan.loader.Loader",

--- a/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
+++ b/shell/platform/fuchsia/flutter/tests/integration/touch-input/meta/touch-input-test.cml
@@ -31,6 +31,7 @@
                 "fuchsia.logger.LogSink",
                 "fuchsia.scheduler.ProfileProvider",
                 "fuchsia.sysmem.Allocator",
+                "fuchsia.sysmem2.Allocator",
                 "fuchsia.tracing.provider.Registry",
                 "fuchsia.ui.input.ImeService",
                 "fuchsia.vulkan.loader.Loader",

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/BUILD.gn
@@ -43,6 +43,8 @@ source_set("portable_ui_test") {
     ":check_view",
     "${fuchsia_sdk}/fidl/fuchsia.inspect",
     "${fuchsia_sdk}/fidl/fuchsia.logger",
+    "${fuchsia_sdk}/fidl/fuchsia.sysmem",
+    "${fuchsia_sdk}/fidl/fuchsia.sysmem2",
     "${fuchsia_sdk}/fidl/fuchsia.tracing.provider",
     "${fuchsia_sdk}/fidl/fuchsia.ui.app",
     "${fuchsia_sdk}/fidl/fuchsia.ui.composition",

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -6,6 +6,8 @@
 
 #include <fuchsia/inspect/cpp/fidl.h>
 #include <fuchsia/logger/cpp/fidl.h>
+#include <fuchsia/sysmem/cpp/fidl.h>
+#include <fuchsia/sysmem2/cpp/fidl.h>
 #include <fuchsia/tracing/provider/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>
 #include <lib/async/cpp/task.h>
@@ -80,6 +82,11 @@ void PortableUITest::SetUpRealmBase() {
       .capabilities = {Protocol{fuchsia::logger::LogSink::Name_},
                        Protocol{fuchsia::inspect::InspectSink::Name_},
                        Protocol{fuchsia::sysmem::Allocator::Name_},
+
+                       // Replace string with
+                       // fuchsia::sysmem2::Allocator::Name_
+                       // when available (fuchsia SDK >= 19).
+                       Protocol{"fuchsia.sysmem2.Allocator"},
                        Protocol{fuchsia::tracing::provider::Registry::Name_},
                        Protocol{fuchsia::ui::input::ImeService::Name_},
                        Protocol{kPosixSocketProviderName},


### PR DESCRIPTION
Fuchsia's fake-display will be migrating to sysmem2, which requires fuchsia.sysmem2.Allocator to be routed in a few places.

fixes flutter/flutter#146858

## Pre-launch Checklist

- [y] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [y] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [na] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [y] I listed at least one issue that this PR fixes in the description above.
- [fixes to existing tests] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [na] I updated/added relevant documentation (doc comments with `///`).
- [na / googler] I signed the [CLA].
- [y] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
