### PR TITLE
Update Skia's BUILD.gn

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -344,9 +344,6 @@ optional("fontmgr_win") {
   ]
   public = [ "$_skia_root/include/ports/SkTypeface_win.h" ]
   sources = [
-    "$_skia_root/include/ports/SkFontMgr_indirect.h",
-    "$_skia_root/include/ports/SkRemotableFontMgr.h",
-    "$_skia_root/src/fonts/SkFontMgr_indirect.cpp",
     "$_skia_root/src/ports/SkFontMgr_win_dw.cpp",
     "$_skia_root/src/ports/SkScalerContext_win_dw.cpp",
     "$_skia_root/src/ports/SkScalerContext_win_dw.h",


### PR DESCRIPTION
Remove references to `SkFontMgr_indirect` and `SkFontMgrRemotable`. These are not used by Flutter and Skia is removing them.