### PR TITLE
[macOS] Rename viewId to viewIdentifier

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -13,6 +13,14 @@
 #import "FlutterPluginRegistrarMacOS.h"
 
 /**
+ * A unique identifier for a view within which Flutter content is hosted.
+ *
+ * Identifiers are guaranteed to be unique for views owned by a given engine but
+ * may collide for views owned by different engines.
+ */
+typedef int64_t FlutterViewIdentifier;
+
+/**
  * Values for the `mouseTrackingMode` property.
  */
 typedef NS_ENUM(NSInteger, FlutterMouseTrackingMode) {
@@ -109,6 +117,17 @@ FLUTTER_DARWIN_EXPORT
 - (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
                                nibName:(nullable NSString*)nibName
                                 bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
+
+/**
+ * The identifier for this view controller, if it is attached.
+ *
+ * The identifier is assigned when the view controller is attached to a
+ * `FlutterEngine`.
+ *
+ * If the view controller is detached (see `FlutterViewController#attached`),
+ * reading this property throws an assertion.
+ */
+@property(nonatomic, readonly) FlutterViewIdentifier viewIdentifier;
 
 /**
  * Return YES if the view controller is attached to an engine.

--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h
@@ -63,7 +63,7 @@ class FlutterCompositor {
 
   // Presents the FlutterLayers by updating the FlutterView specified by
   // `view_id` using the layer content.
-  bool Present(FlutterViewId view_id, const FlutterLayer** layers, size_t layers_count);
+  bool Present(FlutterViewIdentifier view_id, const FlutterLayer** layers, size_t layers_count);
 
  private:
   // A class that contains the information for a view to be presented.

--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositor.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h"
 
+#include "flutter/common/constants.h"
 #include "flutter/fml/logging.h"
 
 namespace flutter {
@@ -45,7 +46,7 @@ bool FlutterCompositor::CreateBackingStore(const FlutterBackingStoreConfig* conf
   // TODO(dkwingsmt): This class only supports single-view for now. As more
   // classes are gradually converted to multi-view, it should get the view ID
   // from somewhere.
-  FlutterView* view = [view_provider_ viewForId:kFlutterImplicitViewId];
+  FlutterView* view = [view_provider_ viewForIdentifier:kFlutterImplicitViewId];
   if (!view) {
     return false;
   }
@@ -60,10 +61,10 @@ bool FlutterCompositor::CreateBackingStore(const FlutterBackingStoreConfig* conf
   return true;
 }
 
-bool FlutterCompositor::Present(FlutterViewId view_id,
+bool FlutterCompositor::Present(FlutterViewIdentifier view_id,
                                 const FlutterLayer** layers,
                                 size_t layers_count) {
-  FlutterView* view = [view_provider_ viewForId:view_id];
+  FlutterView* view = [view_provider_ viewForIdentifier:view_id];
   if (!view) {
     return false;
   }

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -877,10 +877,10 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 #pragma mark - Framework-internal methods
 
 - (void)addViewController:(FlutterViewController*)controller {
-  NSCAssert(controller.engine == nil,
-            @"The FlutterViewController is unexpectedly attached to "
-            @"engine %@ before initialization.",
-            controller.engine);
+  NSAssert(controller.engine == nil,
+           @"The FlutterViewController is unexpectedly attached to "
+           @"engine %@ before initialization.",
+           controller.engine);
   [self registerViewController:controller forIdentifier:kFlutterImplicitViewId];
   NSAssert(controller.attached,
            @"The FlutterViewController unexpectedly stays unattached after being added. "

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <vector>
 
+#include "flutter/common/constants.h"
 #include "flutter/shell/platform/common/app_lifecycle_state.h"
 #include "flutter/shell/platform/common/engine_switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -33,6 +34,8 @@
 NSString* const kFlutterPlatformChannel = @"flutter/platform";
 NSString* const kFlutterSettingsChannel = @"flutter/settings";
 NSString* const kFlutterLifecycleChannel = @"flutter/lifecycle";
+
+using flutter::kFlutterImplicitViewId;
 
 /**
  * Constructs and returns a FlutterLocale struct corresponding to |locale|, which must outlive
@@ -106,7 +109,8 @@ constexpr char kTextPlainFormat[] = "text/plain";
 @property(nonatomic, readonly)
     NSMutableDictionary<NSString*, FlutterEngineRegistrar*>* pluginRegistrars;
 
-- (nullable FlutterViewController*)viewControllerForId:(FlutterViewId)viewId;
+- (nullable FlutterViewController*)viewControllerForIdentifier:
+    (FlutterViewIdentifier)viewIdentifier;
 
 /**
  * An internal method that adds the view controller with the given ID.
@@ -114,7 +118,8 @@ constexpr char kTextPlainFormat[] = "text/plain";
  * This method assigns the controller with the ID, puts the controller into the
  * map, and does assertions related to the implicit view ID.
  */
-- (void)registerViewController:(FlutterViewController*)controller forId:(FlutterViewId)viewId;
+- (void)registerViewController:(FlutterViewController*)controller
+                 forIdentifier:(FlutterViewIdentifier)viewIdentifier;
 
 /**
  * An internal method that removes the view controller with the given ID.
@@ -123,7 +128,7 @@ constexpr char kTextPlainFormat[] = "text/plain";
  * map. This is an no-op if the view ID is not associated with any view
  * controllers.
  */
-- (void)deregisterViewControllerForId:(FlutterViewId)viewId;
+- (void)deregisterViewControllerForIdentifier:(FlutterViewIdentifier)viewIdentifier;
 
 /**
  * Shuts down the engine if view requirement is not met, and headless execution
@@ -303,7 +308,7 @@ constexpr char kTextPlainFormat[] = "text/plain";
 - (instancetype)initWithPlugin:(nonnull NSString*)pluginKey
                  flutterEngine:(nonnull FlutterEngine*)flutterEngine;
 
-- (nullable NSView*)viewForId:(FlutterViewId)viewId;
+- (nullable NSView*)viewForIdentifier:(FlutterViewIdentifier)viewIdentifier;
 
 /**
  * The value published by this plugin, or NSNull if nothing has been published.
@@ -341,11 +346,11 @@ constexpr char kTextPlainFormat[] = "text/plain";
 }
 
 - (NSView*)view {
-  return [self viewForId:kFlutterImplicitViewId];
+  return [self viewForIdentifier:kFlutterImplicitViewId];
 }
 
-- (NSView*)viewForId:(FlutterViewId)viewId {
-  FlutterViewController* controller = [_flutterEngine viewControllerForId:viewId];
+- (NSView*)viewForIdentifier:(FlutterViewIdentifier)viewIdentifier {
+  FlutterViewController* controller = [_flutterEngine viewControllerForIdentifier:viewIdentifier];
   if (controller == nil) {
     return nil;
   }
@@ -452,7 +457,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
   FlutterThreadSynchronizer* _threadSynchronizer;
 
   // The next available view ID.
-  int _nextViewId;
+  int _nextviewIdentifier;
 
   // Whether the application is currently the active application.
   BOOL _active;
@@ -511,7 +516,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   _isResponseValid = [[NSMutableArray alloc] initWithCapacity:1];
   [_isResponseValid addObject:@YES];
   // kFlutterImplicitViewId is reserved for the implicit view.
-  _nextViewId = kFlutterImplicitViewId + 1;
+  _nextviewIdentifier = kFlutterImplicitViewId + 1;
 
   _embedderAPI.struct_size = sizeof(FlutterEngineProcTable);
   FlutterEngineGetProcAddresses(&_embedderAPI);
@@ -620,7 +625,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
     // only operates on the implicit view. To support multi-view, we need a
     // way to pass in the ID (probably through FlutterSemanticsUpdate).
     FlutterEngine* engine = (__bridge FlutterEngine*)user_data;
-    [[engine viewControllerForId:kFlutterImplicitViewId] updateSemantics:update];
+    [[engine viewControllerForIdentifier:kFlutterImplicitViewId] updateSemantics:update];
   };
   flutterArguments.custom_dart_entrypoint = entrypoint.UTF8String;
   flutterArguments.shutdown_dart_vm_when_done = true;
@@ -728,14 +733,18 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   }
 }
 
-- (void)registerViewController:(FlutterViewController*)controller forId:(FlutterViewId)viewId {
+- (void)registerViewController:(FlutterViewController*)controller
+                 forIdentifier:(FlutterViewIdentifier)viewIdentifier {
   NSAssert(controller != nil, @"The controller must not be nil.");
   NSAssert(![controller attached],
            @"The incoming view controller is already attached to an engine.");
-  NSAssert([_viewControllers objectForKey:@(viewId)] == nil, @"The requested view ID is occupied.");
-  [controller setUpWithEngine:self viewId:viewId threadSynchronizer:_threadSynchronizer];
-  NSAssert(controller.viewId == viewId, @"Failed to assign view ID.");
-  [_viewControllers setObject:controller forKey:@(viewId)];
+  NSAssert([_viewControllers objectForKey:@(viewIdentifier)] == nil,
+           @"The requested view ID is occupied.");
+  [controller setUpWithEngine:self
+               viewIdentifier:viewIdentifier
+           threadSynchronizer:_threadSynchronizer];
+  NSAssert(controller.viewIdentifier == viewIdentifier, @"Failed to assign view ID.");
+  [_viewControllers setObject:controller forKey:@(viewIdentifier)];
 
   if (controller.viewLoaded) {
     [self viewControllerViewDidLoad:controller];
@@ -763,20 +772,20 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
                         }];
                       }
                     }];
-  FML_DCHECK([_vsyncWaiters objectForKey:@(viewController.viewId)] == nil);
+  FML_DCHECK([_vsyncWaiters objectForKey:@(viewController.viewIdentifier)] == nil);
   @synchronized(_vsyncWaiters) {
-    [_vsyncWaiters setObject:waiter forKey:@(viewController.viewId)];
+    [_vsyncWaiters setObject:waiter forKey:@(viewController.viewIdentifier)];
   }
 }
 
-- (void)deregisterViewControllerForId:(FlutterViewId)viewId {
-  FlutterViewController* oldController = [self viewControllerForId:viewId];
+- (void)deregisterViewControllerForIdentifier:(FlutterViewIdentifier)viewIdentifier {
+  FlutterViewController* oldController = [self viewControllerForIdentifier:viewIdentifier];
   if (oldController != nil) {
     [oldController detachFromEngine];
-    [_viewControllers removeObjectForKey:@(viewId)];
+    [_viewControllers removeObjectForKey:@(viewIdentifier)];
   }
   @synchronized(_vsyncWaiters) {
-    [_vsyncWaiters removeObjectForKey:@(viewId)];
+    [_vsyncWaiters removeObjectForKey:@(viewIdentifier)];
   }
 }
 
@@ -786,9 +795,9 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   }
 }
 
-- (FlutterViewController*)viewControllerForId:(FlutterViewId)viewId {
-  FlutterViewController* controller = [_viewControllers objectForKey:@(viewId)];
-  NSAssert(controller == nil || controller.viewId == viewId,
+- (FlutterViewController*)viewControllerForIdentifier:(FlutterViewIdentifier)viewIdentifier {
+  FlutterViewController* controller = [_viewControllers objectForKey:@(viewIdentifier)];
+  NSAssert(controller == nil || controller.viewIdentifier == viewIdentifier,
            @"The stored controller has unexpected view ID.");
   return controller;
 }
@@ -808,12 +817,12 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
              @"If you wanted to create an FlutterViewController and set it to an existing engine, "
              @"you should use FlutterViewController#init(engine:, nibName, bundle:) instead.",
              controller.engine);
-    [self registerViewController:controller forId:kFlutterImplicitViewId];
+    [self registerViewController:controller forIdentifier:kFlutterImplicitViewId];
   } else if (currentController != nil && controller == nil) {
-    NSAssert(currentController.viewId == kFlutterImplicitViewId,
-             @"The default controller has an unexpected ID %llu", currentController.viewId);
+    NSAssert(currentController.viewIdentifier == kFlutterImplicitViewId,
+             @"The default controller has an unexpected ID %llu", currentController.viewIdentifier);
     // From non-nil to nil.
-    [self deregisterViewControllerForId:kFlutterImplicitViewId];
+    [self deregisterViewControllerForIdentifier:kFlutterImplicitViewId];
     [self shutDownIfNeeded];
   } else {
     // From non-nil to a different non-nil view controller.
@@ -827,7 +836,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 }
 
 - (FlutterViewController*)viewController {
-  return [self viewControllerForId:kFlutterImplicitViewId];
+  return [self viewControllerForIdentifier:kFlutterImplicitViewId];
 }
 
 - (FlutterCompositor*)createFlutterCompositor {
@@ -868,13 +877,27 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 #pragma mark - Framework-internal methods
 
 - (void)addViewController:(FlutterViewController*)controller {
-  [self registerViewController:controller forId:kFlutterImplicitViewId];
+  NSCAssert(controller.engine == nil,
+            @"The FlutterViewController is unexpectedly attached to "
+            @"engine %@ before initialization.",
+            controller.engine);
+  [self registerViewController:controller forIdentifier:kFlutterImplicitViewId];
+  NSAssert(controller.attached,
+           @"The FlutterViewController unexpectedly stays unattached after being added. "
+           @"In unit tests, this is likely because either the FlutterViewController or "
+           @"the FlutterEngine is mocked. Please subclass these classes instead.");
+  NSAssert(controller.engine == self,
+           @"The FlutterViewController #%lld has unexpected engine %@ after being added, "
+           @"instead of %@. "
+           @"In unit tests, this is likely because either the FlutterViewController or "
+           @"the FlutterEngine is mocked. Please subclass these classes instead.",
+           controller.viewIdentifier, controller.engine, self);
 }
 
 - (void)removeViewController:(nonnull FlutterViewController*)viewController {
   NSAssert([viewController attached] && viewController.engine == self,
            @"The given view controller is not associated with this engine.");
-  [self deregisterViewControllerForId:viewController.viewId];
+  [self deregisterViewControllerForIdentifier:viewController.viewIdentifier];
   [self shutDownIfNeeded];
 }
 
@@ -963,7 +986,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   if (!_engine || !viewController || !viewController.viewLoaded) {
     return;
   }
-  NSAssert([self viewControllerForId:viewController.viewId] == viewController,
+  NSAssert([self viewControllerForIdentifier:viewController.viewIdentifier] == viewController,
            @"The provided view controller is not attached to this engine.");
   NSView* view = viewController.flutterView;
   CGRect scaledBounds = [view convertRectToBacking:view.bounds];
@@ -978,14 +1001,14 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       .left = static_cast<size_t>(scaledBounds.origin.x),
       .top = static_cast<size_t>(scaledBounds.origin.y),
       .display_id = static_cast<uint64_t>(displayId),
-      .view_id = viewController.viewId,
+      .view_id = viewController.viewIdentifier,
   };
   _embedderAPI.SendWindowMetricsEvent(_engine, &windowMetricsEvent);
 }
 
 - (void)sendPointerEvent:(const FlutterPointerEvent&)event {
   _embedderAPI.SendPointerEvent(_engine, &event, 1);
-  _lastViewWithPointerEvent = [self viewControllerForId:kFlutterImplicitViewId].flutterView;
+  _lastViewWithPointerEvent = [self viewControllerForIdentifier:kFlutterImplicitViewId].flutterView;
 }
 
 - (void)sendKeyEvent:(const FlutterKeyEvent&)event
@@ -1239,7 +1262,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 - (void)announceAccessibilityMessage:(NSString*)message
                         withPriority:(NSAccessibilityPriorityLevel)priority {
   NSAccessibilityPostNotificationWithUserInfo(
-      [self viewControllerForId:kFlutterImplicitViewId].flutterView,
+      [self viewControllerForIdentifier:kFlutterImplicitViewId].flutterView,
       NSAccessibilityAnnouncementRequestedNotification,
       @{NSAccessibilityAnnouncementKey : message, NSAccessibilityPriorityKey : @(priority)});
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -48,8 +48,9 @@ constexpr int64_t kImplicitViewId = 0ll;
 @end
 
 @implementation TestPlatformViewFactory
-- (nonnull NSView*)createWithViewIdentifier:(int64_t)viewId arguments:(nullable id)args {
-  return viewId == 42 ? [[NSView alloc] init] : nil;
+- (nonnull NSView*)createWithViewIdentifier:(FlutterViewIdentifier)viewIdentifier
+                                  arguments:(nullable id)args {
+  return viewIdentifier == 42 ? [[NSView alloc] init] : nil;
 }
 
 @end
@@ -887,7 +888,7 @@ TEST_F(FlutterEngineTest, ManageControllersIfInitiatedByController) {
   @autoreleasepool {
     // Create FVC1.
     viewController1 = [[FlutterViewController alloc] initWithProject:project];
-    EXPECT_EQ(viewController1.viewId, 0ll);
+    EXPECT_EQ(viewController1.viewIdentifier, 0ll);
 
     engine = viewController1.engine;
     engine.viewController = nil;
@@ -904,7 +905,7 @@ TEST_F(FlutterEngineTest, ManageControllersIfInitiatedByController) {
 
   engine.viewController = viewController1;
   EXPECT_EQ(engine.viewController, viewController1);
-  EXPECT_EQ(viewController1.viewId, 0ll);
+  EXPECT_EQ(viewController1.viewIdentifier, 0ll);
 }
 
 TEST_F(FlutterEngineTest, ManageControllersIfInitiatedByEngine) {
@@ -918,7 +919,7 @@ TEST_F(FlutterEngineTest, ManageControllersIfInitiatedByEngine) {
 
   @autoreleasepool {
     viewController1 = [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-    EXPECT_EQ(viewController1.viewId, 0ll);
+    EXPECT_EQ(viewController1.viewIdentifier, 0ll);
     EXPECT_EQ(engine.viewController, viewController1);
 
     engine.viewController = nil;
@@ -926,7 +927,7 @@ TEST_F(FlutterEngineTest, ManageControllersIfInitiatedByEngine) {
     FlutterViewController* viewController2 = [[FlutterViewController alloc] initWithEngine:engine
                                                                                    nibName:nil
                                                                                     bundle:nil];
-    EXPECT_EQ(viewController2.viewId, 0ll);
+    EXPECT_EQ(viewController2.viewIdentifier, 0ll);
     EXPECT_EQ(engine.viewController, viewController2);
   }
   // FVC2 is deallocated but FVC1 is retained.
@@ -935,7 +936,7 @@ TEST_F(FlutterEngineTest, ManageControllersIfInitiatedByEngine) {
 
   engine.viewController = viewController1;
   EXPECT_EQ(engine.viewController, viewController1);
-  EXPECT_EQ(viewController1.viewId, 0ll);
+  EXPECT_EQ(viewController1.viewIdentifier, 0ll);
 }
 
 TEST_F(FlutterEngineTest, HandlesTerminationRequest) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -155,7 +155,8 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
 /**
  * The |FlutterViewController| associated with the given view ID, if any.
  */
-- (nullable FlutterViewController*)viewControllerForId:(FlutterViewId)viewId;
+- (nullable FlutterViewController*)viewControllerForIdentifier:
+    (FlutterViewIdentifier)viewIdentifier;
 
 /**
  * Informs the engine that the specified view controller's window metrics have changed.

--- a/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.h
@@ -7,6 +7,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
+
 /**
  * Takes care of synchronization between raster and platform thread.
  *
@@ -24,7 +26,7 @@
 /**
  * Blocks until all views have a commit with their given sizes (or empty) is requested.
  */
-- (void)beginResizeForView:(int64_t)viewId
+- (void)beginResizeForView:(FlutterViewIdentifier)viewIdentifier
                       size:(CGSize)size
                     notify:(nonnull dispatch_block_t)notify;
 
@@ -37,7 +39,7 @@
  *
  * The notify block is guaranteed to be called within a core animation transaction.
  */
-- (void)performCommitForView:(int64_t)viewId
+- (void)performCommitForView:(FlutterViewIdentifier)viewIdentifier
                         size:(CGSize)size
                       notify:(nonnull dispatch_block_t)notify;
 
@@ -55,14 +57,14 @@
  * performCommitForView:. It is typically done when the view controller is
  * created.
  */
-- (void)registerView:(int64_t)viewId;
+- (void)registerView:(FlutterViewIdentifier)viewIdentifier;
 
 /**
  * Requests the synchronizer to no longer track a view.
  *
  * It is typically done when the view controller is destroyed.
  */
-- (void)deregisterView:(int64_t)viewId;
+- (void)deregisterView:(FlutterViewIdentifier)viewIdentifier;
 
 /**
  * Called when the engine shuts down.

--- a/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizer.mm
@@ -57,7 +57,7 @@
 }
 
 - (BOOL)allViewsHaveFrame {
-  for (auto const& [viewId, contentSize] : _contentSizes) {
+  for (auto const& [viewIdentifier, contentSize] : _contentSizes) {
     if (CGSizeEqualToSize(contentSize, CGSizeZero)) {
       return NO;
     }
@@ -66,7 +66,7 @@
 }
 
 - (BOOL)someViewsHaveFrame {
-  for (auto const& [viewId, contentSize] : _contentSizes) {
+  for (auto const& [viewIdentifier, contentSize] : _contentSizes) {
     if (!CGSizeEqualToSize(contentSize, CGSizeZero)) {
       return YES;
     }
@@ -99,7 +99,7 @@
   _beginResizeWaiting = NO;
 }
 
-- (void)beginResizeForView:(int64_t)viewId
+- (void)beginResizeForView:(FlutterViewIdentifier)viewIdentifier
                       size:(CGSize)size
                     notify:(nonnull dispatch_block_t)notify {
   dispatch_assert_queue(_mainQueue);
@@ -115,7 +115,7 @@
 
   notify();
 
-  _contentSizes[viewId] = CGSizeMake(-1, -1);
+  _contentSizes[viewIdentifier] = CGSizeMake(-1, -1);
 
   _beginResizeWaiting = YES;
 
@@ -123,7 +123,7 @@
     if (_shuttingDown) {
       break;
     }
-    const CGSize& contentSize = _contentSizes[viewId];
+    const CGSize& contentSize = _contentSizes[viewIdentifier];
     if (CGSizeEqualToSize(contentSize, size) || CGSizeEqualToSize(contentSize, CGSizeZero)) {
       break;
     }
@@ -134,7 +134,7 @@
   _beginResizeWaiting = NO;
 }
 
-- (void)performCommitForView:(int64_t)viewId
+- (void)performCommitForView:(FlutterViewIdentifier)viewIdentifier
                         size:(CGSize)size
                       notify:(nonnull dispatch_block_t)notify {
   dispatch_assert_queue_not(_mainQueue);
@@ -149,7 +149,7 @@
     fml::AutoResetWaitableEvent& e = event;
     _scheduledBlocks.push_back(^{
       notify();
-      _contentSizes[viewId] = size;
+      _contentSizes[viewIdentifier] = size;
       e.Signal();
     });
     if (_beginResizeWaiting) {
@@ -177,16 +177,16 @@
   }
 }
 
-- (void)registerView:(int64_t)viewId {
+- (void)registerView:(FlutterViewIdentifier)viewIdentifier {
   dispatch_assert_queue(_mainQueue);
   std::unique_lock<std::mutex> lock(_mutex);
-  _contentSizes[viewId] = CGSizeZero;
+  _contentSizes[viewIdentifier] = CGSizeZero;
 }
 
-- (void)deregisterView:(int64_t)viewId {
+- (void)deregisterView:(FlutterViewIdentifier)viewIdentifier {
   dispatch_assert_queue(_mainQueue);
   std::unique_lock<std::mutex> lock(_mutex);
-  _contentSizes.erase(viewId);
+  _contentSizes.erase(viewIdentifier);
 }
 
 - (void)shutdown {

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -12,19 +12,6 @@
 
 #include <stdint.h>
 
-typedef int64_t FlutterViewId;
-
-/**
- * The view ID for APIs that don't support multi-view.
- *
- * Some single-view APIs will eventually be replaced by their multi-view
- * variant. During the deprecation period, the single-view APIs will coexist with
- * and work with the multi-view APIs as if the other views don't exist.  For
- * backward compatibility, single-view APIs will always operate on the view with
- * this ID. Also, the first view assigned to the engine will also have this ID.
- */
-constexpr FlutterViewId kFlutterImplicitViewId = 0ll;
-
 /**
  * Delegate for FlutterView.
  */
@@ -54,7 +41,8 @@ constexpr FlutterViewId kFlutterImplicitViewId = 0ll;
                               commandQueue:(nonnull id<MTLCommandQueue>)commandQueue
                                   delegate:(nonnull id<FlutterViewDelegate>)delegate
                         threadSynchronizer:(nonnull FlutterThreadSynchronizer*)threadSynchronizer
-                                    viewId:(int64_t)viewId NS_DESIGNATED_INITIALIZER;
+                            viewIdentifier:(FlutterViewIdentifier)viewIdentifier
+    NS_DESIGNATED_INITIALIZER;
 
 - (nullable instancetype)initWithFrame:(NSRect)frameRect
                            pixelFormat:(nullable NSOpenGLPixelFormat*)format NS_UNAVAILABLE;

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -10,7 +10,7 @@
 #import <QuartzCore/QuartzCore.h>
 
 @interface FlutterView () <FlutterSurfaceManagerDelegate> {
-  int64_t _viewId;
+  FlutterViewIdentifier _viewIdentifier;
   __weak id<FlutterViewDelegate> _viewDelegate;
   FlutterThreadSynchronizer* _threadSynchronizer;
   FlutterSurfaceManager* _surfaceManager;
@@ -25,13 +25,13 @@
                      commandQueue:(id<MTLCommandQueue>)commandQueue
                          delegate:(id<FlutterViewDelegate>)delegate
                threadSynchronizer:(FlutterThreadSynchronizer*)threadSynchronizer
-                           viewId:(int64_t)viewId {
+                   viewIdentifier:(FlutterViewIdentifier)viewIdentifier {
   self = [super initWithFrame:NSZeroRect];
   if (self) {
     [self setWantsLayer:YES];
     [self setBackgroundColor:[NSColor blackColor]];
     [self setLayerContentsRedrawPolicy:NSViewLayerContentsRedrawDuringViewResize];
-    _viewId = viewId;
+    _viewIdentifier = viewIdentifier;
     _viewDelegate = delegate;
     _threadSynchronizer = threadSynchronizer;
     _surfaceManager = [[FlutterSurfaceManager alloc] initWithDevice:device
@@ -43,7 +43,7 @@
 }
 
 - (void)onPresent:(CGSize)frameSize withBlock:(dispatch_block_t)block {
-  [_threadSynchronizer performCommitForView:_viewId size:frameSize notify:block];
+  [_threadSynchronizer performCommitForView:_viewIdentifier size:frameSize notify:block];
 }
 
 - (FlutterSurfaceManager*)surfaceManager {
@@ -52,7 +52,7 @@
 
 - (void)reshaped {
   CGSize scaledSize = [self convertSizeToBacking:self.bounds.size];
-  [_threadSynchronizer beginResizeForView:_viewId
+  [_threadSynchronizer beginResizeForView:_viewIdentifier
                                      size:scaledSize
                                    notify:^{
                                      [_viewDelegate viewDidReshape:self];

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -8,6 +8,9 @@
 #include <Carbon/Carbon.h>
 #import <objc/message.h>
 
+#include "flutter/common/constants.h"
+#include "flutter/shell/platform/embedder/embedder.h"
+
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h"
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
@@ -17,7 +20,6 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputSemanticsObject.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
-#import "flutter/shell/platform/embedder/embedder.h"
 
 #pragma mark - Static types and data.
 
@@ -322,14 +324,12 @@ static void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
 
   std::shared_ptr<flutter::AccessibilityBridgeMac> _bridge;
 
-  FlutterViewId _id;
-
   // FlutterViewController does not actually uses the synchronizer, but only
   // passes it to FlutterView.
   FlutterThreadSynchronizer* _threadSynchronizer;
 }
 
-@synthesize viewId = _viewId;
+@synthesize viewIdentifier = _viewIdentifier;
 @dynamic accessibilityBridge;
 
 /**
@@ -350,7 +350,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
             @"The FlutterViewController unexpectedly stays unattached after initialization. "
             @"In unit tests, this is likely because either the FlutterViewController or "
             @"the FlutterEngine is mocked. Please subclass these classes instead.",
-            controller.engine, controller.viewId);
+            controller.engine, controller.viewIdentifier);
   controller->_mouseTrackingMode = kFlutterMouseTrackingModeInKeyWindow;
   controller->_textInputPlugin = [[FlutterTextInputPlugin alloc] initWithViewController:controller];
   [controller initializeKeyboard];
@@ -468,9 +468,9 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
   [_flutterView setBackgroundColor:_backgroundColor];
 }
 
-- (FlutterViewId)viewId {
+- (FlutterViewIdentifier)viewIdentifier {
   NSAssert([self attached], @"This view controller is not attached.");
-  return _viewId;
+  return _viewIdentifier;
 }
 
 - (void)onPreEngineRestart {
@@ -498,18 +498,18 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
 }
 
 - (void)setUpWithEngine:(FlutterEngine*)engine
-                 viewId:(FlutterViewId)viewId
+         viewIdentifier:(FlutterViewIdentifier)viewIdentifier
      threadSynchronizer:(FlutterThreadSynchronizer*)threadSynchronizer {
   NSAssert(_engine == nil, @"Already attached to an engine %@.", _engine);
   _engine = engine;
-  _viewId = viewId;
+  _viewIdentifier = viewIdentifier;
   _threadSynchronizer = threadSynchronizer;
-  [_threadSynchronizer registerView:_viewId];
+  [_threadSynchronizer registerView:_viewIdentifier];
 }
 
 - (void)detachFromEngine {
   NSAssert(_engine != nil, @"Not attached to any engine.");
-  [_threadSynchronizer deregisterView:_viewId];
+  [_threadSynchronizer deregisterView:_viewIdentifier];
   _threadSynchronizer = nil;
   _engine = nil;
 }
@@ -742,7 +742,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
       .device_kind = deviceKind,
       // If a click triggered a synthesized kAdd, don't pass the buttons in that event.
       .buttons = phase == kAdd ? 0 : _mouseState.buttons,
-      .view_id = static_cast<FlutterViewId>(_viewId),
+      .view_id = static_cast<FlutterViewIdentifier>(_viewIdentifier),
   };
 
   if (phase == kPanZoomUpdate) {
@@ -833,7 +833,7 @@ static void CommonInit(FlutterViewController* controller, FlutterEngine* engine)
                                    commandQueue:commandQueue
                                        delegate:self
                              threadSynchronizer:_threadSynchronizer
-                                         viewId:_viewId];
+                                 viewIdentifier:_viewIdentifier];
 }
 
 - (void)onKeyboardLayoutChanged {
@@ -1070,7 +1070,7 @@ static NSData* CurrentKeyboardLayoutData() {
           .device = kPointerPanZoomDeviceId,
           .signal_kind = kFlutterPointerSignalKindScrollInertiaCancel,
           .device_kind = kFlutterPointerDeviceKindTrackpad,
-          .view_id = static_cast<FlutterViewId>(_viewId),
+          .view_id = static_cast<FlutterViewIdentifier>(_viewIdentifier),
       };
 
       [_engine sendPointerEvent:flutterEvent];

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -16,16 +16,6 @@
 
 @interface FlutterViewController () <FlutterKeyboardViewDelegate>
 
-/**
- * The identifier for this view controller.
- *
- * The ID is assigned by FlutterEngine when the view controller is attached.
- *
- * If the view controller is unattached (see FlutterViewController#attached),
- * reading this property throws an assertion.
- */
-@property(nonatomic, readonly) FlutterViewId viewId;
-
 // The FlutterView for this view controller.
 @property(nonatomic, readonly, nullable) FlutterView* flutterView;
 
@@ -48,7 +38,7 @@
  * before being used, and must be set up only once until detachFromEngine:.
  */
 - (void)setUpWithEngine:(nonnull FlutterEngine*)engine
-                 viewId:(FlutterViewId)viewId
+         viewIdentifier:(FlutterViewIdentifier)viewIdentifier
      threadSynchronizer:(nonnull FlutterThreadSynchronizer*)threadSynchronizer;
 
 /**

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProvider.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProvider.mm
@@ -22,8 +22,8 @@
   return self;
 }
 
-- (nullable FlutterView*)viewForId:(FlutterViewId)viewId {
-  return [_engine viewControllerForId:viewId].flutterView;
+- (nullable FlutterView*)viewForIdentifier:(FlutterViewIdentifier)viewIdentifier {
+  return [_engine viewControllerForIdentifier:viewIdentifier].flutterView;
 }
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProviderTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProviderTest.mm
@@ -6,13 +6,11 @@
 #import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 
+#include "flutter/common/constants.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewEngineProvider.h"
-#import "flutter/testing/testing.h"
-#include "third_party/googletest/googletest/include/gtest/gtest.h"
-
 #import "flutter/testing/testing.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
@@ -22,12 +20,12 @@ TEST(FlutterViewEngineProviderUnittests, GetViewReturnsTheCorrectView) {
   FlutterViewEngineProvider* viewProvider;
   id mockEngine = CreateMockFlutterEngine(@"");
   __block id mockFlutterViewController;
-  OCMStub([mockEngine viewControllerForId:0])
+  OCMStub([mockEngine viewControllerForIdentifier:0])
       .ignoringNonObjectArgs()
       .andDo(^(NSInvocation* invocation) {
-        FlutterViewId viewId;
-        [invocation getArgument:&viewId atIndex:2];
-        if (viewId == kFlutterImplicitViewId) {
+        FlutterViewIdentifier viewIdentifier;
+        [invocation getArgument:&viewIdentifier atIndex:2];
+        if (viewIdentifier == kFlutterImplicitViewId) {
           if (mockFlutterViewController != nil) {
             [invocation setReturnValue:&mockFlutterViewController];
           }
@@ -36,13 +34,13 @@ TEST(FlutterViewEngineProviderUnittests, GetViewReturnsTheCorrectView) {
   viewProvider = [[FlutterViewEngineProvider alloc] initWithEngine:mockEngine];
 
   // When the view controller is not set, the returned view is nil.
-  EXPECT_EQ([viewProvider viewForId:0], nil);
+  EXPECT_EQ([viewProvider viewForIdentifier:0], nil);
 
   // When the view controller is set, the returned view is the controller's view.
   mockFlutterViewController = OCMStrictClassMock([FlutterViewController class]);
   id mockView = OCMStrictClassMock([FlutterView class]);
   OCMStub([mockFlutterViewController flutterView]).andReturn(mockView);
-  EXPECT_EQ([viewProvider viewForId:0], mockView);
+  EXPECT_EQ([viewProvider viewForIdentifier:0], mockView);
 }
 
 }  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewProvider.h
@@ -21,7 +21,7 @@
  *
  * Returns nil if the ID is invalid.
  */
-- (nullable FlutterView*)viewForId:(FlutterViewId)id;
+- (nullable FlutterView*)viewForIdentifier:(FlutterViewIdentifier)id;
 
 @end
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewTest.mm
@@ -34,7 +34,7 @@ TEST(FlutterView, ShouldInheritContentsScaleReturnsYes) {
                                                 commandQueue:queue
                                                     delegate:delegate
                                           threadSynchronizer:threadSynchronizer
-                                                      viewId:kImplicitViewId];
+                                              viewIdentifier:kImplicitViewId];
   EXPECT_EQ([view layer:view.layer shouldInheritContentsScale:3.0 fromWindow:view.window], YES);
 }
 
@@ -79,7 +79,7 @@ TEST(FlutterView, CursorUpdateDoesHitTest) {
                                                         commandQueue:queue
                                                             delegate:delegate
                                                   threadSynchronizer:threadSynchronizer
-                                                              viewId:kImplicitViewId];
+                                                      viewIdentifier:kImplicitViewId];
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                  styleMask:NSBorderlessWindowMask
                                                    backing:NSBackingStoreBuffered
@@ -123,7 +123,7 @@ TEST(FlutterView, CursorUpdateDoesNotOverridePlatformView) {
                                                         commandQueue:queue
                                                             delegate:delegate
                                                   threadSynchronizer:threadSynchronizer
-                                                              viewId:kImplicitViewId];
+                                                      viewIdentifier:kImplicitViewId];
   NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
                                                  styleMask:NSBorderlessWindowMask
                                                    backing:NSBackingStoreBuffered


### PR DESCRIPTION
This PR adds `FlutterViewController` with new API `viewIdentifier` and renames all occasions that mention "viewId" to "viewIdentifier", to align with the requirement for the iOS shell.

A new typedef `FlutterViewIdentifier` is also added. ~~The problem is, we don't have a file to contain this typedef. Currently I put them in a new file called `common.h`. I'm open to other suggestions.~~ It has been moved to `FlutterViewController.h`.
* Another alternative is to not use the type def, but use `int64_t` directly. I'm ok with this choice too, since honestly it's just a 64 int.

Also, macOS's definition for `kFlutterImplicitViewId` has been removed in favor of the one in `common/constants.h`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
